### PR TITLE
examples/micropython: re-enable CI test on non-native

### DIFF
--- a/examples/micropython/Makefile
+++ b/examples/micropython/Makefile
@@ -32,6 +32,6 @@ FEATURES_OPTIONAL += periph_spi
 TESTRUNNER_RESET_AFTER_TERM ?= 1
 
 # failing on native with floating point exception (#15870)
-TEST_ON_CI_BLACKLIST = all
+TEST_ON_CI_BLACKLIST = native
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Accidentally disabled for _all_ in https://github.com/RIOT-OS/RIOT/pull/18652.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18652

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
