### PR TITLE
cpu/sam0_common: adc: drop pin from adc_conf_chan_t

### DIFF
--- a/boards/adafruit-itsybitsy-m4/include/periph_conf.h
+++ b/boards/adafruit-itsybitsy-m4/include/periph_conf.h
@@ -241,12 +241,12 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos, dev */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0), ADC0},
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN5), ADC0},
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN2), ADC0},
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN3), ADC0},
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN4), ADC0},
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6), ADC0},
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA02, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA05, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB08, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB09, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA04, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA06, .dev = ADC0 },
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/adafruit-pybadge/include/periph_conf.h
+++ b/boards/adafruit-pybadge/include/periph_conf.h
@@ -272,13 +272,13 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos, dev */
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN5), ADC0},   /* A1 */
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN2), ADC0},   /* A2 */
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN3), ADC0},   /* A3 */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN4), ADC0},   /* A4 */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6), ADC0},   /* A5 */
-    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN13), ADC0},  /* A6 - VMEAS */
-    {GPIO_PIN(PB, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6), ADC1},   /* A7 - Light sensor */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA05, .dev = ADC0 },   /* A1 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB08, .dev = ADC0 },   /* A2 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB09, .dev = ADC0 },   /* A3 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA04, .dev = ADC0 },   /* A4 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA06, .dev = ADC0 },   /* A5 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB01, .dev = ADC0 },  /* A6 - VMEAS */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB04, .dev = ADC1 },   /* A7 - Light sensor */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/arduino-nano-33-iot/include/periph_conf.h
+++ b/boards/arduino-nano-33-iot/include/periph_conf.h
@@ -192,14 +192,14 @@ static const pwm_conf_t pwm_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},    /* A0 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},   /* A1 */
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},  /* A2 */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},  /* A3 */
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},    /* A4 */
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},    /* A5 */
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},   /* A6 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},   /* A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },    /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },   /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },  /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },  /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },    /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },    /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },   /* A6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },   /* A7 */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/bastwan/include/periph_conf.h
+++ b/boards/bastwan/include/periph_conf.h
@@ -176,11 +176,11 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    { GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN17) },
-    { GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN16) },
-    { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7) },
-    { GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6) },
-    { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN4) }
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 }
 };
 
 #define ADC_NUMOF                               ARRAY_SIZE(adc_channels)

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -158,13 +158,13 @@ static const pwm_conf_t pwm_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A1 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A2 */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A3 */
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* A4 */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* A5 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },    /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },     /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },     /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* A6 */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -214,12 +214,12 @@ static const pwm_conf_t pwm_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},   /* A0 */
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},   /* A1 */
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},   /* A2 */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},   /* A3 */
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},   /* A4 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},  /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },   /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },   /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },   /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },   /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },   /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },  /* A5 */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -241,7 +241,7 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN8)},
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -191,13 +191,13 @@ static const pwm_conf_t pwm_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    { GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0 },     /* A0 */
-    { GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2 },     /* A1 */
-    { GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3 },     /* A2 */
-    { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4 },     /* A3 */
-    { GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5 },     /* A4 */
-    { GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10 },    /* A5 */
-    { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7 },     /* A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },     /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },     /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },     /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* A7 */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -150,9 +150,9 @@ static const tc32_conf_t timer_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/samd10-xmini/include/periph_conf.h
+++ b/boards/samd10-xmini/include/periph_conf.h
@@ -236,12 +236,12 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN2},
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN3},
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN4},
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN5},
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/samd20-xpro/include/periph_conf.h
+++ b/boards/samd20-xpro/include/periph_conf.h
@@ -304,12 +304,12 @@ static const pwm_conf_t pwm_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},      /* EXT1, pin 3 */
-    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},      /* EXT1, pin 4 */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* EXT2, pin 3 */
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* EXT2, pin 4 */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},      /* EXT3, pin 3 */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1}       /* EXT3, pin 4.*/
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB00 },      /* EXT1, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB01 },      /* EXT1, pin 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },    /* EXT2, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },    /* EXT2, pin 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },      /* EXT3, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 }       /* EXT3, pin 4.*/
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -339,12 +339,12 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},      /* EXT1, pin 3 */
-    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},      /* EXT1, pin 4 */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* EXT2, pin 3 */
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* EXT2, pin 4 */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},      /* EXT3, pin 3 */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1}       /* EXT3, pin 4. This is
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB00 },      /* EXT1, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB01 },      /* EXT1, pin 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },    /* EXT2, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },    /* EXT2, pin 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },      /* EXT3, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 }       /* EXT3, pin 4. This is
                         disconnected by default. PA3 is connected to USB_ID.
                         Move PA03 SELECT jumper to EXT3 to connect. */
 };

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -340,9 +340,9 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos, dev */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN1), ADC0},
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN5), ADC0},
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7), ADC0}
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA03, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA05, .dev = ADC0 },
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA07, .dev = ADC0 }
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -241,9 +241,9 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN18)},
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN19)},
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)}
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 }
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -306,8 +306,8 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},      /* EXT1, pin 3 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},      /* EXT1, pin 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },      /* EXT1, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },      /* EXT1, pin 4 */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -171,11 +171,11 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6)}, /* EXT1, pin 3 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7)}, /* EXT1, pin 4 */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN18)},
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN19)},
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)}
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 }, /* EXT1, pin 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 }, /* EXT1, pin 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 }
 };
 
 #define ADC_NUMOF                               ARRAY_SIZE(adc_channels)

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -204,8 +204,8 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6)},
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7)}
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 }
 };
 
 #define ADC_NUMOF                               ARRAY_SIZE(adc_channels)

--- a/boards/seeeduino_xiao/include/periph_conf.h
+++ b/boards/seeeduino_xiao/include/periph_conf.h
@@ -204,15 +204,15 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3}
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 }
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_channels)

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -235,12 +235,12 @@ static const i2c_conf_t i2c_config[] = {
 /* Digital pins (1 to 6) on the board can be configured as analog inputs */
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4 },     /* Digital 1 */
-    { GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5 },     /* Digital 2 */
-    { GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6 },     /* Digital 3 */
-    { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7 },     /* Digital 4 */
-    { GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1 },     /* Digital 5 */
-    { GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0 },     /* Digital 6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },     /* Digital 1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* Digital 2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },     /* Digital 3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* Digital 4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 },     /* Digital 5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* Digital 6 */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/serpente/include/periph_conf.h
+++ b/boards/serpente/include/periph_conf.h
@@ -270,12 +270,12 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_channels)

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -122,22 +122,22 @@ static const uart_conf_t uart_config[] = {
 static const adc_conf_chan_t adc_channels[] = {
     /* port, muxpos/pin */
     /* Use the Arduino pin number order */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* ADC/AIN[0], A0 */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* ADC/AIN[6], A1 */
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* ADC/AIN[5], A2 */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* ADC/AIN[4], A3 */
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},     /* ADC/AIN[3], A4 */
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},     /* ADC/AIN[2], A5 */
-    {GPIO_PIN(PB, 7), ADC_INPUTCTRL_MUXPOS_PIN15},    /* ADC/AIN[15], A6 */
-    {GPIO_PIN(PB, 6), ADC_INPUTCTRL_MUXPOS_PIN14},    /* ADC/AIN[14], A7 */
-    {GPIO_PIN(PB, 5), ADC_INPUTCTRL_MUXPOS_PIN13},    /* ADC/AIN[13], A8 */
-    {GPIO_PIN(PB, 4), ADC_INPUTCTRL_MUXPOS_PIN12},    /* ADC/AIN[12], A9 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* ADC/AIN[7], A10 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* ADC/AIN[11], A11 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* ADC/AIN[10], A12 */
-    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* ADC/AIN[9], A13 (pin also used for DTR) */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* ADC/AIN[0], A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },     /* ADC/AIN[6], A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* ADC/AIN[5], A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },     /* ADC/AIN[4], A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },     /* ADC/AIN[3], A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },     /* ADC/AIN[2], A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB07 },    /* ADC/AIN[15], A6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB06 },    /* ADC/AIN[14], A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB05 },    /* ADC/AIN[13], A8 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB04 },    /* ADC/AIN[12], A9 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* ADC/AIN[7], A10 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },    /* ADC/AIN[11], A11 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* ADC/AIN[10], A12 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB01 },     /* ADC/AIN[9], A13 (pin also used for DTR) */
 
