### PR TITLE
draft: uri_parser: Proposal to rewrite the unittest

### DIFF
--- a/tests/unittests/tests-uri_parser/new-tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/new-tests-uri_parser.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2022 Bennet Blischke / HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include "embUnit.h"
+
+#include "uri_parser.h"
+
+#include "unittests-constants.h"
+#include "tests-uri_parser.h"
+
+typedef struct {
+    char *input_uri;
+    char *scheme;
+    char *userinfo;
+    char *host;
+    char *ipv6addr;
+    char *zoneid;
+    char *port_str;
+    uint16_t port;
+    char *path;
+    char *query;
+} expected_uri_result_t;
+
+static void _print_return_expectation(const char *uri, int expected, int observed)
+{
+    printf("\nURI-Input: %s\n", uri);
+    printf("Expected return: %d\n", expected);
+    printf("Observed return: %d", observed);
+}
+
+/*
+ * This explicit version has the advantage, that in case of a test failure,
+ * the failed line number is exactly on point:
+ * uri_parser_tests.test_process_string_error_if_port_str_is_too_long \
+ * (tests/unittests/tests-uri_parser/tests-uri_parser.c 87) Failure: \
+ * The uri_parser did *NOT* detect an invalid port-length as invalid.
+ */
+
+/*
+ * This test checks if the uri parser raises an error if the port length
+ * (as a string) is invalid, that is, longer than 5 characters
+ */
+static void _error_if_port_str_is_too_long(void)
+{
+    uri_parser_result_t uri_res;
+    int ret = 0;
+    int expected_ret = -1; // Indicates an invalid uri
+
+    char *too_many_digits = "https://example.org:123456/foo/bar";
+
+    ret = uri_parser_process_string(&uri_res, too_many_digits);
+    if (ret != expected_ret) {
+        _print_return_expectation(too_many_digits, expected_ret, ret);
+        TEST_FAIL("Failure: The uri_parser did not detect an invalid port-length as invalid.");
+    }
+
+    char *leading_zeroes_arent_ignored = "https://example.org:000456/foo/bar";
+
+    ret = uri_parser_process_string(&uri_res, leading_zeroes_arent_ignored);
+    if (ret != expected_ret) {
+        _print_return_expectation(leading_zeroes_arent_ignored, expected_ret, ret);
+        TEST_FAIL("Failure: The uri_parser did not detect an invalid port-length as invalid.");
+    }
+
+    char *too_much_whitespace = "https://example.org: 23456/foo/bar";
+
+    ret = uri_parser_process_string(&uri_res, leading_zeroes_arent_ignored);
+    if (ret != expected_ret) {
+        _print_return_expectation(too_much_whitespace, expected_ret, ret);
+        TEST_FAIL("Failure: The uri_parser did not detect an invalid port-length as invalid.");
+    }
+
+    // Just for demonstration of the failure output in this PR: This one fails.
+    char *valid_this_fails_the_test_on_purpose = "https://example.org:1234/foo/bar";
+
+    ret = uri_parser_process_string(&uri_res, valid_this_fails_the_test_on_purpose);
+    if (ret != expected_ret) {
+        _print_return_expectation(valid_this_fails_the_test_on_purpose, expected_ret, ret);
+        TEST_FAIL("Failure: The uri_parser did not detect an invalid port-length as invalid.");
+    }
+}
+
+/*
+ * This compact version has the disadvantage, that in case of a test failure,
+ * the failed line number is inconclusive and it is less concise:
+ * uri_parser_tests.test_process_string_error_if_port_str_is_too_long \
+ * (tests/unittests/tests-uri_parser/tests-uri_parser.c 139) Failure: \
+ * The uri_parser did *NOT* detect an invalid port-length as invalid.
+ *
+ * However, it is much shorter which might be a worthwhile trade-off.
+ */
+
+/*
+ * This test checks if the uri parser raises an error if the port length
+ * (as a string) is invalid, that is, longer than 5 characters
+ */
+static void _error_if_port_str_is_too_long_array(void)
+{
+    char *failure_msg = "Failure: The uri_parser did not detect an invalid port-length as invalid.";
+    int expected_ret = -1; // Indicates an invalid uri
+
+    char *leading_zeroes_arent_ignored = "https://example.org:000456/foo/bar";
+    char *too_many_digits = "https://example.org:123456/foo/bar";
+    char *too_much_whitespace = "https://example.org: 23456/foo/bar";
+    // Just for demonstration of the failure output in this PR: This one fails.
+    char *valid_this_fails_the_test_on_purpose = "https://example.org:1234/foo/bar";
+
+    /*
+     * Why don't you just add the strings to the array? We don't need an
+     * extra variable for that!
+     *
+     * Glad you are asking, imagine seeing this test vector:
+     * ftp://123@example.org:/foo
+     * What is being tested? What is the edge case that is explored?
+     * You don't know. If we would name that string, it gets easy:
+     * char *username_must_not_start_with_a_number = ftp://123@example.org:/foo
+     */
+    char *test_vec[] = {
+        too_many_digits,
+        leading_zeroes_arent_ignored,
+        too_much_whitespace,
+        valid_this_fails_the_test_on_purpose
+    };
+
+    uri_parser_result_t uri_res;
+    int ret = 0;
+
+    for (unsigned int i = 0; i < ARRAY_SIZE(test_vec); ++i) {
+        ret = uri_parser_process_string(&uri_res, test_vec[i]);
+        if (ret != expected_ret) {
+            _print_return_expectation(test_vec[i], expected_ret, ret);
+            TEST_FAIL(failure_msg);
+        }
+    }
+}
+
+static void _successfull_parsing_of_valid_uri_with_scheme_and_path(void)
+{
+    char *failure_msg = "Failure: The uri_parser failed to parse a correct uri.";
+    int expected_ret = 0;
+
+    char *simple_uri_0 = "coap://example.org/foo/bar";
+    char *simple_uri_1 = "ftp://riot-os.org/bar/foo";
+    // Just for demonstration of the failure output in this PR: This one fails.
+    char *invalid_this_fails_the_test_uri = "ftp://example.org:99999/foo/bar";
+
+    char *test_vec[] = {
+        simple_uri_0,
+        simple_uri_1,
+        invalid_this_fails_the_test_uri,
+    };
+
+    uri_parser_result_t uri_res;
+    int ret = 0;
+
+    for (unsigned int i = 0; i < ARRAY_SIZE(test_vec); ++i) {
+        ret = uri_parser_process_string(&uri_res, test_vec[i]);
+        if (ret != expected_ret) {
+            _print_return_expectation(test_vec[i], expected_ret, ret);
+            TEST_FAIL(failure_msg);
+        }
+    }
+}
+
+static void _result_component_scheme_matches_input_scheme(void)
+{
+    char *failure_msg = "Failure: The uri_parser did not parse the scheme correctly.";
+    int expected_ret = 0;
+
+    expected_uri_result_t very_long_scheme = {
+        .input_uri = "wowlongcoap://example.org/foo/bar",
+        .scheme = "wowlongcoap",
+    };
+    expected_uri_result_t normal_scheme = {
+        .input_uri = "coap://example.org/foo/bar",
+        .scheme = "coap",
+    };
+    expected_uri_result_t short_scheme = {
+        .input_uri = "a://example.org/foo/bar",
+        .scheme = "a",
+    };
+    // Just for demonstration of the failure output in this PR: This one fails.
+    expected_uri_result_t invalid_scheme = {
+        .input_uri = "coap://example.org:99999/foo/bar",
+        .scheme = "coap",
+    };
+
+    expected_uri_result_t *test_vec[] = {
+        &very_long_scheme,
+        &normal_scheme,
+        &short_scheme,
+        &invalid_scheme,
+    };
+
+    uri_parser_result_t uri_res;
+    int ret = 0;
+
+    for (unsigned int i = 0; i < ARRAY_SIZE(test_vec); ++i) {
+        ret = uri_parser_process_string(&uri_res, test_vec[i]->input_uri);
+        /* One should only test for success OR failure. Here, we provide valid uri.
+         * If you are interested in testing for failure using broken schemes,
+         * write a separate test */
+        if (ret != expected_ret) {
+            _print_return_expectation(test_vec[i]->input_uri, expected_ret, ret);
+            TEST_FAIL(failure_msg);
+        }
+        else {
+            /* if the uri_parser return indicates success
+             * the length of the schemes must match.
+             * we can't use strlen on the result scheme as it is not null terminated,
+             * but the uri_provides the length separately */
+            if (uri_res.scheme_len != strlen(test_vec[i]->scheme)) {
+                printf(
+                    "With given input uri '%s', expected a scheme with the length '%d' "
+                    "but got '%d'\n",
+                    test_vec[i]->input_uri, strlen(test_vec[i]->scheme), uri_res.scheme_len);
+                TEST_FAIL(failure_msg);
+            }
+            else {
+                /* If the schemes have the same length, they also should look identical */
+                if (strncmp(uri_res.scheme, test_vec[i]->scheme, uri_res.scheme_len) != 0) {
+                    printf("With given input uri '%s', expected scheme '%s' but got '%.*s'\n",
+                           test_vec[i]->input_uri, test_vec[i]->scheme, uri_res.scheme_len,
+                           uri_res.scheme);
+                    TEST_FAIL(failure_msg);
+                }
+            }
+        }
+    }
+}
+
+Test *tests_uri_parser_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(_error_if_port_str_is_too_long),
+        new_TestFixture(_error_if_port_str_is_too_long_array),
+        new_TestFixture(_successfull_parsing_of_valid_uri_with_scheme_and_path),
+        new_TestFixture(_result_component_scheme_matches_input_scheme),
+    };
+
+    EMB_UNIT_TESTCALLER(uri_parser_tests, NULL, NULL, fixtures);
+
+    return (Test *)&uri_parser_tests;
+}
+
+void tests_uri_parser(void)
+{
+    TESTS_RUN(tests_uri_parser_tests());
+}
+/** @} */


