### PR TITLE
drivers/sht1x: fix doccheck

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -8119,7 +8119,6 @@ drivers/include/pn532\.h:[0-9]+: warning: Member PN532_FW_FEATURES\(fwver\) \(ma
 drivers/include/pn532\.h:[0-9]+: warning: Member PN532_FW_REVISION\(fwver\) \(macro definition\) of group drivers_pn532 is not documented\.
 drivers/include/pn532\.h:[0-9]+: warning: Member PN532_FW_VERSION\(fwver\) \(macro definition\) of group drivers_pn532 is not documented\.
 drivers/include/pn532\.h:[0-9]+: warning: Member PN532_IC_VERSION\(fwver\) \(macro definition\) of group drivers_pn532 is not documented\.
-drivers/include/sht1x\.h:[0-9]+: warning: return value '\-EBADMSG' of sht1x_read has multiple documentation sections
 drivers/include/sht2x\.h:[0-9]+: warning: Member SHT2X_USER_EOB_MASK \(macro definition\) of group drivers_sht2x is not documented\.
 drivers/include/sht2x\.h:[0-9]+: warning: Member SHT2X_USER_HEATER_MASK \(macro definition\) of group drivers_sht2x is not documented\.
 drivers/include/sht2x\.h:[0-9]+: warning: Member SHT2X_USER_OTP_MASK \(macro definition\) of group drivers_sht2x is not documented\.
@@ -10029,11 +10028,6 @@ drivers/seesaw_soil/include/seesaw_soil_regs\.h:[0-9]+: warning: Member SEESAW_S
 drivers/sgp30/include/sgp30_params\.h:[0-9]+: warning: Member SGP30_PARAMS \(macro definition\) of file sgp30_params\.h is not documented\.
 drivers/sgp30/include/sgp30_params\.h:[0-9]+: warning: Member SGP30_PARAM_I2C_DEV \(macro definition\) of file sgp30_params\.h is not documented\.
 drivers/sgp30/include/sgp30_params\.h:[0-9]+: warning: Member SGP30_SAUL_INFO \(macro definition\) of file sgp30_params\.h is not documented\.
-drivers/sht1x/include/sht1x_params\.h:[0-9]+: warning: Member SHT1X_PARAMS \(macro definition\) of file sht1x_params\.h is not documented\.
-drivers/sht1x/include/sht1x_params\.h:[0-9]+: warning: Member SHT1X_PARAM_CLK \(macro definition\) of file sht1x_params\.h is not documented\.
-drivers/sht1x/include/sht1x_params\.h:[0-9]+: warning: Member SHT1X_PARAM_DATA \(macro definition\) of file sht1x_params\.h is not documented\.
-drivers/sht1x/include/sht1x_params\.h:[0-9]+: warning: Member SHT1X_PARAM_VDD \(macro definition\) of file sht1x_params\.h is not documented\.
-drivers/sht1x/include/sht1x_params\.h:[0-9]+: warning: Member SHT1X_SAULINFO \(macro definition\) of file sht1x_params\.h is not documented\.
 drivers/sht2x/include/sht2x_params\.h:[0-9]+: warning: Member SHT2X_PARAMS_DEFAULT \(macro definition\) of file sht2x_params\.h is not documented\.
 drivers/sht2x/include/sht2x_params\.h:[0-9]+: warning: Member SHT2X_PARAM_CRC_MODE \(macro definition\) of file sht2x_params\.h is not documented\.
 drivers/sht2x/include/sht2x_params\.h:[0-9]+: warning: Member SHT2X_PARAM_I2C_ADDR \(macro definition\) of file sht2x_params\.h is not documented\.

--- a/dist/tools/doccheck/generic_exclude_patterns
+++ b/dist/tools/doccheck/generic_exclude_patterns
@@ -17,3 +17,6 @@ warning: Member LED[0-9]_PIN_NUM \(macro definition\) of
 warning: Member LED[0-9]_PORT \(macro definition\) of
 warning: Member LED[0-9]_PORT_NUM \(macro definition\) of
 warning: Member LED[0-9]_TOGGLE \(macro definition\) of
+warning: Member SHT1X_PARAMS \(macro definition\) of
+warning: Member SHT1X_PARAM_[A-Z0-9_]* \(macro definition\) of
+warning: Member SHT1X_SAULINFO \(macro definition\) of

--- a/drivers/include/sht1x.h
+++ b/drivers/include/sht1x.h
@@ -125,9 +125,8 @@ int16_t sht1x_humidity(const sht1x_dev_t *dev, uint16_t raw, int16_t temp);
  *
  * @retval  0         Success
  * @retval -EIO       IO failure (`gpio_init()` failed)
- * @retval -EBADMSG   CRC-8 checksum didn't match (--> Retry)
+ * @retval -EBADMSG   CRC-8 checksum didn't match
  * @retval -EINVAL    Passed `NULL` for dev or for both `temp` and `hum`
- * @retval -EBADMSG   CRC checksum didn't match
  * @retval -ECANCELED Measurement timed out
  * @retval -EPROTO    Sensor did not acknowledge command
  *

--- a/drivers/sht1x/include/sht1x_params.h
+++ b/drivers/sht1x/include/sht1x_params.h
@@ -32,15 +32,29 @@ extern "C" {
  * @{
  */
 #ifndef SHT1X_PARAM_CLK
+/**
+ * @brief   SHT1x the clock pin
+ */
 #define SHT1X_PARAM_CLK               (GPIO_PIN(1, 25))
 #endif
 #ifndef SHT1X_PARAM_DATA
+/**
+ * @brief   SHT1x the data pin
+ */
 #define SHT1X_PARAM_DATA              (GPIO_PIN(1, 26))
 #endif
 #ifndef SHT1X_PARAM_VDD
+/**
+ * @brief   SHT1x the supply voltage
+ *
+ * @see sht1x_vdd_t
+ */
 #define SHT1X_PARAM_VDD               (SHT1X_VDD_3_5V)
 #endif
 #ifndef SHT1X_PARAMS
+/**
+ * @brief   The initialization parameters for the SHT1x driver
+ */
 #define SHT1X_PARAMS                  { .clk = SHT1X_PARAM_CLK,  \
                                         .data = SHT1X_PARAM_DATA, \
                                         .vdd = SHT1X_PARAM_VDD }


### PR DESCRIPTION
### Contribution description

- replace auto-generated patterns with generic ones
- fix `warning: return value '\-EBADMSG' of sht1x_read has multiple documentation sections`

### Testing procedure

The CI will do

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18597#issuecomment-1248232952