### PR TITLE
doccheck: make the file pattern more match riot.doxyfile

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -66,8 +66,8 @@ exclude_filter() {
 
 # Check groups are correctly defined (e.g. no undefined groups and no group
 # defined multiple times)
-ALL_RAW_DEFGROUP=$(git grep -n @defgroup -- '*.h' '*.c' '*.txt' | exclude_filter)
-ALL_RAW_INGROUP=$(git grep -n '@ingroup' -- '*.h' '*.c' '*.txt' | exclude_filter)
+ALL_RAW_DEFGROUP=$(git grep -n @defgroup -- '*.h' '*.hpp' '*.txt' 'makefiles/pseudomodules.inc.mk' 'sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c'| exclude_filter)
+ALL_RAW_INGROUP=$(git grep -n '@ingroup' -- '*.h' '*.hpp' '*.txt' 'makefiles/pseudomodules.inc.mk' 'sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c'| exclude_filter)
 DEFINED_GROUPS=$(echo "${ALL_RAW_DEFGROUP}" | \
                     grep -oE '@defgroup[ ]+[^ ]+' | \
                     grep -oE '[^ ]+$' | \

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup   sys_ztimer_util
+ * @defgroup  sys_ztimer_xtimer_compat ztimer_xtimer_compat: xtimer wrapper
+ * @ingroup   sys_ztimer
  * @{
  * @file
  * @brief   ztimer xtimer wrapper interface

--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup   sys_ztimer_util
+ * @defgroup  sys_ztimer64_xtimer_compat ztimer64_xtimer_compat: 64 Bit xtimer wrapper
+ * @ingroup   sys_ztimer64
  * @{
  * @file
  * @brief   ztimer64 xtimer wrapper interface


### PR DESCRIPTION
### Contribution description

doccheck checks the `@defgroup` and  `@ingroup` commands for doxygen sadly it uses a wrong list of files
this brings them more in sync 

the file pattern used by doxygen can be found here: https://github.com/RIOT-OS/RIOT/blob/2dd185448f1b65fc97df885f9933f70b96377ecc/doc/doxygen/riot.doxyfile#L801-L804

### Testing procedure

run doccheck

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
