### PR TITLE
core/sched: Provide thread state names for OpenOCD

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -155,10 +155,7 @@ static inline int pid_is_valid(kernel_pid_t pid)
 typedef struct _thread thread_t;
 
 /**
- * @name Thread states supported by RIOT
- *
- *       Keep in sync with OpenOCD src/rtos/riot.c
- * @{
+ * @brief   Thread states supported by RIOT
  */
 typedef enum {
     STATUS_STOPPED,                 /**< has terminated                           */
@@ -176,7 +173,14 @@ typedef enum {
     STATUS_PENDING,                 /**< waiting to be scheduled to run           */
     STATUS_NUMOF                    /**< number of supported thread states        */
 } thread_status_t;
-/** @} */
+
+/**
+ * @brief   List of thread state names
+ *
+ * This is a look up table for @ref thread_status_t used by OpenOCD and to
+ * implement @ref thread_state_to_string
+ */
+extern const char * const * const thread_state_names;
 
 /**
  * @name Helpers to work with thread states

--- a/core/sched.c
+++ b/core/sched.c
@@ -67,6 +67,27 @@ const uint8_t max_threads = ARRAY_SIZE(sched_threads);
 FORCE_USED_SECTION
 const uint8_t _tcb_name_offset = offsetof(thread_t, name);
 #endif
+
+FORCE_USED_SECTION
+static const char * const _thread_state_names[STATUS_NUMOF] = {
+    [STATUS_STOPPED] = "stopped",
+    [STATUS_ZOMBIE] = "zombie",
+    [STATUS_SLEEPING] = "sleeping",
+    [STATUS_MUTEX_BLOCKED] = "bl mutex",
+    [STATUS_RECEIVE_BLOCKED] = "bl rx",
+    [STATUS_SEND_BLOCKED] = "bl send",
+    [STATUS_REPLY_BLOCKED] = "bl reply",
+    [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",
+    [STATUS_FLAG_BLOCKED_ALL] = "bl allfl",
+    [STATUS_MBOX_BLOCKED] = "bl mbox",
+    [STATUS_COND_BLOCKED] = "bl cond",
+    [STATUS_RUNNING] = "running",
+    [STATUS_PENDING] = "pending",
+};
+FORCE_USED_SECTION
+const char * const * const thread_state_names = _thread_state_names;
+FORCE_USED_SECTION
+const uint8_t thread_state_names_numof = ARRAY_SIZE(_thread_state_names);
 /** @} */
 
 volatile thread_t *sched_active_thread;

--- a/core/thread.c
+++ b/core/thread.c
@@ -321,27 +321,12 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
     return pid;
 }
 
-static const char *state_names[STATUS_NUMOF] = {
-    [STATUS_STOPPED] = "stopped",
-    [STATUS_ZOMBIE] = "zombie",
-    [STATUS_SLEEPING] = "sleeping",
-    [STATUS_MUTEX_BLOCKED] = "bl mutex",
-    [STATUS_RECEIVE_BLOCKED] = "bl rx",
-    [STATUS_SEND_BLOCKED] = "bl send",
-    [STATUS_REPLY_BLOCKED] = "bl reply",
-    [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",
-    [STATUS_FLAG_BLOCKED_ALL] = "bl allfl",
-    [STATUS_MBOX_BLOCKED] = "bl mbox",
-    [STATUS_COND_BLOCKED] = "bl cond",
-    [STATUS_RUNNING] = "running",
-    [STATUS_PENDING] = "pending",
-};
-
 #define STATE_NAME_UNKNOWN "unknown"
 
 const char *thread_state_to_string(thread_status_t state)
 {
-    const char *name = state_names[state] ? state_names[state] : NULL;
+    assert((unsigned)state < STATUS_NUMOF);
+    const char *name = thread_state_names[state];
 
     assert(name != NULL); /* if compiling with assertions, this is an error that
                              indicates that the table above is incomplete */


### PR DESCRIPTION
### Contribution description

This provides the thread state names as used in ps() as a symbol that OpenOCD can read out. This allows implementing OpenOCD's RIOT awareness in a way that changes to thread states can be picked up at runtime, without having to patch OpenOCD for every change. Apparently RIOT is a bit faster moving in this regard than other bare metal RTOSes.

### Testing procedure

`ps()` should still work as before. In addition, a to be posted OpenOCD patch should result in OpenOCD picking up the RIOT thread state names as provided.

### Issues/PRs references

Useful for https://github.com/RIOT-OS/RIOT/pull/18454 which will break OpenOCD's RIOT-awareness. With this, at least future thread state changes should no longer require patching OpenOCD.