### PR TITLE
dns_cache: handle TTL=0 properly

### DIFF
--- a/tests/unittests/tests-dns_cache/tests-dns_cache.c
+++ b/tests/unittests/tests-dns_cache/tests-dns_cache.c
@@ -37,10 +37,25 @@ static void test_dns_cache_add(void)
     TEST_ASSERT_EQUAL_INT(0, dns_cache_query("example.com", &addr_out, AF_INET6));
 }
 
+static void test_dns_cache_add_ttl0(void)
+{
+    ipv6_addr_t addr_in = IPV6_ADDR_ALL_NODES_IF_LOCAL;
+    ipv6_addr_t addr_out;
+
+    TEST_ASSERT_EQUAL_INT(0, dns_cache_query("example.com", &addr_out, AF_INET6));
+    dns_cache_add("example.com", &addr_in, sizeof(addr_in), 0);
+    TEST_ASSERT_EQUAL_INT(0, dns_cache_query("example.com", &addr_out, AF_INET6));
+    dns_cache_add("example.com", &addr_in, sizeof(addr_in), 1);
+    TEST_ASSERT_EQUAL_INT(sizeof(addr_out), dns_cache_query("example.com", &addr_out, AF_INET6));
+    dns_cache_add("example.com", &addr_in, sizeof(addr_in), 0);
+    TEST_ASSERT_EQUAL_INT(0, dns_cache_query("example.com", &addr_out, AF_INET6));
+}
+
 Test *tests_dns_cache_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_dns_cache_add),
+        new_TestFixture(test_dns_cache_add_ttl0),
     };
 
     EMB_UNIT_TESTCALLER(dns_cache_tests, NULL, NULL, fixtures);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Existing entries should be expired, new entries should not be created.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I added a test case for TTL=0 to the unittests, so

```sh
make -C tests/unittests/ tests-dns_cache test
```

should succeed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
