### PR TITLE
doc: change protocol for git clone in docs

### DIFF
--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -15,7 +15,7 @@ In order to clone the RIOT repository, you need the
 command:
 
 ~~~~~~~~ {.sh}
-git clone git://github.com/RIOT-OS/RIOT.git
+git clone https://github.com/RIOT-OS/RIOT.git
 ~~~~~~~~
 
 Compiling RIOT                                                {#compiling-riot}

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -54,7 +54,7 @@ IoT-lab), and also directly as a process on your Linux/FreeBSD/macOS machine (we
 call this the `native` port). Try it right now in your terminal window:
 
 ~~~~~~~{.sh}
-git clone git://github.com/RIOT-OS/RIOT.git # assumption: git is pre-installed
+git clone https://github.com/RIOT-OS/RIOT.git # assumption: git is pre-installed
 cd RIOT
 git checkout <LATEST_RELEASE>
 sudo ./dist/tools/tapsetup/tapsetup         # create virtual Ethernet


### PR DESCRIPTION
### Contribution description

Small change in the docs regarding cloning with git in the get started parts of the project. 
Github dropped the unauthenticated `git://` protocol a while a go: [link](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git).
This commit simply changes it to the `https://` url in the docs instead.
