### PR TITLE
treewide: Use deprecations in code rather than comments

### DIFF
--- a/core/lib/include/kernel_defines.h
+++ b/core/lib/include/kernel_defines.h
@@ -280,6 +280,28 @@ extern "C" {
 
 /* end{code-style-ignore} */
 
+/** @brief Declare an item as deprecated
+ *
+ * On modern (C2x) compilers, this expands to the C++11 style attribute
+ * `[[deprecated(reason)]]`; otherwise to the GNUism
+ * `__((attribute(deprecated))`, or is ignored.
+ *
+ * In Doxygen, it is rendered as a deprecation; note that currently, no Doxygen
+ * commands work in the reason.
+ *
+ * Example:
+ *
+ * ```c
+ * DEPRECATED("Use foo_iniit2() instead")
+ * void foo_init(struct foo *);
+ * ```
+ * */
+#if __STDC_VERSION__ >= 202000L
+#define DEPRECATED(reason) [[deprecated(reason)]]
+#elif defined(__GNUC__)
+#define DEPRECATED(reason) __attribute__((deprecated(reason)))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -2033,7 +2033,8 @@ PREDEFINED             = DOXYGEN \
                          MODULE_GNRC_SIXLOWPAN_ND_ROUTER \
                          MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER \
                          MODULE_GNRC_UDP \
-                         RIOT_FILE_RELATIVE
+                         RIOT_FILE_RELATIVE \
+                         "DEPRECATED(x):=/** \deprecated x */"
 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -238,24 +238,20 @@ void flashpage_erase(unsigned page);
 
 /**
  * @brief Get number of first free flashpage
- * @deprecated Use @ref FLASH_WRITABLE_INIT instead, which is usable in modules
- *             as well as applications. The function will be removed after
- *             the 2022.04 release.
  *
  * If riotboot is used in two slot mode, this number will change across
  * firmware updates as the firmware slots alternate.
  */
+DEPRECATED("Use FLASH_WRITABLE_INIT instead, which is usable in modules as well as applications. The function will be removed after the 2022.04 release.")
 unsigned flashpage_first_free(void);
 
 /**
  * @brief Get number of last free flashpage
- * @deprecated Use @ref FLASH_WRITABLE_INIT instead, which is usable in modules
- *             as well as applications. The function will be removed after
- *             the 2022.04 release.
  *
  * If riotboot is used in two slot mode, this number will change across
  * firmware updates as the firmware slots alternate.
  */
+DEPRECATED("Use FLASH_WRITABLE_INIT instead, which is usable in modules as well as applications. The function will be removed after the 2022.04 release.")
 unsigned flashpage_last_free(void);
 
 /**


### PR DESCRIPTION
### Contribution description

This executes <https://github.com/RIOT-OS/RIOT/issues/18561>.

It already has the macros and Doxygen stuff, it lacks
* change of all `@deprecated` to `DEPRECATED`
* CI time rejection of non-code deprecation (unsure if possible, maybe we still need it for module level deprecations)
* Removal of deprecated functions in the code base, or annotation with `-Wno-error=deprecated-declarations` if we still want to test the deprecated functions.

### Testing procedure

Right now:

* See how CI starts breaking because we -Werror and the one function that got changed is still used in tests.
* Look at Doxygen output on the changed function.

Long term:

* Try using a deprecated function, see things fail.