### PR TITLE
cpu/esp32: add ESP32-S2 support to makefiles

### DIFF
--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -4,7 +4,7 @@ ifeq (esp32,$(CPU_FAM))
 else ifneq (,$(filter esp32c3,$(CPU_FAM)))
   CPU_ARCH = rv32
   CPU_CORE = rv32imc
-else ifneq (,$(filter esp32s3,$(CPU_FAM)))
+else ifneq (,$(filter esp32s2 esp32s3,$(CPU_FAM)))
   CPU_ARCH = xtensa
   CPU_CORE = xtensa-lx7
 else
@@ -23,7 +23,7 @@ ifeq (xtensa,$(CPU_ARCH))
   FEATURES_PROVIDED += esp_hw_counter
 endif
 
-ifneq (,$(filter esp32-wrover% esp32s3%r2 esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))
+ifneq (,$(filter esp32-wrover% esp32s2%r2 esp32s3%r2 esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))
   FEATURES_PROVIDED += esp_spi_ram
   ifneq (,$(filter esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))
     FEATURES_PROVIDED += esp_spi_oct

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -13,6 +13,11 @@ else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
   export FLASH_FREQ ?= 80m
   export FLASH_SIZE ?= 2
   BOOTLOADER_POS = 0x0000
+else ifneq (,$(filter esp32s2,$(CPU_FAM)))
+  FLASH_MODE ?= qio
+  FLASH_FREQ ?= 80m
+  FLASH_SIZE ?= 4
+  BOOTLOADER_POS = 0x1000
 else
   $(error Unkwnown ESP32x SoC variant (family))
 endif
@@ -151,7 +156,7 @@ LINKFLAGS += -T$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/ld/$(CPU_FAM).peripher
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.ld
 
-ifeq (esp32,$(CPU_FAM))
+ifneq (,$(filter esp32 esp32s2,$(CPU_FAM)))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-data.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-funcs.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-time.ld

--- a/cpu/esp32/esp-idf/adc/Makefile
+++ b/cpu/esp32/esp-idf/adc/Makefile
@@ -8,13 +8,17 @@ ESP32_SDK_SRC = \
   components/soc/$(CPU_FAM)/adc_periph.c \
   #
 
-ifneq (,$(filter esp32c3,$(CPU_FAM)))
+ifneq (,$(filter esp32c3 esp32s2,$(CPU_FAM)))
   ESP32_SDK_SRC += components/driver/$(CPU_FAM)/adc2_init_cal.c
   INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/include/driver
 endif
 
 ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
   ESP32_SDK_SRC += components/efuse/$(CPU_FAM)/esp_efuse_rtc_calib.c
+endif
+
+ifneq (,$(filter esp32s2,$(CPU_FAM)))
+  ESP32_SDK_SRC += components/efuse/esp32s2/esp_efuse_rtc_table.c
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -103,6 +103,17 @@ ifeq (esp32c3,$(CPU_FAM))
   ESP32_SDK_SRC += components/hal/systimer_hal.c
 endif
 
+ifeq (esp32s2,$(CPU_FAM))
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/regi2c_ctrl.c
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/memprot.c
+  ESP32_SDK_SRC += components/esp_hw_support/sleep_retention.c
+  ESP32_SDK_SRC += components/esp_system/port/brownout.c
+  ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c
+  ESP32_SDK_SRC += components/hal/$(CPU_FAM)/brownout_hal.c
+  ESP32_SDK_SRC += components/hal/$(CPU_FAM)/touch_sensor_hal.c
+  ESP32_SDK_SRC += components/hal/systimer_hal.c
+endif
+
 ifeq (esp32s3,$(CPU_FAM))
   ESP32_SDK_SRC += components/esp_hw_support/sleep_retention.c
   ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c

--- a/cpu/esp32/esp-idf/spi_flash/Makefile
+++ b/cpu/esp32/esp-idf/spi_flash/Makefile
@@ -18,7 +18,7 @@ ifneq (,$(filter esp32,$(CPU_FAM)))
   ESP32_SDK_SRC += components/spi_flash/esp_flash_spi_init.c
 endif
 
-ifneq (,$(filter esp32 esp32s3,$(CPU_FAM)))
+ifneq (,$(filter esp32 esp32s2 esp32s3,$(CPU_FAM)))
   ESP32_SDK_SRC += components/spi_flash/flash_mmap.c
 endif
 


### PR DESCRIPTION
### Contribution description

This PR is a split-off from #18235 and adds the support of ESP32-S2 to the makefiles.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from #18235