### PR TITLE
nanocoap_sock: use correct error code in nanocoap_get_blockwise_url_to_buf()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -308,8 +308,9 @@ int nanocoap_get_blockwise_url(const char *url,
  * @param[in]   buf        Target buffer
  * @param[in]   len        Target buffer length
  *
+ * @returns     <0 on error
  * @returns     -EINVAL    if an invalid url is provided
- * @returns     -1         if failed to fetch the url content
+ * @returns     -ENOBUFS   if the provided buffer was too small
  * @returns     size of the response payload on success
  */
 ssize_t nanocoap_get_blockwise_url_to_buf(const char *url,

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -568,7 +568,7 @@ static int _2buf(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
     _buf_t *dst = arg;
 
     if (offset + len > dst->len) {
-        return -1;
+        return -ENOBUFS;
     }
 
     memcpy(dst->ptr + offset, buf, len);


### PR DESCRIPTION



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It should return `-ENOBUFS` like the other `nanocoap_…()` functions, not `-1`.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
