### PR TITLE
tests/pkg_tinyvcdiff: Initialize mtd->write_size

### DIFF
--- a/tests/pkg_tinyvcdiff/fakemtd.h
+++ b/tests/pkg_tinyvcdiff/fakemtd.h
@@ -65,7 +65,8 @@ typedef struct {
 #define FAKE_MTD_INIT { .mtd = { .driver = &fake_mtd_driver, \
                                  .sector_count = FAKE_MTD_SECTOR_COUNT, \
                                  .pages_per_sector = FAKE_MTD_PAGES_PER_SECTOR, \
-                                 .page_size = FAKE_MTD_PAGE_SIZE } }
+                                 .page_size = FAKE_MTD_PAGE_SIZE, \
+                                 .write_size = 1 } }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION

### Contribution description

An assert `assert(mtd->write_size != 0);` is being hit with `native`.
```
main(): This is RIOT! (Version: buildtest)
..drivers/mtd/mtd.c:53 => *** RIOT kernel panic:
FAILED ASSERTION.

*** halted.
```
It seems that initializing this to 1 in the fakemtd fixes it.
Not that I know anything about what it should be.  If one looks at some of the other write_sizes it seems that would make sense.

### Testing procedure
Run the following, it should not longer fail:
```
make all test -C tests/pkg_tinyvcdiff/
```
I think murdock should have caught it... Maybe add CI: run_tests label.

### Issues/PRs references

Introduced with the initial test #17797
