### PR TITLE
sys/string_utils : new (header-only) module for string utilities

### DIFF
--- a/sys/fido2/ctap/ctap.c
+++ b/sys/fido2/ctap/ctap.c
@@ -19,10 +19,11 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "byteorder.h"
 #include "errno.h"
 #include "fmt.h"
+#include "string_utils.h"
 #include "ztimer.h"
-#include "byteorder.h"
 
 #include "fido2/ctap/transport/ctap_transport.h"
 #include "fido2/ctap.h"
@@ -433,7 +434,7 @@ static int _reset(void)
     _rem_pin_att_boot = CTAP_PIN_MAX_ATTS_BOOT;
 
     /* invalidate AES CCM key */
-    memset(_state.cred_key, 0, sizeof(_state.cred_key));
+    explicit_bzero(_state.cred_key, sizeof(_state.cred_key));
     _state.cred_key_is_initialized = false;
 
     _state.config.options |= CTAP_INFO_OPTIONS_FLAG_PLAT;
@@ -589,7 +590,7 @@ static int _make_credential(ctap_req_t *req_raw)
 
 done:
     /* clear rk to remove private key from memory */
-    memset(&k, 0, sizeof(k));
+    explicit_bzero(&k, sizeof(k));
     return ret;
 }
 
@@ -748,7 +749,7 @@ static int _get_assertion(ctap_req_t *req_raw)
 done:
     /* clear rk to remove private key from memory */
     if (rk) {
-        memset(rk, 0, sizeof(*rk));
+        explicit_bzero(rk, sizeof(*rk));
     }
     return ret;
 }
@@ -831,7 +832,7 @@ static int _get_next_assertion(void)
 done:
     /* clear rk to remove private key from memory */
     if (rk) {
-        memset(rk, 0, sizeof(*rk));
+        explicit_bzero(rk, sizeof(*rk));
     }
     return ret;
 }
@@ -1018,7 +1019,7 @@ static int _set_pin(ctap_client_pin_req_t *req)
 
 done:
     /* clear key agreement key */
-    memset(&_state.ag_key, 0, sizeof(_state.ag_key));
+    explicit_bzero(&_state.ag_key, sizeof(_state.ag_key));
     return ret;
 }
 
@@ -1159,7 +1160,7 @@ static int _change_pin(ctap_client_pin_req_t *req)
 
 done:
     /* clear key agreement key */
-    memset(&_state.ag_key, 0, sizeof(_state.ag_key));
+    explicit_bzero(&_state.ag_key, sizeof(_state.ag_key));
     return ret;
 }
 
@@ -1254,7 +1255,7 @@ static int _get_pin_token(ctap_client_pin_req_t *req)
 
 done:
     /* clear key agreement key */
-    memset(&_state.ag_key, 0, sizeof(_state.ag_key));
+    explicit_bzero(&_state.ag_key, sizeof(_state.ag_key));
     return ret;
 }
 

--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_string_utils    Utility functions that are missing in
+ *                                  `string.h`
+ * @ingroup     sys
+ *
+ * This header provides utility functions that the standard C libs `string.h`
+ * lacks, such as @ref explicit_bzero
+ *
+ * @{
+ *
+ * @file
+ * @brief       Utility functions that are missing in `string.h`
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+/* if explicit_bzero() is provided by standard C lib, it may be defined in
+ * either `string.h` or `strings.h`, so just include both here */
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+
+#include "kernel_defines.h"
+
+#ifndef STRING_UTILS_H
+#define STRING_UTILS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* explicit_bzero is provided if:
+ * - glibc is used as C lib (only with board natvie)
+ * - newlib is used and __BSD_VISIBILE is set
+ *      - except for ESP8266, which is using an old version of newlib without it
+ * - picolibc is used and __BSD_VISIBLE is set
+ *
+ * for all other cases, we provide it here
+ */
+#if !defined(BOARD_NATIVE) \
+    && !(IS_USED(MODULE_PICOLIBC) && __BSD_VISIBLE) \
+    && !(IS_USED(MODULE_NEWLIB) && __BSD_VISIBLE && !defined(MCU_ESP8266))
+
+/**
+ * @brief   Like `memset(dest, 0, n_bytes)`, but secure
+ *
+ * Unlike `memset(dest, 0, n_bytes)`, this will zero out the memory even in
+ * cases the compiler would optimize out the call to `memset()`.
+ *
+ * @note    This is only sensible to use for sensitive data. For non-sensitive
+ *          data, keep using `memset()` for performance reasons.
+ *
+ * @param[in,out]   dest        Memory to clear
+ * @param[in]       n_bytes     Size of memory to clear in bytes
+ */
+static inline void explicit_bzero(void *dest, size_t n_bytes)
+{
+    volatile uint8_t *tmp = dest;
+    for (size_t i = 0; i < n_bytes; i++) {
+        tmp[i] = 0;
+    }
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STRING_UTILS_H */
+/** @} */

--- a/sys/net/credman/credman.c
+++ b/sys/net/credman/credman.c
@@ -16,9 +16,10 @@
  * @author  Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
  */
 
-#include "net/credman.h"
-#include "mutex.h"
 #include "kernel_defines.h"
+#include "mutex.h"
+#include "net/credman.h"
+#include "string_utils.h"
 
 #include <assert.h>
 #include <string.h>
@@ -395,7 +396,7 @@ void credman_delete(credman_tag_t tag, credman_type_t type)
     mutex_lock(&_mutex);
     int pos = _find_credential_pos(tag, type, NULL);
     if (pos >= 0) {
-        memset(&credentials[pos], 0, sizeof(credman_credential_t));
+        explicit_bzero(&credentials[pos], sizeof(credman_credential_t));
         used--;
     }
     mutex_unlock(&_mutex);


### PR DESCRIPTION
### Contribution description

This header-only module provides a `string_utils.h` that currently only provides the non-standard function `explicit_bzero()` to securely wipe memory. It may be extended with other utility functions in the future.

Using this, the insecure memory wiping in `sys/fido2` and `sys/net/credman` is fixed.

### Testing procedure

Code review should be sufficient here, as the change is rather trivial.

https://godbolt.org/z/rzxbrhxTn shows an example where `memset()` is optimized out, but `explicit_bzero()` is (under the same circumstances) not.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/10751