### PR TITLE
pkg/nimble:derive peer address type from peer address

### DIFF
--- a/pkg/nimble/statconn/nimble_statconn.c
+++ b/pkg/nimble/statconn/nimble_statconn.c
@@ -86,7 +86,8 @@ static void _activate(uint8_t role)
 
     if (slot && (role == ROLE_M)) {
         ble_addr_t peer;
-        peer.type = BLE_ADDR_RANDOM;
+        peer.type = ((slot->addr[0] & 0xc0) == 0xc0) ? BLE_ADDR_RANDOM
+                                                     : BLE_ADDR_PUBLIC;
         bluetil_addr_swapped_cp(slot->addr, peer.val);
         /* try to (re)open the connection */
 #if IS_USED(MODULE_NIMBLE_STATCONN_EXT)

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -229,6 +229,7 @@ static void _cmd_info(void)
     bluetil_addr_swapped_cp(tmp_addr, own_addr);
     printf("Own Address: ");
     bluetil_addr_print(own_addr);
+    printf(" (%s)", nimble_riot_own_addr_type ? "static random" : "public");
 #ifdef MODULE_GNRC_IPV6
     printf(" -> ");
     bluetil_addr_ipv6_l2ll_print(own_addr);


### PR DESCRIPTION
### Contribution description

This PR fixes a problem when using `nimble_statconn`.

`nimble_statconn` master has to define the peer address type of the slave node to which the connection is established by the master. Using a `BLE_ADDR_RANDOM` as the peer address type allows connecting only to peers that have a static random address. Deriving the peer address type from the peer address is simple and allows connections to be established with peers that have either a public or static random address.

Furthermore, to see which type of address is used as own address, the output of the `ble info` command has been extended by the address type info.

The problem was found when investigating in PR #18439 the reason why `tests/nimble_statconn_gnrc*` failed.

### Testing procedure

Use two BLE nodes and flash `tests/nimble_statconn_gnrc` and check that the test still works. Execeute the `ble info` command.

Node 1:
```
> ble info 
Own Address: DD:67:34:05:2D:D6 (static random) -> [FE80::DD67:34FF:FE05:2DD6]
Supported PHY modes: 1M 2M CODED
 Free slots: 3/3
Advertising: no
Connections: 0
Slots:
[ 0] state: 0x8000 - unused
[ 1] state: 0x8000 - unused
[ 2] state: 0x8000 - unused

> statconn addm 60:55:F9:6E:6E:69
success: connecting to peer as slave
> 
> [ble] CONNECTED slave (0|60:55:F9:6E:6E:69)
```

Node 2:
```
> ble info
Own Address: 60:55:F9:6E:6E:69 (public) -> [FE80::6055:F9FF:FE6E:6E69]
Supported PHY modes: 1M
 Free slots: 3/3
Advertising: no
Connections: 0
Slots:
[ 0] state: 0x8000 - unused
[ 1] state: 0x8000 - unused
[ 2] state: 0x8000 - unused

> statconn adds DD:67:34:05:2D:D6
success: connecting to peer as master
[ble] CONNECTED master (0|DD:67:34:05:2D:D6)
```

### Issues/PRs references

Prerequisite for PR #18439 