### PR TITLE
makefiles/tools/serial.inc.mk: Improve PORT selection when RIOT's USB CDC ACM is used for stdio

### DIFF
--- a/dist/tools/usb-serial/ttys.py
+++ b/dist/tools/usb-serial/ttys.py
@@ -213,11 +213,14 @@ def print_ttys(args):
             ttys.append(tty)
 
     if args.most_recent:
-        most_recent = ttys[0]
-        for tty in ttys:
-            if tty["ctime"] > most_recent["ctime"]:
-                most_recent = tty
-        ttys = [most_recent]
+        if len(ttys) > 0:
+            most_recent = ttys[0]
+            for tty in ttys:
+                if tty["ctime"] > most_recent["ctime"]:
+                    most_recent = tty
+            ttys = [most_recent]
+        else:
+            ttys = []
 
     print_results(args, ttys)
 

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,7 +1,11 @@
 # Select the most recently attached tty interface
 ifeq (1,$(MOST_RECENT_PORT))
+  ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+    TTY_BOARD_FILTER ?= --model $(BOARD) --vendor 'RIOT-os\.org'
+  endif
   TTYS_FLAGS := --most-recent --format path $(TTY_BOARD_FILTER)
-  PORT ?= $(shell $(RIOTTOOLS)/usb-serial/ttys.py $(TTYS_FLAGS))
+  PORT_DETECTED := $(shell $(RIOTTOOLS)/usb-serial/ttys.py $(TTYS_FLAGS))
+  PORT ?= $(PORT_DETECTED)
 endif
 # Otherwise, use as default the most commonly used ports on Linux and OSX
 PORT_LINUX ?= /dev/ttyACM0

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -86,7 +86,7 @@ extern "C" {
  * @brief USB peripheral product string
  */
 #ifndef CONFIG_USB_PRODUCT_STR
-#define CONFIG_USB_PRODUCT_STR  "USB device"
+#define CONFIG_USB_PRODUCT_STR  RIOT_BOARD
 #endif
 
 /**

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -62,7 +62,7 @@ config USB_MANUF_STR
 
 config USB_PRODUCT_STR
     string "Product string"
-    default "USB device"
+    default BOARD
 
 config USB_CONFIGURATION_STR
     string "Configuration string"


### PR DESCRIPTION
### Contribution description

This does mainly two things:

- Set the USB model to `$(BOARD)` by default
- Filter USB serials with `--vendor RIOT-os\.org` and `--model $(BOARD)`, so that the right board type is picked automagically with `MOST_RECENT_PORT=1`

### Testing procedure

Flash two boards of different type that use USB CDC ACM for serial. Test if `MOST_RECENT_PORT=1 BOARD=<foo> make term` picks the right board when both are plugged in, no matter which board was plugged in first.

### Issues/PRs references

Suggested in https://github.com/RIOT-OS/RIOT/pull/18512#discussion_r954983129