### PR DESCRIPTION
Hi 👋 

The current testing of the `uri_parser` is inadequate and an obstacle when working on changes.

This PR proposes a new approach. It follows some basic guidelines, which typically lead to good tests.

<details>
  <summary>Short list of basic guidelines</summary>

1. When a test fails...reparability:
	There are two reasons for test failures:
		A - There is a bug or a problem in the system under test. This is exactly what tests are written for - alert that something is broken in this system.
		B - The system under test is fine but the test itself has an issue. The test was most likely written incorrectly.

	A good test is VERY clear about its own reason for existing. When it fails, the RIOT developer can immediatly tell in which of the two categories this failure belongs. This not only safes time but is also much more fun to fix.
	This is the reason why the proposed tests have such verbose names and extra debug output on failure.

2. A new user comes along...helpfulness:
	There are two main reasons to look at existing tests:
		A - They failed.
		B - You are new to the system under test and where looking for an example on how to use it. Maybe the documentation was unclear. Or the system does not work as expected even though you are confidend to use it correctly.

	Tests, as all code, is much more often read than written. When writing them, they should prioritise readability over elegance. (I personally think that applies to all code, always.) In tests, you can't claim execution speed or resource constrains as an excuse for poor readability.
	This is the reason why the proposed tests clearly show how to invoke the `uri_parser` and what to expect from its results. Making it easy to understand the usage and behavoir of the system under test.
