### PR TITLE
boards/common/stm32: clean up LED definitions

### DIFF
--- a/boards/alientek-pandora/include/board.h
+++ b/boards/alientek-pandora/include/board.h
@@ -31,26 +31,14 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_E, 7)  /**< LED0 gpio pin  */
-#define LED0_MASK           (1 << 7)             /**< LED0 gpio mask */
+#define LED0_PIN_NUM        7
+#define LED0_PORT_NUM       PORT_E
 
-#define LED0_ON             (GPIOB->BSRR = LED0_MASK)  /**< Turn on LED0  */
-#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))  /**< Turn off LED0  */
-#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)  /**< Toggle LED0  */
+#define LED1_PIN_NUM        8
+#define LED1_PORT_NUM       PORT_E
 
-#define LED1_PIN            GPIO_PIN(PORT_E, 8)  /**< LED1 gpio pin  */
-#define LED1_MASK           (1 << 8)             /**< LED1 gpio mask */
-
-#define LED1_ON             (GPIOE->BSRR = LED1_MASK)  /**< Turn on LED1  */
-#define LED1_OFF            (GPIOE->BSRR = (LED1_MASK << 16))  /**< Turn off LED1  */
-#define LED1_TOGGLE         (GPIOE->ODR  ^= LED1_MASK)  /**< Toggle LED1  */
-
-#define LED2_PIN            GPIO_PIN(PORT_E, 9)  /**< LED2 gpio pin  */
-#define LED2_MASK           (1 << 9)             /**< LED2 gpio mask */
-
-#define LED2_ON             (GPIOE->BSRR = LED2_MASK)  /**< Turn on LED2  */
-#define LED2_OFF            (GPIOE->BSRR = (LED2_MASK << 16))  /**< Turn off LED2  */
-#define LED2_TOGGLE         (GPIOE->ODR  ^= LED2_MASK)  /**< Toggle LED2  */
+#define LED2_PIN_NUM        9
+#define LED2_PORT_NUM       PORT_E
 
 /** @} */
 
@@ -74,6 +62,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -54,33 +54,17 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_A, 5)
-#define LED0_MASK           (1 << 5)
+#define LED0_PIN_NUM        5
+#define LED0_PORT_NUM       PORT_A
 
-#define LED0_ON             (GPIOA->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOA->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOA->ODR  ^= LED0_MASK)
+#define LED1_PIN_NUM        5
+#define LED1_PORT_NUM       PORT_B
 
-#define LED1_PIN            GPIO_PIN(PORT_B, 5)
-#define LED1_MASK           (1 << 5)
+#define LED2_PIN_NUM        6
+#define LED2_PORT_NUM       PORT_B
 
-#define LED1_ON             (GPIOB->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOB->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOB->ODR  ^= LED1_MASK)
-
-#define LED2_PIN            GPIO_PIN(PORT_B, 6)
-#define LED2_MASK           (1 << 6)
-
-#define LED2_ON             (GPIOB->BSRR = LED2_MASK)
-#define LED2_OFF            (GPIOB->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (GPIOB->ODR  ^= LED2_MASK)
-
-#define LED3_PIN            GPIO_PIN(PORT_B, 7)
-#define LED3_MASK           (1 << 7)
-
-#define LED3_ON             (GPIOB->BSRR = LED3_MASK)
-#define LED3_OFF            (GPIOB->BSRR = (LED3_MASK << 16))
-#define LED3_TOGGLE         (GPIOB->ODR  ^= LED3_MASK)
+#define LED3_PIN_NUM        7
+#define LED3_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -94,6 +78,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -31,19 +31,11 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_A, 5)
-#define LED0_MASK           (1 << 5)
+#define LED0_PIN_NUM        5
+#define LED0_PORT_NUM       PORT_A
 
-#define LED0_ON             (GPIOA->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOA->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOA->ODR  ^= LED0_MASK)
-
-#define LED1_PIN            GPIO_PIN(PORT_B, 14)
-#define LED1_MASK           (1 << 14)
-
-#define LED1_ON             (GPIOB->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOB->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOB->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        14
+#define LED1_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -86,6 +78,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/b-u585i-iot02a/include/board.h
+++ b/boards/b-u585i-iot02a/include/board.h
@@ -31,26 +31,14 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_E, 13)
-#define LED0_MASK           (1 << 13)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_E
 
-#define LED0_ON             (GPIOE->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOE->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOE->ODR  ^= LED0_MASK)
+#define LED1_PIN_NUM        6
+#define LED1_PORT_NUM       PORT_H
 
-#define LED1_PIN            GPIO_PIN(PORT_H, 6)
-#define LED1_MASK           (1 << 6)
-
-#define LED1_ON             (GPIOH->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOH->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOH->ODR  ^= LED1_MASK)
-
-#define LED2_PIN            GPIO_PIN(PORT_H, 7)
-#define LED2_MASK           (1 << 7)
-
-#define LED2_ON             (GPIOH->BSRR = LED2_MASK)
-#define LED2_OFF            (GPIOH->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (GPIOH->ODR  ^= LED2_MASK)
+#define LED2_PIN_NUM        7
+#define LED2_PORT_NUM       PORT_H
 /** @} */
 
 /**
@@ -78,6 +66,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/blackpill-128kib/include/board.h
+++ b/boards/blackpill-128kib/include/board.h
@@ -35,9 +35,8 @@ extern "C" {
  * @name   Macros for controlling the on-board LED.
  * @{
  */
