### PR TITLE
cpu/esp32: enable BLE and NimBLE host support for ESP32-S3

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -31,7 +31,7 @@ config HAS_ESP_BLE_ESP32C3
     bool
     help
         Indicates that the ESP32x SoC uses the SDK Bluetooth LE library
-        for the ESP32-C3 variant.
+        for the ESP32-C3 or ESP32-S3 variant.
 
 config HAS_ESP_HW_COUNTER
     bool

--- a/cpu/esp32/Kconfig.esp32s3
+++ b/cpu/esp32/Kconfig.esp32s3
@@ -11,6 +11,12 @@ config CPU_FAM_ESP32S3
     select CPU_CORE_XTENSA_LX7
     select HAS_ARCH_ESP32
     select HAS_CPU_ESP32
+    select HAS_BLE_ADV_EXT
+    select HAS_BLE_NIMBLE
+    select HAS_BLE_NIMBLE_NETIF
+    select HAS_BLE_PHY_2MBIT
+    select HAS_ESP_BLE
+    select HAS_ESP_BLE_ESP32C3
     select HAS_ESP_HW_COUNTER
     select HAS_ESP_WIFI_ENTERPRISE
     select HAS_PUF_SRAM

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -25,7 +25,7 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   ifeq (esp32,$(CPU_FAM))
     FEATURES_REQUIRED += esp_ble_esp32
     USEPKG += esp32_sdk_lib_bt_esp32
-  else ifeq (esp32c3,$(CPU_FAM))
+  else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
     FEATURES_REQUIRED += esp_ble_esp32c3
     USEPKG += esp32_sdk_lib_bt_esp32c3
   endif

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -28,7 +28,7 @@ ifeq (esp32,$(CPU_FAM))
   FEATURES_PROVIDED += ble_nimble_netif
   FEATURES_PROVIDED += esp_ble
   FEATURES_PROVIDED += esp_ble_esp32
-else ifeq (esp32c3,$(CPU_FAM))
+else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
   FEATURES_PROVIDED += ble_adv_ext
   FEATURES_PROVIDED += ble_nimble
   FEATURES_PROVIDED += ble_nimble_netif

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -216,7 +216,7 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   ARCHIVES += -lphy -lstdc++
   ifeq (esp32,$(CPU_FAM))
     ARCHIVES += -lrtc
-  else ifeq (esp32c3,$(CPU_FAM))
+  else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
     ARCHIVES += -lbtbb
   endif
 endif

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -313,7 +313,7 @@ The key features of ESP32-S3 are:
 | SPIs              | 4                                                                 | yes (2) |
 | UARTs             | 3                                                                 | yes |
 | WiFi              | IEEE 802.11 b/g/n built in                                        | yes |
-| Bluetooth         | Bluetooth LE: Bluetooth 5, Bluetooth mesh                         | no  |
+| Bluetooth         | Bluetooth 5 (LE)                                                  | yes |
 | Ethernet          | -                                                                 | -   |
 | CAN               | version 2.0                                                       | yes |
 | IR                | up to 8 channels TX/RX                                            | no |

--- a/cpu/esp32/include/esp_ble_nimble/syscfg/syscfg.h
+++ b/cpu/esp32/include/esp_ble_nimble/syscfg/syscfg.h
@@ -16,7 +16,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-
 #ifndef ESP_BLE_NIMBLE_SYSCFG_SYSCFG_H
 #define ESP_BLE_NIMBLE_SYSCFG_SYSCFG_H
 

