### PR TITLE
makefiles/boards/stm32.inc.mk: improve stm32flash support

### DIFF
--- a/doc/doxygen/src/flashing.md
+++ b/doc/doxygen/src/flashing.md
@@ -135,6 +135,27 @@ JTAG. Also JTAG requires more signal lines to be connected compared to SWD and
 some internal programmers only have the SWD signal lines connected, so that
 JTAG will not be possible.
 
+`stm32flash` Configuration                  {#flashing-configuration-stm32flash}
+--------------------------
+
+It is possible to automatically boot the STM32 board into the in-ROM bootloader
+that `stm32flash` communicates with for flashing by connecting the RST pin to
+DTR and the BOOT pin (or BOOT0 for STM32 MCU families with BOOT0 and BOOT1 pins)
+to RTS of the TTL adapter. In addition, set `STM32FLASH_RESET` to `1` via
+environment or command line to actually issue a reset with BOOT (or BOOT0)
+pulled high prior flashing to enter the bootloader, and a second reset with BOOT
+(or BOOT0) pulled low to reboot into the application. `STM32FLASH_RESET`
+defaults to `0` as of know, as with `PROGRAMMER=stm32flash STM32FLASH_RESET=1`
+additional terminal flags are set, so that `make term` doesn't accidentally
+keeps the reset signal pulled low or boot the board into the bootloader.
+
+The TTL adapter this was tested with had inverted RTS and DTR signal. By setting
+`STM32FLASH_RESET_INVERT` to `1` RIOT will assume RTS and DTR signals to be
+inverted, by setting it to `0` non-inverted signals will be generated. As of
+now, `STM32FLASH_RESET_INVERT` is by default `1`. This may change if it
+becomes evident that non-inverted TTL adapters are in fact more common than
+inverted adapters.
+
 Handling Multiple Boards With UDEV-Rules                {#multiple-boards-udev}
 ========================================
 

--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -30,11 +30,36 @@ ifeq (dfu-util,$(PROGRAMMER))
 endif
 
 ifeq (stm32flash,$(PROGRAMMER))
-	ROM_OFFSET ?= 0x0
-	FLASHER = stm32flash
-	DEBUGGER =
-	FLASHFILE ?= $(BINFILE)
-	PROG_BAUD ?= 57600
-	BIN_ADDR ?= $(shell echo  $$(($(ROM_START_ADDR) + $(ROM_OFFSET))))
-	FFLAGS = -v -b $(PROG_BAUD) -w $(FLASHFILE) -S $(BIN_ADDR) -g $(BIN_ADDR) $(PORT)
+  ROM_OFFSET ?= 0x0
+  FLASHER = stm32flash
+  DEBUGGER =
+  FLASHFILE ?= $(BINFILE)
+  PROG_BAUD ?= 57600
+  BIN_ADDR ?= $(shell echo  $$(($(ROM_START_ADDR) + $(ROM_OFFSET))))
+  STM32FLASH_RESET ?= 0
+  STM32FLASH_RESET_INVERT ?= 1
+  # sequence to reset board into bootloader:
+  #   BOOT0 --> HIGH, RST --> LOW
+  #   BOOT0 --> HIGH, RST --> HIGH
+  # sequence to reset board into application
+  #   BOOT0 --> LOW, RST --> LOW
+  #   BOOT0 --> LOW, RST --> HIGH
+  # This can be done via a TTL adapter when BOOT0 is connected to RTS and
+  # RST is connected to DTR
+  ifeq (1,$(STM32FLASH_RESET))
+    # The TTL adapter this was tested with actually has inverted outputs. But
+    # we can just support both via a simple flag:
+    ifeq (1,$(STM32FLASH_RESET_INVERT))
+      FFLAGS += -i '-rts,dtr,-dtr:rts,dtr,-dtr'
+      # set term flags so BOOT0 is low and RST is high
+      MINITERMFLAGS += --rts 1 --dtr 0
+      PYTERMFLAGS += --set-rts 1 --set-dtr 0
+    else
+      FFLAGS += -i 'rts,-dtr,dtr:-rts,-dtr,dtr'
+      # set term flags so BOOT0 is low and RST is high
+      MINITERMFLAGS += --rts 0 --dtr 1
+      PYTERMFLAGS += --set-rts 0 --set-dtr 1
+    endif
+  endif
+  FFLAGS += -v -b $(PROG_BAUD) -w $(FLASHFILE) -S $(BIN_ADDR) -g $(BIN_ADDR) $(PORT)
 endif


### PR DESCRIPTION
### Contribution description

Allow issuing a reset to bootloader sequence by abusing the RTS and the DTR pins of a TTL adapter. This makes flashing via UART much more convenient, as no jumpers need to be placed to select booting to the bootloader / flash and no reset buttons need to be pressed.

~~It is btw. about time we create a documentation page on programmers. I hope to open a PR adding this today. If this PR is not merged by then, I will rebase this on top and document the new feature in the newly added `stm32flash` programmer documentation page.~~

Update: Documentation added in this PR :smile:

### Testing procedure

I tested this with a Blackpill (but a Bluepill or any other STM32 board should also work), but this also needs https://github.com/RIOT-OS/RIOT/pull/18450 to map stdio to UASRT1 for Bluepill/Blackpill boards.

- wire TXD/RXD of USART1 of your board to RX/TX of you TTL adapter as usual
- wire RTS to BOOT0 (or just BOOT on non STM32F1 boards)
- wire DTR to the reset pin of your board
- Flash with `make BOARD=blackpill PROGRAMMER=stm32flash STM32FLASH_RESET=1 -C examples/default flash term`

My TTL adapter had inverted RTS / DTR outputs. Maybe this is the default, maybe not. If your TTL adapter does not invert RTS / DTR, pass `STM32FLASH_RESET_INVERT=0`.

### Issues/PRs references

None