### PR TITLE
cpu/esp32: add support for ESP32-S3

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -37,6 +37,7 @@ esp32-heltec-lora32-v2
 esp32-olimex-evb
 esp32c3-ci
 esp32c3-devkit
+esp32s3-devkit
 esp8266-ci
 esp8266-esp-12x
 hamilton

--- a/boards/common/esp32s3/Kconfig
+++ b/boards/common/esp32s3/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ESP32S3
+    bool
+    select HAS_PERIPH_UART
+    select HAVE_SAUL_GPIO
+
+config MODULE_BOARDS_COMMON_ESP32S3
+    bool
+    depends on TEST_KCONFIG
+    depends on BOARD_COMMON_ESP32S3
+    depends on HAS_ARCH_ESP32
+    default y
+    help
+      Common ESP32-S3 boards code.

--- a/boards/common/esp32s3/Makefile
+++ b/boards/common/esp32s3/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_esp32s3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32s3/Makefile.dep
+++ b/boards/common/esp32s3/Makefile.dep
@@ -1,0 +1,5 @@
+USEMODULE += boards_common_esp32s3
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/common/esp32s3/Makefile.features
+++ b/boards/common/esp32s3/Makefile.features
@@ -1,0 +1,5 @@
+CPU = esp32
+CPU_FAM = esp32s3
+
+# additional features provided by all boards is at least one UART
+FEATURES_PROVIDED += periph_uart

--- a/boards/common/esp32s3/Makefile.include
+++ b/boards/common/esp32s3/Makefile.include
@@ -1,0 +1,5 @@
+INCLUDES += -I$(RIOTBOARD)/common/esp32s3/include
+
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/esp32s3/board_common.c
+++ b/boards/common/esp32s3/board_common.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32s3
+ * @{
+ *
+ * @file
+ * @brief       Common declarations and functions for all ESP32-S3 boards.
+ *
+ * This file contains default declarations and functions that are valid
+ * for all ESP32-S3 boards.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+#include "esp_common.h"
+#include "kernel_defines.h"
+#include "log.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void adc_print_config(void);
+extern void dac_print_config(void);
+extern void pwm_print_config(void);
+extern void i2c_print_config(void);
+extern void spi_print_config(void);
+extern void uart_print_config(void);
+extern void can_print_config(void);
+
+void print_board_config(void)
+{
+    ets_printf("\nBoard configuration:\n");
+
+#if IS_USED(MODULE_PERIPH_ADC)
+    adc_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_DAC)
+    dac_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_PWM)
+    pwm_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_I2C)
+    i2c_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_SPI)
+    spi_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_UART)
+    uart_print_config();
+#endif
+
+#if IS_USED(MODULE_PERIPH_CAN)
+    can_print_config();
+#endif
+
+    ets_printf("\tLED\t\tpins=[ ");
+#ifdef LED0_PIN
+    ets_printf("%d ", LED0_PIN);
+#endif
+#ifdef LED1_PIN
+    ets_printf("%d ", LED1_PIN);
+#endif
+#ifdef LED2_PIN
+    ets_printf("%d ", LED2_PIN);
+#endif
+    ets_printf("]\n");
+
+    ets_printf("\tBUTTONS\t\tpins=[ ");
+#ifdef BUTTON0_PIN
+    ets_printf("%d ", BUTTON0_PIN);
+#endif
+#ifdef BUTTON2_PIN
+    ets_printf("%d ", BUTTON1_PIN);
+#endif
+#ifdef BUTTON3_PIN
+    ets_printf("%d ", BUTTON2_PIN);
+#endif
+    ets_printf("]\n");
+
+    ets_printf("\n");
+}
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/common/esp32s3/doc.txt
+++ b/boards/common/esp32s3/doc.txt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_common_esp32s3  ESP32-S3 Common
+ * @ingroup     boards_common
+ * @ingroup     boards_esp32s3
+ * @brief       Definitions and configurations that are common for
+ *              all ESP32-S3 boards.
+ *
+ * For detailed information about the ESP32-S3, configuring and compiling RIOT
+ * for ESP32-S3 boards, please refer \ref esp32_riot.
+ */
+
+/**
+ * @defgroup    boards_esp32s3  ESP32-S3 Boards
+ * @ingroup     boards
+ * @brief       This group of boards contains the documentation of ESP32-S3 boards.
+ *
+ * @note        For detailed information about the ESP32-S3 SoC, the tool chain
+ *              as well as configuring and compiling RIOT for ESP32-S3 boards,
+ *              see \ref esp32_riot.
+ */

--- a/boards/common/esp32s3/include/arduino_board_common.h
+++ b/boards/common/esp32s3/include/arduino_board_common.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32s3
+ * @{
+ *
+ * @file
+ * @brief       Common board definitions for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_COMMON_H
+#define ARDUINO_BOARD_COMMON_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_COMMON_H */
+/** @} */

--- a/boards/common/esp32s3/include/board_common.h
+++ b/boards/common/esp32s3/include/board_common.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32s3
+ * @brief       Common board definitions for ESP32-S3 boards.
+ *
+ * This file contains board configurations that are valid for all
+ * ESP32-S3 boards.
+ *
+ * For detailed information about the configuration of ESP32-S3 boards, see
+ * section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+#if MODULE_ARDUINO
+#include "arduino_pinmap.h"
+#endif
+
+#include "periph/gpio.h"
+#include "sdkconfig.h"
+
+#if MODULE_MTD
+#include "mtd.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   LED configuration (three predefined LEDs at maximum)
+ *
+ * @note LEDx_ACTIVE value must be declared in board configuration.
+ * @{
+ */
+#if defined(LED0_PIN) || DOXYGEN
+#define LED0_MASK       (BIT(LED0_PIN))
+#define LED0_ON         (gpio_write(LED0_PIN,  LED0_ACTIVE))
+#define LED0_OFF        (gpio_write(LED0_PIN, !LED0_ACTIVE))
+#define LED0_TOGGLE     (gpio_toggle(LED0_PIN))
+#endif
+
+#if defined(LED1_PIN) || DOXYGEN
+#define LED1_MASK       (BIT(LED1_PIN))
+#define LED1_ON         (gpio_write(LED1_PIN,  LED1_ACTIVE))
+#define LED1_OFF        (gpio_write(LED1_PIN, !LED1_ACTIVE))
+#define LED1_TOGGLE     (gpio_toggle(LED1_PIN))
+#endif
+
+#if defined(LED2_PIN) || DOXYGEN
+#define LED2_MASK       (BIT(LED2_PIN))
+#define LED2_ON         (gpio_write(LED2_PIN,  LED2_ACTIVE))
+#define LED2_OFF        (gpio_write(LED2_PIN, !LED2_ACTIVE))
+#define LED2_TOGGLE     (gpio_toggle(LED2_PIN))
+#endif
+/** @} */
+
+/**
+ * @name    STDIO configuration
+ * @{
+ */
+/**< Default baudrate of UART for stdio */
+#ifndef STDIO_UART_BAUDRATE
+#define STDIO_UART_BAUDRATE      (115200)
+#endif
+/** @} */
+
+#if MODULE_MTD || DOXYGEN
+/**
+ * @name    MTD system drive configuration
+ *
+ * Built-in SPI flash memory is used as MTD system drive.
+ * @{
+ */
+
+/**
+ * @brief   MTD drive start address in SPI flash memory
+ *
+ * Defines the start address of the MTD system device in the SPI
+ * flash memory. It can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration"
+ *
+ * If the MTD start address is not defined or is 0, the first possible
+ * multiple of 0x100000 (1 MByte) is used in free SPI flash memory,
+ * which was determined from the partition table.
+ */
+#ifndef SPI_FLASH_DRIVE_START
+#define SPI_FLASH_DRIVE_START  0
+#endif
+
+/** Default MTD drive definition */
+#define MTD_0 mtd0
+
+/** Pointer to the default MTD drive structure */
+extern mtd_dev_t *mtd0;
+
+/** @} */
+#endif /* MODULE_MTD || DOXYGEN */
+
+/**
+  * @brief Print the board configuration in a human readable format
+  */
+void print_board_config(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_COMMON_H */
+/** @} */

--- a/boards/common/esp32s3/include/periph_conf_common.h
+++ b/boards/common/esp32s3/include/periph_conf_common.h
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32s3
+ * @brief       Common peripheral configurations for ESP32-S3 boards
+ *
+ * This file contains the peripheral configurations that are valid for all
+ * ESP32-S3 boards.
+ *
+ * For detailed information about the peripheral configuration for ESP32-S3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef PERIPH_CONF_COMMON_H
+#define PERIPH_CONF_COMMON_H
+
+/* include periph_cpu.h to make it visible in any case */
+#include "periph_cpu.h"
+#include "kernel_defines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * ADC_GPIOS is defined in board-specific peripheral configuration. Since
+ * ADC_GPIOS must be defined even if there are no ADC channels, an empty
+ * list definition is done here as fallback configuration.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { }
+#endif
+
+/**
+ * @brief   Static array with declared ADC channels
+ */
+static const gpio_t adc_channels[] = ADC_GPIOS;
+
+/**
+ * @brief Number of GPIOs declared as ADC channels
+ *
+ * The number of GPIOs that are declared as ADC channels is determined from
+ * the ADC_GPIOS definition.
+ *
+ * @note ADC_NUMOF definition must not be changed.
+ */
+#define ADC_NUMOF   ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name    DAC configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * DAC_GPIOS is defined in board-specific peripheral configuration. Since
+ * DAC_GPIOS must be defined even if there are no DAC channels, an empty
+ * list definition is done here as fallback configuration.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { }
+#endif
+
+/**
+ * @brief   Static array with declared DAC channels
+ */
+static const gpio_t dac_channels[] = DAC_GPIOS;
+
+/**
+ * @brief Number of GPIOs declared as DAC channels
+ *
+ * The number of GPIOs that are declared as DAC channels is determined from
+ * the DAC_GPIOS definition.
+ *
+ * @note DAC_NUMOF definition must not be changed.
+ */
+#define DAC_NUMOF   ARRAY_SIZE(dac_channels)
+/** @} */
+
+/**
+ * @name   I2C configuration
+ * @{
+ */
+
+#if defined(I2C0_SCL) && !defined(I2C0_SCL_PULLUP)
+/** Define SCL pullup enabled by default */
+#define I2C0_SCL_PULLUP true
+#endif
+#if defined(I2C0_SDA) && !defined(I2C0_SDA_PULLUP)
+/** Define SDA pullup enabled by default */
+#define I2C0_SDA_PULLUP true
+#endif
+
+#if defined(I2C1_SCL) && !defined(I2C1_SCL_PULLUP)
+/** Define SCL pullup enabled by default */
+#define I2C1_SCL_PULLUP true
+#endif
+#if defined(I2C1_SDA) && !defined(I2C1_SDA_PULLUP)
+/** Define SDA pullup enabled by default */
+#define I2C1_SDA_PULLUP true
+#endif
+
+/**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const i2c_conf_t i2c_config[] = {
+#if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
+    {
+        .module = PERIPH_I2C0_MODULE,
+        .speed = I2C0_SPEED,
+        .scl = I2C0_SCL,
+        .sda = I2C0_SDA,
+        .scl_pullup = I2C0_SCL_PULLUP,
+        .sda_pullup = I2C0_SCL_PULLUP,
+    },
+#endif
+#if defined(I2C1_SCL) && defined(I2C1_SDA) && defined(I2C1_SPEED)
+    {
+        .module = PERIPH_I2C1_MODULE,
+        .speed = I2C1_SPEED,
+        .scl = I2C1_SCL,
+        .sda = I2C1_SDA,
+        .scl_pullup = I2C1_SCL_PULLUP,
+        .sda_pullup = I2C1_SCL_PULLUP,
+    },
+#endif
+};
+
+/**
+ * @brief Number of I2C interfaces
+ *
+ * The number of I2C interfaces is determined from board-specific peripheral
+ * definitions of I2Cn_SPEED, I2Cn_SCK, and I2Cn_SDA.
+ *
+ * @note I2C_NUMOF definition must not be changed.
+ */
+#define I2C_NUMOF   ARRAY_SIZE(i2c_config)
+
+/** @} */
+
+/**
+ * @name   PWM configuration
+ * @{
+ */
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM0_GPIOS
+static const gpio_t pwm0_gpios[] = PWM0_GPIOS;
+#endif
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM1_GPIOS
+static const gpio_t pwm1_gpios[] = PWM1_GPIOS;
+#endif
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM2_GPIOS
+static const gpio_t pwm2_gpios[] = PWM2_GPIOS;
+#endif
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM3_GPIOS
+static const gpio_t pwm3_gpios[] = PWM3_GPIOS;
+#endif
+
+/**
+ * @brief   PWM device configuration based on defined PWM channel GPIOs
+ */
+static const pwm_config_t pwm_config[] =
+{
+#ifdef PWM0_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+        .group = LEDC_LOW_SPEED_MODE,
+        .timer = LEDC_TIMER_0,
+        .ch_numof = ARRAY_SIZE(pwm0_gpios),
+        .gpios = pwm0_gpios,
+    },
+#endif
+#ifdef PWM1_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+#ifdef SOC_LEDC_SUPPORT_HS_MODE
+        .group = LEDC_HIGH_SPEED_MODE,
+#else
+        .group = LEDC_LOW_SPEED_MODE,
+#endif
+        .timer = LEDC_TIMER_1,
+        .ch_numof = ARRAY_SIZE(pwm1_gpios),
+        .gpios = pwm1_gpios,
+    },
+#endif
+#ifdef PWM2_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+        .group = LEDC_LOW_SPEED_MODE,
+        .timer = LEDC_TIMER_2,
+        .ch_numof = ARRAY_SIZE(pwm2_gpios),
+        .gpios = pwm2_gpios,
+    },
+#endif
+#ifdef PWM3_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+#ifdef SOC_LEDC_SUPPORT_HS_MODE
+        .group = LEDC_HIGH_SPEED_MODE,
+#else
+        .group = LEDC_LOW_SPEED_MODE,
+#endif
+        .timer = LEDC_TIMER_3,
+        .ch_numof = ARRAY_SIZE(pwm3_gpios),
+        .gpios = pwm3_gpios,
+    },
+#endif
+};
+
+/**
+ * @brief   Number of PWM devices
+ *
+ * The number of PWM devices is determined from the PWM device configuration.
+ *
+ * @note PWM_NUMOF definition must not be changed.
+ */
+#define PWM_NUMOF   ARRAY_SIZE(pwm_config)
+
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+
+/**
+ * @brief   Static array with configuration for declared SPI devices
+ */
+static const spi_conf_t spi_config[] = {
+#ifdef SPI0_CTRL
+    {
+        .ctrl = SPI0_CTRL,
+        .sck = SPI0_SCK,
+        .mosi = SPI0_MOSI,
+        .miso = SPI0_MISO,
+        .cs = SPI0_CS0,
+    },
+#endif
+#ifdef SPI1_CTRL
+    {
+        .ctrl = SPI1_CTRL,
+        .sck = SPI1_SCK,
+        .mosi = SPI1_MOSI,
+        .miso = SPI1_MISO,
+        .cs = SPI1_CS0,
+    },
+#endif
+};
+
+/**
+ * @brief Number of SPI interfaces
+ *
+ * The number of SPI interfaces is determined from board-specific peripheral
+ * definitions of SPIn_*.
+ *
+ * @note SPI_NUMOF definition must not be changed.
+ */
+#define SPI_NUMOF   ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+
+#ifndef UART0_TXD
+#define UART0_TXD   (GPIO43)  /**< TxD of UART_DEV(0) used on all ESP32-S3 boards */
+#endif
+#ifndef UART0_RXD
+#define UART0_RXD   (GPIO44)  /**< RxD of UART_DEV(0) used on all ESP32-S3 boards */
+#endif
+
+/**
+ * @brief   Static array with configuration for declared UART devices
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .txd = UART0_TXD,
+        .rxd = UART0_RXD,
+    },
+#if defined(UART1_TXD) && defined(UART1_RXD)
+    {
+        .txd = UART1_TXD,
+        .rxd = UART1_RXD,
+    },
+#endif
+#if defined(UART2_TXD) && defined(UART2_RXD)
+    {
+        .txd = UART2_TXD,
+        .rxd = UART2_RXD,
+    },
+#endif
+};
+
+/**
+ * @brief Number of UART interfaces
+ *
+ * The number of UART interfaces is determined from board-specific peripheral
+ * definitions of UARTn_*.
+ *
+ * @note UART_NUMOF definition must not be changed.
+ */
+#define UART_NUMOF  ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* PERIPH_CONF_COMMON_H */
+/** @} */

