### PR TITLE
vfs: drop unused abs_path parameter

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -222,14 +222,12 @@ static fatfs_file_desc_t * _get_fatfs_file_desc(vfs_file_t *f)
     return (fatfs_file_desc_t *)(uintptr_t)f->private_data.buffer;
 }
 
-static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode,
-                 const char *abs_path)
+static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode)
 {
     fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
     fatfs_desc_t *fs_desc = (fatfs_desc_t *)filp->mp->private_data;
     _build_abs_path(fs_desc, name);
 
-    (void) abs_path;
     (void) mode; /* fatfs can't use mode param with f_open*/
     DEBUG("fatfs_vfs.c: _open: private_data = %p, name = %s; flags = 0x%x\n",
           filp->mp->private_data, name, flags);
@@ -416,11 +414,10 @@ static inline DIR * _get_DIR(vfs_DIR *d)
     return (DIR *)(uintptr_t)d->private_data.buffer;
 }
 
-static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
+static int _opendir(vfs_DIR *dirp, const char *dirname)
 {
     DIR *dir = _get_DIR(dirp);
     fatfs_desc_t *fs_desc = (fatfs_desc_t *)dirp->mp->private_data;
-    (void) abs_path;
 
     _build_abs_path(fs_desc, dirname);
 

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -286,11 +286,10 @@ static inline lfs_file_t * _get_lfs_file(vfs_file_t *f)
     return (lfs_file_t *)(uintptr_t)f->private_data.buffer;
 }
 
-static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
+static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode)
 {
     littlefs_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = _get_lfs_file(filp);
-    (void) abs_path;
     (void) mode;
 
     mutex_lock(&fs->lock);
@@ -320,7 +319,7 @@ static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, con
         l_flags |= LFS_O_EXCL;
     }
 
-    DEBUG("littlefs: open: %s (abs_path: %s), flags: 0x%x\n", name, abs_path, (int) l_flags);
+    DEBUG("littlefs: open: %s, flags: 0x%x\n", name, (int) l_flags);
 
     int ret = lfs_file_open(&fs->fs, fp, name, l_flags);
     mutex_unlock(&fs->lock);
@@ -477,16 +476,15 @@ static inline lfs_dir_t * _get_lfs_dir(vfs_DIR *dirp)
     return (lfs_dir_t *)(uintptr_t)dirp->private_data.buffer;
 }
 
-static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
+static int _opendir(vfs_DIR *dirp, const char *dirname)
 {
-    (void)abs_path;
     littlefs_desc_t *fs = dirp->mp->private_data;
     lfs_dir_t *dir = _get_lfs_dir(dirp);
 
     mutex_lock(&fs->lock);
 
-    DEBUG("littlefs: opendir: dirp=%p, dirname=%s (abs_path=%s)\n",
-          (void *)dirp, dirname, abs_path);
+    DEBUG("littlefs: opendir: dirp=%p, dirname=%s\n",
+          (void *)dirp, dirname);
 
     int ret = lfs_dir_open(&fs->fs, dir, dirname);
     mutex_unlock(&fs->lock);

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -291,11 +291,10 @@ static inline lfs_file_t * _get_lfs_file(vfs_file_t *f)
     return (lfs_file_t *)(uintptr_t)f->private_data.buffer;
 }
 
-static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
+static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode)
 {
     littlefs2_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = _get_lfs_file(filp);
-    (void) abs_path;
     (void) mode;
 
     mutex_lock(&fs->lock);
@@ -325,7 +324,7 @@ static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, con
         l_flags |= LFS_O_EXCL;
     }
 
-    DEBUG("littlefs: open: %s (abs_path: %s), flags: 0x%x\n", name, abs_path, (int) l_flags);
+    DEBUG("littlefs: open: %s, flags: 0x%x\n", name, (int) l_flags);
 
     int ret = lfs_file_open(&fs->fs, fp, name, l_flags);
     mutex_unlock(&fs->lock);
@@ -482,16 +481,15 @@ static inline lfs_dir_t * _get_lfs_dir(vfs_DIR *dirp)
     return (lfs_dir_t *)(uintptr_t)dirp->private_data.buffer;
 }
 
