### PR TITLE
gcoap_forward_proxy: copy Max-Age from forwarded Valid if it exists

### DIFF
--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -210,8 +210,19 @@ static void _forward_resp_handler(const gcoap_request_memo_t *memo,
             /* check if we can just send 2.03 Valid instead */
             if ((cep->req_etag_len == coap_opt_get_opaque(pdu, COAP_OPT_ETAG, &resp_etag)) &&
                 (memcmp(cep->req_etag, resp_etag, cep->req_etag_len) == 0)) {
+                uint32_t max_age;
+
+                if (coap_opt_get_uint(pdu, COAP_OPT_MAX_AGE, &max_age) < 0) {
+                    /* use default,
+                     * see https://datatracker.ietf.org/doc/html/rfc7252#section-5.10.5 */
+                    max_age = 60U;
+                }
                 gcoap_resp_init(pdu, (uint8_t *)pdu->hdr, buf_len, COAP_CODE_VALID);
                 coap_opt_add_opaque(pdu, COAP_OPT_ETAG, cep->req_etag, cep->req_etag_len);
+                if (max_age != 60U) {
+                    /* only include Max-Age option if it is not the default value */
+                    coap_opt_add_uint(pdu, COAP_OPT_MAX_AGE, max_age);
+                }
                 coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
             }
         }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1334,7 +1334,7 @@ static ssize_t _cache_check(const uint8_t *buf, size_t len,
                     uint8_t *start = coap_find_option(&req, COAP_OPT_ETAG);
                     /* option length must always be <= COAP_ETAG_LENGTH_MAX = 8 < 12, so the length
                      * is encoded in the first byte, see also RFC 7252, section 3.1 */
-                    *start &= 0x0f;
+                    *start &= 0xf0;
                     /* first if around here should make sure we are <= 8 < 0xf, so we don't need to
                      * bitmask resp_etag_len */
                     *start |= (uint8_t)resp_etag_len;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
At the moment, the Max-Age option is not set in a forwarded Valid message by a forward proxy. This is a bug, as the downstream clients then assume that the Max-Age is the default 60s, possibly breaking Cache validation, if Max-Age actually was smaller. This PR fixes that.

During testing this fix, I found another bug in the client-side cache validation: when the ETag is shorter than 8 bytes (e.g. with the fileserver), it is shortened after the fact. For that the wrong bitmask was used to protect the Option Delta.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I applied the following patch to add a Max-Age option to `gcoap_fileserver`

<details>

```patch
diff --git a/sys/net/application_layer/gcoap/fileserver.c b/sys/net/application_layer/gcoap/fileserver.c
index eaf14a252b..45bf652507 100644
--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -172,2 +172,3 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
         coap_opt_add_opaque(pdu, COAP_OPT_ETAG, &etag, sizeof(etag));
+        coap_opt_add_uint(pdu, COAP_OPT_MAX_AGE, 5U);
         return coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
@@ -182,2 +183,3 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     coap_opt_add_opaque(pdu, COAP_OPT_ETAG, &etag, sizeof(etag));
+    coap_opt_add_uint(pdu, COAP_OPT_MAX_AGE, 5U);
     coap_block_slicer_t slicer;
```
</details>

The following script should succeed:

```py
#! /usr/bin/env python3
import sys
import time

from scapy.all import load_contrib, AsyncSniffer
from scapy.contrib.coap import CoAP

from riotctrl.ctrl import RIOTCtrl

sys.path.append("dist/pythonlibs")
from riotctrl_shell.netif import IfconfigListParser, Ifconfig


def set_proxy(client, proxy):
    netifs = IfconfigListParser().parse(proxy.ifconfig_list())
    proxy_addr = list(netifs.values())[0]["ipv6_addrs"][0]["addr"]
    res = client.cmd(f"coap proxy set {proxy_addr} 5683")
    assert f"coap proxy set {proxy_addr} 5683" in res


def get_test_txt(client, server_addr):
    ret = client.cmd(f"coap get -c {server_addr} 5683 /vfs/test.txt")
    if "00000000  48  65  6C  6C  6F  20  57  6F  72  6C  64  21" not in ret:
        # may come in asynchronously, (synchronously when cached) so we need to expect
        # instead of checking result
        client.riotctrl.term.expect_exact(
            "00000000  48  65  6C  6C  6F  20  57  6F  72  6C  64  21"
        )


def test_proxy(modules=["gcoap_forward_proxy", "nanocoap_cache"]):
    RIOTCtrl.MAKE_ARGS = ("-j", "--no-print-directory")
    apps = ["examples/gcoap_fileserver"] + (2 * ["examples/gcoap"])
    envs = [
        {"PORT": "tap0", "QUIETER": "1", "USEMODULE": "vfs_auto_format"},
        {
            "USEMODULE": " ".join(modules),
            "PORT": "tap1",
            "BINDIRBASE": "proxy-bin",
            "QUIETER": "1",
        },
        {"USEMODULE": "nanocoap_cache", "PORT": "tap2", "QUIETER": "1", "TERMLOG":
            "test.log"},
    ]
    ctrls = [
        RIOTCtrl(application_directory=app, env=env)
        for app, env in zip(apps, envs)
    ]
    for ctrl in ctrls:
        ctrl.flash(stdout=None, stderr=None)
    with (
        ctrls[0].run_term(reset=False),
        ctrls[1].run_term(reset=False),
        ctrls[2].run_term(reset=False),
    ):
        shells = []
        for ctrl in ctrls:
            ctrl.term.logfile = sys.stdout
            shells.append(Ifconfig(ctrl))
        netifs = IfconfigListParser().parse(shells[0].ifconfig_list())
        server_addr = list(netifs.values())[0]["ipv6_addrs"][0]["addr"]
        set_proxy(shells[2], shells[1])
        sniffer = AsyncSniffer(iface="tapbr0")
        sniffer.start()
        get_test_txt(shells[2], server_addr)
        get_test_txt(shells[2], server_addr)   # should come from cache
        time.sleep(6)
        get_test_txt(shells[2], server_addr)   # should be validated
        time.sleep(6)
        get_test_txt(shells[2], server_addr)   # should be validated
        pkts = sniffer.stop()
        coap_pkts = [pkt for pkt in pkts if CoAP in pkt]
        # 1 GET request was fulfilled, 1 cached, 2 validated
        # => 3 GET requests, 1 Content, 2 Valid, multiplied by two due to the proxy
        get_pkts = [pkt for pkt in coap_pkts if pkt[CoAP].code == 1]
        assert len(get_pkts) == 6, f"{len(get_pkts)} != 6"
        content_pkts = [pkt for pkt in coap_pkts if pkt[CoAP].code == ((2 << 5) | 5)]
        assert len(content_pkts) == 2, f"{len(content_pkts)} != 2"
        valid_pkts = [pkt for pkt in coap_pkts if pkt[CoAP].code == ((2 << 5) | 3)]
        assert len(valid_pkts) == 4, f"{len(valid_pkts)} != 4"
        assert len(coap_pkts) == (6 + 2 + 4), f"{len(coap_pkts)} != (6 + 2 + 4)"
        for shell in reversed(shells):
            shell.cmd("help")


if __name__ == "__main__":
    load_contrib("coap")
    test_proxy()
    print("")
```

On master (with 1135cc0f7e2c98c cherry-picked, otherwise the proxy will mangle the ETag), this does not succeed, as for the fourth get_test_txt() the client does not validate, but gets it from a wrongly configured cache.

```
Traceback (most recent call last):
  File "/home/mlenders/Repositories/RIOT-OS/RIOT/./test_upstream_proxy.py", line 88, in <module>
    test_proxy()
  File "/home/mlenders/Repositories/RIOT-OS/RIOT/./test_upstream_proxy.py", line 76, in test_proxy
    assert len(get_pkts) == 6, f"{len(get_pkts)} != 6"
AssertionError: 4 != 6
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
