### PR TITLE
net/gnrc_netif: add support for priority queues

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -77,6 +77,25 @@ extern "C" {
 #endif
 
 /**
+ * @brief Index of the high priority queue
+ */
+#define GNRC_NETIF_EVQ_INDEX_PRIO_HIGH  (0)
+
+/**
+ * @brief Index of the low priority queue
+ */
+#if IS_USED(MODULE_BHP_EVENT)
+#define GNRC_NETIF_EVQ_INDEX_PRIO_LOW   (GNRC_NETIF_EVQ_INDEX_PRIO_HIGH + 1)
+#else
+#define GNRC_NETIF_EVQ_INDEX_PRIO_LOW   GNRC_NETIF_EVQ_INDEX_PRIO_HIGH
+#endif
+
+/**
+ * @brief Number of event queues
+ */
+#define GNRC_NETIF_EVQ_NUMOF            (GNRC_NETIF_EVQ_INDEX_PRIO_LOW + 1)
+
+/**
  * @brief   Per-Interface Event Message Buses
  */
 typedef enum {
@@ -142,7 +161,7 @@ typedef struct {
     /**
      * @brief   Event queue for asynchronous events
      */
-    event_queue_t evq;
+    event_queue_t evq[GNRC_NETIF_EVQ_NUMOF];
     /**
      * @brief   ISR event for the network device
      */

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -2030,7 +2030,7 @@ static void _gomach_event_cb(netdev_t *dev, netdev_event_t event)
     gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
 
     if (event == NETDEV_EVENT_ISR) {
-        event_post(&netif->evq, &netif->event_isr);
+        event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &netif->event_isr);
     }
     else {
         DEBUG("gnrc_netdev: event triggered -> %i\n", event);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -795,7 +795,7 @@ static void _lwmac_event_cb(netdev_t *dev, netdev_event_t event)
     gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
 
     if (event == NETDEV_EVENT_ISR) {
-        event_post(&netif->evq, &netif->event_isr);
+        event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &netif->event_isr);
     }
     else {
         DEBUG("gnrc_netdev: event triggered -> %i\n", event);

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
@@ -56,10 +56,10 @@ void auto_init_kw2xrf(void)
         LOG_DEBUG("[auto_init_netif] initializing kw2xrf #%u\n", i);
 
         /* Init Bottom Half Processor (with events module) and radio */
-        bhp_event_init(&kw2xrf_bhp[i], &_netif[i].evq, &kw2xrf_radio_hal_irq_handler, &kw2xrf_netdev[i].submac.dev);
-        kw2xrf_init(&kw2xrf_devs[i], (kw2xrf_params_t*) p,&kw2xrf_netdev[i].submac.dev,
+        bhp_event_init(&kw2xrf_bhp[i], &_netif[i].evq[GNRC_NETIF_EVQ_INDEX_PRIO_HIGH],
+                       &kw2xrf_radio_hal_irq_handler, &kw2xrf_netdev[i].submac.dev);
+        kw2xrf_init(&kw2xrf_devs[i], p, &kw2xrf_netdev[i].submac.dev,
                         bhp_event_isr_cb, &kw2xrf_bhp[i]);
-
 
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
         netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -200,7 +200,7 @@ static void _driver_cb(netdev_t *dev, netdev_event_t event)
     gnrc_lorawan_t *mac = &netif->lorawan.mac;
 
     if (event == NETDEV_EVENT_ISR) {
-        event_post(&netif->evq, &netif->event_isr);
+        event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &netif->event_isr);
     }
     else {
         DEBUG("gnrc_netif: event triggered -> %i\n", event);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds support for `gnrc_netif` priority queues.
Since some drivers run a Bottom Half Processor in the same `gnrc_netif` thread, events from MAC layers (e.g submac) can delay IRQ offloading. To avoid that, a second event queue with high priority is introduced if `MODULE_BHP_EVENT` is present.

I also use this queue for the event based Bottom Half Processor of `kw2xrf` radios.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure all unittests pass. Also, `kw2xrf` should still work in GNRC.
Since I'm currently on the train I couldn't test it on real hardware. I will post tests results asap.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
This should make MAC layers such as the SubMAC or openDSME more robust.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