-static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
+static int _opendir(vfs_DIR *dirp, const char *dirname)
 {
-    (void)abs_path;
     littlefs2_desc_t *fs = dirp->mp->private_data;
     lfs_dir_t *dir = _get_lfs_dir(dirp);
 
     mutex_lock(&fs->lock);
 
-    DEBUG("littlefs: opendir: dirp=%p, dirname=%s (abs_path=%s)\n",
-          (void *)dirp, dirname, abs_path);
+    DEBUG("littlefs: opendir: dirp=%p, dirname=%s\n",
+          (void *)dirp, dirname);
 
     int ret = lfs_dir_open(&fs->fs, dir, dirname);
     mutex_unlock(&fs->lock);

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -246,10 +246,9 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
     return 0;
 }
 
-static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
+static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode)
 {
     spiffs_desc_t *fs_desc = filp->mp->private_data;
-    (void) abs_path;
     DEBUG("spiffs: open: private_data = %p\n", filp->mp->private_data);
 
     spiffs_flags s_flags = 0;
@@ -280,7 +279,7 @@ static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, con
         s_flags |= SPIFFS_O_EXCL;
     }
 
-    DEBUG("spiffs: open: %s (abs_path: %s), flags: 0x%x, mode: %d\n", name, abs_path, (int) s_flags, (int) mode);
+    DEBUG("spiffs: open: %s, flags: 0x%x, mode: %d\n", name, (int) s_flags, (int) mode);
 
     s32_t ret = SPIFFS_open(&fs_desc->fs, name, s_flags, mode);
     if (ret >= 0) {
@@ -368,11 +367,10 @@ static spiffs_DIR * _get_spifs_dir(vfs_DIR *dirp)
     return (spiffs_DIR *)(uintptr_t)&dirp->private_data.buffer[0];
 }
 
