### PR TITLE
make: buildtest: assume valid toolchain when BUILD_IN_DOCKER=1

### DIFF
--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -6,7 +6,7 @@ buildtest:
 	@ \
 	RESULT=true ; \
 	for board in $(BOARDS); do \
-		if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
+		if test "$(BUILD_IN_DOCKER)" = "1" || BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
 			$(COLOR_ECHO) -n "Building for $$board ... " ; \
 			BOARD=$${board} RIOT_CI_BUILD=1 \
 				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Previously, that check would have been executed _on the host_. Now, just assume that when building in docker, the toolchain is valid.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Trust my testing:

master:
<details>

```
❯ BUILDTEST_MAKE_REDIRECT="" BUILD_IN_DOCKER=1 BOARDS=hifive1b make -Cexamples/rust-hello-world buildtest
make: Entering directory '/home/kaspar/src/riot/examples/rust-hello-world'
make: Leaving directory '/home/kaspar/src/riot/examples/rust-hello-world'
```

</details>

Note that it is not even trying to build.

Now:
<details>

```
❯ BUILDTEST_MAKE_REDIRECT="" BUILD_IN_DOCKER=1 BOARDS=hifive1b make -Cexamples/rust-hello-world buildtest
make: Entering directory '/home/kaspar/src/riot/examples/rust-hello-world'
Building for hifive1b ... make[1]: Entering directory '/home/kaspar/src/riot/examples/rust-hello-world'
/home/kaspar/src/riot/makefiles/arch/riscv.inc.mk:37: *** No RISC-V toolchain detected. Make sure a RISC-V toolchain is installed..  Stop.
make[1]: Leaving directory '/home/kaspar/src/riot/examples/rust-hello-world'
failed!
make: *** [/home/kaspar/src/riot/makefiles/buildtests.inc.mk:6: buildtest] Error 1
make: Leaving directory '/home/kaspar/src/riot/examples/rust-hello-world'

```
</details>

Note that it is now "Building for hifive1b..." but choking on https://github.com/RIOT-OS/RIOT/pull/18654.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18654

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
