### PR TITLE
cpu/esp32: enable BLE and NimBLE host support for ESP32-C3

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -27,6 +27,12 @@ config HAS_ESP_BLE_ESP32
         Indicates that the ESP32x SoC uses the SDK Bluetooth LE library
         for the ESP32 variant.
 
+config HAS_ESP_BLE_ESP32C3
+    bool
+    help
+        Indicates that the ESP32x SoC uses the SDK Bluetooth LE library
+        for the ESP32-C3 variant.
+
 config HAS_ESP_HW_COUNTER
     bool
     help

--- a/cpu/esp32/Kconfig.common
+++ b/cpu/esp32/Kconfig.common
@@ -15,6 +15,7 @@ config MODULE_ESP_BLE
     select MODULE_ESP_IDF_BLE
     select PACKAGE_ESP32_SDK_LIB_PHY
     select PACKAGE_ESP32_SDK_LIB_BT_ESP32 if HAS_ESP_BLE_ESP32
+    select PACKAGE_ESP32_SDK_LIB_BT_ESP32C3 if HAS_ESP_BLE_ESP32C3
 
 config MODULE_ESP_JTAG
     bool "Enable JTAG debugging interface"

--- a/cpu/esp32/Kconfig.esp32c3
+++ b/cpu/esp32/Kconfig.esp32c3
@@ -31,6 +31,12 @@ config CPU_FAM_ESP32C3
     select CPU_CORE_RV32IMC
     select HAS_ARCH_ESP32
     select HAS_CPU_ESP32
+    select HAS_BLE_ADV_EXT
+    select HAS_BLE_NIMBLE
+    select HAS_BLE_NIMBLE_NETIF
+    select HAS_BLE_PHY_2MBIT
+    select HAS_ESP_BLE
+    select HAS_ESP_BLE_ESP32C3
     select HAS_ESP_WIFI_ENTERPRISE
     select HAS_PUF_SRAM
 

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -25,6 +25,9 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   ifeq (esp32,$(CPU_FAM))
     FEATURES_REQUIRED += esp_ble_esp32
     USEPKG += esp32_sdk_lib_bt_esp32
+  else ifeq (esp32c3,$(CPU_FAM))
+    FEATURES_REQUIRED += esp_ble_esp32c3
+    USEPKG += esp32_sdk_lib_bt_esp32c3
   endif
 endif
 

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -28,6 +28,13 @@ ifeq (esp32,$(CPU_FAM))
   FEATURES_PROVIDED += ble_nimble_netif
   FEATURES_PROVIDED += esp_ble
   FEATURES_PROVIDED += esp_ble_esp32
