### PR TITLE
sys/xtimer: deprecate for 2023.04

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -3,4 +3,5 @@
 DEPRECATED_MODULES += event_thread_lowest
 DEPRECATED_MODULES += gnrc_netdev_default
 DEPRECATED_MODULES += sema_deprecated
+DEPRECATED_MODULES += xtimer
 DEPRECATED_MODULES += ztimer_now64

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -14,6 +14,10 @@
  *            timers, get current system time, and let a thread sleep for
  *            a certain amount of time.
  *
+ * @deprecated use @ref ztimer instead, in fact most examples use ztimer only
+ *             with the xtimer API.
+ *             Will be removed after 2023.04 release.
+ *
  * The implementation takes one low-level timer and multiplexes it.
  *
  * Insertion and removal of timers has O(n) complexity with (n) being the


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Now that we have ztimer running on all RIOT applications we should simplify
and only use ztimer.

### Testing procedure

Read the docs?  Check to see if you have a message in the `make -C tests`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
