### PR TITLE
event_periodic_callback: add getter for user context, one-shot event

### DIFF
--- a/sys/include/event/callback.h
+++ b/sys/include/event/callback.h
@@ -61,6 +61,24 @@ typedef struct {
 void event_callback_init(event_callback_t *event_callback, void (*callback)(void *), void *arg);
 
 /**
+ * @brief   Generate a one-shot callback event on @p queue
+ *
+ * This will initialize @p event and post it immediately
+ *
+ * @param[in]   event           event_callback object to initialize
+ * @param[in]   queue           queue that the event will be added to
+ * @param[in]   callback        callback to set up
+ * @param[in]   arg             callback argument to set up
+ */
+static inline void event_callback_oneshot(event_callback_t *event,
+                                          event_queue_t *queue,
+                                          void (*callback)(void *), void *arg)
+{
+    event_callback_init(event, callback, arg);
+    event_post(queue, &event->super);
+}
+
+/**
  * @brief   event callback handler function (used internally)
  *
  * @internal

--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -41,6 +41,17 @@ typedef struct {
 } event_periodic_callback_t;
 
 /**
+ * @brief   Get user context from Periodic Callback Event
+ *
+ * @param[in]   event           event_periodic_callback object to initialize
+ * @return      User supplied argument to the event
+ */
+static inline void *event_periodic_callback_get_arg(event_periodic_callback_t *event)
+{
+    return event->event.arg;
+}
+
+/**
  * @brief   Initialize a periodic callback event
  *
  * @note: On init the periodic event is to to run forever.

--- a/tests/event_periodic_callback/main.c
+++ b/tests/event_periodic_callback/main.c
@@ -32,6 +32,9 @@ int main(void)
 {
     event_periodic_callback_t a, b, c;
 
+    event_callback_t oneshot;
+    event_callback_oneshot(&oneshot, EVENT_PRIO_MEDIUM, _event_cb, "event 0");
+
     event_periodic_callback_init(&a, ZTIMER_MSEC, EVENT_PRIO_MEDIUM, _event_cb, "event A");
     event_periodic_callback_init(&b, ZTIMER_MSEC, EVENT_PRIO_MEDIUM, _event_cb, "event B");
     event_periodic_callback_init(&c, ZTIMER_MSEC, EVENT_PRIO_MEDIUM, _event_cb, "event C");

--- a/tests/event_periodic_callback/tests/01-run.py
+++ b/tests/event_periodic_callback/tests/01-run.py
@@ -5,6 +5,7 @@ from testrunner import run
 
 
 def testfunc(child):
+    child.expect_exact("event 0")
     child.expect_exact("event A")
     child.expect_exact("event B")
     child.expect_exact("event A")


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

#### `event_periodic_callback_get_arg()`

This is a purely aesthetic addition: When initializing an event, e.g. to measure a sensor, I want to have a locally visible `static lm75_t lm75_dev` that I use as the event argument.

I can access this in the callback, but if I want to access it outside the callback, e.g. to re-init the sensor after the callback was suspended, I have to access `event->event.arg` which feels dirty.

Instead, add a nice getter function that does the same.

#### `event_callback_oneshot()`

An easy helper to execute a function by the event thread, to be called e.g. in an interrupt or by another function that is not supposed to block.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
