### PR TITLE
boards/nrf52dk: fix doc

### DIFF
--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -4,91 +4,37 @@
 @brief       Support for the nRF52 DK
 
 ## Overview:
-There are some nameless simple development Boards with an nRF52832 available.
-These boards providing access to most SoC ports. There are two buttons (RST,
-KEY), two LED’s (Pin 30, 31), a voltage regulator and a current measurement shunt
-on board. A serial connection and flashing must be provided by external
-Hardware.
 
-The nRF52832 is a SoC with a 32-bit ARM® Cortex™-M4F CPU with 512KiB Flash and
-64KiB RAM. The embedded 2.4GHz transceiver supports Bluetooth low energy, ANT and
-proprietary 2.4 GHz protocol stack. It is on air compatible with the nRF51
-Series, nRF24L and nRF24AP Series products from Nordic Semiconductor.
+The
+[nRF52 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF52-DK)
+is a development board featuring the nRF52832 MCU with Arduino compatible
+pin headers and an integrated J-Link programmer, debugger and UART adapter.
 
 ## Hardware:
-![nRF52 minimal development
-board](https://github.com/d00616/temp/raw/master/nrf52-minidev.jpg)
 
-| MCU               | NRF52832                                                                              |
-|:----------------- |:------------------------------------------------------------------------------------- |
-| Family            | ARM Cortex-M4F                                                                        |
-| Vendor            | Nordic Semiconductor                                                                  |
-| RAM               | 64KiB                                                                                 |
-| Flash             | 512KiB                                                                                |
-| Frequency         | 64MHz                                                                                 |
-| FPU               | yes                                                                                   |
-| Timers            | 5 (32-bit)                                                                            |
-| RTC               | 3                                                                                     |
-| ADCs              | 1x 12-bit (8 channels)                                                                |
-| UARTs             | 1                                                                                     |
-| SPIs              | 3                                                                                     |
-| I2Cs              | 2                                                                                     |
-| I2S               | 1                                                                                     |
-| PWM               | 3*4 Channels                                                                          |
-| Radio             | 2.4GHz BLE compatiple, -20 dBm to +4 dBm output, -96 dBm RX sensitivity               |
-| Vcc               | 1.7V - 3.6V                                                                           |
-| Datasheet         | [Datasheet](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832)    |
-| Reference Manual  | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf)        |
+![nRF52 DK](https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF52-Series/nRF52-DK/nRF52-DK/nRF52-DK-prod-page.png)
 
-##Pin layout
-
-|MCU pin|Board pin|Function|
-|:-----------|:-----------|:----------|
-|P0.0| n.c. | |
-|P0.1| n.c. | |
-|P0.2| D07 | |
-|P0.3| D08 | |
-|P0.4| D09 | KEY |
-|P0.5| D10 | |
-|P0.6| D13 | |
-|P0.7| D14 | |
-|P0.8| D15 | |
-|P0.9| n.c. | |
-|P0.10| n.c. | NFC antenna 2 (unusable) |
-|P0.11|  D18 | RXD (software defined) |
-|P0.12|  D19 | TXD (software defined) |
-|P0.13|  D20 | |
-|P0.14|  D21 | |
-|P0.15|  D22 | |
-|P0.16|  D23 | |
-|P0.17|  D24 | |
-|P0.18|  D25 | |
-|P0.19|  D26 | |
-|P0.20|  D27 | |
-|P0.21|  RST | RESET |
-|P0.22|  D28 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.23|  D29 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.24|  D30 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.25|  D00 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.26|  D01 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.27|  D02 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.28|  D03 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.29|  D04 | near Radio! -> Low drive, low frequency I/O only. |
-|P0.30|  D05 | LED0, near Radio! -> Low drive, low frequency I/O only. |
-|P0.31|  D06 | LED1, near Radio! -> Low drive, low frequency I/O only. |
-|  |  V33 | 3.3V for MCU |
-|  |  D16 | ? |
-|  |  D17 | ? |
-|  | VBUS | 5V input |
-|  | GND |  |
-|  | RXD  | n.c. |
-|  | TXD  | n.c. |
-|  | TD0  | n.c. |
-|  | TD1  | n.c. |
-| SWDIO | TMS  |  |
-| SWCLK | TCK  |  |
-
-**Caution**: NFC is not usable with this board.
+| MCU                   | NRF52832                                                                              |
+|:--------------------- |:------------------------------------------------------------------------------------- |
+| Family                | ARM Cortex-M4F                                                                        |
+| Vendor                | Nordic Semiconductor                                                                  |
+| RAM                   | 64 KiB                                                                                |
+| Flash                 | 512 KiB                                                                               |
+| Frequency             | 64 MHz                                                                                |
+| FPU                   | yes                                                                                   |
+| Timers                | 5 (32-bit)                                                                            |
+| RTC                   | 3                                                                                     |
+| ADCs                  | 1x 12-bit (8 channels)                                                                |
+| UARTs                 | 1                                                                                     |
+| SPIs                  | 3                                                                                     |
+| I2Cs                  | 2                                                                                     |
+| I2S                   | 1                                                                                     |
+| PWM                   | 3*4 Channels                                                                          |
+| Radio                 | 2.4GHz BLE compatiple, -20 dBm to +4 dBm output, -96 dBm RX sensitivity               |
+| Vcc                   | 1.7V - 3.6V                                                                           |
+| MCU Datasheet         | [Datasheet](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832)    |
+| MCU Reference Manual  | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf)        |
+| Board Datasheet       | [User Guide](https://infocenter.nordicsemi.com/pdf/nRF52_DK_User_Guide_v1.3.1.pdf)    |
 
 ### RESET pin configuration
 


### PR DESCRIPTION
### Contribution description

The board definition of the `nrf52dk` was likely created for some clone board. However, an official board name nRF52 DK provided by Nordic also exists. This resulted in previous contributors in confusing this with the official board and "fixing" the board definition to match the nRF52 DK board.

Or maybe it always has been meant to be the official board and someone just added a wrong image to it.

In either case, this brings the documentation back in alignment with the code by replacing references to some random clone board and the image of the random clone board with those to/of the official Nordic nRF52 DK board.

### Testing procedure

Proof reading the doc should be sufficient. In addition, one may want to check that e.g. the button and LED definitions in SAUL indeed work with a legitimate nRF52 DK board (it does so for me).

### Issues/PRs references

None