### PR TITLE
boards/samr34-xpro: configure SPI NOR flash 

### DIFF
--- a/boards/samr34-xpro/Kconfig
+++ b/boards/samr34-xpro/Kconfig
@@ -23,3 +23,4 @@ config BOARD_SAMR34_XPRO
 
     select HAVE_SX1276
     select HAVE_SAUL_GPIO
+    select HAVE_MTD_SPI_NOR

--- a/boards/samr34-xpro/Makefile.dep
+++ b/boards/samr34-xpro/Makefile.dep
@@ -5,3 +5,12 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_spi_nor
+endif
+
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif

--- a/boards/samr34-xpro/board.c
+++ b/boards/samr34-xpro/board.c
@@ -29,6 +29,42 @@
 #include "sx127x_params.h"
 #endif
 
+#ifdef MODULE_MTD_SPI_NOR
+#include "timex.h"
+#include "mtd_spi_nor.h"
+/* AT25DF041B */
+static const mtd_spi_nor_params_t _mtd_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 3600 * US_PER_MS,
+    .wait_64k_erase = 450 * US_PER_MS,
+    .wait_32k_erase = 250 * US_PER_MS,
+    .wait_sector_erase = 35 * US_PER_MS,
+    .wait_chip_wake_up = 1 * US_PER_MS,
+    .clk  = MHZ(16),
+    .flag = SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K | SPI_NOR_F_SECT_64K,
+    .spi  = SPI_DEV(1),
+    .mode = SPI_MODE_0,
+    .cs   = GPIO_PIN(PA, 22),
+    .wp   = GPIO_UNDEF,
+    .hold = GPIO_UNDEF,
+};
+
+static mtd_spi_nor_t _nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = 256,
+        .pages_per_sector = 16,
+    },
+    .params = &_mtd_nor_params,
+};
+mtd_dev_t *mtd0 = (mtd_dev_t *)&_nor_dev;
+
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
+#endif /* MODULE_MTD_SPI_NOR */
+
 void board_init(void)
 {
     /* initialize board specific pins for LoRa */

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -74,6 +75,14 @@ extern "C" {
 #define BTN0_PORT                   PORT->Group[0]                      /**< GPIO port      */
 #define BTN0_PIN                    GPIO_PIN(PA, 28)                    /**< GPIO pin       */
 #define BTN0_MODE                   GPIO_IN_PU                          /**< Pull Up GPIO   */
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+extern mtd_dev_t *mtd0;             /**< First memory type device */
+#define MTD_0 mtd0                  /**< First memory type device */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -118,7 +118,7 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const spi_conf_t spi_config[] = {
-    {
+    {   /* internal, wired to sx1276 */
         .dev      = &(SERCOM4->SPI),
         .miso_pin = GPIO_PIN(PC, 19),
         .mosi_pin = GPIO_PIN(PB, 30),
@@ -133,7 +133,23 @@ static const spi_conf_t spi_config[] = {
         .tx_trigger = SERCOM4_DMAC_ID_TX,
         .rx_trigger = SERCOM4_DMAC_ID_RX,
 #endif
-    }
+    },
+    {   /* EXT1, EXT3, NOR Flash */
+        .dev      = &(SERCOM5->SPI),
+        .miso_pin = GPIO_PIN(PB, 2),
+        .mosi_pin = GPIO_PIN(PB, 22),
+        .clk_pin  = GPIO_PIN(PB, 23),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = DMA_TRIGGER_DISABLED,
+        .rx_trigger = DMA_TRIGGER_DISABLED,
+#endif
+    },
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There was only SPI config for the internal SPI (wired to sx1276). Also add an external SPI bus wired to the EXT pin headers.

The WLR089 board also comes with a NOR flash soldered on that is connected to this bus, so also configure it.
(It's the same as on `samd21-xpro`, see #17692)


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