+else ifeq (esp32c3,$(CPU_FAM))
+  FEATURES_PROVIDED += ble_adv_ext
+  FEATURES_PROVIDED += ble_nimble
+  FEATURES_PROVIDED += ble_nimble_netif
+  FEATURES_PROVIDED += ble_phy_2mbit
+  FEATURES_PROVIDED += esp_ble
+  FEATURES_PROVIDED += esp_ble_esp32c3
 endif
 
 ifneq (,$(filter esp32-wrover% esp32s2%r2 esp32s3%r2 esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -161,10 +161,10 @@ endif
 
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ld/$(CPU_FAM)/
 
-ifeq (,$(filter esp_ble,$(USEMODULE)))
-  LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/$(CPU_FAM)/memory.ld
-else
+ifneq (,$(filter esp32_sdk_lib_bt_esp32,$(USEPKG)))
   LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/$(CPU_FAM)/memory_bt.ld
+else
+  LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/$(CPU_FAM)/memory.ld
 endif
 LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/$(CPU_FAM)/sections.ld
 
@@ -216,6 +216,8 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   ARCHIVES += -lphy -lstdc++
   ifeq (esp32,$(CPU_FAM))
     ARCHIVES += -lrtc
+  else ifeq (esp32c3,$(CPU_FAM))
+    ARCHIVES += -lbtbb
   endif
 endif
 

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -241,7 +241,7 @@ The key features of ESP32-C3 are:
 | SPIs              | 3                                                                 | yes (1) |
 | UARTs             | 2                                                                 | yes |
 | WiFi              | IEEE 802.11 b/g/n built in                                        | yes |
-| Bluetooth         | Bluetooth 5 (LE)                                                  | no  |
+| Bluetooth         | Bluetooth 5 (LE)                                                  | yes |
 | Ethernet          | -                                                                 | -   |
 | CAN               | version 2.0                                                       | yes |
 | IR                | up to 4 channels TX/RX                                            | -   |

--- a/cpu/esp32/include/sdkconfig.h
+++ b/cpu/esp32/include/sdkconfig.h
@@ -108,7 +108,6 @@
 #define CONFIG_BT_CONTROLLER_ONLY                       1
 #else
 #define CONFIG_BT_ENABLED                               0
-#define CONFIG_BTDM_RESERVE_DRAM                        0
 #endif
 
 /**

--- a/cpu/esp32/include/sdkconfig_esp32c3.h
+++ b/cpu/esp32/include/sdkconfig_esp32c3.h
@@ -94,6 +94,44 @@ extern "C" {
 #define CONFIG_ESP_SLEEP_POWER_DOWN_FLASH       1
 #define CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND  1
 
+/**
+ * ESP32-C3 BLE driver configuration (DO NOT CHANGE)
+ */
+#ifdef MODULE_ESP_BLE
+#define CONFIG_BT_CTRL_ADV_DUP_FILT_MAX                 30
+#define CONFIG_BT_CTRL_BLE_ADV_REPORT_DISCARD_THRSHOLD  20
+#define CONFIG_BT_CTRL_BLE_ADV_REPORT_FLOW_CTRL_NUM     100
+#define CONFIG_BT_CTRL_BLE_ADV_REPORT_FLOW_CTRL_SUPP    1
+#define CONFIG_BT_CTRL_BLE_MAX_ACT                      10
+#define CONFIG_BT_CTRL_BLE_MAX_ACT_EFF                  10
+#define CONFIG_BT_CTRL_BLE_SCAN_DUPL                    1
+#define CONFIG_BT_CTRL_BLE_STATIC_ACL_TX_BUF_NB         0
+#define CONFIG_BT_CTRL_CE_LENGTH_TYPE_EFF               0
+#define CONFIG_BT_CTRL_CE_LENGTH_TYPE_ORIG              1
+#define CONFIG_BT_CTRL_COEX_PHY_CODED_TX_RX_TLIM_DIS    1
+#define CONFIG_BT_CTRL_COEX_PHY_CODED_TX_RX_TLIM_EFF    0
+#define CONFIG_BT_CTRL_DFT_TX_POWER_LEVEL_EFF           10
+#define CONFIG_BT_CTRL_DFT_TX_POWER_LEVEL_P3            1
+#define CONFIG_BT_CTRL_HCI_MODE_VHCI                    1
+#define CONFIG_BT_CTRL_HCI_TL                           1
+#define CONFIG_BT_CTRL_HCI_TL_EFF                       1
+#define CONFIG_BT_CTRL_HW_CCA_EFF                       0
+#define CONFIG_BT_CTRL_HW_CCA_VAL                       20
+#define CONFIG_BT_CTRL_MODE_EFF                         1
+#define CONFIG_BT_CTRL_PINNED_TO_CORE                   0
+#define CONFIG_BT_CTRL_RX_ANTENNA_INDEX_0               1
+#define CONFIG_BT_CTRL_RX_ANTENNA_INDEX_EFF             0
+#define CONFIG_BT_CTRL_SCAN_DUPL_CACHE_SIZE             100
+#define CONFIG_BT_CTRL_SCAN_DUPL_TYPE                   0
+#define CONFIG_BT_CTRL_SCAN_DUPL_TYPE_DEVICE            1
+#define CONFIG_BT_CTRL_SLEEP_CLOCK_EFF                  0
+#define CONFIG_BT_CTRL_SLEEP_MODE_EFF                   0
+#define CONFIG_BT_CTRL_TX_ANTENNA_INDEX_0               1
+#define CONFIG_BT_CTRL_TX_ANTENNA_INDEX_EFF             0
+#define CONFIG_BT_ENABLED                               1
+#define CONFIG_BT_SOC_SUPPORT_5_0                       1
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/ld/esp32c3/sections.ld
+++ b/cpu/esp32/ld/esp32c3/sections.ld
@@ -258,7 +258,7 @@ SECTIONS
     KEEP (*(SORT(.esp_system_init_fn) SORT(.esp_system_init_fn.*)))
     _esp_system_init_fn_array_end = ABSOLUTE(.);
 
-    *(EXCLUDE_FILE(*libbt.a *libbtdm_app.a *libnimble.a) .data EXCLUDE_FILE(*libbt.a *libbtdm_app.a *libnimble.a) .data.*)
+    *(EXCLUDE_FILE(*components/bt/* *libbtdm_app.a) .data EXCLUDE_FILE(*components/bt/* *libbtdm_app.a) .data.*)
     *(.dram1 .dram1.*)
     _coredump_dram_start = ABSOLUTE(.);
     *(.dram1.coredump .dram1.coredump.*)
@@ -266,7 +266,7 @@ SECTIONS
     *components/app_trace/app_trace.*(.rodata .rodata.*)
     *components/app_trace/app_trace_util.*(.rodata .rodata.*)
     _bt_data_start = ABSOLUTE(.);
-    *libbt.a:(.data .data.*)
+    *components/bt/*(.data .data.*)
     . = ALIGN(4);
     _bt_data_end = ABSOLUTE(.);
     _btdm_data_start = ABSOLUTE(.);
@@ -355,7 +355,7 @@ SECTIONS
     *(.dynbss .dynsbss .gnu.linkonce.b .gnu.linkonce.b.* .gnu.linkonce.sb .gnu.linkonce.sb.* .gnu.linkonce.sb2 .gnu.linkonce.sb2.* .sbss .sbss.* .sbss2 .sbss2.* .scommon .share.mem)
     *(COMMON)
     _bt_bss_start = ABSOLUTE(.);
-    *libbt.a:(.bss .bss.* COMMON)
+    *components/bt/*(.bss .bss.* COMMON)
     . = ALIGN(4);
     _bt_bss_end = ABSOLUTE(.);
     _btdm_bss_start = ABSOLUTE(.);

--- a/cpu/esp8266/vendor/esp-idf/esp8266/source/esp_wifi_os_adapter.c
+++ b/cpu/esp8266/vendor/esp-idf/esp8266/source/esp_wifi_os_adapter.c
@@ -42,7 +42,6 @@
 
 extern void vPortYield(void);
 extern void vPortYieldFromInt(void);
-#define portYIELD vPortYield
 void  thread_yield_higher(void);
 
 #endif /* RIOT_VERSION */

--- a/cpu/esp_common/include/freertos/portmacro.h
+++ b/cpu/esp_common/include/freertos/portmacro.h
@@ -39,6 +39,7 @@ extern "C" {
 #define portMUX_INITIALIZE              mutex_init
 #define portMUX_INITIALIZER_UNLOCKED    MUTEX_INIT
 
+#define portYIELD                       thread_yield_higher
 #define portYIELD_FROM_ISR              thread_yield_higher
 
 #define portENTER_CRITICAL              vTaskEnterCritical
@@ -64,6 +65,7 @@ extern "C" {
 
 #define portNUM_PROCESSORS              1
 #define xPortGetCoreID()                PRO_CPU_NUM
+#define vPortYield                      portYIELD
 
 #endif /* defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3) */
 

--- a/pkg/esp32_sdk_lib_bt_esp32c3/Kconfig
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config PACKAGE_ESP32_SDK_LIB_BT_ESP32C3
+    bool "ESP32 SDK Bluetooth library for the ESP32-C3 SoC"
+    depends on TEST_KCONFIG
+    depends on HAS_ARCH_ESP32
+    depends on HAS_ESP_BLE_ESP32C3
+    help
+        Vendor SDK Bluetooth library for ESP32-C3 SoC

--- a/pkg/esp32_sdk_lib_bt_esp32c3/Makefile
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/Makefile
@@ -1,0 +1,10 @@
+PKG_NAME=esp32_sdk_lib_bt_esp32c3
+PKG_URL=https://github.com/espressif/esp32c3-bt-lib
+# This is a version in the v4.4.1 release branch
+PKG_VERSION=98dcc9591365b5ac486a9f0b474c36bf8c4ca97b
+PKG_LICENSE=Apache-2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+# there is nothing to compile
+all:

--- a/pkg/esp32_sdk_lib_bt_esp32c3/Makefile.dep
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/Makefile.dep
@@ -1,0 +1,4 @@
+# This package can only be used with the ESP32 CPU
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += esp_ble
+FEATURES_REQUIRED += esp_ble_esp32c3

--- a/pkg/esp32_sdk_lib_bt_esp32c3/Makefile.include
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/Makefile.include
@@ -1,0 +1,3 @@
+export ESP32_SDK_LIB_BT_DIR ?= $(PKGDIRBASE)/esp32_sdk_lib_bt_esp32c3
+
+PSEUDOMODULES += esp32_sdk_lib_bt_esp32c3

--- a/pkg/esp32_sdk_lib_bt_esp32c3/doc.txt
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup pkg_esp32_sdk_lib_bt_esp32c3  ESP32 SDK Bluetooth library for the ESP32-C3 SoC
+ * @ingroup  pkg_esp32_sdk
+ * @brief    Vendor SDK Bluetooth library for ESP32-C3 SoC by Espressif
+ * @see      https://github.com/espressif/esp32c3-bt-lib
+ */


### PR DESCRIPTION
### Contribution description

This PR enables the Bluetooth 5 including advertising extension and NimBLE host support for ESP32-C3.

BLE and NimBLE host support for ESP32-C3 including advertising extension was already tested when BLE and NimBLE host support was tesed for ESP32 in  PR #18439.

### Testing procedure

The easiest way to test the PR is to use an ESP32 node and an ESP32-C3 node and flash `tests/nimble_autoconn_gnrc` and test it.
```
BOARD=esp32-wroom-32 make -j8 -C examples/nimble_autoconn_gnrc flash term
```
```
BOARD=esp32c3-devkit make -j8 -C examples/nimble_autoconn_gnrc flash term
```
Use command `ble info` to check that a connection between the two nodes is established after some seconds.

Node 1:
```
> ble info
Own Address: 60:55:F9:6E:6E:69 (public) -> [FE80::6055:F9FF:FE6E:6E69]
Supported PHY modes: 1M
 Free slots: 1/3
Advertising: yes
Connections: 1
[ 0] 7C:DF:A1:E2:94:99 [FE80::7CDF:A1FF:FEE2:9499] (M,75ms,2500ms,0,1M)
     (role, conn itvl, superv. timeout, slave latency, PHY)
Slots:
[ 0] state: 0x0011 - GAP-master L2CAP-client
[ 1] state: 0x0100 - advertising
[ 2] state: 0x8000 - unused
```
Node 2:
```
> ble info
Own Address: 7C:DF:A1:E2:94:99 (public) -> [FE80::7CDF:A1FF:FEE2:9499]
Supported PHY modes: 1M
 Free slots: 2/3
Advertising: no
Connections: 1
[ 0] 60:55:F9:6E:6E:69 [FE80::6055:F9FF:FE6E:6E69] (S,75ms,2500ms,0,1M)
     (role, conn itvl, superv. timeout, slave latency, PHY)
Slots:
[ 0] state: 0x0022 - GAP-slave L2CAP-server
[ 1] state: 0x8000 - unused
[ 2] state: 0x8000 - unused
```

### Issues/PRs references
