### PR TITLE
drivers/sdcard_spi: make 8-bit safe

### DIFF
--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -231,8 +231,9 @@ int sdcard_spi_init(sdcard_spi_t *card, const sdcard_spi_params_t *params);
  *
  * @return                number of successfully read blocks (0 if no block was read).
  */
-int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, uint8_t *data, int blocksize,
-                           int nblocks, sd_rw_response_t *state);
+int sdcard_spi_read_blocks(sdcard_spi_t *card, uint32_t blockaddr,
+                           void *data, uint16_t blocksize,
+                           uint16_t nblocks, sd_rw_response_t *state);
 
 /**
  * @brief                 Writes data blocks (usually multiples of 512 Bytes) from buffer to card.
@@ -253,8 +254,9 @@ int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, uint8_t *data, int
  *
  * @return                number of successfully written blocks (0 if no block was written).
  */
-int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const uint8_t *data, int blocksize,
-                            int nblocks, sd_rw_response_t *state);
+int sdcard_spi_write_blocks(sdcard_spi_t *card, uint32_t blockaddr,
+                            const void *data, uint16_t blocksize,
+                            uint16_t nblocks, sd_rw_response_t *state);
 
 /**
  * @brief                 Gets the capacity of the card.

--- a/tests/vfs_default/Makefile
+++ b/tests/vfs_default/Makefile
@@ -4,6 +4,12 @@ USEMODULE += vfs_default
 USEMODULE += vfs_auto_format
 
 USEMODULE += shell
+USEMODULE += ps
 USEMODULE += shell_commands
 
 include $(RIOTBASE)/Makefile.include
+
+ifneq (,$(filter avr8_common,$(USEMODULE)))
+  # the main thread stack on AVR is too small for the vfs shell command
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
+endif


### PR DESCRIPTION
### Contribution description

- replace all `int`s and `unsigned`s with integers with fixed width
- replaced all signed integers of sizes with unsigned ones (sizes cannot be negative)
- made bitshifts 8-bit safe (e.g. `1 << 24` is valid on 32-bit, but undefined behavior on 8-bit, as a 16 bit wide `int` would be shifted by more than the type width)
- use `void *` / `const void *` for data buffers to ease use

### Testing procedure

```
$ make BOARD=<RANDOM_BEEFY_AVR_BOARD_WITH_SD_CARD> -C examples/vfs_default
> vfs ls /sd0
```

```
2022-09-09 17:08:51,026 # main(): This is RIOT! (Version: 2022.10-devel-591-g494f5d-drivers/sdcard_spi)
2022-09-09 17:08:51,040 # mount points:
2022-09-09 17:08:51,046 # 	/sd0
2022-09-09 17:08:51,047 # 
2022-09-09 17:08:51,063 # data dir: /sd0
> vfs ls /sd0
2022-09-09 17:08:56,155 # vfs ls /sd0
2022-09-09 17:08:56,191 # FIXUP.DAT	7314 B
2022-09-09 17:08:56,210 # FIXUP4.DAT	5448 B
2022-09-09 17:08:56,234 # SYSTEM~1.MAP	4328313 B
2022-09-09 17:08:56,256 # START4.ELF	2228800 B
2022-09-09 17:08:56,275 # CONFIG~1	207723 B
2022-09-09 17:08:56,295 # VMLINU~1	19730944 B
2022-09-09 17:08:56,356 # START.ELF	2952960 B
2022-09-09 17:08:56,509 # ALPINE~1	25 B
2022-09-09 17:08:56,639 # OVERLAYS/
2022-09-09 17:08:56,769 # DTBS-R~1/
2022-09-09 17:08:56,908 # INITRA~1	4162721 B
2022-09-09 17:08:57,049 # BCM271~1.DTB	26894 B
2022-09-09 17:08:57,211 # BCM271~2.DTB	29011 B
2022-09-09 17:08:57,453 # BCM271~3.DTB	28392 B
2022-09-09 17:08:57,670 # CONFIG.TXT	378 B
2022-09-09 17:08:57,892 # BOOTCODE.BIN	52456 B
2022-09-09 17:08:58,114 # BCM271~4.DTB	26890 B
2022-09-09 17:08:58,336 # BCM271~5.DTB	49218 B
2022-09-09 17:08:58,578 # BCM283~1.DTB	20120 B
2022-09-09 17:08:58,899 # BCM283~2.DTB	20989 B
2022-09-09 17:08:59,200 # BCM283~3.DTB	20525 B
2022-09-09 17:08:59,502 # BCM283~4.DTB	19852 B
2022-09-09 17:08:59,800 # CMDLINE.TXT	162 B
2022-09-09 17:09:00,097 # USERCFG.TXT	92 B
2022-09-09 17:09:00,448 # CMDLINE.BAK	256 B
2022-09-09 17:09:00,916 # BCM271~6.DTB	49214 B
2022-09-09 17:09:01,364 # BCM271~7.DTB	49892 B
2022-09-09 17:09:01,633 # total 25 files
```

### Issues/PRs references

Fixes issue reported in https://github.com/RIOT-OS/RIOT/pull/18445#issuecomment-1213034344