### PR TITLE
WIP: drivers/dht: use IRQs for decoding

### DIFF
--- a/drivers/dht/Makefile.dep
+++ b/drivers/dht/Makefile.dep
@@ -1,2 +1,4 @@
-USEMODULE += xtimer
 FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+
+USEMODULE += ztimer_usec

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -23,25 +23,27 @@
  * @}
  */
 
+#include <errno.h>
 #include <stdint.h>
 #include <string.h>
 
-#include "log.h"
 #include "assert.h"
-#include "xtimer.h"
-#include "timex.h"
-#include "periph/gpio.h"
-
 #include "dht.h"
 #include "dht_params.h"
+#include "log.h"
+#include "periph/gpio.h"
+#include "time_units.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG            0
 #include "debug.h"
 
 /* Every pulse send by the DHT longer than 40µs is interpreted as 1 */
 #define PULSE_WIDTH_THRESHOLD   (40U)
-/* If an expected pulse is not detected within 1000µs, something is wrong */
-#define TIMEOUT                 (1000U)
+/* The communication should take at most 41 * (70 us + 50 us) = 4,920 us
+ * theoretically. If it didn't complete after 10,000 us, we can be sure it
+ * failed */
+#define TIMEOUT_US              (10000U)
 /* The DHT sensor cannot measure more than once a second */
 #define DATA_HOLD_TIME          (US_PER_SEC)
 /* The start signal by pulling data low for at least 18ms and then up for
@@ -49,61 +51,29 @@
 #define START_LOW_TIME          (20U * US_PER_MS)
 #define START_HIGH_TIME         (40U)
 
+#define INIT_DELAY_SEC          (2U)
+
+enum {
+    BYTEPOS_HUMIDITY_INTEGRAL = 0,
+    BYTEPOS_HUMIDITY_FRACTUAL = 1,
+    BYTEPOS_TEMPERATURE_INTEGRAL = 2,
+    BYTEPOS_TEMPERATURE_FRACTUAL = 3,
+    BYTEPOS_CHECKSUM = 4,
+};
+
 static inline void _reset(dht_t *dev)
 {
     gpio_init(dev->params.pin, GPIO_OUT);
     gpio_set(dev->params.pin);
 }
 
-/**
- * @brief   Wait until the pin @p pin has level @p expect
- *
- * @param   pin     GPIO pin to wait for
- * @param   expect  Wait until @p pin has this logic level
- * @param   timeout Timeout in µs
- *
- * @retval  0       Success
- * @retval  -1      Timeout occurred before level was reached
- */
-static inline int _wait_for_level(gpio_t pin, bool expect, unsigned timeout)
-{
-    while (((gpio_read(pin) > 0) != expect) && timeout) {
-        xtimer_usleep(1);
-        timeout--;
-    }
-
-    return (timeout > 0) ? 0 : -1;
-}
-
-static int _read(uint8_t *dest, gpio_t pin)
-{
-    DEBUG("[dht] read\n");
-    uint16_t res = 0;
-
-    for (int i = 0; i < 8; i++) {
-        uint32_t start, end;
-        res <<= 1;
-        /* measure the length between the next rising and falling flanks (the
-         * time the pin is high - smoke up :-) */
-        if (_wait_for_level(pin, 1, TIMEOUT)) {
-            return -1;
-        }
-        start = xtimer_now_usec();
-
-        if (_wait_for_level(pin, 0, TIMEOUT)) {
-            return -1;
-        }
-        end = xtimer_now_usec();
-
-        /* if the high phase was more than 40us, we got a 1 */
-        if ((end - start) > PULSE_WIDTH_THRESHOLD) {
-            res |= 0x0001;
-        }
-    }
-
-    *dest = res;
-    return 0;
-}
+struct dht_irq_data {
+    mutex_t sync;
+    uint32_t time;
+    gpio_t pin;
+    uint8_t data[5];
+    int8_t bit_pos;
+};
 
 int dht_init(dht_t *dev, const dht_params_t *params)
 {
@@ -117,90 +87,143 @@ int dht_init(dht_t *dev, const dht_params_t *params)
 
     _reset(dev);
 
-    xtimer_msleep(2000);
+    if (IS_USED(MODULE_ZTIMER_SEC)) {
+        ztimer_sleep(ZTIMER_SEC, INIT_DELAY_SEC);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer_sleep(ZTIMER_MSEC, INIT_DELAY_SEC * MS_PER_SEC);
+    }
+    else {
+        ztimer_sleep(ZTIMER_USEC, INIT_DELAY_SEC * US_PER_SEC);
+    }
 
     DEBUG("[dht] dht_init: success\n");
-    return DHT_OK;
+    return 0;
 }
