### PR TITLE
makefiles/tools/dfu-util: add option to pass DFU_SERIAL id

### DIFF
--- a/makefiles/tools/dfu-util.inc.mk
+++ b/makefiles/tools/dfu-util.inc.mk
@@ -21,3 +21,7 @@ FFLAGS ?= --device $(DFU_USB_ID) \
 ifeq ($(DFU_USE_DFUSE),1)
   FFLAGS += --dfuse-address $(FLASH_ADDR):leave
 endif
+
+ifneq (,$(DEBUG_ADAPTER_ID))
+  FFLAGS += --serial $(DEBUG_ADAPTER_ID)
+endif


### PR DESCRIPTION
### Contribution description

Add an option to dfu-util to pass DFU Serial ID.
This is useful when you need to flash a board and you have more than one DFU capable devices connected on your computer. 

### Testing procedure
Get your DFU Serial ID of your boards using:
`dfu-util -l`
Flash the right board using:
`DEBUG_ADAPTER_ID=XXXXX USEMODULE+=usbus_dfu make -C tests/leds BOARD=samr21-xpro PROGRAMMER=dfu-util riotboot/flash-slot0 `

### Issues/PRs references
None
