### PR TITLE
boards/samr21-xpro: add a note about EDBG UART limitation

### DIFF
--- a/boards/samr21-xpro/doc.txt
+++ b/boards/samr21-xpro/doc.txt
@@ -182,6 +182,12 @@ toolchain.
 
 ## Known Issues / Problems
 
+### 64 character input limit on EDBG UART
+When using STDIO directly through the debugger UART, no more than 64 bytes can
+be read at once. This does limit the length of shell command lines to 63 bytes
+(since a newline is needed) when using a terminal that only transmits whole lines.
+(e.g. pyterm).
+
 ### I2C
 When connecting an I2C device and a logic analyzer to an I2C port at the same
 time, the internal pull-up resistors are not sufficient for stable bus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The stdin line length limitation can be very surprising and there is nothing in RIOT that would explain it.
To prevent users from scratching their head, add a note to the docs. 


### Testing procedure

execute 

    echo 012345678901234567890123456789012345678901234567890123456789

in e.g. `tests/shell`

<!--echo 012345678901234567890123456789012345678901234567890123456789
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
