### PR TITLE
boards/stm32f746g-disco: add LD1 as LED0 definition

### DIFF
--- a/boards/stm32f746g-disco/include/board.h
+++ b/boards/stm32f746g-disco/include/board.h
@@ -58,6 +58,14 @@ extern "C" {
 /** @} */
 
 /**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED0_PIN_NUM        1           /**< LD1 pin number */
+#define LED0_PORT_NUM       PORT_I      /**< LD1 port */
+/** @} */
+
+/**
  * @name User button
  * @{
  */
@@ -79,6 +87,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include "stm32_leds.h"
 
 #endif /* BOARD_H */
 /** @} */

--- a/boards/stm32f746g-disco/include/gpio_params.h
+++ b/boards/stm32f746g-disco/include/gpio_params.h
@@ -32,6 +32,11 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
+        .name = "LD1 (green)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
         .name = "BTN USER",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE


### PR DESCRIPTION
### Contribution description

This PR adds LED LD1 of STM32F746-DISCO as LED0.

LED LD1 has no special function on the board STM32F746-DISCO and therefore can be used freely. This LED is also defined as ARDUINO LED pin D13 in the schematic.

### Testing procedure

Compile and flash
```
BOARD=stm32f746g-disco make -j8 -C tests/leds flash term
```
and check that LD1 works.

### Issues/PRs references
