### PR TITLE
cpu/stm32/periph_eth: fix typo in initialization code

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -242,7 +242,7 @@ static void _init_dma_descriptors(void)
     for (i = 0; i < ETH_TX_DESCRIPTOR_COUNT - 1; i++) {
         tx_desc[i].desc_next = &tx_desc[i + 1];
     }
-    tx_desc[ETH_RX_DESCRIPTOR_COUNT - 1].desc_next = &tx_desc[0];
+    tx_desc[ETH_TX_DESCRIPTOR_COUNT - 1].desc_next = &tx_desc[0];
 
     rx_curr = &rx_desc[0];
     tx_curr = &tx_desc[0];


### PR DESCRIPTION
### Contribution description

A single character type resulted in way fewer TX descriptors being available than allocated. Not only resulted this in wasting memory, but also when more iolist chunks than descriptors are send, the

```C
    assert(iolist_count(iolist) <= ETH_TX_DESCRIPTOR_COUNT);
```

does not trigger. As a result, old TX descriptors are being overwritten in this case.

### Testing procedure

@fabian18 has a test that reliably triggers the bug. He should be able to confirm it is gone now. But actually, it should be pretty obvious from the code that this fixes a typo.

### Issues/PRs references

None