### PR TITLE
makefiles: Select suitable terminal when stdio_rtt is used

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -23,6 +23,16 @@ PROG_DEV ?= $(PORT)
 
 export BAUD ?= 115200
 
+ifneq (,$(filter stdio_rtt,$(USEMODULE)))
+  ifeq (${PROGRAMMER},openocd)
+    RIOT_TERMINAL ?= openocd-rtt
+  else ifeq (${PROGRAMMER},jlink)
+    RIOT_TERMINAL ?= jlink
+  else ifeq (${RIOT_TERMINAL},)
+    $(warning "Warning: No RIOT_TERMINAL set, but using stdio_rtt: The default terminal is likely not to work.")
+  endif
+endif
+
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm


### PR DESCRIPTION
### Contribution description

When stdio_rtt is used, the default value of RIOT_TERMINAL (pyterm) with some PORT makes little sense -- the board won't be using that.

Instead, when stdio_rtt is detected, the selected PROGRAMMER is introspected, and the used to pick the corresponding terminal transport.

### Testing procedure

* Pick any board that is used with a debugger and usually runs serial stdio; I picked `microbit-v2`, and an example that has nice shell (eg. `saul`)
* Add lines to the Makefile:
  ```
  USEMODULE += stdio_rtt
  ```
* `make -C examples/saul BOARD=microbit-v2 all flash term`

(Note that this is identical to that of #18526 except that no RIOT_TERMINAL is set).

I've tried this with PROGRAMMER values of openocd and pyocd (for which RTT is not implemented, falling back to the pyterm default but issuing a warning); I'd appreciate if someone who uses JLink could test it with that too.

### Issues/PRs references

Follow-up for #18526, based on a comment @benpicco left there.