### PR TITLE
shell: fix gnrc_netif_lorawan dependency

### DIFF
--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -56,6 +56,9 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   endif
   ifneq (,$(filter gnrc_netif,$(USEMODULE)))
     USEMODULE += shell_cmd_gnrc_netif
+    ifneq (,$(filter gnrc_netif_lorawan,$(USEMODULE)))
+      USEMODULE += gnrc_netif_cmd_lora
+    endif
   endif
   ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
       USEMODULE += shell_cmd_gnrc_pktbuf


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Restores LoRa functionality for the `ifconfig` command (see https://github.com/RIOT-OS/RIOT/pull/18355#issuecomment-1257780845 ff).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run and compile `examples/gnrc_lorawan` for `BOARD=b-l072z-lrwan1`. With this change LoRa specific output will be provided with `ifconfig`

```console
> ifconfig
ifconfig
Iface  3  HWaddr: 00:00:00:00  Frequency: 868299987Hz  RSSI: -157  BW: 125kHz  SF: 7  CR: 4/5  Link: down 
           TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
          OTAA  
          L2-PDU:255  
          
> version
version
2022.10-devel-882-g43fab-shell/fix/netif_lorawan_dependency
```

Without it, it is missing

```console
> ifconfig
ifconfig
Iface  3  HWaddr: 00:00:00:00  Frequency: 868299987Hz  RSSI: -157  Link: down 
           TX-Power: 14dBm  State: SLEEP 
          OTAA  
          L2-PDU:255  
          
> version
version
2022.10-devel-881-g6988db
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #18355
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
