### PR TITLE
pkg/{littlefs,littlefs2}: fix unaligned memory accesses

### DIFF
--- a/sys/include/fs/littlefs2_fs.h
+++ b/sys/include/fs/littlefs2_fs.h
@@ -24,14 +24,16 @@
 #ifndef FS_LITTLEFS2_FS_H
 #define FS_LITTLEFS2_FS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <stdalign.h>
 
 #include "vfs.h"
 #include "lfs.h"
 #include "mtd.h"
 #include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name    littlefs configuration
@@ -95,24 +97,24 @@ typedef struct {
      * total number of block is defined in @p config.
      * if set to 0, the total number of sectors from the mtd is used */
     uint32_t base_addr;
-    uint16_t sectors_per_block; /**< number of sectors per block */
 #if CONFIG_LITTLEFS2_FILE_BUFFER_SIZE || DOXYGEN
     /** file buffer to use internally if CONFIG_LITTLEFS2_FILE_BUFFER_SIZE
      * is set */
-    uint8_t file_buf[CONFIG_LITTLEFS2_FILE_BUFFER_SIZE];
+    alignas(uint32_t) uint8_t file_buf[CONFIG_LITTLEFS2_FILE_BUFFER_SIZE];
 #endif
 #if CONFIG_LITTLEFS2_READ_BUFFER_SIZE || DOXYGEN
     /** read buffer to use internally if CONFIG_LITTLEFS2_READ_BUFFER_SIZE
      * is set */
-    uint8_t read_buf[CONFIG_LITTLEFS2_READ_BUFFER_SIZE];
+    alignas(uint32_t) uint8_t read_buf[CONFIG_LITTLEFS2_READ_BUFFER_SIZE];
 #endif
 #if CONFIG_LITTLEFS2_PROG_BUFFER_SIZE || DOXYGEN
     /** prog buffer to use internally if CONFIG_LITTLEFS2_PROG_BUFFER_SIZE
      * is set */
-    uint8_t prog_buf[CONFIG_LITTLEFS2_PROG_BUFFER_SIZE];
+    alignas(uint32_t) uint8_t prog_buf[CONFIG_LITTLEFS2_PROG_BUFFER_SIZE];
 #endif
     /** lookahead buffer to use internally */
-    uint8_t lookahead_buf[CONFIG_LITTLEFS2_LOOKAHEAD_SIZE];
+    alignas(uint32_t) uint8_t lookahead_buf[CONFIG_LITTLEFS2_LOOKAHEAD_SIZE];
+    uint16_t sectors_per_block; /**< number of sectors per block */
 } littlefs2_desc_t;
 
 /** The littlefs vfs driver */

--- a/sys/include/fs/littlefs_fs.h
+++ b/sys/include/fs/littlefs_fs.h
@@ -22,14 +22,17 @@
 #ifndef FS_LITTLEFS_FS_H
 #define FS_LITTLEFS_FS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <stdalign.h>
 
 #include "vfs.h"
 #include "lfs.h"
 #include "mtd.h"
 #include "mutex.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name    littlefs configuration
@@ -79,21 +82,21 @@ typedef struct {
      * total number of block is defined in @p config.
      * if set to 0, the total number of sectors from the mtd is used */
     uint32_t base_addr;
-    uint16_t sectors_per_block; /**< number of sectors per block */
 #if LITTLEFS_FILE_BUFFER_SIZE || DOXYGEN
     /** file buffer to use internally if LITTLEFS_FILE_BUFFER_SIZE is set */
-    uint8_t file_buf[LITTLEFS_FILE_BUFFER_SIZE];
+    alignas(uint32_t) uint8_t file_buf[LITTLEFS_FILE_BUFFER_SIZE];
 #endif
 #if LITTLEFS_READ_BUFFER_SIZE || DOXYGEN
     /** read buffer to use internally if LITTLEFS_READ_BUFFER_SIZE is set */
-    uint8_t read_buf[LITTLEFS_READ_BUFFER_SIZE];
+    alignas(uint32_t) uint8_t read_buf[LITTLEFS_READ_BUFFER_SIZE];
 #endif
 #if LITTLEFS_PROG_BUFFER_SIZE || DOXYGEN
     /** prog buffer to use internally if LITTLEFS_PROG_BUFFER_SIZE is set */
-    uint8_t prog_buf[LITTLEFS_PROG_BUFFER_SIZE];
+    alignas(uint32_t) uint8_t prog_buf[LITTLEFS_PROG_BUFFER_SIZE];
 #endif
     /** lookahead buffer to use internally */
-    uint8_t lookahead_buf[LITTLEFS_LOOKAHEAD_SIZE / 8];
+    alignas(uint32_t) uint8_t lookahead_buf[LITTLEFS_LOOKAHEAD_SIZE / 8];
+    uint16_t sectors_per_block; /**< number of sectors per block */
 } littlefs_desc_t;
 
 /** The littlefs vfs driver */


### PR DESCRIPTION
### Contribution description

This aligns the buffers in `littlefs_desc_t` / `littlefs2_desc_t` to fix hard faults on Cortex M0+ MCUs such as the `samr21-xpro`.

### Testing procedure

- [x] `make BOARD=samr21-xpro -C tests/pkg_littlefs`
- [x] `make BOARD=samr21-xpro -C tests/pkg_littlefs2`

### Issues/PRs references

Prior to https://github.com/RIOT-OS/RIOT/pull/18141 the alignment requirement was met but luck. With this, the alignment requirement is now communicated to the compiler, which should fix future issues.