### PR TITLE
cpu/esp32: add ESP32-S2 support in Kconfig

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -47,5 +47,6 @@ config CPU
 rsource "Kconfig.esp32"
 rsource "Kconfig.esp32c3"
 rsource "Kconfig.esp32s3"
+rsource "Kconfig.esp32s2"
 
 source "$(RIOTCPU)/esp_common/Kconfig"

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -44,6 +44,29 @@ config HAS_ESP_SPI_OCT
 config CPU
     default "esp32" if HAS_CPU_ESP32
 
+config CPU_CORE_XTENSA_LX6
+    bool
+    select CPU_ARCH_XTENSA
+    help
+        CPU core of the ESP32x SoC is a Xtensa LX6.
+
+config CPU_CORE_XTENSA_LX7
+    bool
+    select CPU_ARCH_XTENSA
+    help
+        CPU core of the ESP32x SoC is a Xtensa LX7.
+
+config CPU_CORE_RV32IMC
+    bool
+    select CPU_ARCH_RISCV
+    help
+        CPU core of the ESP32x SoC is a RISC-V core.
+
+config CPU_CORE
+    default "xtensa-lx6" if CPU_CORE_XTENSA_LX6
+    default "xtensa-lx7" if CPU_CORE_XTENSA_LX7
+    default "rv32imc" if CPU_CORE_RV32IMC
+
 rsource "Kconfig.esp32"
 rsource "Kconfig.esp32c3"
 rsource "Kconfig.esp32s3"

--- a/cpu/esp32/Kconfig.esp32
+++ b/cpu/esp32/Kconfig.esp32
@@ -5,13 +5,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-config CPU_CORE_XTENSA_LX6
-    bool
-    select CPU_ARCH_XTENSA
-
-config CPU_CORE
-    default "xtensa-lx6" if CPU_CORE_XTENSA_LX6
-
 config CPU_FAM_ESP32
     bool
     select CPU_COMMON_ESP

--- a/cpu/esp32/Kconfig.esp32c3
+++ b/cpu/esp32/Kconfig.esp32c3
@@ -5,26 +5,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-config CPU_ARCH_RISCV
-    bool
-    select HAS_ARCH_32BIT
-    select HAS_ARCH_ESP
-    select HAS_ARCH_ESP_RISCV
-    help
-        RISC-V based ESP32x SoC variant is used.
-
-config CPU_ARCH
-    default "rv32" if CPU_ARCH_RISCV
-
-config CPU_CORE_RV32IMC
-    bool
-    select CPU_ARCH_RISCV
-    help
-        CPU core of the ESP32x SoC is a RISC-V core.
-
-config CPU_CORE
-    default "rv32imc" if CPU_CORE_RV32IMC
-
 config CPU_FAM_ESP32C3
     bool
     select CPU_COMMON_ESP

--- a/cpu/esp32/Kconfig.esp32s2
+++ b/cpu/esp32/Kconfig.esp32s2
@@ -5,13 +5,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-config CPU_CORE_XTENSA_LX7
-    bool
-    select CPU_ARCH_XTENSA
-
-config CPU_CORE
-    default "xtensa-lx7" if CPU_CORE_XTENSA_LX7
-
 config CPU_FAM_ESP32S2
     bool
     select CPU_COMMON_ESP

