### PR TITLE
boards/nucleo-f446ze: add support for ADC

### DIFF
--- a/boards/nucleo-f446ze/Kconfig
+++ b/boards/nucleo-f446ze/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_F446ZE
     select CPU_MODEL_STM32F446ZE
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_CAN

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -169,6 +169,43 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @brief   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F446 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5.
+ *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC1_IN10 is device 0,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC1_IN10 is channel 10
+ *
+ * For Nucleo-F446ZE this information is in board manual,
+ * Table 18, page 56.
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 0), .dev = 2, .chan =  3 }, /* ADC123_IN3   */
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 2, .chan = 10 }, /* ADC123_IN10  */
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 2, .chan = 13 }, /* ADC123_IN13  */
+    { .pin = GPIO_PIN(PORT_B, 0), .dev = 2, .chan =  9 }, /* ADC123_IN9   */
+    { .pin = GPIO_PIN(PORT_C, 1), .dev = 2, .chan = 15 }, /* ADC3_IN15    */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 2, .chan =  8 }, /* ADC3_IN8     */
+};
+
+/**
+ * @brief Number of ADC devices
+ */
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -197,12 +197,15 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_PIN(PORT_B, 0), .dev = 2, .chan =  9 }, /* ADC123_IN9   */
     { .pin = GPIO_PIN(PORT_C, 1), .dev = 2, .chan = 15 }, /* ADC3_IN15    */
     { .pin = GPIO_PIN(PORT_C, 0), .dev = 2, .chan =  8 }, /* ADC3_IN8     */
+    { .pin = GPIO_UNDEF, 	  .dev = 0, .chan = 18 }, /* VBAT */
 };
 
 /**
  * @brief Number of ADC devices
  */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+#define VBAT_ADC            ADC_LINE(6) /**< VBAT ADC line */
 
 /** @} */
 


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-f446ze ADC configuration.

### Testing procedure

Flash the board using `tests/periph_adc` program. Check if measured values changes when A0-A5 pins are
connected to the 3,3V, GND or to the potentiometer. 

### Issues/PRs references

None