### PR TITLE
dist/tools/esptools: add ESP32-S2 toolchain support to {install,export}.sh

### DIFF
--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -27,6 +27,9 @@ export_arch()
         esp32c3)
             TARGET_ARCH="riscv32-esp-elf"
             ;;
+        esp32s2)
+            TARGET_ARCH="xtensa-esp32s2-elf"
+            ;;
         esp32s3)
             TARGET_ARCH="xtensa-esp32s3-elf"
             ;;
@@ -77,9 +80,9 @@ export_qemu()
 
 if [ -z $1 ]; then
     echo "Usage: export.sh <tool>"
-    echo "tool = all | esp32 | esp32c3 | esp32s3 | openocd | qemu"
+    echo "tool = all | esp32 | esp32c3 | esp32s2 | esp32s3 | openocd | qemu"
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp32 esp32c3 esp32s3"
+    ARCH_ALL="esp32 esp32c3 esp32s2 esp32s3"
     for arch in ${ARCH_ALL}; do
         export_arch $arch
     done

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -85,6 +85,9 @@ install_arch()
         esp32c3)
             TARGET_ARCH="riscv32-esp-elf"
             ;;
+        esp32s2)
+            TARGET_ARCH="xtensa-esp32s2-elf"
+            ;;
         esp32s3)
             TARGET_ARCH="xtensa-esp32s3-elf"
             ;;
@@ -158,10 +161,10 @@ install_qemu()
 
 if [ -z $1 ]; then
     echo "Usage: install.sh <tool>"
-    echo "tool = all | esp32 | esp32c3 | esp32s3 | openocd | qemu"
+    echo "tool = all | esp32 | esp32c3 | esp32s2 | esp32s3 | openocd | qemu"
     exit 1
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp32 esp32c3 esp32s3"
+    ARCH_ALL="esp32 esp32c3 esp32s2 esp32s3"
     for arch in ${ARCH_ALL}; do
         install_arch $arch
     done


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #18235 which extends the  the `{install,export}.sh` scripts  by the support of the ESP32-S2 toolchain.

### Testing procedure

Test the installation and the export of the path of the ESP32-S2 toolchain by executing following commands:
```
dist/tools/esptools/install.sh esp32s2
. dist/tools/esptools/export.sh esp32s2
```

### Issues/PRs references

Split-off from #18235 