--- a/cpu/esp32/Kconfig.esp32s2
+++ b/cpu/esp32/Kconfig.esp32s2
@@ -1,0 +1,277 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_CORE_XTENSA_LX7
+    bool
+    select CPU_ARCH_XTENSA
+
+config CPU_CORE
+    default "xtensa-lx7" if CPU_CORE_XTENSA_LX7
+
+config CPU_FAM_ESP32S2
+    bool
+    select CPU_COMMON_ESP
+    select CPU_CORE_XTENSA_LX7
+    select HAS_ARCH_ESP32
+    select HAS_CPU_ESP32
+    select HAS_ESP_HW_COUNTER
+    select HAS_ESP_WIFI_ENTERPRISE
+    select HAS_PUF_SRAM
+
+    select PACKAGE_ESP32_SDK if TEST_KCONFIG
+
+    select MODULE_MALLOC_THREAD_SAFE if !MODULE_ESP_IDF_HEAP && TEST_KCONFIG
+    select MODULE_PERIPH_RTT if HAS_PERIPH_RTT && MODULE_PM_LAYERED
+    select MODULE_PS if MODULE_SHELL
+    select MODULE_PTHREAD if MODULE_CPP
+    select MODULE_RTT_RTC if HAS_PERIPH_RTT && MODULE_PERIPH_RTC
+    imply MODULE_NEWLIB_NANO
+
+config CPU_FAM
+    default "esp32s2" if CPU_FAM_ESP32S2
+
+## CPU Models
+config CPU_MODEL_ESP32S2
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that CPU version ESP32-S2 is used.
+
+config CPU_MODEL_ESP32S2_FH2
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that CPU version ESP32-S2FH2 with 2 MB embedded Flash is used.
+
+config CPU_MODEL_ESP32S2_FH4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that CPU version ESP32-S2FN4R2 with 4 MB embedded Flash is used.
+
+config CPU_MODEL_ESP32S2_FN4R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that CPU version ESP32-S2FN4R2 with 4 MB embedded Flash and
+        2 MB embedded SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that CPU version ESP32-S2R2 with 2 MB embedded SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_MINI_1X_H4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-MINI-1-H4 or ESP32-S2-MINI-1U-H4 module
+        with 8 MB Flash is used.
+
+config CPU_MODEL_ESP32S2_MINI_1X_N4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-MINI-1-N4 or ESP32-S2-MINI-1U-N4 module
+        with 8 MB Flash is used.
+
+config CPU_MODEL_ESP32S2_MINI_1X_N4R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-MINI-1-N4R2 or ESP32-S2-MINI-1U-N4R2 module
+        with 4 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_MINI_2X_H4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-MINI-2-H4 or ESP32-S2-MINI-2U-H4 module
+        with 4 MB Flash is used.
+
+config CPU_MODEL_ESP32S2_MINI_2X_N4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-MINI-2-N4 or ESP32-S2-MINI-2U-N4 module
+        with 4 MB Flash is used.
+
+config CPU_MODEL_ESP32S2_MINI_2X_N4R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-MINI-2-N4R2 or ESP32-S2-MINI-2U-N4R2 module
+        with 4 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_SOLO_H4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-SOLO-H4 or ESP32-S2-SOLO-U-H4 module with
+        4 MB Flash.
+
+config CPU_MODEL_ESP32S2_SOLO_N4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-SOLO-N4 or ESP32-S2-SOLO-U-N4 module with
+        4 MB Flash.
+
+config CPU_MODEL_ESP32S2_SOLO_N8
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-SOLO-N4 or ESP32-S2-SOLO-U-N4 module with
+        4 MB Flash.
+
+config CPU_MODEL_ESP32S2_SOLO_N16
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-SOLO-N4 or ESP32-S2-SOLO-U-N4 module with
+        4 MB Flash.
+
+config CPU_MODEL_ESP32S2_SOLO_N4R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-SOLO-N4R2 or ESP32-S2-SOLO-U-N4R2 module with
+        4 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_SOLO_2X_H4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-SOLO-2-H4 or ESP32-S2-SOLO-2U-H4 module with
+        4 MB Flash.
+
+config CPU_MODEL_ESP32S2_SOLO_2X_N4
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-SOLO-2-N4 or ESP32-S2-SOLO-2U-N4 module with
+        4 MB Flash.
+
+config CPU_MODEL_ESP32S2_SOLO_2X_N4R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-SOLO-2-N4R2 or ESP32-S2-SOLO-2U-N4R2 module with
+        4 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_WROOM
+    bool
+    select CPU_FAM_ESP32S2
+    help
+        Indicates that ESP32-S2-WROOM or ESP32-S2-WROOM-I module with
+        4 MB Flash is used.
+
+config CPU_MODEL_ESP32S2_WROVER_N4R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-WROVER-N4R2 or ESP32-S2-WROVER-I-N4R2 module with
+        4 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_WROVER_N8R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-WROVER-N8R2 or ESP32-S2-WROVER-I-N8R2 module with
+        8 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL_ESP32S2_WROVER_N16R2
+    bool
+    select CPU_FAM_ESP32S2
+    select HAS_ESP_SPI_RAM
+    help
+        Indicates that ESP32-S2-WROVER-N16R2 or ESP32-S2-WROVER-I-N16R2 module with
+        16 MB Flash and 2 MB SPI RAM is used.
+
+config CPU_MODEL
+    depends on CPU_FAM_ESP32S2
+    default "esp32s2" if CPU_MODEL_ESP32S2
+    default "esp32s2_fh2" if CPU_MODEL_ESP32S2_FH2
+    default "esp32s2_fh4" if CPU_MODEL_ESP32S2_FH4
+    default "esp32s2_fn4r2" if CPU_MODEL_ESP32S2_FN4R2
+    default "esp32s2_r2" if CPU_MODEL_ESP32S2_R2
+    default "esp32s2_mini_1x_h4" if CPU_MODEL_ESP32S2_MINI_1X_H4
+    default "esp32s2_mini_1x_n4" if CPU_MODEL_ESP32S2_MINI_1X_N4
+    default "esp32s2_mini_1x_n4r2" if CPU_MODEL_ESP32S2_MINI_1X_N4R2
+    default "esp32s2_mini_2x_h4" if CPU_MODEL_ESP32S2_MINI_2X_H4
+    default "esp32s2_mini_2x_n4" if CPU_MODEL_ESP32S2_MINI_2X_N4
+    default "esp32s2_mini_2x_n4r2" if CPU_MODEL_ESP32S2_MINI_2X_N4R2
+    default "esp32s2_solo_h4" if CPU_MODEL_ESP32S2_SOLO_H4
+    default "esp32s2_solo_n4" if CPU_MODEL_ESP32S2_SOLO_N4
+    default "esp32s2_solo_n8" if CPU_MODEL_ESP32S2_SOLO_N8
+    default "esp32s2_solo_n16" if CPU_MODEL_ESP32S2_SOLO_N16
+    default "esp32s2_solo_n4r2" if CPU_MODEL_ESP32S2_SOLO_N4R2
+    default "esp32s2_solo_2x_h4" if CPU_MODEL_ESP32S2_SOLO_2X_H4
+    default "esp32s2_solo_2x_n4" if CPU_MODEL_ESP32S2_SOLO_2X_N4
+    default "esp32s2_solo_2x_n4r2" if CPU_MODEL_ESP32S2_SOLO_2X_N4R2
+    default "esp32s2_wroom" if CPU_MODEL_ESP32S2_WROOM
+    default "esp32s2_wrover_n4r2" if CPU_MODEL_ESP32S2_WROVER_N4R2
+    default "esp32s2_wrover_n8r2" if CPU_MODEL_ESP32S2_WROVER_N8R2
+    default "esp32s2_wrover_n16r2" if CPU_MODEL_ESP32S2_WROVER_N16R2
+
+if CPU_FAM_ESP32S2
+
+menu "ESP32-S2 specific configurations"
+    depends on TEST_KCONFIG
+    depends on HAS_ARCH_ESP32
+
+    # define configuration menu entries for ESP32-S3 variant (family)
+
+    choice
+        bool "CPU clock frequency"
+        default ESP32S2_DEFAULT_CPU_FREQ_MHZ_80
+        help
+            CPU clock frequency used (default 80 MHz).
+            Please note that peripherals such as I2C or SPI might not work at
+            the specified clock frequency if the selected CPU clock frequency
+            is too low. These peripherals are clocked by the APB clock, which
+            has a clock rate of 80 MHz for CPU clock frequencies greater than
+            or equal to 80 MHz, but is equal to the CPU clock frequency for
+            CPU clock frequencies less than 80 MHz. Thus, for SPI, the APB
+            clock rate must be at least five times the SPI clock rate. For the
+            I2C hardware implementation, the APB clock rate must be at least
+            40 times the I2C clock rate. For the I2C software implementation,
+            the maximum I2C clock rate is 1/200 times the CPU clock rate.
+
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_2
+            bool "2 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_5
+            bool "5 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_10
+            bool "10 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_20
+            bool "20 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_40
+            bool "40 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_80
+            bool "80 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_160
+            bool "160 MHz"
+        config ESP32S2_DEFAULT_CPU_FREQ_MHZ_240
+            bool "240 MHz"
+    endchoice
+
+    # import configuration menu entries that are common for all ESP32x SoCs
+    rsource "Kconfig.common"
+
+endmenu
+
+endif # CPU_FAM_ESP32S2

