### PR TITLE
drivers/atwinc15x0: reset device if m2m_wifi_handle_events() fails

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -588,7 +588,10 @@ static void _atwinc15x0_isr(netdev_t *netdev)
     DEBUG("%s dev=%p\n", __func__, (void *)dev);
 
     /* handle pending ATWINC15x0 module events */
-    while (m2m_wifi_handle_events(NULL) != M2M_SUCCESS) { }
+    if (m2m_wifi_handle_events(NULL) != M2M_SUCCESS) {
+        DEBUG("%s handle events failed, reset device\n", __func__);
+        _atwinc15x0_init(netdev);
+    }
 }
 
 const netdev_driver_t atwinc15x0_netdev_driver = {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently when `m2m_wifi_handle_events()` fails, we end up in a busy loop and the netdev thread becomes unusable.

Instead, reset (re-init) the WiFi module if this condition occurs.
While not ideal, it's certainly an improvement to the current situation.


### Testing procedure

This is still untested!
I will test this on Monday - in our setup, we have a board receive data on the SLIP interface, write it to SD card and send out data from SD card via the `atwinc15x0` WiFi module.

If sending and receiving happen at the same time, the wifi thread will end up in this busy loop and any attempt to communicate with the wifi thread will block forever. 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
