### PR TITLE
tests/periph_timer_short_relative_set: clarify outcome

### DIFF
--- a/tests/periph_timer_short_relative_set/README.md
+++ b/tests/periph_timer_short_relative_set/README.md
@@ -26,6 +26,8 @@ timeouts.
 For example, as of this writing (30-Oct-19), samr21-xpro fails for values below
 8, nrf52dk for values below 2.
 
+Note: _THIS IS EXPECTED TO FAIL ON MOST BOARDS_.
+
 ## Expected Result
 
 After 100 "interval N ok" messages the test should print "TEST SUCCEEDED".

--- a/tests/periph_timer_short_relative_set/main.c
+++ b/tests/periph_timer_short_relative_set/main.c
@@ -92,7 +92,8 @@ int main(void)
             if (diff > TEST_MAX_DIFF) {
                 printf("ERROR: too long delay, aborted after %" PRIu32
                         " (TEST_MAX_DIFF=%lu)\n"
-                        "TEST FAILED\n",
+                        "TEST FAILED\n"
+                        "Note: This is currently expected to fail on most boards.\n",
                         diff, TEST_MAX_DIFF);
                 while(1) {}
             }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Clarify the outcome of `tests/periph_timer_short_relative_set`, just so the next tester doesn't get confused/frustrated.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This is purely changing output, so, run `tests/periph_timer_short_relative_set` and see it output an additional note on failure.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Improves on #12610.
Fixes #18511.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
