### PR TITLE
makefiles/suit: make it possible to accept multiple SUIT keys

### DIFF
--- a/dist/tools/suit/suit-manifest-generator/suit_tool/get_pubkey.py
+++ b/dist/tools/suit/suit-manifest-generator/suit_tool/get_pubkey.py
@@ -49,11 +49,11 @@ def to_header(pk):
     if isinstance(pk, ed25519.Ed25519PrivateKey):
         public_bytes = pk.public_key().public_bytes(ks.Encoding.Raw,
                                                       ks.PublicFormat.Raw)
-        public_c_def = ['const uint8_t public_key[] = {'] + textwrap.wrap(
+        public_c_def = ['{'] + textwrap.wrap(
             ', '.join(['{:0=#4x}'.format(x) for x in public_bytes]),
             76
         )
-        return str.encode('\n    '.join(public_c_def) + '\n};\n')
+        return str.encode('\n    '.join(public_c_def) + '\n},\n')
 
 
 OutputFormaters = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A board may be flashed with a development firmware. The development firmware should accept SUIT updates signed with *both* the development *and* the production key.

Therefore allow to include multiple public keys to verify the SUIT manifest with.

### Testing procedure

Run `tests/suit_manifest` with multiple keys, e.g.

    SUIT_SECS="/home/benpicco/dev/RIOT/keys/default.pem /home/benpicco/.local/share/RIOT/keys/default.pem" make -C tests/suit_manifest all term

The tests should still success even though the 'wrong' key is tried first.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
