### PR TITLE
pkg/lwip: add support for HAL radios that require IRQ offloading

### DIFF
--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -142,16 +142,6 @@ typedef struct {
 } kw2xrf_t;
 
 /**
- * @brief   Setup an KW2XRF based device state
- *
- * @param[out] dev          device descriptor
- * @param[in]  params       parameters for device initialization
- * @param[in]  index        index of @p params in a global parameter struct array.
- *                          If initialized manually, pass a unique identifier instead.
- */
-void kw2xrf_setup(kw2xrf_t *dev, const kw2xrf_params_t *params, uint8_t index);
-
-/**
  * @brief   Initialize the given KW2XRF device
  * @param[out] dev          device descriptor
  * @param[in]  params       parameters for device initialization

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -89,6 +89,9 @@ endif
 ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   USEMODULE += sema
   USEMODULE += ztimer_msec
+  ifneq (,$(filter bhp,$(USEMODULE)))
+    USEMODULE += bhp_msg
+  endif
 endif
 
 ifneq (,$(filter lwip_netif,$(USEMODULE)))

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -87,7 +87,11 @@ err_t lwip_netdev_init(struct netif *netif)
         }
     }
 
-    /* initialize netdev and netif */
+    /* initialize Bottom Half Processor, netdev and netif */
+    if (IS_USED(MODULE_BHP_MSG)) {
+        bhp_msg_claim_thread(lwip_netif_get_bhp(netif), _pid);
+    }
+
     netdev = netif->state;
     lwip_netif_dev_acquire(netif);
     netdev->driver->init(netdev);
@@ -332,6 +336,9 @@ static void *_event_loop(void *arg)
             lwip_netif_dev_acquire(netif);
             dev->driver->isr(dev);
             lwip_netif_dev_release(netif);
+        }
+        else if (IS_USED(MODULE_BHP_MSG) && msg.type == BHP_MSG_BH_REQUEST) {
+            bhp_msg_handler(&msg);
         }
     }
     return NULL;

--- a/pkg/lwip/include/lwip/netif/compat.h
+++ b/pkg/lwip/include/lwip/netif/compat.h
@@ -22,6 +22,7 @@
 
 #include "lwip/netif.h"
 #include "net/netif.h"
+#include "bhp/msg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,6 +35,9 @@ typedef struct {
     netif_t common_netif;                /**< network interface descriptor */
     struct netif lwip_netif;             /**< lwIP interface data */
     rmutex_t lock;                       /**< lock for the interface */
+#if IS_USED(MODULE_BHP_MSG)
+    bhp_msg_t bhp;                       /**< IPC Bottom Half Processor */
+#endif
 } lwip_netif_t;
 
 /**
@@ -67,6 +71,26 @@ static inline void lwip_netif_dev_release(struct netif *netif)
 {
     lwip_netif_t *compat_netif = container_of(netif, lwip_netif_t, lwip_netif);
     rmutex_unlock(&compat_netif->lock);
+}
+
+/**
+ * @brief Get the IPC based Bottom Half Processor for LWIP
+ *
+ * @param[in]   netif pointer to the LWIP network interface
+ *
+ * @return      pointer to the IPC based Bottom Half Processor descriptor, if
+ *              @ref sys_bhp_msg is present.
+ * @return      NULL otherwise
+ */
+static inline bhp_msg_t *lwip_netif_get_bhp(struct netif *netif)
+{
+#if IS_USED(MODULE_BHP_MSG)
+    lwip_netif_t *compat_netif = container_of(netif, lwip_netif_t, lwip_netif);
+    return &compat_netif->bhp;
+#else
+    (void) netif;
+    return NULL;
+#endif
 }
 
 #ifdef __cplusplus

--- a/pkg/lwip/init_devs/auto_init_kw2xrf.c
+++ b/pkg/lwip/init_devs/auto_init_kw2xrf.c
@@ -1,0 +1,55 @@
+/*
+￼* Copyright (C) 2022 HAW Hamburg
+￼*
+￼* This file is subject to the terms and conditions of the GNU Lesser
+￼* General Public License v2.1. See the file LICENSE in the top level
+￼* directory for more details.
+￼*
+￼*/
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for KW2XRF network interfaces
+ *
+ * @author  José I. Álamos <jose.alamos@haw-hamburg.de>
+ */
+
+#include "kw2xrf.h"
+#include "kw2xrf_params.h"
+
+#include "lwip_init_devs.h"
+
+#include "bhp/msg.h"
+#include "net/netdev/ieee802154_submac.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_KW2XRF_NUMOF        ARRAY_SIZE(kw2xrf_params)
+
+static lwip_netif_t netif[NETIF_KW2XRF_NUMOF];
+static kw2xrf_t kw2xrf_devs[NETIF_KW2XRF_NUMOF];
+static netdev_ieee802154_submac_t kw2xrf_netdev[NETIF_KW2XRF_NUMOF];
+
+static void auto_init_kw2xrf(void)
+{
+    for (unsigned i = 0; i < NETIF_KW2XRF_NUMOF; i++) {
+        bhp_msg_init(&netif[i].bhp, &kw2xrf_radio_hal_irq_handler, &kw2xrf_netdev[i].submac.dev);
+        kw2xrf_init(&kw2xrf_devs[i], &kw2xrf_params[i], &kw2xrf_netdev[i].submac.dev,
+                    bhp_msg_isr_cb, &netif[i].bhp);
+
+        netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+
+        if (lwip_add_6lowpan(&netif[i], &kw2xrf_netdev[i].dev.netdev) == NULL) {
+            DEBUG("Could not add kw2xrf device\n");
+            return;
+        }
+    }
+}
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_kw2xrf);
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR utilizes https://github.com/RIOT-OS/RIOT/pull/18464 to run radio HAL based devices with LWIP. This also allows the usage of other non-netdev devices that require ISR offloading.

As a result of this PR, I also push support for KW2XRF radios on LWIP.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Murdock compile output should be fine
Test LWIP with any KW2XRF based radio.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~Depends on https://github.com/RIOT-OS/RIOT/pull/18464~
Now it depends on https://github.com/RIOT-OS/RIOT/pull/18479
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
