### PR TITLE
dist/tools/bossa*: add missing include

### DIFF
--- a/dist/tools/bossa-1.8/patches/0002-src-PosixSerialPort.cpp-Add-missing-include.patch
+++ b/dist/tools/bossa-1.8/patches/0002-src-PosixSerialPort.cpp-Add-missing-include.patch
@@ -1,0 +1,24 @@
+From e293c603cac41f691bba26cd3973ebe48aae5e0c Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Thu, 8 Sep 2022 20:38:20 +0200
+Subject: [PATCH] src/PosixSerialPort.cpp: Add missing include
+
+---
+ src/PosixSerialPort.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/PosixSerialPort.cpp b/src/PosixSerialPort.cpp
+index 5da4b42..cf4274b 100644
+--- a/src/PosixSerialPort.cpp
++++ b/src/PosixSerialPort.cpp
+@@ -35,6 +35,7 @@
+ #include <errno.h>
+ #include <termios.h>
+ #include <errno.h>
++#include <sys/select.h>
+ 
+ #include <string>
+ 
+-- 
+2.37.1
+

--- a/dist/tools/bossa-1.9/patches/0001-src-PosixSerialPort.cpp-add-missing-include.patch
+++ b/dist/tools/bossa-1.9/patches/0001-src-PosixSerialPort.cpp-add-missing-include.patch
@@ -1,0 +1,24 @@
+From 060033a3e724c2a081a8b52072b1ababea21e5ca Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Thu, 8 Sep 2022 20:36:43 +0200
+Subject: [PATCH] src/PosixSerialPort.cpp: add missing include
+
+---
+ src/PosixSerialPort.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/PosixSerialPort.cpp b/src/PosixSerialPort.cpp
+index 45eaca9..cee31fb 100644
+--- a/src/PosixSerialPort.cpp
++++ b/src/PosixSerialPort.cpp
+@@ -36,6 +36,7 @@
+ #include <termios.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
++#include <sys/select.h>
+ 
+ #include <string>
+ 
+-- 
+2.37.1
+

--- a/dist/tools/bossa-nrf52/patches/0001-src-PosixSerialPort.cpp-Add-missing-include.patch
+++ b/dist/tools/bossa-nrf52/patches/0001-src-PosixSerialPort.cpp-Add-missing-include.patch
@@ -1,0 +1,24 @@
+From 8af8b1d8b148acf089df1f5dbb794bd6f4c564dd Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Thu, 8 Sep 2022 20:40:02 +0200
+Subject: [PATCH] src/PosixSerialPort.cpp: Add missing include
+
+---
+ src/PosixSerialPort.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/PosixSerialPort.cpp b/src/PosixSerialPort.cpp
+index 4ca7954..b877e29 100644
+--- a/src/PosixSerialPort.cpp
++++ b/src/PosixSerialPort.cpp
+@@ -36,6 +36,7 @@
+ #include <termios.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
++#include <sys/select.h>
+ 
+ #include <string>
+ 
+-- 
+2.37.1
+


### PR DESCRIPTION
### Contribution description

As the title says. This fixes compilation on systems with a sane C lib, such as:

```
[INFO] bossac 1.9 binary not found - building it from source
[INFO] compiling bossac from source now
make[2]: wx-config: No such file or directory
make[2]: wx-config: No such file or directory
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
CPP COMMON src/Flash.cpp
CPP COMMON src/D5xNvmFlash.cpp
CPP COMMON src/D2xNvmFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/Device.cpp
CPP COMMON src/PosixSerialPort.cpp
src/PosixSerialPort.cpp: In member function 'virtual int PosixSerialPort::read(uint8_t*, int)':
src/PosixSerialPort.cpp:216:5: error: 'fd_set' was not declared in this scope
  216 |     fd_set fds;
      |     ^~~~~~
src/PosixSerialPort.cpp:217:20: error: aggregate 'PosixSerialPort::read(uint8_t*, int)::timeval tv' has incomplete type and cannot be defined
  217 |     struct timeval tv;
      |                    ^~
src/PosixSerialPort.cpp:226:18: error: 'fds' was not declared in this scope; did you mean 'ffs'?
  226 |         FD_ZERO(&fds);
      |                  ^~~
      |                  ffs
src/PosixSerialPort.cpp:226:9: error: 'FD_ZERO' was not declared in this scope; did you mean 'NZERO'?
  226 |         FD_ZERO(&fds);
      |         ^~~~~~~
      |         NZERO
src/PosixSerialPort.cpp:227:9: error: 'FD_SET' was not declared in this scope; did you mean 'L_SET'?
  227 |         FD_SET(_devfd, &fds);
      |         ^~~~~~
      |         L_SET
src/PosixSerialPort.cpp:232:18: error: 'select' was not declared in this scope
  232 |         retval = select(_devfd + 1, &fds, NULL, NULL, &tv);
      |                  ^~~~~~
src/PosixSerialPort.cpp:242:18: error: 'FD_ISSET' was not declared in this scope; did you mean 'CPU_ISSET'?
  242 |         else if (FD_ISSET(_devfd, &fds))
      |                  ^~~~~~~~
      |                  CPU_ISSET
make[2]: *** [Makefile:234: obj/PosixSerialPort.o] Error 1
make[1]: *** [/home/maribu/Repos/software/RIOT/makefiles/tools/bossa-build.inc.mk:10: /home/maribu/Repos/software/RIOT/dist/tools/bossa-1.9/bossac] Error 2
make: *** [/home/maribu/Repos/software/RIOT/makefiles/tools/targets.inc.mk:12: /home/maribu/Repos/software/RIOT/dist/tools/bossa-1.9/bossac] Error 2
```

### Testing procedure

Type `man 2 select`. This will display:

> ### NAME
>        select, pselect, FD_CLR, FD_ISSET, FD_SET, FD_ZERO - synchronous I/O
>        multiplexing
> 
> ### SYNOPSIS
>        #include <sys/select.h>
> 
>        int select(int nfds, fd_set *restrict readfds,
>                   fd_set *restrict writefds, fd_set *restrict exceptfds,
>                   struct timeval *restrict timeout);
> 
>        void FD_CLR(int fd, fd_set *set);
>        int  FD_ISSET(int fd, fd_set *set);
>        void FD_SET(int fd, fd_set *set);
>        void FD_ZERO(fd_set *set);

So the include of `<sys/select.h>` is per standard indeed required, even when compilation on a C lib not following the standard closely does work.

### Issues/PRs references

None