### PR TITLE
makefiles: Add openocd-rtt

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -859,7 +859,7 @@ termdeps: $(TERMDEPS)
 
 term: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
-	$(TERMPROG) $(TERMFLAGS) $(TERMTEE)
+	${TERMENV} $(TERMPROG) $(TERMFLAGS) $(TERMTEE)
 
 # Term without the pyterm added logging
 # PYTERMFLAGS must be exported for `jlink.sh term-rtt`.

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -101,6 +101,7 @@ info-build:
 	@echo ''
 	@echo 'TERMPROG:  $(TERMPROG)'
 	@echo 'TERMFLAGS: $(TERMFLAGS)'
+	@echo 'TERMENV:   $(TERMENV)'
 	@echo 'PORT:      $(PORT)'
 	@echo 'PROG_DEV:  $(PROG_DEV)'
 	@echo ''

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -43,4 +43,8 @@ else ifeq ($(RIOT_TERMINAL),semihosting)
   TERMFLAGS = $(DEBUGGER_FLAGS)
   OPENOCD_DBG_EXTRA_CMD += -c 'arm semihosting enable'
   $(call target-export-variables,term cleanterm,OPENOCD_DBG_EXTRA_CMD)
+else ifeq (${RIOT_TERMINAL},openocd-rtt)
+  TERMENV = RAM_START_ADDR=${RAM_START_ADDR} RAM_LEN=${RAM_LEN}
+  TERMPROG = $(RIOTTOOLS)/openocd/openocd.sh
+  TERMFLAGS = term-rtt
 endif

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -97,6 +97,7 @@ export WPEDANTIC             # Issue all (extensive) compiler warnings demanded 
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 # TERMPROG                   # The command to call on "make term".
 # TERMFLAGS                  # Additional parameters to supply to TERMPROG.
+# TERMENV                    # Environment variables passed to TERMPROG
 # TERMLOG                    # Optional file to log "make term" output to.
 # TERMTEE                    # Optional pipe to redirect "make term" output. Default: '| tee -a ${TERMLOG}' when TERMLOG is defined else undefined.
 # PORT                       # The port to connect the TERMPROG to.


### PR DESCRIPTION
### Contribution description

The RTT mechanism, by which a debugger emulates a serial interface, has been [invented and described by Segger (creator of JLink)](https://wiki.segger.com/RTT), but was so far only available through their own JLink program. As the same interface is also implemented by OpenOCD, it can be used with that and thus any debug adapter (eg. STLink).

### Open issues

* Do we need any parametrization?
  * Channel 0 is hard-coded which is probably OK
  * No clue where the addresses come from.
  * The string "SEGGER JLINK" is the sentinel value also hardcoded in stdio_rtt.c, so that should be OK.
* Do we need better autoselection? (See future steps)

### Testing procedure

* Pick any board that has an OpenOCD-style debugger and usually runs serial stdio; I picked `microbit-v2`, and an example that has nice shell (eg. `saul`)
* Add lines to the Makefile:
  ```
  USEMODULE += stdio_rtt
  RIOT_TERMINAL = openocd-rtt
  ```
* `make -C examples/saul BOARD=microbit-v2 all flash term`

### Issues/PRs references

This is based on the existing code in jlink.sh, and notes from @nica-f.

### Future steps

* There's a lot of code duplication both internally to `openocd.sh` and between it and `jlink.sh`.
* The process of picking a terminal happens inside these scripts, so they have their own JLINK_TERMPROG rather than having composition from the terminal selection.

Both of these are probably doable in shell and Makefile, but IMO too complex to be done there well and maintainably -- so some duplication it is for now, as it has been for some time.

* The default RIOT_TERMINAL is pyterm, and only overridden by board or application. It might make sense to set defaults based on the selected `stdio_` modules. As this would also affect `stdio_acm` (in which case it'd influence MOST_RECENT_BOARD selectors as in #18525), I think that's better done in a follow-up step.