### PR TITLE
pkg/nimble: add feature ble_adv_ext and cleanup ble_* features

### DIFF
--- a/cpu/nrf52/Kconfig
+++ b/cpu/nrf52/Kconfig
@@ -9,6 +9,7 @@ config CPU_FAM_NRF52
     select CPU_COMMON_NRF5X
 # The ADC does not depend on any board configuration, so always available
     select HAS_PERIPH_ADC
+    select HAS_BLE_ADV_EXT
 # So far, NimBLE netif does not support nrf51 platforms, so we use a dedicated
 # feature to mark this
     select HAS_BLE_NIMBLE_NETIF

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -33,4 +33,6 @@ ifneq (,$(filter nrf52811% nrf52820% nrf52833% nrf52840%,$(CPU_MODEL)))
   FEATURES_PROVIDED += ble_phy_coded
 endif
 
+FEATURES_PROVIDED += ble_adv_ext
+
 include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf5x_common/Kconfig
+++ b/cpu/nrf5x_common/Kconfig
@@ -27,26 +27,6 @@ config CPU_COMMON_NRF5X
     select HAS_RADIO_NRFMIN
 
 ## Definition of specific features
-config HAS_BLE_NIMBLE
-    bool
-    help
-        Indicates that the NimBLE stack is supported on the current platform.
-
-config HAS_BLE_NIMBLE_NETIF
-    bool
-    help
-        Indicates that NimBLE netif is supported on the current platform.
-
-config HAS_BLE_PHY_2MBIT
-    bool
-    help
-        Indicates that the BLE radio supports the 2Mbit PHY mode
-
-config HAS_BLE_PHY_CODED
-    bool
-    help
-        Indicates that the BLE radio supports the CODED PHY mode
-
 config HAS_RADIO_NRFBLE
     bool
     select HAVE_NRF5X_RADIO

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -42,10 +42,25 @@ config HAS_BACKUP_RAM
     help
         Indicates that Backup RAM is supported.
 
-config HAS_RUST_TARGET
+config HAS_BLE_NIMBLE
     bool
     help
-        Indicates that a Rust target definition ("triple") is known.
+        Indicates that the NimBLE stack is supported on the current platform.
+
+config HAS_BLE_NIMBLE_NETIF
+    bool
+    help
+        Indicates that NimBLE netif is supported on the current platform.
+
+config HAS_BLE_PHY_2MBIT
+    bool
+    help
+        Indicates that the BLE radio supports the 2Mbit PHY mode
+
+config HAS_BLE_PHY_CODED
+    bool
+    help
+        Indicates that the BLE radio supports the CODED PHY mode
 
 config HAS_CPP
     bool
@@ -437,6 +452,11 @@ config HAS_RIOTBOOT
     bool
     help
         Indicates that the riotboot booloader is supported.
+
+config HAS_RUST_TARGET
+    bool
+    help
+        Indicates that a Rust target definition ("triple") is known.
 
 config HAS_SDCARD_SPI
     bool

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -42,6 +42,12 @@ config HAS_BACKUP_RAM
     help
         Indicates that Backup RAM is supported.
 
+config HAS_BLE_ADV_EXT
+    bool
+    help
+        Indicates the current platform supports Bluetooth 5 Advertising
+        Extension
+
 config HAS_BLE_NIMBLE
     bool
     help

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -65,6 +65,10 @@ ifneq (,$(filter nimble_addr,$(USEMODULE)))
   USEMODULE += bluetil_addr
 endif
 
+ifneq (,$(filter nimble_adv_ext,$(USEMODULE)))
+  FEATURES_REQUIRED += ble_adv_ext
+endif
+
 ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
   USEMODULE += bluetil_ad
   USEMODULE += bluetil_addr


### PR DESCRIPTION
### Contribution description

This PR provides the following changes regarding BLE features:
- Since the existing Kconfig features `HAS_BLE_NIMBLE*` and `HAS_BLE_PHY_*` can also be provided by other platforms, the definition of these features are moved to the common file `$(RIOTBASE)/kconfigs/Kconfig.feature`.
- To control the compilation of NimBLE modules `nimble_*_ext` that require the Bluetooth 5 Advertising Extension, the `ble_adv_ext`/`HAS_BLE_ADV_EXT` feature is introduced to indicate that a platform supports this feature.
- Add feature `ble_adv_ext`/`HAS_BLE_ADV_EXT` for nRF52 MCUs.
- Fixes the alphabetical order of Kconfig feature `HAS_RUST_TARGET` in file `$(RIOTBASE)/kconfigs/Kconfig.feature`.

### Testing procedure

Green CI

### Issues/PRs references

Prerequisite for PR #18439 