### PR TITLE
pkg/lwip: make use of confirm send

### DIFF
--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -93,9 +93,12 @@ ifneq (,$(filter esp_wifi,$(USEMODULE)))
 endif
 
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
-  USEMODULE += netdev_legacy_api
   USEMODULE += netopt
   USEMODULE += ztimer_msec
+endif
+
+ifneq (,$(filter esp_eth esp_wifi esp_now,$(USEMODULE)))
+  USEMODULE += netdev_legacy_api
 endif
 
 ifneq (,$(filter esp_freertos_common,$(USEMODULE)))

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -40,6 +40,10 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter netdev_tap,$(USEMODULE)))
+  USEMODULE += netdev_legacy_api
+endif
+
 ifneq (,$(filter libc_gettimeofday,$(USEMODULE)))
   USEMODULE += ztimer64_usec
 endif

--- a/cpu/nrf5x_common/Makefile.dep
+++ b/cpu/nrf5x_common/Makefile.dep
@@ -14,3 +14,7 @@ FEATURES_OPTIONAL += vdd_lc_filter_reg0
 ifneq (,$(filter nimble,$(USEPKG)))
   USEPKG += nrfx
 endif
+
+ifneq (,$(filter nrfmin,$(USEMODULE)))
+  USEMODULE += netdev_legacy_api
+endif

--- a/cpu/nrf5x_common/radio/nrfmin/Makefile.dep
+++ b/cpu/nrf5x_common/radio/nrfmin/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += netdev_legacy_api

--- a/drivers/kw41zrf/Makefile.dep
+++ b/drivers/kw41zrf/Makefile.dep
@@ -1,5 +1,6 @@
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
+USEMODULE += netdev_legacy_api
 USEMODULE += core_thread_flags
 USEMODULE += random
 USEMODULE += mcux_xcvr_mkw41z

--- a/examples/benchmark_udp/Makefile
+++ b/examples/benchmark_udp/Makefile
@@ -18,7 +18,6 @@ ifeq (0,$(LWIP))
   USEMODULE += gnrc_ipv6_default
 else
   USEMODULE += lwip_ipv6
-  USEMODULE += lwip_netdev
 endif
 
 # Add also the shell, some shell commands

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -24,8 +24,6 @@ ifeq (,$(filter 1, $(LWIP_IPV4) $(LWIP_IPV6)))
   # Additional networking modules that can be dropped if not needed
   USEMODULE += gnrc_icmpv6_echo
 else
-  USEMODULE += lwip_netdev
-
   ifeq (1,$(LWIP_IPV4))
     USEMODULE += ipv4_addr
 

--- a/examples/gcoap_dtls/Makefile
+++ b/examples/gcoap_dtls/Makefile
@@ -24,8 +24,6 @@ ifeq (,$(filter 1, $(LWIP_IPV4) $(LWIP_IPV6)))
   # Additional networking modules that can be dropped if not needed
   USEMODULE += gnrc_icmpv6_echo
 else
-  USEMODULE += lwip_netdev
-
   ifeq (1,$(LWIP_IPV4))
     USEMODULE += ipv4_addr
 

--- a/examples/paho-mqtt/Makefile.lwip
+++ b/examples/paho-mqtt/Makefile.lwip
@@ -20,6 +20,5 @@ ifneq (0,$(LWIP_IPV6))
 endif
 
 ifneq (0,$(USE_LWIP))
-  USEMODULE += lwip_netdev
   USEMODULE += lwip
 endif

--- a/examples/telnet_server/Makefile
+++ b/examples/telnet_server/Makefile
@@ -24,7 +24,6 @@ ifeq (0,$(LWIP))
   USEMODULE += gnrc_icmpv6_echo
 else
   USEMODULE += lwip_ipv6
-  USEMODULE += lwip_netdev
 endif
 
 USEMODULE += netutils

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -103,6 +103,11 @@ ifneq (,$(filter lwip_dhcp_auto,$(USEMODULE)))
   USEMODULE += lwip_dhcp
 endif
 