-#define LED0_PORT           GPIOB   /**< GPIO-Port the LED is connected to */
-#define LED0_PORTNUM        PORT_B  /**< GPIO Port number the LED is connected to */
-#define LED0_PINNUM         (12)    /**< Pin number the LED is connected to */
+#define LED0_PORT_NUM       PORT_B  /**< GPIO Port number the LED is connected to */
+#define LED0_PIN_NUM        (12)    /**< Pin number the LED is connected to */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/blackpill/include/board.h
+++ b/boards/blackpill/include/board.h
@@ -35,9 +35,8 @@ extern "C" {
  * @name   Macros for controlling the on-board LED.
  * @{
  */
-#define LED0_PORT           GPIOB   /**< GPIO-Port the LED is connected to */
-#define LED0_PORTNUM        PORT_B  /**< GPIO Port number the LED is connected to */
-#define LED0_PINNUM         (12)    /**< Pin number the LED is connected to */
+#define LED0_PORT_NUM       PORT_B  /**< GPIO Port number the LED is connected to */
+#define LED0_PIN_NUM        12      /**< Pin number the LED is connected to */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/bluepill-stm32f030c8/include/board.h
+++ b/boards/bluepill-stm32f030c8/include/board.h
@@ -39,18 +39,16 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOC
-#define LED0_PIN            GPIO_PIN(PORT_C, 13)
-#define LED0_MASK           (1 << 13)
-
-#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK <<  0))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_C
+#define LED0_IS_INVERTED    1
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/common/blxxxpill/include/board_common.h
+++ b/boards/common/blxxxpill/include/board_common.h
@@ -32,21 +32,15 @@ extern "C" {
  * @name   Macros for controlling the on-board LED.
  * @{
  */
-#ifndef LED0_PORT
-#define LED0_PORT           GPIOC                                   /**< GPIO-Port the LED is connected to */
+#ifndef LED0_PORT_NUM
+#define LED0_PORT_NUM       PORT_C                                  /**< GPIO Port number the LED is connected to */
 #endif
-#ifndef LED0_PORTNUM
-#define LED0_PORTNUM        PORT_C                                  /**< GPIO Port number the LED is connected to */
+#ifndef LED0_PIN_NUM
+#define LED0_PIN_NUM        (13)                                    /**< Pin number the LED is connected to */
 #endif
-#ifndef LED0_PINNUM
-#define LED0_PINNUM         (13)                                    /**< Pin number the LED is connected to */
+#ifndef LED0_IS_INVERTED
+#define LED0_IS_INVERTED    1
 #endif
-#define LED0_PIN            GPIO_PIN(LED0_PORTNUM, LED0_PINNUM)     /**< GPIO-Pin the LED is connected to */
-#define LED0_MASK           (1 << LED0_PINNUM)
-
-#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))   /**< Turn LED0 on */
-#define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)           /**< Turn LED0 off */
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)          /**< Toggle LED0 */
 /** @} */
 
 /**
@@ -73,6 +67,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_COMMON_H */
 /** @} */

--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -77,30 +77,21 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_D, 2)
-#define LED1_PIN            GPIO_PIN(PORT_B, 5)
-#define LED2_PIN            GPIO_PIN(PORT_C, 10)
+#define LED0_PIN_NUM        2
+#define LED0_PORT_NUM       PORT_D
 
-#define LED0_MASK           (1 << 2)
-#define LED1_MASK           (1 << 5)
-#define LED2_MASK           (1 << 10)
+#define LED1_PIN_NUM        5
+#define LED1_PORT_NUM       PORT_B
 
-#define LED0_ON             (GPIOD->ODR &= ~LED0_MASK)
-#define LED0_OFF            (GPIOD->ODR |=  LED0_MASK)
-#define LED0_TOGGLE         (GPIOD->ODR ^=  LED0_MASK)
-
-#define LED1_ON             (GPIOB->ODR &= ~LED1_MASK)
-#define LED1_OFF            (GPIOB->ODR |=  LED1_MASK)
-#define LED1_TOGGLE         (GPIOB->ODR ^=  LED1_MASK)
-
-#define LED2_ON             (GPIOC->ODR &= ~LED2_MASK)
-#define LED2_OFF            (GPIOC->ODR |=  LED2_MASK)
-#define LED2_TOGGLE         (GPIOC->ODR ^=  LED2_MASK)
+#define LED2_PIN_NUM        10
+#define LED2_PORT_NUM       PORT_C
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_COMMON_H */
 /** @} */

--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -39,36 +39,23 @@ extern "C" {
  */
 #if defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI) || \
     defined(CPU_MODEL_STM32L552ZE)
-#define LED0_PORT           GPIOC
-#define LED0_PIN            GPIO_PIN(PORT_C, 7)
-#define LED0_MASK           (1 << 7)
+#define LED0_PIN_NUM        7
+#define LED0_PORT_NUM       PORT_C
 #else
-#define LED0_PORT           GPIOB
-#define LED0_PIN            GPIO_PIN(PORT_B, 0)
-#define LED0_MASK           (1 << 0)
+#define LED0_PIN_NUM        0
+#define LED0_PORT_NUM       PORT_B
 #endif
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
 
-#define LED1_PIN            GPIO_PIN(PORT_B, 7)
-#define LED1_MASK           (1 << 7)
-#define LED1_ON             (GPIOB->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOB->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOB->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        7
+#define LED1_PORT_NUM       PORT_B
 
 #if defined(CPU_MODEL_STM32L552ZE)
-#define LED2_PORT           GPIOA
-#define LED2_PIN            GPIO_PIN(PORT_A, 9)
-#define LED2_MASK           (1 << 9)
+#define LED2_PIN_NUM        9
+#define LED2_PORT_NUM       PORT_A
 #else
-#define LED2_PORT           GPIOB
-#define LED2_PIN            GPIO_PIN(PORT_B, 14)
-#define LED2_MASK           (1 << 14)
+#define LED2_PIN_NUM        14
+#define LED2_PORT_NUM       PORT_B
 #endif
-#define LED2_ON             (LED2_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED2_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED2_PORT->ODR  ^= LED2_MASK)
 /** @} */
 
 /**
@@ -82,6 +69,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -33,16 +33,15 @@ extern "C" {
  * @name Macros for controlling the on-board LED (LD3).
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 3)
-#define LED0_MASK           (1 << 3)
-#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        3
+#define LED0_PORT_NUM       PORT_B
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -35,18 +35,12 @@ extern "C" {
  * @{
  */
 #if defined(CPU_MODEL_STM32F302R8) || defined(CPU_MODEL_STM32L433RC)
-#define LED0_PORT           GPIOB
-#define LED0_PIN            GPIO_PIN(PORT_B, 13)
-#define LED0_MASK           (1 << 13)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_B
 #else
-#define LED0_PORT           GPIOA
-#define LED0_PIN            GPIO_PIN(PORT_A, 5)
-#define LED0_MASK           (1 << 5)
+#define LED0_PIN_NUM        5
+#define LED0_PORT_NUM       PORT_A
 #endif
-
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
 /** @} */
 
 /**
@@ -96,6 +90,8 @@ static const motor_driver_config_t motor_driver_config[] = {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/common/stm32/include/stm32_leds.h
+++ b/boards/common/stm32/include/stm32_leds.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @brief       Common LED macros
+ * @{
+ *
+ * @file
+ * @brief       Common LED macros
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * This idea is that STM32 boards only define the pin and port number of LEDs
+ * and this header provides the rest of the defines
+ */
+
+#ifndef STM32_LEDS_H
+#define STM32_LEDS_H
+
+/* GPIO_PORT() macro. This define even works when GPIO LL is not in used */
+#include "gpio_ll_arch.h"
+#include "kernel_defines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Common LED pin definitions for STM32 boards
+ * @{
+ */
+#if defined(LED0_PORT_NUM) && defined (LED0_PIN_NUM)
+#  define LED0_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED0_PORT_NUM))
+#  define LED0_PIN            GPIO_PIN(LED0_PORT_NUM, LED0_PIN_NUM)
+#  define LED0_MASK           (1 << LED0_PIN_NUM)
+#  if IS_ACTIVE(LED_0_IS_INVERTED)
+#    define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
+#    define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
+#  else
+#    define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
+#    define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)
+#  endif
+#  define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#endif
+
+#if defined(LED1_PORT_NUM) && defined (LED1_PIN_NUM)
+#  define LED1_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED1_PORT_NUM))
+#  define LED1_PIN            GPIO_PIN(LED1_PORT_NUM, LED1_PIN_NUM)
+#  define LED1_MASK           (1 << LED1_PIN_NUM)
+#  if IS_ACTIVE(LED_1_IS_INVERTED)
+#    define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
+#    define LED1_OFF            (LED1_PORT->BSRR = (LED1_MASK << 16))
+#  else
+#    define LED1_ON             (LED1_PORT->BSRR = (LED1_MASK << 16))
+#    define LED1_OFF            (LED1_PORT->BSRR = LED1_MASK)
+#  endif
+#  define LED1_TOGGLE         (LED1_PORT->ODR  ^= LED1_MASK)
+#endif
+
+#if defined(LED2_PORT_NUM) && defined (LED2_PIN_NUM)
+#  define LED2_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED2_PORT_NUM))
+#  define LED2_PIN            GPIO_PIN(LED2_PORT_NUM, LED2_PIN_NUM)
+#  define LED2_MASK           (1 << LED2_PIN_NUM)
+#  if IS_ACTIVE(LED_2_IS_INVERTED)
+#    define LED2_ON             (LED2_PORT->BSRR = LED2_MASK)
+#    define LED2_OFF            (LED2_PORT->BSRR = (LED2_MASK << 16))
+#  else
+#    define LED2_ON             (LED2_PORT->BSRR = (LED2_MASK << 16))
+#    define LED2_OFF            (LED2_PORT->BSRR = LED2_MASK)
+#  endif
+#  define LED2_TOGGLE         (LED2_PORT->ODR  ^= LED2_MASK)
+#endif
+
+#if defined(LED3_PORT_NUM) && defined (LED3_PIN_NUM)
+#  define LED3_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED3_PORT_NUM))
+#  define LED3_PIN            GPIO_PIN(LED3_PORT_NUM, LED3_PIN_NUM)
+#  define LED3_MASK           (1 << LED3_PIN_NUM)
+#  if IS_ACTIVE(LED_3_IS_INVERTED)
+#    define LED3_ON             (LED3_PORT->BSRR = LED3_MASK)
+#    define LED3_OFF            (LED3_PORT->BSRR = (LED3_MASK << 16))
+#  else
+#    define LED3_ON             (LED3_PORT->BSRR = (LED3_MASK << 16))
+#    define LED3_OFF            (LED3_PORT->BSRR = LED3_MASK)
+#  endif
+#  define LED3_TOGGLE         (LED3_PORT->ODR  ^= LED3_MASK)
+#endif
+
+#if defined(LED4_PORT_NUM) && defined (LED4_PIN_NUM)
+#  define LED4_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED4_PORT_NUM))
+#  define LED4_PIN            GPIO_PIN(LED4_PORT_NUM, LED4_PIN_NUM)
+#  define LED4_MASK           (1 << LED4_PIN_NUM)
+#  if IS_ACTIVE(LED_4_IS_INVERTED)
+#    define LED4_ON             (LED4_PORT->BSRR = LED4_MASK)
+#    define LED4_OFF            (LED4_PORT->BSRR = (LED4_MASK << 16))
+#  else
+#    define LED4_ON             (LED4_PORT->BSRR = (LED4_MASK << 16))
+#    define LED4_OFF            (LED4_PORT->BSRR = LED4_MASK)
+#  endif
+#  define LED4_TOGGLE         (LED4_PORT->ODR  ^= LED4_MASK)
+#endif
+
+#if defined(LED5_PORT_NUM) && defined (LED5_PIN_NUM)
+#  define LED5_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED5_PORT_NUM))
+#  define LED5_PIN            GPIO_PIN(LED5_PORT_NUM, LED5_PIN_NUM)
+#  define LED5_MASK           (1 << LED5_PIN_NUM)
+#  if IS_ACTIVE(LED_5_IS_INVERTED)
+#    define LED5_ON             (LED5_PORT->BSRR = LED5_MASK)
+#    define LED5_OFF            (LED5_PORT->BSRR = (LED5_MASK << 16))
+#  else
+#    define LED5_ON             (LED5_PORT->BSRR = (LED5_MASK << 16))
+#    define LED5_OFF            (LED5_PORT->BSRR = LED5_MASK)
+#  endif
+#  define LED5_TOGGLE         (LED5_PORT->ODR  ^= LED5_MASK)
+#endif
+
+#if defined(LED6_PORT_NUM) && defined (LED6_PIN_NUM)
+#  define LED6_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED6_PORT_NUM))
+#  define LED6_PIN            GPIO_PIN(LED6_PORT_NUM, LED6_PIN_NUM)
+#  define LED6_MASK           (1 << LED6_PIN_NUM)
+#  if IS_ACTIVE(LED_6_IS_INVERTED)
+#    define LED6_ON             (LED6_PORT->BSRR = LED6_MASK)
+#    define LED6_OFF            (LED6_PORT->BSRR = (LED6_MASK << 16))
+#  else
+#    define LED6_ON             (LED6_PORT->BSRR = (LED6_MASK << 16))
+#    define LED6_OFF            (LED6_PORT->BSRR = LED6_MASK)
+#  endif
+#  define LED6_TOGGLE         (LED6_PORT->ODR  ^= LED6_MASK)
+#endif
+
+#if defined(LED7_PORT_NUM) && defined (LED7_PIN_NUM)
+#  define LED7_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED7_PORT_NUM))
+#  define LED7_PIN            GPIO_PIN(LED7_PORT_NUM, LED7_PIN_NUM)
+#  define LED7_MASK           (1 << LED7_PIN_NUM)
+#  if IS_ACTIVE(LED_7_IS_INVERTED)
+#    define LED7_ON             (LED7_PORT->BSRR = LED7_MASK)
+#    define LED7_OFF            (LED7_PORT->BSRR = (LED7_MASK << 16))
+#  else
+#    define LED7_ON             (LED7_PORT->BSRR = (LED7_MASK << 16))
+#    define LED7_OFF            (LED7_PORT->BSRR = LED7_MASK)
+#  endif
+#  define LED7_TOGGLE         (LED7_PORT->ODR  ^= LED7_MASK)
+#endif
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32_LEDS_H */
+/** @} */

--- a/boards/common/weact-f4x1cx/include/board.h
+++ b/boards/common/weact-f4x1cx/include/board.h
@@ -40,13 +40,9 @@ extern "C" {
  * @name    LED pin definition and handlers
  * @{
  */
-#define LED0_PORT           GPIOC
-#define LED0_PIN            GPIO_PIN(PORT_C, 13)
-#define LED0_MASK           (1 << 13)
-
-#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK <<  0))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_C
+#define LED0_IS_INVERTED    1
 /** @} */
 
 /**
@@ -84,6 +80,8 @@ extern mtd_dev_t *mtd0;
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -31,31 +31,21 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_A, 1)
-#define LED1_PIN            GPIO_PIN(PORT_A, 3)
-#define LED2_PIN            GPIO_PIN(PORT_A, 2)
+#define LED0_PIN_NUM        1
+#define LED0_PORT_NUM       PORT_A
 
-#define LED_PORT            GPIOA
-#define LED0_MASK           (1 << 1)
-#define LED1_MASK           (1 << 3)
-#define LED2_MASK           (1 << 2)
+#define LED1_PIN_NUM        3
+#define LED1_PORT_NUM       PORT_A
 
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)
-
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)
-
-#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)
+#define LED2_PIN_NUM        2
+#define LED2_PORT_NUM       PORT_A
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -32,14 +32,8 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_C, 3)
-
-#define LED0_PORT           (GPIOC)
-#define LED0_MASK           (1 << 3)
-
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        3
+#define LED0_PORT_NUM       PORT_C
  /** @} */
 
  /**
@@ -60,6 +54,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/lobaro-lorabox/include/board.h
+++ b/boards/lobaro-lorabox/include/board.h
@@ -37,13 +37,9 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOA
-#define LED0_PIN            GPIO_PIN(PORT_A, 1)
-#define LED0_MASK           (1 << 1)
-
-#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        1
+#define LED0_PORT_NUM       PORT_A
+#define LED0_IS_INVERTED    1
 
 #define EN3V3_PORT          GPIOA
 #define EN3V3_PIN           GPIO_PIN(PORT_A, 11)
@@ -71,6 +67,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/lora-e5-dev/include/board.h
+++ b/boards/lora-e5-dev/include/board.h
@@ -46,12 +46,8 @@ extern void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mo
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOB
-#define LED0_PIN            GPIO_PIN(PORT_B, 5)
-#define LED0_MASK           (1 << 5)
-#define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 5))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PORT_NUM       PORT_B
+#define LED0_PIN_NUM        5
 /** @} */
 
 /**
@@ -98,6 +94,8 @@ extern void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mo
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -36,14 +36,8 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 1)
-
-#define LED_PORT            GPIOB
-#define LED0_MASK           (1 << 1)
-
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BRR  = LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT->ODR ^= LED0_MASK)
+#define LED0_PIN_NUM        1
+#define LED0_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -62,6 +56,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -48,26 +48,14 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 8)     /**< Pin of red LED */
-#define LED1_PIN            GPIO_PIN(PORT_B, 14)    /**< Pin of yellow LED */
-#define LED2_PIN            GPIO_PIN(PORT_B, 15)    /**< Pin of green LED */
+#define LED0_PIN_NUM        8       /**< Pin number of red LED */
+#define LED0_PORT_NUM       PORT_B  /**< Port number of red LED */
 
-#define LED_PORT            GPIOB       /**< GPIO port LEDs are connected to */
-#define LED0_MASK           (1 << 8)    /**< Bitmask to address red LED in @ref LED_PORT */
-#define LED1_MASK           (1 << 14)   /**< Bitmask to address yellow LED in @ref LED_PORT */
-#define LED2_MASK           (1 << 15)   /**< Bitmask to address green LED in @ref LED_PORT */
+#define LED1_PIN_NUM        14      /**< Pin number of yellow LED */
+#define LED1_PORT_NUM       PORT_B  /**< Port number of yellow LED */
 
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)            /**< Turn red LED on */
-#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))    /**< Turn red LED off */
-#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)           /**< Toggle red LED */
-
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)            /**< Turn yellow LED on */
-#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))    /**< Turn yellow LED off */
-#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)           /**< Toggle yellow LED */
-
-#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)            /**< Turn green LED on */
-#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))    /**< Turn green LED off */
-#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)           /**< Toggle green LED */
+#define LED2_PIN_NUM        15      /**< Pin number of green LED */
+#define LED2_PORT_NUM       PORT_B  /**< Port number of green LED */
 /** @} */
 
 /**
@@ -81,6 +69,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/nucleo-wl55jc/include/board.h
+++ b/boards/nucleo-wl55jc/include/board.h
@@ -48,26 +48,14 @@ extern void nucleo_wl55jc_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOB
-#define LED0_PIN            GPIO_PIN(PORT_B, 15)
-#define LED0_MASK           (1 << 15)
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        15
+#define LED0_PORT_NUM       PORT_B
 
-#define LED1_PORT           GPIOB
-#define LED1_PIN            GPIO_PIN(PORT_B, 9)
-#define LED1_MASK           (1 << 9)
-#define LED1_ON             (LED0_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED0_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED0_PORT->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        9
+#define LED1_PORT_NUM       PORT_B
 
-#define LED2_PORT           GPIOB
-#define LED2_PIN            GPIO_PIN(PORT_B, 11)
-#define LED2_MASK           (1 << 11)
-#define LED2_ON             (LED0_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED0_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED0_PORT->ODR  ^= LED2_MASK)
+#define LED2_PIN_NUM        11
+#define LED2_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -96,6 +84,8 @@ extern void nucleo_wl55jc_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/nz32-sc151/include/board.h
+++ b/boards/nz32-sc151/include/board.h
@@ -32,18 +32,15 @@ extern "C" {
  * @name    User LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 2)
-
-#define LED0_MASK           (1 << 2)
-
-#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        2
+#define LED0_PORT_NUM       PORT_B
  /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/olimexino-stm32/include/board.h
+++ b/boards/olimexino-stm32/include/board.h
@@ -38,21 +38,11 @@ extern "C" {
  * @name LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOA
-#define LED0_PIN            GPIO_PIN(PORT_A, 1)
-#define LED0_MASK           (1 << 1)
+#define LED0_PIN_NUM        1
+#define LED0_PORT_NUM       PORT_A
 
-#define LED1_PORT           GPIOA
-#define LED1_PIN            GPIO_PIN(PORT_A, 5)
-#define LED1_MASK           (1 << 5)
-
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
-
-#define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED1_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED1_PORT->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        5
+#define LED1_PORT_NUM       PORT_A
 
 #define LED_PANIC           LED0_ON
 /** @} */
@@ -68,6 +58,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -36,14 +36,8 @@ extern "C" {
  * @name Macros for controlling the on-board LED.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 9)
-
-#define LED_PORT            GPIOB
-#define LED0_MASK           (1 << 9)
-
-#define LED0_ON             (LED_PORT->BRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR  = LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT->ODR ^= LED0_MASK)
+#define LED0_PIN_NUM        9
+#define LED0_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -80,6 +74,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/p-l496g-cell02/include/board.h
+++ b/boards/p-l496g-cell02/include/board.h
@@ -31,19 +31,11 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_A, 5)
-#define LED0_MASK           (1 << 5)
+#define LED0_PIN_NUM        5
+#define LED0_PORT_NUM       PORT_A
 
-#define LED0_ON             (GPIOA->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOA->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOA->ODR  ^= LED0_MASK)
-
-#define LED1_PIN            GPIO_PIN(PORT_B, 13)
-#define LED1_MASK           (1 << 13)
-
-#define LED1_ON             (GPIOB->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOB->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOB->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        13
+#define LED1_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -69,6 +61,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/p-nucleo-wb55/include/board.h
+++ b/boards/p-nucleo-wb55/include/board.h
@@ -29,26 +29,14 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOB
-#define LED0_PIN            GPIO_PIN(PORT_B, 5)
-#define LED0_MASK           (1 << 5)
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        5
+#define LED0_PORT_NUM       PORT_B
 
-#define LED1_PORT           GPIOB
-#define LED1_PIN            GPIO_PIN(PORT_B, 0)
-#define LED1_MASK           (1 << 0)
-#define LED1_ON             (LED0_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED0_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED0_PORT->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        0
+#define LED1_PORT_NUM       PORT_B
 
-#define LED2_PORT           GPIOB
-#define LED2_PIN            GPIO_PIN(PORT_B, 1)
-#define LED2_MASK           (1 << 1)
-#define LED2_ON             (LED0_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED0_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED0_PORT->ODR  ^= LED2_MASK)
+#define LED2_PIN_NUM        1
+#define LED2_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -66,6 +54,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/pyboard/include/board.h
+++ b/boards/pyboard/include/board.h
@@ -33,12 +33,8 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 4)
-#define LED0_MASK           (1 << 4)
-
-#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        4
+#define LED0_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -52,6 +48,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -37,32 +37,17 @@
  * @name    Macros for controlling the on-board LEDs
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_A, 9)
-#define LED1_PIN            GPIO_PIN(PORT_A, 10)
-#define LED2_PIN            GPIO_PIN(PORT_A, 8)
-#define LED3_PIN            GPIO_PIN(PORT_A, 13)
+#define LED0_PIN_NUM        9
+#define LED0_PORT_NUM       PORT_A
 
-#define LED_PORT            (GPIOA)
-#define LED0_MASK           (1 << 9)
-#define LED1_MASK           (1 << 10)
-#define LED2_MASK           (1 << 8)
-#define LED3_MASK           (1 << 13)
+#define LED1_PIN_NUM        10
+#define LED1_PORT_NUM       PORT_A
 
-#define LED0_ON             (LED_PORT->BRR  = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR = LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT->ODR ^= LED0_MASK)
+#define LED2_PIN_NUM        8
+#define LED2_PORT_NUM       PORT_A
 
-#define LED1_ON             (LED_PORT->BRR  = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BSRR = LED1_MASK)
-#define LED1_TOGGLE         (LED_PORT->ODR ^= LED1_MASK)
-
-#define LED2_ON             (LED_PORT->BRR  = LED2_MASK)
-#define LED2_OFF            (LED_PORT->BSRR = LED2_MASK)
-#define LED2_TOGGLE         (LED_PORT->ODR ^= LED2_MASK)
-
-#define LED3_ON             (LED_PORT->BRR  = LED3_MASK)
-#define LED3_OFF            (LED_PORT->BSRR = LED3_MASK)
-#define LED3_TOGGLE         (LED_PORT->ODR ^= LED3_MASK)
+#define LED3_PIN_NUM        13
+#define LED3_PORT_NUM       PORT_A
 /** @} */
 
 /**
@@ -93,6 +78,8 @@
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f030f4-demo/include/board.h
+++ b/boards/stm32f030f4-demo/include/board.h
@@ -39,18 +39,16 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PORT           GPIOA
-#define LED0_PIN            GPIO_PIN(PORT_A, 4)
-#define LED0_MASK           (1 << 4)
-
-#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK <<  0))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        4
+#define LED0_PORT_NUM       PORT_A
+#define LED0_IS_INVERTED    1
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -30,20 +30,11 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_C, 9)
-#define LED1_PIN            GPIO_PIN(PORT_C, 8)
+#define LED0_PIN_NUM        9
+#define LED0_PORT_NUM       PORT_C
 
-#define LED_PORT            GPIOC
-#define LED0_MASK           (1 << 9)
-#define LED1_MASK           (1 << 8)
-
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BRR  = LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT->ODR ^= LED0_MASK)
-
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BRR  = LED1_MASK)
-#define LED1_TOGGLE         (LED_PORT->ODR ^= LED1_MASK)
+#define LED1_PIN_NUM        8
+#define LED1_PORT_NUM       PORT_C
 /** @} */
 
 /**
@@ -57,6 +48,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -30,56 +30,29 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_E, 9)
-#define LED1_PIN            GPIO_PIN(PORT_E, 8)
-#define LED2_PIN            GPIO_PIN(PORT_E, 10)
-#define LED3_PIN            GPIO_PIN(PORT_E, 15)
-#define LED4_PIN            GPIO_PIN(PORT_E, 11)
-#define LED5_PIN            GPIO_PIN(PORT_E, 14)
-#define LED6_PIN            GPIO_PIN(PORT_E, 12)
-#define LED7_PIN            GPIO_PIN(PORT_E, 13)
+#define LED0_PIN_NUM        9
+#define LED0_PORT_NUM       PORT_E
 
-#define LED_PORT            GPIOE
-#define LED0_MASK           (1 << 9)
-#define LED1_MASK           (1 << 8)
-#define LED2_MASK           (1 << 10)
-#define LED3_MASK           (1 << 15)
-#define LED4_MASK           (1 << 11)
-#define LED5_MASK           (1 << 14)
-#define LED6_MASK           (1 << 12)
-#define LED7_MASK           (1 << 13)
+#define LED1_PIN_NUM        8
+#define LED1_PORT_NUM       PORT_E
 
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)
+#define LED2_PIN_NUM        10
+#define LED2_PORT_NUM       PORT_E
 
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)
+#define LED3_PIN_NUM        15
+#define LED3_PORT_NUM       PORT_E
 
-#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)
+#define LED4_PIN_NUM        11
+#define LED4_PORT_NUM       PORT_E
 
-#define LED3_ON             (LED_PORT->BSRR = LED3_MASK)
-#define LED3_OFF            (LED_PORT->BSRR = (LED3_MASK << 16))
-#define LED3_TOGGLE         (LED_PORT->ODR  ^= LED3_MASK)
+#define LED5_PIN_NUM        14
+#define LED5_PORT_NUM       PORT_E
 
-#define LED4_ON             (LED_PORT->BSRR = LED4_MASK)
-#define LED4_OFF            (LED_PORT->BSRR = (LED4_MASK << 16))
-#define LED4_TOGGLE         (LED_PORT->ODR  ^= LED4_MASK)
+#define LED6_PIN_NUM        12
+#define LED6_PORT_NUM       PORT_E
 
-#define LED5_ON             (LED_PORT->BSRR = LED5_MASK)
-#define LED5_OFF            (LED_PORT->BSRR = (LED5_MASK << 16))
-#define LED5_TOGGLE         (LED_PORT->ODR  ^= LED5_MASK)
-
-#define LED6_ON             (LED_PORT->BSRR = LED6_MASK)
-#define LED6_OFF            (LED_PORT->BSRR = (LED6_MASK << 16))
-#define LED6_TOGGLE         (LED_PORT->ODR  ^= LED6_MASK)
-
-#define LED7_ON             (LED_PORT->BSRR = LED7_MASK)
-#define LED7_OFF            (LED_PORT->BSRR = (LED7_MASK << 16))
-#define LED7_TOGGLE         (LED_PORT->ODR  ^= LED7_MASK)
+#define LED7_PIN_NUM        13
+#define LED7_PORT_NUM       PORT_E
 /** @} */
 
 /**
@@ -110,6 +83,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f429i-disc1/include/board.h
+++ b/boards/stm32f429i-disc1/include/board.h
@@ -30,19 +30,11 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_G, 13)
-#define LED1_PIN            GPIO_PIN(PORT_G, 14)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_G
 
-#define LED0_MASK           (1 << 13)
-#define LED1_MASK           (1 << 14)
-
-#define LED0_ON             (GPIOG->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOG->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOG->ODR  ^= LED0_MASK)
-
-#define LED1_ON             (GPIOG->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOG->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOG->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        14
+#define LED1_PORT_NUM       PORT_G
 /** @} */
 
 /**
@@ -66,6 +58,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f469i-disco/include/board.h
+++ b/boards/stm32f469i-disco/include/board.h
@@ -30,36 +30,21 @@ extern "C"
  * @name Macros for controlling the on-board LEDs
  * @{
  */
-#define LED0_PIN GPIO_PIN(PORT_G, 6)
-#define LED1_PIN GPIO_PIN(PORT_D, 4)
-#define LED2_PIN GPIO_PIN(PORT_D, 5)
-#define LED3_PIN GPIO_PIN(PORT_K, 3)
+#define LED0_PIN_NUM    6
+#define LED0_PORT_NUM   PORT_G
+#define LED0_IS_INVERTED    1
 
-#define LED0_PORT GPIOG
-#define LED1_PORT GPIOD
-#define LED2_PORT GPIOD
-#define LED3_PORT GPIOK
+#define LED1_PIN_NUM    4
+#define LED1_PORT_NUM   PORT_D
+#define LED1_IS_INVERTED    1
 
-#define LED0_MASK (1 << 6)
-#define LED1_MASK (1 << 4)
-#define LED2_MASK (1 << 5)
-#define LED3_MASK (1 << 3)
+#define LED2_PIN_NUM    5
+#define LED2_PORT_NUM   PORT_D
+#define LED2_IS_INVERTED    1
 
-#define LED0_ON (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_OFF (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_TOGGLE (LED0_PORT->ODR ^= LED0_MASK)
-
-#define LED1_ON (LED1_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_OFF (LED1_PORT->BSRR = LED1_MASK)
-#define LED1_TOGGLE (LED1_PORT->ODR ^= LED1_MASK)
-
-#define LED2_ON (LED2_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_OFF (LED2_PORT->BSRR = LED2_MASK)
-#define LED2_TOGGLE (LED2_PORT->ODR ^= LED2_MASK)
-
-#define LED3_ON (LED3_PORT->BSRR = (LED3_MASK << 16))
-#define LED3_OFF (LED3_PORT->BSRR = LED3_MASK)
-#define LED3_TOGGLE (LED3_PORT->ODR ^= LED3_MASK)
+#define LED3_PIN_NUM    3
+#define LED3_PORT_NUM   PORT_K
+#define LED3_IS_INVERTED    1
 /** @} */
 
 /**
@@ -73,6 +58,8 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -35,41 +35,20 @@ extern "C" {
 /** @} */
 
 /**
- * @name LED pin definitions
- * @{
- */
-/** @} */
-
-/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_D, 13)
-#define LED1_PIN            GPIO_PIN(PORT_D, 12)
-#define LED2_PIN            GPIO_PIN(PORT_D, 14)
-#define LED3_PIN            GPIO_PIN(PORT_D, 15)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_D
 
