### PR TITLE
boards/im880b: refactor code

### DIFF
--- a/boards/im880b/Makefile.include
+++ b/boards/im880b/Makefile.include
@@ -1,16 +1,8 @@
 # this board uses shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 CFLAGS+=-DSX127X_TX_SWITCH
 CFLAGS+=-DSX127X_RX_SWITCH
 
-# this board uses openocd
-PROGRAMMER ?= openocd
-# openocd programmer is supported
-PROGRAMMERS_SUPPORTED += openocd
-
-OPENOCD_DEBUG_ADAPTER ?= stlink
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk


### PR DESCRIPTION
### Contribution description

Using the common STM32 board makefile provides all supported programmers for STM32 boards. This allows e.g. to flash with stm32flash via `make BOARD=im880b PROGRAMMER=stm32flash flash`.

### Testing procedure

`make flash` and `make term` should still work for OpenOCD with ST-Links as before, but additional programmers should now be available. I was able to program with `stm32flash`.

### Issues/PRs references

None