### PR TITLE
cpu/stm32/periph_eth: optimize IRQ handler

### DIFF
--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -81,15 +81,14 @@ void isr_eth(void)
         extern netdev_t *stm32_eth_netdev;
         extern mutex_t stm32_eth_tx_completed;
         unsigned tmp = ETH->DMASR;
+        ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_TS | ETH_DMASR_RS;
 
         if ((tmp & ETH_DMASR_TS)) {
-            ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_TS;
             DEBUG("isr_eth: TX completed\n");
             mutex_unlock(&stm32_eth_tx_completed);
         }
 
         if ((tmp & ETH_DMASR_RS)) {
-            ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_RS;
             DEBUG("isr_eth: RX completed\n");
             if (stm32_eth_netdev) {
                 netdev_trigger_event_isr(stm32_eth_netdev);


### PR DESCRIPTION
### Contribution description

We can just clear both TX and RX IRQ flags in any case, as clearing a non-set flag is just a nop.

### Testing procedure

Network operation should still work as usual.

### Issues/PRs references

- [x] Includes https://github.com/RIOT-OS/RIOT/pull/18416