### PR TITLE
event_periodic_callback: remove unnecessary dependency

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -528,7 +528,6 @@ endif
 ifneq (,$(filter event_periodic_callback,$(USEMODULE)))
   USEMODULE += event_callback
   USEMODULE += event_periodic
-  USEMODULE += event_thread
 endif
 
 ifneq (,$(filter emcute,$(USEMODULE)))

--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -27,7 +27,6 @@
 
 #include "event/callback.h"
 #include "event/periodic.h"
-#include "event/thread.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/event_periodic_callback/Makefile
+++ b/tests/event_periodic_callback/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += event_periodic_callback
+USEMODULE += event_thread
 USEMODULE += ztimer_msec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/event_periodic_callback/main.c
+++ b/tests/event_periodic_callback/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 
 #include "event/periodic_callback.h"
+#include "event/thread.h"
 
 static void _event_cb(void *ctx)
 {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Removes an unnecessary dependency I saw during the review #18598. Since I did not deactivate @maribu's auto-merge and did make a change request, it slipped into master.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/event_periodic_callback/` should still run and work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #18598
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