-#define LED_PORT            GPIOD
-#define LED0_MASK           (1 << 13)
-#define LED1_MASK           (1 << 12)
-#define LED2_MASK           (1 << 14)
-#define LED3_MASK           (1 << 15)
+#define LED1_PIN_NUM        12
+#define LED1_PORT_NUM       PORT_D
 
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)
+#define LED2_PIN_NUM        14
+#define LED2_PORT_NUM       PORT_D
 
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)
-
-#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)
-
-#define LED3_ON             (LED_PORT->BSRR = LED3_MASK)
-#define LED3_OFF            (LED_PORT->BSRR = (LED3_MASK << 16))
-#define LED3_TOGGLE         (LED_PORT->ODR  ^= LED3_MASK)
+#define LED3_PIN_NUM        15
+#define LED3_PORT_NUM       PORT_D
 /** @} */
 
 /**
@@ -83,6 +62,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f723e-disco/include/board.h
+++ b/boards/stm32f723e-disco/include/board.h
@@ -30,26 +30,14 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_A, 5)
-#define LED0_PORT           GPIOA
-#define LED0_MASK           (1 << 5)
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        5
+#define LED0_PORT_NUM       PORT_A
 
-#define LED1_PIN            GPIO_PIN(PORT_A, 7)
-#define LED1_PORT           GPIOA
-#define LED1_MASK           (1 << 7)
-#define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED1_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED1_PORT->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        7
+#define LED1_PORT_NUM       PORT_A
 
-#define LED2_PIN            GPIO_PIN(PORT_B, 1)
-#define LED2_PORT           GPIOB
-#define LED2_MASK           (1 << 1)
-#define LED2_ON             (LED2_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED2_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED2_PORT->ODR  ^= LED2_MASK)
+#define LED2_PIN_NUM        1
+#define LED2_PORT_NUM       PORT_B
 /** @} */
 
 /**
@@ -74,6 +62,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f769i-disco/include/board.h
+++ b/boards/stm32f769i-disco/include/board.h
@@ -31,35 +31,17 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_J, 13)
-#define LED1_PIN            GPIO_PIN(PORT_J, 5)
-#define LED2_PIN            GPIO_PIN(PORT_A, 12)
-#define LED3_PIN            GPIO_PIN(PORT_D, 4)
+#define LED0_PIN_NUM        13
+#define LED0_PORT_NUM       PORT_J
 
-#define LED0_PORT           GPIOJ
-#define LED1_PORT           GPIOJ
-#define LED2_PORT           GPIOA
-#define LED3_PORT           GPIOD
-#define LED0_MASK           (1 << 13)
-#define LED1_MASK           (1 << 5)
-#define LED2_MASK           (1 << 12)
-#define LED3_MASK           (1 << 4)
+#define LED1_PIN_NUM        5
+#define LED1_PORT_NUM       PORT_J
 
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#define LED2_PIN_NUM        12
+#define LED2_PORT_NUM       PORT_A
 
-#define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED1_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED1_PORT->ODR  ^= LED1_MASK)
-
-#define LED2_ON             (LED2_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED2_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED2_PORT->ODR  ^= LED2_MASK)
-
-#define LED3_ON             (LED3_PORT->BSRR = LED3_MASK)
-#define LED3_OFF            (LED3_PORT->BSRR = (LED3_MASK << 16))
-#define LED3_TOGGLE         (LED3_PORT->ODR  ^= LED3_MASK)
+#define LED3_PIN_NUM        4
+#define LED3_PORT_NUM       PORT_D
 /** @} */
 
 /**
@@ -73,6 +55,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32g0316-disco/include/board.h
+++ b/boards/stm32g0316-disco/include/board.h
@@ -28,19 +28,17 @@ extern "C" {
 #endif
 
 
-#define LED0_PIN            GPIO_PIN(PORT_A, 12)
-#define LED0_MODE           GPIO_OUT
-#define LED0_MASK           (1 << 12)
-
-#define LED0_ON             (GPIOA->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOA->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOA->ODR  ^= LED0_MASK)
+#define LED0_PIN_NUM        12
+#define LED0_PORT_NUM       PORT_A
 
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)
 #define BTN0_MODE           GPIO_IN
+
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32l0538-disco/include/board.h
+++ b/boards/stm32l0538-disco/include/board.h
@@ -36,21 +36,11 @@ extern "C" {
  * @name Macros for controlling the on-board LEDs.
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 4)
-#define LED0_PORT           GPIOB
-#define LED0_MASK           (1 << 4)
+#define LED0_PIN_NUM        4
+#define LED0_PORT_NUM       PORT_B
 
-#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED0_PORT->BRR  = LED0_MASK)
-#define LED0_TOGGLE         (LED0_PORT->ODR ^= LED0_MASK)
-
-#define LED1_PIN            GPIO_PIN(PORT_A, 5)
-#define LED1_PORT           GPIOA
-#define LED1_MASK           (1 << 5)
-
-#define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED1_PORT->BRR  = LED1_MASK)
-#define LED1_TOGGLE         (LED1_PORT->ODR ^= LED1_MASK)
+#define LED1_PIN_NUM        5
+#define LED1_PORT_NUM       PORT_A
 /** @} */
 
 /**
@@ -65,6 +55,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32l476g-disco/include/board.h
+++ b/boards/stm32l476g-disco/include/board.h
@@ -33,19 +33,11 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_B, 2)
-#define LED0_MASK           (1 << 2)
+#define LED0_PIN_NUM        2
+#define LED0_PORT_NUM       PORT_B
 
-#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
-
-#define LED1_PIN            GPIO_PIN(PORT_E, 8)
-#define LED1_MASK           (1 << 8)
-
-#define LED1_ON             (GPIOE->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOE->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOE->ODR  ^= LED1_MASK)
+#define LED1_PIN_NUM        8
+#define LED1_PORT_NUM       PORT_E
 /** @} */
 
 /**
@@ -71,6 +63,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/ublox-c030-u201/include/board.h
+++ b/boards/ublox-c030-u201/include/board.h
@@ -33,26 +33,14 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(PORT_E, 3)
-#define LED0_MASK           (1 << 3)
+#define LED0_PIN_NUM        3
+#define LED0_PORT_NUM       PORT_E
 
-#define LED0_ON             (GPIOE->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOE->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOE->ODR  ^= LED0_MASK)
+#define LED1_PIN_NUM        4
+#define LED1_PORT_NUM       PORT_E
 
-#define LED1_PIN            GPIO_PIN(PORT_E, 4)
-#define LED1_MASK           (1 << 4)
-
-#define LED1_ON             (GPIOE->BSRR = LED1_MASK)
-#define LED1_OFF            (GPIOE->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (GPIOE->ODR  ^= LED1_MASK)
-
-#define LED2_PIN            GPIO_PIN(PORT_E, 1)
-#define LED2_MASK           (1 << 1)
-
-#define LED2_ON             (GPIOE->BSRR = LED2_MASK)
-#define LED2_OFF            (GPIOE->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (GPIOE->ODR  ^= LED2_MASK)
+#define LED2_PIN_NUM        1
+#define LED2_PORT_NUM       PORT_E
 /** @} */
 
 /**
@@ -98,6 +86,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -1,30 +1,28 @@
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/6lowpan\-clicker/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
+warning: Member BTN[0-9]_INT_FLANK \(macro definition\) of
+warning: Member BTN[0-9]_MASK \(macro definition\) of
+warning: Member BTN[0-9]_MODE \(macro definition\) of
+warning: Member BTN[0-9]_PIN \(macro definition\) of
+warning: Member BTN[0-9]_PORT \(macro definition\) of
+warning: Member BTN[0-9]_PRESSED \(macro definition\) of
+warning: Member BTN[0-9]_RELEASED \(macro definition\) of
+warning: Member LED[0-9]_ENABLE_PORT \(macro definition\) of
+warning: Member LED[0-9]_IS_INVERTED \(macro definition\) of
+warning: Member LED[0-9]_MASK \(macro definition\) of
+warning: Member LED[0-9]_MODE \(macro definition\) of
+warning: Member LED[0-9]_NAME \(macro definition\) of
+warning: Member LED[0-9]_OFF \(macro definition\) of
+warning: Member LED[0-9]_ON \(macro definition\) of
+warning: Member LED[0-9]_PIN \(macro definition\) of
+warning: Member LED[0-9]_PIN_NUM \(macro definition\) of
+warning: Member LED[0-9]_PORT \(macro definition\) of
+warning: Member LED[0-9]_PORT_NUM \(macro definition\) of
+warning: Member LED[0-9]_TOGGLE \(macro definition\) of
 boards/6lowpan\-clicker/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/6lowpan\-clicker/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/6lowpan\-clicker/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/6lowpan\-clicker/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/6lowpan\-clicker/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/6lowpan\-clicker/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/acd52832/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/acd52832/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/acd52832/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/acd52832/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -38,11 +36,6 @@ boards/adafruit\-clue/include/board\.h:[0-9]+: warning: end of file with unbalan
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member APA102_PARAM_CLK_PIN \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member APA102_PARAM_DATA_PIN \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member APA102_PARAM_LED_NUMOF \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member MTD_0 \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member XTIMER_HZ \(macro definition\) of file board\.h is not documented\.
@@ -103,31 +96,13 @@ boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARA
 boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_SSN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_WAKE_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkr1000/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member ATA8520E_PARAM_CS_PIN \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member ATA8520E_PARAM_INT_PIN \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member ATA8520E_PARAM_POWER_PIN \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member ATA8520E_PARAM_RESET_PIN \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member ATA8520E_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrfox1200/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrwan1300/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrwan1300/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/arduino\-mkrwan1300/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
@@ -135,12 +110,6 @@ boards/arduino\-mkrwan1300/include/periph_conf\.h:[0-9]+: warning: Member UART_1
 boards/arduino\-mkrwan1300/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/arduino\-mkrwan1300/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/arduino\-mkrwan1300/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_CLK \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_CS \(macro definition\) of file board\.h is not documented\.
@@ -148,31 +117,6 @@ boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARA
 boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_MOSI \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_POWER \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mkrzero/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED4_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED4_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED4_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-ble/include/board\.h:[0-9]+: warning: Member LED4_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
@@ -181,12 +125,6 @@ boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: Member i2c
 boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/arduino\-nano\-33\-ble/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-nano\-33\-iot/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-nano\-33\-iot/include/periph_conf\.h:[0-9]+: warning: Member ADC_GAIN_FACTOR_DEFAULT \(macro definition\) of file periph_conf\.h is not documented\.
 boards/arduino\-nano\-33\-iot/include/periph_conf\.h:[0-9]+: warning: Member ADC_NEG_INPUT \(macro definition\) of file periph_conf\.h is not documented\.
@@ -224,16 +162,8 @@ boards/atmega1284p/include/board\.h:[0-9]+: warning: Member XTIMER_HZ \(macro de
 boards/atmega1284p/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/atmega1284p/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/atmega1284p/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SET \(macro definition\) of file board\.h is not documented\.
 boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SLEEP \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ENABLE_PORT \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_HZ \(macro definition\) of file board\.h is not documented\.
 boards/atmega256rfr2\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -250,78 +180,6 @@ boards/atmega328p\-xplained\-mini/include/board\.h:[0-9]+: warning: Member XTIME
 boards/atmega328p\-xplained\-mini/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/atmega328p\-xplained\-mini/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/atmega328p\-xplained\-mini/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN0_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN1_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN2_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN3_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN3_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN4_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN4_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN5_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN5_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN5_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN6_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN6_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN6_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN7_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN7_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member BTN7_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED3_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED4_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED4_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED4_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED4_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED4_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED5_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED5_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED5_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED5_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED5_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED5_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED6_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED6_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED6_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED6_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED6_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED6_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED7_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED7_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED7_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED7_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED7_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED7_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member LED_PORT_MASK \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a1\-xplained/include/board\.h:[0-9]+: warning: Member STDIO_UART_BAUDRATE \(macro definition\) of file board\.h is not documented\.
@@ -355,15 +213,6 @@ boards/atxmega\-a1\-xplained/include/periph_conf\.h:[0-9]+: warning: Member i2c_
 boards/atxmega\-a1\-xplained/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/atxmega\-a1\-xplained/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/atxmega\-a1\-xplained/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT_MASK \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a1u\-xpro/include/board\.h:[0-9]+: warning: Member STDIO_UART_BAUDRATE \(macro definition\) of file board\.h is not documented\.
@@ -390,27 +239,6 @@ boards/atxmega\-a1u\-xpro/include/periph_conf\.h:[0-9]+: warning: Member i2c_con
 boards/atxmega\-a1u\-xpro/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/atxmega\-a1u\-xpro/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/atxmega\-a1u\-xpro/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN0_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN1_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN2_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member LED_PORT_MASK \(macro definition\) of file board\.h is not documented\.
 boards/atxmega\-a3bu\-xplained/include/board\.h:[0-9]+: warning: Member STDIO_UART_BAUDRATE \(macro definition\) of file board\.h is not documented\.
@@ -442,23 +270,9 @@ boards/atxmega\-a3bu\-xplained/include/periph_conf\.h:[0-9]+: warning: Member ua
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member AT24MAC_PARAM_I2C_DEV \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member AT24MAC_PARAM_TYPE \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member BOOTLOADER_CLEARS_WATCHDOG_AND_PASSES_MCUSR \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member CPU_ATMEGA_CLK_SCALE_INIT \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member DS18_PARAM_PIN \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member DS18_PARAM_PULL \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED_PANIC \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/avr\-rss2/include/board\.h:[0-9]+: warning: Member LED_PORT_DDR \(macro definition\) of file board\.h is not documented\.
@@ -472,16 +286,6 @@ boards/avr\-rss2/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PR
 boards/avr\-rss2/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_INDEX \(macro definition\) of file eui_provider_params\.h is not documented\.
 boards/avr\-rss2/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_TYPE \(macro definition\) of file eui_provider_params\.h is not documented\.
 boards/avr\-rss2/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/avsextrem/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_PCLK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -490,26 +294,6 @@ boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(mac
 boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member XTAL_HZ \(macro definition\) of file periph_conf\.h is not documented\.
 boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/avsextrem/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member RADIO_TCXO_VCC_PIN \(macro definition\) of file board\.h is not documented\.
 boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of file board\.h is not documented\.
 boards/b\-l072z\-lrwan1/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of file board\.h is not documented\.
@@ -533,16 +317,6 @@ boards/b\-l072z\-lrwan1/include/periph_conf\.h:[0-9]+: warning: Member dma_confi
 boards/b\-l072z\-lrwan1/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/b\-l072z\-lrwan1/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member HTS221_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LIS3MDL_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LPSXXX_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/b\-l475e\-iot01a/include/board\.h:[0-9]+: warning: Member LSM6DSL_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
@@ -572,11 +346,6 @@ boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member pwm_confi
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/bastwan/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_bastwan is not documented\.
-boards/bastwan/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_bastwan is not documented\.
-boards/bastwan/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_bastwan is not documented\.
-boards/bastwan/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_bastwan is not documented\.
-boards/bastwan/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_bastwan is not documented\.
 boards/bastwan/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of group boards_bastwan is not documented\.
 boards/bastwan/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of group boards_bastwan is not documented\.
 boards/bastwan/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of group boards_bastwan is not documented\.
@@ -610,12 +379,6 @@ boards/bastwan/include/periph_conf\.h:[0-9]+: warning: Member sam_usbdev_config\
 boards/bastwan/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/bastwan/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/bastwan/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/bluepill\-stm32f030c8/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/bluepill\-stm32f030c8/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/bluepill\-stm32f030c8/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -632,10 +395,6 @@ boards/bluepill\-stm32f030c8/include/periph_conf\.h:[0-9]+: warning: Member pwm_
 boards/bluepill\-stm32f030c8/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/bluepill\-stm32f030c8/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/bluepill\-stm32f030c8/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member MINI_LED_COL1 \(macro definition\) of file board\.h is not documented\.
 boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member MINI_LED_COL2 \(macro definition\) of file board\.h is not documented\.
 boards/calliope\-mini/include/board\.h:[0-9]+: warning: Member MINI_LED_COL3 \(macro definition\) of file board\.h is not documented\.
@@ -656,16 +415,6 @@ boards/calliope\-mini/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF 
 boards/calliope\-mini/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/calliope\-mini/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/calliope\-mini/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_ISR_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1312\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -677,16 +426,6 @@ boards/cc1312\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NU
 boards/cc1312\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/cc1312\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc1312\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_ISR_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1350\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -698,16 +437,6 @@ boards/cc1350\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NU
 boards/cc1350\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/cc1350\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc1350\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_ISR_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1352\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -720,16 +449,6 @@ boards/cc1352\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member UART_NUM
 boards/cc1352\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc1352\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc1352\-launchpad/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_ISR_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc1352p\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -742,22 +461,6 @@ boards/cc1352p\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member UART_NU
 boards/cc1352p\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc1352p\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc2538dk/include/board\.h:[0-9]+: warning: Member CCA_BACKDOOR_ENABLE \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc2538dk/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/cc2538dk/include/board\.h:[0-9]+: warning: Member UPDATE_CCA \(macro definition\) of file board\.h is not documented\.
 boards/cc2538dk/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
@@ -774,16 +477,6 @@ boards/cc2538dk/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(
 boards/cc2538dk/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc2538dk/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc2538dk/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_ISR_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc2650\-launchpad/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -795,18 +488,6 @@ boards/cc2650\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NU
 boards/cc2650\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/cc2650\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/cc2650\-launchpad/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/cc2650stk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/cc2650stk/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc2650stk/include/board\.h:[0-9]+: warning: Member XTIMER_ISR_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/cc2650stk/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -920,10 +601,6 @@ boards/common/arduino\-due/include/arduino_pinmap\.h:[0-9]+: warning: Member ARD
 boards/common/arduino\-due/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_78 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/arduino\-due/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_8 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/arduino\-due/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_9 \(macro definition\) of file arduino_pinmap\.h is not documented\.
-boards/common/arduino\-due/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_arduino_due is not documented\.
-boards/common/arduino\-due/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_arduino_due is not documented\.
-boards/common/arduino\-due/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_arduino_due is not documented\.
-boards/common/arduino\-due/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_arduino_due is not documented\.
 boards/common/arduino\-due/include/board\.h:[0-9]+: warning: Member W5100_PARAM_CS \(macro definition\) of group boards_common_arduino_due is not documented\.
 boards/common/arduino\-due/include/board\.h:[0-9]+: warning: Member W5100_PARAM_EVT \(macro definition\) of group boards_common_arduino_due is not documented\.
 boards/common/arduino\-due/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
@@ -1038,11 +715,6 @@ boards/common/arduino\-zero/include/arduino_pinmap\.h:[0-9]+: warning: Member AR
 boards/common/arduino\-zero/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A4 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/arduino\-zero/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/arduino\-zero/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_arduino_zero is not documented\.
-boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_arduino_zero is not documented\.
-boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_arduino_zero is not documented\.
-boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_arduino_zero is not documented\.
-boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_arduino_zero is not documented\.
 boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of group boards_common_arduino_zero is not documented\.
 boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of group boards_common_arduino_zero is not documented\.
 boards/common/arduino\-zero/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of group boards_common_arduino_zero is not documented\.
@@ -1080,7 +752,6 @@ boards/common/arduino\-zero/include/periph_conf\.h:[0-9]+: warning: Member uart_
 boards/common/atmega/include/periph_conf_atmega_common\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf_atmega_common\.h is not documented\.
 boards/common/atmega/include/periph_conf_atmega_common\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/common/atxmega/include/periph_conf_common\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf_common\.h is not documented\.
-boards/common/blxxxpill/include/board_common\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board_common\.h is not documented\.
 boards/common/blxxxpill/include/board_common\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board_common\.h is not documented\.
 boards/common/blxxxpill/include/board_common\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board_common\.h is not documented\.
 boards/common/blxxxpill/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -1124,20 +795,6 @@ boards/common/cc2538/include/cfg_clk_default\.h:[0-9]+: warning: Member SYS_CTRL
 boards/common/cc2538/include/cfg_timer_default\.h:[0-9]+: warning: Member TIMER_IRQ_PRIO \(macro definition\) of file cfg_timer_default\.h is not documented\.
 boards/common/cc2538/include/cfg_timer_default\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file cfg_timer_default\.h is not documented\.
 boards/common/cc2538/include/cfg_timer_default\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file cfg_timer_default\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/common/e104\-bt50xxa\-tb/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/common/e104\-bt50xxa\-tb/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HFCLK \(macro definition\) of file periph_conf\.h is not documented\.
@@ -1150,18 +807,6 @@ boards/common/e104\-bt50xxa\-tb/include/periph_conf\.h:[0-9]+: warning: Member i
 boards/common/e104\-bt50xxa\-tb/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/common/e104\-bt50xxa\-tb/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member ESP32_XTAL_FREQ \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board_common\.h is not documented\.
-boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board_common\.h is not documented\.
 boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member SPIFFS_ALIGNED_OBJECT_INDEX_TABLES \(macro definition\) of file board_common\.h is not documented\.
 boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member SPIFFS_CACHE \(macro definition\) of file board_common\.h is not documented\.
 boards/common/esp32/include/board_common\.h:[0-9]+: warning: Member SPIFFS_HAL_CALLBACK_EXTRA \(macro definition\) of file board_common\.h is not documented\.
@@ -1181,21 +826,6 @@ boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member AT86RF2XX_P
 boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_DEV \(macro definition\) of group boards_common_iotlab is not documented\.
 boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_MIN \(macro definition\) of group boards_common_iotlab is not documented\.
 boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of group boards_common_iotlab is not documented\.
-boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of group boards_common_iotlab is not documented\.
 boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member STDIO_UART_BAUDRATE \(macro definition\) of group boards_common_iotlab is not documented\.
 boards/common/iotlab/include/board_common\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of group boards_common_iotlab is not documented\.
 boards/common/iotlab/include/openwsn_defs\.h:[0-9]+: warning: Member PORT_delayTx \(macro definition\) of file openwsn_defs\.h is not documented\.
@@ -1245,11 +875,6 @@ boards/common/kw41z/include/periph_conf_common\.h:[0-9]+: warning: Member UART_N
 boards/common/kw41z/include/periph_conf_common\.h:[0-9]+: warning: Member clock_config \(variable\) of file periph_conf_common\.h is not documented\.
 boards/common/kw41z/include/periph_conf_common\.h:[0-9]+: warning: Member spi_clk_config\[\] \(variable\) of file periph_conf_common\.h is not documented\.
 boards/common/kw41z/include/periph_conf_common\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf_common\.h is not documented\.
-boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_msb\-430 is not documented\.
-boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_msb\-430 is not documented\.
-boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_msb\-430 is not documented\.
-boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_msb\-430 is not documented\.
-boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_msb\-430 is not documented\.
 boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member LED_OUT_REG \(macro definition\) of group boards_common_msb\-430 is not documented\.
 boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of group boards_common_msb\-430 is not documented\.
 boards/common/msb\-430/include/board_common\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of group boards_common_msb\-430 is not documented\.
@@ -1331,25 +956,6 @@ boards/common/nucleo144/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUIN
 boards/common/nucleo144/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo144/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member PERIPH_INIT_LED0 \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of group boards_common_nucleo144 is not documented\.
-boards/common/nucleo144/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of group boards_common_nucleo144 is not documented\.
 boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A0 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A1 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A2 \(macro definition\) of file arduino_pinmap\.h is not documented\.
@@ -1380,11 +986,6 @@ boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO
 boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A6 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo32/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A7 \(macro definition\) of file arduino_pinmap\.h is not documented\.
-boards/common/nucleo32/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_nucleo32 is not documented\.
-boards/common/nucleo32/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_nucleo32 is not documented\.
-boards/common/nucleo32/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_nucleo32 is not documented\.
-boards/common/nucleo32/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_nucleo32 is not documented\.
-boards/common/nucleo32/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_nucleo32 is not documented\.
 boards/common/nucleo32/include/gpio_params\.h:[0-9]+: warning: Member SAUL_GPIO_NUMOF \(macro definition\) of file gpio_params\.h is not documented\.
 boards/common/nucleo64/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A0 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo64/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A1 \(macro definition\) of file arduino_pinmap\.h is not documented\.
@@ -1414,33 +1015,8 @@ boards/common/nucleo64/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO
 boards/common/nucleo64/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A4 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo64/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/common/nucleo64/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of group boards_common_nucleo64 is not documented\.
-boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_nucleo64 is not documented\.
 boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member MOTOR_DRIVER_NUMOF \(macro definition\) of group boards_common_nucleo64 is not documented\.
 boards/common/nucleo64/include/board\.h:[0-9]+: warning: Member motor_driver_config\[\] \(variable\) of group boards_common_nucleo64 is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/common/particle\-mesh/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/common/particle\-mesh/include/periph_conf_common\.h:[0-9]+: warning: Member PWM_NUMOF \(macro definition\) of file periph_conf_common\.h is not documented\.
@@ -1451,12 +1027,6 @@ boards/common/particle\-mesh/include/periph_conf_common\.h:[0-9]+: warning: end 
 boards/common/particle\-mesh/include/pwm_params\.h:[0-9]+: warning: Member SAUL_PWM_NO_DIMMER \(macro definition\) of file pwm_params\.h is not documented\.
 boards/common/particle\-mesh/include/pwm_params\.h:[0-9]+: warning: Member saul_pwm_rgb_params\[\] \(variable\) of file pwm_params\.h is not documented\.
 boards/common/remote/include/board_common\.h:[0-9]+: warning: Member CCA_BACKDOOR_ENABLE \(macro definition\) of group boards_common_remote is not documented\.
-boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of group boards_common_remote is not documented\.
-boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of group boards_common_remote is not documented\.
-boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of group boards_common_remote is not documented\.
-boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED4_OFF \(macro definition\) of group boards_common_remote is not documented\.
-boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED4_ON \(macro definition\) of group boards_common_remote is not documented\.
-boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED4_TOGGLE \(macro definition\) of group boards_common_remote is not documented\.
 boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED_ALL_OFF \(macro definition\) of group boards_common_remote is not documented\.
 boards/common/remote/include/board_common\.h:[0-9]+: warning: Member LED_ALL_ON \(macro definition\) of group boards_common_remote is not documented\.
 boards/common/remote/include/board_common\.h:[0-9]+: warning: Member UPDATE_CCA \(macro definition\) of group boards_common_remote is not documented\.
@@ -1478,14 +1048,6 @@ boards/common/remote/include/cfg_uart_default\.h:[0-9]+: warning: Member uart_co
 boards/common/remote/include/fancy_leds\.h:[0-9]+: warning: Member LED_FADE\(led\) \(macro definition\) of file fancy_leds\.h is not documented\.
 boards/common/remote/include/fancy_leds\.h:[0-9]+: warning: Member LED_FADE_EXPAND\(led\) \(macro definition\) of file fancy_leds\.h is not documented\.
 boards/common/remote/include/fancy_leds\.h:[0-9]+: warning: Member LED_RAINBOW\(\) \(macro definition\) of file fancy_leds\.h is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_common_saml1x is not documented\.
-boards/common/saml1x/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_common_saml1x is not documented\.
 boards/common/saml1x/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of group boards_common_saml1x is not documented\.
 boards/common/saml1x/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of group boards_common_saml1x is not documented\.
 boards/common/saml1x/include/board\.h:[0-9]+: warning: Member _PORT \(macro definition\) of group boards_common_saml1x is not documented\.
@@ -1535,14 +1097,6 @@ boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member DISP_COM_PIN 
 boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member DISP_CS_PIN \(macro definition\) of file board\.h is not documented\.
 boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member DISP_EN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member DISP_SPI \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/common/slwstk6000b/include/board\.h:[0-9]+: warning: Member SI7021_EN_PIN \(macro definition\) of file board\.h is not documented\.
@@ -1744,14 +1298,6 @@ boards/common/stm32/include/cfg_timer_tim5\.h:[0-9]+: warning: Member TIMER_NUMO
 boards/common/stm32/include/cfg_timer_tim5\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file cfg_timer_tim5\.h is not documented\.
 boards/common/stm32/include/cfg_usb_otg_fs\.h:[0-9]+: warning: Member stm32_usb_otg_fshs_config\[\] \(variable\) of file cfg_usb_otg_fs\.h is not documented\.
 boards/common/stm32/include/cfg_usb_otg_hs_fs\.h:[0-9]+: warning: Member stm32_usb_otg_fshs_config\[\] \(variable\) of file cfg_usb_otg_hs_fs\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member MTD_0 \(macro definition\) of file board\.h is not documented\.
 boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member WEACT_4X1CX_NOR_FLAGS \(macro definition\) of file board\.h is not documented\.
 boards/common/weact\-f4x1cx/include/board\.h:[0-9]+: warning: Member WEACT_4X1CX_NOR_PAGES_PER_SECTOR \(macro definition\) of file board\.h is not documented\.
@@ -1788,27 +1334,9 @@ boards/derfmega256/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_
 boards/derfmega256/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_INDEX \(macro definition\) of file eui_provider_params\.h is not documented\.
 boards/derfmega256/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_TYPE \(macro definition\) of file eui_provider_params\.h is not documented\.
 boards/derfmega256/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/dwm1001/include/board\.h:[0-9]+: warning: Member DW1000_PARAM_CS_PIN \(macro definition\) of file board\.h is not documented\.
 boards/dwm1001/include/board\.h:[0-9]+: warning: Member DW1000_PARAM_INT_PIN \(macro definition\) of file board\.h is not documented\.
 boards/dwm1001/include/board\.h:[0-9]+: warning: Member DW1000_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/dwm1001/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/dwm1001/include/board\.h:[0-9]+: warning: Member LIS2DH12_PARAM_INT_PIN1 \(macro definition\) of file board\.h is not documented\.
@@ -1820,14 +1348,6 @@ boards/dwm1001/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macr
 boards/dwm1001/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/dwm1001/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member CORETEMP_ADC \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/e180\-zg120b\-tb/include/board\.h:[0-9]+: warning: Member PB2_PIN \(macro definition\) of file board\.h is not documented\.
@@ -1852,28 +1372,9 @@ boards/e180\-zg120b\-tb/include/periph_conf\.h:[0-9]+: warning: Member adc_chann
 boards/e180\-zg120b\-tb/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/e180\-zg120b\-tb/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/e180\-zg120b\-tb/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_DEV \(macro definition\) of file board\.h is not documented\.
 boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_MIN \(macro definition\) of file board\.h is not documented\.
 boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/ek\-lm4f120xl/include/board\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/ek\-lm4f120xl/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -1904,7 +1405,6 @@ boards/ek\-lm4f120xl/include/periph_conf\.h:[0-9]+: warning: end of file with un
 boards/esp32\-ethernet\-kit\-v1_0/include/periph_conf\.h:[0-9]+: warning: Member PWM0_GPIOS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/esp32\-ethernet\-kit\-v1_0/include/periph_conf\.h:[0-9]+: warning: unbalanced grouping commands
 boards/esp32\-heltec\-lora32\-v2/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO2 \(macro definition\) of file board\.h is not documented\.
@@ -1914,7 +1414,6 @@ boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member SX127X
 boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-heltec\-lora32\-v2/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_SPI_NSS \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-mh\-et\-live\-minikit/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/esp32\-mh\-et\-live\-minikit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-mh\-et\-live\-minikit/include/board\.h:[0-9]+: warning: Member LED_BLUE_PIN \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-olimex\-evb/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/esp32\-olimex\-evb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_CLK \(macro definition\) of file board\.h is not documented\.
@@ -1924,7 +1423,6 @@ boards/esp32\-olimex\-evb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PA
 boards/esp32\-olimex\-evb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_POWER \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-olimex\-evb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-ttgo\-t\-beam/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/esp32\-ttgo\-t\-beam/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-ttgo\-t\-beam/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-ttgo\-t\-beam/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-ttgo\-t\-beam/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO2 \(macro definition\) of file board\.h is not documented\.
@@ -1933,7 +1431,6 @@ boards/esp32\-ttgo\-t\-beam/include/board\.h:[0-9]+: warning: Member SX127X_PARA
 boards/esp32\-ttgo\-t\-beam/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_SPI_NSS \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-wemos\-lolin\-d32\-pro/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/esp32\-wemos\-lolin\-d32\-pro/include/board\.h:[0-9]+: warning: Member LED0_ACTIVE \(macro definition\) of file board\.h is not documented\.
-boards/esp32\-wemos\-lolin\-d32\-pro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-wroom\-32/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/esp32\-wrover\-kit/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/esp32\-wrover\-kit/include/board\.h:[0-9]+: warning: Member BACKLIGHT_OFF \(macro definition\) of file board\.h is not documented\.
@@ -1952,21 +1449,6 @@ boards/esp32\-wrover\-kit/include/board\.h:[0-9]+: warning: Member LCD_DC \(macr
 boards/esp32\-wrover\-kit/include/board\.h:[0-9]+: warning: Member LCD_RST \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-wrover\-kit/include/board\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/esp8266\-olimex\-mod/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/f4vi1/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/f4vi1/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/f4vi1/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -1983,11 +1465,6 @@ boards/feather\-m0/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_RES
 boards/feather\-m0/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/feather\-m0/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_SSN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/feather\-m0/include/board\.h:[0-9]+: warning: Member ATWINC15X0_PARAM_WAKE_PIN \(macro definition\) of file board\.h is not documented\.
-boards/feather\-m0/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/feather\-m0/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/feather\-m0/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/feather\-m0/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/feather\-m0/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/feather\-m0/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/feather\-m0/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of file board\.h is not documented\.
 boards/feather\-m0/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of file board\.h is not documented\.
@@ -2027,18 +1504,6 @@ boards/feather\-m0/include/periph_conf\.h:[0-9]+: warning: Member sam_usbdev_con
 boards/feather\-m0/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/feather\-m0/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/feather\-m0/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/feather\-nrf52840/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/feather\-nrf52840/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2049,8 +1514,6 @@ boards/feather\-nrf52840/include/periph_conf\.h:[0-9]+: warning: Member i2c_conf
 boards/feather\-nrf52840/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/feather\-nrf52840/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/feather\-nrf52840/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/firefly/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_CSN_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_GPD0_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_GPD2_GPIO \(macro definition\) of file board\.h is not documented\.
@@ -2059,44 +1522,10 @@ boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_MOSI_GPIO \(macro
 boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_RESET_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_SCLK_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/firefly/include/board\.h:[0-9]+: warning: Member CC1200_SPI_DEV \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/firefly/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/firefly/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/firefly/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k22f/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member ADC_REF_SETTING \(macro definition\) of file periph_conf\.h is not documented\.
 boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_BUSCLOCK \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2125,27 +1554,8 @@ boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] 
 boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member spi_clk_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/frdm\-k22f/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-k64f/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member ADC_REF_SETTING \(macro definition\) of file periph_conf\.h is not documented\.
 boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_BUSCLOCK \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2173,16 +1583,6 @@ boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] 
 boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member spi_clk_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/frdm\-k64f/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_frdm\-kl43z is not documented\.
-boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_frdm\-kl43z is not documented\.
 boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member MAG3110_PARAM_ADDR \(macro definition\) of group boards_frdm\-kl43z is not documented\.
 boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member MAG3110_PARAM_I2C \(macro definition\) of group boards_frdm\-kl43z is not documented\.
 boards/frdm\-kl43z/include/board\.h:[0-9]+: warning: Member MMA8X5X_PARAM_ADDR \(macro definition\) of group boards_frdm\-kl43z is not documented\.
@@ -2218,36 +1618,12 @@ boards/frdm\-kl43z/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\]
 boards/frdm\-kl43z/include/periph_conf\.h:[0-9]+: warning: Member clock_config \(variable\) of file periph_conf\.h is not documented\.
 boards/frdm\-kl43z/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/frdm\-kl43z/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_DEV \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member FRDM_NOR_SPI_CLK \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member FRDM_NOR_SPI_DEV \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
 boards/frdm\-kw41z/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of file board\.h is not documented\.
@@ -2265,9 +1641,6 @@ boards/hamilton/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_RESET \
 boards/hamilton/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SLEEP \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SPI \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SPI_CLK \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_ADDR \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_I2C \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member FXOS8700_PARAM_RENEW_INTERVAL \(macro definition\) of group boards_hamilton is not documented\.
@@ -2275,12 +1648,6 @@ boards/hamilton/include/board\.h:[0-9]+: warning: Member HDC1000_PARAM_ADDR \(ma
 boards/hamilton/include/board\.h:[0-9]+: warning: Member HDC1000_PARAM_I2C \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member HDC1000_PARAM_RENEW_INTERVAL \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member HDC1000_PARAM_RES \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of group boards_hamilton is not documented\.
-boards/hamilton/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member PIR_PARAM_ACTIVE_HIGH \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member PIR_PARAM_GPIO \(macro definition\) of group boards_hamilton is not documented\.
 boards/hamilton/include/board\.h:[0-9]+: warning: Member PULSE_COUNTER_GPIO \(macro definition\) of group boards_hamilton is not documented\.
@@ -2318,18 +1685,6 @@ boards/hamilton/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(
 boards/hamilton/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/hamilton/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/hamilton/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of group boards_hifive1 is not documented\.
-boards/hifive1/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of group boards_hifive1 is not documented\.
 boards/hifive1/include/board\.h:[0-9]+: warning: Member XTIMER_HZ \(macro definition\) of group boards_hifive1 is not documented\.
 boards/hifive1/include/periph_conf\.h:[0-9]+: warning: Member PWM_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/hifive1/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2357,18 +1712,6 @@ boards/hifive1b/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_6 
 boards/hifive1b/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_7 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/hifive1b/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_8 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/hifive1b/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_9 \(macro definition\) of file arduino_pinmap\.h is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of group boards_hifive1b is not documented\.
-boards/hifive1b/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of group boards_hifive1b is not documented\.
 boards/hifive1b/include/board\.h:[0-9]+: warning: Member XTIMER_HZ \(macro definition\) of group boards_hifive1b is not documented\.
 boards/hifive1b/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/hifive1b/include/periph_conf\.h:[0-9]+: warning: Member PWM_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2404,14 +1747,6 @@ boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member IKEA_TRADFRI_NOR_S
 boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member IKEA_TRADFRI_NOR_SPI_CS \(macro definition\) of file board\.h is not documented\.
 boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member IKEA_TRADFRI_NOR_SPI_DEV \(macro definition\) of file board\.h is not documented\.
 boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member IKEA_TRADFRI_NOR_SPI_MODE \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member MTD_0 \(macro definition\) of file board\.h is not documented\.
 boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
 boards/ikea\-tradfri/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of file board\.h is not documented\.
@@ -2480,12 +1815,6 @@ boards/iotlab\-m3/include/board\.h:[0-9]+: warning: Member LSM303DLHC_PARAM_ACC_
 boards/iotlab\-m3/include/board\.h:[0-9]+: warning: Member LSM303DLHC_PARAM_MAG_PIN \(macro definition\) of file board\.h is not documented\.
 boards/iotlab\-m3/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/iotlab\-m3/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LIS3MDL_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member LIS3MDL_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/limifrog\-v1/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -2508,12 +1837,6 @@ boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member EN3V3_ON \(macro
 boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member EN3V3_PIN \(macro definition\) of file board\.h is not documented\.
 boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member EN3V3_PORT \(macro definition\) of file board\.h is not documented\.
 boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member EN3V3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of file board\.h is not documented\.
 boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of file board\.h is not documented\.
 boards/lobaro\-lorabox/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO2 \(macro definition\) of file board\.h is not documented\.
@@ -2534,18 +1857,8 @@ boards/lobaro\-lorabox/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF
 boards/lobaro\-lorabox/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/lobaro\-lorabox/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/lobaro\-lorabox/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member FE_CTRL1 \(macro definition\) of file board\.h is not documented\.
 boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member FE_CTRL2 \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member SX126X_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/lora\-e5\-dev/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/lora\-e5\-dev/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2587,13 +1900,6 @@ boards/lsn50/include/periph_conf\.h:[0-9]+: warning: Member dma_config\[\] \(var
 boards/lsn50/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/lsn50/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/lsn50/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/maple\-mini/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/maple\-mini/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/maple\-mini/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/maple\-mini/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -2613,22 +1919,6 @@ boards/maple\-mini/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\]
 boards/maple\-mini/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/maple\-mini/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/maple\-mini/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mbed_lpc1768/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CLKDIS\(\) \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CLKEN\(\) \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2645,55 +1935,12 @@ boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member UART_1_ISR \(
 boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member UART_IRQ_PRIO \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mbed_lpc1768/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member BTN0_INT_FLANK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/board\.h:[0-9]+: warning: Member HD44780_PARAM_COLS \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/board\.h:[0-9]+: warning: Member HD44780_PARAM_PINS_DATA \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/board\.h:[0-9]+: warning: Member HD44780_PARAM_PIN_ENABLE \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/board\.h:[0-9]+: warning: Member HD44780_PARAM_PIN_RS \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/board\.h:[0-9]+: warning: Member HD44780_PARAM_PIN_RW \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/board\.h:[0-9]+: warning: Member HD44780_PARAM_ROWS \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED4_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED4_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED4_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED4_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED5_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED5_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED5_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED5_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED5_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED6_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED6_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED6_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED6_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED6_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED7_MASK \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED7_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED7_ON \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED7_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mcb2388/include/board\.h:[0-9]+: warning: Member LED7_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/mcb2388/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mcb2388/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mcb2388/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_PCLK \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2742,10 +1989,6 @@ boards/mega\-xplained/include/mega\-xplained_pinmap\.h:[0-9]+: warning: Member J
 boards/mega\-xplained/include/mega\-xplained_pinmap\.h:[0-9]+: warning: Member J4_PIN8 \(macro definition\) of file mega\-xplained_pinmap\.h is not documented\.
 boards/mega\-xplained/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/mega\-xplained/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/microbit/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/microbit/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/microbit/include/board\.h:[0-9]+: warning: Member MAG3110_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/microbit/include/board\.h:[0-9]+: warning: Member MAG3110_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/microbit/include/board\.h:[0-9]+: warning: Member MICROBIT_LED_COL1 \(macro definition\) of file board\.h is not documented\.
@@ -2767,18 +2010,6 @@ boards/microbit/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macr
 boards/microbit/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/microbit/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/microbit/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN3_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN4_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN5_MODE \(macro definition\) of file board\.h is not documented\.
-boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member BTN5_PIN \(macro definition\) of file board\.h is not documented\.
 boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member LSM303AGR_PARAM_ACC_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member LSM303AGR_PARAM_MAG_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/microbit\-v2/include/board\.h:[0-9]+: warning: Member MICROBIT_LED_COL1 \(macro definition\) of file board\.h is not documented\.
@@ -2880,16 +2111,6 @@ boards/msb\-430h/include/periph_conf\.h:[0-9]+: warning: Member UART_RX_PIN \(ma
 boards/msb\-430h/include/periph_conf\.h:[0-9]+: warning: Member UART_TX_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/msb\-430h/include/periph_conf\.h:[0-9]+: warning: Member UART_TX_PIN \(macro definition\) of file periph_conf\.h is not documented\.
 boards/msb\-430h/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/msba2/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/msba2/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/msba2/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/msba2/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_PCLK \(macro definition\) of file periph_conf\.h is not documented\.
@@ -2945,20 +2166,8 @@ boards/mulle/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_INT \(macr
 boards/mulle/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_RESET \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SLEEP \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member LED0_BIT \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member LED1_BIT \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member LED2_BIT \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/mulle/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member LIS3DH_PARAM_CLK \(macro definition\) of file board\.h is not documented\.
 boards/mulle/include/board\.h:[0-9]+: warning: Member LIS3DH_PARAM_CS \(macro definition\) of file board\.h is not documented\.
@@ -3012,12 +2221,6 @@ boards/mulle/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(var
 boards/mulle/include/periph_conf\.h:[0-9]+: warning: Member spi_clk_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/mulle/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/mulle/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/native/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/native/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/native/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/native/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/native/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/native/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/native/include/board\.h:[0-9]+: warning: Member MTD_NATIVE_FILENAME \(macro definition\) of file board\.h is not documented\.
 boards/native/include/board\.h:[0-9]+: warning: Member MTD_PAGE_SIZE \(macro definition\) of file board\.h is not documented\.
 boards/native/include/board\.h:[0-9]+: warning: Member MTD_SECTOR_NUM \(macro definition\) of file board\.h is not documented\.
@@ -3035,34 +2238,6 @@ boards/native/include/board\.h:[0-9]+: warning: Member _native_LED_RED_TOGGLE\(v
 boards/native/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_FUNC \(macro definition\) of file eui_provider_params\.h is not documented\.
 boards/native/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_INDEX \(macro definition\) of file eui_provider_params\.h is not documented\.
 boards/native/include/eui_provider_params\.h:[0-9]+: warning: Member EUI64_PROVIDER_TYPE \(macro definition\) of file eui_provider_params\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN3_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member BTN3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dk/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -3072,64 +2247,17 @@ boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macr
 boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nrf51dk/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf51dongle/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf51dongle/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dongle/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_CTS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dongle/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RTS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dongle/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf51dongle/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/nrf52832\-mdk/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/nrf52832\-mdk/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf52832\-mdk/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf52832\-mdk/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf52832\-mdk/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/nrf52840\-mdk/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/nrf52840\-mdk/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
@@ -3144,34 +2272,6 @@ boards/nrf52840\-mdk\-dongle/include/periph_conf\.h:[0-9]+: warning: Member UART
 boards/nrf52840\-mdk\-dongle/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nrf52840\-mdk\-dongle/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nrf52840\-mdk\-dongle/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN3_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member BTN3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/nrf52840dk/include/board\.h:[0-9]+: warning: Member NRF52840DK_NOR_FLAGS \(macro definition\) of file board\.h is not documented\.
@@ -3199,34 +2299,6 @@ boards/nrf52840dongle/include/periph_conf\.h:[0-9]+: warning: Member spi_config\
 boards/nrf52840dongle/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nrf52840dongle/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/nrf52840dongle/include/pwm_params\.h:[0-9]+: warning: Member saul_pwm_rgb_params\[\] \(variable\) of file pwm_params\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN3_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member BTN3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/nrf52dk/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/nrf52dk/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -3234,21 +2306,6 @@ boards/nrf52dk/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro
 boards/nrf52dk/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf52dk/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf52dk/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nrf6310/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nrf6310/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf6310/include/periph_conf\.h:[0-9]+: warning: Member UART_IRQ_PRIO \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nrf6310/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -3901,33 +2958,9 @@ boards/nucleo\-wl55jc/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_
 boards/nucleo\-wl55jc/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A4 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/nucleo\-wl55jc/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/nucleo\-wl55jc/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
 boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member FE_CTRL1 \(macro definition\) of file board\.h is not documented\.
 boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member FE_CTRL2 \(macro definition\) of file board\.h is not documented\.
 boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member FE_CTRL3 \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nucleo\-wl55jc/include/board\.h:[0-9]+: warning: Member SX126X_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/nucleo\-wl55jc/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-wl55jc/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -3941,11 +2974,6 @@ boards/nucleo\-wl55jc/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF 
 boards/nucleo\-wl55jc/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nucleo\-wl55jc/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nucleo\-wl55jc/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/nz32\-sc151/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/nz32\-sc151/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/nz32\-sc151/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/nz32\-sc151/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/nz32\-sc151/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member DAC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member I2C_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
@@ -3962,20 +2990,6 @@ boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\]
 boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nz32\-sc151/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member LED_PANIC \(macro definition\) of file board\.h is not documented\.
 boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/olimexino\-stm32/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
@@ -4002,21 +3016,9 @@ boards/olimexino\-stm32/include/periph_conf\.h:[0-9]+: warning: Member pwm_confi
 boards/olimexino\-stm32/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/olimexino\-stm32/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/olimexino\-stm32/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/omote/include/board\.h:[0-9]+: warning: Member CCA_BACKDOOR_ENABLE \(macro definition\) of file board\.h is not documented\.
 boards/omote/include/board\.h:[0-9]+: warning: Member INTERNAL_PERIPHERAL_PID \(macro definition\) of file board\.h is not documented\.
 boards/omote/include/board\.h:[0-9]+: warning: Member INTERNAL_PERIPHERAL_VID \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/omote/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/omote/include/board\.h:[0-9]+: warning: Member LED_ALL_OFF \(macro definition\) of file board\.h is not documented\.
 boards/omote/include/board\.h:[0-9]+: warning: Member LED_ALL_ON \(macro definition\) of file board\.h is not documented\.
 boards/omote/include/board\.h:[0-9]+: warning: Member UPDATE_CCA \(macro definition\) of file board\.h is not documented\.
@@ -4035,13 +3037,6 @@ boards/omote/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(var
 boards/omote/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/omote/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/omote/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/opencm904/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/opencm904/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/opencm904/include/board\.h:[0-9]+: warning: Member STDIO_UART_BAUDRATE \(macro definition\) of file board\.h is not documented\.
 boards/opencm904/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
@@ -4058,11 +3053,6 @@ boards/opencm904/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\]
 boards/opencm904/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/opencm904/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member KINETIS_FOPT \(macro definition\) of file board\.h is not documented\.
-boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
 boards/openlabs\-kw41z\-mini/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of file board\.h is not documented\.
@@ -4113,32 +3103,10 @@ boards/openmote\-b/include/board\.h:[0-9]+: warning: Member AT86RF215_PARAM_CS \
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member AT86RF215_PARAM_INT \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member AT86RF215_PARAM_RESET \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member AT86RF215_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member CCA_BACKDOOR_ENABLE \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member CONFIG_CC2538_RF_OBS_SIG_0_PCX \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member CONFIG_CC2538_RF_OBS_SIG_1_PCX \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member CONFIG_CC2538_RF_OBS_SIG_2_PCX \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member OPENWSN_DEBUGPIN_FRAME \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-b/include/board\.h:[0-9]+: warning: Member OPENWSN_DEBUGPIN_FSM \(macro definition\) of file board\.h is not documented\.
@@ -4179,26 +3147,6 @@ boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member CCA_BACKDOOR_EN
 boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member CONFIG_CC2538_RF_OBS_SIG_0_PCX \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member CONFIG_CC2538_RF_OBS_SIG_1_PCX \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member CONFIG_CC2538_RF_OBS_SIG_2_PCX \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member UPDATE_CCA \(macro definition\) of file board\.h is not documented\.
 boards/openmote\-cc2538/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
@@ -4215,16 +3163,6 @@ boards/openmote\-cc2538/include/periph_conf\.h:[0-9]+: warning: Member adc_confi
 boards/openmote\-cc2538/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/openmote\-cc2538/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/openmote\-cc2538/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-l496g\-cell02/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/p\-l496g\-cell02/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/p\-l496g\-cell02/include/periph_conf\.h:[0-9]+: warning: Member I2C_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/p\-l496g\-cell02/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4264,30 +3202,6 @@ boards/p\-nucleo\-wb55/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO
 boards/p\-nucleo\-wb55/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A4 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/p\-nucleo\-wb55/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/p\-nucleo\-wb55/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/p\-nucleo\-wb55/include/board\.h:[0-9]+: warning: unbalanced grouping commands
 boards/p\-nucleo\-wb55/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_EXTAHB \(macro definition\) of file periph_conf\.h is not documented\.
 boards/p\-nucleo\-wb55/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_EXTAHB_DIV \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4315,32 +3229,11 @@ boards/particle\-xenon/include/periph_conf\.h:[0-9]+: warning: Member UART_1_ISR
 boards/particle\-xenon/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/particle\-xenon/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/particle\-xenon/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member BTN1_PORT \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member KW2XRF_PARAM_CS \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member KW2XRF_PARAM_INT \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member KW2XRF_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member KW2XRF_PARAM_SPI_CLK \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member KW2XRF_SHARED_SPI \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/board\.h:[0-9]+: warning: Member TMP00X_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/periph_conf\.h:[0-9]+: warning: Member ADC_REF_SETTING \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4368,8 +3261,6 @@ boards/pba\-d\-01\-kw2x/include/periph_conf\.h:[0-9]+: warning: Member pwm_confi
 boards/pba\-d\-01\-kw2x/include/periph_conf\.h:[0-9]+: warning: Member spi_clk_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/pba\-d\-01\-kw2x/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member CCS811_PARAM_I2C_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member CCS811_PARAM_I2C_DEV \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member CCS811_PARAM_INT_MODE \(macro definition\) of file board\.h is not documented\.
@@ -4379,26 +3270,6 @@ boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member CCS811_PARAM_WAKE
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_DEV \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member KINETIS_FOPT \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member MMA8X5X_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member MMA8X5X_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/phynode\-kw41z/include/board\.h:[0-9]+: warning: Member TCS37727_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
@@ -4419,30 +3290,6 @@ boards/phynode\-kw41z/include/periph_conf\.h:[0-9]+: warning: Member ADC_REF_SET
 boards/phynode\-kw41z/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/phynode\-kw41z/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/phynode\-kw41z/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED4_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED4_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED4_ON \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pic32\-wifire/include/board\.h:[0-9]+: warning: Member LED4_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/pic32\-wifire/include/gpio_params\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/pic32\-wifire/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
 boards/pic32\-wifire/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4497,11 +3344,6 @@ boards/pinetime/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro
 boards/pinetime/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/pinetime/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/pinetime/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/pyboard/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/pyboard/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/pyboard/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/pyboard/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/pyboard/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4520,10 +3362,6 @@ boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(v
 boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/pyboard/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/qn9080dk/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/qn9080dk/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/qn9080dk/include/board\.h:[0-9]+: warning: Member BTN2_MODE \(macro definition\) of file board\.h is not documented\.
-boards/qn9080dk/include/board\.h:[0-9]+: warning: Member BTN2_PIN \(macro definition\) of file board\.h is not documented\.
 boards/qn9080dk/include/board\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file board\.h is not documented\.
 boards/qn9080dk/include/board\.h:[0-9]+: warning: Member LED_BLUE_PIN \(macro definition\) of file board\.h is not documented\.
 boards/qn9080dk/include/board\.h:[0-9]+: warning: Member LED_GREEN_PIN \(macro definition\) of file board\.h is not documented\.
@@ -4545,31 +3383,9 @@ boards/qn9080dk/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \
 boards/reel/include/board\.h:[0-9]+: warning: Member ADPS9960_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member ADPS9960_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member ADPS9960_PARAM_PIN_INT \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member HDC1010_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member HDC1010_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member HDC1010_PIN_DRDY \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/reel/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member LED_MASK_P0 \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member LED_MASK_P1 \(macro definition\) of file board\.h is not documented\.
 boards/reel/include/board\.h:[0-9]+: warning: Member MMA8X5X_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
@@ -4588,23 +3404,6 @@ boards/reel/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro de
 boards/reel/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/reel/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/reel/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-pa/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/remote\-pa/include/board\.h:[0-9]+: warning: Member RF_SWITCH_2_4_GHZ \(macro definition\) of file board\.h is not documented\.
 boards/remote\-pa/include/board\.h:[0-9]+: warning: Member RF_SWITCH_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-pa/include/board\.h:[0-9]+: warning: Member RF_SWITCH_SUB_GHZ \(macro definition\) of file board\.h is not documented\.
@@ -4617,8 +3416,6 @@ boards/remote\-pa/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(mac
 boards/remote\-pa/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/remote\-pa/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/remote\-pa/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_CSN_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_GPD0_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_GPD2_GPIO \(macro definition\) of file board\.h is not documented\.
@@ -4627,21 +3424,6 @@ boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_MOSI_GPIO \(
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_RESET_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_SCLK_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member CC1200_SPI_DEV \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-reva/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member RF_SWITCH_2_4_GHZ \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member RF_SWITCH_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-reva/include/board\.h:[0-9]+: warning: Member RF_SWITCH_SUB_GHZ \(macro definition\) of file board\.h is not documented\.
@@ -4683,8 +3465,6 @@ boards/remote\-revb/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PI
 boards/remote\-revb/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A3 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/remote\-revb/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A4 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/remote\-revb/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_CSN_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_GPD0_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_GPD2_GPIO \(macro definition\) of file board\.h is not documented\.
@@ -4693,21 +3473,6 @@ boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_MOSI_GPIO \(
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_RESET_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_SCLK_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member CC1200_SPI_DEV \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/remote\-revb/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member RF_SWITCH_2_4_GHZ \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member RF_SWITCH_GPIO \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member RF_SWITCH_SUB_GHZ \(macro definition\) of file board\.h is not documented\.
@@ -4720,11 +3485,6 @@ boards/remote\-revb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_PO
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_POWER_AH \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
 boards/remote\-revb/include/board\.h:[0-9]+: warning: Member SHUTDOWN_EN_GPIO \(macro definition\) of file board\.h is not documented\.
-boards/rpi\-pico/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/rpi\-pico/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/rpi\-pico/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/rpi\-pico/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/rpi\-pico/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/rpi\-pico/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISRA \(macro definition\) of file periph_conf\.h is not documented\.
 boards/rpi\-pico/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISRB \(macro definition\) of file periph_conf\.h is not documented\.
 boards/rpi\-pico/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISRC \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4737,19 +3497,7 @@ boards/rpi\-pico/include/periph_conf\.h:[0-9]+: warning: Member timer0_channel_c
 boards/rpi\-pico/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/rpi\-pico/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/ruuvitag/include/board\.h:[0-9]+: warning: Member BMX280_PARAM_CS \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/ruuvitag/include/board\.h:[0-9]+: warning: Member CS_PIN_MASK \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED_MASK \(macro definition\) of file board\.h is not documented\.
 boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/ruuvitag/include/board\.h:[0-9]+: warning: Member LIS2DH12_PARAM_CS \(macro definition\) of file board\.h is not documented\.
@@ -4760,14 +3508,6 @@ boards/ruuvitag/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macr
 boards/ruuvitag/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/ruuvitag/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/ruuvitag/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/samd10\-xmini/include/board\.h:[0-9]+: warning: Member STDIO_UART_BAUDRATE \(macro definition\) of file board\.h is not documented\.
 boards/samd10\-xmini/include/periph_conf\.h:[0-9]+: warning: Member ADC_GAIN_FACTOR_DEFAULT \(macro definition\) of file periph_conf\.h is not documented\.
@@ -4800,14 +3540,6 @@ boards/samd10\-xmini/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[
 boards/samd10\-xmini/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samd10\-xmini/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samd10\-xmini/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
 boards/samd20\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of file board\.h is not documented\.
@@ -4843,14 +3575,6 @@ boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
 boards/samd21\-xpro/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of file board\.h is not documented\.
@@ -4896,14 +3620,6 @@ boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member AT24MAC_PARAM_I2C_A
 boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member AT24MAC_PARAM_I2C_DEV \(macro definition\) of file board\.h is not documented\.
 boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member AT24MAC_PARAM_TYPE \(macro definition\) of file board\.h is not documented\.
 boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member ATCA_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member MTD_0 \(macro definition\) of file board\.h is not documented\.
 boards/same54\-xpro/include/board\.h:[0-9]+: warning: Member MTD_1 \(macro definition\) of file board\.h is not documented\.
@@ -4959,14 +3675,6 @@ boards/same54\-xpro/include/periph_conf\.h:[0-9]+: warning: end of file with unb
 boards/saml21\-xpro/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A1 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/saml21\-xpro/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_A2 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/saml21\-xpro/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_1 \(macro definition\) of file arduino_pinmap\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/saml21\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/saml21\-xpro/include/periph_conf\.h:[0-9]+: warning: Member ADC_NEG_INPUT \(macro definition\) of file periph_conf\.h is not documented\.
 boards/saml21\-xpro/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -5001,17 +3709,9 @@ boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_CS 
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_INT \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_RESET \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SLEEP \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_DEV \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_MIN \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member RFCTL1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/samr21\-xpro/include/board\.h:[0-9]+: warning: Member RFCTL2_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5066,19 +3766,6 @@ boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_RES
 boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SLEEP \(macro definition\) of group boards_samr30\-xpro is not documented\.
 boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SPI \(macro definition\) of group boards_samr30\-xpro is not documented\.
 boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member AT86RF2XX_PARAM_SPI_CLK \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_samr30\-xpro is not documented\.
-boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_samr30\-xpro is not documented\.
 boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of group boards_samr30\-xpro is not documented\.
 boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member RFCTL1_PIN \(macro definition\) of group boards_samr30\-xpro is not documented\.
 boards/samr30\-xpro/include/board\.h:[0-9]+: warning: Member RFCTL2_PIN \(macro definition\) of group boards_samr30\-xpro is not documented\.
@@ -5105,19 +3792,6 @@ boards/samr30\-xpro/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\
 boards/samr30\-xpro/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samr30\-xpro/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samr30\-xpro/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_samr34\-xpro is not documented\.
-boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_samr34\-xpro is not documented\.
 boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of group boards_samr34\-xpro is not documented\.
 boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO0 \(macro definition\) of group boards_samr34\-xpro is not documented\.
 boards/samr34\-xpro/include/board\.h:[0-9]+: warning: Member SX127X_PARAM_DIO1 \(macro definition\) of group boards_samr34\-xpro is not documented\.
@@ -5163,22 +3837,6 @@ boards/seeedstudio\-gd32/include/periph_conf\.h:[0-9]+: warning: Member UART_0_I
 boards/seeedstudio\-gd32/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/seeedstudio\-gd32/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/seeedstudio\-gd32/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_arch\-pro/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/seeeduino_arch\-pro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/seeeduino_arch\-pro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CLKDIS\(\) \(macro definition\) of file periph_conf\.h is not documented\.
 boards/seeeduino_arch\-pro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CLKEN\(\) \(macro definition\) of file periph_conf\.h is not documented\.
@@ -5197,24 +3855,6 @@ boards/seeeduino_arch\-pro/include/periph_conf\.h:[0-9]+: warning: Member UART_N
 boards/seeeduino_arch\-pro/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member INTERNAL_PERIPHERAL_PID \(macro definition\) of file board\.h is not documented\.
 boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member INTERNAL_PERIPHERAL_VID \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED1_NAME \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED2_NAME \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/seeeduino_xiao/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/seeeduino_xiao/include/periph_conf\.h:[0-9]+: warning: Member ADC_GAIN_FACTOR_DEFAULT \(macro definition\) of file periph_conf\.h is not documented\.
 boards/seeeduino_xiao/include/periph_conf\.h:[0-9]+: warning: Member ADC_NEG_INPUT \(macro definition\) of file periph_conf\.h is not documented\.
@@ -5240,25 +3880,12 @@ boards/seeeduino_xiao/include/periph_conf\.h:[0-9]+: warning: Member sam_usbdev_
 boards/seeeduino_xiao/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/seeeduino_xiao/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/seeeduino_xiao/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member I2C_DISABLE \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member I2C_ENABLE \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member I2C_EN_MASK \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member I2C_EN_MODE \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member I2C_EN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member I2C_EN_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member MTD_0 \(macro definition\) of file board\.h is not documented\.
 boards/sensebox_samd21/include/board\.h:[0-9]+: warning: Member MTD_SD_CARD_PAGES_PER_SECTOR \(macro definition\) of file board\.h is not documented\.
@@ -5315,24 +3942,6 @@ boards/sensebox_samd21/include/periph_conf\.h:[0-9]+: warning: Member uart_confi
 boards/sensebox_samd21/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/serpente/include/board\.h:[0-9]+: warning: Member INTERNAL_PERIPHERAL_PID \(macro definition\) of file board\.h is not documented\.
 boards/serpente/include/board\.h:[0-9]+: warning: Member INTERNAL_PERIPHERAL_VID \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED0_NAME \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED1_NAME \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED2_NAME \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/serpente/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/serpente/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/serpente/include/board\.h:[0-9]+: warning: Member MTD_0 \(macro definition\) of file board\.h is not documented\.
 boards/serpente/include/board\.h:[0-9]+: warning: Member SERPENTE_NOR_FLAGS \(macro definition\) of file board\.h is not documented\.
@@ -5383,14 +3992,6 @@ boards/slstk3400a/include/board\.h:[0-9]+: warning: Member DISP_COM_PIN \(macro 
 boards/slstk3400a/include/board\.h:[0-9]+: warning: Member DISP_CS_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3400a/include/board\.h:[0-9]+: warning: Member DISP_EN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3400a/include/board\.h:[0-9]+: warning: Member DISP_SPI \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slstk3400a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/slstk3400a/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3400a/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3400a/include/board\.h:[0-9]+: warning: Member SI7021_EN_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5427,14 +4028,6 @@ boards/slstk3401a/include/board\.h:[0-9]+: warning: Member DISP_COM_PIN \(macro 
 boards/slstk3401a/include/board\.h:[0-9]+: warning: Member DISP_CS_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3401a/include/board\.h:[0-9]+: warning: Member DISP_EN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3401a/include/board\.h:[0-9]+: warning: Member DISP_SPI \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slstk3401a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/slstk3401a/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3401a/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3401a/include/board\.h:[0-9]+: warning: Member SI7021_EN_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5473,14 +4066,6 @@ boards/slstk3402a/include/board\.h:[0-9]+: warning: Member DISP_COM_PIN \(macro 
 boards/slstk3402a/include/board\.h:[0-9]+: warning: Member DISP_CS_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3402a/include/board\.h:[0-9]+: warning: Member DISP_EN_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3402a/include/board\.h:[0-9]+: warning: Member DISP_SPI \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slstk3402a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/slstk3402a/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3402a/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slstk3402a/include/board\.h:[0-9]+: warning: Member SI7021_EN_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5528,14 +4113,6 @@ boards/sltb001a/include/board\.h:[0-9]+: warning: Member ICM20648_ENABLED \(macr
 boards/sltb001a/include/board\.h:[0-9]+: warning: Member ICM20648_PIC_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/sltb001a/include/board\.h:[0-9]+: warning: Member ICM20648_PIC_EN_BIT \(macro definition\) of file board\.h is not documented\.
 boards/sltb001a/include/board\.h:[0-9]+: warning: Member ICM20648_SPI \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sltb001a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sltb001a/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/sltb001a/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/sltb001a/include/board\.h:[0-9]+: warning: Member PIC_I2C \(macro definition\) of file board\.h is not documented\.
@@ -5591,14 +4168,6 @@ boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member DISP_CS_PIN \(macro 
 boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member DISP_POWER_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member DISP_SELECT_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member DISP_SPI \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/slwstk6220a/include/board\.h:[0-9]+: warning: Member SI7021_EN_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5638,11 +4207,6 @@ boards/slwstk6220a/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\]
 boards/slwstk6220a/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/slwstk6220a/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/slwstk6220a/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/sodaq\-autonomo/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-autonomo/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-autonomo/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-autonomo/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-autonomo/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-autonomo/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-autonomo/include/periph_conf\.h:[0-9]+: warning: Member ADC_GAIN_FACTOR_DEFAULT \(macro definition\) of file periph_conf\.h is not documented\.
 boards/sodaq\-autonomo/include/periph_conf\.h:[0-9]+: warning: Member ADC_NEG_INPUT \(macro definition\) of file periph_conf\.h is not documented\.
@@ -5664,14 +4228,6 @@ boards/sodaq\-autonomo/include/periph_conf\.h:[0-9]+: warning: Member pwm_chan0_
 boards/sodaq\-autonomo/include/periph_conf\.h:[0-9]+: warning: Member pwm_chan1_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/sodaq\-autonomo/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/sodaq\-autonomo/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member RN2XX3_PARAM_PIN_RESET \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: Member RN2XX3_PARAM_UART \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-explorer/include/board\.h:[0-9]+: warning: unbalanced grouping commands
@@ -5688,8 +4244,6 @@ boards/sodaq\-explorer/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF
 boards/sodaq\-explorer/include/periph_conf\.h:[0-9]+: warning: Member adc_channels\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/sodaq\-explorer/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/sodaq\-explorer/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_MASK \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_OFF \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_ON \(macro definition\) of file board\.h is not documented\.
@@ -5697,24 +4251,6 @@ boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_PIN \(macr
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_PORT \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_TIMEPULSE_MODE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member GPS_TIMEPULSE_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LORA_RESET_MASK \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LORA_RESET_OFF \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-one/include/board\.h:[0-9]+: warning: Member LORA_RESET_ON \(macro definition\) of file board\.h is not documented\.
@@ -5743,30 +4279,6 @@ boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_PIN 
 boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_PORT \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member GPS_TIMEPULSE_MODE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member GPS_TIMEPULSE_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED3_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED_BLUE_OFF \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED_BLUE_ON \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-aff/include/board\.h:[0-9]+: warning: Member LED_BLUE_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5811,8 +4323,6 @@ boards/sodaq\-sara\-aff/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMO
 boards/sodaq\-sara\-aff/include/periph_conf\.h:[0-9]+: warning: Member adc_channels\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/sodaq\-sara\-aff/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/sodaq\-sara\-aff/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_MASK \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_OFF \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member GPS_ENABLE_ON \(macro definition\) of file board\.h is not documented\.
@@ -5826,24 +4336,6 @@ boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member INT2_XL_MODE \(
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member INT2_XL_PIN \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member INT_MAG_MODE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member INT_MAG_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED_BLUE_OFF \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED_BLUE_ON \(macro definition\) of file board\.h is not documented\.
 boards/sodaq\-sara\-sff/include/board\.h:[0-9]+: warning: Member LED_BLUE_PIN \(macro definition\) of file board\.h is not documented\.
@@ -5893,26 +4385,6 @@ boards/spark\-core/include/board\.h:[0-9]+: warning: Member CC3000_INT \(macro d
 boards/spark\-core/include/board\.h:[0-9]+: warning: Member CC3000_SPI \(macro definition\) of file board\.h is not documented\.
 boards/spark\-core/include/board\.h:[0-9]+: warning: Member EXTFLASH \(macro definition\) of file board\.h is not documented\.
 boards/spark\-core/include/board\.h:[0-9]+: warning: Member EXTFLASH_SPI \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/spark\-core/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/spark\-core/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/spark\-core/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -5931,14 +4403,6 @@ boards/stk3200/include/board\.h:[0-9]+: warning: Member DISP_CS_PIN \(macro defi
 boards/stk3200/include/board\.h:[0-9]+: warning: Member DISP_POWER_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3200/include/board\.h:[0-9]+: warning: Member DISP_SELECT_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3200/include/board\.h:[0-9]+: warning: Member DISP_SPI \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stk3200/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stk3200/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3200/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3200/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
@@ -5967,14 +4431,6 @@ boards/stk3200/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \
 boards/stk3200/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stk3600/include/board\.h:[0-9]+: warning: Member BC_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3600/include/board\.h:[0-9]+: warning: Member CORETEMP_ADC \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stk3600/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stk3600/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3600/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3600/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
@@ -6014,14 +4470,6 @@ boards/stk3600/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \
 boards/stk3600/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stk3700/include/board\.h:[0-9]+: warning: Member BC_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3700/include/board\.h:[0-9]+: warning: Member CORETEMP_ADC \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stk3700/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stk3700/include/board\.h:[0-9]+: warning: Member PB0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3700/include/board\.h:[0-9]+: warning: Member PB1_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stk3700/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
@@ -6059,12 +4507,6 @@ boards/stk3700/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(v
 boards/stk3700/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stk3700/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stk3700/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f030f4\-demo/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/stm32f030f4\-demo/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f030f4\-demo/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6080,18 +4522,6 @@ boards/stm32f030f4\-demo/include/periph_conf\.h:[0-9]+: warning: Member pwm_conf
 boards/stm32f030f4\-demo/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f030f4\-demo/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f030f4\-demo/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f0discovery/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/stm32f0discovery/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f0discovery/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6106,48 +4536,6 @@ boards/stm32f0discovery/include/periph_conf\.h:[0-9]+: warning: Member spi_confi
 boards/stm32f0discovery/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f0discovery/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f0discovery/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED4_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED4_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED4_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED4_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED4_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED5_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED5_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED5_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED5_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED5_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED6_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED6_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED6_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED6_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED6_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED7_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED7_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED7_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED7_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED7_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/stm32f3discovery/include/board\.h:[0-9]+: warning: Member LSM303DLHC_PARAM_MAG_PIN \(macro definition\) of file board\.h is not documented\.
 boards/stm32f3discovery/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6170,17 +4558,6 @@ boards/stm32f3discovery/include/periph_conf\.h:[0-9]+: warning: Member spi_confi
 boards/stm32f3discovery/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f3discovery/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f3discovery/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f429i\-disc1/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f429i\-disc1/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f429i\-disc1/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f429i\-disc1/include/periph_conf\.h:[0-9]+: warning: Member DMA_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6210,28 +4587,6 @@ boards/stm32f4discovery/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUIN
 boards/stm32f4discovery/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_6 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/stm32f4discovery/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_7 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/stm32f4discovery/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/stm32f4discovery/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/stm32f4discovery/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6260,26 +4615,6 @@ boards/stm32f4discovery/include/periph_conf\.h:[0-9]+: warning: Member pwm_confi
 boards/stm32f4discovery/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f4discovery/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f4discovery/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f723e\-disco/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6298,32 +4633,6 @@ boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member i2c_conf
 boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f723e\-disco/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED3_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f769i\-disco/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6331,21 +4640,6 @@ boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_0_D
 boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f769i\-disco/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member BTN0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/stm32l0538\-disco/include/board\.h:[0-9]+: warning: Member XTIMER_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/stm32l0538\-disco/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32l0538\-disco/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6356,16 +4650,6 @@ boards/stm32l0538\-disco/include/periph_conf\.h:[0-9]+: warning: Member spi_conf
 boards/stm32l0538\-disco/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32l0538\-disco/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32l0538\-disco/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
-boards/stm32l476g\-disco/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_stm32l476g\-disco is not documented\.
 boards/stm32l476g\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32l476g\-disco/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32l476g\-disco/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6381,10 +4665,6 @@ boards/stm32mp157c\-dk2/include/periph_conf\.h:[0-9]+: warning: Member UART_0_IS
 boards/stm32mp157c\-dk2/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32mp157c\-dk2/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/teensy31/include/board\.h:[0-9]+: warning: Member LED0_BIT \(macro definition\) of file board\.h is not documented\.
-boards/teensy31/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/teensy31/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/teensy31/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/teensy31/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/teensy31/include/board\.h:[0-9]+: warning: Member LED_PORT \(macro definition\) of file board\.h is not documented\.
 boards/teensy31/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/teensy31/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
@@ -6417,21 +4697,6 @@ boards/telosb/include/board\.h:[0-9]+: warning: Member CC2420_PARAM_SPI_CLK \(ma
 boards/telosb/include/board\.h:[0-9]+: warning: Member CC2420_PARAM_VREFEN \(macro definition\) of file board\.h is not documented\.
 boards/telosb/include/board\.h:[0-9]+: warning: Member F_CPU \(macro definition\) of file board\.h is not documented\.
 boards/telosb/include/board\.h:[0-9]+: warning: Member F_RC_OSCILLATOR \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/telosb/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/telosb/include/board\.h:[0-9]+: warning: Member LED_OUT_REG \(macro definition\) of file board\.h is not documented\.
 boards/telosb/include/board\.h:[0-9]+: warning: Member MSP430_HAS_DCOR \(macro definition\) of file board\.h is not documented\.
 boards/telosb/include/board\.h:[0-9]+: warning: Member MSP430_HAS_EXTERNAL_CRYSTAL \(macro definition\) of file board\.h is not documented\.
@@ -6469,8 +4734,6 @@ boards/telosb/include/periph_conf\.h:[0-9]+: warning: Member UART_RX_PIN \(macro
 boards/telosb/include/periph_conf\.h:[0-9]+: warning: Member UART_TX_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/telosb/include/periph_conf\.h:[0-9]+: warning: Member UART_TX_PIN \(macro definition\) of file periph_conf\.h is not documented\.
 boards/telosb/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/thingy52/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/thingy52/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/thingy52/include/board\.h:[0-9]+: warning: Member LIS2DH12_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/thingy52/include/board\.h:[0-9]+: warning: Member LPSXXX_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
 boards/thingy52/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
@@ -6508,21 +4771,6 @@ boards/ublox\-c030\-u201/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUI
 boards/ublox\-c030\-u201/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_A5 \(macro definition\) of file arduino_pinmap\.h is not documented\.
 boards/ublox\-c030\-u201/include/arduino_pinmap\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member GPS_RST_PIN \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
-boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
 boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member M_GPIO2_PIN \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
 boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member M_GPIO3_PIN \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
 boards/ublox\-c030\-u201/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_CLK \(macro definition\) of group boards_ublox\-c030\-u201 is not documented\.
@@ -6556,18 +4804,11 @@ boards/ublox\-c030\-u201/include/periph_conf\.h:[0-9]+: warning: Member dma_conf
 boards/ublox\-c030\-u201/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/ublox\-c030\-u201/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/ublox\-c030\-u201/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_DEV \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_FREQ \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member KINETIS_FOPT \(macro definition\) of file board\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member XTIMER_BACKOFF \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member XTIMER_CHAN \(macro definition\) of file board\.h is not documented\.
 boards/usb\-kw41z/include/board\.h:[0-9]+: warning: Member XTIMER_DEV \(macro definition\) of file board\.h is not documented\.
@@ -6653,18 +4894,6 @@ boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC
 boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_TYPE \(macro definition\) of file board\.h is not documented\.
 boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_WIDTH \(macro definition\) of file board\.h is not documented\.
 boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member CPU_ATMEGA_CLK_SCALE_INIT \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED0_ENABLE_PORT \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED1_ENABLE_PORT \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED_GREEN_OFF \(macro definition\) of file board\.h is not documented\.
 boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED_GREEN_ON \(macro definition\) of file board\.h is not documented\.
 boards/waspmote\-pro/include/board\.h:[0-9]+: warning: Member LED_GREEN_TOGGLE \(macro definition\) of file board\.h is not documented\.
@@ -6788,11 +5017,6 @@ boards/yunjia\-nrf51822/include/periph_conf\.h:[0-9]+: warning: Member i2c_confi
 boards/yunjia\-nrf51822/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/yunjia\-nrf51822/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/z1/include/board\-conf\.h:[0-9]+: warning: Member INFOMEM \(macro definition\) of file board\-conf\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member BTN0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member BTN0_PRESSED \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member BTN0_RELEASED \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member CC2420_PARAM_CCA \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member CC2420_PARAM_CS \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member CC2420_PARAM_FIFO \(macro definition\) of file board\.h is not documented\.
@@ -6804,21 +5028,6 @@ boards/z1/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SET
 boards/z1/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SLEEP \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member F_CPU \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member F_RC_OSCILLATOR \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/z1/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member LED_OUT_REG \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member MSP430_HAS_DCOR \(macro definition\) of file board\.h is not documented\.
 boards/z1/include/board\.h:[0-9]+: warning: Member MSP430_HAS_EXTERNAL_CRYSTAL \(macro definition\) of file board\.h is not documented\.
@@ -14516,40 +12725,6 @@ boards/nucleo\-g071rb/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \
 boards/nucleo\-g071rb/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nucleo\-g070rb/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-g070rb/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED3_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED0_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED1_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED2_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED3_PORT \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED3_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED3_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED3_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member LED3_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32f469i\-disco/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member LED0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/stm32g0316\-disco/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
 boards/esp32\-ethernet\-kit\-v1_0/include/periph_conf\.h:[0-9]+: warning: Member DAC_GPIOS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-g431rb/include/periph_conf\.h:[0-9]+: warning: Member PWM_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-g431rb/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
@@ -14628,23 +12803,6 @@ boards/b\-u585i\-iot02a/include/periph_conf\.h:[0-9]+: warning: Member I2C_1_ISR
 boards/b\-u585i\-iot02a/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/b\-u585i\-iot02a/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 	boards/b\-u585i\-iot02a/include/periph_conf\.h
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED1_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED1_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED1_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED1_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED2_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED2_MASK \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED2_ON \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED2_OFF \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LED2_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
 boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member HTS221_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 boards/b\-u585i\-iot02a/include/board\.h:[0-9]+: warning: Member LPSXXX_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
 	boards/b\-u585i\-iot02a/include/board\.h
@@ -14973,7 +13131,6 @@ boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member LED[0-9]_[A
 boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member SPIFFS_[_A-Z]+ \(macro definition\) of file board_common\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
-boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED[A-Z0-9_]+ \(macro definition\) of file board\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member BTN[A-Z0-9_]+ \(macro definition\) of file board\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_[A-Z]+ \(macro definition\) of file board\.h is not documented.


### PR DESCRIPTION
### Contribution description

Let boards only define the port and pin number of each LEDs. The common definitions in `stm32_leds.h` will provide `LED<x>_ON`, `LED<x>_OFF`, `LED<x>_TOGGLE`, `LED<x>_PIN`, `LED<x>_MASK` and `LED<x>_PORT`.

In addition to code de-duplication, this also makes it easier to use LEDs in GPIO LL, which can be beneficial for super low overhead debugging output - e.g. when a bug is timing sensitive and `DEBUG()` would spent to much time for stdio to reproduce a bug.

### Testing procedure

The LED macros should not change to master. Hence, the (except for debug symbols) the binaries generated should not change compared to master.

One could also test if controlling LEDs still works for all the changed boards...

### Issues/PRs references

None