3. You discovered a bug and therefor a test hole...extensibility:
	When ever a bug is found in a system that has tests, the tests were incomplete. The next step is to fix that hole. Tests should be written in a way that makes it easy, simple and obvious how and where to add a new test case. This is especially problematic with the current tests. You'll need extensive C knowledge and time to understand all the macros and the test itself. It absolutly not clear where you would put your hole covering tests. 
	This proposal features easy to understand patterns which one can replicate to add a new test vector or implement a new test.
4. Time flies by...maintainability:
	Code ages, developers come and go. It is easy to imagine that the author of a test has left the RIOT team years ago - when it suddendly fails. Understanding, expectations and requierments of the system under test might have changed. Without the author, the tests will need to explain themself. Hence the clarity of the tests is so important. If you don't know how or why a test is performed, neither do you know why it failed. Being verbose and clear is the key element for a maintainable test.
	In this proposal, maintainability is archived by being concise and complete. They are complete because every testcase includes all information needed by the reader to understand how/why the result of the `uri_parser` occures (here, typically the input uri and why this specific uri was choosen) and how/why we expect it to be a specific value. They are concise this they are scarce, only containing the absolute minimum of code requiered to run the specific test. Thats the exact opposite of the current tests, which are as unconcise as possible, containing so many unclear loops, macros and global references that you might want to write tests for the test.
</details>

I could go on and on about testing. About not testing methodes but behaviors instead. Or why one shouldn't put logic, complex concatinations, loops etc into tests. Hopefully this way to long PR description is already enough to convice you that the current state of testing is inadequate.

Please let me know if you have any questions, ideas or criticism. Also make sure to show your approval if you believe I should push this forward & replace the current `uri_parser` tests for real. 

~~Thanks for comming to my RIOT-Summit talk~~