### PR TITLE
rust: Update cstr dependency [backport 2022.07]

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "cstr_core"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
  "cty",
  "memchr",

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -660,7 +660,12 @@ dependencies = [
  "coap-message-demos",
  "riot-coap-handler-demos",
  "riot-wrappers",
+ "rust_riotmodules",
 ]
+
+[[package]]
+name = "rust_riotmodules"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-hash"

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -536,7 +536,12 @@ name = "rust-hello-world"
 version = "0.1.0"
 dependencies = [
  "riot-wrappers",
+ "rust_riotmodules",
 ]
+
+[[package]]
+name = "rust_riotmodules"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-hash"

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cstr_core"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
  "cty",
  "memchr",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cstr_core"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
  "cty",
  "memchr",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -493,7 +493,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.22"
+version = "0.7.23"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#db9d163e3eddcb7154edcf25db7207e4123964ee"
 dependencies = [
  "bare-metal 1.0.0",
  "cstr_core",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -536,7 +536,12 @@ name = "rust-minimal"
 version = "0.1.0"
 dependencies = [
  "riot-wrappers",
+ "rust_riotmodules",
 ]
+
+[[package]]
+name = "rust_riotmodules"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-hash"

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cstr_core"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
  "cty",
  "memchr",


### PR DESCRIPTION
# Backport of #18389

### Contribution description

A change in Rust nightly features broke version 0.2.5 of the `cstr`
crate, whose nightly-only features are enabled in some examples. The
breakage was quickly fixed upstream in the 0.2.6 version, this updates
the locks.

---

We could (and should, to minimize this on the long run) also stop using the nightly features -- but given that riot-wrappers are about to switch over to what the standard library now provides anyway, this is the least intrusive fix.

The issue doesn't hit us now because our Rust nightly version is pinned, but it'd hit us as soon as we updated the Rust nightly version in riotdocker.

### Testing procedure

* Green CI
* The breakage before this PR only shows when using a local Rust installation and building the rust-gcoap example with a recent nightly. (I tested that).

### Issues/PRs references

Builds on #18388 (they wouldn't merge conflict if I wrote them separately, but it'd still be practically useless rebasing). Look at the second change if that is 

## Backporting

This only needs backporting if riotdocker updates its nightly version, and after that a point release is to be made. (Because only the automated tests use the latest riotdocker image; regular users would get the riotdocker image that was versioned together with the release AIU).