### PR TITLE
cpu/stm32/periph_eth: Add stm32_eth_tracing

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -16,6 +16,10 @@ ifneq (,$(filter stm32_eth_%,$(USEMODULE)))
   USEMODULE += stm32_eth
 endif
 
+ifneq (,$(filter stm32_eth_tracing,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_ll
+endif
+
 ifneq (,$(filter stm32_eth_auto,$(USEMODULE)))
   USEMODULE += stm32_eth_link_up
 endif

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -21,15 +21,48 @@
  */
 #include <string.h>
 
+#include "board.h"
 #include "mutex.h"
 #include "net/netdev/eth.h"
 #include "periph/gpio.h"
+#include "periph/gpio_ll.h"
 #include "periph/ptp.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+
+/**
+ * @name    GPIOs to use for tracing STM32 Ethernet state via module
+ *          `stm32_eth_tracing`
+ * @{
+ */
+#ifndef STM32_ETH_TRACING_IRQ_PIN_NUM
+#  if defined(LED0_PIN_NUM) || defined(DOXYGEN)
+/**
+ * @brief   pin to trace IRQs
+ *
+ * This GPIO pin will be toggled every time the Ethernet ISR is executed
+ * (upon entry of the ISR).
+ */
+#    define STM32_ETH_TRACING_IRQ_PIN_NUM LED0_PIN_NUM
+#  else
+#    define STM32_ETH_TRACING_IRQ_PIN_NUM 0
+#  endif
+#endif
+
+#ifndef STM32_ETH_TRACING_IRQ_PORT_NUM
+#  if defined(LED0_PORT_NUM) || defined(DOXYGEN)
+/**
+ * @brief   port to trace IRQs
+ */
+#    define STM32_ETH_TRACING_IRQ_PORT_NUM LED0_PORT_NUM
+#  else
+#    define STM32_ETH_TRACING_IRQ_PORT_NUM 0
+#  endif
+#endif
+/** @} */
 
 void stm32_eth_common_init(void)
 {
@@ -59,6 +92,12 @@ void stm32_eth_common_init(void)
     ETH->DMABMR |= ETH_DMABMR_SR;
     while (ETH->DMABMR & ETH_DMABMR_SR) {}
 
+    if (IS_USED(MODULE_STM32_ETH_TRACING)) {
+        gpio_ll_init(GPIO_PORT(STM32_ETH_TRACING_IRQ_PORT_NUM),
+                     STM32_ETH_TRACING_IRQ_PIN_NUM,
+                     &gpio_ll_out);
+    }
+
     if (IS_USED(MODULE_PERIPH_ETH) || IS_USED(MODULE_PERIPH_PTP_TIMER)) {
         NVIC_EnableIRQ(ETH_IRQn);
     }
@@ -68,6 +107,10 @@ void stm32_eth_common_init(void)
 void isr_eth(void)
 {
     DEBUG("[periph_eth_common] isr_eth()\n");
+    if (IS_USED(MODULE_STM32_ETH_TRACING)) {
+        gpio_ll_toggle(GPIO_PORT(STM32_ETH_TRACING_IRQ_PORT_NUM),
+                       (1U << STM32_ETH_TRACING_IRQ_PIN_NUM));
+    }
 
     if (IS_USED(MODULE_PERIPH_PTP_TIMER)) {
         if (ETH->MACSR & ETH_MACSR_TSTS) {

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -82,6 +82,7 @@ void isr_eth(void)
         extern mutex_t stm32_eth_tx_completed;
         unsigned tmp = ETH->DMASR;
         ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_TS | ETH_DMASR_RS;
+        DEBUG("[periph_eth_common] DMASR = 0x%x\n", tmp);
 
         if ((tmp & ETH_DMASR_TS)) {
             DEBUG("isr_eth: TX completed\n");

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -236,6 +236,7 @@ PSEUDOMODULES += stdio_telnet
 PSEUDOMODULES += stm32_eth
 PSEUDOMODULES += stm32_eth_auto
 PSEUDOMODULES += stm32_eth_link_up
+PSEUDOMODULES += stm32_eth_tracing
 PSEUDOMODULES += stm32mp1_eng_mode
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%


### PR DESCRIPTION
### Contribution description

This PR improves debugging of the peripheral STM32 Ethernet driver. It was used to debug the issue fixed in https://github.com/RIOT-OS/RIOT/pull/18416

It does two things:
- sprinkle a bit more and more verbose `DEBUG()` output over the code
- introduce the module `stm32_eth_tracing` that allows tracing and debugging the STM32 state
     - it uses GPIO LL for low overhead to be useful when `DEBUG()` impacts performance to much
     - one GPIO is toggled for each ISR entry
     - one GPIO is set on TX start and cleared on TX done
     - one GPIO is set on RX completed and cleared when the frame is passed up the network stack
     - by default, LEDs are used to allow seeing where the state machine is stuck without a scope or logic analyzer

### Testing procedure

On an STM32 board with Ethernet and at least three LEDs, e.g. the Nucleo-F767ZI, run

```
USEMODULE=stm32_eth_tracing BOARD=nucleo-f767zi` -C examples/gnrc_networking flash term
```
For each IRQ LED0 should be toggled, LED1 should flash on TX briefly, and LED2 should flash on RX briefly. (LED1 and LED2 are flashed so fast that it is a bit tricky to see, but quite possible for the human eye when the room is a bit darker.

### Issues/PRs references

Depends on and includes:

- [x] https://github.com/RIOT-OS/RIOT/pull/18416
- [x] https://github.com/RIOT-OS/RIOT/pull/18417
- [x] https://github.com/RIOT-OS/RIOT/pull/18415