### PR TITLE
pkg/nimble: fix of legacy advertising in statconn

### DIFF
--- a/pkg/nimble/statconn/nimble_statconn.c
+++ b/pkg/nimble/statconn/nimble_statconn.c
@@ -49,7 +49,7 @@ typedef struct {
 #endif
 } slot_t;
 
-static const uint8_t _ad[2] = { BLE_GAP_AD_FLAGS, BLUETIL_AD_FLAGS_DEFAULT };
+static const uint8_t _ad[] = { 2, BLE_GAP_AD_FLAGS, BLUETIL_AD_FLAGS_DEFAULT };
 
 static mutex_t _lock = MUTEX_INIT;
 static slot_t _slots[NIMBLE_NETIF_MAX_CONN];


### PR DESCRIPTION
### Contribution description

This PR fixes a small formatting bug of the flags in Advertising Data in Legacy Advertising for `pkg/nimble/statconn`.

Without this PR, the slave nodes advertise improperly formatted data. The `nRFConnect` app shows "Error while parsing EIR (0x06)". The reason is that a static character buffer is used as Advertising Data https://github.com/RIOT-OS/RIOT/blob/f2720940d76829ac494cde582e2d347efdf4e755/pkg/nimble/statconn/nimble_statconn.c#L52 which is not formatted properly. Each Advertising Data field has to consist of a length, the type and the data.

In case of the flags that are advertised in `pkg/nimble/statconn`, the data have to consist of the 3 bytes:
```
static const uint8_t _ad[] = { 2, BLE_GAP_AD_FLAGS, BLUETIL_AD_FLAGS_DEFAULT };
```
Furthermore, it is not necessary to define the length of the array if a static initializer is used.

### Testing procedure

Flash an nRF52x node with `tests/nimble_statconn_gnrc` and execute the following command:
```
statconn addm DD:67:34:05:2D:D6
``` 
Use the nRFConnect app and check the Advertisment of the node. Without this PR, nRFConnect should show:
```
Error while parsing EIR (0x06)
```
With this PR: nRFConnect should show:
```
Flags: GeneralDiscoverable, BrEdrNotSupported
```

### Issues/PRs references

Found when investigating a problem in #18439 