### PR TITLE
boards/nucleo-l4r5zi:  support for ADC

### DIFF
--- a/boards/nucleo-l4r5zi/Kconfig
+++ b/boards/nucleo-l4r5zi/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_L4R5ZI
     select CPU_MODEL_STM32L4R5ZI
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_LPUART
     select HAS_PERIPH_RTC

--- a/boards/nucleo-l4r5zi/Makefile.features
+++ b/boards/nucleo-l4r5zi/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l4r5zi
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -117,6 +117,49 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @brief   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32L4R5 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5 and the internal VBAT channel.
+ *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC1_IN10 is device 0,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC1_IN10 is channel 10
+ *
+ * For Nucleo-L4R5ZI this information is in board manual,
+ * Table 11, page 38.
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 3), .dev = 0, .chan =  8 }, /* ADC12_IN8   */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 0, .chan =  1 }, /* ADC123_IN1  */
+    { .pin = GPIO_PIN(PORT_C, 3), .dev = 0, .chan =  4 }, /* ADC123_IN4  */
+    { .pin = GPIO_PIN(PORT_C, 1), .dev = 0, .chan =  2 }, /* ADC123_IN2  */
+    { .pin = GPIO_PIN(PORT_C, 4), .dev = 0, .chan = 13 }, /* ADC12_IN13  */
+    { .pin = GPIO_PIN(PORT_C, 5), .dev = 0, .chan = 14 }, /* ADC12_IN14  */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 18 }, /* VBAT */
+};
+
+/**
+ * @brief Number of ADC devices
+ */
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+/**
+ * @brief VBAT ADC line
+ */
+#define VBAT_ADC            ADC_LINE(6)
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -29,12 +29,14 @@ extern "C" {
  */
 #if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG)
 #define ADC_DEVS            (3U)
-#elif defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC)
+#elif defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC) || \
+ defined(CPU_MODEL_STM32L4R5ZI)
 #define ADC_DEVS            (1U)
 #endif
 
 #if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG) || \
-    defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC)
+    defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC) || \
+    defined(CPU_MODEL_STM32L4R5ZI)
 /**
  * @brief   ADC voltage regulator start-up time [us]
  */

--- a/cpu/stm32/periph/adc_l4.c
+++ b/cpu/stm32/periph/adc_l4.c
@@ -29,9 +29,20 @@
 #include "ztimer.h"
 
 /**
+ * @brief Not all STM32 L4 boards have 3 ADC devices
+ * for example, L4R5ZI has only one ADC
+ */
+#if defined ADC_DEVS && ADC_DEVS == 1
+#define ADC ADC1_COMMON
+#endif
+#if defined ADC_DEVS && ADC_DEVS == 3
+#define ADC ADC123_COMMON
+#endif
+
+/**
  * @brief map CPU specific register/value names
  */
-#if defined(CPU_MODEL_STM32L476RG)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L4R5ZI)
 #define ADC_CR_REG      CR
 #define ADC_ISR_REG     ISR
 #define ADC_PERIPH_CLK  AHB2
@@ -117,16 +128,16 @@ int adc_init(adc_t line)
     prep(line);
 
     /* set prescaler to 0 to let the ADC run with maximum speed */
-    ADC123_COMMON->CCR &= ~(ADC_CCR_PRESC);
+    ADC->CCR &= ~(ADC_CCR_PRESC);
 
     /* Setting ADC clock to HCLK/1 is only allowed if AHB clock prescaler is 1*/
     if (!(RCC->CFGR & RCC_CFGR_HPRE_3)) {
         /* set ADC clock to HCLK/1 */
-        ADC123_COMMON->CCR |= (ADC_CCR_CKMODE_0);
+        ADC->CCR |= (ADC_CCR_CKMODE_0);
     }
     else {
         /* set ADC clock to HCLK/2 otherwise */
-        ADC123_COMMON->CCR |= (ADC_CCR_CKMODE_1);
+        ADC->CCR |= (ADC_CCR_CKMODE_1);
     }
 
     /* configure the pin */


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-l4r5zi ADC configuration.

### Testing procedure

Flash the board using `tests/periph_adc` program. Check if measured values changes when A0-A5 pins are
connected to the 3,3V, GND or to the potentiometer. 

### Issues/PRs references

None