### PR TITLE
murdock: make available boards instance dependent

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -5,8 +5,19 @@
 # and / or
 #export APPS="examples/hello-world tests/unittests"
 
-#
-: ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 samr21-xpro"}
+# this configures boards that are available via pifleet
+case "${CI_MURDOCK_PROJECT}" in
+    riot)
+        : ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 samr21-xpro"}
+        ;;
+    riot-staging)
+        : ${TEST_BOARDS_AVAILABLE:=""}
+        ;;
+    *)
+        : ${TEST_BOARDS_AVAILABLE:=""}
+        ;;
+esac
+
 #: ${EMULATED_BOARDS_AVAILABLE:="microbit"}
 
 # temporarily disabling llvm builds until https://github.com/RIOT-OS/RIOT/pull/15595
@@ -166,7 +177,8 @@ export OPTIONAL_CFLAGS_BLACKLIST="-gz"
 
 DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE
          -E TEST_HASH -E CI_PULL_LABELS -ECI_BASE_BRANCH -ECI_BASE_COMMIT
-         -EPKG_USE_MIRROR -EAPPS_CHANGED -EBOARDS_CHANGED -ESTATIC_TESTS"
+         -EPKG_USE_MIRROR -EAPPS_CHANGED -EBOARDS_CHANGED -ESTATIC_TESTS
+         -E CI_MURDOCK_PROJECT"
 
 if [ ${NIGHTLY} -eq 1 ]; then
     export PKG_USE_MIRROR=0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR is the next step in migrating to the new CI frontend.
It basically configures the available pifleet boards depending on the actual CI instance.
This also disables the default test board collection for our current CI, ci-prod will take over once this is merged.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
