### PR TITLE
examples/filesystem: drop manual mounts

### DIFF
--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -24,20 +24,12 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# Use MTD (flash layer)
-USEMODULE += mtd
-# USEMODULE += mtd_sdcard
-
-# Use VFS
-USEMODULE += vfs
-
-# Use a file system
-# USEMODULE += littlefs
-USEMODULE += littlefs2
-# USEMODULE += spiffs
-# USEMODULE += fatfs_vfs
-# USEMODULE += fatfs_vfs_format
+# Use the default file system
+USEMODULE += vfs_default
 USEMODULE += constfs
 # USEMODULE += devfs
+
+# Enable to automatically format if mount fails
+#USEMODULE += vfs_auto_format
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/filesystem/README.md
+++ b/examples/filesystem/README.md
@@ -27,13 +27,12 @@ With newlib, `fopen/fclose/fread/fwrite/...` can also be used transparently.
 
 The following commands are available:
 
-- `format`: should be called the first time only, it will format the `mtd`
-  with the configured file system
-- `mount`: mount the file system on the configured mount point (default is
-  `/sda` but it can be configured with `FLASH_MOUNT_POINT` define). The
-  `constfs` file system is mounted automatically on `/const` when the
+- `vfs format /nvm0`: should be called the first time only, it will format the
+  `/nvm0` mountpoint with the configured file system
+- `vfs mount /nvm0`: mount the file system on the configured mount point
+   The `constfs` file system is mounted automatically on `/const` when the
    application starts
-- `umount`: unmount `/sda`
+- `vfs umount /nvm0`: unmount `/nvm0`
 - `cat <file>`: similarly to unix `cat` unix command, it prints the given
   `<file>` on stdout
 - `tee <file> <str>`: similarly to `tee` unix command, it writes `<str>` in

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -24,212 +24,6 @@
 #include <fcntl.h>
 
 #include "shell.h"
