### PR TITLE
core: Treat stack overflows as an unrecoverable error

### DIFF
--- a/core/lib/include/panic.h
+++ b/core/lib/include/panic.h
@@ -51,6 +51,7 @@ typedef enum {
     PANIC_DUMMY_HANDLER,        /**< unhandled interrupt */
 #endif
     PANIC_SSP,                  /**< stack smashing protector failure */
+    PANIC_STACK_OVERFLOW,       /**< stack overflow detected */
     PANIC_UNDEFINED
 } core_panic_t;
 

--- a/core/sched.c
+++ b/core/sched.c
@@ -30,6 +30,7 @@
 #include "log.h"
 #include "sched.h"
 #include "thread.h"
+#include "panic.h"
 
 #ifdef MODULE_MPU_STACK_GUARD
 #include "mpu.h"
@@ -130,9 +131,10 @@ static void _unschedule(thread_t *active_thread)
      */
     if (*((uintptr_t *)(uintptr_t)active_thread->stack_start) !=
         (uintptr_t)active_thread->stack_start) {
-        LOG_WARNING(
+        LOG_ERROR(
             "scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n",
             active_thread->pid);
+        core_panic(PANIC_STACK_OVERFLOW, "STACK OVERFLOW");
     }
 #endif
 #ifdef MODULE_SCHED_CB


### PR DESCRIPTION
### Contribution description

Presently, RIOT just emits a warning when a stack overflow is encountered but still resumes execution. In my view, execution should be aborted as the detection of a stack overflows via the heuristic provided by the scheduler is an unrecoverable error.

I ran into this while performing automated tests of a RIOT application where a stack overflow occurred but I only noticed this after inspecting the application output more closely.

Similar to SSP failures, I added crash_code for stack overflows and also bumped the log level from warning to error.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I don't think there is a test case for the `SCHED_TEST_STACK` heuristic but basically the testing procedure would boil down to ensuring that execution does not continue after a stack overflow is detected by the scheduler.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None.