-    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* ADC/AIN[8], BATVOLT */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB00 },     /* ADC/AIN[8], BATVOLT */
 };
 
 #define ADC_NUMOF                          ARRAY_SIZE(adc_channels)

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -102,16 +102,16 @@ static const uart_conf_t uart_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* A0 */
-    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* A1 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A2 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A3 */
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A4 */
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A5 */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A6 (temperature) */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},   /* A7 */
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},   /* A8 */
-    {GPIO_PIN(PB, 5), ADC_INPUTCTRL_MUXPOS_PIN13},    /* BATVOLT */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB00 },     /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB01 },     /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },    /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },    /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },    /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },     /* A6 (temperature) */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },   /* A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },   /* A8 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB05 },    /* BATVOLT */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -90,23 +90,23 @@ static const uart_conf_t uart_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* A1 */
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},     /* A2 */
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},     /* A3 */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* A4 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A5 */
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A6 */
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A7 */
-    {GPIO_PIN(PA,10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* A8 */
-    {GPIO_PIN(PA,11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* A9 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 },     /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },     /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },     /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },     /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },    /* A6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },    /* A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },    /* A8 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },    /* A9 */
 #if 0
     /* These pins are also used for RX/TX uart0 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A10, TX */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A11, RX */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A10, TX */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },    /* A11, RX */
 #endif
 
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* BAT_VOLT */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* BAT_VOLT */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -93,17 +93,17 @@ static const uart_conf_t uart_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* A0 */
-    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* A1 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A2 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A3 */
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A4 */
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A5 */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},   /* GROVE1/A6 */
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},   /* GROVE2/A7 */
-    {GPIO_PIN(PB, 5), ADC_INPUTCTRL_MUXPOS_PIN13},    /* BAT_VOLT/A8 */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* D2/DAC */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* AREF */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB00 },     /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB01 },     /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },    /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },    /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },    /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },   /* GROVE1/A6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },   /* GROVE2/A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB05 },    /* BAT_VOLT/A8 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* D2/DAC */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 },     /* AREF */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/sodaq-sara-sff/include/periph_conf.h
+++ b/boards/sodaq-sara-sff/include/periph_conf.h
@@ -90,22 +90,22 @@ static const uart_conf_t uart_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* A1 */
-    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},     /* A2 */
-    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3},     /* A3 */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* A4 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A5 */
-    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A6 */
-    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A7 */
-    {GPIO_PIN(PA,10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* A8 */
-    {GPIO_PIN(PA,11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* A9 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },     /* A0 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 },     /* A1 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB08 },     /* A2 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },     /* A3 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA06 },     /* A4 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA08 },    /* A6 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA09 },    /* A7 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },    /* A8 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },    /* A9 */
 #if 0
     /* These pins are also used for RX/TX uart0 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A10, TX */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A11, RX */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A10, TX */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB03 },    /* A11, RX */
 #endif
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* BAT_VOLT */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* BAT_VOLT */
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/boards/yarm/include/periph_conf.h
+++ b/boards/yarm/include/periph_conf.h
@@ -163,10 +163,10 @@ static const i2c_conf_t i2c_config[] = {
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
-    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN18)},
-    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN19)},
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)},
-    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN1)}
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA10 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA11 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA02 },
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA03 }
 };
 
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -772,8 +772,7 @@ static inline bool cpu_woke_from_backup(void)
  * @brief ADC Channel Configuration
  */
 typedef struct {
-    gpio_t pin;             /**< ADC channel pin */
-    uint32_t muxpos;        /**< ADC channel pin multiplexer value */
+    uint32_t inputctrl;      /**< ADC channel pin multiplexer value */
 #ifdef ADC0
     Adc *dev;               /**< ADC device descriptor */
 #endif

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -264,9 +264,9 @@ int adc_init(adc_t line)
 
     _prep();
 
-    uint8_t muxpos = (adc_channels[line].muxpos & ADC_INPUTCTRL_MUXPOS_Msk)
+    uint8_t muxpos = (adc_channels[line].inputctrl & ADC_INPUTCTRL_MUXPOS_Msk)
                    >> ADC_INPUTCTRL_MUXPOS_Pos;
-    uint8_t muxneg = (adc_channels[line].muxpos & ADC_INPUTCTRL_MUXNEG_Msk)
+    uint8_t muxneg = (adc_channels[line].inputctrl & ADC_INPUTCTRL_MUXNEG_Msk)
                    >> ADC_INPUTCTRL_MUXNEG_Pos;
 
     /* configure positive input pin */
@@ -277,7 +277,7 @@ int adc_init(adc_t line)
     }
 
     /* configure negative input pin */
