### PR TITLE
usbus/dfu: move ztimer init to USB level

### DIFF
--- a/bootloaders/riotboot_dfu/main.c
+++ b/bootloaders/riotboot_dfu/main.c
@@ -26,7 +26,6 @@
 #include "panic.h"
 #include "riotboot/slot.h"
 #include "riotboot/usb_dfu.h"
-#include "ztimer.h"
 
 #include "riotboot/bootloader_selection.h"
 
@@ -70,9 +69,6 @@ void kernel_init(void)
     if (slot != -1 && !_bootloader_alternative_mode()) {
         riotboot_slot_jump(slot);
     }
-
-    /* Init ztimer before starting DFU mode */
-    ztimer_init();
 
     /* Nothing to boot, stay in DFU mode to flash a slot */
     riotboot_usb_dfu_init(1);

--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -112,6 +112,12 @@ void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, unsigned mode)
                 USB_DFU_STATE_DFU_IDLE : USB_DFU_STATE_APP_IDLE;
 
     usbus_register_event_handler(usbus, (usbus_handler_t *)handler);
+#ifdef MODULE_RIOTBOOT_USB_DFU
+    if (handler->mode == USB_DFU_PROTOCOL_DFU_MODE) {
+        /* Init ztimer for DFU mode */
+        ztimer_init();
+    }
+#endif
 }
 
 static void _init(usbus_t *usbus, usbus_handler_t *handler)


### PR DESCRIPTION
### Contribution description

In the current place, ztimer_init is misplaced within riotboot_dfu app and leads to timer not being initialized in some case. (When updating an app to the second slot for instance). In such case, the scheduled reboot is broken and restart the bootloader right at the end of the flashing procedure instead of waiting a bit, closing the remaining USB transfers, leading to error in dfu-util.
such as : `dfu-util: unable to read DFU status after completion`

Moving the `ztimer_init()` function higher in `riotboot_dfu` main won't help as it will introduce a second issue: ztimer being initialized twice in some cases. (Looks like SAM0 isn't happy about this...)

Thus, move it at USB DFU level.

### Testing procedure

Flash riotboot_dfu bootloader on a board.
Flash several applications using dfu-util. (more than one at least)
No more error message should be printed by dfu-util.


### Issues/PRs references

Fixes #18456
