### PR TITLE
gcoap: accept resources in any order

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -750,8 +750,7 @@ typedef struct {
  * @brief   A modular collection of resources for a server
  */
 struct gcoap_listener {
-    const coap_resource_t *resources;   /**< First element in the array of
-                                         *   resources; must order alphabetically */
+    const coap_resource_t *resources;   /**< First element in the array of resources */
     size_t resources_len;               /**< Length of array */
     /**
      * @brief   Transport type for the listener

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -744,12 +744,8 @@ static int _request_matcher_default(gcoap_listener_t *listener,
         int res = coap_match_path(*resource, uri);
 
         /* URI mismatch */
-        if (res > 0) {
+        if (res != 0) {
             continue;
-        }
-        /* resources expected in alphabetical order */
-        else if (res < 0) {
-            break;
         }
 
         /* potential match, check for method */

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -454,18 +454,14 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
         }
 
         int res = coap_match_path(resource, uri);
-        if (res > 0) {
+        if (res != 0) {
             continue;
         }
-        else if (res < 0) {
-            break;
-        }
-        else {
-            coap_request_ctx_t ctx = {
-                .resource = resource,
-            };
-            return resource->handler(pkt, resp_buf, resp_buf_len, &ctx);
-        }
+
+        coap_request_ctx_t ctx = {
+            .resource = resource,
+        };
+        return resource->handler(pkt, resp_buf, resp_buf_len, &ctx);
     }
 
     return coap_build_reply(pkt, COAP_CODE_404, resp_buf, resp_buf_len, 0);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`coap_match_path()` returns the result of `strcmp`, so 0 is a match, non-zero give the order of the two strings.

For some reason GCoAP things the order is important - which leads to surprising results.

E.g. if you have

```C
static const coap_resource_t _resources[] = {
    { "/fw", COAP_GET | COAP_MATCH_SUBTREE, gcoap_fileserver_handler, SUIT_FW_DIR },
    { "/cmd", COAP_PUT, _coap_cmd_handler, NULL },
    { "/log", COAP_PUT, _coap_log_handler, NULL },
};
```

The `/cmd` endpoint will always return 404.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
