### PR TITLE
pkg/ccn-lite: patch to fix use-after-free

### DIFF
--- a/pkg/ccn-lite/patches/0004-ccnl_content_remove-Fix-use-after-free.patch
+++ b/pkg/ccn-lite/patches/0004-ccnl_content_remove-Fix-use-after-free.patch
@@ -1,0 +1,37 @@
+From e6e2d9184130fbf3f3403723b0f292fe1bb239f7 Mon Sep 17 00:00:00 2001
+From: chrysn <chrysn@fsfe.org>
+Date: Sat, 20 Aug 2022 16:44:15 +0200
+Subject: [PATCH] ccnl_content_remove: Fix use-after-free
+
+---
+ src/ccnl-core/src/ccnl-relay.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/ccnl-core/src/ccnl-relay.c b/src/ccnl-core/src/ccnl-relay.c
+index 57a11800..05e19903 100644
+--- a/src/ccnl-core/src/ccnl-relay.c
++++ b/src/ccnl-core/src/ccnl-relay.c
+@@ -533,6 +533,10 @@ ccnl_content_remove(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
+     c2 = c->next;
+     DBL_LINKED_LIST_REMOVE(ccnl->contents, c);
+ 
++#ifdef CCNL_RIOT
++    evtimer_del((evtimer_t *)(&ccnl_evtimer), (evtimer_event_t *)&c->evtmsg_cstimeout);
++#endif
++
+ //    free_content(c);
+     if (c->pkt) {
+         ccnl_prefix_free(c->pkt->pfx);
+@@ -543,9 +547,6 @@ ccnl_content_remove(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
+     ccnl_free(c);
+ 
+     ccnl->contentcnt--;
+-#ifdef CCNL_RIOT
+-    evtimer_del((evtimer_t *)(&ccnl_evtimer), (evtimer_event_t *)&c->evtmsg_cstimeout);
+-#endif
+     return c2;
+ }
+ 
+-- 
+2.36.1
+


### PR DESCRIPTION
### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build the pkg/ccn-lite example with a current GCC. Before this patch, this fails as described in https://github.com/RIOT-OS/RIOT/issues/18480 -- after, it passes.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/18480

Found while doing final tests for the 2022.07-RC3 at https://github.com/RIOT-OS/Release-Specs/issues/257

This has been reported upstream as https://github.com/cn-uofbasel/ccn-lite/pull/388