### PR TITLE
tools/openocd: add generic FTDI adapter

### DIFF
--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -1,0 +1,13 @@
+# Select default FTDI debug adapter board
+OPENOCD_FTDI_ADAPTER ?= tigard
+
+# FTDI debug adapter interface
+OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/$(OPENOCD_FTDI_ADAPTER).cfg]'
+
+# default to SWD
+OPENOCD_TRANSPORT ?= swd
+
+# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
+ifneq (,$(DEBUG_ADAPTER_ID))
+  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a generic `ftdi` OpenOCD debug adapter.

There are [many](https://github.com/openocd-org/openocd/tree/master/tcl/interface/ftdi) programmers based on the FTDI interface and they all work the same, with varying pin configurations. Instead of wrapping them all individually, a generic `ftdi.inc.mk` is provided, the exact board type can then be specified by setting `OPENOCD_FTDI_ADAPTER`.

This defaults to [`tigard`](https://github.com/tigard-tools/tigard) for personal convenience.  


### Testing procedure

Flash any board with 

    PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=ftdi

In case you are on an older version of OpenOCD than 0.12, you have to provide the `tigard.cfg`

```
adapter driver ftdi
ftdi_vid_pid 0x0403 0x6010
ftdi_channel 1
adapter speed 2000
ftdi_layout_init 0x0028 0x002b
ftdi_layout_signal SWD_EN -data 0
ftdi_layout_signal nSRST -data 0x0020
```

in `/usr/share/openocd/scripts/interface/ftdi`

If you have a different ftdi board, specify `OPENOCD_FTDI_ADAPTER` to select the config appropriate for your debugger.

<details><summary>Flashing works</summary>

```
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00000000
Open On-Chip Debugger 0.11.0
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : FTDI SWD mode enabled
Warn : Transport "swd" was already selected
swd
Info : clock speed 2000 kHz
Info : SWD DPIDR 0x2ba01477
Info : atsame5.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for atsame5.cpu on 0
Info : Listening on port 36885 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* atsame5.cpu        cortex_m   little atsame5.cpu        halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000560 msp: 0x20000200
Info : SAM MCU: SAMD51J19A (512KB Flash, 192KB RAM)
auto erase enabled
wrote 278528 bytes from file /home/benpicco/dev/IoT_RIOT_Products/apps/ict_base_power_b/bin/ict_base_power-v3/riotboot_files/slot0-extended.bin in 5.224435s (52.063 KiB/s)

verified 271360 bytes in 0.665769s (398.036 KiB/s)

shutdown command invoked
Done flashing
make PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=ftdi -j flash   12,05s user 2,26s system 126% cpu 11,355 total
``` 
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
