### PR TITLE
sys/shell/cmds: fix shell_cmd_netif LoRaWAN integration

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -2,6 +2,7 @@
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
 DEPRECATED_MODULES += event_thread_lowest
 DEPRECATED_MODULES += gnrc_netdev_default
+DEPRECATED_MODULES += gnrc_netif_cmd_lora # use shell_cmd_gnrc_netif_lorawan instead
 DEPRECATED_MODULES += gnrc_pktbuf_cmd # use shell_cmd_gnrc_pktbuf instead
 DEPRECATED_MODULES += gnrc_udp_cmd # use shell_cmd_grnc_udp instead
 DEPRECATED_MODULES += heap_cmd # use shell_cmd_heap instead
@@ -10,7 +11,7 @@ DEPRECATED_MODULES += md5sum # use shell_cmd_md5sum instead
 DEPRECATED_MODULES += nice # use shell_cmd_nice instead
 DEPRECATED_MODULES += random_cmd # use shell_cmd_random instead
 DEPRECATED_MODULES += sema_deprecated
-DEPRECATED_MODULES += shell_commands # use shell_cmds_default instead
 DEPRECATED_MODULES += sha1sum # use shell_cmd_sha1sum instead
 DEPRECATED_MODULES += sha256sum # use shell_cmd_sha256sum instead
+DEPRECATED_MODULES += shell_commands # use shell_cmds_default instead
 DEPRECATED_MODULES += ztimer_now64

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -227,6 +227,7 @@ PSEUDOMODULES += shell_cmd_gnrc_ipv6_frag_stats
 PSEUDOMODULES += shell_cmd_gnrc_ipv6_nib
 PSEUDOMODULES += shell_cmd_gnrc_ipv6_whitelist
 PSEUDOMODULES += shell_cmd_gnrc_netif
+PSEUDOMODULES += shell_cmd_gnrc_netif_lorawan
 PSEUDOMODULES += shell_cmd_gnrc_pktbuf
 PSEUDOMODULES += shell_cmd_gnrc_rpl
 PSEUDOMODULES += shell_cmd_gnrc_sixlowpan_ctx

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -76,6 +76,10 @@ ifneq (,$(filter gnrc_dhcpv6_client_simple_pd,$(USEMODULE)))
   USEMODULE += dhcpv6_client_ia_pd
 endif
 
+ifneq (,$(filter gnrc_netif_cmd_lora,$(USEMODULE)))
+  USEMODULE += shell_cmd_gnrc_netif_lorawan
+endif
+
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_uhcpc
   USEMODULE += uhcpc

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -57,6 +57,9 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter gnrc_netif,$(USEMODULE)))
     USEMODULE += shell_cmd_gnrc_netif
   endif
+  ifneq (,$(filter gnrc_netif_lorawan,$(USEMODULE)))
+    USEMODULE += shell_cmd_gnrc_netif_lorawan
+  endif
   ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
       USEMODULE += shell_cmd_gnrc_pktbuf
   endif
@@ -184,6 +187,10 @@ ifneq (,$(filter shell_cmd_gnrc_ipv6_whitelist,$(USEMODULE)))
 endif
 ifneq (,$(filter shell_cmd_gnrc_netif,$(USEMODULE)))
   USEMODULE += gnrc_netif
+endif
+ifneq (,$(filter shell_cmd_gnrc_netif_lorawan,$(USEMODULE)))
+  USEMODULE += gnrc_netif_lorawan
+  USEMODULE += shell_cmd_gnrc_netif
 endif
 ifneq (,$(filter shell_cmd_gnrc_pktbuf,$(USEMODULE)))
     USEMODULE += gnrc_pktbuf

--- a/sys/shell/cmds/Kconfig
+++ b/sys/shell/cmds/Kconfig
@@ -119,6 +119,14 @@ config MODULE_SHELL_CMD_GNRC_NETIF
     depends on MODULE_SHELL_CMDS
     depends on MODULE_GNRC_NETIF
 
+config MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN
+    bool "LoRa integration to the GNRC network interface command (ifconfig)"
+    default y if MODULE_SHELL_CMD_GNRC_NETIF && MODULE_GNRC_NETIF_LORAWAN
+    depends on MODULE_GNRC_NETIF
+    depends on MODULE_GNRC_NETIF_LORAWAN
+    depends on MODULE_SHELL_CMDS
+    depends on MODULE_SHELL_CMD_GNRC_NETIF
+
 config MODULE_SHELL_CMD_GNRC_PKTBUF
     bool "Command to print stats of the GNRC packet buffer"
     default y if MODULE_SHELL_CMDS_DEFAULT

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -214,7 +214,7 @@ static void _set_usage(char *cmd_name)
          "       * \"pan\" - alias for \"nid\"\n"
          "       * \"pan_id\" - alias for \"nid\"\n"
          "       * \"phy_busy\" - set busy mode on-off\n"
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
          "       * \"bw\" - alias for channel bandwidth\n"
          "       * \"sf\" - alias for spreading factor\n"
          "       * \"cr\" - alias for coding rate\n"
