### PR TITLE
tests/rust: Run library tests on stable

### DIFF
--- a/tests/rust_libs/Makefile
+++ b/tests/rust_libs/Makefile
@@ -4,6 +4,7 @@ USEMODULE += shell
 USEMODULE += shell_democommands
 
 FEATURES_REQUIRED += rust_target
+CARGO_CHANNEL = stable
 
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation


### PR DESCRIPTION
### Contribution description

Tests all RIOT modules that are backed by Rust modules on stable.

### Status

<del>This doesn't work yet was the commands' static conversion to C strings is not used with stable tools yet. Could be fixed by updating the cstr_core crate, but given it will be obsolete with Rust 1.64 (due in 30 days), I'll wait for that one rather than bugging them.</del>

All prerequisites have been fulfilled as of late September 2022.

### Testing procedure

* Green CI

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/18500