--- a/cpu/esp32/include/sdkconfig_esp32s3.h
+++ b/cpu/esp32/include/sdkconfig_esp32s3.h
@@ -145,6 +145,46 @@ extern "C" {
 #define CONFIG_ESP32S3_DATA_CACHE_LINE_32B          1
 #define CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE         32
 
+/**
+ * ESP32-S3 BLE driver configuration (DO NOT CHANGE)
+ */
+#ifdef MODULE_ESP_BLE
+#define CONFIG_BT_CONTROLLER_ONLY                       1
+#define CONFIG_BT_CTRL_ADV_DUP_FILT_MAX                 30
+#define CONFIG_BT_CTRL_BLE_ADV_REPORT_DISCARD_THRSHOLD  20
+#define CONFIG_BT_CTRL_BLE_ADV_REPORT_FLOW_CTRL_NUM     100
+#define CONFIG_BT_CTRL_BLE_ADV_REPORT_FLOW_CTRL_SUPP    1
+#define CONFIG_BT_CTRL_BLE_MAX_ACT                      10
+#define CONFIG_BT_CTRL_BLE_MAX_ACT_EFF                  10
+#define CONFIG_BT_CTRL_BLE_SCAN_DUPL                    1
+#define CONFIG_BT_CTRL_BLE_STATIC_ACL_TX_BUF_NB         0
+#define CONFIG_BT_CTRL_CE_LENGTH_TYPE_EFF               0
+#define CONFIG_BT_CTRL_CE_LENGTH_TYPE_ORIG              1
+#define CONFIG_BT_CTRL_COEX_PHY_CODED_TX_RX_TLIM_DIS    1
+#define CONFIG_BT_CTRL_COEX_PHY_CODED_TX_RX_TLIM_EFF    0
+#define CONFIG_BT_CTRL_DFT_TX_POWER_LEVEL_EFF           10
+#define CONFIG_BT_CTRL_DFT_TX_POWER_LEVEL_P3            1
+#define CONFIG_BT_CTRL_HCI_MODE_VHCI                    1
+#define CONFIG_BT_CTRL_HCI_TL                           1
+#define CONFIG_BT_CTRL_HCI_TL_EFF                       1
+#define CONFIG_BT_CTRL_HW_CCA_EFF                       0
+#define CONFIG_BT_CTRL_HW_CCA_VAL                       20
+#define CONFIG_BT_CTRL_MODE_EFF                         1
+#define CONFIG_BT_CTRL_PINNED_TO_CORE                   0
+#define CONFIG_BT_CTRL_PINNED_TO_CORE_0                 1
+#define CONFIG_BT_CTRL_RX_ANTENNA_INDEX_0               1
+#define CONFIG_BT_CTRL_RX_ANTENNA_INDEX_EFF             0
+#define CONFIG_BT_CTRL_SCAN_DUPL_CACHE_SIZE             100
+#define CONFIG_BT_CTRL_SCAN_DUPL_TYPE                   0
+#define CONFIG_BT_CTRL_SCAN_DUPL_TYPE_DEVICE            1
+#define CONFIG_BT_CTRL_SLEEP_CLOCK_EFF                  0
+#define CONFIG_BT_CTRL_SLEEP_MODE_EFF                   0
+#define CONFIG_BT_CTRL_TX_ANTENNA_INDEX_0               1
+#define CONFIG_BT_CTRL_TX_ANTENNA_INDEX_EFF             0
+#define CONFIG_BT_ENABLED                               1
+#define CONFIG_BT_SOC_SUPPORT_5_0                       1
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/ld/esp32s3/sections.ld
+++ b/cpu/esp32/ld/esp32s3/sections.ld
@@ -304,7 +304,7 @@ SECTIONS
     KEEP (*(SORT(.esp_system_init_fn) SORT(.esp_system_init_fn.*)))
     _esp_system_init_fn_array_end = ABSOLUTE(.);
 
-    *(EXCLUDE_FILE(*libbt.a *libbtdm_app.a *libnimble.a) .data EXCLUDE_FILE(*libbt.a *libbtdm_app.a *libnimble.a) .data.*)
+    *(EXCLUDE_FILE(*components/bt/* *libbtdm_app.a) .data EXCLUDE_FILE(*components/bt/* *libbtdm_app.a) .data.*)
     *(.dram1 .dram1.*)
     _coredump_dram_start = ABSOLUTE(.);
     *(.dram1.coredump .dram1.coredump.*)
@@ -312,7 +312,7 @@ SECTIONS
     *libapp_trace.a:app_trace.*(.rodata .rodata.*)
     *libapp_trace.a:app_trace_util.*(.rodata .rodata.*)
     _bt_data_start = ABSOLUTE(.);
-    *libbt.a:(.data .data.*)
+    *components/bt/*(.data .data.*)
     . = ALIGN(4);
     _bt_data_end = ABSOLUTE(.);
     _btdm_data_start = ABSOLUTE(.);
@@ -402,7 +402,7 @@ SECTIONS
     *(.dynbss .dynsbss .gnu.linkonce.b .gnu.linkonce.b.* .gnu.linkonce.sb .gnu.linkonce.sb.* .gnu.linkonce.sb2 .gnu.linkonce.sb2.* .sbss .sbss.* .sbss2 .sbss2.* .scommon .share.mem)
     *(COMMON)
     _bt_bss_start = ABSOLUTE(.);
-    *libbt.a:(.bss .bss.* COMMON)
+    *components/bt/*(.bss .bss.* COMMON)
     . = ALIGN(4);
     _bt_bss_end = ABSOLUTE(.);
     _btdm_bss_start = ABSOLUTE(.);

--- a/cpu/esp_common/include/freertos/portmacro.h
+++ b/cpu/esp_common/include/freertos/portmacro.h
@@ -60,6 +60,7 @@ extern "C" {
 
 #define portNUM_PROCESSORS              2
 #define xPortGetCoreID()                PRO_CPU_NUM
+#define vPortYield                      portYIELD
 
 #else /* defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3) */
 


### PR DESCRIPTION
### Contribution description

This PR enables the Bluetooth 5 including advertising extension and NimBLE host support for ESP32-S3.

~The PR includes the changes of PR #18510 for now to be compilable. It has to be rebased once PR #18510 is merged.~

Please note: The binary Bluetooth library that is used as package is the same as for ESP32-C3 and is called [esp32c3-bt-lib](https://github.com/espressif/esp32c3-bt-lib). That's the reason why feature `esp_ble_esp32c3` is enabled for ESP32-S3 BLE implementation.

### Testing procedure

The easiest way to test the PR is to use an ESP32 node and an ESP32-S3 node and flash `tests/nimble_autoconn_gnrc` and test it.
```
BOARD=esp32-wroom-32 make -j8 -C examples/nimble_autoconn_gnrc flash term
```
```
BOARD=esp32s3-devkit make -j8 -C examples/nimble_autoconn_gnrc flash term
```
Use command `ble info` to check that a connection between the two nodes is established after some seconds.

Node 1:
```
> ble info
Own Address: 60:55:F9:6E:6E:69 (public) -> [FE80::6055:F9FF:FE6E:6E69]
Supported PHY modes: 1M
 Free slots: 1/3
Advertising: yes
Connections: 1
[ 0] 7C:DF:A1:E2:94:99 [FE80::7CDF:A1FF:FEE2:9499] (M,75ms,2500ms,0,1M)
     (role, conn itvl, superv. timeout, slave latency, PHY)
Slots:
[ 0] state: 0x0011 - GAP-master L2CAP-client
[ 1] state: 0x0100 - advertising
[ 2] state: 0x8000 - unused
```
Node 2:
```
> ble info
Own Address: 7C:DF:A1:E2:94:99 (public) -> [FE80::7CDF:A1FF:FEE2:9499]
Supported PHY modes: 1M
 Free slots: 2/3
Advertising: no
Connections: 1
[ 0] 60:55:F9:6E:6E:69 [FE80::6055:F9FF:FE6E:6E69] (S,75ms,2500ms,0,1M)
     (role, conn itvl, superv. timeout, slave latency, PHY)
Slots:
[ 0] state: 0x0022 - GAP-slave L2CAP-server
[ 1] state: 0x8000 - unused
[ 2] state: 0x8000 - unused
```

### Issues/PRs references
