### PR TITLE
security: Reference CPE used for RIOT

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,11 @@
 All security bugs reported will be silently fixed in `master` and backported
 to the previous release.
 
+When CVE numbers are assigned to RIOT vulnerabilities, they are associated with
+[CPE] identifiers in the shape of `cpe:2.3:o:riot-os:riot:<VERSION>`.
+
+[CPE]: https://nvd.nist.gov/products/cpe
+
 ## Reporting a Vulnerability
 
 If a security issue is discovered, please report it to security@riot-os.org.


### PR DESCRIPTION
### Contribution description

CVEs reported about RIOT have been assigned to the CPE `cpe:2.3:o:riot-os:riot:2021.01` and similar. Adding this to the SECURITY file makes it more accessible both to users (who can add it to their filter for advisories of which they will be notified) and to reporters.

### Context

I was approached about whether RIOT has a CPE number and a CSAF file by a visitor from DGUV during FrOSCon. Given that I've gone through the process of reporting a RIOT security vulnerability, I should really have known that we already have a CPE identifier that is used -- I didn't because the security documentation did not tell me.