### PR TITLE
suit: start worker thread on demand, make suit_handle_url() public

### DIFF
--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -211,8 +211,6 @@ int main(void)
 #endif
     /* initialize suit storage */
     suit_storage_init_all();
-    /* start suit updater thread */
-    suit_worker_run();
 
     /* start nanocoap server thread */
     thread_create(_nanocoap_server_stack, sizeof(_nanocoap_server_stack),

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -35,12 +35,10 @@ extern "C" {
 /**
  * @brief    Start SUIT CoAP thread
  *
- * @deprecated This is an alias for @ref suit_worker_run and will be removed
- *             after after the 2023.01 release.
+ * @deprecated This will be removed after after the 2023.01 release.
  */
 static inline void suit_coap_run(void)
 {
-    suit_worker_run();
 }
 
 /**

--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -37,12 +37,25 @@ extern "C" {
 void suit_worker_run(void);
 
 /**
- * @brief   Trigger a SUIT udate
+ * @brief   Trigger a SUIT udate via a worker thread
  *
  * @param[in] url       url pointer containing the full coap url to the manifest
  * @param[in] len       length of the url
  */
 void suit_worker_trigger(const char *url, size_t len);
+
+/**
+ * @brief   Trigger a SUIT udate
+ *
+ * @note Make sure the thread calling this function has enough stack space to fit
+ *       a whole flash page.
+ *
+ * @param[in] url       url pointer containing the full coap url to the manifest
+ *
+ * @return 0 on success
+ *        <0 on error
+ */
+int suit_handle_url(const char *url);
 
 #ifdef __cplusplus
 }

--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -32,11 +32,6 @@ extern "C" {
 #endif
 
 /**
- * @brief    Start SUIT worker thread
- */
-void suit_worker_run(void);
-
-/**
  * @brief   Trigger a SUIT udate via a worker thread
  *
  * @param[in] url       url pointer containing the full coap url to the manifest

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -23,11 +23,12 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <string.h>
 #include <sys/types.h>
 
-#include "msg.h"
+#include "mutex.h"
 #include "log.h"
 #include "thread.h"
 #include "time_units.h"
@@ -73,15 +74,13 @@
 #define SUIT_MANIFEST_BUFSIZE   640
 #endif
 
-#define SUIT_MSG_TRIGGER        0x12345
-
 static char _stack[SUIT_WORKER_STACKSIZE];
 static char _url[CONFIG_SOCK_URLPATH_MAXLEN];
 static uint8_t _manifest_buf[SUIT_MANIFEST_BUFSIZE];
 
-static kernel_pid_t _suit_worker_pid;
+static mutex_t _worker_lock = MUTEX_INIT_LOCKED;
 
-static void _suit_handle_url(const char *url)
+int suit_handle_url(const char *url)
 {
     ssize_t size;
     LOG_INFO("suit_worker: downloading \"%s\"\n", url);
@@ -102,46 +101,38 @@ static void _suit_handle_url(const char *url)
 #endif
     else {
         LOG_WARNING("suit_worker: unsupported URL scheme!\n)");
-        return;
+        return -ENOTSUP;
     }
 
-    if (size >= 0) {
-        LOG_INFO("suit_worker: got manifest with size %u\n", (unsigned)size);
+    if (size < 0) {
+        LOG_INFO("suit_worker: error getting manifest\n");
+        return size;
+    }
+
+    LOG_INFO("suit_worker: got manifest with size %u\n", (unsigned)size);
 
 #ifdef MODULE_SUIT
-        suit_manifest_t manifest;
-        memset(&manifest, 0, sizeof(manifest));
+    suit_manifest_t manifest;
+    memset(&manifest, 0, sizeof(manifest));
 
-        manifest.urlbuf = _url;
-        manifest.urlbuf_len = CONFIG_SOCK_URLPATH_MAXLEN;
+    manifest.urlbuf = _url;
+    manifest.urlbuf_len = CONFIG_SOCK_URLPATH_MAXLEN;
 
-        int res;
-        if ((res = suit_parse(&manifest, _manifest_buf, size)) != SUIT_OK) {
-            LOG_INFO("suit_worker: suit_parse() failed. res=%i\n", res);
-            return;
-        }
-
+    int res;
+    if ((res = suit_parse(&manifest, _manifest_buf, size)) != SUIT_OK) {
+        LOG_INFO("suit_worker: suit_parse() failed. res=%i\n", res);
+        return res;
+    }
 #endif
 #ifdef MODULE_SUIT_STORAGE_FLASHWRITE
-        if (res == 0) {
-            const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(
-                riotboot_slot_other());
-            riotboot_hdr_print(hdr);
-            ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
+    const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(riotboot_slot_other());
+    riotboot_hdr_print(hdr);
+    ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
-            if (riotboot_hdr_validate(hdr) == 0) {
-                LOG_INFO("suit_worker: rebooting...\n");
-                pm_reboot();
-            }
-            else {
-                LOG_INFO("suit_worker: update failed, hdr invalid\n ");
-            }
-        }
+    return riotboot_hdr_validate(hdr);
 #endif
-    }
-    else {
-        LOG_INFO("suit_worker: error getting manifest\n");
-    }
+
+    return res;
 }
 
 static void *_suit_worker_thread(void *arg)
@@ -149,22 +140,19 @@ static void *_suit_worker_thread(void *arg)
     (void)arg;
 
     LOG_INFO("suit_worker: started.\n");
-    msg_t msg_queue[4];
-    msg_init_queue(msg_queue, 4);
 
-    _suit_worker_pid = thread_getpid();
-
-    msg_t m;
     while (true) {
-        msg_receive(&m);
-        DEBUG("suit_worker: got msg with type %" PRIu32 "\n", m.content.value);
-        switch (m.content.value) {
-            case SUIT_MSG_TRIGGER:
-                LOG_INFO("suit_worker: trigger received\n");
-                _suit_handle_url(_url);
-                break;
-            default:
-                LOG_WARNING("suit_worker: warning: unhandled msg\n");
+        mutex_lock(&_worker_lock);
+
+        if (suit_handle_url(_url) == 0) {
+            LOG_INFO("suit_worker: update successful\n");
+            if (IS_USED(MODULE_SUIT_STORAGE_FLASHWRITE)) {
+                LOG_INFO("suit_worker: rebooting...\n");
+                pm_reboot();
+            }
+        }
+        else {
+            LOG_INFO("suit_worker: update failed, hdr invalid\n ");
         }
     }
     return NULL;
@@ -181,6 +169,5 @@ void suit_worker_trigger(const char *url, size_t len)
 {
     memcpy(_url, url, len);
     _url[len] = '\0';
-    msg_t m = { .content.value = SUIT_MSG_TRIGGER };
-    msg_send(&m, _suit_worker_pid);
+    mutex_unlock(&_worker_lock);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Drop the need to call `suit_worker_run()` before calling `suit_worker_trigger()` - the thread only has a single purpose anyway.

Also make the `suit_handle_url()` function available to users who already have a sufficiently large stack, when no worker thread should be started at all.


### Testing procedure

Follow the steps in `examples/suit_update`:

```
> suit: received URL: "coap://[2001:db8::1]/fw/suit_update/samr21-xpro/riot.suit.latest.bin"
suit_worker: started.
suit_worker: downloading "coap://[2001:db8::1]/fw/suit_update/samr21-xpro/riot.suit.latest.bin"
suit_worker: got manifest with size 485
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1669802730, highest available: 1669802619
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 1000 with other slot offset
Comparing manifest offset 20800 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 8818989e-a257-5994-ac9a-554b77898083 to 8818989e-a257-5994-ac9a-554b77898083 from manifest
validating class id: OK
Comparing manifest offset 1000 with other slot offset
Comparing manifest offset 20800 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verified installed payload
Verifying image digest
Starting digest verification against image
Verified installed payload
Image magic_number: 0x544f4952
Image Version: 0x63872aea
Image start address: 0x00020900
Header chksum: 0x45bb3515

suit_worker: update successful
suit_worker: rebooting...
----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.10-devel-570-g15a43-suit_worker_cleanup)
RIOT SUIT update example application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x63872aea
Image start address: 0x00020900
Header chksum: 0x45bb3515

Starting the shell
> 
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
