### PR TITLE
sys/malloc_thread_safe: fixes the locking if not needed or if not possible

### DIFF
--- a/tests/thread_priority_inversion/Makefile
+++ b/tests/thread_priority_inversion/Makefile
@@ -11,11 +11,6 @@ else
   FANCY ?= 0
 endif
 
-# KNOWN ISSUE #18534
-# Currently this is failing, causing unrelated errors to block other PRs.
-# This issue will be looked into but for now we need to just close our eyes.
-TEST_ON_CI_BLACKLIST += esp32-wroom-32
-
 include $(RIOTBASE)/Makefile.include
 
 CFLAGS += -DFANCY=$(FANCY)


### PR DESCRIPTION
### Contribution description

This PR fixes the locking mechanism in `sys/malloc_thread_safe`.

If threads are not yet created and the scheduling is not active, locking is not required. Even more if the module `core_mutex_priority_inheritance` is used, the mutex must not be locked before threads are created and scheduling is active. Otherwise, priority inheritance will cause a crash if `malloc` is used.

The PR fixes issue #18534 and reverts the change made in PR #18535.

### Testing procedure

```
BOARD=esp32-wroom-32 make flash test -C tests/thread_priority_inversion flash test
```
should work with this PR.
```
BOARD=esp32-wroom-32 make -C tests/shell flash term
```
should still work.

### Issues/PRs references

Fixes #18534 
