### PR TITLE
nanocoap_sock: consitfy remote

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -181,8 +181,12 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
  * @returns     0 on success
  * @returns     <0 on error
  */
-int nanocoap_sock_connect(nanocoap_sock_t *sock, sock_udp_ep_t *local,
-                          sock_udp_ep_t *remote);
+static inline int nanocoap_sock_connect(nanocoap_sock_t *sock,
+                                        const sock_udp_ep_t *local,
+                                        const sock_udp_ep_t *remote)
+{
+    return sock_udp_create(sock, local, remote, 0);
+}
 
 /**
  * @brief   Create a CoAP client socket by URL
@@ -362,8 +366,8 @@ ssize_t nanocoap_sock_request_cb(sock_udp_t *sock, coap_pkt_t *pkt,
  * @returns     length of response on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
-                         sock_udp_ep_t *remote, size_t len);
+ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
+                         const sock_udp_ep_t *remote, size_t len);
 
 /**
  * @brief   Simple synchronous CoAP (confirmable) get
@@ -376,8 +380,8 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
  * @returns     length of response payload on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, void *buf,
-                     size_t len);
+ssize_t nanocoap_get(const sock_udp_ep_t *remote, const char *path,
+                     void *buf, size_t len);
 
 /**
  * @brief   Initialize block request context
@@ -392,7 +396,7 @@ ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, void *buf,
  * @retval      <0      Error (see @ref nanocoap_sock_connect for details)
  */
 static inline int nanocoap_block_request_init(coap_block_request_t *ctx,
-                                              sock_udp_ep_t *remote,
+                                              const sock_udp_ep_t *remote,
                                               const char *path,
                                               uint8_t method,
                                               coap_blksize_t blksize)

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -56,15 +56,6 @@ static uint16_t _get_id(void)
     return atomic_fetch_add_u16(&id, 1);
 }
 
-int nanocoap_sock_connect(nanocoap_sock_t *sock, sock_udp_ep_t *local, sock_udp_ep_t *remote)
-{
-    if (!remote->port) {
-        remote->port = COAP_PORT;
-    }
-
-    return sock_udp_create(sock, local, remote, 0);
-}
-
 static int _get_error(const coap_pkt_t *pkt)
 {
     switch (coap_get_code_class(pkt)) {
@@ -370,8 +361,8 @@ ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
     return _sock_put_post(sock, path, COAP_METHOD_POST, request, len, response, len_max);
 }
 
-ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
-                         sock_udp_ep_t *remote, size_t len)
+ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
+                         const sock_udp_ep_t *remote, size_t len)
 {
     int res;
     nanocoap_sock_t sock;
@@ -387,7 +378,7 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
     return res;
 }
 
-ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, void *buf, size_t len)
+ssize_t nanocoap_get(const sock_udp_ep_t *remote, const char *path, void *buf, size_t len)
 {
     int res;
     nanocoap_sock_t sock;
@@ -537,6 +528,10 @@ int nanocoap_sock_url_connect(const char *url, nanocoap_sock_t *sock)
     if (sock_udp_name2ep(&remote, hostport) < 0) {
         DEBUG("nanocoap: invalid URL\n");
         return -EINVAL;
+    }
+
+    if (!remote.port) {
+        remote.port = COAP_PORT;
     }
 
     return nanocoap_sock_connect(sock, NULL, &remote);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `remote` argument is passed to a function that accepts a `const` pointer.
Since we might want to store `remote` in flash or use the one returned by `coap_request_ctx_get_remote_udp()`, also make the `remote` argument `const` in nanoCoAP sock.


### Testing procedure

Green CI
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