--- a/boards/esp32s3-devkit/Kconfig
+++ b/boards/esp32s3-devkit/Kconfig
@@ -1,0 +1,73 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32s3-devkit" if BOARD_ESP32S3_DEVKIT
+
+config BOARD_VERSION
+    string
+    default "esp32s3-devkitc-1-n8" if BOARD_VERSION_ESP32S3_DEVKITC_1_N8
+    default "esp32s3-devkitc-1-n8r2" if BOARD_VERSION_ESP32S3_DEVKITC_1_N8R2
+    default "esp32s3-devkitc-1-n8r8" if BOARD_VERSION_ESP32S3_DEVKITC_1_N8R8
+    default "esp32s3-devkitc-1-n16r8v" if BOARD_VERSION_ESP32S3_DEVKITC_1_N16R8V
+    default "esp32s3-devkitc-1-n32r8v" if BOARD_VERSION_ESP32S3_DEVKITC_1_N32R8V
+    default "esp32s3-devkitc-1u-n8" if BOARD_VERSION_ESP32S3_DEVKITC_1U_N8
+    default "esp32s3-devkitc-1u-n8r2" if BOARD_VERSION_ESP32S3_DEVKITC_1U_N8R2
+    default "esp32s3-devkitc-1u-n8r8" if BOARD_VERSION_ESP32S3_DEVKITC_1U_N8R8
+    default "esp32s3-devkitm-1-n8" if BOARD_VERSION_ESP32S3_DEVKITM_1_N8
+    default "esp32s3-devkitm-1u-n8" if BOARD_VERSION_ESP32S3_DEVKITM_1U_N8
+    help
+        Set variable BOARD_VERSION for the make system.
+
+config BOARD_ESP32S3_DEVKIT
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8 if BOARD_VERSION_ESP32S3_DEVKITC_1_N8
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8R2 if BOARD_VERSION_ESP32S3_DEVKITC_1_N8R2
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8R8 if BOARD_VERSION_ESP32S3_DEVKITC_1_N8R8
+    select CPU_MODEL_ESP32S3_WROOM_1X_N16R8V if BOARD_VERSION_ESP32S3_DEVKITC_1_N16R8V
+    select CPU_MODEL_ESP32S3_WROOM_1X_N32R8V if BOARD_VERSION_ESP32S3_DEVKITC_1_N32R8V
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8 if BOARD_VERSION_ESP32S3_DEVKITC_1U_N8
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8R2 if BOARD_VERSION_ESP32S3_DEVKITC_1U_N8R2
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8R8 if BOARD_VERSION_ESP32S3_DEVKITC_1U_N8R8
+    select CPU_MODEL_ESP32S3_MINI_1X_N8 if BOARD_VERSION_ESP32S3_DEVKITM_1_N8
+    select CPU_MODEL_ESP32S3_MINI_1X_N8 if BOARD_VERSION_ESP32S3_DEVKITM_1U_N8
+    select HAS_ARDUINO
+    select HAS_ESP_JTAG
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+
+    choice
+        bool "ESP32-S3-DevKit board version"
+        default BOARD_VERSION_ESP32S3_DEVKITC_1_N8
+
+        config BOARD_VERSION_ESP32S3_DEVKITC_1_N8
+            bool "ESP32-S3-DevKitC-1-N8"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1_N8R2
+            bool "ESP32-S3-DevKitC-1-N8R2"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1_N8R8
+            bool "ESP32-S3-DevKitC-1-N8R8"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1_N16R8V
+            bool "ESP32-S3-DevKitC-1-N16R8V"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1_N32R8V
+            bool "ESP32-S3-DevKitC-1-N32R8V"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1U_N8
+            bool "ESP32-S3-DevKitC-1U-N8"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1U_N8R2
+            bool "ESP32-S3-DevKitC-1U-N8R2"
+        config BOARD_VERSION_ESP32S3_DEVKITC_1U_N8R8
+            bool "ESP32-S3-DevKitC-1U-N8R8"
+        config BOARD_VERSION_ESP32S3_DEVKITM_1_N8
+            bool "ESP32-S3-DevKitM-1-N8"
+        config BOARD_VERSION_ESP32S3_DEVKITM_1U_N8
+            bool "ESP32-S3-DevKitM-1U-N8"
+    endchoice
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/esp32s3-devkit/Makefile
+++ b/boards/esp32s3-devkit/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32s3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-devkit/Makefile.dep
+++ b/boards/esp32s3-devkit/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep

