### PR TITLE
tests/periph_gpio_ll: drop core dump merged by accident

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,6 @@
+/*/core
+/*/core.*
+!/*/core.c
+!/*/core.h
+!/*/core.md
+!/*/core.txt

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,6 @@
+/*/core
+/*/core.*
+!/*/core.c
+!/*/core.h
+!/*/core.md
+!/*/core.txt


### PR DESCRIPTION
### Contribution description

As the title says. It also adds a `.gitignore` in `tests/` and `examples/` that matches files named `core` in a direct subfolder of `tests/` and `examples/`

### Testing procedure

```
$ touch core/foo # should *NOT* be ignored
$ touch core/core # should *NOT* be ignored
$ touch drivers/core # should *NOT* be ignored
$ touch examples/hello-world/core # should be ignored
$ touch tests/unittests/core # should be ignored
$ git add .
$ git status
On branch core_dumps
Your branch is up to date with 'origin/core_dumps'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	new file:   core/core
	new file:   core/foo
	new file:   drivers/core
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16787#issuecomment-1232793630