### PR TITLE
treewide: fix conditionals on deprecated module

### DIFF
--- a/drivers/dfplayer/Kconfig
+++ b/drivers/dfplayer/Kconfig
@@ -15,13 +15,13 @@ menuconfig MODULE_DFPLAYER
     select MODULE_XTIMER
     select HAVE_MULTIMEDIA_DEVICE
 # Perhaps this could be moved to its own symbol to enable the dfplayer commands
-    select MODULE_FMT if MODULE_SHELL_COMMANDS
+    select MODULE_FMT if MODULE_SHELL_CMDS
 
 config DFPLAYER_NO_STRERROR
     bool
     prompt "Avoid using strerror in shell command" if !(HAS_ARCH_AVR8 || HAS_ARCH_MSP430)
     depends on MODULE_DFPLAYER
-    depends on MODULE_SHELL_COMMANDS
+    depends on MODULE_SHELL_CMDS
     # no strerror() on AVR and MSP430
     default y if (HAS_ARCH_AVR8 || HAS_ARCH_MSP430)
     help

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -143,7 +143,7 @@ extern "C" {
 #define LWIP_NETCONN            0
 #endif /* MODULE_LWIP_SOCK */
 
-#ifdef MODULE_SHELL_COMMANDS
+#ifdef MODULE_SHELL_CMD_LWIP_NETIF
 #define LWIP_DEBUG              1
 #endif
 

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -151,7 +151,7 @@ void nimble_riot_init(void)
 #ifdef MODULE_NIMBLE_NETIF
     extern void nimble_netif_init(void);
     nimble_netif_init();
-#ifdef MODULE_SHELL_COMMANDS
+#ifdef MODULE_SHELL_CMD_NIMBLE_NETIF
     extern void sc_nimble_netif_init(void);
     sc_nimble_netif_init();
 #endif


### PR DESCRIPTION
### Contribution description

As a leftovers from https://github.com/RIOT-OS/RIOT/pull/18355 are still present that check for `MODULE_SHELL_COMMANDS` rather than `MODULE_SHELL_CMDS`. This updates the conditionals as needed.

### Testing procedure

- The `ifconfig` shell command in `tests/lwip` should show an IPv6 address again. (I can confirm that is does so.)
- Some regression in `tests/nimble_netif_ext` should be fixed. (I can confirm that the text size grows with this, but I wasn't able to detect an obvious issue with the `ifconfig` cmd there.)

### Issues/PRs references

Regression introduced in https://github.com/RIOT-OS/RIOT/pull/18355