### PR TITLE
pkg/lwip: Set netdev callback before driver init 

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -100,19 +100,14 @@ static esp_err_t IRAM_ATTR _eth_input_callback(esp_eth_handle_t hdl,
 
     mutex_lock(&_esp_eth_dev.dev_lock);
 
-    /* Don't overwrite other events, drop packet instead.
-     * Keep the latest received packet if previous has not been read. */
-    if (_esp_eth_dev.event == SYSTEM_EVENT_MAX ||
-        _esp_eth_dev.event == SYSTEM_EVENT_ETH_RX_DONE) {
-        memcpy(_esp_eth_dev.rx_buf, buffer, len);
-        /* buffer is allocated by the `emac_esp32_rx_task` upon receipt of a
-         * MAC frame and is forwarded to the consumer who responsible for
-         * freeing the buffer. */
-        free(buffer);
-        _esp_eth_dev.rx_len = len;
-        _esp_eth_dev.event = SYSTEM_EVENT_ETH_RX_DONE;
-        netdev_trigger_event_isr(&_esp_eth_dev.netdev);
-    }
+    memcpy(_esp_eth_dev.rx_buf, buffer, len);
+    /* buffer is allocated by the `emac_esp32_rx_task` upon receipt of a
+     * MAC frame and is forwarded to the consumer who responsible for
+     * freeing the buffer. */
+    free(buffer);
+    _esp_eth_dev.rx_len = len;
+    _esp_eth_dev.event = SYSTEM_EVENT_ETH_RX_DONE;
+    netdev_trigger_event_isr(&_esp_eth_dev.netdev);
 
     mutex_unlock(&_esp_eth_dev.dev_lock);
 

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -94,8 +94,8 @@ err_t lwip_netdev_init(struct netif *netif)
 
     netdev = netif->state;
     lwip_netif_dev_acquire(netif);
-    netdev->driver->init(netdev);
     netdev->event_callback = _event_cb;
+    netdev->driver->init(netdev);
     if (netdev->driver->get(netdev, NETOPT_DEVICE_TYPE, &dev_type,
                             sizeof(dev_type)) < 0) {
         res = ERR_IF;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

lwIP did not set the netdev callback early enough, so events triggered during or right after initialization were lost.

After the IDF upgrade my board could not receive packets via Ethernet anymore since the cable connect event id was still stored as the pending event. This had not been processed by the ISR due to the missing callback, and the stored event id stopped other events from triggering.


This explains why the connect/rx event clash seen in "esp32/eth: Don't overwrite queued event with RX packet" (https://github.com/RIOT-OS/RIOT/commit/95196fb7e40b12c7824e9827aadcc2ace35016a5) only happened with lwIP. The fix for that is no longer needed and therefore reverted.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`tests/lwip` still works and interfaces can get IPv4 or IPv6 address dynamically (meaning RX & TX works).

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Broken for me since #17601. Reverting #16084 