--- a/boards/esp32s3-devkit/Makefile.features
+++ b/boards/esp32s3-devkit/Makefile.features
@@ -1,0 +1,42 @@
+# default board version if not defined
+ifeq (,$(BOARD_VERSION))
+  BOARD_VERSION = esp32s3-devkitc-1-n8
+endif
+
+ifeq (esp32s3-devkitc-1-n8,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_1x_n8
+else ifeq (esp32s3-devkitc-1-n8r2,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_1x_n8r2
+else ifeq (esp32s3-devkitc-1-n8r8,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_1x_n8r8
+else ifeq (esp32s3-devkitc-1-n16r8v,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_2_n16r8v
+else ifeq (esp32s3-devkitc-1-n32r8v,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_2_n32r8v
+else ifeq (esp32s3-devkitc-1u-n8,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_1x_n8
+else ifeq (esp32s3-devkitc-1u-n8r2,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_1x_n8r2
+else ifeq (esp32s3-devkitc-1u-n8r8,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_wroom_1x_n8r8
+else ifeq (esp32s3-devkitm-1-n8,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_mini_1x_n8
+else ifeq (esp32s3-devkitm-1u-n8,$(BOARD_VERSION))
+  CPU_MODEL = esp32s3_mini_1x_n8
+else
+  $(error BOARD_VERSION is unknown)
+endif
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_jtag
+
+FEATURES_PROVIDED += arduino

--- a/boards/esp32s3-devkit/Makefile.include
+++ b/boards/esp32s3-devkit/Makefile.include
@@ -1,0 +1,12 @@
+PSEUDOMODULES += esp32s3_devkitc_1_n8
+PSEUDOMODULES += esp32s3_devkitc_1_n8r2
+PSEUDOMODULES += esp32s3_devkitc_1_n8r8
+PSEUDOMODULES += esp32s3_devkitc_1_n16r8v
+PSEUDOMODULES += esp32s3_devkitc_1_n32r8v
+PSEUDOMODULES += esp32s3_devkitc_1u_n8
+PSEUDOMODULES += esp32s3_devkitc_1u_n8r2
+PSEUDOMODULES += esp32s3_devkitc_1u_n8r8
+PSEUDOMODULES += esp32s3_devkitm_1_n8r8
+PSEUDOMODULES += esp32s3_devkitm_1u_n8r8
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/esp32s3-devkit/doc.txt
+++ b/boards/esp32s3-devkit/doc.txt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32s3_devkit ESP32-S3-DevKit Board
+ * @ingroup     boards_esp32s3
+ * @brief       Support for generic ESP32S3 boards
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32s3_devkit ESP32-S3-DevKit
+
+## Table of Contents {#esp32s3_devkit_toc}
+
+1. [Overview](#esp32s3_devkit_overview)
+2. [Hardware](#esp32s3_devkit_hardware)
+    1. [MCU](#esp32s3_devkit_mcu)
+    2. [Board Configuration](#esp32s3_devkit_board_configuration)
+    3. [Board Pinout](#esp32s3_devkit_pinout)
+3. [Flashing the Device](#esp32s3_devkit_flashing)
+
+## Overview {#esp32s3_devkit_overview}
+
+The Espressif ESP32-S3-DevKit boards are a couple of boards that use one of
+the following modules:
+
+- ESP32-S3-MINI-1x module (ESP32-S3-DevKitM-1 board)
+- ESP32-S3-WROOM-1x module (ESP32-S3-DevKitC-1 board)
+- ESP32-S3-WROOM-2 module (ESP32-S3-DevKitC-1 board)
+
+\image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/_images/ESP32-S3-DevKitC-1_v2-annotated-photo.png" "Espressif ESP32-S3-DevKitM-1" width=600px
+
+<br>
+Due to the different modules used, the available versions of the
+ESP32-S3-DevKit board differ regarding the Flash size, the integrated SPI RAM
+and the SPI voltage. To be able to use all these different versions of the
+board with a single board definition, used board version can be specified
+by the variable `BOARD_VERSION` during compilation, for example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s3-devkit BOARD_VERSION=esp32s3-devkitc-1-n8 make ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following table shows the available board versions, the size of the
+Flash and the SPI RAM as well as the value of the variable `BOARD_VERSION`
+that is used to specify the board version.
+
+<center>
+| Board Version             | Flash (Mode)  | SPI RAM (Mode) | `BOARD_VERSION`
+|:--------------------------|:--------------|:---------------|:-------------------
+| <b>ESP32-S3-DevKitC-1-N8  | 8 MB (Quad)   | -              | `esp32s3-devkitc-1-n8` (default)</b>
+| ESP32-S3-DevKitC-1-N8R2   | 8 MB (Quad)   | 2 MB (Quad)    | `esp32s3-devkitc-1-n8r2`
+| ESP32-S3-DevKitC-1-N8R8   | 8 MB (Quad)   | 8 MB (Octal)   | `esp32s3-devkitc-1-n8r8`
+| ESP32-S3-DevKitC-1-N16R8V | 16 MB (Octal) | 8 MB (Octal)   | `esp32s3-devkitc-1-n16r8v`
+| ESP32-S3-DevKitC-1-N32R8V | 32 MB (Octal) | 8 MB (Octal)   | `esp32s3-devkitc-1-n32r8v`
+| ESP32-S3-DevKitC-1U-N8    | 8 MB (Quad)   | -              | `esp32s3-devkitc-1u-n8`
+| ESP32-S3-DevKitC-1U-N8R2  | 8 MB (Quad)   | 2 MB (Quad)    | `esp32s3-devkitc-1u-n8r2`
+| ESP32-S3-DevKitC-1U-N8R8  | 8 MB (Quad)   | 8 MB (Octal)   | `esp32s3-devkitc-1u-n8r8`
+| ESP32-S3-DevKitM-1-N8     | 8 MB (Quad)   | -              | `esp32s3-devkitm-1-n8`
+| ESP32-S3-DevKitM-1U-N8    | 8 MB (Quad)   | -              | `esp32s3-devkitm-1u-n8`
+</center>
+<br>
+
+@note
+- If the board version is not specified, <b>ESP32-S3-DevKitC-1-N8 with 8 MByte
+  Flash</b> is assumed and `BOARD_VERSION` is set to <b>`esp32s3-devkitc-1-n8`</b>
+  by default.
+- Using a board version with embedded SPI RAM (`BOARD_VERSION` is any of
+  <b>`esp32s3-devkitx-1x-*r*`</b> values) enables the
+  \ref esp32_spi_ram "esp_spi_ram" feature. The SPI RAM can then be used as
+  heap by enabling the \ref esp32_spi_ram "esp_spi_ram" pseudomodule.
+- Depending on the specified board version, one of the following modes is used
+  for the SPI RAM:
+  - **Quad SPI mode**: If `BOARD_VERSION` is one of the values
+    <b>`esp32s3_devkitx-1x-*r2`</b>, the Quad SPI mode is used. In this mode,
+    **GPIO26 ... GPIO32** are occupied and are not available for other purposes.
+  - **Octal SPI mode**: If `BOARD_VERSION` is one of the values
+    <b>`esp32s3_devkitx-1x-*r8x`</b>, the Octal-SPI mode is used and the
+    feature \ref esp32_spi_ram "esp_spi_oct" is additionally enabled. If
+    then the SPI RAM is activated by using the pseudomodule \ref esp32_spi_ram
+    "esp_spi_ram", **GPIO33 ... GPIO37** are occupied and are not available
+    for other purposes. Conflicts may then occur when using these GPIOs.
+
+[Back to table of contents](#esp32s3_devkit_toc)
+
+## Hardware {#esp32s3_devkit_hardware}
+
+This section describes
+
+- the [MCU](#esp32s3_devkit_mcu),
+- the default [board configuration](#esp32s3_devkit_board_configuration),
+- [optional hardware configurations](#esp32s3_devkit_optional_hardware),
+- the [board pinout](#esp32s3_devkit_pinout).
+
+[Back to table of contents](#esp32s3_devkit_toc)
+
+### MCU {#esp32s3_devkit_mcu}
+
+Most features of the board are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32s3_devkit_toc)
+
+### Board Configuration {#esp32s3_devkit_board_configuration}
+
+ESP32-S3-DevKit boards have no special hardware on board with the exception
+of a single pin RGB-LED that uses a special bit-oriented protocol to
+control the RGB-LED by 24-bit RGB values which is not supported yet.
+
+All GPIOs are simply broken out for flexibility. Therefore, the board
+configuration is the most flexible one which provides:
+
+- 20 x ADC channels at maximum
+- 2 x SPI
+- 1 x I2C
+- 2 x UART
+- 1 RGB-LED
+
+Since almost GPIOs have broken out, GPIOs can be used for different purposes
+in different applications. Following GPIOs are not broken out:
+
+- ESP32-S3-DevKitC-1x: GPIO26..GPIO34
+- ESP32-S3-DevKitM-1x: GPIO27..GPIO32
+
+For flexibility, GPIOs can be used in multiple peripheral configurations,
+but they can only be used for one peripheral at a time. For example, GPIO9
+is used in the ADC channel definition and the definition of the SCL signal
+for I2C_DEV(0).
+
+This is possible because GPIOs are only used for a specific peripheral
+interface when either
+
+- the corresponding peripheral module is used, e.g. `periph_i2c`, or
+- the corresponding init function is called, e.g. `adc_init`.
+
+That is, the purpose for which a GPIO is used depends on which module
+or function is used first.
+
+For example, if module `periph_i2c` is not used, the GPIOs listed in I2C
+configuration can be used for the other purposes, that is, GPIO9 can be
+used as ADC channel.
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks | Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO0  | | |
+ADC_LINE(n)     | GPIO1, GPIO2, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO9 | | \ref esp32_adc_channels "ADC Channels"
+PWM_DEV(0)      | GPIO14, GPIO17, GPIO18, GPIO21 | - | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1)      | GPIO15, GPIO16 | if module `esp_rtc_timer_32k` is not used | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0) SCL  | GPIO9  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0) SDA  | GPIO8  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0) CLK  | GPIO12 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MISO | GPIO13 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MOSI | GPIO11 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) CS0  | GPIO10 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0) TxD | GPIO43 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0) RxD | GPIO44 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+\n
+
+For detailed information about the peripheral configurations of ESP32-S3
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32s3_devkit_toc)
+
+### Board Pinout {#esp32s3_devkit_pinout}
+
+The following figures show the pinouts as configured by default board
+definition.
+
+@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/_images/ESP32-S3_DevKitC-1_pinlayout.jpg "ESP32-S3-DevKitC-1 Pinout" width=900px
+@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/_images/ESP32-S3_DevKitM-1_pinlayout.jpg "ESP32-S3-DevKitM-1 Pinout" width=900px
+
+The corresponding board schematics can be found:
+
+- [ESP32-S3-DevKitC-1](https://dl.espressif.com/dl/SCH_ESP32-S3-DEVKITC-1_V1_20210312C.pdf)
+- [ESP32-S3-DevKitM-1](https://dl.espressif.com/dl/schematics/SCH_ESP32-S3-DEVKITM-1_V1_20210310A.pdf)
+
+[Back to table of contents](#esp32s3_devkit_toc)
+
+## Flashing the Device {#esp32s3_devkit_flashing}
+
+Flashing RIOT is quite easy. The board has a Micro-USB connector with
+reset/boot/flash logic. Just connect the board to your host computer
+and type using the programming port:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s3-devkit make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For detailed information about ESP32-S3 as well as configuring and compiling
+RIOT for ESP32-S3 boards, see \ref esp32_riot.
+
+[Back to table of contents](#esp32s3_devkit_toc)
+ */

--- a/boards/esp32s3-devkit/include/arduino_board.h
+++ b/boards/esp32s3-devkit/include/arduino_board.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_devkit
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is not available
+ */
+#define ARDUINO_LED         (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/esp32s3-devkit/include/arduino_pinmap.h
+++ b/boards/esp32s3-devkit/include/arduino_pinmap.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_devkit
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO44      /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO43      /**< Arduino Uno pin 1 (TxD) */
+#define ARDUINO_PIN_2   GPIO0       /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO14      /**< Arduino Uno pin 3 (PWM) */
+#define ARDUINO_PIN_4   GPIO3       /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO17      /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO18      /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO6       /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO7       /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO21      /**< Arduino Uno pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO10      /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO11      /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO13      /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO12      /**< Arduino Uno pin 13 (SCK)  */
+
+#define ARDUINO_PIN_A0  GPIO1       /**< Arduino Uno pin A0 */
+#define ARDUINO_PIN_A1  GPIO2       /**< Arduino Uno pin A1 */
+#define ARDUINO_PIN_A2  GPIO4       /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO5       /**< Arduino Uno pin A3 */
+
+#define ARDUINO_PIN_A4  GPIO8       /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO9       /**< Arduino Uno pin A5 (SCL) */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/esp32s3-devkit/include/board.h
+++ b/boards/esp32s3-devkit/include/board.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_devkit
+ * @brief       Board definitions for ESP32-S3-DevKit boards
+ * @{
+ *
+ * The board definitions in this file are valid for Espressif
+ * ESP32-S3-DevKitx boards that use one of the following modules:
+ *
+ * - ESP32-S3-MINI-1x module (ESP32-S3-DevKitM-1 board)
+ * - ESP32-S3-WROOM-1x module (ESP32-S3-DevKitC-1 board)
+ * - ESP32-S3-WROOM-2x module (ESP32-S3-DevKitC-1 board)
+ *
+ * where x stands for the module version with and without U
+ * (external antenna connector).
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * ESP32-S3-DevKit boards have a BOOT button connected to GPIO9, which can be
+ * used as button during normal operation. Since the GPIO9 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * ESP32-S3-DevKit boards have a SK68XXMINI-HS smart RGB-LED connected to
+ * GPIO48 on-board. This RGB-LEDs uses a special bit-oriented protocol to
+ * control the RGB-LED by 24-bit RGB values. Therefore, it can't be used as
+ * default LED definition for RIOT.
+ * @{
+ */
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32s3-devkit/include/gpio_params.h
+++ b/boards/esp32s3-devkit/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32s3_devkit
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32s3-devkit/include/periph_conf.h
+++ b/boards/esp32s3-devkit/include/periph_conf.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_devkit
+ * @brief       Peripheral configurations for ESP32-S3-DevKit boards
+ * @{
+ *
+ * The peripheral configurations in this file can be used for Espressif
+ * ESP32-S3-DevKitx boards that use one of the following modules:
+ *
+ * - ESP32-S3-WROOM-1x module (ESP32-S3-DevKitC-1 board)
+ * - ESP32-S3-WROOM-2x module (ESP32-S3-DevKitC-1 board)
+ * - ESP32-S3-MINI-1x module (ESP32-S3-DevKitM-1 board)
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-S3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * For generic boards, almost all ADC pins of ADC1 that are broken out are
+ * declared as ADC channels, except GPIO3, which is a strapping pin.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO1, GPIO2, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO9 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * For generic boards, only one I2C interface I2C_DEV(0) is defined.
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO9           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO8           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * For generic boards, two PWM devices are configured. These devices
+ * contain all GPIOs that are not defined as I2C, SPI or UART for this board.
+ * Generally, all outputs pins could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO14, GPIO17, GPIO18, GPIO21 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ *
+ * These PWM channels cannot be used if an external 32 kHz crystal is
+ * connected to the board at GPIO15 and GPIO16.
+ */
+#ifndef MODULE_ESP_RTC_TIMER_32K
+#ifndef PWM1_GPIOS
+#define PWM1_GPIOS  { GPIO15, GPIO16 }
+#endif
+#endif
+
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   FSPI    /**< FSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO12  /**< FSPI SCK (pin FSPICLK) */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO13  /**< FSPI MISO (pin FSPIQ) */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO11  /**< FSPI MOSI (pin FSPID) */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO10  /**< FSPI CS0 (pin FSPICS0) */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S3 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/esp32/bootloader/Makefile
+++ b/cpu/esp32/bootloader/Makefile
@@ -228,7 +228,6 @@ LINKFLAGS += \
   -Wno-frame-address \
   -o $(ESP_SDK_BOOTLOADER_DIR)/bootloader.elf \
   -Wl,--cref \
-  -Wl,--defsym=IDF_TARGET_ESP32=0 \
   -Wl,--gc-sections \
   -fno-lto \
   -fno-rtti \

--- a/cpu/esp32/bootloader/sdkconfig.h
+++ b/cpu/esp32/bootloader/sdkconfig.h
@@ -35,6 +35,8 @@
 #include "sdkconfig_default_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #include "sdkconfig_default_esp32c3.h"
+#elif defined(CPU_FAM_ESP32S3)
+#include "sdkconfig_default_esp32s3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32s3.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32s3.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Default SDK configuration for the ESP32-S3 SoC bootloader
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef SDKCONFIG_DEFAULT_ESP32S3_H
+#define SDKCONFIG_DEFAULT_ESP32S3_H
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ 160
+#endif
+
+#define CONFIG_ESP32S3_DEBUG_OCDAWARE 1
+
+#define CONFIG_BOOTLOADER_OFFSET_IN_FLASH 0x0
+#define CONFIG_EFUSE_MAX_BLK_LEN 256
+#define CONFIG_IDF_FIRMWARE_CHIP_ID 0x0009
+
+#define CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+#endif /* SDKCONFIG_DEFAULT_ESP32S3_H */
+/** @} */

--- a/cpu/esp32/esp-idf-api/dac.c
+++ b/cpu/esp32/esp-idf-api/dac.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#ifdef MODULE_PERIPH_DAC
+
 #include <stdbool.h>
 
 #include "driver/dac_common.h"
@@ -35,3 +37,5 @@ esp_err_t esp_idf_dac_output_disable(dac_channel_t channel)
 {
     return dac_output_disable(channel);
 }
+
+#endif

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -65,6 +65,8 @@
 #include "cpu_conf_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #include "cpu_conf_esp32c3.h"
+#elif defined(CPU_FAM_ESP32S3)
+#include "cpu_conf_esp32s3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/include/cpu_conf_esp32s3.h
+++ b/cpu/esp32/include/cpu_conf_esp32s3.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     config
+ * @brief       Compile-time configuration macros for ESP32-S3 SoCs
+ * @{
+ *
+ * @file
+ * @brief       ESP32-S3 specific compile-time configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef CPU_CONF_ESP32S3_H
+#define CPU_CONF_ESP32S3_H
+
+#ifndef ESP_ISR_STACKSIZE
+/** Stack size used in interrupt context */
+#define ESP_ISR_STACKSIZE               (THREAD_STACKSIZE_DEFAULT)
+#endif /* ESP_ISR_STACKSIZE */
+
+/** Number of DRAM sections that can be used as heap. */
+#define NUM_HEAPS (1)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_CONF_ESP32S3_H */
+/** @} */

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -154,6 +154,7 @@ typedef enum {
  *
  * - \ref esp32_adc_channels_esp32 "ESP32"
  * - \ref esp32_adc_channels_esp32c3 "ESP32-C3"
+ * - \ref esp32_adc_channels_esp32s3 "ESP32-S3"
  *
  * #ADC_GPIOS in the board-specific peripheral configuration defines the
  * list of GPIOs that can be used as ADC channels on the board, for example:
@@ -211,6 +212,7 @@ typedef enum {
  *
  * - \ref esp32_adc_channels_esp32 "ESP32"
  * - \ref esp32_adc_channels_esp32c3 "ESP32-C3"
+ * - \ref esp32_adc_channels_esp32s3 "ESP32-S3"
  *
  * @{
  */
@@ -739,6 +741,8 @@ typedef struct {
 #include "periph_cpu_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #include "periph_cpu_esp32c3.h"
+#elif defined(CPU_FAM_ESP32S3)
+#include "periph_cpu_esp32s3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/include/periph_cpu_esp32.h
+++ b/cpu/esp32/include/periph_cpu_esp32.h
@@ -19,9 +19,14 @@
 #ifndef PERIPH_CPU_ESP32_H
 #define PERIPH_CPU_ESP32_H
 
+#include "sdkconfig.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Mapping configured ESP32 default clock to CLOCK_CORECLOCK define */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 
 /**
  * @name   Predefined GPIO names

--- a/cpu/esp32/include/periph_cpu_esp32c3.h
+++ b/cpu/esp32/include/periph_cpu_esp32c3.h
@@ -19,9 +19,14 @@
 #ifndef PERIPH_CPU_ESP32C3_H
 #define PERIPH_CPU_ESP32C3_H
 
+#include "sdkconfig.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Mapping configured ESP32-C3 default clock to CLOCK_CORECLOCK define */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ)
 
 /**
  * @name   Predefined GPIO names

--- a/cpu/esp32/include/periph_cpu_esp32s3.h
+++ b/cpu/esp32/include/periph_cpu_esp32s3.h
@@ -19,6 +19,9 @@
 #ifndef PERIPH_CPU_ESP32S3_H
 #define PERIPH_CPU_ESP32S3_H
 
+/** Mapping configured ESP32-S3 default clock to CLOCK_CORECLOCK define */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/esp32/include/periph_cpu_esp32s3.h
+++ b/cpu/esp32/include/periph_cpu_esp32s3.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       ESP32-S3 specific peripheral configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CPU_ESP32S3_H
+#define PERIPH_CPU_ESP32S3_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Predefined GPIO names
+ * @{
+ */
+#define GPIO0       (GPIO_PIN(PORT_GPIO, 0))
+#define GPIO1       (GPIO_PIN(PORT_GPIO, 1))
+#define GPIO2       (GPIO_PIN(PORT_GPIO, 2))
+#define GPIO3       (GPIO_PIN(PORT_GPIO, 3))
+#define GPIO4       (GPIO_PIN(PORT_GPIO, 4))
+#define GPIO5       (GPIO_PIN(PORT_GPIO, 5))
+#define GPIO6       (GPIO_PIN(PORT_GPIO, 6))
+#define GPIO7       (GPIO_PIN(PORT_GPIO, 7))
+#define GPIO8       (GPIO_PIN(PORT_GPIO, 8))
+#define GPIO9       (GPIO_PIN(PORT_GPIO, 9))
+#define GPIO10      (GPIO_PIN(PORT_GPIO, 10))
+#define GPIO11      (GPIO_PIN(PORT_GPIO, 11))
+#define GPIO12      (GPIO_PIN(PORT_GPIO, 12))
+#define GPIO13      (GPIO_PIN(PORT_GPIO, 13))
+#define GPIO14      (GPIO_PIN(PORT_GPIO, 14))
+#define GPIO15      (GPIO_PIN(PORT_GPIO, 15))
+#define GPIO16      (GPIO_PIN(PORT_GPIO, 16))
+#define GPIO17      (GPIO_PIN(PORT_GPIO, 17))
+#define GPIO18      (GPIO_PIN(PORT_GPIO, 18))
+#define GPIO19      (GPIO_PIN(PORT_GPIO, 19))
+#define GPIO20      (GPIO_PIN(PORT_GPIO, 20))
+#define GPIO21      (GPIO_PIN(PORT_GPIO, 21))
+/* GPIOs 22 ...25 are not available */
+#define GPIO26      (GPIO_PIN(PORT_GPIO, 26))
+#define GPIO27      (GPIO_PIN(PORT_GPIO, 27))
+#define GPIO28      (GPIO_PIN(PORT_GPIO, 28))
+#define GPIO29      (GPIO_PIN(PORT_GPIO, 29))
+#define GPIO30      (GPIO_PIN(PORT_GPIO, 30))
+#define GPIO31      (GPIO_PIN(PORT_GPIO, 31))
+#define GPIO32      (GPIO_PIN(PORT_GPIO, 32))
+#define GPIO33      (GPIO_PIN(PORT_GPIO, 33))
+#define GPIO34      (GPIO_PIN(PORT_GPIO, 34))
+#define GPIO35      (GPIO_PIN(PORT_GPIO, 35))
+#define GPIO36      (GPIO_PIN(PORT_GPIO, 36))
+#define GPIO37      (GPIO_PIN(PORT_GPIO, 37))
+#define GPIO38      (GPIO_PIN(PORT_GPIO, 38))
+#define GPIO39      (GPIO_PIN(PORT_GPIO, 39))
+#define GPIO40      (GPIO_PIN(PORT_GPIO, 40))
+#define GPIO41      (GPIO_PIN(PORT_GPIO, 41))
+#define GPIO42      (GPIO_PIN(PORT_GPIO, 42))
+#define GPIO43      (GPIO_PIN(PORT_GPIO, 43))
+#define GPIO44      (GPIO_PIN(PORT_GPIO, 44))
+#define GPIO45      (GPIO_PIN(PORT_GPIO, 45))
+#define GPIO46      (GPIO_PIN(PORT_GPIO, 46))
+#define GPIO47      (GPIO_PIN(PORT_GPIO, 47))
+#define GPIO48      (GPIO_PIN(PORT_GPIO, 48))
+/** @} */
+
+/**
+ * @name   ADC configuration
+ *
+ * ESP32-S3 integrates two 12-bit ADCs (ADC1 and ADC2) with 20 channels in
+ * total:
+ *
+ * - **ADC1** supports 10 channels: GPIO1 ... GPIO10
+ * - **ADC2** supports 10 channels: GPIO11 ... GPIO20
+ *
+ * @note
+ * - ADC2 is also used by the WiFi module. The GPIOs connected to ADC2 are
+ *   therefore not available as ADC channels if the modules `esp_wifi` or
+ *   `esp_now` are used.
+ * - Vref can be read with function #adc_line_vref_to_gpio at an ADC2 channel,
+ *   that is at GPIO11 ... GPIO20.
+ * - GPIO3 is a strapping pin und shouldn't be used as ADC channel
+ */
+
+/**
+ * @name   I2C configuration
+ *
+ * ESP32-S3 has two built-in I2C interfaces.
+ *
+ * The following table shows the default configuration of I2C interfaces
+ * used for ESP32-S3 boards. It can be overridden by
+ * [application-specific configurations](#esp32_application_specific_configurations).
+ *
+ * <center>
+ *
+ * Device     | Signal | Pin    | Symbol        | Remarks
+ * :----------|:-------|:-------|:--------------|:----------------
+ * I2C_DEV(0) |        |        | `#I2C0_SPEED` | default is `I2C_SPEED_FAST`
+ * I2C_DEV(0) | SCL    | GPIO9  | `#I2C0_SCL`   | -
+ * I2C_DEV(0) | SDA    | GPIO8  | `#I2C0_SDA`   | -
+ *
+ * </center><br>
+ */
+
+/**
+ * @name   PWM configuration
+ *
+ * The ESP32-S3 LEDC module has 1 channel group with 8 channels. Each of
+ * these channels can be clocked by one of the 4 timers.
+ */
+
+/**
+ * @name   SPI configuration
+ *
+ * ESP32-S3 has four SPI controllers where SPI0 and SPI1 share the same bus
+ * and can only operate in memory mode while SPI2 and SPI3 can be used as general
+ * purpose SPI:
+ *
+ * - controller SPI0 is reserved for external memories like Flash and PSRAM
+ * - controller SPI1 is reserved for external memories like Flash and PSRAM
+ * - controller SPI2 can be used for peripherals (also called FSPI)
+ * - controller SPI3 can be used for peripherals
+ *
+ * Thus, SPI2 (`FSPI`) and SPI3 can be used as general purpose SPI in
+ * RIOT as SPI_DEV(0) and SPI_DEV(1) by defining the symbols `SPI0_*`
+ * and `SPI1_*`.
+ *
+ * The following table shows the pin configuration used by default, even
+ * though it **can vary** from board to board.
+ *
+ * <center>
+ *
+ * Device (Alias)          | Signal | Pin    | Symbol      | Remarks
+ * :-----------------------|:------:|:-------|:-----------:|:---------------------------
+ * `SPI_HOST0`/`SPI_HOST1` | SPICS0 | GPIO29 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPICS1 | GPIO26 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPICLK | GPIO30 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPID   | GPIO32 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIQ   | GPIO31 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIHD  | GPIO27 | - | reserved for Flash and PSRAM (only in `qio` or `qout` mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIWP  | GPIO28 | - | reserved for Flash and PSRAM (only in `qio` or `qout` mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIIO4 | GPIO33 | - | reserved for Flash and PSRAM (only in octal mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIIO5 | GPIO34 | - | reserved for Flash and PSRAM (only in octal mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIIO6 | GPIO35 | - | reserved for Flash and PSRAM (only in octal mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIIO7 | GPIO36 | - | reserved for Flash and PSRAM (only in octal mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIDQA | GPIO37 | - | reserved for Flash and PSRAM (only in octal mode)
+ * `SPI_HOST2` (`FSPI`)    | SCK    | GPIO12 |`#SPI0_SCK`  | can be used
+ * `SPI_HOST2` (`FSPI`)    | MOSI   | GPIO11 |`#SPI0_MOSI` | can be used
+ * `SPI_HOST2` (`FSPI`)    | MISO   | GPIO13 |`#SPI0_MISO` | can be used
+ * `SPI_HOST2` (`FSPI`)    | CS0    | GPIO10 |`#SPI0_CS0`  | can be used
+ * `SPI_HOST3`             | SCK    | -      |`#SPI1_SCK`  | can be used
+ * `SPI_HOST3`             | MOSI   | -      |`#SPI1_MOSI` | can be used
+ * `SPI_HOST3`             | MISO   | -      |`#SPI1_MISO` | can be used
+ * `SPI_HOST3`             | CS0    | -      |`#SPI1_CS0`  | can be used
+ *
+ * </center><br>
+ */
+
+/**
+ * @name   Timer configuration depending on which implementation is used
+ *
+ * Timers are MCU built-in feature and not board-specific. They are therefore
+ * configured here.
+ *
+ * ESP32-S3 has two timer groups with two timers each, resulting in a total of
+ * four timers. Since one timer is used as system timer, up to three timers
+ * with one channel each can be used in RIOT as timer devices
+ * TIMER_DEV(0) ... TIMER_DEV(2).
+ *
+ * Additionally ESP32-S3 has three CCOMPARE registers which can be used
+ * alternatively as timer devices TIMER_DEV(0) ... TIMER_DEV(2) can be used
+ * in RIOT if the module `esp_hw_counter` is enabled.
+ */
+
+#ifdef MODULE_ESP_HW_COUNTER
+/** Hardware ccount/ccompare registers are used for timer implementation */
+#define TIMER_NUMOF         (2)
+#define TIMER_CHANNEL_NUMOF (1)
+#endif
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S3 integrates three UART interfaces. The following default pin
+ * configuration of UART interfaces as used by a most boards can be overridden
+ * by the application, see section [Application-Specific Configurations]
+ * (#esp32_application_specific_configurations).
+ *
+ * <center>
+ *
+ * Device      |Signal|Pin     |Symbol      |Remarks
+ * :-----------|:-----|:-------|:-----------|:----------------
+ * UART_DEV(0) | TxD  | GPIO43 |`#UART0_TXD`| cannot be changed
+ * UART_DEV(0) | RxD  | GPIO44 |`#UART0_RXD`| cannot be changed
+ * UART_DEV(1) | TxD  | GPIO17 |`#UART1_TXD`| optional, can be overridden
+ * UART_DEV(1) | RxD  | GPIO18 |`#UART1_RXD`| optional, can be overridden
+ * UART_DEV(2) | TxD  | -      |`UART2_TXD` | optional, can be overridden (no direct I/O)
+ * UART_DEV(2) | RxD  | -      |`UART2_RXD` | optional, can be overridden (no direct I/O)
+ *
+ * </center><br>
+ *
+ */
+
+#ifdef MODULE_PERIPH_CAN
+#include "can_esp.h"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CPU_ESP32S3_H */
+/** @} */

--- a/cpu/esp32/include/sdkconfig.h
+++ b/cpu/esp32/include/sdkconfig.h
@@ -23,6 +23,15 @@
 #define SDKCONFIG_H
 
 /*
+ * Some files in ESP-IDF use functions from `stdlib.h` without including the
+ * header. To avoid having to patch all these files, `stdlib.h` is included
+ * in this header file, which in turn is included by every ESP-IDF file.
+ */
+#ifndef __ASSEMBLER__
+#include <stdlib.h>
+#endif
+
+/*
  * The SoC capability definitions are often included indirectly in the
  * ESP-IDF files, although all ESP-IDF files require them. Since not all
  * ESP-IDF header files are included in RIOT, the SoC capability definitions
@@ -158,7 +167,7 @@
 #define CONFIG_ESP32_WIFI_TX_BA_WIN             6
 #define CONFIG_ESP32_WIFI_AMPDU_RX_ENABLED      1
 #define CONFIG_ESP32_WIFI_RX_BA_WIN             6
-#ifdef MODULE_ESP_IDF_NVS_ENABLED
+#if defined(MODULE_ESP_IDF_NVS_FLASH) && !defined(CPU_FAM_ESP32C3)
 #define CONFIG_ESP32_WIFI_NVS_ENABLED           1
 #endif
 #define CONFIG_ESP32_WIFI_TASK_PINNED_TO_CORE_0 1
@@ -194,6 +203,8 @@
 #include "sdkconfig_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #include "sdkconfig_esp32c3.h"
+#elif defined(CPU_FAM_ESP32S3)
+#include "sdkconfig_esp32s3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/include/sdkconfig_esp32.h
+++ b/cpu/esp32/include/sdkconfig_esp32.h
@@ -58,11 +58,6 @@ extern "C" {
 #ifndef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ
 #define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ       80
 #endif
-
-/**
- * @brief Mapping configured ESP32 default clock to CLOCK_CORECLOCK define
- */
-#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 /** @} */
 
 /**

--- a/cpu/esp32/include/sdkconfig_esp32.h
+++ b/cpu/esp32/include/sdkconfig_esp32.h
@@ -99,8 +99,13 @@ extern "C" {
 #define CONFIG_BROWNOUT_DET                     CONFIG_ESP32_BROWNOUT_DET
 
 #define CONFIG_ESP32_DEEP_SLEEP_WAKEUP_DELAY    2000
-#define CONFIG_ESP32_TRACEMEM_RESERVE_DRAM      0
+#define CONFIG_ESP32_TRACEMEM_RESERVE_DRAM      0x0
 #define CONFIG_ESP32_ULP_COPROC_RESERVE_MEM     0
+
+/**
+ * ESP32 specific sleep configuration (DO NOT CHANGE)
+ */
+#define CONFIG_ESP_SLEEP_RTC_BUS_ISO_WORKAROUND 1
 
 /**
  * ESP32 specific ADC calibration

--- a/cpu/esp32/include/sdkconfig_esp32c3.h
+++ b/cpu/esp32/include/sdkconfig_esp32c3.h
@@ -56,11 +56,6 @@ extern "C" {
 #ifndef CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ
 #define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     80
 #endif
-
-/**
- * @brief Mapping configured ESP32-C3 default clock to CLOCK_CORECLOCK define
- */
-#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ)
 /** @} */
 
 /**

--- a/cpu/esp32/include/sdkconfig_esp32s3.h
+++ b/cpu/esp32/include/sdkconfig_esp32s3.h
@@ -58,10 +58,6 @@ extern "C" {
 #ifndef CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ
 #define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     80
 #endif
-/**
- * @brief Mapping configured ESP32 default clock to CLOCK_CORECLOCK define
- */
-#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
 /** @} */
 
 /**

--- a/cpu/esp32/include/sdkconfig_esp32s3.h
+++ b/cpu/esp32/include/sdkconfig_esp32s3.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       SDK configuration used by the ESP-IDF for ESP32-S3 SoC variant (family)
+ *
+ * The SDK configuration can be partially overridden by application-specific
+ * board configuration.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef SDKCONFIG_ESP32S3_H
+#define SDKCONFIG_ESP32S3_H
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name ESP32-S3 specific clock configuration
+ * @{
+ */
+
+/* Mapping of Kconfig defines to the respective enumeration values */
+#if CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_2
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     2
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_5
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     5
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_10
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     10
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_20
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     20
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_40
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     40
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_80
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     80
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_160
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     160
+#elif CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ_240
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     240
+#endif
+
+/**
+ * @brief Defines the CPU frequency [values = 2, 5, 10, 10, 40, 80, 160, 240]
+ */
+#ifndef CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ     80
+#endif
+/**
+ * @brief Mapping configured ESP32 default clock to CLOCK_CORECLOCK define
+ */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
+/** @} */
+
+/**
+ * ESP32-S3 specific RTC clock configuration
+ */
+#define CONFIG_ESP32S3_RTC_CLK_CAL_CYCLES       (8 * 1024)
+
+/**
+ * ESP32-S3 specific EFUSE configuration
+ */
+#define CONFIG_EFUSE_MAX_BLK_LEN                256
+
+/**
+ * ESP32-S3 specific MAC configuration
+ */
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_STA   1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_AP    1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_BT         1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_ETH        1
+#define CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES  4
+
+/**
+ * ESP32-S3 specific serial flasher config (DO NOT CHANGE)
+ */
+#define CONFIG_ESPTOOLPY_FLASHFREQ_80M          1
+#define CONFIG_ESPTOOLPY_FLASHFREQ              "80m"
+
+/**
+ * ESP32-S3 specific system configuration (DO NOT CHANGE)
+ */
+#define CONFIG_ESP_TIMER_IMPL_SYSTIMER          1
+#define CONFIG_ESP_CONSOLE_MULTIPLE_UART        1
+
+#define CONFIG_ESP32S3_DEBUG_OCDAWARE           1
+
+#define CONFIG_ESP32S3_BROWNOUT_DET             1
+#define CONFIG_ESP32S3_BROWNOUT_DET_LVL         7
+
+#define CONFIG_ESP32S3_DEEP_SLEEP_WAKEUP_DELAY  2000
+#define CONFIG_ESP32S3_TRACEMEM_RESERVE_DRAM    0x0
+#define CONFIG_ESP32S3_ULP_COPROC_RESERVE_MEM   0
+
+/**
+ * ESP32-S3 specific sleep configuration (DO NOT CHANGE)
+ */
+#define CONFIG_ESP_SLEEP_RTC_BUS_ISO_WORKAROUND 1
+#define CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND  1
+
+/**
+ * ESP32-S3 specific PHY configuration
+ */
+#define CONFIG_ESP_PHY_ENABLE_USB               1
+#define CONFIG_USB_OTG_SUPPORTED 0
+#define CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE 256
+#define CONFIG_USB_HOST_HW_BUFFER_BIAS_BALANCED 1
+
+/**
+ * ESP32-S3 specific SPI RAM configuration
+ */
+#ifdef  MODULE_ESP_SPI_RAM
+#define CONFIG_ESP32S3_SPIRAM_SUPPORT           1
+#ifdef MODULE_ESP_SPI_OCT
+#define CONFIG_SPIRAM_MODE_OCT                  1
+#else
+#define CONFIG_SPIRAM_MODE_QUAD                 1
+#endif
+#define CONFIG_DEFAULT_PSRAM_CLK_IO             30
+#define CONFIG_DEFAULT_PSRAM_CS_IO              26
+#define CONFIG_SPIRAM_SUPPORT                   CONFIG_ESP32S3_SPIRAM_SUPPORT
+#endif
+
+/**
+ * ESP32-S3 specific Cache config
+ */
+#define CONFIG_ESP32S3_INSTRUCTION_CACHE_16KB       1
+#define CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE       0x4000
+#define CONFIG_ESP32S3_INSTRUCTION_CACHE_8WAYS      1
+#define CONFIG_ESP32S3_ICACHE_ASSOCIATED_WAYS       8
+#define CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_32B   1
+#define CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_SIZE  32
+#define CONFIG_ESP32S3_DATA_CACHE_32KB              1
+#define CONFIG_ESP32S3_DATA_CACHE_SIZE              0x8000
+#define CONFIG_ESP32S3_DATA_CACHE_8WAYS             1
+#define CONFIG_ESP32S3_DCACHE_ASSOCIATED_WAYS       8
+#define CONFIG_ESP32S3_DATA_CACHE_LINE_32B          1
+#define CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE         32
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+#endif /* SDKCONFIG_ESP32S3_H */
+/** @} */

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -215,6 +215,8 @@ int adc_line_vref_to_gpio(adc_t line, gpio_t gpio)
 
     /* the GPIO for the output must be a channel of ADC2 */
     assert(_adc_hw[rtcio_out].adc_ctrl == ADC_UNIT_2);
+    /* given ADC line has to be a channel of ADC2  */
+    assert(_adc_hw[rtcio_vref].adc_ctrl == ADC_UNIT_2);
 
     esp_err_t res = ESP_OK;
 

--- a/cpu/esp32/periph/adc_arch_esp32s3.c
+++ b/cpu/esp32/periph/adc_arch_esp32s3.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Architecture-specific ADC/DAC definitions for ESP32-S3 variant (family)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+#include "adc_arch_private.h"
+#include "esp_common.h"
+#include "soc/adc_channel.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   ADC hardware descriptor table (for internal use only)
+ *
+ * Reference: Technical Reference Manual, Section 5.13 Table 5-5
+ * https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+ *
+ * @note    The index of entries in the table MUST correspond to the
+ *          RTCIO GPIO number.
+ */
+const _adc_hw_desc_t _adc_hw[] = {
+    /* rtcio,          gpio,                    adc_ctrl,   adc_channel,   pad_name */
+    {  RTCIO_GPIO(0),  GPIO0,                   ADC_UNIT_MAX, ADC_CHANNEL_MAX, "GPIO0" },
+    {  RTCIO_GPIO(1),  ADC1_CHANNEL_0_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_0,   "TOUCH1" },
+    {  RTCIO_GPIO(2),  ADC1_CHANNEL_1_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_1,   "TOUCH2" },
+    {  RTCIO_GPIO(3),  ADC1_CHANNEL_2_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_2,   "TOUCH3" },
+    {  RTCIO_GPIO(4),  ADC1_CHANNEL_3_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_3,   "TOUCH4" },
+    {  RTCIO_GPIO(5),  ADC1_CHANNEL_4_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_4,   "TOUCH5" },
+    {  RTCIO_GPIO(6),  ADC1_CHANNEL_5_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_5,   "TOUCH6" },
+    {  RTCIO_GPIO(7),  ADC1_CHANNEL_6_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_6,   "TOUCH7" },
+    {  RTCIO_GPIO(8),  ADC1_CHANNEL_7_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_7,   "TOUCH8" },
+    {  RTCIO_GPIO(9),  ADC1_CHANNEL_8_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_8,   "TOUCH9" },
+    {  RTCIO_GPIO(10), ADC1_CHANNEL_9_GPIO_NUM, ADC_UNIT_1,   ADC_CHANNEL_9,   "TOUCH10" },
+    {  RTCIO_GPIO(11), ADC2_CHANNEL_0_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_0,   "TOUCH11" },
+    {  RTCIO_GPIO(12), ADC2_CHANNEL_1_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_1,   "TOUCH12" },
+    {  RTCIO_GPIO(13), ADC2_CHANNEL_2_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_2,   "TOUCH13" },
+    {  RTCIO_GPIO(14), ADC2_CHANNEL_3_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_3,   "TOUCH14" },
+    {  RTCIO_GPIO(15), ADC2_CHANNEL_4_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_4,   "XTAL_32K_P" },
+    {  RTCIO_GPIO(16), ADC2_CHANNEL_5_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_5,   "XTAL_32K_N" },
+    {  RTCIO_GPIO(17), ADC2_CHANNEL_6_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_6,   "GPIO17" },
+    {  RTCIO_GPIO(18), ADC2_CHANNEL_7_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_7,   "GPIO18" },
+    {  RTCIO_GPIO(19), ADC2_CHANNEL_8_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_8,   "USB_D-" },
+    {  RTCIO_GPIO(20), ADC2_CHANNEL_9_GPIO_NUM, ADC_UNIT_2,   ADC_CHANNEL_9,   "USB_D+" },
+    {  RTCIO_GPIO(21), GPIO21,                  ADC_UNIT_MAX, ADC_CHANNEL_MAX, "GPIO21" },
+};
+
+/**
+ * @brief   GPIO to RTC IO map (for internal use only)
+ *
+ * Reference: Technical Reference Manual, Section 5.13 Table 5-5
+ * https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+ */
+const gpio_t _gpio_rtcio_map[] = {
+    RTCIO_GPIO(0),      /* GPIO0 */
+    RTCIO_GPIO(1),      /* GPIO1 TOUCH1 */
+    RTCIO_GPIO(2),      /* GPIO2 TOUCH2 */
+    RTCIO_GPIO(3),      /* GPIO3 TOUCH3 */
+    RTCIO_GPIO(4),      /* GPIO4 TOUCH4 */
+    RTCIO_GPIO(5),      /* GPIO5 TOUCH5 */
+    RTCIO_GPIO(6),      /* GPIO6 TOUCH6 */
+    RTCIO_GPIO(7),      /* GPIO7 TOUCH7 */
+    RTCIO_GPIO(8),      /* GPIO8 TOUCH8 */
+    RTCIO_GPIO(9),      /* GPIO9 TOUCH9 */
+    RTCIO_GPIO(10),     /* GPIO10 TOUCH10 */
+    RTCIO_GPIO(11),     /* GPIO11 TOUCH11 */
+    RTCIO_GPIO(12),     /* GPIO12 TOUCH12 */
+    RTCIO_GPIO(13),     /* GPIO13 TOUCH13 */
+    RTCIO_GPIO(14),     /* GPIO14 TOUCH14 */
+    RTCIO_GPIO(15),     /* GPIO15 XTAL_32K_P */
+    RTCIO_GPIO(16),     /* GPIO16 XTAL_32K_N */
+    RTCIO_GPIO(17),     /* GPIO17 */
+    RTCIO_GPIO(18),     /* GPIO18 */
+    RTCIO_GPIO(19),     /* GPIO19 USB_D- */
+    RTCIO_GPIO(20),     /* GPIO20 USB_D+ */
+    RTCIO_GPIO(21),     /* GPIO21 */
+    RTCIO_NA,           /* GPIO22 */
+    RTCIO_NA,           /* GPIO23 */
+    RTCIO_NA,           /* GPIO24 */
+    RTCIO_NA,           /* GPIO25 */
+    RTCIO_NA,           /* GPIO26 */
+    RTCIO_NA,           /* GPIO27 */
+    RTCIO_NA,           /* GPIO28 */
+    RTCIO_NA,           /* GPIO29 */
+    RTCIO_NA,           /* GPIO30 */
+    RTCIO_NA,           /* GPIO31 */
+    RTCIO_NA,           /* GPIO32 */
+    RTCIO_NA,           /* GPIO33 */
+    RTCIO_NA,           /* GPIO34 */
+    RTCIO_NA,           /* GPIO35 */
+    RTCIO_NA,           /* GPIO36 */
+    RTCIO_NA,           /* GPIO37 */
+    RTCIO_NA,           /* GPIO38 */
+    RTCIO_NA,           /* GPIO39 */
+    RTCIO_NA,           /* GPIO40 */
+    RTCIO_NA,           /* GPIO41 */
+    RTCIO_NA,           /* GPIO42 */
+    RTCIO_NA,           /* GPIO43 */
+    RTCIO_NA,           /* GPIO44 */
+    RTCIO_NA,           /* GPIO45 */
+    RTCIO_NA,           /* GPIO46 */
+    RTCIO_NA,           /* GPIO47 */
+    RTCIO_NA,           /* GPIO48 */
+};
+
+_Static_assert(ARRAY_SIZE(_adc_hw) == SOC_RTCIO_PIN_COUNT,
+               "size of _adc_hw does not match SOC_RTCIO_PIN_COUNT");
+_Static_assert(ARRAY_SIZE(_gpio_rtcio_map) == SOC_GPIO_PIN_COUNT,
+               "size of _gpio_rtcio_map does not match SOC_GPIO_PIN_COUNT");

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -101,7 +101,7 @@ static bool _gpio_pin_pu[GPIO_PIN_NUMOF] = { };
 static bool _gpio_pin_pd[GPIO_PIN_NUMOF] = { };
 #endif
 
-#if defined(CPU_FAM_ESP32)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3)
 
 #define GPIO_IN_GET(b)  (b < 32) ? GPIO.in & BIT(b) : GPIO.in1.val & BIT(b-32)
 #define GPIO_OUT_SET(b) if (b < 32) { GPIO.out_w1ts = BIT(b); } else { GPIO.out1_w1ts.val = BIT(b-32); }

--- a/cpu/esp32/periph/gpio_arch_esp32s3.c
+++ b/cpu/esp32/periph/gpio_arch_esp32s3.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     drivers_periph_gpio
+ * @{
+ *
+ * @file
+ * @brief       Architecture-specific GPIO definitions for ESP32-S3 variant (family)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "gpio_arch.h"
+#include "soc/io_mux_reg.h"
+
+#if !IS_USED(MODULE_ESP_IDF_GPIO_HAL)
+
+/* GPIO to IOMUX register mapping (see Technical Reference, Section 5.14.2 Register Summary)
+   https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf */
+
+const uint32_t _gpio_to_iomux_reg[GPIO_PIN_NUMOF] =
+{
+    PERIPHS_IO_MUX_GPIO0_U,      /* GPIO0 */
+    PERIPHS_IO_MUX_GPIO1_U,      /* GPIO1 */
+    PERIPHS_IO_MUX_GPIO2_U,      /* GPIO2 */
+    PERIPHS_IO_MUX_GPIO3_U,      /* GPIO3 */
+    PERIPHS_IO_MUX_GPIO4_U,      /* GPIO4 */
+    PERIPHS_IO_MUX_GPIO5_U,      /* GPIO5 */
+    PERIPHS_IO_MUX_GPIO6_U,      /* GPIO6 */
+    PERIPHS_IO_MUX_GPIO7_U,      /* GPIO7 */
+    PERIPHS_IO_MUX_GPIO8_U,      /* GPIO8 */
+    PERIPHS_IO_MUX_GPIO9_U,      /* GPIO9 */
+    PERIPHS_IO_MUX_GPIO10_U,     /* GPIO10 */
+    PERIPHS_IO_MUX_GPIO11_U,     /* GPIO11 */
+    PERIPHS_IO_MUX_GPIO12_U,     /* GPIO12 */
+    PERIPHS_IO_MUX_GPIO13_U,     /* GPIO13 */
+    PERIPHS_IO_MUX_GPIO14_U,     /* GPIO14 */
+    PERIPHS_IO_MUX_XTAL_32K_P_U, /* GPIO15 used for 32k XTAL */
+    PERIPHS_IO_MUX_XTAL_32K_N_U, /* GPIO16 used for 32k XTAL */
+    PERIPHS_IO_MUX_DAC_1_U,      /* GPIO17 */
+    PERIPHS_IO_MUX_DAC_2_U,      /* GPIO18 */
+    PERIPHS_IO_MUX_GPIO19_U,     /* GPIO19 */
+    PERIPHS_IO_MUX_GPIO20_U,     /* GPIO20 */
+    PERIPHS_IO_MUX_GPIO21_U,     /* GPIO21 */
+    0,                           /* GPIO22 is not available */
+    0,                           /* GPIO23 is not available */
+    0,                           /* GPIO24 is not available */
+    0,                           /* GPIO25 is not available */
+    PERIPHS_IO_MUX_SPICS1_U,     /* GPIO26 used as SPI CS1 */
+    PERIPHS_IO_MUX_SPIHD_U,      /* GPIO27 used as SPI HS for Flash */
+    PERIPHS_IO_MUX_SPIWP_U,      /* GPIO28 used as SPI WP for Flash */
+    PERIPHS_IO_MUX_SPICS0_U,     /* GPIO29 used as SPI CS0 for Flash */
+    PERIPHS_IO_MUX_SPICLK_U,     /* GPIO30 used as SPI CLK for Flash */
+    PERIPHS_IO_MUX_SPID_U,       /* GPIO31 used as SPI D for Flash */
+    PERIPHS_IO_MUX_SPIQ_U,       /* GPIO32 used as SPI Q for Flash */
+    PERIPHS_IO_MUX_GPIO33_U,     /* GPIO33 */
+    PERIPHS_IO_MUX_GPIO34_U,     /* GPIO34 */
+    PERIPHS_IO_MUX_GPIO35_U,     /* GPIO35 */
+    PERIPHS_IO_MUX_GPIO36_U,     /* GPIO36 */
+    PERIPHS_IO_MUX_GPIO37_U,     /* GPIO37 */
+    PERIPHS_IO_MUX_GPIO38_U,     /* GPIO38 */
+    PERIPHS_IO_MUX_MTCK_U,       /* GPIO39 used as JTAG*/
+    PERIPHS_IO_MUX_MTDO_U,       /* GPIO40 used as JTAG*/
+    PERIPHS_IO_MUX_MTDI_U,       /* GPIO41 used as JTAG*/
+    PERIPHS_IO_MUX_MTMS_U,       /* GPIO42 used as JTAG*/
+    PERIPHS_IO_MUX_U0TXD_U,      /* GPIO43 used as UART0 TxD */
+    PERIPHS_IO_MUX_U0RXD_U,      /* GPIO44 used as UART0 RxD */
+    PERIPHS_IO_MUX_GPIO45_U,     /* GPIO45 */
+    PERIPHS_IO_MUX_GPIO46_U,     /* GPIO46 */
+    PERIPHS_IO_MUX_SPICLK_P_U,   /* GPIO47 */
+    PERIPHS_IO_MUX_SPICLK_N_U,   /* GPIO48 */
+};
+
+#endif /* !IS_USED(MODULE_ESP_IDF_GPIO_HAL) */
+
+/* Table of the usage type of each GPIO pin */
+gpio_pin_usage_t _gpio_pin_usage[GPIO_PIN_NUMOF] = {
+    _GPIO,        /* GPIO0 */
+    _GPIO,        /* GPIO1 */
+    _GPIO,        /* GPIO2 */
+    _GPIO,        /* GPIO3 */
+    _GPIO,        /* GPIO4 */
+    _GPIO,        /* GPIO5 */
+    _GPIO,        /* GPIO6 */
+    _GPIO,        /* GPIO7 */
+    _GPIO,        /* GPIO8 */
+    _GPIO,        /* GPIO9 */
+    _GPIO,        /* GPIO10 */
+    _GPIO,        /* GPIO11 */
+    _GPIO,        /* GPIO12 */
+    _GPIO,        /* GPIO13 */
+    _GPIO,        /* GPIO14 */
+#if MODULE_ESP_RTC_TIMER_32K
+    _NOT_EXIST,   /* GPIO15 is used for external 32K crystal */
+    _NOT_EXIST,   /* GPIO16 is used for external 32K crystal */
+#else
+    _GPIO,        /* GPIO15 */
+    _GPIO,        /* GPIO16 */
+#endif
+    _GPIO,        /* GPIO17 */
+    _GPIO,        /* GPIO18 */
+    _GPIO,        /* GPIO19 could be used for ESP USB/builtin USB2JTAG bridge */
+    _GPIO,        /* GPIO20 could be used for ESP USB/builtin USB2JTAG bridge */
+    _GPIO,        /* GPIO21 */
+    _NOT_EXIST,   /* GPIO22 does not exist */
+    _NOT_EXIST,   /* GPIO23 does not exist */
+    _NOT_EXIST,   /* GPIO24 does not exist */
+    _NOT_EXIST,   /* GPIO25 does not exist */
+    _NOT_EXIST,   /* GPIO26 is used as direct I/O SPI CS1 for Flash/PSRAM */
+#if defined(FLASH_MODE_QIO) || defined(FLASH_MODE_QOUT)
+    _SPIF,        /* GPIO27 is used as direct I/O SPI HD for Flash/PSRAM */
+    _SPIF,        /* GPIO28 is used as direct I/O SPI WP for Flash/PSRAM */
+#else
+    _GPIO,        /* GPIO27 */
+    _GPIO,        /* GPIO28 */
+#endif
+    _SPIF,        /* GPIO29 is used as direct I/O SPI CS0 for Flash/PSRAM */
+    _SPIF,        /* GPIO30 is used as direct I/O SPI CLK for Flash/PSRAM */
+    _SPIF,        /* GPIO31 is used as direct I/O SPI Q for Flash/PSRAM */
+    _SPIF,        /* GPIO32 is used as direct I/O SPI D for Flash/PSRAM */
+    _GPIO,        /* GPIO33 */
+    _GPIO,        /* GPIO34 */
+    _GPIO,        /* GPIO35 */
+    _GPIO,        /* GPIO36 */
+    _GPIO,        /* GPIO37 */
+    _GPIO,        /* GPIO38 */
+    _GPIO,        /* GPIO39 */
+    _GPIO,        /* GPIO40 */
+    _GPIO,        /* GPIO41 */
+    _GPIO,        /* GPIO42 */
+    _UART,        /* GPIO43 is used as direct I/O UART0 TxD */
+    _UART,        /* GPIO44 is used as direct I/O UART0 RxD */
+    _GPIO,        /* GPIO45 */
+    _GPIO,        /* GPIO46 */
+    _GPIO,        /* GPIO47 */
+    _GPIO,        /* GPIO48 */
+};

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -147,7 +147,7 @@ void i2c_init(i2c_t dev)
     cfg.scl_io_num = i2c_config[dev].scl;
     cfg.sda_pullup_en = i2c_config[dev].sda_pullup;
     cfg.scl_pullup_en = i2c_config[dev].scl_pullup;
-#if SOC_I2C_SUPPORT_RTC
+#if defined(SOC_I2C_SUPPORT_RTC) && !defined(CPU_FAM_ESP32S3)
     cfg.clk_flags = I2C_SCLK_SRC_FLAG_LIGHT_SLEEP;
 #endif
 

--- a/cpu/esp32/periph/rtt_hw_rtc.c
+++ b/cpu/esp32/periph/rtt_hw_rtc.c
@@ -105,7 +105,7 @@ uint64_t _rtc_get_counter(void)
     }
     /* read the time from 48-bit counter and return */
     return (((uint64_t)RTCCNTL.time1.val) << 32) + RTCCNTL.time0;
-#elif defined(CPU_FAM_ESP32C3)
+#elif defined(CPU_FAM_ESP32C3) || defined(CPU_FAM_ESP32S3)
     /* read the time from 48-bit counter and return */
     return (((uint64_t)RTCCNTL.time_high0.val) << 32) + RTCCNTL.time_low0;
 #else

--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -274,10 +274,10 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
     spi_ll_master_set_clock_by_reg(_spi[bus].periph->hw,
                                    &_spi[bus].timing.clock_reg);
 
-#if defined(CPU_FAM_ESP32C3)
+#if defined(CPU_FAM_ESP32C3) || defined(CPU_FAM_ESP32S3)
     /*
      * If the SPI mode has been changed, the clock signal is only set to the
-     * correct level at the beginning of the transfer on the ESP32C3. However,
+     * correct level at the beginning of the transfer on the ESP32x3. However,
      * if a generic GPIO is used as CS signal instead of the hardware CS,
      * the CS signal is already LOW at this time. Thus, the clock signal will
      * have the wrong level when the SPI mode is changed and the CS signal
@@ -312,6 +312,8 @@ void IRAM_ATTR spi_release(spi_t bus)
 static const char* _spi_names[] = { "CSPI/FSPI", "HSPI", "VSPI"  };
 #elif defined(CPU_FAM_ESP32C3)
 static const char* _spi_names[] = { "SPI", "FSPI"  };
+#elif defined(CPU_FAM_ESP32S3)
+static const char* _spi_names[] = { "SPI", "FSPI", "SPI" };
 #else
 #error Platform implementation required
 #endif

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -96,6 +96,11 @@
 #define HW_TIMER_CORRECTION   10
 #define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION << 1, 5))
 
+#elif defined(CPU_FAM_ESP32S3)
+
+#define HW_TIMER_CORRECTION   (RTC_PLL_320M / CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
+#define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION << 1, 5))
+
 #else
 #error "MCU implementation needed"
 #endif
@@ -121,7 +126,7 @@ struct _hw_timer_desc_t {
 
 static const struct _hw_timer_desc_t _timers_desc[] =
 {
-#if defined(CPU_FAM_ESP32)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3)
     {
         .module = PERIPH_TIMG0_MODULE,
         .group = TIMER_GROUP_0,
@@ -389,11 +394,24 @@ void IRAM_ATTR timer_stop(tim_t dev)
 #define HW_TIMER_DELTA_RSHIFT 24
 #define HW_TIMER_FREQUENCY    (1000000UL) /* only 1MHz is supported */
 
+#if defined(CPU_FAM_ESP32)
+
 #define HW_TIMER_CORRECTION   (RTC_PLL_480M / CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 #define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION, 5))
 
+#elif defined(CPU_FAM_ESP32S3)
+
+#define HW_TIMER_CORRECTION   (RTC_PLL_480M / CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
+#define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION, 5))
+
+#else
+#error "MCU implementation needed"
+#endif
+
 #define US_TO_HW_TIMER_TICKS(t)     (t * system_get_cpu_freq())
 #define HW_TIMER_TICKS_TO_US(t)     (t / system_get_cpu_freq())
+
+extern int esp_clk_cpu_freq(void);
 
 struct hw_channel_t {
     bool        used;         /* indicates whether the channel is used */

--- a/cpu/esp_common/include/esp_common.h
+++ b/cpu/esp_common/include/esp_common.h
@@ -107,7 +107,7 @@ extern "C" {
   * @brief  function name mappings for source code compatibility with ESP8266 port
   * @{
   */
-#ifdef CPU_FAM_ESP32
+#ifdef MCU_ESP32
 #define system_get_cpu_freq     ets_get_cpu_frequency
 #define system_update_cpu_freq  ets_update_cpu_frequency
 #endif /* CPU_FAM_ESP32 */

--- a/cpu/esp_common/include/freertos/portmacro.h
+++ b/cpu/esp_common/include/freertos/portmacro.h
@@ -55,17 +55,17 @@ extern "C" {
 
 #define errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY    ( -1 )
 
-#ifdef CPU_FAM_ESP32
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3)
 
 #define portNUM_PROCESSORS              2
 #define xPortGetCoreID()                PRO_CPU_NUM
 
-#else /* CPU_FAM_ESP32 */
+#else /* defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3) */
 
 #define portNUM_PROCESSORS              1
 #define xPortGetCoreID()                PRO_CPU_NUM
 
-#endif /* CPU_FAM_ESP32 */
+#endif /* defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3) */
 
 extern void vTaskEnterCritical(portMUX_TYPE *mux);
 extern void vTaskExitCritical(portMUX_TYPE *mux);

--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -59,7 +59,7 @@
 #define I2C_CLOCK_STRETCH 200
 
 /* gpio access macros */
-#if defined(CPU_FAM_ESP32)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3)
 #define GPIO_SET(lo, hi, b) if (b < 32) { GPIO.lo =  BIT(b); } else { GPIO.hi.val =  BIT(b-32); }
 #define GPIO_GET(lo, hi, b) ((b < 32) ? GPIO.lo & BIT(b) : GPIO.hi.val & BIT(b-32))
 #elif defined(CPU_FAM_ESP32C3)
@@ -119,6 +119,8 @@ static _i2c_bus_t _i2c_bus[I2C_NUMOF] = {};
 #define I2C_CLK_CAL     62      /* clock calibration offset */
 #elif defined(CPU_FAM_ESP32C3)
 #define I2C_CLK_CAL     32      /* clock calibration offset */
+#elif defined(CPU_FAM_ESP32S3)
+#define I2C_CLK_CAL     82      /* clock calibration offset */
 #elif defined(MCU_ESP8266)
 #define I2C_CLK_CAL     47      /* clock calibration offset */
 #else

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14973,6 +14973,8 @@ cpu/esp32/include/periph_cpu_esp32c3\.h:[0-9]+: warning: Member GPIO[0-9]+ \(mac
 boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member LED[0-9]_[A-Z]+ \(macro definition\) of file board_common\.h is not documented.
 boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member SPIFFS_[_A-Z]+ \(macro definition\) of file board_common\.h is not documented.
 cpu/esp32/include/periph_cpu_esp32s3\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32s3\.h is not documented.
+boards/common/esp32s3/include/board_common.h:[0-9]+: warning: Member LED[0-9]_[A-Z]+ \(macro definition\) of file board_common\.h is not documented.
+boards/common/esp32s3/include/board_common.h:[0-9]+: warning: Member SPIFFS_[_A-Z]+ \(macro definition\) of file board_common\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented.

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14972,6 +14972,7 @@ cpu/esp32/include/periph_cpu_esp32\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro
 cpu/esp32/include/periph_cpu_esp32c3\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32c3\.h is not documented.
 boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member LED[0-9]_[A-Z]+ \(macro definition\) of file board_common\.h is not documented.
 boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member SPIFFS_[_A-Z]+ \(macro definition\) of file board_common\.h is not documented.
+cpu/esp32/include/periph_cpu_esp32s3\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32s3\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented.


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #18185, which provides
- the support for ESP32-S3 SoC
- a common ESP32-S3 board definition
- the board definition for the ESP32S3-DevKit board.

This PR requires PRs ~#18408, #18409, #18410 and #18411~ to be compilable in CI. ~Furthermore the CI workers need an update with [riotdocker #200](https://github.com/RIOT-OS/riotdocker/pull/201)~

### Testing procedure

Beside of Green CI some basic tests should work (Of course, I have already tested all of them and many more):
- `tests/shell`
- `tests/periph_cpuid`
- `tests/periph_gpio`
- `tests/periph_hwrng`
- `tests/periph_i2c`
- `tests/periph_spi`
- `tests/periph_rtt`
- `tests/periph_timer`
- `examples/gnrc_networking` using `esp_wifi` as optional module.

### Issues/PRs references

~Depends on #18408
Depends on #18409
Depends on #18410
Depends on #18411~