### PR TITLE
Add shell commands to change eol char for "send" in tests/periph_uart

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -66,6 +66,8 @@ static char printer_stack[THREAD_STACKSIZE_MAIN];
 
 static bool test_mode;
 
+static char *endline = "\n";
+
 #ifdef MODULE_PERIPH_UART_MODECFG
 static uart_data_bits_t data_bits_lut[] = { UART_DATA_BITS_5, UART_DATA_BITS_6,
                                             UART_DATA_BITS_7, UART_DATA_BITS_8 };
@@ -204,6 +206,30 @@ static void sleep_test(int num, uart_t uart)
     puts("[OK]");
 }
 
+static int cmd_eol_cr(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    endline = "\r";
+    return 0;
+}
+
+static int cmd_eol_lf(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    endline = "\n";
+    return 0;
+}
+
+static int cmd_eol_crlf(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    endline = "\r\n";
+    return 0;
+}
+
 static int cmd_init(int argc, char **argv)
 {
     int dev, res;
@@ -310,7 +336,6 @@ static int cmd_mode(int argc, char **argv)
 static int cmd_send(int argc, char **argv)
 {
     int dev;
-    uint8_t endline = (uint8_t)'\n';
 
     if (argc < 3) {
         printf("usage: %s <dev> <data (string)>\n", argv[0]);
@@ -324,7 +349,7 @@ static int cmd_send(int argc, char **argv)
 
     printf("UART_DEV(%i) TX: %s\n", dev, argv[2]);
     uart_write(UART_DEV(dev), (uint8_t *)argv[2], strlen(argv[2]));
-    uart_write(UART_DEV(dev), &endline, 1);
+    uart_write(UART_DEV(dev), (uint8_t *)endline, strlen(endline));
     return 0;
 }
 
@@ -357,6 +382,9 @@ static int cmd_test(int argc, char **argv)
 }
 
 static const shell_command_t shell_commands[] = {
+    { "eol_cr", "Set CR as the end-of-line for send", cmd_eol_cr },
+    { "eol_crlf", "Set CRLF as the end-of-line for send", cmd_eol_crlf },
+    { "eol_lf", "Set LF as the end-of-line for send (default)", cmd_eol_lf },
     { "init", "Initialize a UART device with a given baudrate", cmd_init },
 #ifdef MODULE_PERIPH_UART_MODECFG
     { "mode", "Setup data bits, stop bits and parity for a given UART device", cmd_mode },

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -182,15 +182,19 @@ static void *printer(void *arg)
         do {
             c = (int)ringbuffer_get_one(&(ctx[dev].rx_buf));
             if (c == '\n') {
-                puts("]\\n");
+                printf("\\n");
+            }
+            else if (c == '\r') {
+                printf("\\r");
             }
             else if (c >= ' ' && c <= '~') {
                 printf("%c", c);
             }
             else {
-                printf("0x%02x", (unsigned char)c);
+                printf("\\x%02x", (unsigned char)c);
             }
         } while (c != '\n');
+        printf("]\n");
     }
 
     /* this should never be reached */


### PR DESCRIPTION
### Contribution description

Two little changes to the `periph_uart` test.

1. make it possible to change the end-of-line character of the send command
2. change to printout of the `\r` and `\n` control characters when they are received

The first comes in handy when a modem is connected to the UART. AT commands are normally terminated with a CR ('\r`).

The second change gives more insight to the actual characters that are received on the UART's input. Here is an example output
```
> eol_cr
2022-09-28 22:18:01,761 # eol_cr
> send 3 at
2022-09-28 22:18:05,801 # send 3 at
2022-09-28 22:18:05,802 # UART_DEV(3) TX: at
> 2022-09-28 22:18:05,830 # Success: UART_DEV(3) RX: [at\r\r\n]
2022-09-28 22:18:05,830 # Success: UART_DEV(3) RX: [OK\r\n]
```

### Testing procedure

None really.