### PR TITLE
sys/shell/commands: add suit revert sub-command

### DIFF
--- a/sys/shell/commands/sc_suit.c
+++ b/sys/shell/commands/sc_suit.c
@@ -26,10 +26,18 @@
 #include "suit/storage.h"
 #include "suit/transport/coap.h"
 
+#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
+#include "riotboot/flashwrite.h"
+#include "periph/pm.h"
+#endif
+
 static void _print_usage(char **argv)
 {
     printf("Usage: %s fetch <manifest url>\n", argv[0]);
     printf("       %s seq_no\n", argv[0]);
+    if (IS_USED(MODULE_SUIT_STORAGE_FLASHWRITE)) {
+        printf("       %s revert\n", argv[0]);
+    }
 }
 
 static int _suit_handler(int argc, char **argv)
@@ -47,6 +55,18 @@ static int _suit_handler(int argc, char **argv)
         suit_storage_get_highest_seq_no(&seq_no);
         printf("seq_no: 0x%08" PRIx32 "\n", seq_no);
     }
+#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
+    else if (strcmp(argv[1], "revert") == 0) {
+        int res = riotboot_flashwrite_invalidate_latest();
+        if (res) {
+            printf("revert failed: %d\n", res);
+        }
+        else {
+            printf("reverted to previous version, rebooting…\n");
+            pm_reboot();
+        }
+    }
+#endif
     else {
         _print_usage(argv);
         return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the `suit revert` sub-command to roll-back to the previous image.
This can be useful for testing firmware updates or to revert in case of a bug.


### Testing procedure

Can be tested with `examples/suit_update`:

```
2022-09-05 09:46:52,965 - INFO # > suit revert
2022-09-05 09:46:52,965 - INFO # 
2022-09-05 09:46:52,969 - INFO # reverted to previous version, rebooting…
2022-09-05 09:46:53,011 - INFO # main(): This is RIOT! (Version: 2022.10-devel-577-gc9b69-suit_enhance)
2022-09-05 09:46:53,015 - INFO # RIOT SUIT update example application
2022-09-05 09:46:53,016 - INFO # Running from slot 0
2022-09-05 09:46:53,019 - INFO # Image magic_number: 0x544f4952
2022-09-05 09:46:53,022 - INFO # Image Version: 0x00000001
2022-09-05 09:46:53,024 - INFO # Image start address: 0x00001100
2022-09-05 09:46:53,027 - INFO # Header chksum: 0x7f7eaea2
2022-09-05 09:46:53,027 - INFO # 
2022-09-05 09:46:53,029 - INFO # suit_worker: started.
2022-09-05 09:46:53,031 - INFO # Starting the shell

2022-09-05 09:46:59,773 - INFO # > suit seq_no
2022-09-05 09:46:59,774 - INFO # 
2022-09-05 09:46:59,775 - INFO # seq_no: 0x00000001
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