@@ -390,7 +390,7 @@ static void _print_netopt(netopt_t opt)
         printf("encryption key");
         break;
 
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
     case NETOPT_BANDWIDTH:
         printf("bandwidth");
         break;
@@ -402,7 +402,7 @@ static void _print_netopt(netopt_t opt)
     case NETOPT_CODING_RATE:
         printf("coding rate");
         break;
-#endif /* MODULE_GNRC_NETIF_CMD_LORA */
+#endif /* MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN */
 #ifdef MODULE_NETDEV_IEEE802154_MULTIMODE
 
     case NETOPT_IEEE802154_PHY:
@@ -503,7 +503,7 @@ static const char *_netopt_state_str[] = {
     [NETOPT_STATE_STANDBY] = "STANDBY"
 };
 
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
 static const char *_netopt_bandwidth_str[] = {
     [LORA_BW_125_KHZ] = "125",
     [LORA_BW_250_KHZ] = "250",
@@ -675,7 +675,7 @@ static void _netif_list(netif_t *iface)
     if (res >= 0) {
         printf(" RSSI: %d ", i16);
     }
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
     res = netif_get_opt(iface, NETOPT_BANDWIDTH, 0, &u8, sizeof(u8));
     if (res >= 0) {
         printf(" BW: %skHz ", _netopt_bandwidth_str[u8]);
@@ -688,7 +688,7 @@ static void _netif_list(netif_t *iface)
     if (res >= 0) {
         printf(" CR: %s ", _netopt_coding_rate_str[u8]);
     }
-#endif /* MODULE_GNRC_NETIF_CMD_LORA */
+#endif /* MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN */
 #ifdef MODULE_NETDEV_IEEE802154
     res = netif_get_opt(iface, NETOPT_IEEE802154_PHY, 0, &u8, sizeof(u8));
     if (res >= 0) {
@@ -808,7 +808,7 @@ static void _netif_list(netif_t *iface)
         }
         line_thresh++;
     }
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
     res = netif_get_opt(iface, NETOPT_DEMOD_MARGIN, 0, &u8, sizeof(u8));
     if (res >= 0) {
         printf(" Demod margin.: %u ", (unsigned)u8);
@@ -998,7 +998,7 @@ static int _netif_set_u32(netif_t *iface, netopt_t opt, uint32_t context,
     return 0;
 }
 
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
 static int _netif_set_bandwidth(netif_t *iface, char *value)
 {
     uint8_t bw;
@@ -1059,7 +1059,7 @@ static int _netif_set_coding_rate(netif_t *iface, char *value)
 
     return 0;
 }
-#endif /* MODULE_GNRC_NETIF_CMD_LORA */
+#endif /* MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN */
 
 #ifdef MODULE_NETDEV_IEEE802154_MR_FSK
 static int _netif_set_fsk_fec(netif_t *iface, char *value)
@@ -1251,7 +1251,7 @@ static int _netif_set_flag(netif_t *iface, netopt_t opt, netopt_enable_t set)
     return 0;
 }
 
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
 static int _netif_set_lw_key(netif_t *iface, netopt_t opt, char *key_str)
 {
     /* This is the longest key */
@@ -1503,7 +1503,7 @@ static int _netif_set(char *cmd_name, netif_t *iface, char *key, char *value)
     else if ((strcmp("frequency", key) == 0) || (strcmp("freq", key) == 0)) {
         return _netif_set_u32(iface, NETOPT_CHANNEL_FREQUENCY, 0, value);
     }
-#ifdef MODULE_GNRC_NETIF_CMD_LORA
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
     else if ((strcmp("bandwidth", key) == 0) || (strcmp("bw", key) == 0)) {
         return _netif_set_bandwidth(iface, value);
     }
@@ -1553,7 +1553,7 @@ static int _netif_set(char *cmd_name, netif_t *iface, char *key, char *value)
     else if (strcmp("rx2_dr", key) == 0) {
         return _netif_set_u8(iface, NETOPT_LORAWAN_RX2_DR, 0, value);
     }
-#endif /* MODULE_GNRC_NETIF_CMD_LORA */
+#endif /* MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN */
 #ifdef MODULE_NETDEV_IEEE802154_MULTIMODE
     else if ((strcmp("phy_mode", key) == 0) || (strcmp("phy", key) == 0)) {
         return _netif_set_ieee802154_phy_mode(iface, value);


### PR DESCRIPTION
### Contribution description

Model the LoRaWAN integration to GNRC's netif command (ifconfig) as submodule of it, namely `shell_cmd_gnrc_netif_lorawan`.

This should fix a regression introduced by https://github.com/RIOT-OS/RIOT/pull/18355

### Testing procedure

Run and compile `examples/gnrc_lorawan` for `BOARD=b-l072z-lrwan1` as described in https://github.com/RIOT-OS/RIOT/pull/18355#issuecomment-1257780845

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18355#issuecomment-1257780845

Alternative to https://github.com/RIOT-OS/RIOT/pull/18648