### PR TITLE
examples/gcoap_dtls: Add coap-client example

### DIFF
--- a/examples/gcoap_dtls/README.md
+++ b/examples/gcoap_dtls/README.md
@@ -10,3 +10,14 @@ must be sent to this port.
 
 Since DTLS has higher memory and and ROM requirements, more boards are blacklisted
 for this example compared to the non-DTLS gcoap example.
+
+### CoAP query with DTLS enabled
+
+With DTLS enabled the server can be queried
+using the default DTLS pre-shared key from the `tinydtls_keys.h` file.
+
+    ./coap-client coaps://[fe80::1843:8eff:fe40:4eaa%tap0]/.well-known/core -k "secretPSK" -u "Client_identity"
+
+Example response:
+
+    </cli/stats>;ct=0;rt="count";obs,</riot/board>


### PR DESCRIPTION
### Contribution description

Add a simple usage example to the gcoap_dtls example 

### Testing procedure

Read the new documentation, and:

In one shell:
```Console
$ make -C examples/gcoap_dtls/ all term
```

In the other:
```Console
$ coap-client coaps://[fe80::d83c:a5ff:fe9c:3a41%tapbr0]/.well-known/core -k "secretPSK" -u "Client_identity"
```
Adjust the IP address of course

### Issues/PRs references

None