### PR TITLE
suit: rename worker thread functions

### DIFF
--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -83,7 +83,7 @@ static void cb(void *arg)
 {
     (void) arg;
     printf("Button pressed! Triggering suit update! \n");
-    suit_coap_trigger((uint8_t *) SUIT_MANIFEST_RESOURCE, sizeof(SUIT_MANIFEST_RESOURCE));
+    suit_worker_trigger(SUIT_MANIFEST_RESOURCE, sizeof(SUIT_MANIFEST_RESOURCE));
 }
 #endif
 
@@ -211,8 +211,8 @@ int main(void)
 #endif
     /* initialize suit storage */
     suit_storage_init_all();
-    /* start suit coap updater thread */
-    suit_coap_run();
+    /* start suit updater thread */
+    suit_worker_run();
 
     /* start nanocoap server thread */
     thread_create(_nanocoap_server_stack, sizeof(_nanocoap_server_stack),

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -26,6 +26,7 @@
 #define SUIT_TRANSPORT_COAP_H
 
 #include "net/nanocoap.h"
+#include "suit/transport/worker.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,8 +34,14 @@ extern "C" {
 
 /**
  * @brief    Start SUIT CoAP thread
+ *
+ * @deprecated This is an alias for @ref suit_worker_run and will be removed
+ *             after after the 2023.01 release.
  */
-void suit_coap_run(void);
+static inline void suit_coap_run(void)
+{
+    suit_worker_run();
+}
 
 /**
  * @brief SUIT CoAP endpoint entry.
@@ -82,10 +89,16 @@ extern const coap_resource_subtree_t coap_resource_subtree_suit;
 /**
  * @brief   Trigger a SUIT udate
  *
+ * @deprecated This is an alias for @ref suit_worker_trigger and will be removed
+ *             after after the 2023.01 release.
+ *
  * @param[in] url       url pointer containing the full coap url to the manifest
  * @param[in] len       length of the url
  */
-void suit_coap_trigger(const uint8_t *url, size_t len);
+static inline void suit_coap_trigger(const uint8_t *url, size_t len)
+{
+    suit_worker_trigger((const char *)url, len);
+}
 
 #endif /* DOXYGEN */
 

--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2019 Inria
+ *               2019 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit
+ * @defgroup    sys_suit_transport_worker SUIT firmware worker thread
+ * @brief       SUIT secure firmware updates worker thread
+ *
+ * @{
+ *
+ * @brief       SUIT CoAP helper API
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef SUIT_TRANSPORT_WORKER_H
+#define SUIT_TRANSPORT_WORKER_H
+
+#include "net/nanocoap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    Start SUIT worker thread
+ */
+void suit_worker_run(void);
+
+/**
+ * @brief   Trigger a SUIT udate
+ *
+ * @param[in] url       url pointer containing the full coap url to the manifest
+ * @param[in] len       length of the url
+ */
+void suit_worker_trigger(const char *url, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_TRANSPORT_WORKER_H */
+/** @} */

--- a/sys/shell/commands/sc_suit.c
+++ b/sys/shell/commands/sc_suit.c
@@ -40,7 +40,7 @@ static int _suit_handler(int argc, char **argv)
     }
 
     if (strcmp(argv[1], "fetch") == 0) {
-        suit_coap_trigger((uint8_t *)argv[2], strlen(argv[2]));
+        suit_worker_trigger(argv[2], strlen(argv[2]));
     }
     else if (strcmp(argv[1], "seq_no") == 0) {
         uint32_t seq_no = 0;

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -53,7 +53,7 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
         else {
             code = COAP_CODE_CREATED;
             LOG_INFO("suit: received URL: \"%s\"\n", (char *)pkt->payload);
-            suit_coap_trigger(pkt->payload, payload_len);
+            suit_worker_trigger((char *)pkt->payload, payload_len);
         }
     }
     else {

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -170,14 +170,14 @@ static void *_suit_worker_thread(void *arg)
     return NULL;
 }
 
-void suit_coap_run(void)
+void suit_worker_run(void)
 {
     thread_create(_stack, SUIT_WORKER_STACKSIZE, SUIT_COAP_WORKER_PRIO,
                   THREAD_CREATE_STACKTEST,
                   _suit_worker_thread, NULL, "suit worker");
 }
 
-void suit_coap_trigger(const uint8_t *url, size_t len)
+void suit_worker_trigger(const char *url, size_t len)
 {
     memcpy(_url, url, len);
     _url[len] = '\0';


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The SUIT worker thread functions do not deal with CoAP but only signal the worker thread. The worker thread can also use the VFS backed (and no CoAP backend at all), so the name is misleading.


`static inline` aliases have been provided for compatibility. 


### Testing procedure

CI should verify everything still compiles.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
