### PR TITLE
tests/heap_cmd: fix test script

### DIFF
--- a/tests/heap_cmd/tests/01-run.py
+++ b/tests/heap_cmd/tests/01-run.py
@@ -24,7 +24,7 @@ def testfunc(child):
     child.sendline('heap')
     child.expect(r'heap: \d+ \(used \d+, free \d+\) \[bytes\]')
     child.sendline('free 0x' + addr)
-    child.expect('freed 0x' + addr)
+    child.expect('freeing 0x' + addr)
     child.expect_exact('>')
     child.sendline('heap')
     child.expect(r'heap: \d+ \(used \d+, free \d+\) \[bytes\]')


### PR DESCRIPTION
### Contribution description

In c95e8553ef4761f145b51ebc9997bcfa8def48b4 the shell output of the heap command was changed and no longer matched the expectation of the test script. This adapts the test to again match the output.

### Testing procedure

```
$ make BOARD=nucleo-f767zi -C tests/heap_cmd flash test
make: Entering directory '/home/maribu/Repos/software/RIOT/tests/heap_cmd'
Building application "tests_heap_cmd" for "nucleo-f767zi" with MCU "stm32".
[...]
   text	  data	   bss	   dec	   hex	filename
  16016	   132	  2424	 18572	  488c	/home/maribu/Repos/software/RIOT/tests/heap_cmd/bin/nucleo-f767zi/tests_heap_cmd.elf
/home/maribu/Repos/software/RIOT/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/tests/heap_cmd/bin/nucleo-f767zi/tests_heap_cmd.elf
[...]
Welcome to pyterm!
Type '/exit' to exit.

> heap

> heap
heap: 521732 (used 2500, free 519232) [bytes]
> malloc 100
malloc 100
allocated 0x200013c8
> heap
heap
heap: 521732 (used 2608, free 519124) [bytes]
free 0x200013c8
> free 0x200013c8
freeing 0x200013c8
> heap
heap
heap: 521732 (used 2500, free 519232) [bytes]

make: Leaving directory '/home/maribu/Repos/software/RIOT/tests/heap_cmd'
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18355#issuecomment-1256145439