### PR TITLE
sys/shell: ncput: add option to read from stdin

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -241,6 +241,22 @@ ssize_t nanocoap_sock_put(nanocoap_sock_t *sock, const char *path,
                           void *response, size_t len_max);
 
 /**
+ * @brief   Simple synchronous CoAP (confirmable) PUT to URL
+ *
+ * @param[in]   url     Absolute URL pointer to source path
+ * @param[in]   request buffer containing the payload
+ * @param[in]   len     length of the payload to send
+ * @param[out]  response buffer for the response, may be NULL
+ * @param[in]   len_max length of @p response
+ *
+ * @returns     length of response payload on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_put_url(const char *url,
+                              const void *request, size_t len,
+                              void *response, size_t len_max);
+
+/**
  * @brief   Simple synchronous CoAP (confirmable) POST
  *
  * @param[in]   sock    socket to use for the request
@@ -256,6 +272,22 @@ ssize_t nanocoap_sock_put(nanocoap_sock_t *sock, const char *path,
 ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
                            const void *request, size_t len,
                            void *response, size_t len_max);
+
+/**
+ * @brief   Simple synchronous CoAP (confirmable) POST to URL
+ *
+ * @param[in]   url     Absolute URL pointer to source path
+ * @param[in]   request buffer containing the payload
+ * @param[in]   len     length of the payload to send
+ * @param[out]  response buffer for the response, may be NULL
+ * @param[in]   len_max length of @p response
+ *
+ * @returns     length of response payload on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_post_url(const char *url,
+                               const void *request, size_t len,
+                               void *response, size_t len_max);
 
 /**
  * @brief    Performs a blockwise coap get request on a socket.

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -361,6 +361,36 @@ ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
     return _sock_put_post(sock, path, COAP_METHOD_POST, request, len, response, len_max);
 }
 
+static ssize_t _sock_put_post_url(const char *url, unsigned code,
+                                  const void *request, size_t len,
+                                  void *response, size_t len_max)
+{
+    nanocoap_sock_t sock;
+    int res = nanocoap_sock_url_connect(url, &sock);
+    if (res) {
+        return res;
+    }
+
+    res = _sock_put_post(&sock, sock_urlpath(url), code, request, len, response, len_max);
+    nanocoap_sock_close(&sock);
+
+    return res;
+}
+
+ssize_t nanocoap_sock_put_url(const char *url,
+                              const void *request, size_t len,
+                              void *response, size_t len_max)
+{
+    return _sock_put_post_url(url, COAP_METHOD_PUT, request, len, response, len_max);
+}
+
+ssize_t nanocoap_sock_post_url(const char *url,
+                               const void *request, size_t len,
+                               void *response, size_t len_max)
+{
+    return _sock_put_post_url(url, COAP_METHOD_POST, request, len, response, len_max);
+}
+
 ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
                          const sock_udp_ep_t *remote, size_t len)
 {

--- a/sys/shell/cmds/nanocoap_vfs.c
+++ b/sys/shell/cmds/nanocoap_vfs.c
@@ -184,7 +184,16 @@ static int _nanocoap_put_handler(int argc, char **argv)
         url = buffer;
     }
 
-    res = nanocoap_vfs_put_url(url, file, work_buf, sizeof(work_buf));
+    if (strcmp(file, "-") == 0) {
+        if (argc < 4) {
+            printf("Usage: %s - <url> <data>\n", argv[0]);
+            return -EINVAL;
+        }
+        res = nanocoap_sock_put_url(url, argv[3], strlen(argv[3]), NULL, 0);
+    } else {
+        res = nanocoap_vfs_put_url(url, file, work_buf, sizeof(work_buf));
+    }
+
     if (res < 0) {
         printf("Upload failed: %s\n", strerror(-res));
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`ncput` is a useful command line tool to interact with a CoAP server.
In addition to uploading files, also add an option to put data directly from the command line in the same fashion was we can tell `ncget` to output to the command line instead of to a file.

### Testing procedure

 - in one terminal, start `examples/nanocoap_server`
 - in another terminal, start `tests/nanocoap_cli`:

```
> ncget coap://[fe80::581a:98ff:fe23:2d6c]/.well-known/core -
</.well-known/core>,</echo/>,</riot/board>,</riot/value>,</riot/ver>,</sha256>

> ncget coap://[fe80::581a:98ff:fe23:2d6c]/riot/value -
0

> ncput - coap://[fe80::581a:98ff:fe23:2d6c]/riot/value 23
Saved to coap://[fe80::581a:98ff:fe23:2d6c]/riot/value

> ncget coap://[fe80::581a:98ff:fe23:2d6c]/riot/value -
23
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
