### PR TITLE
core/mutex: clean up

### DIFF
--- a/cpu/atxmega/periph/gpio.c
+++ b/cpu/atxmega/periph/gpio.c
@@ -19,13 +19,14 @@
  * @}
  */
 
-#include <stdio.h>
 #include <avr/interrupt.h>
+#include <stdio.h>
 
-#include "cpu.h"
-#include "periph_conf.h"
-#include "periph/gpio.h"
 #include "bitarithm.h"
+#include "cpu.h"
+#include "irq.h"
+#include "periph/gpio.h"
+#include "periph_conf.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/cpu/atxmega/periph/pm.c
+++ b/cpu/atxmega/periph/pm.c
@@ -21,9 +21,10 @@
 
 #include <avr/sleep.h>
 
-#include "periph_conf.h"
-#include "periph/pm.h"
 #include "cpu_pm.h"
+#include "irq.h"
+#include "periph/pm.h"
+#include "periph_conf.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/cpu/atxmega/periph/timer.c
+++ b/cpu/atxmega/periph/timer.c
@@ -19,18 +19,16 @@
  * @}
  */
 
+#include <assert.h>
 #include <avr/interrupt.h>
 
-#include <assert.h>
-
+#include "board.h"
 #include "cpu.h"
 #include "cpu_pm.h"
-#include "thread.h"
-
+#include "irq.h"
 #include "periph/timer.h"
-
-#include "board.h"
 #include "periph_conf.h"
+#include "thread.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/cpu/atxmega/periph/uart.c
+++ b/cpu/atxmega/periph/uart.c
@@ -30,10 +30,11 @@
 #include "board.h"
 #include "cpu.h"
 #include "cpu_pm.h"
+#include "irq.h"
+#include "periph/gpio.h"
+#include "periph/uart.h"
 #include "sched.h"
 #include "thread.h"
-#include "periph/uart.h"
-#include "periph/gpio.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -30,6 +30,7 @@
 #include "driver/include/m2m_wifi.h"
 
 #include "assert.h"
+#include "irq.h"
 #include "log.h"
 #include "net/netdev/eth.h"
 #include "od.h"

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -19,11 +19,11 @@
  */
 #include <string.h>
 
+#include "checksum/crc8.h"
+#include "irq.h"
 #include "sgp30.h"
 #include "sgp30_constants.h"
 #include "sgp30_params.h"
-
-#include "checksum/crc8.h"
 #include "ztimer.h"
 
 #define ENABLE_DEBUG    0

--- a/drivers/sm_pwm_01c/sm_pwm_01c.c
+++ b/drivers/sm_pwm_01c/sm_pwm_01c.c
@@ -19,13 +19,12 @@
 #include <assert.h>
 #include <string.h>
 
+#include "irq.h"
 #include "log.h"
-#include "ztimer.h"
-
 #include "periph/gpio.h"
-
 #include "sm_pwm_01c.h"
 #include "sm_pwm_01c_params.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/pkg/driver_bme680/contrib/bme680_hal.c
+++ b/pkg/driver_bme680/contrib/bme680_hal.c
@@ -25,6 +25,7 @@
 
 #include "bme680.h"
 #include "bme680_hal.h"
+#include "irq.h"
 
 #ifdef MODULE_PERIPH_I2C
 #include "periph/i2c.h"

--- a/sys/riotboot/reset.c
+++ b/sys/riotboot/reset.c
@@ -18,6 +18,8 @@
  */
 
 #include <string.h>
+
+#include "irq.h"
 #include "periph/pm.h"
 #include "riotboot/magic.h"
 

--- a/tests/periph_gpio_ll/main.c
+++ b/tests/periph_gpio_ll/main.c
@@ -23,12 +23,13 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "irq.h"
 #include "mutex.h"
 #include "periph/gpio_ll.h"
 #include "periph/gpio_ll_irq.h"
 #include "test_utils/expect.h"
-#include "ztimer.h"
 #include "timex.h"
+#include "ztimer.h"
 
 #ifndef LOW_ROM
 #define LOW_ROM 0


### PR DESCRIPTION
### Contribution description

This restores a pre-existing design decision to implement both blocking and non-blocking mutex locking with the same code. Those implementations have been split prior to the introduction of the `core_mutex_priority_inheritance` module when `mutex_trylock()` indeed was trivial. This decision didn't age well, so undo it.

### Testing procedure

Let's have the CI run some tests.

### Issues/PRs references

None