### PR TITLE
cpu/{sam0_common, stm32}: select netdev_legacy_api in KConfig

### DIFF
--- a/cpu/sam0_common/sam0_eth/Kconfig
+++ b/cpu/sam0_common/sam0_eth/Kconfig
@@ -11,6 +11,7 @@ config MODULE_SAM0_ETH
     depends on CPU_COMMON_SAM0
     depends on HAS_PERIPH_ETH
     select MODULE_NETDEV_ETH
+    select MODULE_NETDEV_LEGACY_API
     select MODULE_NETOPT
     select MODULE_IOLIST
     select MODULE_PERIPH_ETH

--- a/cpu/stm32/periph/Kconfig.eth
+++ b/cpu/stm32/periph/Kconfig.eth
@@ -14,6 +14,7 @@ menuconfig MODULE_STM32_ETH
     depends on HAS_PERIPH_ETH
     select MODULE_PERIPH_ETH
     select MODULE_NETDEV_ETH
+    select MODULE_NETDEV_LEGACY_API
     select MODULE_IOLIST
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC

--- a/drivers/sx1280/Kconfig
+++ b/drivers/sx1280/Kconfig
@@ -10,6 +10,7 @@ config MODULE_SX1280
     depends on TEST_KCONFIG
     select PACKAGE_LORABASICS
     select MODULE_LORABASICS_SX1280_DRIVER
+    select MODULE_NETDEV_LEGACY_API
 
 config HAVE_SX1280
     bool

--- a/pkg/lorabasics/patches/0003-ral_sx1280-fix-unused-parameter-warning.patch
+++ b/pkg/lorabasics/patches/0003-ral_sx1280-fix-unused-parameter-warning.patch
@@ -1,0 +1,34 @@
+From 0606d43c2ea293d4ed96843406736a9b2a159fdd Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Thu, 18 Aug 2022 01:04:22 +0200
+Subject: [PATCH] ral_sx1280: fix unused parameter warning
+
+---
+ smtc_ral/src/ral_sx1280.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/smtc_ral/src/ral_sx1280.c b/smtc_ral/src/ral_sx1280.c
+index ecd8c03..bc75dff 100644
+--- a/smtc_ral/src/ral_sx1280.c
++++ b/smtc_ral/src/ral_sx1280.c
+@@ -474,11 +474,17 @@ ral_status_t ral_sx1280_setup_tx_flrc( const ral_t* ral, const ral_params_flrc_t
+ 
+ ral_status_t ral_sx1280_setup_tx_lora_e( const ral_t* ral, const ral_params_lora_e_t* params )
+ {
++    (void)ral;
++    (void)params;
++
+     return RAL_STATUS_UNSUPPORTED_FEATURE;
+ }
+ 
+ ral_status_t ral_sx1280_tx_bpsk( const ral_t* ral, const ral_params_bpsk_t* params )
+ {
++    (void)ral;
++    (void)params;
++
+     return RAL_STATUS_UNSUPPORTED_FEATURE;
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This fixes the discrepancy between the `USEMODULE` based dependency resolution and the KConfig based dependency resolution.


### Testing procedure

CI should build again


### Issues/PRs references

follow-up to #18426