### PR TITLE
core/thread: add thread flags for FreeRTOS queue implementation

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -172,6 +172,10 @@ typedef enum {
     STATUS_FLAG_BLOCKED_ALL,        /**< waiting for all flags in flag_mask       */
     STATUS_MBOX_BLOCKED,            /**< waiting for get/put on mbox              */
     STATUS_COND_BLOCKED,            /**< waiting for a condition variable         */
+#if IS_USED(MODULE_ESP_FREERTOS_COMMON)
+    STATUS_QUEUE_FULL_BLOCKED,      /**< FreeRTOS compatibility layer queue full  */
+    STATUS_QUEUE_EMPTY_BLOCKED,     /**< FreeRTOS compatibility layer queue empty */
+#endif
     STATUS_RUNNING,                 /**< currently running                        */
     STATUS_PENDING,                 /**< waiting to be scheduled to run           */
     STATUS_NUMOF                    /**< number of supported thread states        */

--- a/core/thread.c
+++ b/core/thread.c
@@ -333,6 +333,10 @@ static const char *state_names[STATUS_NUMOF] = {
     [STATUS_FLAG_BLOCKED_ALL] = "bl allfl",
     [STATUS_MBOX_BLOCKED] = "bl mbox",
     [STATUS_COND_BLOCKED] = "bl cond",
+#if IS_USED(MODULE_ESP_FREERTOS_COMMON)
+    [STATUS_QUEUE_FULL_BLOCKED] = "bl qfull",
+    [STATUS_QUEUE_EMPTY_BLOCKED] = "bl qempt",
+#endif
     [STATUS_RUNNING] = "running",
     [STATUS_PENDING] = "pending",
 };

--- a/cpu/esp_common/freertos/queue.c
+++ b/cpu/esp_common/freertos/queue.c
@@ -279,7 +279,7 @@ BaseType_t IRAM_ATTR _queue_generic_send(QueueHandle_t xQueue,
         else {
             /* suspend the calling thread to wait for space in the queue */
             thread_t *me = thread_get_active();
-            sched_set_status(me, STATUS_SEND_BLOCKED);
+            sched_set_status(me, STATUS_QUEUE_FULL_BLOCKED);
             /* waiting list is sorted by priority */
             thread_add_to_list(&queue->sending, me);
 
@@ -407,7 +407,7 @@ BaseType_t IRAM_ATTR _queue_generic_recv (QueueHandle_t xQueue,
         else {
             /* suspend the calling thread to wait for an item in the queue */
             thread_t *me = thread_get_active();
-            sched_set_status(me, STATUS_RECEIVE_BLOCKED);
+            sched_set_status(me, STATUS_QUEUE_EMPTY_BLOCKED);
             /* waiting list is sorted by priority */
             thread_add_to_list(&queue->receiving, me);
 


### PR DESCRIPTION
### Contribution description

This PR adds the thread states `STATE_QUEUE_FULL_BLOCKED` and `STATE_QUEUE_EMPTY_BLOCKED` which are compiled in depending on whether the FreeRTOS compatibility layer for ESP SoCs is used.

This change fixes a problem that was figured out when investigating a crash in `tests/nimble_rpble_gnrc` in PR #18439.

The FreeRTOS queue and semaphore implementation of the FreeRTOS compatibility layer previously used `STATUS_RECEIVE_BLOCKED` and `STATE_SEND_BLOCKED` to block a thread when the corresponding queue was empty and full, respectively. This was compatible to the blocking mechanism used for `msg` by `gnrc_netif`. However, since PR #16748, `gnrc_netif` no longer uses the `msg` blocking mechanism, but uses thread flags.

As a consequence, RIOT may crash when using FreeRTOS queues and semaphores together with `gnrc_netif` for the ESP network interfaces if `STATUS_RECEIVE_BLOCKED` in same thread and `STATUS_RECEIVE_BLOCKED` is used by FreeRTOS compatibility layer. If the `gnrc_netif` thread is blocked because of a FreeRTOS semaphore and is therefore in `STATUS_RECEIVE_BLOCKED` state, the `_msg_send` function will cause a crash because it then assumes that `target->wait_data` contains a pointer to a message of type `msg_t`, but by using thread flags it contains just the flag mask. This situation can easily occur when the ESP hardware is used by the `gnrc_netif` thread while another thread is sending something timer controlled to the `gnrc_netif` thread. See also https://github.com/RIOT-OS/RIOT/pull/18439#issuecomment-1214700678.

To solve this problem `STATE_QUEUE_FULL_BLOCKED` and `STATE_QUEUE_EMPTY_BLOCKED` are introduced.

### Testing procedure

Use command
```
USEMODULE=esp_wifi CFLAGS='-DESP_WIFI_SSID=\"myssid\" -DESP_WIFI_PASS=\"mypass\" -DDEBUG_ASSERT_VERBOSE' BOARD=esp32-wrover-kit make -j8 -C examples/gnrc_networking flash term
```
and check that the WiFi network interface still works.

Use command `ps`, the output should look like
```
	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
	  1 | sys_evt              | bl qempt _ |   4 |   2616 ( 1188) ( 1428) | 0x3ffbd3cc | 0x3ffbdba0 
	  2 | esp_timer            | sleeping _ |   2 |   3640 (  464) ( 3176) | 0x3ffbde08 | 0x3ffbea70 
	  3 | idle                 | pending  Q |  31 |   2048 (  448) ( 1600) | 0x3ffb2390 | 0x3ffb29d0 
	  4 | main                 | running  Q |  15 |   3584 ( 1424) ( 2160) | 0x3ffb2b90 | 0x3ffb3430 
	  5 | pktdump              | bl rx    _ |  14 |   3584 (  560) ( 3024) | 0x3ffb84f0 | 0x3ffb90c0 
	  6 | ipv6                 | bl rx    _ |  12 |   2048 (  784) ( 1264) | 0x3ffb6110 | 0x3ffb66c0 
	  7 | udp                  | bl rx    _ |  13 |   2048 (  572) ( 1476) | 0x3ffb9d3c | 0x3ffba300 
	  8 | wifi                 | bl qempt _ |   1 |   6200 ( 2172) ( 4028) | 0x3ffbec44 | 0x3ffc0240 
	  9 | netif-esp-wifi       | bl anyfl _ |  10 |   2048 (  844) ( 1204) | 0x3ffb45bc | 0x3ffb4b50 
	 10 | RPL                  | bl rx    _ |  13 |   2048 (  504) ( 1544) | 0x3ffb9538 | 0x3ffb9b40 
	    | SUM                  |            |     |  29864 ( 8960) (20904)
```
The `sys_evt` thread should be in state `bl qemt`.

### Issues/PRs references

Prerequisite for PR #18439