--- a/cpu/esp32/Kconfig.esp32s3
+++ b/cpu/esp32/Kconfig.esp32s3
@@ -5,13 +5,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-config CPU_CORE_XTENSA_LX7
-    bool
-    select CPU_ARCH_XTENSA
-
-config CPU_CORE
-    default "xtensa-lx7" if CPU_CORE_XTENSA_LX7
-
 config CPU_FAM_ESP32S3
     bool
     select CPU_COMMON_ESP

--- a/cpu/esp_common/Kconfig
+++ b/cpu/esp_common/Kconfig
@@ -9,6 +9,16 @@ config CPU_ARCH_XTENSA
     select HAS_ARCH_32BIT
     select HAS_ARCH_ESP
     select HAS_ARCH_ESP_XTENSA
+    help
+        Xtensa based architecture is used for the ESP8266 or the ESP32x SoC variant
+
+config CPU_ARCH_RISCV
+    bool
+    select HAS_ARCH_32BIT
+    select HAS_ARCH_ESP
+    select HAS_ARCH_ESP_RISCV
+    help
+        RISC-V based architecture is used for the ESP32x SoC variant.
 
 config CPU_COMMON_ESP
     bool
@@ -83,6 +93,7 @@ config HAS_ESP_WIFI_ENTERPRISE
 ## Common CPU symbols
 config CPU_ARCH
     default "xtensa" if CPU_ARCH_XTENSA
+    default "rv32" if CPU_ARCH_RISCV
 
 config MODULE_ESP_COMMON
     bool


### PR DESCRIPTION
### Contribution description

This PR is a split-off from #18235 and adds the support of ESP32-S2 in Kconfig.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from #18235