### PR TITLE
cpu/native: get mtd size from file size

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -129,6 +129,7 @@ extern const char* (*real_gai_strerror)(int errcode);
 extern FILE* (*real_fopen)(const char *path, const char *mode);
 extern int (*real_fclose)(FILE *stream);
 extern int (*real_fseek)(FILE *stream, long offset, int whence);
+extern long (*real_ftell)(FILE *stream);
 extern int (*real_fputc)(int c, FILE *stream);
 extern int (*real_fgetc)(FILE *stream);
 extern mode_t (*real_umask)(mode_t cmask);

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -47,6 +47,10 @@ static int _init(mtd_dev_t *dev)
         for (size_t i = 0; i < size; i++) {
             real_fputc(0xff, f);
         }
+    } else {
+        real_fseek(f, 0, SEEK_END);
+        size_t size = real_ftell(f);
+        dev->sector_count = size / (dev->pages_per_sector * dev->page_size);
     }
 
     real_fclose(f);

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -95,6 +95,7 @@ const char* (*real_gai_strerror)(int errcode);
 FILE* (*real_fopen)(const char *path, const char *mode);
 int (*real_fclose)(FILE *stream);
 int (*real_fseek)(FILE *stream, long offset, int whence);
+long (*real_ftell)(FILE *stream);
 int (*real_fputc)(int c, FILE *stream);
 int (*real_fgetc)(FILE *stream);
 mode_t (*real_umask)(mode_t cmask);
@@ -540,6 +541,7 @@ void _native_init_syscalls(void)
     *(void **)(&real_send) = dlsym(RTLD_NEXT, "send");
     *(void **)(&real_fclose) = dlsym(RTLD_NEXT, "fclose");
     *(void **)(&real_fseek) = dlsym(RTLD_NEXT, "fseek");
+    *(void **)(&real_ftell) = dlsym(RTLD_NEXT, "ftell");
     *(void **)(&real_fputc) = dlsym(RTLD_NEXT, "fputc");
     *(void **)(&real_fgetc) = dlsym(RTLD_NEXT, "fgetc");
 #ifdef __MACH__


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When `native` is provided with a `MEMORY.bin` file that is a file system image, it should use the whole image and not just the size specified by `MTD_SECTOR_NUM`.


### Testing procedure

Create a 16 MiB file in `tests/vfs_default`

    dd if=/dev/zero of=MEMORY.bin bs=4096 count=4096

and verify that `native` detects the whole size

```
Manual MTD test
init MTD_0… OK (16 MiB)
> info
info
mtd devices: 1
 -=[ MTD_0 ]=-
sectors: 4096
pages per sector: 16
page size: 256
total: 16 MiB
> test 0
test 0
[START]
[SUCCESS]
``` 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
