### PR TITLE
boards: drop unused BTN0_PORT define

### DIFF
--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -66,7 +66,6 @@ extern "C" {
  * @name SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           _PORT->Group[PA]
 #define BTN0_PIN            GPIO_PIN(PA, 27)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -68,7 +68,6 @@ extern "C" {
  * @name    Button pin definitions
  * @{
  */
-#define BTN0_PORT                PORT->Group[0]
 #define BTN0_PIN                 GPIO_PIN(0, 18)
 #define BTN0_MODE                GPIO_IN_PU
 /** @} */

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -58,7 +58,6 @@ extern "C"
  * @name Macro for button S1/S2.
  * @{
  */
-#define BTN0_PORT           PORTD
 #define BTN0_PIN            GPIO_PIN(PORT_D, 1)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/samd10-xmini/include/board.h
+++ b/boards/samd10-xmini/include/board.h
@@ -56,7 +56,6 @@ extern "C" {
  * @name SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[PA]
 #define BTN0_PIN            GPIO_PIN(PA, 25)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/samd20-xpro/include/board.h
+++ b/boards/samd20-xpro/include/board.h
@@ -54,7 +54,6 @@ extern "C" {
  * @name SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[PA]
 #define BTN0_PIN            GPIO_PIN(PA, 15)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/samd21-xpro/include/board.h
+++ b/boards/samd21-xpro/include/board.h
@@ -57,7 +57,6 @@ extern "C" {
  * @name SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[PA]
 #define BTN0_PIN            GPIO_PIN(PA, 15)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -63,7 +63,6 @@ extern "C" {
  * @name SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[PB]
 #define BTN0_PIN            GPIO_PIN(PB, 31)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/saml21-xpro/include/board.h
+++ b/boards/saml21-xpro/include/board.h
@@ -44,7 +44,6 @@ extern "C" {
  * @name SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[PA]
 #define BTN0_PIN            GPIO_PIN(PA, 2)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -75,7 +75,6 @@ extern "C" {
  * @name    SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[0]
 #define BTN0_PIN            GPIO_PIN(0, 28)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -62,7 +62,6 @@ extern "C" {
  * @name    BTN0 (SW0 Button) pin definitions
  * @{
  */
-#define BTN0_PORT                   PORT->Group[0]
 #define BTN0_PIN                    GPIO_PIN(PA, 28)
 #define BTN0_MODE                   GPIO_IN_PU
 /** @} */

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -72,7 +72,6 @@ extern "C" {
  * @name    BTN0 (SW0 Button) pin definitions
  * @{
  */
-#define BTN0_PORT                   PORT->Group[0]                      /**< GPIO port      */
 #define BTN0_PIN                    GPIO_PIN(PA, 28)                    /**< GPIO pin       */
 #define BTN0_MODE                   GPIO_IN_PU                          /**< Pull Up GPIO   */
 /** @} */

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -56,7 +56,6 @@ extern "C" {
  * @name    SW0 (Button) pin definitions
  * @{
  */
-#define BTN0_PORT           PORT->Group[PA]
 #define BTN0_PIN            GPIO_PIN(PA, 20)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */

--- a/boards/stm32l0538-disco/include/board.h
+++ b/boards/stm32l0538-disco/include/board.h
@@ -48,7 +48,6 @@ extern "C" {
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)
-#define BTN0_PORT           GPIOA
 #define BTN0_MODE           GPIO_IN
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This define isn't used anywhere in RIOT and only some boards have it, so drop it.


### Testing procedure

CI will tell that this was indeed unused.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
