### PR TITLE
boards/remote-revb: define default MTD device

### DIFF
--- a/boards/remote-revb/Kconfig
+++ b/boards/remote-revb/Kconfig
@@ -14,5 +14,13 @@ config BOARD_REMOTE_REVB
     select HAS_ARDUINO
     select HAVE_SAUL_ADC
     select HAVE_SAUL_GPIO
+    select HAS_SDCARD_SPI
+
+    select HAVE_MTD_SDCARD
+    select HAVE_SDCARD_SPI
+
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
+    select MODULE_MTD if MODULE_VFS_DEFAULT
+    select MODULE_SDCARD_SPI if MODULE_MTD
 
 source "$(RIOTBOARD)/common/remote/Kconfig"

--- a/boards/remote-revb/Makefile.dep
+++ b/boards/remote-revb/Makefile.dep
@@ -1,3 +1,13 @@
 USEMODULE += boards_common_remote
 
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_sdcard
+endif
+
+# default to using fatfs on SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif
+
 include $(RIOTBOARD)/common/remote/Makefile.dep

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -1,3 +1,4 @@
 include $(RIOTBOARD)/common/remote/Makefile.features
 
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += sdcard_spi

--- a/boards/remote-revb/board.c
+++ b/boards/remote-revb/board.c
@@ -24,6 +24,35 @@
 #include "cpu.h"
 #include "fancy_leds.h"
 
+#if defined(MODULE_MTD_SDCARD)
+#include "mtd_sdcard.h"
+#include "sdcard_spi.h"
+#include "sdcard_spi_params.h"
+
+#if defined(MODULE_FATFS_VFS)
+#include "fs/fatfs.h"
+#include "vfs_default.h"
+#endif
+
+/* this is provided by the sdcard_spi driver see drivers/sdcard_spi/sdcard_spi.c */
+extern sdcard_spi_t sdcard_spi_devs[ARRAY_SIZE(sdcard_spi_params)];
+
+mtd_sdcard_t mtd_sdcard_dev = {
+    .base = {
+        .driver = &mtd_sdcard_driver,
+    },
+    .sd_card = &sdcard_spi_devs[0],
+    .params = &sdcard_spi_params[0]
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd_sdcard_dev;
+
+#if IS_USED(MODULE_FATFS_VFS)
+VFS_AUTO_MOUNT(fatfs, VFS_MTD(mtd_sdcard_dev), VFS_DEFAULT_SD(0), 0);
+#endif /* MODULE_FATFS_VFS */
+
+#endif /* MODULE_MTD_SDCARD */
+
 /**
  * @brief Initialize the boards on-board LEDs
  *

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -23,6 +23,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "mtd.h"
 #include "board_common.h"
 
 #ifdef __cplusplus
@@ -121,6 +122,12 @@
 #define SDCARD_SPI_PARAM_POWER     GPIO_PIN(0, 6)
 #define SDCARD_SPI_PARAM_POWER_AH  false
 /** @} */
+
+/** Default MTD device */
+#define MTD_0 mtd0
+
+/** mtd flash emulation device */
+extern mtd_dev_t *mtd0;
 
 #ifdef __cplusplus
 } /* end extern "C" */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Add MTD configuration to the remote-revb board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

```
$ BOARD=remote-revb make -C tests/mtd_raw all flash term
[...]
2022-09-20 09:48:12,881 # main(): This is RIOT! (Version: 2022.10-devel-680-gf03f5-remote-revb-mtd)
2022-09-20 09:48:12,881 # Manual MTD test
2022-09-20 09:48:12,882 # init MTD_0… OK (1915 MiB)
> info
2022-09-20 09:48:52,809 # info
2022-09-20 09:48:52,809 # mtd devices: 1
2022-09-20 09:48:52,809 #  -=[ MTD_0 ]=-
2022-09-20 09:48:52,810 # sectors: 3921920
2022-09-20 09:48:52,810 # pages per sector: 1
2022-09-20 09:48:52,810 # page size: 512
2022-09-20 09:48:52,810 # total: 1915 MiB
```

```
$ BOARD=remote-revb make -C tests/vfs_default all flash term
[...]
2022-09-20 09:49:37,168 # main(): This is RIOT! (Version: 2022.10-devel-680-gf03f5-remote-revb-mtd)
2022-09-20 09:49:37,168 # mount points:
2022-09-20 09:49:37,168 # 	/sd0
2022-09-20 09:49:37,168 # 
2022-09-20 09:49:37,168 # data dir: /sd0
> ls /sd0
2022-09-20 09:50:07,623 # ls /sd0
2022-09-20 09:50:07,631 # DATA/
2022-09-20 09:50:07,632 # LOG.TXT	32144 B
2022-09-20 09:50:07,634 # FIFO.BIN	45 B
2022-09-20 09:50:07,636 # FIDX.BIN	4 B
2022-09-20 09:50:07,639 # TIME.TXT	10 B
2022-09-20 09:50:07,640 # total 4 files
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


