### PR TITLE
tests/thread_priorty_inversion: blacklist esp32

### DIFF
--- a/tests/thread_priority_inversion/Makefile
+++ b/tests/thread_priority_inversion/Makefile
@@ -11,6 +11,11 @@ else
   FANCY ?= 0
 endif
 
+# KNOWN ISSUE #18534
+# Currently this is failing, causing unrelated errors to block other PRs.
+# This issue will be looked into but for now we need to just close our eyes.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include
 
 CFLAGS += -DFANCY=$(FANCY)


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The test is causing hardware test failure, in some cases blocking PRs that should have passed.
This should blacklist it until we have a proper fix.

### Testing procedure

Set `CI: run tests` and let murdock pass.

### Issues/PRs references

Reported in #18534
Introduced in #17040
