### PR TITLE
tests: call gnrc_ipv6_nib_iface_up() after gnrc_ipv6_nib_init_iface()

### DIFF
--- a/tests/gnrc_ipv6_fwd_w_sub/mockup_netif.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/mockup_netif.c
@@ -69,10 +69,11 @@ void _tests_init(void)
         );
     _mock_netif = &_netif;
     expect(res == 0);
+
     gnrc_ipv6_nib_init();
-    gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
-    gnrc_netif_release(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
+
     /* we do not want to test for SLAAC here so just assure the configured
      * address is valid */
     expect(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));

--- a/tests/gnrc_ipv6_nib/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib/mockup_netif.c
@@ -39,9 +39,8 @@ void _common_set_up(void)
 {
     expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
-    gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
-    gnrc_netif_release(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
 }
 
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)

--- a/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
@@ -39,9 +39,8 @@ void _common_set_up(void)
 {
     expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
-    gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
-    gnrc_netif_release(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
 }
 
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)

--- a/tests/gnrc_sixlowpan_frag_minfwd/main.c
+++ b/tests/gnrc_sixlowpan_frag_minfwd/main.c
@@ -310,6 +310,7 @@ static void _set_up(void)
            sizeof(_mock_netif->ipv6.addrs_flags));
     gnrc_ipv6_nib_init();
     gnrc_ipv6_nib_init_iface(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
     /* re-init for syncing */
     mutex_init(&_target_buf_filled);
     mutex_lock(&_target_buf_filled);

--- a/tests/gnrc_sixlowpan_frag_minfwd/mockup_netif.c
+++ b/tests/gnrc_sixlowpan_frag_minfwd/mockup_netif.c
@@ -38,9 +38,8 @@ void _common_set_up(void)
 {
     expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
-    gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
-    gnrc_netif_release(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
 }
 
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)

--- a/tests/gnrc_sixlowpan_frag_sfr/main.c
+++ b/tests/gnrc_sixlowpan_frag_sfr/main.c
@@ -340,6 +340,7 @@ static void _set_up(void)
            sizeof(_mock_netif->ipv6.addrs_flags));
     gnrc_ipv6_nib_init();
     gnrc_ipv6_nib_init_iface(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
     /* re-init for syncing */
     mutex_init(&_target_buf_filled);
     mutex_lock(&_target_buf_filled);

--- a/tests/gnrc_sixlowpan_frag_sfr/mockup_netif.c
+++ b/tests/gnrc_sixlowpan_frag_sfr/mockup_netif.c
@@ -38,9 +38,8 @@ void _common_set_up(void)
 {
     expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
-    gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
-    gnrc_netif_release(_mock_netif);
+    gnrc_ipv6_nib_iface_up(_mock_netif);
 }
 
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We now have to call `gnrc_ipv6_nib_iface_up()` to configure addresses / start ARSM after calling `gnrc_ipv6_nib_init_iface()`


### Testing procedure

Run the tests *on a board*. For some reason this is not failing on `native` without the patch, but does on e.g. `samd20-xpro`.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17893#issuecomment-1256123393
