### PR TITLE
murdock: honour RUN_TESTS setting

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -143,8 +143,8 @@ export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}
 export MURDOCK_REDIS_HOST=${MURDOCK_REDIS_HOST:-127.0.0.1}
+
 NIGHTLY=${NIGHTLY:-0}
-RUN_TESTS=${RUN_TESTS:-${NIGHTLY}}
 FULL_BUILD=${FULL_BUILD:-${NIGHTLY}}
 
 # This is a work around for a bug in CCACHE which interacts very badly with
@@ -229,9 +229,16 @@ check_label() {
     return $?
 }
 
-[ "$RUN_TESTS" != "1" ] && {
-    check_label "CI: run tests" && RUN_TESTS=1
-}
+# if RUN_TESTS is unset (e.g., not passed from the outside),
+# set to 1 if NIGHTLY=1 or if the label "CI: run tests" is set,
+# otherwise set 0.
+if [ -z "$RUN_TESTS" ]; then
+    if [ "$NIGHTLY" = "1" ] || check_label "CI: run tests" ; then
+        RUN_TESTS=1
+    else
+        RUN_TESTS=0
+    fi
+fi
 
 [ "$ENABLE_TEST_CACHE" = "1" ] && {
     check_label "CI: disable test cache" && export ENABLE_TEST_CACHE=0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, if CI runs `./.murdock`, it blindly sets`RUN_TESTS=1` if `CI: run tests` is set, even if it was already set to `0`. This makes it impossible to disable tests altogether, e.g., for https://ci-staging.riot-os.org`.
This PR provides a change in the logic that keeps a previously set RUN_TESTS.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
