### PR TITLE
doc/getting-started: Add C++ standard library to the list

### DIFF
--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -70,7 +70,7 @@ developing for:
 
 For example, in Ubuntu the above tools can be installed with the following command:
 
-    sudo apt install git gcc-arm-none-eabi make gcc-multilib openocd gdb-multiarch doxygen wget unzip python3-serial
+    sudo apt install git gcc-arm-none-eabi make gcc-multilib libstdc++-arm-none-eabi-newlib openocd gdb-multiarch doxygen wget unzip python3-serial
 
 @details Running `BOARD=<INSERT_TARGET_BOARD_HERE> make info-programmers-supported` in your
          application folder lists the programmers supported by RIOT for the given board.


### PR DESCRIPTION
### Contribution description

Several packages (openthread, utensor, and openDSME coming in #18156) nowadays use C++, so it makes sense to add the C++ standard libraries to the set we recommend that be installed on a Debian-style system.

### Testing procedure

* Look at the documentation change; verify that the package exists on Ubuntu by entering it into the [Ubuntu package search](https://packages.ubuntu.com/search?keywords=libstdc%2B%2B-arm-none-eabi-newlib&searchon=names&suite=all&section=all)

* If you're feeling diligent, try building any C++ using application with the default set of packages, see that it can't find `#include <cmath>`, and then see the error go away once you install that package.

  (And maybe put yourself into the shoes of a newcomer who's trying to find out where to find this particular file)