### PR TITLE
gitignore: Ignore core dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ bin
 /build
 # AFL findings
 fuzzing/**/findings/
+# core dumps
+core
 # Backup files
 *~
 *.orig


### PR DESCRIPTION
### Contribution description

https://github.com/RIOT-OS/RIOT/pull/18541 illustrates that core dumps can get in by accident. As these are a similar category as built binaries, 

This excludes all files (but not directories) named `core`

### Testing

* Touch a file `core`; it will not show in `git status`.
* Touch a file named differently inside `core/` (or a newly created directory of that name); it will show.