### PR TITLE
cpu/atxmega: fix building with avr-libc 2.1.0

### DIFF
--- a/boards/atxmega-a1u-xpro/include/periph_conf.h
+++ b/boards/atxmega-a1u-xpro/include/periph_conf.h
@@ -155,7 +155,7 @@ static const ebi_conf_t ebi_config = {
                                   0x0UL,
                                 }, /* CS2 - 256K SRAM   */
                                 { EBI_CS_MODE_LPC_gc,
-                                  EBI_CS_ASPACE_256KB_gc,
+                                  EBI_CS_ASIZE_256KB_gc,
                                   EBI_CS_SRWS_1CLK_gc,
                                   0x0UL,
                                 }, /* Reserved LCD      */

--- a/cpu/atxmega/include/periph_cpu.h
+++ b/cpu/atxmega/include/periph_cpu.h
@@ -415,16 +415,36 @@ typedef enum {
  */
 #define PERIPH_EBI_SDRAM_CS (3)
 
+/* for compatibility between different versions of AVR libc: Legacy versions
+ * occasionally use ASPACE instead of ASIZE for some MCUs, while new AVR libc
+ * uses ASIZE as name consistently */
+#ifdef EBI_CS_ASPACE_gm
+typedef EBI_CS_ASPACE_t EBI_CS_ASIZE_t;
+#define EBI_CS_ASIZE_256B_gc EBI_CS_ASPACE_256B_gc
+#define EBI_CS_ASIZE_512B_gc EBI_CS_ASPACE_512B_gc
+#define EBI_CS_ASIZE_1KB_gc EBI_CS_ASPACE_1KB_gc
+#define EBI_CS_ASIZE_2KB_gc EBI_CS_ASPACE_2KB_gc
+#define EBI_CS_ASIZE_4KB_gc EBI_CS_ASPACE_4KB_gc
+#define EBI_CS_ASIZE_8KB_gc EBI_CS_ASPACE_8KB_gc
+#define EBI_CS_ASIZE_16KB_gc EBI_CS_ASPACE_16KB_gc
+#define EBI_CS_ASIZE_32KB_gc EBI_CS_ASPACE_32KB_gc
+#define EBI_CS_ASIZE_64KB_gc EBI_CS_ASPACE_64KB_gc
+#define EBI_CS_ASIZE_128KB_gc EBI_CS_ASPACE_128KB_gc
+#define EBI_CS_ASIZE_256KB_gc EBI_CS_ASPACE_256KB_gc
+#define EBI_CS_ASIZE_512KB_gc EBI_CS_ASPACE_512KB_gc
+#define EBI_CS_ASIZE_1MB_gc EBI_CS_ASPACE_1MB_gc
+#define EBI_CS_ASIZE_2MB_gc EBI_CS_ASPACE_2MB_gc
+#define EBI_CS_ASIZE_4MB_gc EBI_CS_ASPACE_4MB_gc
+#define EBI_CS_ASIZE_8MB_gc EBI_CS_ASPACE_8MB_gc
+#define EBI_CS_ASIZE_16MB_gc EBI_CS_ASPACE_16MB_gc
+#endif
+
 /**
  * @brief   EBI Chip Select configuration structure
  */
 typedef struct {
     EBI_CS_MODE_t   mode;               /**< Chip Select address mode */
-#if defined (__AVR_ATxmega64A1U__) || defined (__AVR_ATxmega128A1U__)
-    EBI_CS_ASPACE_t space;              /**< Chip Select address space */
-#else
     EBI_CS_ASIZE_t  space;              /**< Chip Select address space */
-#endif
     EBI_CS_SRWS_t   wait;               /**< SRAM Wait State Selection */
     uint32_t        address;            /**< Chip Select Base Address */
 } ebi_cs_t;
@@ -508,7 +528,7 @@ typedef struct {
  *                                0x0UL,
  *                              },
  *                              { EBI_CS_MODE_LPC_gc,
- *                                EBI_CS_ASPACE_256KB_gc,
+ *                                EBI_CS_ASIZE_256KB_gc,
  *                                EBI_CS_SRWS_1CLK_gc,
  *                                0x0UL,
  *                              },
@@ -542,12 +562,12 @@ typedef struct {
  *                                0x0UL,
  *                              },
  *                              { EBI_CS_MODE_LPC_gc,
- *                                EBI_CS_ASPACE_32KB_gc,
+ *                                EBI_CS_ASIZE_32KB_gc,
  *                                EBI_CS_SRWS_1CLK_gc,
  *                                0x0UL,
  *                              },
  *                              { EBI_CS_MODE_LPC_gc,
- *                                EBI_CS_ASPACE_256B_gc,
+ *                                EBI_CS_ASIZE_256B_gc,
  *                                EBI_CS_SRWS_5CLK_gc,
  *                                0x100000UL,
  *                              },


### PR DESCRIPTION
### Contribution description

Due to the lack of new official avr-libc releases (which includes the vendor header files needed to support different version of MCUs), support for new MCUs was lacking. Distributions such as Debian addressed this by extending the upstream code with vendor header files directly obtained from Atmel / Microchip, but without paying attention to details. As such, a naming inconsistency (ASIZE vs ASPACE) between officially supported MCUs and new MCUs was introduced.

Now that avr-libc 2.1.0 is officially released, hardware support for new MCUs is provided by upstream out of the box and only ASIZE is used as name. This commit adds a bit of glue code to create aliases for ASIZE on older avr-libc versions where needed. This fixes compilation with the new avr-libc release and results in more consistent code.

### Testing procedure

- CI should be happy
- compilation with avr-libc 2.1.0 should pass


#### On `master` with `avr-libc` in version 2.1.0

```
$ make BOARD=atxmega-a1u-xpro -C examples/default
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/default'
Building application "default" for "atxmega-a1u-xpro" with MCU "atxmega".

In file included from /home/maribu/Repos/software/RIOT/drivers/include/periph/pm.h:27,
                 from /home/maribu/Repos/software/RIOT/sys/include/shell.h:24,
                 from /home/maribu/Repos/software/RIOT/examples/default/main.c:29:
/home/maribu/Repos/software/RIOT/cpu/atxmega/include/periph_cpu.h:424:5: error: unknown type name 'EBI_CS_ASPACE_t'
  424 |     EBI_CS_ASPACE_t space;              /**< Chip Select address space */
      |     ^~~~~~~~~~~~~~~
make[1]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:146: /home/maribu/Repos/software/RIOT/examples/default/bin/atxmega-a1u-xpro/application_default/main.o] Error 1
make: *** [/home/maribu/Repos/software/RIOT/examples/default/../../Makefile.include:738: application_default.module] Error 2
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/default'
```

#### This PR

```
$ make BOARD=atxmega-a1u-xpro -C examples/default
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/default'
Building application "default" for "atxmega-a1u-xpro" with MCU "atxmega".

"make" -C /home/maribu/Repos/software/RIOT/boards/atxmega-a1u-xpro
"make" -C /home/maribu/Repos/software/RIOT/boards/common/atxmega
"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/atxmega
"make" -C /home/maribu/Repos/software/RIOT/cpu/atxmega/ebi
"make" -C /home/maribu/Repos/software/RIOT/cpu/atxmega/periph
"make" -C /home/maribu/Repos/software/RIOT/cpu/avr8_common
"make" -C /home/maribu/Repos/software/RIOT/cpu/avr8_common/avr_libc_extra
"make" -C /home/maribu/Repos/software/RIOT/drivers
"make" -C /home/maribu/Repos/software/RIOT/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/drivers/saul
"make" -C /home/maribu/Repos/software/RIOT/drivers/saul/init_devs
"make" -C /home/maribu/Repos/software/RIOT/sys
"make" -C /home/maribu/Repos/software/RIOT/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/sys/fmt
"make" -C /home/maribu/Repos/software/RIOT/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/sys/phydat
"make" -C /home/maribu/Repos/software/RIOT/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/sys/ps
"make" -C /home/maribu/Repos/software/RIOT/sys/saul_reg
"make" -C /home/maribu/Repos/software/RIOT/sys/shell
"make" -C /home/maribu/Repos/software/RIOT/sys/shell/cmds
"make" -C /home/maribu/Repos/software/RIOT/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  16696	  3054	  1203	 20953	  51d9	/home/maribu/Repos/software/RIOT/examples/default/bin/atxmega-a1u-xpro/default.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/default'
```

### Issues/PRs references

None