### PR TITLE
cpu/stm32/periph/stm32_eth: provide confirm_send

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -49,7 +49,7 @@ ifneq (,$(filter stm32_eth,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eth
   USEMODULE += iolist
   USEMODULE += netdev_eth
-  USEMODULE += netdev_legacy_api
+  USEMODULE += netdev_new_api
   USEMODULE += ztimer
   USEMODULE += ztimer_msec
 

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -122,14 +122,14 @@ void isr_eth(void)
 
     if (IS_USED(MODULE_STM32_ETH)) {
         extern netdev_t *stm32_eth_netdev;
-        extern mutex_t stm32_eth_tx_completed;
         unsigned tmp = ETH->DMASR;
         ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_TS | ETH_DMASR_RS;
         DEBUG("[periph_eth_common] DMASR = 0x%x\n", tmp);
 
         if ((tmp & ETH_DMASR_TS)) {
             DEBUG("isr_eth: TX completed\n");
-            mutex_unlock(&stm32_eth_tx_completed);
+            stm32_eth_netdev->event_callback(stm32_eth_netdev,
+                                             NETDEV_EVENT_TX_COMPLETE);
         }
 
         if ((tmp & ETH_DMASR_RS)) {

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -2061,7 +2061,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
 #if IS_USED(MODULE_NETDEV_NEW_API)
     else if (gnrc_netif_netdev_new_api(netif)
              && (event == NETDEV_EVENT_TX_COMPLETE)) {
-        event_post(&netif->evq, &netif->event_tx_done);
+        event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW],
+                   &netif->event_tx_done);
     }
 #endif
     else {


### PR DESCRIPTION
### Contribution description

This updates the STM32 Ethernet driver to the new netdev API that includes `netdev_driver_t::confirm_send()`. It changes the `netdev_driver_t::send()` function to no longer block.

### Testing procedure

Networking with the STM32 Ethernet peripheral should still work correctly.

### Issues/PRs references

Depends on and includes:
- [x] https://github.com/RIOT-OS/RIOT/pull/18426
- [x] https://github.com/RIOT-OS/RIOT/pull/18139
- [x] https://github.com/RIOT-OS/RIOT/pull/18427
- [x] https://github.com/RIOT-OS/RIOT/pull/18417
- [x] https://github.com/RIOT-OS/RIOT/pull/18418