### PR TITLE
event_timeout: abstract away ztimer

### DIFF
--- a/sys/event/timeout_ztimer.c
+++ b/sys/event/timeout_ztimer.c
@@ -19,17 +19,10 @@ static void _event_timeout_callback(void *arg)
     event_post(event_timeout->queue, event_timeout->event);
 }
 
-#if IS_USED(MODULE_EVENT_TIMEOUT)
-void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, event_t *event)
+void event_timeout_scale_init(event_timeout_t *event_timeout, event_timeout_scale_t scale,
+                              event_queue_t *queue, event_t *event)
 {
-    event_timeout_ztimer_init(event_timeout, ZTIMER_USEC, queue, event);
-}
-#endif
-
-void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *clock,
-                               event_queue_t *queue, event_t *event)
-{
-    event_timeout->clock = clock;
+    event_timeout->clock = scale;
     event_timeout->timer.callback = _event_timeout_callback;
     event_timeout->timer.arg = event_timeout;
     event_timeout->queue = queue;

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -44,6 +44,16 @@
 extern "C" {
 #endif
 
+#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER) || defined(DOXYGEN)
+typedef ztimer_clock_t *event_timeout_scale_t;  /**< Timeout scale */
+
+#define EVENT_TIMEOUT_SCALE_USEC    ZTIMER_USEC /**< interpret timeout delay in microseconds */
+#define EVENT_TIMEOUT_SCALE_MSEC    ZTIMER_MSEC /**< interpret timeout delay in milliseconds */
+#define EVENT_TIMEOUT_SCALE_SEC     ZTIMER_SEC  /**< interpret timeout delay in seconds */
+#else
+#error "No timer backend provided"
+#endif
+
 /**
  * @brief   Timeout Event structure
  */
@@ -58,25 +68,50 @@ typedef struct {
  * @brief   Initialize timeout event object
  *
  * @param[in]   event_timeout   event_timeout object to initialize
+ * @param[in]   scale           scale, i.e. time-unit to use with the timeout.
+ *                              See @ref event_timeout_scale_t.
+ * @param[in]   queue           queue that the timed-out event will be added to
+ * @param[in]   event           event to add to queue after timeout
+ */
+void event_timeout_scale_init(event_timeout_t *event_timeout, event_timeout_scale_t scale,
+                              event_queue_t *queue, event_t *event);
+
+/**
+ * @brief   Initialize timeout event object
+ *
+ * @deprecated  This function will be deprecated after the 2023.01 release. Use
+ *              @ref event_timeout_scale_init() instead.
+ *
+ * @param[in]   event_timeout   event_timeout object to initialize
  * @param[in]   clock           the clock backend, eg: ZTIMER_USEC, ZTIMER_MSEC
  * @param[in]   queue           queue that the timed-out event will be added to
  * @param[in]   event           event to add to queue after timeout
  */
-void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *clock,
-                               event_queue_t *queue, event_t *event);
+static inline void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *clock,
+                                             event_queue_t *queue, event_t *event)
+{
+    event_timeout_scale_init(event_timeout, (event_timeout_scale_t)clock, queue, event);
+}
 
 #if IS_USED(MODULE_EVENT_TIMEOUT) || DOXYGEN
 /**
  * @brief   Initialize timeout event object
  *
- * @note    If ztimer is used the default time clock backend is ZTIMER_USEC
+ * @deprecated  This function will be deprecated after the 2023.01 release. Use
+ *              @ref event_timeout_scale_init() instead. After the 2023.01 event_timeout_init()
+ *              will become an alias for event_timeout_scale_init().
+ *
+ * @note    EVENT_TIMEOUT_SCALE_USEC is used as timeout scale.
  *
  * @param[in]   event_timeout   event_timeout object to initialize
  * @param[in]   queue           queue that the timed-out event will be added to
  * @param[in]   event           event to add to queue after timeout
  */
-void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
-                        event_t *event);
+static inline void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
+                                      event_t *event)
+{
+    event_timeout_scale_init(event_timeout, EVENT_TIMEOUT_SCALE_USEC, queue, event);
+}
 #endif
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This provides an API cleanup for `event_timeout`. Currently, there is a weird mixture with `ztimer` going on (which, if you not explicitly include `event_timeout`, is the only way to actually initialize the timeout), so why not abstract this away properly? This is only an intermediary step to utilizing our deprecation cycle. Once `event_timeout_ztimer_init()` and `event_timeout_init()` are phased out, we can rename `event_timeout_scale_init()` to `event_timeout_init()` (with another grace period where both exist). 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Any application that uses `event_timeout` should still compile and work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