-#include "board.h" /* MTD_0 is defined in board.h */
-
-/* Configure MTD device for SD card if none is provided */
-#if !defined(MTD_0) && MODULE_MTD_SDCARD
-#include "mtd_sdcard.h"
-#include "sdcard_spi.h"
-#include "sdcard_spi_params.h"
-
-#define SDCARD_SPI_NUM ARRAY_SIZE(sdcard_spi_params)
-
-/* SD card devices are provided by drivers/sdcard_spi/sdcard_spi.c */
-extern sdcard_spi_t sdcard_spi_devs[SDCARD_SPI_NUM];
-
-/* Configure MTD device for the first SD card */
-static mtd_sdcard_t mtd_sdcard_dev = {
-    .base = {
-        .driver = &mtd_sdcard_driver
-    },
-    .sd_card = &sdcard_spi_devs[0],
-    .params = &sdcard_spi_params[0],
-};
-static mtd_dev_t *mtd_sdcard = (mtd_dev_t*)&mtd_sdcard_dev;
-#define MTD_0 mtd_sdcard
-#endif
-
-/* Flash mount point */
-#define FLASH_MOUNT_POINT   "/sda"
-
-/* In this example, MTD_0 is used as mtd interface for littlefs or spiffs */
-/* littlefs and spiffs basic usage are shown */
-#ifdef MTD_0
-/* File system descriptor initialization */
-#if defined(MODULE_LITTLEFS)
-/* include file system header for driver */
-#include "fs/littlefs_fs.h"
-
-/* file system specific descriptor
- * for littlefs, some fields can be tweaked to define the size
- * of the partition, see header documentation.
- * In this example, default behavior will be used, i.e. the entire
- * memory will be used (parameters come from mtd) */
-static littlefs_desc_t fs_desc = {
-    .lock = MUTEX_INIT,
-};
-
-/* littlefs file system driver will be used */
-#define FS_DRIVER littlefs_file_system
-
-#elif defined(MODULE_LITTLEFS2)
-/* include file system header for driver */
-#include "fs/littlefs2_fs.h"
-
-/* file system specific descriptor
- * for littlefs2, some fields can be tweaked to define the size
- * of the partition, see header documentation.
- * In this example, default behavior will be used, i.e. the entire
- * memory will be used (parameters come from mtd) */
-static littlefs2_desc_t fs_desc = {
-    .lock = MUTEX_INIT,
-};
-
-/* littlefs file system driver will be used */
-#define FS_DRIVER littlefs2_file_system
-
-#elif defined(MODULE_SPIFFS)
-/* include file system header */
-#include "fs/spiffs_fs.h"
-
-/* file system specific descriptor
- * as for littlefs, some fields can be changed if needed,
- * this example focus on basic usage, i.e. entire memory used */
-static spiffs_desc_t fs_desc = {
-    .lock = MUTEX_INIT,
-};
-
-/* spiffs driver will be used */
-#define FS_DRIVER spiffs_file_system
-
-#elif defined(MODULE_FATFS_VFS)
-/* include file system header */
-#include "fs/fatfs.h"
-
-/* file system specific descriptor
- * as for littlefs, some fields can be changed if needed,
- * this example focus on basic usage, i.e. entire memory used */
-static fatfs_desc_t fs_desc;
-
-/* fatfs driver will be used */
-#define FS_DRIVER fatfs_file_system
-#endif
-
-/* this structure defines the vfs mount point:
- *  - fs field is set to the file system driver
- *  - mount_point field is the mount point name
- *  - private_data depends on the underlying file system. For both spiffs and
- *  littlefs, it needs to be a pointer to the file system descriptor */
-static vfs_mount_t flash_mount = {
-    .fs = &FS_DRIVER,
-    .mount_point = FLASH_MOUNT_POINT,
-    .private_data = &fs_desc,
-};
-#endif /* MTD_0 */
-
-/* Add simple macro to check if an MTD device together with a filesystem is
- * compiled in */
-#if  defined(MTD_0) && \
-     (defined(MODULE_SPIFFS) || \
-      defined(MODULE_LITTLEFS) || \
-      defined(MODULE_LITTLEFS2) || \
-      defined(MODULE_FATFS_VFS))
-#define FLASH_AND_FILESYSTEM_PRESENT    1
-#else
-#define FLASH_AND_FILESYSTEM_PRESENT    0
-#endif
-
-/* constfs example */
-#include "fs/constfs.h"
-
-#define HELLO_WORLD_CONTENT "Hello World!\n"
-#define HELLO_RIOT_CONTENT  "Hello RIOT!\n"
-
-/* this defines two const files in the constfs */
-static constfs_file_t constfs_files[] = {
-    {
-        .path = "/hello-world",
-        .size = sizeof(HELLO_WORLD_CONTENT),
-        .data = (const uint8_t *)HELLO_WORLD_CONTENT,
-    },
-    {
-        .path = "/hello-riot",
-        .size = sizeof(HELLO_RIOT_CONTENT),
-        .data = (const uint8_t *)HELLO_RIOT_CONTENT,
-    }
-};
-
-/* this is the constfs specific descriptor */
-static constfs_t constfs_desc = {
-    .nfiles = ARRAY_SIZE(constfs_files),
-    .files = constfs_files,
-};
-
-/* constfs mount point, as for previous example, it needs a file system driver,
- * a mount point and private_data as a pointer to the constfs descriptor */
-static vfs_mount_t const_mount = {
-    .fs = &constfs_file_system,
-    .mount_point = "/const",
-    .private_data = &constfs_desc,
-};
-
-/* Command handlers */
-static int _mount(int argc, char **argv)
-{
-    (void)argc;
-    (void)argv;
-#if FLASH_AND_FILESYSTEM_PRESENT
-    int res = vfs_mount(&flash_mount);
-    if (res < 0) {
-        printf("Error while mounting %s...try format\n", FLASH_MOUNT_POINT);
-        return 1;
-    }
-
-    printf("%s successfully mounted\n", FLASH_MOUNT_POINT);
-    return 0;
-#else
-    puts("No external flash file system selected");
-    return 1;
-#endif
-}
-
-static int _format(int argc, char **argv)
-{
-    (void)argc;
-    (void)argv;
-#if FLASH_AND_FILESYSTEM_PRESENT
-    int res = vfs_format(&flash_mount);
-    if (res < 0) {
-        printf("Error while formatting %s\n", FLASH_MOUNT_POINT);
-        return 1;
-    }
-
-    printf("%s successfully formatted\n", FLASH_MOUNT_POINT);
-    return 0;
-#else
-    puts("No external flash file system selected");
-    return 1;
-#endif
-}
-
-static int _umount(int argc, char **argv)
-{
-    (void)argc;
-    (void)argv;
-#if FLASH_AND_FILESYSTEM_PRESENT
-    int res = vfs_umount(&flash_mount);
-    if (res < 0) {
-        printf("Error while unmounting %s\n", FLASH_MOUNT_POINT);
-        return 1;
-    }
-
-    printf("%s successfully unmounted\n", FLASH_MOUNT_POINT);
-    return 0;
-#else
-    puts("No external flash file system selected");
-    return 1;
-#endif
-}
 
 static int _cat(int argc, char **argv)
 {
@@ -298,23 +92,47 @@ static int _tee(int argc, char **argv)
 }
 
 static const shell_command_t shell_commands[] = {
-    { "mount", "mount flash filesystem", _mount },
-    { "format", "format flash file system", _format },
-    { "umount", "unmount flash filesystem", _umount },
     { "cat", "print the content of a file", _cat },
     { "tee", "write a string in a file", _tee },
     { NULL, NULL, NULL }
 };
 
+/* constfs example */
+#include "fs/constfs.h"
+
+#define HELLO_WORLD_CONTENT "Hello World!\n"
+#define HELLO_RIOT_CONTENT  "Hello RIOT!\n"
+
+/* this defines two const files in the constfs */
+static constfs_file_t constfs_files[] = {
+    {
+        .path = "/hello-world",
+        .size = sizeof(HELLO_WORLD_CONTENT),
+        .data = (const uint8_t *)HELLO_WORLD_CONTENT,
+    },
+    {
+        .path = "/hello-riot",
+        .size = sizeof(HELLO_RIOT_CONTENT),
+        .data = (const uint8_t *)HELLO_RIOT_CONTENT,
+    }
+};
+
+/* this is the constfs specific descriptor */
+static constfs_t constfs_desc = {
+    .nfiles = ARRAY_SIZE(constfs_files),
+    .files = constfs_files,
+};
+
+/* constfs mount point, as for previous example, it needs a file system driver,
+ * a mount point and private_data as a pointer to the constfs descriptor */
+static vfs_mount_t const_mount = {
+    .fs = &constfs_file_system,
+    .mount_point = "/const",
+    .private_data = &constfs_desc,
+};
+
 int main(void)
 {
-#if defined(MTD_0) && \
-   (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || \
-    defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
-    /* spiffs and littlefs need a mtd pointer
-     * by default the whole memory is used */
-    fs_desc.dev = MTD_0;
-#endif
     int res = vfs_mount(&const_mount);
     if (res < 0) {
         puts("Error while mounting constfs");


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

File systems should be mounted via `vfs_default`, not manually by the application.

Also, `vfs` gained the `format` sub-command, so no need to provide it in the example application.


### Testing procedure

Run the example. 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
