### PR TITLE
tools/avarice: deduce debugger from AVRDUDE_PROGRAMMER

### DIFF
--- a/makefiles/tools/avrdude.inc.mk
+++ b/makefiles/tools/avrdude.inc.mk
@@ -3,9 +3,15 @@ DIST_PATH = $(BOARDDIR)/dist
 AVARICE_PATH = $(RIOTTOOLS)/avarice
 DEBUGSERVER_PORT = 4242
 DEBUGSERVER ?= $(AVARICE_PATH)/debug_srv.sh
-# Allow choosing debugger hardware via AVR_DEBUGDEVICE, default to Atmel ICE,
-# which is compatible to all AVR devices and since the AVR Dragon is no longer
-# produced, the least expensive option
+# Allow choosing debugger hardware via AVR_DEBUGDEVICE. If the
+# AVRDUDE_PROGRAMMER however is also capable of debugging, use that by default
+ifneq (,$(filter $(AVRDUDE_PROGRAMMER),atmelice xplainedpro xplainedpro_pdi))
+  AVR_DEBUGDEVICE ?= --edbg
+endif
+ifneq (,$(filter dragon%,$(AVRDUDE_PROGRAMMER)))
+  AVR_DEBUGDEVICE ?= --dragon
+endif
+# Atmel ICE / EDBG is the most sensible fallback
 AVR_DEBUGDEVICE ?= --edbg
 AVR_DEBUGINTERFACE ?= usb
 ifneq (,$(filter $(CPU),atmega328p))


### PR DESCRIPTION
### Contribution description

If `AVRDUDE_PROGRAMMER` is already set to a programmer that is also capable of debugging, we can assume that typically the user will want to use the same hardware for debugging. Thus, let `AVR_DEBUGDEVICE` default to the matching hardware.

### Testing procedure

`$ make BOARD=microduino-corerf AVRDUDE_PROGRAMMER=dragon_jtag -C examples/hello-world debug` should call AVaRICE with `--dragon` to select the AVR Dragon:

```
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
"/home/maribu/Repos/software/RIOT/dist/tools/avarice/debug.sh" "--dragon -j usb :4242" /home/maribu/Repos/software/RIOT/dist/tools/avarice 4242 "-x /home/maribu/Repos/software/RIOT/dist/tools/avarice/gdb.conf /home/maribu/Repos/software/RIOT/examples/hello-world/bin/microduino-corerf/hello-world.elf"
```

But `$ make BOARD=microduino-corerf AVRDUDE_PROGRAMMER=atmelice -C examples/hello-world debug` should call it with `--edbg` to select the EDBG interface provided by the Atmel ICE, XPRO/XMINI EDBG integrated debuggers:

```
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
"/home/maribu/Repos/software/RIOT/dist/tools/avarice/debug.sh" "--edbg -j usb :4242" /home/maribu/Repos/software/RIOT/dist/tools/avarice 4242 "-x /home/maribu/Repos/software/RIOT/dist/tools/avarice/gdb.conf /home/maribu/Repos/software/RIOT/examples/hello-world/bin/microduino-corerf/hello-world.elf"
```

### Issues/PRs references

None