### PR TITLE
core/msg.c: irq was not restored properly 

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -492,6 +492,7 @@ void msg_queue_print(void)
 
     if (msg_counter < 1) {
         /* no msg queue */
+        irq_restore(state);
         printf("No messages or no message queue\n");
         return;
     }


### PR DESCRIPTION
### Contribution description
The irqs are not restored properly in function `msg_queue_print()`