### PR TITLE
tests/unittests: Correct typo in documentation

### DIFF
--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -256,7 +256,7 @@ Test *tests_<module>_<header>_tests(void)
     EMB_UNIT_TESTCALLER(<module>_<header>_tests, set_up, tear_down, fixtures);
     /* set up and tear down function can be NULL if omitted */
 
-    return (Test *)&<module>_<header>;
+    return (Test *)&<module>_<header>_tests;
 }
 ```
 


### PR DESCRIPTION
### Contribution description

This pull request corrects a typo in the documentation for the unit tests.

The name in `EMB_UNIT_TESTCALLER` and the name in the cast should be equal:

``` c++
EMB_UNIT_TESTCALLER(<module>_<header>_tests, set_up, tear_down, fixtures);
return (Test *)&<module>_<header>; // should be <module>_<header>_test
```
