### PR TITLE
gcoap_fileserver: bugfix recursive delete

### DIFF
--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -480,7 +480,7 @@ static ssize_t _delete_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
         if ((err = vfs_unlink_recursive(request->namebuf,
                                         request->namebuf,
                                         sizeof(request->namebuf))) < 0) {
-            gcoap_fileserver_error_handler(pdu, buf, len, err);
+            return gcoap_fileserver_error_handler(pdu, buf, len, err);
         }
     }
     gcoap_resp_init(pdu, buf, len, COAP_CODE_DELETED);

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -245,7 +245,7 @@ int vfs_unlink_recursive(const char *root, char *path_buf, size_t max_size)
             return err;
         }
         while (vfs_readdir(&dir, &entry) > 0) {
-            if (!strcmp(entry.d_name, "..")) {
+            if (!strcmp(entry.d_name, ".") || !strcmp(entry.d_name, "..")) {
                 continue;
             }
             seg_len = strlen(entry.d_name);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Two stupid bugs have sneaked in from #18133. They are fixed here.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Obvious.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
