### PR TITLE
kw2xrf/Kconfig: remove netdev_ieee802154 from dependency resolution

### DIFF
--- a/drivers/kw2xrf/Kconfig
+++ b/drivers/kw2xrf/Kconfig
@@ -22,6 +22,8 @@ menuconfig MODULE_KW2XRF
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_SPI
+    select MODULE_IOLIST
+    select HAVE_BHP_IRQ_HANDLER
 
 config MODULE_KW2XRF_TESTMODE
     bool "Test mode"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR removes a leftover dependency from the Kconfig file of KW2XRF radios. Since this radio supports the Radio HAL, the `netdev_ieee802154` module is not required anymore
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`NIGHTLY=1 /bin/bash -c "source .murdock; JOBS=4 compile tests/ieee802154_hal pba-d-01-kw2x:gnu"`should pass
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