-    if (adc_channels[line].muxpos & ADC_INPUTCTRL_DIFFMODE) {
+    if (adc_channels[line].inputctrl & ADC_INPUTCTRL_DIFFMODE) {
         assert(muxneg < ARRAY_SIZE(sam0_adc_pins[adc]));
         gpio_init(sam0_adc_pins[adc][muxneg], GPIO_IN);
         gpio_init_mux(sam0_adc_pins[adc][muxneg], GPIO_MUX_B);
@@ -302,7 +302,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     Adc *dev = ADC;
 #endif
 
-    bool diffmode = adc_channels[line].muxpos & ADC_INPUTCTRL_DIFFMODE;
+    bool diffmode = adc_channels[line].inputctrl & ADC_INPUTCTRL_DIFFMODE;
 
     _prep();
 
@@ -313,7 +313,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     }
 
     dev->INPUTCTRL.reg = ADC_GAIN_FACTOR_DEFAULT
-                       | adc_channels[line].muxpos
+                       | adc_channels[line].inputctrl
                        | (diffmode ? 0 : ADC_NEG_INPUT);
 #ifdef ADC_CTRLB_DIFFMODE
     dev->CTRLB.bit.DIFFMODE = diffmode;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `.pin` member is no longer used and the `.muxpos` member is much more than just MUXPOS now - so drop the `.pin` and while we change the API anyway, also rename `.muxpos`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

follow-up to #18146
