### PR TITLE
bootloader/riotboot_dfu: move ztimer_init() prior to usbus start

### DIFF
--- a/bootloaders/riotboot_dfu/main.c
+++ b/bootloaders/riotboot_dfu/main.c
@@ -64,15 +64,15 @@ void kernel_init(void)
         }
     }
 
+    /* Init ztimer before starting DFU mode */
+    ztimer_init();
+
     /* Flash the unused slot if magic word is set */
     riotboot_usb_dfu_init(0);
 
     if (slot != -1 && !_bootloader_alternative_mode()) {
         riotboot_slot_jump(slot);
     }
-
-    /* Init ztimer before starting DFU mode */
-    ztimer_init();
 
     /* Nothing to boot, stay in DFU mode to flash a slot */
     riotboot_usb_dfu_init(1);


### PR DESCRIPTION
### Contribution description

When updating an application to the second `riotboot` slot, `ztimer_init()` is called too late leading to issue with `dfu-util` at the end of the flash process such as:
`dfu-util: unable to read DFU status after completion (LIBUSB_ERROR_PIPE)`

This PR fixes this issue by initializing ztimer prior to setup DFU.

Note: I'm considering dropping ztimer utilisation in the future for USB DFU. But let's fix this issue properly for now.

### Testing procedure
Flash bootloader/riotboot_dfu on your board:
`make BOARD=samr21-xpro -C bootloaders/riotboot_dfu flash`
Flash any application (several times on both slots !)
`USEMODULE+=usbus_dfu make -C tests/leds BOARD=samr21-xpro PROGRAMMER=dfu-util riotboot/flash-slot0`


### Issues/PRs references
Fixes #18456
Replaces #18520

