### PR TITLE
gcoap_dns: implement Max-Age-based TTL calculation

### DIFF
--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -740,11 +740,17 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
     switch (coap_get_content_type(pdu)) {
         case COAP_FORMAT_DNS_MESSAGE:
         case COAP_FORMAT_NONE: {
-            uint32_t ttl;
+            uint32_t ttl = 0;
 
             context->res = dns_msg_parse_reply(data, data_len, family,
                                                context->addr_out, &ttl);
-            if (context->res > 0) {
+            if (IS_USED(MODULE_DNS_CACHE) && (context->res > 0)) {
+                uint32_t max_age;
+
+                if (coap_opt_get_uint(pdu, COAP_OPT_MAX_AGE, &max_age) < 0) {
+                    max_age = 60;
+                }
+                ttl += max_age;
                 dns_cache_add(_domain_name_from_ctx(context), context->addr_out, context->res, ttl);
             }
             else if (ENABLE_DEBUG && (context->res < 0)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This implements the TTL calculation algorithm that is described in [Section 4.3.2](https://www.ietf.org/archive/id/draft-lenders-dns-over-coap-04.html#name-support-of-coap-caching-2) of the current draft.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gcoap_dns` should still compile. DNS caching itself is currently not implemented in tests, but the code should speak for itself.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
