### PR TITLE
ieee802154_security: add internal descriptor organization for replay protection

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -86,6 +86,7 @@ ifneq (,$(filter ieee802154_security,$(USEMODULE)))
   USEMODULE += crypto
   USEMODULE += crypto_aes_128
   USEMODULE += cipher_modes
+  USEMODULE += bitfield
 endif
 
 ifneq (,$(filter rtt_cmd,$(USEMODULE)))

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -31,9 +31,12 @@
 #define NET_IEEE802154_SECURITY_H
 
 #include <stdint.h>
+#include <limits.h>
 #include "kernel_defines.h"
 #include "ieee802154.h"
 #include "crypto/ciphers.h"
+#include "bitfield.h"
+#include "mutex.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,6 +118,34 @@ struct ieee802154_sec_dev {
  *          if you want another key to be set up on initialization
  */
 #define CONFIG_IEEE802154_SEC_DEFAULT_KEY       "pizza_margherita"
+#endif
+
+#if !defined(CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE) || defined(DOXYGEN)
+/**
+ * @brief   Array size to store key lookup structs @ref ieee802154_sec_key_lookup_t
+ */
+#define CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE    1U
+#endif
+
+#if !defined(CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE) || defined(DOXYGEN)
+/**
+ * @brief   Array size to store device lookup structs @ref ieee802154_sec_dev_lookup_t
+ */
+#define CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE     1U
+#endif
+
+#if !defined(CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE) || defined(DOXYGEN)
+/**
+ * @brief   Array size to store key structs @ref ieee802154_sec_key_t
+ */
+#define CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE     1U
+#endif
+
+#if !defined(CONFIG_IEEE802154_SEC_DEFAULT_REPLAY_PROTECTION) || defined(DOXYGEN)
+/**
+ * @brief   Set to 1 if you want to enable replay protection
+ */
+#define CONFIG_IEEE802154_SEC_DEFAULT_REPLAY_PROTECTION 0
 #endif
 
 /**
@@ -223,20 +254,203 @@ typedef enum {
 } ieee802154_sec_scf_keymode_t;
 
 /**
+ * @brief   Device addressing mode of device descriptor
+ */
+typedef enum {
+    IEEE802154_SEC_DEV_ADDRMODE_NONE            = 0x00, /**< PAN coordinator */
+    IEEE802154_SEC_DEV_ADDRMODE_SHORT           = 0x01, /**< Short address as device address */
+    IEEE802154_SEC_DEV_ADDRMODE_LONG            = 0x02  /**< Long address as device address */
+} ieee802154_sec_dev_addrmode_t;
+
+/**
  * @brief   IEEE 802.15.4 security error codes
  */
 typedef enum {
     IEEE802154_SEC_OK,                                  /**< Everything went fine */
     IEEE802154_SEC_FRAME_COUNTER_OVERFLOW,              /**< The requested operation would let the frame counter overflow */
+    IEEE802154_SEC_FRAME_COUNTER_ERROR,                 /**< The received frame counter is less than expected */
     IEEE802154_SEC_NO_KEY,                              /**< Could not find the key to perform a requested cipher operation */
+    IEEE802154_SEC_NO_DEV,                              /**< Could not find peer device to check the frame counter */
+    IEEE802154_SEC_NO_PEER,                             /**< Device was found but pairing has not been done to use the key */
     IEEE802154_SEC_MAC_CHECK_FAILURE,                   /**< The computet MAC did not match */
     IEEE802154_SEC_UNSUPORTED,                          /**< Unsupported operation */
 } ieee802154_sec_error_t;
 
 /**
+ *  @brief  Value to represent an invalid index
+ *
+ *  We shall support 255 valid key slots [0, 254].
+ */
+#define IEEE802154_SEC_NO_IDENT     (UINT8_MAX)
+
+/**
+ * @brief   Type to identify a key
+ */
+typedef uint8_t ieee802154_sec_key_descriptor_t;
+
+/**
+ * @brief   Type to identify a peer device
+ */
+typedef uint8_t ieee802154_sec_dev_descriptor_t;
+
+/**
+ * @brief   Type to identify a key lookup
+ */
+typedef uint8_t ieee802154_sec_key_lookup_descriptor_t;
+
+/**
+ * @brief   Stores peer device information
+ */
+typedef struct ieee802154_sec_dev_lookup {
+    /**
+     * @brief   PAN ID
+     */
+    uint8_t pan_id[2];
+    /**
+     * @brief   Short address
+     */
+    uint8_t short_addr[IEEE802154_SHORT_ADDRESS_LEN];
+    /**
+     * @brief   Extended address
+     */
+    uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
+    /**
+     * @brief   Incoming frame counter for replay protection
+     */
+    uint32_t fc;
+} ieee802154_sec_dev_lookup_t;
+
+/**
+ * @brief   Lookup table for peer devices to securely communicate with
+ */
+typedef struct ieee802154_sec_dev_lookup_table {
+    /**
+     * @brief   Bitmask that shows which slots are occupied
+     */
+    BITFIELD(mask, CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE);
+
+    /**
+     * @brief   Array of peer devices
+     */
+    ieee802154_sec_dev_lookup_t dev_lookup[CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE];
+} ieee802154_sec_dev_lookup_table_t;
+
+/**
+ * @brief   Key structure
+ *
+ * Table 9.10 secKeyDescriptor
+ */
+typedef struct ieee802154_sec_key {
+    /**
+     * @brief   Key
+     */
+    uint8_t key[IEEE802154_SEC_KEY_LENGTH];
+
+    /**
+     *  @brief  Frame counter for the key
+     */
+    uint32_t fc;
+
+    /**
+     * @brief   List of devices which are using the key
+     *
+     * This is a subset of our stored peers.
+     * The device reference is used to check the incoming frame counter.
+     */
+    BITFIELD(dev_fc_list, CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE);
+} ieee802154_sec_key_t;
+
+/**
+ * @brief   Keystore
+ */
+typedef struct ieee802154_sec_key_table {
+    /**
+     *  @brief  Bitmask which shows which key slots are occupied
+     */
+    BITFIELD(mask, CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE);
+
+    /**
+     *  @brief  Stored keys
+     */
+    ieee802154_sec_key_t keys[CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE];
+} ieee802154_sec_key_table_t;
+
+/**
+ * @brief   Struct to store key properties to find the key to be used for
+ *          encryption or decryption
+ *
+ *          Table 9.9 secKeyIdLookupDescriptor
+ */
+typedef struct ieee802154_sec_key_lookup {
+    /**
+     * @brief   Key mode @ref ieee802154_sec_scf_keymode_t
+     */
+    uint8_t key_mode;
+    /**
+     * @brief   Either an implicit or explicit key lookup
+     */
+    union {
+        /**
+         * @brief Explicit key lookup
+         */
+        struct {
+            /**
+             * @brief Key index
+             */
+            uint8_t key_index;
+            /**
+             * @brief Key sourcce
+             */
+            uint8_t key_source[IEEE802154_LONG_ADDRESS_LEN];
+        } explicit;
+        /**
+         * @brief   Implicit key lookup
+         */
+        struct {
+            /**
+             * @brief   Indicates how to match the device address
+             *          @ref ieee802154_sec_dev_addrmode_t
+             */
+            uint8_t dev_mode;
+            /**
+             * @brief   PAN id
+             */
+            uint8_t dev_pan_id[2];
+            /**
+             * @brief   Device address, either short or extended
+             */
+            uint8_t dev_addr[IEEE802154_LONG_ADDRESS_LEN];
+        } implicit;
+    } key_lookup;
+    /**
+     * @brief   Key descriptor of the key which is associated with this key lookup
+     */
+    ieee802154_sec_key_descriptor_t key;
+} ieee802154_sec_key_lookup_t;
+
+/**
+ * @brief   Lookup table for key modes
+ */
+typedef struct ieee802154_sec_key_lookup_table {
+    /**
+     * @brief   Bitmask that shows which slots are occupied
+     */
+    BITFIELD(mask, CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE);
+
+    /**
+     * @brief   Array of key lookup structs
+     */
+    ieee802154_sec_key_lookup_t key_lookup[CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE];
+} ieee802154_sec_key_lookup_table_t;
+
+/**
  * @brief   Struct to hold IEEE 802.15.4 security information
  */
 typedef struct ieee802154_sec_context {
+    /**
+     * @brief   802.15.4 security dev
+     */
+    ieee802154_sec_dev_t dev;
     /**
      * @brief Cipher context with AES128 interface and key storage
      */
@@ -260,13 +474,33 @@ typedef struct ieee802154_sec_context {
      */
     uint8_t key_source[IEEE802154_LONG_ADDRESS_LEN];
     /**
-     * @brief   Own frame counter
+     * @brief   Key lookup table
+     *
+     * @warning This datastructure should be stored in persistent storage.
+     *          Access to this datastructure is likely to be changed in the future.
+     *          Only use dedicated functions and do not assume anything about this type.
      */
-    uint32_t frame_counter;
+    ieee802154_sec_key_lookup_table_t key_lookup_table;
     /**
-     * @brief   802.15.4 security dev
+     * @brief   Keystore for this netdev
+     *
+     * @warning This datastructure should be stored in persistent storage.
+     *          Access to this datastructure is likely to be changed in the future.
+     *          Only use dedicated functions and do not assume anything about this type.
      */
-    ieee802154_sec_dev_t dev;
+    ieee802154_sec_key_table_t keystore;
+    /**
+     * @brief   Peer device lookup table
+     *
+     * @warning This datastructure should be stored in persistent storage.
+     *          Access to this datastructure is likely to be changed in the future.
+     *          Only use dedicated functions and do not assume anything about this type.
+     */
+    ieee802154_sec_dev_lookup_table_t dev_lookup_table;
+    /**
+     * @brief   Internal lock to protect concurrent operations on datastructures
+     */
+    mutex_t lock;
 } ieee802154_sec_context_t;
 
 /**
@@ -380,8 +614,16 @@ typedef struct __attribute__((packed)) {
  * @brief   Initialize IEEE 802.15.4 security context with default values
  *
  * @param[out]      ctx                     IEEE 802.15.4 security context
+ * @param[in]       sec_level               Default security level of outgoing frames
+ * @param[in]       sec_key_mode            Default key mode of outgoing frames
+ * @param[in]       sec_key_index           Default key index of outgoing frames
+ * @param[in]       sec_key_source          Default key source of outgoing frames
  */
-void ieee802154_sec_init(ieee802154_sec_context_t *ctx);
+void ieee802154_sec_init(ieee802154_sec_context_t *ctx,
+                         ieee802154_sec_scf_seclevel_t sec_level,
+                         ieee802154_sec_scf_keymode_t sec_key_mode,
+                         uint8_t sec_key_index,
+                         const void *sec_key_source);
 
 /**
  * @brief   Encrypt IEEE 802.15.4 frame according to @p ctx
@@ -417,7 +659,6 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
  * @param[out]      payload_size            Pointer to store the payload size
  * @param[out]      mic                     Will point to the beginning of the MIC
  * @param[out]      mic_size                Pointer to store the size of the MIC
- * @param[in]       src_address             Pointer to remote long source address
  *
  * @pre     After @p header follows the auxiliary header
  *
@@ -428,8 +669,216 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
                                  uint16_t frame_size,
                                  uint8_t *header, uint8_t *header_size,
                                  uint8_t **payload, uint16_t *payload_size,
-                                 uint8_t **mic, uint8_t *mic_size,
-                                 const uint8_t *src_address);
+                                 uint8_t **mic, uint8_t *mic_size);
+
+/**
+ * @brief   Add a peer device to the device lookup table
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       pan_id                  Peer device PAN ID (host byte order)
+ * @param[in]       short_addr              Peer device short address
+ * @param[in]       long_addr               Peer device long address
+ *
+ * @return          Device descriptor on success
+ * @return          IEEE802154_SEC_NO_IDENT on error
+ */
+ieee802154_sec_dev_descriptor_t ieee802154_sec_add_dev(ieee802154_sec_context_t *ctx,
+                                                       uint16_t pan_id,
+                                                       const uint8_t *short_addr,
+                                                       const uint8_t *long_addr);
+
+/**
+ * @brief   Add new key material
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       key                     16 bytes key material
+ *
+ * @return          Key descriptor on success
+ * @return          IEEE802154_SEC_NO_IDENT on error
+ */
+ieee802154_sec_key_descriptor_t ieee802154_sec_add_key(ieee802154_sec_context_t *ctx,
+                                                       const uint8_t *key);
+
+/**
+ * @brief   Perform a key update
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       k                       Key descriptor
+ * @param[in]       new                     The new key material
+ *
+ * @return          -IEEE802154_SEC_NO_KEY if @p k is invalid
+ * @return          IEEE802154_SEC_OK on success
+ */
+int ieee802154_sec_update_key(ieee802154_sec_context_t *ctx,
+                               ieee802154_sec_key_descriptor_t k,
+                               const uint8_t *new);
+
+/**
+ * @brief   Pair with a device
+ *
+ * @experimental
+ * @warning The current implementation always assumes that the pairing succeeds,
+ *          and does not send an actual pairing request.
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       l                       Key lookup descriptor
+ * @param[in]       pan_id                  Device PAN ID
+ * @param[in]       short_addr              Device short address
+ * @param[in]       long_addr               Device long address
+ *
+ * @return          -IEEE802154_SEC_NO_KEY if @p l is invalid
+ * @return          -IEEE802154_SEC_NO_DEV if no device with matching parameters was found
+ * @return          IEEE802154_SEC_OK on success
+ */
+int ieee802154_sec_peer_dev(ieee802154_sec_context_t *ctx,
+                            ieee802154_sec_key_lookup_descriptor_t l,
+                            uint16_t pan_id,
+                            const uint8_t *short_addr, const uint8_t *long_addr);
+
+/**
+ * @brief   Add an implicit key lookup descriptor to the key lookup table
+ *
+ * A descriptor of this kind allows the recipient to identify the key to be used,
+ * implicitly by the address of the sender.
+ *
+ * @pre A device descriptor corresponding to @p dev_pan_id and @p dev_addr
+ *      must have been added before, using @ref ieee802154_sec_add_dev().
+ *
+ * @pre A key corresponding to @p k must have been added before,
+        using @ref ieee802154_sec_add_key().
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       dev_mode                Device addressing mode
+ * @param[in]       dev_pan_id              Device PAN ID (host byte order)
+ * @param[in]       dev_addr                Device address
+ * @param[in]       k                       Key descriptor
+ *
+ * @return          Key lookup descriptor on success
+ * @return          IEEE802154_SEC_NO_IDENT on error
+ */
+ieee802154_sec_key_lookup_descriptor_t
+ieee802154_sec_add_key_lookup_implicit(ieee802154_sec_context_t *ctx,
+                                       ieee802154_sec_dev_addrmode_t dev_mode,
+                                       uint16_t dev_pan_id,
+                                       const uint8_t *dev_addr,
+                                       ieee802154_sec_key_descriptor_t k);
+
+/**
+ * @brief   Add an explicit key lookup descriptor to the key lookup table
+ *
+ * An explicit key is a group key.
+ * A descriptor of this kind allows the recipient to identify the key to be used,
+ * explicitly by the sent key parameters @p key_mode, @p key_index , and @p key_source.
+ * If @p key_mode is IEEE802154_SEC_SCF_KEYMODE_INDEX, @p key_source is not evaluated.
+ * If @p key_mode is IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX, @p key_source is the key
+ * originator´s PAN ID and short address.
+ * If @p key_mode is IEEE802154_SEC_SCF_KEYMODE_HW_INDEX, @p key_source is the key
+ * originator´s long address.
+ *
+ * @pre A key descriptor corresponding to @p k must have been added before,
+ *      using @ref ieee802154_sec_add_key().
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       key_mode                Key mode
+ * @param[in]       key_index               Key index
+ * @param[in]       key_source              Key source, content depends of @p key_mode
+ * @param[in]       k                       Key descriptor
+ *
+ * @return          Key lookup descriptor on success
+ * @return          IEEE802154_SEC_NO_IDENT on error
+ */
+ieee802154_sec_key_lookup_descriptor_t
+ieee802154_sec_add_key_lookup_explicit(ieee802154_sec_context_t *ctx,
+                                       ieee802154_sec_scf_keymode_t key_mode,
+                                       uint8_t key_index,
+                                       const void *key_source,
+                                       ieee802154_sec_key_descriptor_t k);
+
+/**
+ * @brief   Remove a peer device descriptor
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       d                       Descriptor of the device to be removed
+ */
+void ieee802154_sec_remove_dev(ieee802154_sec_context_t *ctx,
+                               ieee802154_sec_dev_descriptor_t d);
+
+/**
+ * @brief   Remove a key descriptor
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       k                       Descriptor of the key to be removed
+ */
+void ieee802154_sec_remove_key(ieee802154_sec_context_t *ctx,
+                               ieee802154_sec_key_descriptor_t k);
+
+/**
+ * @brief   Remove a key lookup descriptor
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       l                       Descriptor of the key lookup to be removed
+ */
+void ieee802154_sec_remove_key_lookup(ieee802154_sec_context_t *ctx,
+                                      ieee802154_sec_key_lookup_descriptor_t l);
+
+/**
+ * @brief   Acquire the lock of @p ctx
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ */
+void ieee802154_sec_iterator_acquire(ieee802154_sec_context_t *ctx);
+
+/**
+ * @brief   Release the lock of @p ctx
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ */
+void ieee802154_sec_iterator_release(ieee802154_sec_context_t *ctx);
+
+/**
+ * @brief   Iterate over all stored keys of @p ctx
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       prev                    Previously obtained descriptor or
+ *                                          @ref IEEE802154_SEC_NO_IDENT to begin
+ * @param[out]      key                     Output key object
+ *
+ * @return          Key descriptor
+ */
+ieee802154_sec_key_descriptor_t
+ieee802154_sec_key_iterator(ieee802154_sec_context_t *ctx,
+                            ieee802154_sec_key_descriptor_t prev,
+                            ieee802154_sec_key_t *key);
+
+/**
+ * @brief   Iterate over all stored devices of @p ctx
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       prev                    Previously obtained descriptor or
+ *                                          @ref IEEE802154_SEC_NO_IDENT to begin
+ * @param[out]      dev                     Output device object
+ *
+ * @return          device descriptor
+ */
+ieee802154_sec_dev_descriptor_t
+ieee802154_sec_dev_iterator(ieee802154_sec_context_t *ctx,
+                            ieee802154_sec_dev_descriptor_t prev,
+                            ieee802154_sec_dev_lookup_t *dev);
+
+/**
+ * @brief   Iterate over all stored key lookup descriptors of @p ctx
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       prev                    Previously obtained descriptor or
+ *                                          @ref IEEE802154_SEC_NO_IDENT to begin
+ * @param[out]      lookup                  Output key lookup object
+ *
+ * @return          Key lokkup descriptor
+ */
+ieee802154_sec_key_lookup_descriptor_t
+ieee802154_sec_key_lookup_iterator(ieee802154_sec_context_t *ctx,
+                                   ieee802154_sec_key_lookup_descriptor_t prev,
+                                   ieee802154_sec_key_lookup_t *lookup);
 
 /**
  * @brief Default descriptor that will fallback to default implementations

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -123,4 +123,25 @@ menuconfig KCONFIG_USEMODULE_IEEE802154_SECURITY
         default "pizza_margherita"
         depends on KCONFIG_USEMODULE_IEEE802154_SECURITY
 
+    config IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE
+        int "Maximum number of key lookup descriptors per interface"
+        range 1 255
+        default 1
+        depends on KCONFIG_USEMODULE_IEEE802154_SECURITY
+
+    config IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE
+        int "Maximum number of device descriptors per interface"
+        range 1 255
+        depends on KCONFIG_USEMODULE_IEEE802154_SECURITY
+
+    config IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE
+        int "Maximum number of keys per interface"
+        range 1 255
+        depends on KCONFIG_USEMODULE_IEEE802154_SECURITY
+
+    config IEEE802154_SEC_DEFAULT_REPLAY_PROTECTION
+        bool "Enable replay protection"
+        default 0
+        depends on KCONFIG_USEMODULE_IEEE802154_SECURITY
+
 endif # KCONFIG_USEMODULE_IEEE802154

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -10,18 +10,105 @@
  * @{
  *
  * @file
+ * @internal
+ * This is an informal explanation about the internal organization of peer devices that we share a cryptographic key with.
+ * In the Security section of the IEEE 802.15.4 standard, there are some datatype structures defined, which are in some way
+ * connected to make it possible to find the correct key for a frame that needs to be decrypted or encrypted, and to realize
+ * replay protection per peer device. The datatype structures are basically called "descriptors". There are actually a lot of
+ * them, which requires a lot of memory and lookup overhead. So if you wanted to implement the standard very complete, the
+ * process becomes complicated and error prone. Due to that reason, I made some simplifications and I hope I did undersand the
+ * procedures in the standard and did not violate the intended connections between the individual descriptors.
+ *
+ * Our implementation shall get along with the, for my understanding, most important descriptors, which are the so called
+ * secKeyDescriptor, secDeviceDescriptor, and secKeyIdLookupDescriptor. The secKeyDescriptor represents the cryptographic key
+ * material and stores how often this key has been used to secure an outgoing frame. One key may have references to multiple
+ * peer devices. The secDeviceDescriptor represents such a peer device. The device descriptor must of course store the address
+ * information of a device, and additionally the minimum expected frame counter of a frame, decrypted with the key of that
+ * device. The secKeyIdLookupDescriptor stores information, necessary to find the correct key from data contained in a frame.
+ * The key can be found implicitly from a device address in the frmae header, or a frame must contain auxiliary information in
+ * which case the key is identified explicitly. I understand secKeyIdLookupDescriptors as a thing which tells how some devices
+ * and keys are related. Have a look at the following figure, illustration the internal relations.
+ * @verbatim
+ *  +------------------+        +-----------------------------------------------------+         +---------------------+
+ *  | secKeyDescriptor +-       | secKeyIdLookupDescriptor (implicit)                 |      +--+ secDeviceDescriptor |
+ *  +------------------+ \      +-----------------------------------------------------+     /  /+---------------------+
+ *  | byte key[]       |  \     | byte key_mode = IEEE802154_SEC_SCF_KEYMODE_IMPLICIT |    /  / | byte pan_id[2]      |
+ *  | u32 fc           |   \    | byte dev_mode                                       +---+  /  | byte short_addr[2]  |
+ *  | bmap dev_fc_list |    \   | byte dev_pan_id[2]                                  +--+  /   | byte long_addr[8]   |
+ *  +--------------001-+     \  | byte dev_addr[8]                                    +-+  /    +---------------------+
+ *                   |        --+ byte key                                            |   /
+ *                   |          +-----------------------------------------------------+  /
+ *                   |                                                                  /
+ *                   +-----------------------------------------------------------------+
+ *
+ *  +------------------+        +-----------------------------------------------------------+          +---------------------+
+ *  | secKeyDescriptor +-       | secKeyIdLookupDescriptor (explicit)                       |          + secDeviceDescriptor |
+ *  +------------------+ \      +-----------------------------------------------------------+          +---------------------+
+ *  | byte key[]       |  \     | byte key_mode = IEEE802154_SEC_SCF_KEYMODE_INDEX or       |          | byte pan_id[2]      |
+ *  | u32 fc           |   \    |                 IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX or +          | byte short_addr[2]  |
+ *  | bmap dev_fc_list |    \   |                 IEEE802154_SEC_SCF_KEYMODE_HW_INDEX       +          | byte long_addr[8]   |
+ *  +--------------110-+     \  | byte key_index                                            |          | u32 fc              |
+ *                 ||         \ | byte key_source[8]                                        |          +---------------------+
+ *                 ||          -+ byte key                                                  |
+ *                 ||           +-----------------------------------------------------------+
+ *                 ||
+ *                 |+--------------------------------------------------------------------------------- +---------------------+
+ *                 +--------------------------------------------------------------------------------+--+ secDeviceDescriptor |
+ *                                                                                                     +---------------------+
+ *                                                                                                     | byte pan_id[2]      |
+ *                                                                                                     | byte short_addr[2]  |
+ *                                                                                                     | byte long_addr[8]   |
+ *                                                                                                     | u32 fc              |
+ *                                                                                                     +---------------------+
+ * @endverbatim
+ * Furthermore, the standard offers two ways where to store the frame counter. Depending on whether secFrameCounterPerKey is
+ * true or false, you can have a global frame counter for an interface or you can store the outgoing frame counter in the
+ * secKeyDescriptor. As you can see from the picture above, this implementation does not distinguish between two kinds.
+ * We store the outgoing frame counter in the key descriptor, because if we stored it globally, we would have to exchange keys
+ * with all devices at the same time, which appears to be a complicated and error prone task.
+ *
  * @author Fabian Hüßler <fabian.huessler@ovgu.de>
  * @}
  */
 
 #include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
+#include "bitarithm.h"
+#include "bitfield.h"
+#include "byteorder.h"
 #include "crypto/ciphers.h"
 #include "crypto/modes/ecb.h"
 #include "crypto/modes/cbc.h"
 #include "net/ieee802154_security.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define DEBUG_SEC(s, ...)   DEBUG("[IEEE 802.15.4 SEC] function %s: " s, __func__, ## __VA_ARGS__)
+
+#define BITMAP_FOR_EACH(set, element, bitfield, nbits, code)                    \
+for (size_t i = 0; i < (nbits); i++) {                                          \
+    if (bf_isset(bitfield, i)) {                                                \
+        element = set[i];                                                       \
+        code                                                                    \
+    }                                                                           \
+}
+#define KEYLOOKUP_FOR_EACH(ctx, lookup, code) {                                 \
+    BITMAP_FOR_EACH(&(ctx)->key_lookup_table.key_lookup,                        \
+                    (lookup), (ctx)->key_lookup_table.mask,                     \
+                    CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE, code)         \
+}
+#define DEVLOOKUP_FOR_EACH(ctx, dev, code) {                                    \
+    BITMAP_FOR_EACH(&(ctx)->dev_lookup_table.dev_lookup,                        \
+                    (dev), (ctx)->dev_lookup_table.mask,                        \
+                    CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE, code)          \
+}
+
+#define LOCK(ctx)   { DEBUG_SEC("try lock context: %p\n", ctx); mutex_lock(&ctx->lock); }
+#define UNLOCK(ctx) { mutex_unlock(&ctx->lock); DEBUG_SEC("unlocked context: %p\n", ctx); }
 
 const ieee802154_radio_cipher_ops_t ieee802154_radio_cipher_ops = {
     .set_key = NULL,
@@ -32,6 +119,97 @@ const ieee802154_radio_cipher_ops_t ieee802154_radio_cipher_ops = {
 static inline uint16_t _min(uint16_t a, uint16_t b)
 {
     return a < b ? a : b;
+}
+
+static inline const uint8_t * _get_src_pan(const uint8_t *hdr)
+{
+    uint16_t fcf = (((uint16_t)hdr[0]) << 8) | hdr[1];
+    if (((fcf & 0x00ff) & IEEE802154_FCF_SRC_ADDR_MASK) == IEEE802154_FCF_SRC_ADDR_VOID) {
+        /* SRC PAN and SRC address are not present,
+           so the caller must use MAC PAN ID */
+        return NULL;
+    }
+    uint8_t off = 3; /* skip fcf and seq. */
+    if (!(((fcf & 0xff00) >> 8) & IEEE802154_FCF_PAN_COMP)) {
+        switch (((fcf & 0x00ff) & IEEE802154_FCF_DST_ADDR_MASK)) {
+            case IEEE802154_FCF_DST_ADDR_SHORT:
+                off += 4; /* skip dst. PAN and short dst. address */
+                break;
+            case IEEE802154_FCF_DST_ADDR_LONG:
+                off += 10; /* skip dst. PAN and long dst. address */
+                break;
+        }
+    }
+    return &hdr[off];
+}
+
+static inline const uint8_t * _get_dst_pan(const uint8_t *hdr)
+{
+    uint16_t fcf = (((uint16_t)hdr[0]) << 8) | hdr[1];
+    if (((fcf & 0x00ff) & IEEE802154_FCF_DST_ADDR_MASK) == IEEE802154_FCF_DST_ADDR_VOID) {
+        /* DST PAN and DST address are not present,
+           so the caller must use MAC PAN ID */
+        return NULL;
+    }
+    return &hdr[3]; /* skip fcf and seq. */
+}
+
+static inline const uint8_t * _get_src_address(const uint8_t *hdr)
+{
+    uint16_t fcf = (((uint16_t)hdr[0]) << 8) | hdr[1];
+    if (((fcf & 0x00ff) & IEEE802154_FCF_SRC_ADDR_MASK) == IEEE802154_FCF_SRC_ADDR_VOID) {
+        /* SRC PAN and SRC address are not present,
+           so the caller must use MAC PAN coordinator address */
+        return NULL;
+    }
+    uint8_t off = 3; /* skip fcf and seq */
+    switch (((fcf & 0x00ff) & IEEE802154_FCF_DST_ADDR_MASK)) {
+        case IEEE802154_FCF_DST_ADDR_SHORT:
+            off += 4; /* skip dst. PAN and short dst. address */
+            break;
+        case IEEE802154_FCF_DST_ADDR_LONG:
+            off += 10; /* skip dst. PAN and long dst. address */
+            break;
+    }
+    if (!(((fcf & 0xff00) >> 8) & IEEE802154_FCF_PAN_COMP)) {
+        off += 2; /* skip src. PAN */
+    }
+    return &hdr[off];
+}
+
+static inline uint8_t _get_src_address_size(const uint8_t *hdr)
+{
+    uint16_t fcf = (((uint16_t)hdr[0]) << 8) | hdr[1];
+    switch (((fcf & 0x00ff) & IEEE802154_FCF_SRC_ADDR_MASK)) {
+        case IEEE802154_FCF_SRC_ADDR_SHORT:
+            return IEEE802154_SHORT_ADDRESS_LEN;
+        case IEEE802154_FCF_SRC_ADDR_LONG:
+            return IEEE802154_LONG_ADDRESS_LEN;
+    }
+    return 0;
+}
+
+static inline const uint8_t * _get_dst_address(const uint8_t *hdr)
+{
+    uint16_t fcf = (((uint16_t)hdr[0]) << 8) | hdr[1];
+    if (((fcf & 0x00ff) & IEEE802154_FCF_DST_ADDR_MASK) == IEEE802154_FCF_DST_ADDR_VOID) {
+        /* DST PAN and DST address are not present,
+           so the caller must use MAC PAN coordinator address */
+        return NULL;
+    }
+    return &hdr[5]; /* skip fcf, seq. and dst. PAN */
+}
+
+static inline uint8_t _get_dst_address_size(const uint8_t *hdr)
+{
+    uint16_t fcf = (((uint16_t)hdr[0]) << 8) | hdr[1];
+    switch (((fcf & 0x00ff) & IEEE802154_FCF_DST_ADDR_MASK)) {
+        case IEEE802154_FCF_DST_ADDR_SHORT:
+            return IEEE802154_SHORT_ADDRESS_LEN;
+        case IEEE802154_FCF_DST_ADDR_LONG:
+            return IEEE802154_LONG_ADDRESS_LEN;
+    }
+    return 0;
 }
 
 static void _set_key(ieee802154_sec_context_t *ctx,
@@ -175,10 +353,30 @@ static inline bool _req_encryption(uint8_t sec_level)
     }
 }
 
-static inline void _memxor(void *dst, const void* src, size_t size)
+static inline uint8_t _key_source_size(uint8_t key_mode)
+{
+    switch (key_mode) {
+        case IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX:
+            return 4;
+        case IEEE802154_SEC_SCF_KEYMODE_HW_INDEX:
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+static inline void _memxor(void *restrict dst, const void* restrict src, size_t size)
 {
     while (size--) {
         ((uint8_t *)dst)[size] ^= ((const uint8_t *)src)[size];
+    }
+}
+
+static inline void _memrvrscpy(void *restrict dst, const void *restrict src, size_t size)
+{
+    size_t s = 0;
+    while (size--) {
+        ((uint8_t *)dst)[s++] = ((const uint8_t *)src)[size];
     }
 }
 
@@ -208,13 +406,40 @@ static inline uint8_t _get_aux_hdr_size(uint8_t security_level,
     }
 }
 
+static inline uint8_t _get_aux_key_index(uint8_t key_mode, const void *identifier)
+{
+    switch (key_mode) {
+        case IEEE802154_SEC_SCF_KEYMODE_INDEX:
+            return ((const ieee802154_sec_aux_key_identifier_1_t *)identifier)->key_index;
+        case IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX:
+            return ((const ieee802154_sec_aux_key_identifier_5_t *)identifier)->key_index;
+        case IEEE802154_SEC_SCF_KEYMODE_HW_INDEX:
+            return ((const ieee802154_sec_aux_key_identifier_9_t *)identifier)->key_index;
+        default:
+            return 0;
+    }
+}
+
+static inline const void*_get_aux_key_source(uint8_t key_mode, const void *identifier)
+{
+    switch (key_mode) {
+        case IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX:
+            return ((const ieee802154_sec_aux_key_identifier_5_t *)identifier)->key_source;
+        case IEEE802154_SEC_SCF_KEYMODE_HW_INDEX:
+            return ((const ieee802154_sec_aux_key_identifier_9_t *)identifier)->key_source;
+        default:
+            return NULL;
+    }
+}
+
 static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
+                            uint32_t frame_counter,
                             ieee802154_sec_aux_t *ahr)
 {
     ahr->scf = _scf(ctx->security_level, ctx->key_id_mode);
     /* If you look in the specification: Annex C,
        integers values are in little endian */
-    ahr->fc = byteorder_htoll(ctx->frame_counter).u32;
+    ahr->fc = byteorder_htoll(frame_counter).u32;
     size_t len = 5;
     switch (ctx->key_id_mode) {
         case IEEE802154_SEC_SCF_KEYMODE_IMPLICIT:
@@ -279,28 +504,87 @@ static inline void _init_cbc_B0(ieee802154_sec_ccm_block_t *B0,
     memcpy(B0->nonce.src_addr, src_address, IEEE802154_LONG_ADDRESS_LEN);
 }
 
-static const uint8_t *_get_encryption_key(const ieee802154_sec_context_t *ctx,
-                                          const uint8_t *mhr, uint8_t mhr_len,
-                                          const ieee802154_sec_aux_t *ahr)
+/* get key lookup descriptor vgl. 9.2.2 KeyDescriptor lookup procedure */
+static ieee802154_sec_key_lookup_t *_get_key(ieee802154_sec_context_t *ctx,
+                                             const uint8_t *pan,
+                                             const uint8_t *addr,
+                                             uint8_t addr_len,
+                                             uint8_t key_mode,
+                                             uint8_t key_index,
+                                             const void *key_source)
 {
-    (void)mhr;
-    (void)mhr_len;
-    (void)ahr;
-    /* For simplicity, assume that everyone has the same key */
-    /* Else you´d have to look up the key based on the destination address */
-    return ctx->cipher.context.context;
+    ieee802154_sec_key_lookup_t *l, *out = NULL;
+    if (key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+        if (!pan || !addr || !addr_len) {
+            /* PAN coordinator not implemented */
+            return NULL;
+        }
+        ieee802154_sec_dev_addrmode_t dev_mode = IEEE802154_SEC_DEV_ADDRMODE_NONE;
+        if (addr_len == IEEE802154_SHORT_ADDRESS_LEN) {
+            dev_mode = IEEE802154_SEC_DEV_ADDRMODE_SHORT;
+        }
+        else if (addr_len == IEEE802154_LONG_ADDRESS_LEN) {
+            dev_mode = IEEE802154_SEC_DEV_ADDRMODE_LONG;
+        }
+        KEYLOOKUP_FOR_EACH(ctx, l, {
+            if (l->key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+                if (l->key_lookup.implicit.dev_mode == dev_mode &&
+                    !memcmp(pan, l->key_lookup.implicit.dev_pan_id,
+                            sizeof(l->key_lookup.implicit.dev_pan_id)) &&
+                    !memcmp(addr, l->key_lookup.implicit.dev_addr, addr_len)) {
+                    out = l;
+                    break;
+                }
+            }
+        });
+    }
+    else {
+        assert(key_mode == IEEE802154_SEC_SCF_KEYMODE_INDEX ||
+               key_mode == IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX ||
+               key_mode == IEEE802154_SEC_SCF_KEYMODE_HW_INDEX);
+        uint8_t source_size = _key_source_size(key_mode);
+        KEYLOOKUP_FOR_EACH(ctx, l, {
+            if (l->key_mode == key_mode &&
+                l->key_lookup.explicit.key_index == key_index &&
+                !memcmp(l->key_lookup.explicit.key_source, key_source, source_size)) {
+                out = l;
+                break;
+            }
+        });
+    }
+    return out;
 }
 
-static const uint8_t *_get_decryption_key(const ieee802154_sec_context_t *ctx,
-                                          const uint8_t *mhr, uint8_t mhr_len,
-                                          const ieee802154_sec_aux_t *ahr)
+/* get device descriptor vgl. 9.2.5 DeviceDescriptor lookup procedure */
+static ieee802154_sec_dev_lookup_t *_get_dev(ieee802154_sec_context_t *ctx,
+                                             const uint8_t *dev_pan_id,
+                                             const uint8_t *dev_addr,
+                                             uint8_t addr_len)
 {
-    (void)mhr;
-    (void)mhr_len;
-    (void)ahr;
-    /* For simplicity, assume that everyone has the same key */
-    /* Else you´d have to look up the key based on the source address */
-    return ctx->cipher.context.context;
+    ieee802154_sec_dev_lookup_t *d, *out = NULL;
+    if (!addr_len || !dev_pan_id || !dev_addr) {
+        /* PAN coordinator not implemented */
+        return NULL;
+    }
+    else if (addr_len == IEEE802154_SHORT_ADDRESS_LEN) {
+        DEVLOOKUP_FOR_EACH(ctx, d, {
+            if (!memcmp(dev_pan_id, d->pan_id, sizeof(d->pan_id)) &&
+                !memcmp(dev_addr, d->short_addr, sizeof(d->short_addr))) {
+                out = d;
+                break;
+            }
+        });
+    }
+    else if (addr_len == IEEE802154_LONG_ADDRESS_LEN) {
+        DEVLOOKUP_FOR_EACH(ctx, d, {
+            if (!memcmp(dev_pan_id, d->pan_id, sizeof(d->pan_id)) &&
+                !memcmp(dev_addr, d->long_addr, sizeof(d->long_addr))) {
+                out = d;
+                break;
+            }
+        });
+    }
+    return out;
 }
 
 /**
@@ -389,22 +673,106 @@ static void _ctr_mic(ieee802154_sec_context_t *ctx,
     _ecb(ctx, tmp1, tmp2, mic, (uint8_t *)A0, mic_size);
 }
 
-void ieee802154_sec_init(ieee802154_sec_context_t *ctx)
+void _init_dev(ieee802154_sec_dev_lookup_t *dev,
+               const uint8_t *pan,
+               const uint8_t *short_addr,
+               const uint8_t *long_addr)
+{
+    /* save pan and address reversed
+       because that´s how it is ordered in the header */
+    _memrvrscpy(dev->pan_id, pan, sizeof(dev->pan_id));
+    if (short_addr) {
+        _memrvrscpy(dev->short_addr, short_addr, sizeof(dev->short_addr));
+    }
+    else {
+        uint8_t a[] = {0xff, 0xfe}; /* use only long address */
+        _memrvrscpy(dev->short_addr, a, sizeof(dev->short_addr));
+    }
+    _memrvrscpy(dev->long_addr, long_addr, sizeof(dev->long_addr));
+    dev->fc = 0;
+}
+
+static void _init_key_lookup_implicit(ieee802154_sec_key_lookup_t *key_lookup,
+                                      ieee802154_sec_dev_addrmode_t dev_mode,
+                                      const uint8_t *dev_pan_id,
+                                      const uint8_t *dev_addr,
+                                      ieee802154_sec_key_descriptor_t key)
+{
+    /* save pan and address reversed
+       because that´s how it is ordered in the header */
+    memset(key_lookup, 0, sizeof(*key_lookup));
+    key_lookup->key_mode = IEEE802154_SEC_SCF_KEYMODE_IMPLICIT;
+    key_lookup->key_lookup.implicit.dev_mode = dev_mode;
+    if (dev_mode == IEEE802154_SEC_DEV_ADDRMODE_NONE) {
+        /* We cannot deal with NONE addressing mode right now
+           because we do not have a PAN coordinator implementation */
+        return;
+    }
+    else if (dev_mode == IEEE802154_SEC_DEV_ADDRMODE_SHORT) {
+        _memrvrscpy(key_lookup->key_lookup.implicit.dev_pan_id, dev_pan_id,
+                    sizeof(key_lookup->key_lookup.implicit.dev_pan_id));
+        _memrvrscpy(key_lookup->key_lookup.implicit.dev_addr, dev_addr,
+                    IEEE802154_SHORT_ADDRESS_LEN);
+    }
+    else if(dev_mode == IEEE802154_SEC_DEV_ADDRMODE_LONG) {
+        _memrvrscpy(key_lookup->key_lookup.implicit.dev_pan_id, &dev_pan_id,
+                    sizeof(key_lookup->key_lookup.implicit.dev_pan_id));
+        _memrvrscpy(key_lookup->key_lookup.implicit.dev_addr, dev_addr,
+                    IEEE802154_LONG_ADDRESS_LEN);
+    }
+    key_lookup->key = key;
+}
+
+static void _init_key_lookup_explicit(ieee802154_sec_key_lookup_t *key_lookup,
+                                      ieee802154_sec_scf_keymode_t key_mode,
+                                      uint8_t key_index,
+                                      const void *key_source,
+                                      ieee802154_sec_key_descriptor_t key)
+{
+    key_lookup->key_mode = key_mode;
+    key_lookup->key_lookup.explicit.key_index = key_index;
+    memcpy(key_lookup->key_lookup.explicit.key_source, key_source,
+           _key_source_size(key_mode));
+    key_lookup->key = key;
+}
+
+void ieee802154_sec_init(ieee802154_sec_context_t *ctx,
+                         ieee802154_sec_scf_seclevel_t sec_level,
+                         ieee802154_sec_scf_keymode_t sec_key_mode,
+                         uint8_t sec_key_index,
+                         const void *sec_key_source)
 {
     /* device driver can override this */
     ctx->dev.cipher_ops = &ieee802154_radio_cipher_ops;
     /* device driver can override this */
     ctx->dev.ctx = ctx;
-    /* MIC64 is the only mandatory security mode */
-    ctx->security_level = IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC64;
-    ctx->key_id_mode = IEEE802154_SEC_SCF_KEYMODE_IMPLICIT;
-    memset(ctx->key_source, 0, sizeof(ctx->key_source));
-    ctx->key_index = 0;
-    ctx->frame_counter = 0;
+    ctx->security_level = sec_level;
+    ctx->key_id_mode = sec_key_mode;
+    ctx->key_index = sec_key_index;
+    memcpy(ctx->key_source, sec_key_source, _key_source_size(sec_key_mode));
     uint8_t key[] = CONFIG_IEEE802154_SEC_DEFAULT_KEY;
     assert(sizeof(key) >= IEEE802154_SEC_KEY_LENGTH);
     assert(CIPHER_MAX_CONTEXT_SIZE >= IEEE802154_SEC_KEY_LENGTH);
     cipher_init(&ctx->cipher, CIPHER_AES, key, IEEE802154_SEC_KEY_LENGTH);
+    mutex_init(&ctx->lock);
+
+    if (0 /* TODO: initialize from persistent storage */) {
+    }
+    else {
+        /* no persistent storage or failure */
+        LOCK(ctx);
+        memset(&ctx->key_lookup_table, 0, sizeof(ctx->key_lookup_table));
+        memset(&ctx->dev_lookup_table, 0, sizeof(ctx->dev_lookup_table));
+        memset(&ctx->keystore, 0, sizeof(ctx->keystore));
+        UNLOCK(ctx);
+        /* our default key */
+        ieee802154_sec_key_descriptor_t k = ieee802154_sec_add_key(ctx, key);
+        if (sec_key_mode != IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+            ieee802154_sec_add_key_lookup_explicit(ctx, sec_key_mode,
+                                                   sec_key_index,
+                                                   sec_key_source, k);
+        }
+    }
 }
 
 int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
@@ -421,23 +789,38 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
         *mic_size = 0;
         return IEEE802154_SEC_OK;
     }
-    if (ctx->frame_counter == 0xFFFFFFFF) {
-        /* Letting the frame counter overflow is explicitly prohibited by the specification.
-           (see 9.4.2) */
-        return -IEEE802154_SEC_FRAME_COUNTER_OVERFLOW;
+    uint32_t fc;
+    {
+        LOCK(ctx);
+        /* attempt to find the encrypton key */
+        const ieee802154_sec_key_lookup_t *key;
+        if (!(key = _get_key(ctx,
+                            _get_dst_pan(header),
+                            _get_dst_address(header),
+                            _get_dst_address_size(header),
+                            ctx->key_id_mode,
+                            ctx->key_index,
+                            ctx->key_source))) {
+            UNLOCK(ctx);
+            DEBUG_SEC("key not found\n");
+            return -IEEE802154_SEC_NO_KEY;
+        }
+        ieee802154_sec_key_t *k = &ctx->keystore.keys[key->key];
+        if ((fc = k->fc) == 0xFFFFFFFF) {
+            /* Letting the frame counter overflow is explicitly prohibited by the specification.
+            (see 9.4.2) */
+            UNLOCK(ctx);
+            DEBUG_SEC("Frame counter would overflow\n");
+            return -IEEE802154_SEC_FRAME_COUNTER_OVERFLOW;
+        }
+        k->fc++;
+        _set_key(ctx, k->key);
+        UNLOCK(ctx);
     }
-
     /* write the auxiliary header */
     ieee802154_sec_aux_t *aux = (ieee802154_sec_aux_t *)(header + *header_size);
     uint8_t aux_size = _get_aux_hdr_size(ctx->security_level, ctx->key_id_mode);
-    _set_aux_hdr(ctx, aux);
-
-    /* attempt to find the encrypton key */
-    const uint8_t *key;
-    if (!(key = _get_encryption_key(ctx, header, *header_size, aux))) {
-        return -IEEE802154_SEC_NO_KEY;
-    }
-    _set_key(ctx, key);
+    _set_aux_hdr(ctx, fc, aux);
 
     *mic_size = _mac_size(ctx->security_level);
     const uint8_t *a = header;
@@ -448,20 +831,19 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
 
     /* compute MIC */
     if (_req_mac(ctx->security_level)) {
-        _init_cbc_B0(&ccm, ctx->frame_counter, ctx->security_level, m_len, *mic_size, src_address);
+        _init_cbc_B0(&ccm, fc, ctx->security_level, m_len, *mic_size, src_address);
         _comp_mic(ctx, mic, &ccm, a, a_len, m, m_len);
 
         /* encrypt MIC */
-        _init_ctr_A0(&ccm, ctx->frame_counter, ctx->security_level, src_address);
+        _init_ctr_A0(&ccm, fc, ctx->security_level, src_address);
         _ctr_mic(ctx, &ccm, mic, *mic_size);
     }
     /* encrypt payload */
     if (_req_encryption(ctx->security_level)) {
-        _init_ctr_A0(&ccm, ctx->frame_counter, ctx->security_level, src_address);
+        _init_ctr_A0(&ccm, fc, ctx->security_level, src_address);
         _ctr(ctx, &ccm, m, m_len);
     }
     *header_size += aux_size;
-    ctx->frame_counter++;
     return IEEE802154_SEC_OK;
 }
 
@@ -469,8 +851,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
                                  uint16_t frame_size,
                                  uint8_t *header, uint8_t *header_size,
                                  uint8_t **payload, uint16_t *payload_size,
-                                 uint8_t **mic, uint8_t *mic_size,
-                                 const uint8_t *src_address)
+                                 uint8_t **mic, uint8_t *mic_size)
 {
     /* For non data frames (MAC commands, beacons) a and a_len would be larger.
        ACKs are not encrypted. */
@@ -484,6 +865,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     uint8_t mac_size = _mac_size(security_level);
     /* remember that the frame counter was stored in little endian */
     uint32_t frame_counter = byteorder_ltohl((le_uint32_t){aux->fc});
+    uint8_t src_address[IEEE802154_LONG_ADDRESS_LEN];
 
     if (security_level == IEEE802154_SEC_SCF_SECLEVEL_NONE) {
         *payload = header + *header_size;
@@ -497,27 +879,61 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     *payload = header + *header_size + aux_size;
     *mic_size = mac_size;
     *mic = header + frame_size - mac_size;
-
-    /* attempt to find the decryption key */
-    const uint8_t *key;
-    if (!(key = _get_decryption_key(ctx, header, *header_size, aux))) {
-        return -IEEE802154_SEC_NO_KEY;
+    {
+        LOCK(ctx);
+        ieee802154_sec_key_lookup_t *key;
+        /* attempt to find key descriptor */
+        if (!(key = _get_key(ctx,
+                            _get_src_pan(header),
+                            _get_src_address(header),
+                            _get_src_address_size(header),
+                            key_mode,
+                            _get_aux_key_index(key_mode, aux->key_id),
+                            _get_aux_key_source(key_mode, aux->key_id)))) {
+            UNLOCK(ctx);
+            DEBUG_SEC("key not found\n");
+            return -IEEE802154_SEC_NO_KEY;
+        }
+#if IS_ACTIVE(CONFIG_IEEE802154_SEC_DEFAULT_REPLAY_PROTECTION)
+        /* attempt to find device descriptor */
+        ieee802154_sec_dev_lookup_t *dev;
+        if (!(dev = _get_dev(ctx,
+                             _get_src_pan(header),
+                             _get_src_address(header),
+                             _get_src_address_size(header)))) {
+            UNLOCK(ctx);
+            DEBUG_SEC("device not found\n");
+            return -IEEE802154_SEC_NO_DEV;
+        }
+        if (!bf_isset(ctx->keystore.keys[key->key].dev_fc_list, dev - ctx->dev_lookup_table.dev_lookup)) {
+            UNLOCK(ctx);
+            DEBUG_SEC("device not peered\n");
+            return -IEEE802154_SEC_NO_DEV;
+        }
+        /* check frame counter to fend replay attacks */
+        if (frame_counter < dev->fc) {
+            UNLOCK(ctx);
+            DEBUG_SEC("Frame counter indicates replay\n");
+            return -IEEE802154_SEC_FRAME_COUNTER_ERROR;
+        }
+        dev->fc = frame_counter + 1;
+        _memrvrscpy(src_address, dev->long_addr, sizeof(dev->long_addr));
+#else
+        if (_get_src_address_size(header) != IEEE802154_LONG_ADDRESS_LEN) {
+            DEBUG_SEC("No long source address\n");
+            return -IEEE802154_SEC_NO_DEV;
+        }
+        _memrvrscpy(src_address, _get_src_address(header), IEEE802154_LONG_ADDRESS_LEN);
+#endif
+        _set_key(ctx, ctx->keystore.keys[key->key].key);
+        UNLOCK(ctx);
     }
-    _set_key(ctx, key);
-
     const uint8_t *a = header;
     uint8_t *c = *payload;
     uint16_t a_len = *header_size + aux_size;
     uint16_t c_len = *payload_size;
     uint8_t *mac = *mic;
     ieee802154_sec_ccm_block_t ccm; /* Ai or Bi */
-
-    /* TODO:
-       A better implementation would check if the received frame counter is
-       greater then the frame counter that has previously been received from
-       the other endpoint. This is done to protect against replay attacks.
-       But we do not store this information because we also do not have
-       a proper key store, to avoid complexity on embedded devices. */
 
     /* decrypt MIC */
     if (mac_size) {
@@ -535,9 +951,393 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
         _init_cbc_B0(&ccm, frame_counter, security_level, c_len, mac_size, src_address);
         _comp_mic(ctx, tmp_mic, &ccm, a, a_len, c, c_len);
         if (memcmp(tmp_mic, *mic, mac_size)) {
+            DEBUG_SEC("invalid MIC\n");
             return -IEEE802154_SEC_MAC_CHECK_FAILURE;
         }
     }
     *header_size += aux_size;
     return IEEE802154_SEC_OK;
+}
+
+ieee802154_sec_dev_descriptor_t ieee802154_sec_add_dev(ieee802154_sec_context_t *ctx,
+                                                       uint16_t pan_id,
+                                                       const uint8_t *short_addr,
+                                                       const uint8_t *long_addr)
+{
+    pan_id = byteorder_htons(pan_id).u16;
+    ieee802154_sec_dev_lookup_t tmp_dev;
+    _init_dev(&tmp_dev, (uint8_t *)&pan_id, short_addr, long_addr);
+    LOCK(ctx);
+    /* check for duplicate */
+    ieee802154_sec_dev_lookup_t *tmp = NULL;
+    DEVLOOKUP_FOR_EACH(ctx, tmp, {
+        if (!memcmp(&tmp->pan_id, &tmp_dev.pan_id, sizeof(tmp_dev.pan_id)) &&
+            !memcmp(&tmp->short_addr, &tmp_dev.short_addr, sizeof(tmp_dev.short_addr)) &&
+            !memcmp(&tmp->long_addr, &tmp_dev.long_addr, sizeof(tmp_dev.long_addr))) {
+            UNLOCK(ctx);
+            return tmp - ctx->dev_lookup_table.dev_lookup;
+        }
+    })
+    int d = bf_get_unset(ctx->dev_lookup_table.mask,
+                         CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE);
+    if (d < 0) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    ctx->dev_lookup_table.dev_lookup[d] = tmp_dev;
+    UNLOCK(ctx);
+    return d;
+}
+
+ieee802154_sec_key_descriptor_t ieee802154_sec_add_key(ieee802154_sec_context_t *ctx,
+                                                       const uint8_t *key)
+{
+    ieee802154_sec_key_t tmp_key;
+    memset(&tmp_key, 0, sizeof(tmp_key));
+    memcpy(&tmp_key.key, key, sizeof(tmp_key.key));
+    LOCK(ctx);
+    int k = bf_get_unset(ctx->keystore.mask,
+                         CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE);
+    if (k < 0) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    ctx->keystore.keys[k] = tmp_key;
+    UNLOCK(ctx);
+    return k;
+}
+
+ieee802154_sec_key_lookup_descriptor_t
+ieee802154_sec_add_key_lookup_implicit(ieee802154_sec_context_t *ctx,
+                                       ieee802154_sec_dev_addrmode_t dev_mode,
+                                       uint16_t dev_pan_id,
+                                       const uint8_t *dev_addr,
+                                       ieee802154_sec_key_descriptor_t k)
+{
+    /* Check if the key exists */
+    if (dev_mode != IEEE802154_SEC_DEV_ADDRMODE_NONE &&
+        dev_mode != IEEE802154_SEC_DEV_ADDRMODE_SHORT &&
+        dev_mode != IEEE802154_SEC_DEV_ADDRMODE_LONG) {
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    ieee802154_sec_key_lookup_t tmp_lookup;
+    _init_key_lookup_implicit(&tmp_lookup, dev_mode, (uint8_t *)&dev_pan_id, dev_addr, k);
+    LOCK(ctx);
+    /* check for duplicate */
+    ieee802154_sec_key_lookup_t *tmp;
+    KEYLOOKUP_FOR_EACH(ctx, tmp, {
+        if (tmp->key_mode == tmp_lookup.key_mode &&
+            !memcmp(&tmp->key_lookup, &tmp_lookup.key_lookup, sizeof(tmp_lookup.key_lookup))) {
+            UNLOCK(ctx);
+            return tmp - ctx->key_lookup_table.key_lookup;
+        }
+    })
+    if (!bf_isset(ctx->keystore.mask, k)) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    /* Check if the device exists */
+    ieee802154_sec_dev_lookup_t *dev;
+    dev_pan_id = byteorder_htons(dev_pan_id).u16;
+    uint16_t pan = ((dev_pan_id & 0x00ff) << 8) | ((dev_pan_id & 0xff00) >> 8);
+    if (dev_mode == IEEE802154_SEC_DEV_ADDRMODE_NONE) {
+        dev = _get_dev(ctx, (uint8_t *)&pan, NULL, 0);
+    }
+    else if (dev_mode == IEEE802154_SEC_DEV_ADDRMODE_SHORT) {
+        uint8_t addr[IEEE802154_SHORT_ADDRESS_LEN];
+        _memrvrscpy(addr, dev_addr, sizeof(addr));
+        dev = _get_dev(ctx, (uint8_t *)&pan, addr, sizeof(addr));
+    }
+    else {
+        uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
+        _memrvrscpy(addr, dev_addr, sizeof(addr));
+        dev = _get_dev(ctx, (uint8_t *)&pan, addr, sizeof(addr));
+    }
+    if (!dev) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    /* allocate a lookup descriptor */
+    int l = bf_get_unset(ctx->key_lookup_table.mask,
+                         CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE);
+    if (l < 0) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    ctx->key_lookup_table.key_lookup[l] = tmp_lookup;
+    /* device bit in key descriptor should be set during pairings phase,
+       see ieee802154_sec_peer_dev() */
+    UNLOCK(ctx);
+    return l;
+}
+
+ieee802154_sec_key_lookup_descriptor_t
+ieee802154_sec_add_key_lookup_explicit(ieee802154_sec_context_t *ctx,
+                                       ieee802154_sec_scf_keymode_t key_mode,
+                                       uint8_t key_index,
+                                       const void *key_source,
+                                       ieee802154_sec_key_descriptor_t k)
+{
+    if (key_mode != IEEE802154_SEC_SCF_KEYMODE_INDEX &&
+        key_mode != IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX &&
+        key_mode != IEEE802154_SEC_SCF_KEYMODE_HW_INDEX) {
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    if (key_index == 0x00) {
+        return IEEE802154_SEC_NO_IDENT; /* not allowed */
+    }
+    ieee802154_sec_key_lookup_t tmp_lookup;
+    _init_key_lookup_explicit(&tmp_lookup, key_mode, key_index, key_source, k);
+    LOCK(ctx);
+    /* check for duplicate */
+    ieee802154_sec_key_lookup_t *tmp;
+    KEYLOOKUP_FOR_EACH(ctx, tmp, {
+        if (tmp->key_mode == tmp_lookup.key_mode &&
+            !memcmp(&tmp->key_lookup, &tmp_lookup.key_lookup, sizeof(tmp_lookup.key_lookup))) {
+            UNLOCK(ctx);
+            return tmp - ctx->key_lookup_table.key_lookup;
+        }
+    })
+    /* Check if the key exists */
+    if (!bf_isset(ctx->keystore.mask, k)) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    /* allocate a lookup descriptor */
+    int l = bf_get_unset(ctx->key_lookup_table.mask,
+                         CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE);
+    if (l < 0) {
+        UNLOCK(ctx);
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    ctx->key_lookup_table.key_lookup[l] = tmp_lookup;
+    /* device bit in key descriptor should be set during pairings phase,
+       see ieee802154_sec_peer_dev() */
+    UNLOCK(ctx);
+    return l;
+}
+
+void ieee802154_sec_remove_dev(ieee802154_sec_context_t *ctx,
+                               ieee802154_sec_dev_descriptor_t d)
+{
+    assert(d < CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE);
+    LOCK(ctx);
+    /* delete lookup references */
+    ieee802154_sec_key_lookup_t *lookup;
+    KEYLOOKUP_FOR_EACH(ctx, lookup,
+        /* if an association between a key and the device exists */
+        if (bf_isset(ctx->keystore.keys[lookup->key].dev_fc_list, d)) {
+            /* delete association */
+            bf_unset(ctx->keystore.keys[lookup->key].dev_fc_list, d);
+            /* release the lookup descriptor */
+            if (lookup->key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+                bf_unset(ctx->dev_lookup_table.mask, lookup - ctx->key_lookup_table.key_lookup);
+                memset(lookup, 0, sizeof(*lookup));
+            }
+        }
+    )
+    /* release device descriptor */
+    bf_unset(ctx->dev_lookup_table.mask, d);
+    memset(&ctx->dev_lookup_table.dev_lookup[d], 0,
+           sizeof(ctx->dev_lookup_table.dev_lookup[d]));
+    UNLOCK(ctx);
+}
+
+void ieee802154_sec_remove_key(ieee802154_sec_context_t *ctx,
+                               ieee802154_sec_key_descriptor_t k)
+{
+    assert(k < CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE);
+    LOCK(ctx);
+    /* delete lookup references */
+    ieee802154_sec_key_lookup_t *lookup;
+    KEYLOOKUP_FOR_EACH(ctx, lookup,
+        if (lookup->key == k) {
+            /* reset device frame counters which reference the key */
+            for (unsigned d = 0; d < CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE; d++) {
+                if (bf_isset(ctx->keystore.keys[k].dev_fc_list, d)) {
+                    ctx->dev_lookup_table.dev_lookup[d].fc = 0;
+                }
+            }
+            bf_unset(ctx->dev_lookup_table.mask, lookup - ctx->key_lookup_table.key_lookup);
+            memset(lookup, 0, sizeof(*lookup));
+        }
+    )
+    /* release key descriptor */
+    bf_unset(ctx->keystore.mask, k);
+    memset(&ctx->keystore.keys[k], 0, sizeof(ctx->keystore.keys[k]));
+    UNLOCK(ctx);
+}
+
+void ieee802154_sec_remove_key_lookup(ieee802154_sec_context_t *ctx,
+                                      ieee802154_sec_key_lookup_descriptor_t l)
+{
+    assert(l < CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE);
+    LOCK(ctx);
+    bf_unset(ctx->dev_lookup_table.mask, l);
+    memset(&ctx->dev_lookup_table.dev_lookup[l], 0,
+           sizeof(ctx->dev_lookup_table.dev_lookup[l]));
+    UNLOCK(ctx);
+}
+
+int ieee802154_sec_update_key(ieee802154_sec_context_t *ctx,
+                               ieee802154_sec_key_descriptor_t k,
+                               const uint8_t *new)
+{
+    assert(k < CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE);
+    ieee802154_sec_key_t *key = &ctx->keystore.keys[k];
+    LOCK(ctx);
+    if (!bf_isset(ctx->keystore.mask, k)) {
+        UNLOCK(ctx);
+        return -IEEE802154_SEC_NO_KEY;
+    }
+    if (memcmp(new, key->key, sizeof(key->key))) {
+        key->fc = 0;
+        memcpy(key->key, new, sizeof(key->key));
+        for (unsigned d = 0; d < CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE; d++) {
+            if (bf_isset(key->dev_fc_list, d)) {
+                ctx->dev_lookup_table.dev_lookup[d].fc =  0;
+                /* TODO: pairing with device */
+            }
+        }
+    }
+    UNLOCK(ctx);
+    return IEEE802154_SEC_OK;
+}
+
+int ieee802154_sec_peer_dev(ieee802154_sec_context_t *ctx,
+                             ieee802154_sec_key_lookup_descriptor_t l,
+                             uint16_t pan_id,
+                             const uint8_t *short_addr, const uint8_t *long_addr)
+{
+    assert(l < CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE);
+    ieee802154_sec_key_lookup_t *lookup = &ctx->key_lookup_table.key_lookup[l];
+    ieee802154_sec_dev_lookup_t *dev = NULL;
+    pan_id = byteorder_htons(pan_id).u16;
+    uint16_t pan = ((pan_id & 0x00ff) << 8) | ((pan_id & 0xff00) >> 8);
+    LOCK(ctx);
+    if (!bf_isset(ctx->key_lookup_table.mask, l)) {
+        UNLOCK(ctx);
+        return -IEEE802154_SEC_NO_KEY;
+    }
+    /* find device */
+    if (lookup->key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+        if (lookup->key_lookup.implicit.dev_mode == IEEE802154_SEC_DEV_ADDRMODE_NONE) {
+            dev = _get_dev(ctx, (uint8_t *)&pan, NULL, 0);
+        }
+        else if (lookup->key_lookup.implicit.dev_mode == IEEE802154_SEC_DEV_ADDRMODE_SHORT) {
+            uint8_t addr[IEEE802154_SHORT_ADDRESS_LEN];
+            _memrvrscpy(addr, short_addr, sizeof(addr));
+            dev = _get_dev(ctx, (uint8_t *)&pan, addr, sizeof(addr));
+        }
+        else if (lookup->key_lookup.implicit.dev_mode == IEEE802154_SEC_DEV_ADDRMODE_LONG) {
+            uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
+            _memrvrscpy(addr, long_addr, sizeof(addr));
+            dev = _get_dev(ctx, (uint8_t *)&pan, addr, sizeof(addr));
+        }
+    }
+    else {
+        uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
+        _memrvrscpy(addr, long_addr, sizeof(addr));
+        dev = _get_dev(ctx, (uint8_t *)&pan, addr, sizeof(addr));
+    }
+    if (!dev) {
+        UNLOCK(ctx);
+        return -IEEE802154_SEC_NO_DEV;
+    }
+    /* remove previous pairings */
+    ieee802154_sec_key_lookup_t *tmp_lookup = NULL;
+    KEYLOOKUP_FOR_EACH(ctx, tmp_lookup,
+        if (bf_isset(ctx->keystore.keys[tmp_lookup->key].dev_fc_list,
+                        dev - ctx->dev_lookup_table.dev_lookup)) {
+            bf_unset(ctx->keystore.keys[tmp_lookup->key].dev_fc_list,
+                        dev - ctx->dev_lookup_table.dev_lookup);
+            if (tmp_lookup->key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+                bf_unset(ctx->dev_lookup_table.mask,
+                         tmp_lookup - ctx->key_lookup_table.key_lookup);
+                memset(tmp_lookup, 0, sizeof(*tmp_lookup));
+            }
+        }
+    )
+    /* TODO: Send pairings request. For now, assume pairings succeeds unconditionally. */
+    bf_set(ctx->keystore.keys[lookup->key].dev_fc_list,
+           dev - ctx->dev_lookup_table.dev_lookup);
+    dev->fc = 0;
+    UNLOCK(ctx);
+    return IEEE802154_SEC_OK;
+}
+
+void ieee802154_sec_iterator_acquire(ieee802154_sec_context_t *ctx)
+{
+    LOCK(ctx);
+}
+
+void ieee802154_sec_iterator_release(ieee802154_sec_context_t *ctx)
+{
+    UNLOCK(ctx);
+}
+
+ieee802154_sec_key_descriptor_t
+ieee802154_sec_key_iterator(ieee802154_sec_context_t *ctx,
+                            ieee802154_sec_key_descriptor_t prev,
+                            ieee802154_sec_key_t *key)
+{
+    if (prev >= CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE) {
+        prev = 0;
+    }
+    else if (++prev == CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE) {
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    while (prev < CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE &&
+           !bf_isset(ctx->keystore.mask, prev)) {
+        prev++;
+    }
+    if (key && prev < CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE) {
+        *key = ctx->keystore.keys[prev];
+    }
+    return prev < CONFIG_IEEE802154_SEC_DEFAULT_KEYSTORE_SIZE
+           ? prev : IEEE802154_SEC_NO_IDENT;
+}
+
+ieee802154_sec_dev_descriptor_t
+ieee802154_sec_dev_iterator(ieee802154_sec_context_t *ctx,
+                            ieee802154_sec_dev_descriptor_t prev,
+                            ieee802154_sec_dev_lookup_t *dev)
+{
+    if (prev >= CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE) {
+        prev = 0;
+    }
+    else if (++prev == CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE) {
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    while (prev < CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE &&
+           !bf_isset(ctx->dev_lookup_table.mask, prev)) {
+        prev++;
+    }
+    if (dev && prev < CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE) {
+        *dev = ctx->dev_lookup_table.dev_lookup[prev];
+    }
+    return prev < CONFIG_IEEE802154_SEC_DEFAULT_DEVSTORE_SIZE
+           ? prev : IEEE802154_SEC_NO_IDENT;
+}
+
+ieee802154_sec_key_lookup_descriptor_t
+ieee802154_sec_key_lookup_iterator(ieee802154_sec_context_t *ctx,
+                                   ieee802154_sec_key_lookup_descriptor_t prev,
+                                   ieee802154_sec_key_lookup_t *lookup)
+{
+    if (prev >= CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE) {
+        prev = 0;
+    }
+    else if (++prev == CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE) {
+        return IEEE802154_SEC_NO_IDENT;
+    }
+    while (prev < CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE &&
+           !bf_isset(ctx->key_lookup_table.mask, prev)) {
+        prev++;
+    }
+    if (lookup && prev < CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE) {
+        *lookup = ctx->key_lookup_table.key_lookup[prev];
+    }
+    return prev < CONFIG_IEEE802154_SEC_DEFAULT_KEYLOOKUP_SIZE
+           ? prev : IEEE802154_SEC_NO_IDENT;
 }

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -77,6 +77,9 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
   SRC += sc_gnrc_6lo_frag_stats.c
 endif
+ifneq (,$(filter ieee802154_security,$(USEMODULE)))
+  SRC += sc_iwpansec.c
+endif
 ifneq (,$(filter saul_reg,$(USEMODULE)))
   SRC += sc_saul_reg.c
 endif

--- a/sys/shell/commands/sc_iwpansec.c
+++ b/sys/shell/commands/sc_iwpansec.c
@@ -1,0 +1,564 @@
+/*
+ * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Manage IEEE 802.15.4 link layer security
+ *
+ * This is an administrative shell tool, that is used to provide keys, peered
+ * devices and their relations. It is similar to the
+ * <a href="https://github.com/linux-wpan/wpan-tools/wiki/Guide:-Contiki-%E2%86%94-Linux,-with-llsec#linuxiwpan-configuration">wpan-tools</a>
+ * in Linux but only very much limited to the configuration LL security.
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <sys/errno.h>
+
+#include "shell.h"
+#include "net/netif.h"
+#include "net/gnrc/netif.h"
+#include "net/netdev/ieee802154.h"
+#include "net/ieee802154_security.h"
+#include "fmt.h"
+
+#ifndef CSTRLEN
+#define CSTRLEN(cs)     (sizeof((const char[]){cs}) - 1)
+#endif
+#ifndef CSTRCMP
+#define CSTRCMP(p, cs)  (memcmp(p, cs, CSTRLEN(cs)))
+#endif
+#ifndef MIN
+#define MIN(a, b)       ((a) < (b) ? (a) : (b))
+#endif
+
+static inline ieee802154_sec_context_t * _iwpansec_get_sec(netif_t *iface)
+{
+    return &(((netdev_ieee802154_t *)(((gnrc_netif_t *)iface)->dev))->sec_ctx);
+}
+
+static int _iwpansec_enable(netif_t *iface)
+{
+    netopt_enable_t e = NETOPT_ENABLE;
+    return netif_set_opt(iface, NETOPT_ENCRYPTION, 0, &e, sizeof(e));
+}
+
+static int _iwpansec_disable(netif_t *iface)
+{
+    netopt_enable_t e = NETOPT_DISABLE;
+    return netif_set_opt(iface, NETOPT_ENCRYPTION, 0, &e, sizeof(e));
+}
+
+static void _iwpansec_print_devkeys_implicit(const ieee802154_sec_key_lookup_t *key_lookup,
+                                             ieee802154_sec_key_lookup_descriptor_t key)
+{
+    char s_addr[25] = "                       ";
+    if (key_lookup->key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+        if (key_lookup->key_lookup.implicit.dev_mode == IEEE802154_SEC_DEV_ADDRMODE_SHORT) {
+            l2util_addr_to_str(key_lookup->key_lookup.implicit.dev_addr,
+                               IEEE802154_SHORT_ADDRESS_LEN,
+                               s_addr + 18);
+        }
+        else if (key_lookup->key_lookup.implicit.dev_mode == IEEE802154_SEC_DEV_ADDRMODE_LONG) {
+            l2util_addr_to_str(key_lookup->key_lookup.implicit.dev_addr,
+                               IEEE802154_LONG_ADDRESS_LEN,
+                               s_addr);
+        }
+        printf("%8u | 0x%02x%02x | %s |%5u \n",
+                key,
+                key_lookup->key_lookup.implicit.dev_pan_id[0],
+                key_lookup->key_lookup.implicit.dev_pan_id[1],
+                s_addr,
+                key_lookup->key);
+    }
+}
+
+
+static void _iwpansec_list_devkeys_implicit(netif_t *iface)
+{
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    ieee802154_sec_iterator_acquire(ctx);
+    puts("<devkey> |    pan |                adddress | <key>");
+    puts("---------+--------+-------------------------+------");
+    /*         XXX | 0xXXXX | XX:XX:XX:XX:XX:XX:XX:XX |  XXX  */
+    ieee802154_sec_key_lookup_t lookup;
+    ieee802154_sec_key_lookup_descriptor_t l = IEEE802154_SEC_NO_IDENT;
+    while ((l = ieee802154_sec_key_lookup_iterator(ctx, l, &lookup)) != IEEE802154_SEC_NO_IDENT) {
+        if (lookup.key_mode == IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+            _iwpansec_print_devkeys_implicit(&lookup, l);
+        }
+    }
+    ieee802154_sec_iterator_release(ctx);
+}
+
+static void _iwpansec_print_devkeys_explicit(const ieee802154_sec_key_lookup_t *key_lookup,
+                                             ieee802154_sec_key_lookup_descriptor_t key)
+{
+    char s_source[19] = "                  ";
+    if (key_lookup->key_mode != IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+        if (key_lookup->key_mode == IEEE802154_SEC_SCF_KEYMODE_HW_INDEX) {
+            memcpy(s_source, "0x", 2);
+            fmt_bytes_hex(s_source + 2, key_lookup->key_lookup.explicit.key_source, 8);
+        }
+        else if (key_lookup->key_mode == IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX) {
+            memcpy(s_source, "        0x", 10);
+            fmt_bytes_hex(s_source + 10, key_lookup->key_lookup.explicit.key_source, 4);
+        }
+        printf("%8u |%6u | %s |%5u \n",
+                key,
+                key_lookup->key_lookup.explicit.key_index,
+                s_source,
+                key_lookup->key);
+    }
+}
+
+static void _iwpansec_list_devkeys_explicit(netif_t *iface)
+{
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    ieee802154_sec_iterator_acquire(ctx);
+    puts("<devkey> | index |             source | <key>");
+    puts("---------+-------+--------------------+------");
+    /*         XXX |   XXX | 0xXXXXXXXXXXXXXXXX |  XXX  */
+    ieee802154_sec_key_lookup_t lookup;
+    ieee802154_sec_key_lookup_descriptor_t l = IEEE802154_SEC_NO_IDENT;
+    while ((l = ieee802154_sec_key_lookup_iterator(ctx, l, &lookup)) != IEEE802154_SEC_NO_IDENT) {
+        if (lookup.key_mode != IEEE802154_SEC_SCF_KEYMODE_IMPLICIT) {
+            _iwpansec_print_devkeys_explicit(&lookup, l);
+        }
+    }
+    ieee802154_sec_iterator_release(ctx);
+}
+
+
+static int _iwpansec_devkey(netif_t *iface, int argc, char **argv)
+{
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    if (!argc) {
+        _iwpansec_list_devkeys_implicit(iface);
+        _iwpansec_list_devkeys_explicit(iface);
+        return 0;
+    }
+    else if (!CSTRCMP(argv[0], "add")) {
+        if (argc < 3) {
+            return -EINVAL;
+        }
+        long l_k;
+        if (!fmt_is_number(argv[1]) ||
+            (l_k = strtol(argv[1], NULL, 10)) < 0) {
+            return -EINVAL;
+        }
+        argc -= 3;
+        ieee802154_sec_key_lookup_descriptor_t l;
+        if (!CSTRCMP(argv[2], "implicit")) {
+            if (argc < 1) {
+                return -EINVAL;
+            }
+            if (!CSTRCMP(argv[3], "none")) {
+                return IEEE802154_SEC_NO_IDENT !=
+                       (l = ieee802154_sec_add_key_lookup_implicit(ctx,
+                                                                   IEEE802154_SEC_DEV_ADDRMODE_NONE,
+                                                                   0, NULL, l_k))
+                        ? l : -ECANCELED;
+            }
+            else if (!CSTRCMP(argv[3], "short")) {
+                if (argc < 3) {
+                    return -EINVAL;
+                }
+                uint8_t short_addr[IEEE802154_SHORT_ADDRESS_LEN];
+                long l_pan;
+                if (strlen(argv[4]) > CSTRLEN("0xFFFF") ||
+                    (l_pan = strtol(argv[4], NULL, 16)) < 0 || l_pan > 0xffff) {
+                    return -EINVAL;
+                }
+                if (strlen(argv[5]) != CSTRLEN("xx:xx") ||
+                    l2util_addr_from_str(argv[5], short_addr) != sizeof(short_addr)) {
+                    return -EINVAL;
+                }
+                return IEEE802154_SEC_NO_IDENT !=
+                       (l = ieee802154_sec_add_key_lookup_implicit(ctx,
+                                                                   IEEE802154_SEC_DEV_ADDRMODE_SHORT,
+                                                                   l_pan, short_addr, l_k))
+                        ? l : -ECANCELED;
+            }
+            else if (!CSTRCMP(argv[3], "long")) {
+                if (argc < 3) {
+                    return -EINVAL;
+                }
+                uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
+                long l_pan;
+                if (strlen(argv[4]) > CSTRLEN("0xFFFF") ||
+                    (l_pan = strtol(argv[4], NULL, 16)) < 0 || l_pan > 0xffff) {
+                    return -EINVAL;
+                }
+                if (strlen(argv[5]) != CSTRLEN("xx:xx:xx:xx:xx:xx:xx:xx") ||
+                    l2util_addr_from_str(argv[5], long_addr) != sizeof(long_addr)) {
+                    return -EINVAL;
+                }
+                return IEEE802154_SEC_NO_IDENT !=
+                       (l = ieee802154_sec_add_key_lookup_implicit(ctx, IEEE802154_SEC_DEV_ADDRMODE_LONG,
+                                                                   l_pan, long_addr, l_k))
+                        ? l : -ECANCELED;
+            }
+        }
+        else if (!CSTRCMP(argv[2], "explicit")) {
+            if (argc < 1) {
+                return -EINVAL;
+            }
+            long key_id;
+            if (!fmt_is_number(argv[3]) ||
+                !(key_id = strtol(argv[3], NULL, 10)) || key_id < 0 || key_id > 255) {
+                return -EINVAL;
+            }
+            if (!--argc) {
+                return IEEE802154_SEC_NO_IDENT !=
+                       (l = ieee802154_sec_add_key_lookup_explicit(ctx, IEEE802154_SEC_SCF_KEYMODE_INDEX,
+                                                              key_id, NULL, l_k))
+                        ? l : -ECANCELED;
+            }
+            else if (!CSTRCMP(argv[4], "short")) {
+                if (argc < 3) {
+                    return -EINVAL;
+                }
+                struct key_source {
+                    uint16_t pan;
+                    uint8_t short_addr[2];
+                } key_source;
+                long l_pan;
+                if (strlen(argv[5]) > CSTRLEN("0xFFFF") ||
+                    (l_pan = strtol(argv[5], NULL, 16)) < 0 || l_pan > 0xffff) {
+                    return -EINVAL;
+                }
+                if (strlen(argv[6]) != CSTRLEN("xx:xx") ||
+                    l2util_addr_from_str(argv[6], key_source.short_addr) != 2) {
+                    return -EINVAL;
+                }
+                key_source.pan = htons(l_pan);
+                return IEEE802154_SEC_NO_IDENT !=
+                       (l = ieee802154_sec_add_key_lookup_explicit(ctx, IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX,
+                                                                   key_id, &key_source, l_k))
+                        ? l : -ECANCELED;
+            }
+            else if (!CSTRCMP(argv[4], "long")) {
+                if (argc < 2) {
+                    return -EINVAL;
+                }
+                struct key_source {
+                    uint8_t long_addr[8];
+                } key_source;
+                if (strlen(argv[5]) != CSTRLEN("xx:xx:xx:xx:xx:xx:xx:xx") ||
+                    l2util_addr_from_str(argv[5], key_source.long_addr) != 8) {
+                    return -EINVAL;
+                }
+                return IEEE802154_SEC_NO_IDENT !=
+                       (l = ieee802154_sec_add_key_lookup_explicit(ctx, IEEE802154_SEC_SCF_KEYMODE_HW_INDEX,
+                                                                   key_id, &key_source, l_k))
+                        ? l : -ECANCELED;
+            }
+        }
+    }
+    else if (!CSTRCMP(argv[0], "rem")) {
+        if (argc < 2) {
+            return -EINVAL;
+        }
+        if (!fmt_is_number(argv[1])) {
+            return -EINVAL;
+        }
+        int l = atoi(argv[1]);
+        if (l >= 0) {
+            ieee802154_sec_remove_key_lookup(ctx, l);
+            return l;
+        }
+    }
+    return -EINVAL;
+}
+
+static void _iwpansec_print_dev(const ieee802154_sec_dev_lookup_t *dev_lookup,
+                                ieee802154_sec_dev_descriptor_t dev)
+{
+    char s_short[6];
+    char s_long[25];
+    l2util_addr_to_str(dev_lookup->short_addr, sizeof(dev_lookup->short_addr), s_short);
+    l2util_addr_to_str(dev_lookup->long_addr, sizeof(dev_lookup->long_addr), s_long);
+    printf("%5u | 0x%02x%02x | %s | %s | %13"PRIu32"\n",
+            dev,
+            dev_lookup->pan_id[0],
+            dev_lookup->pan_id[1],
+            s_short,
+            s_long,
+            dev_lookup->fc
+    );
+}
+
+static void _iwpansec_list_devs(netif_t *iface)
+{
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    ieee802154_sec_iterator_acquire(ctx);
+    puts("<dev> |    pan | short |                    long | frame counter");
+    puts("------+--------+-------+-------------------------+--------------");
+    /*      XXX | 0xXXXX | XX:XX | XX:XX:XX:XX:XX:XX:XX:XX |   XXXXXXXXXX  */
+
+    ieee802154_sec_dev_lookup_t dev;
+    ieee802154_sec_dev_descriptor_t d = IEEE802154_SEC_NO_IDENT;
+    while ((d = ieee802154_sec_dev_iterator(ctx, d, &dev)) != IEEE802154_SEC_NO_IDENT) {
+        _iwpansec_print_dev(&dev, d);
+    }
+    ieee802154_sec_iterator_release(ctx);
+}
+
+static int _iwpansec_dev(netif_t *iface, int argc, char **argv)
+{
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    if (!argc) {
+        _iwpansec_list_devs(iface);
+        return 0;
+    }
+    else if (!CSTRCMP(argv[0], "add")) {
+        if (argc < 4) {
+            return -EINVAL;
+        }
+        uint8_t short_addr[IEEE802154_SHORT_ADDRESS_LEN];
+        uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
+        long l_pan;
+        if (strlen(argv[1]) > CSTRLEN("0xffff") ||
+            (l_pan = strtol(argv[1], NULL, 16)) < 0 || l_pan > 0xffff) {
+            return -EINVAL;
+        }
+        if (strlen(argv[2]) != CSTRLEN("xx:xx") ||
+            l2util_addr_from_str(argv[2], short_addr) != sizeof(short_addr)) {
+            return -EINVAL;
+        }
+        if (strlen(argv[3]) != CSTRLEN("xx:xx:xx:xx:xx:xx:xx:xx") ||
+            l2util_addr_from_str(argv[3], long_addr) != sizeof(long_addr)) {
+            return -EINVAL;
+        }
+        ieee802154_sec_dev_descriptor_t d;
+        return IEEE802154_SEC_NO_IDENT !=
+               (d = ieee802154_sec_add_dev(ctx, l_pan, short_addr, long_addr))
+               ? d : -ECANCELED;
+    }
+    else if (!CSTRCMP(argv[0], "rem")) {
+        if (argc < 2) {
+            return -EINVAL;
+        }
+        if (!fmt_is_number(argv[1])) {
+            return -EINVAL;
+        }
+        int d = atoi(argv[1]);
+        if (d >= 0) {
+            ieee802154_sec_remove_dev(ctx, d);
+            return d;
+        }
+    }
+    else if (!CSTRCMP(argv[0], "peer")) {
+        if (argc < 5) {
+            return -EINVAL;
+        }
+        int l = atoi(argv[1]);
+        long l_pan;
+        uint8_t short_addr[IEEE802154_SHORT_ADDRESS_LEN];
+        uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];
+        if (strlen(argv[2]) > CSTRLEN("0xffff") ||
+            (l_pan = strtol(argv[2], NULL, 16)) < 0 || l_pan > 0xffff) {
+            return -EINVAL;
+        }
+        if (strlen(argv[3]) != CSTRLEN("xx:xx") ||
+            l2util_addr_from_str(argv[3], short_addr) != sizeof(short_addr)) {
+            return -EINVAL;
+        }
+        if (strlen(argv[4]) != CSTRLEN("xx:xx:xx:xx:xx:xx:xx:xx") ||
+            l2util_addr_from_str(argv[4], long_addr) != sizeof(long_addr)) {
+            return -EINVAL;
+        }
+        if (l >= 0) {
+            if (IEEE802154_SEC_OK !=
+                ieee802154_sec_peer_dev(ctx, l, l_pan, short_addr, long_addr)) {
+                return -ECANCELED;
+            }
+            return 0;
+        }
+    }
+    return -EINVAL;
+}
+
+static void _iwpansec_print_key(const ieee802154_sec_key_t *key, ieee802154_sec_key_descriptor_t k)
+{
+    char s_key[2 * sizeof(key->key) + 3] = "0x";
+    fmt_bytes_hex(s_key + 2, key->key, sizeof(key->key));
+    s_key[sizeof(s_key) - 1] = '\0';
+    printf("%5u | %s | %13"PRIu32"\n",
+           k, s_key, key->fc);
+}
+
+static void _iwpansec_list_keys(netif_t *iface) {
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    ieee802154_sec_iterator_acquire(ctx);
+    puts("<key> |                                key | frame counter");
+    puts("------+------------------------------------+--------------");
+    /*      XXX | 0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX |   XXXXXXXXXX  */
+
+    ieee802154_sec_key_t key;
+    ieee802154_sec_key_descriptor_t k = IEEE802154_SEC_NO_IDENT;
+    while ((k = ieee802154_sec_key_iterator(ctx, k, &key)) != IEEE802154_SEC_NO_IDENT) {
+        _iwpansec_print_key(&key, k);
+    }
+    ieee802154_sec_iterator_release(ctx);
+}
+
+static int _iwpansec_key(netif_t *iface, int argc, char **argv)
+{
+    ieee802154_sec_context_t *ctx = _iwpansec_get_sec(iface);
+    if (!argc) {
+        _iwpansec_list_keys(iface);
+        return 0;
+    }
+    else if (!CSTRCMP(argv[0], "add")) {
+        uint8_t key[16];
+        const char *s_key = argv[1];
+        if (!strncmp(s_key, "0x", 2)) {
+            s_key += 2;
+        }
+        if (strlen(s_key) != 2 * sizeof(key)) {
+            return -EINVAL;
+        }
+        for (unsigned i= 0; i < sizeof(key); i++, s_key += 2) {
+            if (!(
+                (('0' <= s_key[0] && s_key[0] <= '9') ||
+                 ('a' <= s_key[0] && s_key[0] <= 'f') ||
+                 ('A' <= s_key[0] && s_key[0] <= 'F'))
+                &&
+                (('0' <= s_key[1] && s_key[1] <= '9') ||
+                 ('a' <= s_key[1] && s_key[1] <= 'f') ||
+                 ('A' <= s_key[1] && s_key[1] <= 'F')))) {
+                return -EINVAL;
+            }
+            key[i] = scn_u32_hex(s_key, 2);
+        }
+        ieee802154_sec_dev_descriptor_t k;
+        return IEEE802154_SEC_NO_IDENT !=
+               (k = ieee802154_sec_add_key(ctx, key))
+               ? k : -ECANCELED;
+    }
+    else if (!CSTRCMP(argv[0], "rem")) {
+        int k = atoi(argv[1]);
+        if (k >= 0) {
+            ieee802154_sec_remove_dev(ctx, k);
+            return k;
+        }
+    }
+    return -EINVAL;
+}
+
+static int _iwpansec_probe(netif_t *iface)
+{
+    uint16_t type;
+    if (netif_get_opt(iface, NETOPT_DEVICE_TYPE, 0, &type, sizeof(type)) <= 0 ||
+        type != NETDEV_TYPE_IEEE802154) {
+        return -EINVAL;
+    }
+    netopt_enable_t sup;
+    if (netif_get_opt(iface, NETOPT_ENCRYPTION, 0, &sup, sizeof(sup)) <= 0) {
+        return -ENOTSUP;
+    }
+    return 0;
+}
+
+static void _iwpansec_print_help(void)
+{
+    puts("Usage: iwpansec <interface> [COMMAND]\n"
+         "Placeholders in capital letters are user input and placeholders in "
+         "small letters are IDs you have to look up, using this program.\n"
+         "[enable]\n"
+         "[disable]\n"
+         "[devkey]\n"
+         "  [add <key> <implicit <none | short <PAN> <SHORT> | long <PAN> <LONG>>>]\n"
+         "  [add <key> <explicit <ID> [short <PAN> <SHORT_SOURCE> | long <LONG_SOURCE>]>]\n"
+         "  [rem <devkey>]\n"
+         "[dev]\n"
+         "  [add <PAN> <SHORT> <LONG>]\n"
+         "  [rem <dev>]\n"
+         "  [peer <devkey> <PAN> <SHORT> <LONG>]\n"
+         "[key]\n"
+         "  [add <KEY>]\n"
+         "  [rem <key>]\n"
+    );
+}
+
+int _sc_iwpansec(int argc, char **argv)
+{
+    int success = -EINVAL;
+    if (argc < 3) {
+        goto EXIT_HELP;
+    }
+    netif_t *iface;
+    iface = netif_get_by_name(argv[1]);
+    if (!iface) {
+        puts("invalid interface given");
+        goto EXIT_HELP;
+    }
+    switch (_iwpansec_probe(iface)) {
+        case -EINVAL:
+            puts("interface type is not IEEE 802.15.4");
+            goto EXIT_HELP;
+        case -ENOTSUP:
+            puts("interface does not support security");
+            goto EXIT_HELP;
+    }
+
+    if (!CSTRCMP(argv[2], "enable")) {
+        if ((success = _iwpansec_enable(iface)) < 0) {
+            goto EXIT_HELP;
+        }
+    }
+    else if (!CSTRCMP(argv[2], "disable")) {
+        if ((success = _iwpansec_disable(iface)) < 0) {
+            goto EXIT_HELP;
+        }
+    }
+    else if (!CSTRCMP(argv[2], "devkey")) {
+        if ((success = _iwpansec_devkey(iface, argc - 3, argv + 3)) < 0) {
+            goto EXIT_HELP;
+        }
+    }
+    else if (!CSTRCMP(argv[2], "dev")) {
+        if ((success = _iwpansec_dev(iface, argc - 3, argv + 3)) < 0) {
+            goto EXIT_HELP;
+        }
+    }
+    else if (!CSTRCMP(argv[2], "key")) {
+        if ((success = _iwpansec_key(iface, argc - 3, argv + 3)) < 0) {
+            goto EXIT_HELP;
+        }
+    }
+    else {
+        goto EXIT_HELP;
+    }
+
+    puts("iwpansec: ok");
+    return EXIT_SUCCESS;
+
+EXIT_HELP:
+    if (success == -EINVAL) {
+        _iwpansec_print_help();
+    }
+    else {
+        puts("iwpansec: error");
+    }
+    return EXIT_FAILURE;
+}
+
+SHELL_COMMAND(iwpansec, "Manage IEEE 802.15.4 keys and peer devices", _sc_iwpansec);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

At the RIOT summit I got the impression, that there is a big interest in extending the `gnrc` IEEE 802.15.4 security implementation.
I remembered that I had a branch lying around, where I implemented the replay protection, but I did not release it as a PR because I was not satisfied with the quality, nor was I sure if I correctly understood the descriptor relations and lookup procedures from the specification. But after the summit I gave it another look.

This PR does not concern dynamic key management in the sense of key generation, distribution and update. But it implements a constrained variant of the internal descriptor organization, explained in the specification, to keep track of peer devices and key selection, to realize replay protection. I think the descriptors are more of a prerequisite for IEEE 802.15.4 key management.

Additionally, I wrote a shell tool `iwpansec` that can be used to manage keys and devices statically for testing.
Regarding LL security, it shall serve the same purpose as [wpan-tools](https://github.com/linux-wpan/wpan-tools/tree/nl802154_llsec) in Linux. But of course it is more limited than that. Ideally, devices should be discovered dynamically, (maybe from the neighbor cache), and keys and parameters should be exchanged properly between devices. But for testing, the tool should be fine.

More explanation can be found in the code comments.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

This is not so heavily tested yet.

Setup two boards running our `gnrc_networking` example, add each others device addresses and enter the (pseudo-)peering command, which does not actually send a peering request but assumes that the peering succeeds.

board 1:
```
2022-09-11 10:03:19,166 # Iface  7  HWaddr: 00:01  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2022-09-11 10:03:19,167 #           
2022-09-11 10:03:19,172 #           Long HWaddr: 4E:49:6F:54:4F:76:00:01 
2022-09-11 10:03:19,179 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2022-09-11 10:03:19,185 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:88  MTU:1280  HL:64  RTR  
2022-09-11 10:03:19,187 #           6LO  IPHC  
2022-09-11 10:03:19,194 #           Source address length: 8
2022-09-11 10:03:19,196 #           Link type: wireless
2022-09-11 10:03:19,199 #           inet6 addr: fe80::4c49:6f54:4f76:1  scope: link  VAL
2022-09-11 10:03:19,201 #           inet6 group: ff02::2
2022-09-11 10:03:19,205 #           inet6 group: ff02::1
2022-09-11 10:03:19,207 #           inet6 group: ff02::1:ff76:1
2022-09-11 10:03:19,208 #           
2022-09-11 10:03:19,210 #           Statistics for Layer 2
2022-09-11 10:03:19,214 #             RX packets 2  bytes 114
2022-09-11 10:03:19,219 #             TX packets 3 (Multicast: 3)  bytes 171
2022-09-11 10:03:19,223 #             TX succeeded 3 errors 0
2022-09-11 10:03:19,226 #           Statistics for IPv6
2022-09-11 10:03:19,229 #             RX packets 0  bytes 0
2022-09-11 10:03:19,231 #             TX packets 3 (Multicast: 3)  bytes 192
2022-09-11 10:03:19,234 #             TX succeeded 3 errors 0
2022-09-11 10:03:19,234 #

$iwpansec 7 dev add 0x23 00:00 4E:49:6F:54:4F:76:00:00
$iwpansec 7 dev peer 0 0x23 00:00 4E:49:6F:54:4F:76:00:00

```

board 2:
```
2022-09-11 10:03:01,271 # Iface  7  HWaddr: 00:00  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2022-09-11 10:03:01,272 #           
2022-09-11 10:03:01,277 #           Long HWaddr: 4E:49:6F:54:4F:76:00:00 
2022-09-11 10:03:01,283 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2022-09-11 10:03:01,293 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:88  MTU:1280  HL:64  RTR  
2022-09-11 10:03:01,295 #           6LO  IPHC  
2022-09-11 10:03:01,296 #           Source address length: 8
2022-09-11 10:03:01,299 #           Link type: wireless
2022-09-11 10:03:01,313 #           inet6 addr: fe80::4c49:6f54:4f76:0  scope: link  VAL
2022-09-11 10:03:01,315 #           inet6 group: ff02::2
2022-09-11 10:03:01,316 #           inet6 group: ff02::1
2022-09-11 10:03:01,317 #           inet6 group: ff02::1:ff76:0
2022-09-11 10:03:01,318 #           
2022-09-11 10:03:01,319 #           Statistics for Layer 2
2022-09-11 10:03:01,322 #             RX packets 0  bytes 0
2022-09-11 10:03:01,323 #             TX packets 2 (Multicast: 2)  bytes 114
2022-09-11 10:03:01,326 #             TX succeeded 2 errors 0
2022-09-11 10:03:01,331 #           Statistics for IPv6
2022-09-11 10:03:01,336 #             RX packets 0  bytes 0
2022-09-11 10:03:01,338 #             TX packets 2 (Multicast: 2)  bytes 128
2022-09-11 10:03:01,341 #             TX succeeded 2 errors 0
2022-09-11 10:03:01,342 # 

$iwpansec 7 dev add 0x23 00:01 4E:49:6F:54:4F:76:00:01
$iwpansec 7 dev peer 0 0x23 00:01 4E:49:6F:54:4F:76:00:01

```

The boards should be able to ping each other after that.

```
> ping fe80::4c49:6f54:4f76:1%7
2022-09-11 10:07:15,042 # ping fe80::4c49:6f54:4f76:1%7
2022-09-11 10:07:15,057 # 12 bytes from fe80::4c49:6f54:4f76:1%7: icmp_seq=0 ttl=64 rssi=-61 dBm time=7.582 ms
2022-09-11 10:07:16,053 # 12 bytes from fe80::4c49:6f54:4f76:1%7: icmp_seq=1 ttl=64 rssi=-61 dBm time=11.427 ms
2022-09-11 10:07:17,043 # 12 bytes from fe80::4c49:6f54:4f76:1%7: icmp_seq=2 ttl=64 rssi=-61 dBm time=10.796 ms
2022-09-11 10:07:17,043 # 
2022-09-11 10:07:17,047 # --- fe80::4c49:6f54:4f76:1%7 PING statistics ---
2022-09-11 10:07:17,053 # 3 packets transmitted, 3 packets received, 0% packet loss
2022-09-11 10:07:17,057 # round-trip min/avg/max = 7.582/9.935/11.427 ms
```

Now, reset one board and repeat the setup on that board.
The ping intentionally no longer works, because the other board identifies the frame as a replay.

I know replay protection is not so useful until we store the data structures on persistent storage,
but it is good for testing and if I had to implement the persistent storage for LL security and proper key management,
I would go on from here.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

I think before we tackle #16844, we must know what exactly must be stored persistently. This implementation adds the internal data structures that must be stored.