### PR TITLE
cpu/arm7_common: fix compilation with 12.2.0

### DIFF
--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -14,7 +14,7 @@ CFLAGS_DBG  ?= -ggdb -g3
 CFLAGS_OPT  ?= -Os
 
 CFLAGS      += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
-ASFLAGS     += $(CFLAGS_CPU) $(CFLAGS_DBG)
+ASFLAGS     += $(CFLAGS_CPU)
 LINKFLAGS   += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU).ld
 LINKFLAGS   += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 LINKFLAGS   += -Wl,--gc-sections


### PR DESCRIPTION
### Contribution description

This fixes:

    Assembler messages:
    Fatal error: unknown option `-ggdb'

### Testing procedure

Run with a recent toolchain:

```
$ make BOARD=msba2 -C examples/hello-world/
```

##### With `master`

```
$ make BOARD=msba2 -C examples/hello-world/
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
Building application "hello-world" for "msba2" with MCU "lpc23xx".

"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/boards/msba2
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/lpc23xx
Assembler messages:
Fatal error: unknown option `-ggdb'
make[2]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:176: /home/maribu/Repos/software/RIOT/examples/hello-world/bin/msba2/cpu/asmfunc.o] Error 1
make[1]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/cpu/lpc23xx] Error 2
make: *** [/home/maribu/Repos/software/RIOT/examples/hello-world/../../Makefile.include:738: application_hello-world.module] Error 2
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
```

##### This PR

```
$  make BOARD=msba2 -C examples/hello-world/
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
Building application "hello-world" for "msba2" with MCU "lpc23xx".

"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/boards/msba2
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/lpc23xx
"make" -C /home/maribu/Repos/software/RIOT/cpu/arm7_common
"make" -C /home/maribu/Repos/software/RIOT/cpu/arm7_common/periph
"make" -C /home/maribu/Repos/software/RIOT/cpu/lpc23xx/periph
"make" -C /home/maribu/Repos/software/RIOT/drivers
"make" -C /home/maribu/Repos/software/RIOT/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/sys
"make" -C /home/maribu/Repos/software/RIOT/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/sys/bitfield
"make" -C /home/maribu/Repos/software/RIOT/sys/div
"make" -C /home/maribu/Repos/software/RIOT/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/sys/stdio_uart
   text	  data	   bss	   dec	   hex	filename
  12276	   128	  6932	 19336	  4b88	/home/maribu/Repos/software/RIOT/examples/hello-world/bin/msba2/hello-world.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
```

### Issues/PRs references

None