### PR TITLE
lvgl/contrib: allow for SDL display driver height/width to be adjusted

### DIFF
--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -54,6 +54,18 @@
 #define LVGL_THREAD_FLAG                    (1 << 7)
 #endif
 
+#if IS_USED(MODULE_LV_DRIVERS_SDL)
+
+#ifndef LCD_SCREEN_WIDTH
+#define LCD_SCREEN_WIDTH            SDL_HOR_RES
+#endif
+
+#ifndef LCD_SCREEN_HEIGHT
+#define LCD_SCREEN_HEIGHT           SDL_VER_RES
+#endif
+
+#endif
+
 static kernel_pid_t _task_thread_pid;
 
 static lv_disp_draw_buf_t disp_buf;
@@ -79,6 +91,7 @@ static void _disp_map(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *col
     const disp_dev_area_t disp_area = {
         area->x1, area->x2, area->y1, area->y2
     };
+
     disp_dev_map(_screen_dev->display, &disp_area, (const uint16_t *)color_p);
 
     LOG_DEBUG("[lvgl] flush display\n");
@@ -141,6 +154,8 @@ void lvgl_init(screen_dev_t *screen_dev)
     sdl_init();
     /* Used when `LV_VDB_SIZE != 0` in lv_conf.h (buffered drawing) */
     disp_drv.flush_cb = sdl_display_flush;
+    disp_drv.hor_res = LCD_SCREEN_WIDTH;
+    disp_drv.ver_res = LCD_SCREEN_HEIGHT;
 #else
     disp_drv.flush_cb = _disp_map;
     /* Configure horizontal and vertical resolutions based on the


### PR DESCRIPTION
### Contribution description

When running a RIOT native app using SDL, the display window for SDL is adjustable, but the display driver used by LVGL is not - it always defaults to the 320x240 size provided in the lv_disp_drv_init.

When driving an LCD, the resolution for the disp driver is updated post-init of the driver. Following the similar conventions, this tidbit references LCD_SCREEN_HEIGHT/WIDTH defines, which can be passed to an app as a CFLAG in a Makefile.include, or defaulting to the SDL_HOR/VER_RES defines passed in through lv_drv_conf.h in lv_drivers package.

This enables SDL native applications to better emulate the exact resolution of an LCD screen.

### Testing procedure

Using a test package for a custom LVGL RIOT application, I verified that SDL_HOR/VER_RES can adjust the SDL window, but not the display driver used by LVGL when driving an SDL window.

No other defines provided by lv_conf.h, lv_drv_conf.h, or lvgl_riot_conf.h adjust the size of the SDL emulated display driven by LVGL. The simplest fix to me was to adjust the size of the display driver post-init as is done for the non-SDL display driver. This fix enables the emulated display size to be adjusted

### Issues/PRs references

Resolves issue #18461 
