### PR TITLE
vfs: introduce vfs_format_by_path()

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -899,6 +899,21 @@ int vfs_closedir(vfs_DIR *dirp);
 int vfs_format(vfs_mount_t *mountp);
 
 /**
+ * @brief Format a file system
+ *
+ * The file system must not be mounted in order to be formatted.
+ * Call @ref vfs_unmount_by_path first if necessary.
+ *
+ * @note This assumes mount points have been configured with @ref VFS_AUTO_MOUNT.
+ *
+ * @param[in]  path     Path of the pre-configured mount point
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int vfs_format_by_path(const char *path);
+
+/**
  * @brief Mount a file system
  *
  * @p mountp should have been populated in advance with a file system driver,

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -79,6 +79,9 @@ static void _vfs_usage(char **argv)
     if (MOUNTPOINTS_NUMOF > 0) {
         printf("%s remount [path]\n", argv[0]);
     }
+    if (MOUNTPOINTS_NUMOF > 0) {
+        printf("%s format [path]\n", argv[0]);
+    }
     puts("r: Read [bytes] bytes at [offset] in file <path>");
     puts("w: Write (<a>: append, <o> overwrite) <ascii> or <hex> string <data> in file <path>");
     puts("ls: List files in <path>");
@@ -232,6 +235,21 @@ static int _remount_handler(int argc, char **argv)
 
     return res;
 }
+
+static int _format_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s [path]\n", argv[0]);
+        puts("format pre-configured mount point");
+        return -1;
+    }
+
+    char buf[16];
+    int res = vfs_format_by_path(argv[1]);
+    if (res < 0) {
+        _errno_string(res, buf, sizeof(buf));
+        puts(buf);
+    }
 
     return res;
 }
@@ -733,6 +751,9 @@ static int _vfs_handler(int argc, char **argv)
     }
     else if (MOUNTPOINTS_NUMOF > 0 && strcmp(argv[1], "remount") == 0) {
         return _remount_handler(argc - 1, &argv[1]);
+    }
+    else if (MOUNTPOINTS_NUMOF > 0 && strcmp(argv[1], "format") == 0) {
+        return _format_handler(argc - 1, &argv[1]);
     }
     else {
         printf("vfs: unsupported sub-command \"%s\"\n", argv[1]);

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -112,6 +112,7 @@ static int _errno_string(int err, char *buf, size_t buflen)
         err = -err;
     }
     switch (err) {
+        _case_snprintf_errno_name(EBUSY);
         _case_snprintf_errno_name(EACCES);
         _case_snprintf_errno_name(ENOENT);
         _case_snprintf_errno_name(EINVAL);
@@ -185,9 +186,13 @@ static int _mount_handler(int argc, char **argv)
         return -1;
     }
 
-    uint8_t buf[16];
+    char buf[16];
     int res = vfs_mount_by_path(argv[1]);
-    _errno_string(res, (char *)buf, sizeof(buf));
+    if (res < 0) {
+        _errno_string(res, buf, sizeof(buf));
+        puts(buf);
+    }
+
     return res;
 }
 
@@ -199,10 +204,13 @@ static int _umount_handler(int argc, char **argv)
         return -1;
     }
 
-    uint8_t buf[16];
+    char buf[16];
     int res = vfs_unmount_by_path(argv[1]);
+    if (res < 0) {
+        _errno_string(res, buf, sizeof(buf));
+        puts(buf);
+    }
 
-    _errno_string(res, (char *)buf, sizeof(buf));
     return res;
 }
 
@@ -214,10 +222,17 @@ static int _remount_handler(int argc, char **argv)
         return -1;
     }
 
-    uint8_t buf[16];
+    char buf[16];
     vfs_unmount_by_path(argv[1]);
     int res = vfs_mount_by_path(argv[1]);
-    _errno_string(res, (char *)buf, sizeof(buf));
+    if (res < 0) {
+        _errno_string(res, buf, sizeof(buf));
+        puts(buf);
+    }
+
+    return res;
+}
+
     return res;
 }
 

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -1208,4 +1208,15 @@ int vfs_unmount_by_path(const char *path)
     return -ENOENT;
 }
 
+int vfs_format_by_path(const char *path)
+{
+    for (unsigned i = 0; i < MOUNTPOINTS_NUMOF; ++i) {
+        if (strcmp(path, vfs_mountpoints_xfa[i].mount_point) == 0) {
+            return vfs_format(&vfs_mountpoints_xfa[i]);
+        }
+    }
+
+    return -ENOENT;
+}
+
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds `vfs_format_by_path()` analoguous to `vfs_mount_by_path()` and `vfs_unmount_by_path()`.

Just as with `vfs_format()` the file system needs to be unmounted first before it can be formatted.

### Testing procedure

```
> vfs w /nvm0/test.txt ascii a "Hello World!"
> ls /nvm0
./
../
test.txt	12 B
total 1 files

> vfs format /nvm0
-EBUSY

> vfs umount /nvm0
> vfs format /nvm0
> vfs mount /nvm0
> ls /nvm0
./
../
total 0 files
```



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
