### PR TITLE
sys/net/uhcp: make uhcp thread stacksize configurable

### DIFF
--- a/sys/include/net/uhcp.h
+++ b/sys/include/net/uhcp.h
@@ -50,6 +50,11 @@ extern "C" {
 /** @brief UHCP port number (as string for e.g., getaddrinfo() service arg */
 #define UHCP_PORT_STR   "12345"
 
+/** @brief UHCP thread stacksize */
+#ifndef UHCP_THREAD_STACKSIZE
+#define UHCP_THREAD_STACKSIZE (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
+
 /** @brief Enum containing possible UHCP packet types */
 typedef enum {
     UHCP_REQ,               /**< packet is a request packet */

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -86,8 +86,8 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime,
 
 extern void uhcp_client(uhcp_iface_t iface);
 
-static char _uhcp_client_stack[THREAD_STACKSIZE_DEFAULT +
-                               THREAD_EXTRA_STACKSIZE_PRINTF];
+static char _uhcp_client_stack[UHCP_THREAD_STACKSIZE];
+
 static msg_t _uhcp_msg_queue[4];
 
 static void* uhcp_client_thread(void *arg)


### PR DESCRIPTION
### Contribution description

Quite a simple PR, just making the stacksize of the uhcp client thread configurable.

### Testing procedure

Straightforward. Just (re)defining the UCHP_THREAD_STACKSIZE macro it in another app and then checking its size with the ps command in the shell. 

### Issues/PRs references

-