+# if an actual netdev is used, we need lwip_netdev to integrate it
+ifneq (,$(filter lwip_ethernet lwip_sixlowpan,$(USEMODULE)))
+  USEMODULE += lwip_netdev
+endif
+
 ifneq (,$(filter netif,$(USEMODULE)))
   USEMODULE += fmt
 endif

--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -223,7 +223,7 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg,
     return res;
 }
 
-static kernel_pid_t lwip_tcpip_thread = KERNEL_PID_UNDEF;
+kernel_pid_t lwip_tcpip_thread = KERNEL_PID_UNDEF;
 static kernel_pid_t lwip_lock_thread;
 
 void sys_mark_tcpip_thread(void) {

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -117,6 +117,8 @@ static inline void sys_mbox_set_invalid(sys_mbox_t *mbox)
 
 typedef kernel_pid_t sys_thread_t;      /**< Platform specific thread type */
 
+extern kernel_pid_t lwip_tcpip_thread;  /**< PID of the lwIP TCP/IP thread */
+
 /**
  * @name    Functions for locking/unlocking core to assure thread safety.
  * @{

--- a/pkg/lwip/include/lwip/netif/compat.h
+++ b/pkg/lwip/include/lwip/netif/compat.h
@@ -40,6 +40,9 @@ typedef struct {
 #ifdef MODULE_BHP_EVENT
     bhp_event_t bhp;                    /**< IPC Bottom Half Processor */
 #endif
+#if (IS_USED(MODULE_NETDEV_NEW_API))
+    thread_t *thread_doing_tx;          /**< The thread currently doing TX */
+#endif
 } lwip_netif_t;
 
 /**

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -169,6 +169,10 @@ ifneq (,$(filter netdev_tap,$(USEMODULE)))
   USEMODULE += iolist
 endif
 
+ifneq (,$(filter netdev_test,$(USEMODULE)))
+  USEMODULE += netdev_legacy_api
+endif
+
 ifneq (,$(filter eui_provider,$(USEMODULE)))
   USEMODULE += luid
 endif

--- a/tests/pkg/lwip/Makefile
+++ b/tests/pkg/lwip/Makefile
@@ -18,7 +18,7 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
-USEMODULE += lwip lwip_netdev
+USEMODULE += lwip
 USEMODULE += lwip_udp
 USEMODULE += lwip_tcp
 USEMODULE += sock_async_event

--- a/tests/pkg/lwip_sock_ip/Makefile
+++ b/tests/pkg/lwip_sock_ip/Makefile
@@ -22,7 +22,6 @@ endif
 
 USEMODULE += inet_csum
 USEMODULE += l2util
-USEMODULE += lwip_netdev
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps

--- a/tests/pkg/lwip_sock_tcp/Makefile
+++ b/tests/pkg/lwip_sock_tcp/Makefile
@@ -16,7 +16,6 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += inet_csum
-USEMODULE += lwip_netdev
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps

--- a/tests/pkg/lwip_sock_udp/Makefile
+++ b/tests/pkg/lwip_sock_udp/Makefile
@@ -22,7 +22,6 @@ endif
 
 USEMODULE += inet_csum
 USEMODULE += l2util
-USEMODULE += lwip_netdev
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps


### PR DESCRIPTION
### Contribution description

This prepares the lwIP adaption layer to work with netdevs that provide `netdev_driver_t::confirm_send()`, allowing to write event based non-blocking netdevs.

### Testing procedure

This PR does not update any drivers to actually provide `netdev_driver_t::confirm_send()`. 

https://github.com/RIOT-OS/RIOT/pull/18428 ports the STM32 Ethernet driver to the new API, so that this PR can be tested there.

### Issues/PRs references

Same as https://github.com/RIOT-OS/RIOT/pull/18139 but for lwIP

depends on and includes: 

- [x] https://github.com/RIOT-OS/RIOT/pull/18426
- [x] https://github.com/RIOT-OS/RIOT/pull/18359