### PR TITLE
makefiles: quiet messages on CI

### DIFF
--- a/makefiles/tools/kconfiglib.inc.mk
+++ b/makefiles/tools/kconfiglib.inc.mk
@@ -3,9 +3,13 @@ MENUCONFIG ?= $(RIOTTOOLS)/kconfiglib/riot_menuconfig.py
 BASE_MENUCONFIG ?= $(RIOTTOOLS)/kconfiglib/menuconfig.py
 GENCONFIG := $(RIOTTOOLS)/kconfiglib/genconfig.py
 
+ifeq ($(RIOT_CI_BUILD),1)
+  QUIETMESSAGES=\#
+endif
 $(BASE_MENUCONFIG):
-	@echo "[INFO] Kconfiglib not found - getting it"
-	@$(MAKE) -C $(RIOTTOOLS)/kconfiglib
-	@echo "[INFO] Kconfiglib downloaded"
+	@$(QUIETMESSAGES) echo "[INFO] Kconfiglib not found - getting it"
+	@$(MAKE) -C $(RIOTTOOLS)/kconfiglib > /dev/null
+	@$(QUIETMESSAGES) echo "[INFO] Kconfiglib downloaded"
+
 
 $(GENCONFIG): $(BASE_MENUCONFIG)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

After introducing #18423 there are occasional messages that still happen.
These messages cause a diff output when testing with TEST_KCONFIG=1.
This then causes a failure when comparing make/kconfig modules and packages.


### Testing procedure

```
rm -f dist/tools/kconfiglib/menuconfig.py && /bin/bash -c "source .murdock; compile tests/shell native:gnu"
```

### Issues/PRs references

Introduced in #18423
Discovered by #18466