### PR TITLE
makefiles/arch/avr8.inc.mk: Fix compilation with GCC 12.2.0

### DIFF
--- a/makefiles/arch/avr8.inc.mk
+++ b/makefiles/arch/avr8.inc.mk
@@ -38,3 +38,8 @@ endif
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
 OPTIONAL_CFLAGS_BLACKLIST += -gz
+
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+ifneq ($(findstring 12.,$(shell $(CC) --version 2>/dev/null)),)
+  CFLAGS += --param=min-pagesize=0
+endif


### PR DESCRIPTION
### Contribution description

As the title says. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523 for details.

### Testing procedure

#### Using `master`

```
$ make BOARD=arduino-uno -C examples/hello-world
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
Building application "hello-world" for "arduino-uno" with MCU "atmega328p".

"make" -C /home/maribu/Repos/software/RIOT/boards/arduino-uno
"make" -C /home/maribu/Repos/software/RIOT/boards/common/arduino-atmega
"make" -C /home/maribu/Repos/software/RIOT/boards/common/atmega
"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/atmega328p
"make" -C /home/maribu/Repos/software/RIOT/cpu/atmega_common
In file included from /home/maribu/Repos/software/RIOT/cpu/avr8_common/include/cpu.h:40,
                 from /home/maribu/Repos/software/RIOT/boards/common/arduino-atmega/include/board_common.h:28,
                 from /home/maribu/Repos/software/RIOT/boards/arduino-uno/include/board.h:32,
                 from /home/maribu/Repos/software/RIOT/cpu/atmega_common/atmega_cpu.c:29:
In function 'atmega_set_prescaler',
    inlined from 'avr8_clk_init' at /home/maribu/Repos/software/RIOT/cpu/atmega_common/atmega_cpu.c:70:5:
/home/maribu/Repos/software/RIOT/cpu/atmega_common/include/cpu_clock.h:67:11: error: array subscript 0 is outside array bounds of 'volatile uint8_t[0]' {aka 'volatile unsigned char[]'} [-Werror=array-bounds]
   67 |     CLKPR = (1 << CLKPCE);
      |           ^
/home/maribu/Repos/software/RIOT/cpu/atmega_common/include/cpu_clock.h:70:11: error: array subscript 0 is outside array bounds of 'volatile uint8_t[0]' {aka 'volatile unsigned char[]'} [-Werror=array-bounds]
   70 |     CLKPR = clk_scale;
      |           ^
cc1: all warnings being treated as errors
make[3]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:146: /home/maribu/Repos/software/RIOT/examples/hello-world/bin/arduino-uno/atmega_common/atmega_cpu.o] Error 1
make[2]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/cpu/atmega_common] Error 2
make[1]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/cpu/atmega328p] Error 2
make: *** [/home/maribu/Repos/software/RIOT/examples/hello-world/../../Makefile.include:738: application_hello-world.module] Error 2
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
```

#### Using this PR

```
$ make BOARD=arduino-uno -C examples/hello-world
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
Building application "hello-world" for "arduino-uno" with MCU "atmega328p".

"make" -C /home/maribu/Repos/software/RIOT/boards/arduino-uno
"make" -C /home/maribu/Repos/software/RIOT/boards/common/arduino-atmega
"make" -C /home/maribu/Repos/software/RIOT/boards/common/atmega
"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/atmega328p
"make" -C /home/maribu/Repos/software/RIOT/cpu/atmega_common
"make" -C /home/maribu/Repos/software/RIOT/cpu/atmega_common/periph
"make" -C /home/maribu/Repos/software/RIOT/cpu/avr8_common
"make" -C /home/maribu/Repos/software/RIOT/cpu/avr8_common/avr_libc_extra
"make" -C /home/maribu/Repos/software/RIOT/drivers
"make" -C /home/maribu/Repos/software/RIOT/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/sys
"make" -C /home/maribu/Repos/software/RIOT/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/sys/stdio_uart
   text	  data	   bss	   dec	   hex	filename
   4628	   320	   897	  5845	  16d5	/home/maribu/Repos/software/RIOT/examples/hello-world/bin/arduino-uno/hello-world.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
```


### Issues/PRs references

Alternative to https://github.com/RIOT-OS/RIOT/pull/18532