-static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
+static int _opendir(vfs_DIR *dirp, const char *dirname)
 {
     spiffs_desc_t *fs_desc = dirp->mp->private_data;
     spiffs_DIR *d = _get_spifs_dir(dirp);
-    (void) abs_path;
 
     spiffs_DIR *res = SPIFFS_opendir(&fs_desc->fs, dirname, d);
     if (res == NULL) {

--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -39,11 +39,11 @@ static int constfs_statvfs(vfs_mount_t *mountp, const char *restrict path, struc
 /* File operations */
 static int constfs_fstat(vfs_file_t *filp, struct stat *buf);
 static off_t constfs_lseek(vfs_file_t *filp, off_t off, int whence);
-static int constfs_open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path);
+static int constfs_open(vfs_file_t *filp, const char *name, int flags, mode_t mode);
 static ssize_t constfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
 
 /* Directory operations */
-static int constfs_opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path);
+static int constfs_opendir(vfs_DIR *dirp, const char *dirname);
 static int constfs_readdir(vfs_DIR *dirp, vfs_dirent_t *entry);
 
 static const vfs_file_system_ops_t constfs_fs_ops = {
@@ -162,12 +162,11 @@ static off_t constfs_lseek(vfs_file_t *filp, off_t off, int whence)
     return off;
 }
 
-static int constfs_open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
+static int constfs_open(vfs_file_t *filp, const char *name, int flags, mode_t mode)
 {
     (void) mode;
-    (void) abs_path;
     constfs_t *fs = filp->mp->private_data;
-    DEBUG("constfs_open: %p, \"%s\", 0x%x, 0%03lo, \"%s\"\n", (void *)filp, name, flags, (unsigned long)mode, abs_path);
+    DEBUG("constfs_open: %p, \"%s\", 0x%x, 0%03lo\"\n", (void *)filp, name, flags, (unsigned long)mode);
     /* We only support read access */
     if ((flags & O_ACCMODE) != O_RDONLY) {
         return -EROFS;
@@ -203,10 +202,9 @@ static ssize_t constfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
     return nbytes;
 }
 
-static int constfs_opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
+static int constfs_opendir(vfs_DIR *dirp, const char *dirname)
 {
-    (void) abs_path;
-    DEBUG("constfs_opendir: %p, \"%s\", \"%s\"\n", (void *)dirp, dirname, abs_path);
+    DEBUG("constfs_opendir: %p, \"%s\"\n", (void *)dirp, dirname);
     if (strncmp(dirname, "/", 2) != 0) {
         /* We keep it simple and only support a flat file system, only a root directory */
         return -ENOENT;

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -476,12 +476,11 @@ struct vfs_file_ops {
      * @param[in]  name     null-terminated name of the file to open, relative to the file system root, including a leading slash
      * @param[in]  flags    flags for opening, see man 2 open, man 3p open
      * @param[in]  mode     mode for creating a new file, see man 2 open, man 3p open
-     * @param[in]  abs_path null-terminated name of the file to open, relative to the VFS root ("/")
      *
      * @return 0 on success
      * @return <0 on error
      */
-    int (*open) (vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path);
+    int (*open) (vfs_file_t *filp, const char *name, int flags, mode_t mode);
 
     /**
      * @brief Read bytes from an open file
@@ -528,12 +527,11 @@ struct vfs_dir_ops {
      *
      * @param[in]  dirp     pointer to open directory
      * @param[in]  name     null-terminated name of the dir to open, relative to the file system root, including a leading slash
-     * @param[in]  abs_path null-terminated name of the dir to open, relative to the VFS root ("/")
      *
      * @return 0 on success
      * @return <0 on error
      */
-    int (*opendir) (vfs_DIR *dirp, const char *dirname, const char *abs_path);
+    int (*opendir) (vfs_DIR *dirp, const char *dirname);
 
     /**
      * @brief Read a single entry from the open directory dirp and advance the

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -298,7 +298,7 @@ int vfs_open(const char *name, int flags, mode_t mode)
     }
     vfs_file_t *filp = &_vfs_open_files[fd];
     if (filp->f_op->open != NULL) {
-        res = filp->f_op->open(filp, rel_path, flags, mode, name);
+        res = filp->f_op->open(filp, rel_path, flags, mode);
         if (res < 0) {
             /* something went wrong during open */
             DEBUG("vfs_open: open: ERR %d!\n", res);
@@ -420,7 +420,7 @@ int vfs_opendir(vfs_DIR *dirp, const char *dirname)
     dirp->mp = mountp;
     dirp->d_op = mountp->fs->d_op;
     if (dirp->d_op->opendir != NULL) {
-        int res = dirp->d_op->opendir(dirp, rel_path, dirname);
+        int res = dirp->d_op->opendir(dirp, rel_path);
         if (res < 0) {
             /* remember to decrement the open_files count */
             atomic_fetch_sub(&mountp->open_files, 1);
@@ -1114,7 +1114,7 @@ static bool _is_dir(vfs_mount_t *mountp, vfs_DIR *dir, const char *restrict path
     dir->d_op = ops;
     dir->mp = mountp;
 
-    int res = ops->opendir(dir, path, path);
+    int res = ops->opendir(dir, path);
     if (res < 0) {
         return false;
     }
@@ -1140,7 +1140,7 @@ int vfs_sysop_stat_from_fstat(vfs_mount_t *mountp, const char *restrict path, st
         },
     };
 
-    int err = f_op->open(&filedir.file, path, 0, 0, NULL);
+    int err = f_op->open(&filedir.file, path, 0, 0);
     if (err < 0) {
         if (_is_dir(mountp, &filedir.dir, path)) {
             buf->st_mode = S_IFDIR;

--- a/tests/devfs/main.c
+++ b/tests/devfs/main.c
@@ -25,7 +25,7 @@
 
 #include "embUnit.h"
 
-static int _mock_open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path);
+static int _mock_open(vfs_file_t *filp, const char *name, int flags, mode_t mode);
 static ssize_t _mock_read(vfs_file_t *filp, void *dest, size_t nbytes);
 static ssize_t _mock_write(vfs_file_t *filp, const void *src, size_t nbytes);
 
@@ -55,12 +55,11 @@ static vfs_mount_t _test_devfs_mount = {
     .private_data = &_mock_private_data,
 };
 
-static int _mock_open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
+static int _mock_open(vfs_file_t *filp, const char *name, int flags, mode_t mode)
 {
     (void) name;
     (void) flags;
     (void) mode;
-    (void) abs_path;
     if (filp->private_data.ptr != &_mock_private_data_tag) {
         return -4321;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Both `open()` and `opendir()` also get the absolute path in VFS.
This is used by no filesystem and worse, only present for those two functions.

So even if a filesystem would rely on the absolute path, it could not `mkdir`, `unlink` or `rename` files.

Remove it as it only adds clutter and confusion.


### Testing procedure

CI should be enough, this parameter was unused by every implementation.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
