### PR TITLE
core/mutex: fix typo in docs

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -67,7 +67,7 @@
  *    blocking.
  * 2. If the mutex has a value of `MUTEX_LOCKED`, it will be changed to point to
  *    the `thread_t` of the running thread. The single item list is terminated
- *    be setting the `thread_t::rq_entry.next` of the running thread to `NULL`.
+ *    by setting the `thread_t::rq_entry.next` of the running thread to `NULL`.
  *    The running thread blocks as described below.
  * 3. Otherwise, the current thread is inserted into the list of waiting
  *    threads sorted by thread priority. The running thread blocks as described


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Was reading the sacred texts and spotted this one.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
