### PR TITLE
dhcpv6: don't treat zero option as an end-of-payload marker

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -1017,10 +1017,6 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
             default:
                 break;
         }
-        /* 0 option is used as an end marker, len can include bogus bytes */
-        if (!byteorder_ntohs(opt->type)) {
-            break;
-        }
     }
     if ((cid == NULL) || (sid == NULL)) {
         DEBUG("DHCPv6 client: ADVERTISE does not contain either server ID "
@@ -1079,10 +1075,6 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
                  }
             default:
                 break;
-        }
-        /* 0 option is used as an end marker, len can include bogus bytes */
-        if (!byteorder_ntohs(opt->type)) {
-            break;
         }
     }
     return true;


### PR DESCRIPTION
### Contribution description

As far as I can tell, no DHCPv6 RFC specifies this option.

The handling for the zero option was added in #17736 by @benpicco to fix issues encountered while trying to retrieve a DHCHPv6 lease. However, I strongly suspect that the zero option was encountered in this case due to an out-of-bounds read performed in RIOT's DHCPv6 client implementation (i.e. the option parsing loop read beyond the packet bounds). This issue was fixed in #18307 and I strongly suspect that it should also fix the issue @benpicco originally encountered in #17736. As such, I propose that we remove the if statement which treats the zero option as an end-of-payload marker.

### Testing procedure

@benpicco could you test this with the DHCPv6 server implementation with which you originally encountered the error described in #17736 and report back if you still encounter this error with this PR applied? 🙏

### Issues/PRs references

* #17736
* #18307

Fixes #18309