+
+static void gpio_cb(void *_arg)
+{
+    struct dht_irq_data *arg = _arg;
+    uint32_t now = ztimer_now(ZTIMER_USEC);
+
+    if (arg->bit_pos >= 40) {
+        /* stray IRQ, ignoring */
+        return;
+    }
+
+    if (gpio_read(arg->pin)) {
+        arg->time = now;
+        return;
+    }
+
+    int8_t pos = arg->bit_pos++;
+    if (pos == -1) {
+        /* start signal received, ignore */
+        return;
+    }
+
+    unsigned bit = (now - arg->time) > PULSE_WIDTH_THRESHOLD;
+
+    if (bit) {
+        arg->data[pos >> 3] |= (0x80U >> (pos & 7));
+    }
+
+    if (pos == 39) {
+        /* last bit received, signal that we are done now */
+        mutex_unlock(&arg->sync);
+    }
+};
+
+static void timeout_cb(void *_arg)
+{
+    struct dht_irq_data *arg = _arg;
+
+    /* something went wrong, unblocking waiting thread */
+    mutex_unlock(&arg->sync);
+};
 
 int dht_read(dht_t *dev, int16_t *temp, int16_t *hum)
 {
-    uint8_t csum;
-    uint8_t raw_temp_i, raw_temp_d, raw_hum_i, raw_hum_d;
-
     assert(dev);
 
-    uint32_t now_us = xtimer_now_usec();
+    uint32_t now_us = ztimer_now(ZTIMER_USEC);
     if ((now_us - dev->last_read_us) > DATA_HOLD_TIME) {
         /* send init signal to device */
+        gpio_init(dev->params.pin, GPIO_OUT);
         gpio_clear(dev->params.pin);
-        xtimer_usleep(START_LOW_TIME);
+        ztimer_sleep(ZTIMER_USEC, START_LOW_TIME);
         gpio_set(dev->params.pin);
-        xtimer_usleep(START_HIGH_TIME);
+        ztimer_sleep(ZTIMER_USEC, START_HIGH_TIME);
 
-        /* sync on device */
-        gpio_init(dev->params.pin, dev->params.in_mode);
-        if (_wait_for_level(dev->params.pin, 1, TIMEOUT)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
-        }
+        struct dht_irq_data data = {
+            .sync = MUTEX_INIT_LOCKED,
+            .pin = dev->params.pin,
+            /* first bit is start signal, only afterwards actual data is
+             * received */
+            .bit_pos = -1,
+        };
+        ztimer_t timeout = {
+            .callback = timeout_cb,
+            .arg = &data,
+        };
 
-        if (_wait_for_level(dev->params.pin, 0, TIMEOUT)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
-        }
+        ztimer_set(ZTIMER_USEC, &timeout, TIMEOUT_US);
 
-        /*
-         * data is read in sequentially, highest bit first:
-         *  40 .. 24  23   ..   8  7  ..  0
-         * [humidity][temperature][checksum]
-         */
-
-        /* read the humidity, temperature, and checksum bits */
-        if (_read(&raw_hum_i, dev->params.pin)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
-        }
-        if (_read(&raw_hum_d, dev->params.pin)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
-        }
-        if (_read(&raw_temp_i, dev->params.pin)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
-        }
-        if (_read(&raw_temp_d, dev->params.pin)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
+        /* actual reception is done in IRQ */
+        if (gpio_init_int(dev->params.pin, dev->params.in_mode, GPIO_BOTH,
+                          gpio_cb, &data)) {
+            ztimer_remove(ZTIMER_USEC, &timeout);
+            /* IRQs not supported on given GPIO pin or with given mode */
+            return -ENOTSUP;
         }
 
-        if (_read(&csum, dev->params.pin)) {
-            _reset(dev);
-            return DHT_TIMEOUT;
-        }
+        /* wait for IRQ handler to collect all bits */
+        mutex_lock(&data.sync);
+        /* remove timer (doesn't hurt if it fired by now in case of timeout) */
+        ztimer_remove(ZTIMER_USEC, &timeout);
+        gpio_irq_disable(dev->params.pin);
 
         /* Bring device back to defined state - so we can trigger the next reading
          * by pulling the data pin low again */
         _reset(dev);
 
+        if (data.bit_pos == -1) {
+            DEBUG_PUTS("[dht] Not a single bit received, no DHT connected?");
+            return -ENXIO;
+        }
+
+        if (data.bit_pos != 40) {
+            DEBUG_PUTS("[dht] Timeout before all bits received");
+            return -ETIMEDOUT;
+        }
+
+        DEBUG("[dht] RAW data: 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x\n",
+              (unsigned)data.data[0], (unsigned)data.data[1],
+              (unsigned)data.data[2], (unsigned)data.data[3],
+              (unsigned)data.data[4]);
+
         /* validate the checksum */
-        uint8_t sum = (raw_temp_i) + (raw_temp_d) + (raw_hum_i) + (raw_hum_d);
-        if (sum != csum) {
+        uint8_t sum = 0;
+        for (uint_fast8_t i = 0; i < 4; i++) {
+            sum += data.data[i];
+        }
+
+        if (sum != data.data[BYTEPOS_CHECKSUM]) {
             DEBUG("[dht] error: checksum doesn't match\n");
-            return DHT_NOCSUM;
+            return -EIO;
         }
 
-        /* parse the RAW values */
-        DEBUG("[dht] RAW values: temp: %2i.%i hum: %2i.%i\n", (int)raw_temp_i,
-            (int)raw_temp_d, (int)raw_hum_i, (int)raw_hum_d);
+        dev->last_val.humidity = data.data[BYTEPOS_HUMIDITY_INTEGRAL] * 10
+                               + data.data[BYTEPOS_HUMIDITY_FRACTUAL];
+        /* MSB for integral temperature byte gives sign, remaining is abs() of
+         * value (beware: this is not two's complement!) */
+        bool is_negative = data.data[BYTEPOS_TEMPERATURE_INTEGRAL] & 0x80;
+        data.data[BYTEPOS_TEMPERATURE_INTEGRAL] &= 0x7f;
+        dev->last_val.temperature = data.data[BYTEPOS_TEMPERATURE_INTEGRAL] * 10
+                                  + data.data[BYTEPOS_TEMPERATURE_FRACTUAL];
 
-        dev->last_val.humidity = raw_hum_i * 10 + raw_hum_d;
-        /* MSB set means negative temperature on DHT22. Will always be 0 on DHT11 */
-        if (raw_temp_i & 0x80) {
-            dev->last_val.temperature = -((raw_temp_i & ~0x80) * 10 + raw_temp_d);
-        }
-        else {
-            dev->last_val.temperature = raw_temp_i * 10 + raw_temp_d;
+        if (is_negative) {
+            dev->last_val.temperature = -dev->last_val.temperature;
         }
 
         /* update time of last measurement */
@@ -215,5 +238,5 @@ int dht_read(dht_t *dev, int16_t *temp, int16_t *hum)
         *hum = dev->last_val.humidity;
     }
 
-    return DHT_OK;
+    return 0;
 }


### PR DESCRIPTION
### Contribution description

This changed the DHT implementation to use an GPIO IRQ for decoding the received data instead of busy polling. This should improve real time behavior of the system and improve robustness of the reception under load.

### Testing procedure

I used an Nucleo-F767ZI with the DHT data pin connected to the bottom left pin on the bottom left female pin header and the following patch:

``` patch
diff --git a/examples/saul/Makefile b/examples/saul/Makefile
index 7f2ca1e297..4b999c3490 100644
--- a/examples/saul/Makefile
+++ b/examples/saul/Makefile
@@ -14,6 +14,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 # additional modules for debugging:
 USEMODULE += ps
+USEMODULE += dht
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
@@ -24,3 +25,5 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+CFLAGS += '-DDHT_PARAM_PIN=GPIO_PIN(PORT_G, 0)'
```

For some reason, the reading fails every second time because the `ztimer_sleep(ZTIMER_USEC, START_LOW_TIME);` (with `START_LOW_TIME == (20U * US_PER_MS)`) returns every second time after 11 µs instead of after 20 ms. I could reproduce the issue also on the nRF52840 DK.

This indicates either a bug in this driver or in ztimer.

### Issues/PRs references

None