### PR TITLE
nib/_nib-6ln: correct ABR timeout in ABRO

### DIFF
--- a/sys/include/net/sixlowpan/nd.h
+++ b/sys/include/net/sixlowpan/nd.h
@@ -260,6 +260,20 @@ static inline void sixlowpan_nd_opt_abr_set_version(sixlowpan_nd_opt_abr_t *abr_
     abr_opt->vhigh = byteorder_htons((uint16_t)(version >> 16));
 }
 
+/**
+ * @brief   Get the lifetime of an Authoritative Border Router from an ABR option
+ *
+ * @param[in] abr_opt   An Authoritative Border Router option (ABRO).
+ *
+ * @return  The lifetime of @p abr_opt in minutes. If the lifetime is 0,
+ *          @ref SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT is returned.
+ */
+static inline uint16_t gnrc_sixlowpan_nd_opt_get_ltime(const sixlowpan_nd_opt_abr_t *abr_opt)
+{
+    uint16_t ltime = byteorder_ntohs(abr_opt->ltime);
+    return (ltime == 0) ? SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT : ltime;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -249,11 +249,9 @@ _nib_abr_entry_t *_handle_abro(const sixlowpan_nd_opt_abr_t *abro)
     abr = _nib_abr_add(&abro->braddr);
     if (abr != NULL) {
         uint32_t abro_version = sixlowpan_nd_opt_abr_get_version(abro);
-        uint16_t ltime = byteorder_ntohs(abro->ltime);
         /* correct for default value */
-        ltime = (ltime == 0) ? SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT : ltime;
-
-        uint32_t ltime_ms = MS_PER_SEC * SEC_PER_MIN * ltime;
+        uint32_t ltime_ms = MS_PER_SEC * SEC_PER_MIN *
+                            gnrc_sixlowpan_nd_opt_get_ltime(abro);
 
         if (abr->version >= abro_version) {
             abr->version = abro_version;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -701,8 +701,8 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         }
         /* UINT16_MAX * 60 * 1000 < UINT32_MAX so there are no overflows */
         next_timeout = _min(next_timeout,
-                            byteorder_ntohs(abro->ltime) * SEC_PER_MIN *
-                            MS_PER_SEC);
+                            MS_PER_SEC * SEC_PER_MIN *
+                            gnrc_sixlowpan_nd_opt_get_ltime(abro));
     }
 #if !IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)
     else if (gnrc_netif_is_6lr(netif)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

On `master`, a `6LR` is sending Router solicitations like crazy, after it found a `6LBR`, because the lifetime of an `ABR` in an `ABRO` is not corrected to the default value, if it was 0.

A `6LBR` is allowed to set the lifetime of an `ABR` in an `ABRO` to 0, if the default value can be assumed. 
[RFC6775](https://datatracker.ietf.org/doc/html/rfc6775#section-4.3):
>    Valid Lifetime:             16-bit unsigned integer.  The length of
                               time in units of 60 seconds (relative to
                               the time the packet is received) that
                               this set of border router information is
                               valid.  A value of all zero bits (0x0)
                               assumes a default value of 10,000
                               (~one week).

We do that here:
https://github.com/RIOT-OS/RIOT/blob/09fd98c0c6f13c9dba2cbce7c4301465f4bfdab9/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c#L199-L206

When the Router Advertisement is processed, the lifetime of an `ABR` is updated in `_handle_abro()` but the updated value is not considered for the `next_timeout` in `_handle_rtr_adv()`. this results in `next_timeout` always being 0.

~~This PR overrides the lifetime in an `ABRO` with the default value, if it was originally 0.~~

### Testing procedure

First go to `master` and apply this
<details>
<summary>patch</summary>

```patch
diff --git a/sys/net/gnrc/network_layer/ipv6/nib/nib.c b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
index c690d80b51..62ab8af4b3 100644
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -703,6 +703,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         next_timeout = _min(next_timeout,
                             byteorder_ntohs(abro->ltime) * SEC_PER_MIN *
                             MS_PER_SEC);
+        printf("next_timeout (ABRO): %"PRIu32"\n", next_timeout);
     }
 #if !IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)
     else if (gnrc_netif_is_6lr(netif)) {
@@ -727,6 +728,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *
ipv6,
         }
         /* UINT16_MAX * 1000 < UINT32_MAX so there are no overflows */
         next_timeout = _min(next_timeout, rtr_ltime * MS_PER_SEC);
+        printf("next_timeout (def. rtr.): %"PRIu32"\n", next_timeout);
     }
     else {
         dr = _nib_drl_get(&ipv6->src, netif->pid);
@@ -795,6 +797,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *
ipv6,
                                               (ndp_opt_pi_t *)opt);
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
                 next_timeout = _min(next_timeout, min_pfx_timeout);
+                printf("next_timeout (PIO): %"PRIu32"\n", next_timeout);
 
                 /* notify optional PIO consumer */
                 if (IS_USED(MODULE_GNRC_IPV6_NIB_RTR_ADV_PIO_CB)) {
@@ -816,6 +819,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *
ipv6,
                                                 (sixlowpan_nd_opt_6ctx_t *)opt),
                                     next_timeout);
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
+                printf("next_timeout (6PC): %"PRIu32"\n", next_timeout);
                 break;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_DNS)
@@ -824,6 +828,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *
ipv6,
                                                    (icmpv6_hdr_t *)rtr_adv,
                                                    (ndp_opt_rdnss_impl_t *)opt),
                                     next_timeout);
+                printf("next_timeout (RDNSS): %"PRIu32"\n", next_timeout);
                 break;
 #endif
             default:
@@ -858,6 +863,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *
ipv6,
         if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)) {
             _set_rtr_adv(netif);
         }
+        printf("next_timeout (final): %"PRIu32"\n", (next_timeout >> 2) * 3);
         /* but re-fetch information from router in time */
         _evtimer_add(netif, GNRC_IPV6_NIB_SEARCH_RTR,
                      &netif->ipv6.search_rtr, (next_timeout >> 2) * 3);
(END)
```
</details>

and verify that the timeout is always zero.

Then do the same with this PR and verify that the next `RS` is sent after the correct timeout.
```
2022-09-28 14:41:28,109 # next_timeout (ABRO): 600000000
2022-09-28 14:41:28,111 # next_timeout (def. rtr.): 1800000
2022-09-28 14:41:28,112 # next_timeout (PIO): 1800000
2022-09-28 14:41:28,114 # next_timeout (6PC): 1800000
2022-09-28 14:41:28,116 # next_timeout (final): 1350000
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
