### PR TITLE
Make use of 1.64 Rust stabilizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@
 
 [patch.crates-io]
 riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }
-riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers" }
+riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers", branch = "remove-deprecations" }

--- a/tests/rust_libs/Makefile
+++ b/tests/rust_libs/Makefile
@@ -5,6 +5,10 @@ USEMODULE += shell_democommands
 
 FEATURES_REQUIRED += rust_target
 
+# Testing on stable to ensure that no nightly features are needed when Rust is
+# pulled in through modules.
+CARGO_CHANNEL = stable
+
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation
 BOARD_BLACKLIST := ek-lm4f120xl

--- a/tests/rust_minimal/Makefile
+++ b/tests/rust_minimal/Makefile
@@ -5,9 +5,8 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# This example can, on all platforms, be built with a stable version of Rust.
-# For most advanced features (eg. when using CoAP, SAUL or the shell with
-# Rust), this needs to be set to "nightly" for the time being.
+# Testing on stable to ensure that no nightly features are needed for basic
+# Rust usage.
 CARGO_CHANNEL = stable
 
 # Currently unknown, something related to the LED_PORT definition that doesn't


### PR DESCRIPTION
While the actual commit will need to do a bunch of `cargo update`, it should work automatically here, as cargo should see that it's pointing somewhere new.

---

This is to some extent a placeholder, test-driving this through CI. The actual commit will not alter the branches, but update all the Cargo.lock, and might run some more tests through stable.