### PR TITLE
.murdock.yml: Add preview link to documentation to comment

### DIFF
--- a/.murdock.yml
+++ b/.murdock.yml
@@ -7,6 +7,9 @@ push:
 pr:
   enable_comments: true
   sticky_comment: true
+  comment_artifacts:
+  - name: doc-preview/
+    readable_name: Documentation preview
   comment_footer: >
     **This only reflects a subset of all builds from https://ci-prod.riot-os.org.
     Please refer to https://ci.riot-os.org for a complete build for now.**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This will provide a link to the rendered documentation in Murdock's stick comment.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Once https://github.com/murdock-ng/murdock/pull/9 is deployed, we can set the "CI: ready for build" label. The comment by Murdock should then contain a link to the documentation preview.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Requares https://github.com/murdock-ng/murdock/pull/9 and the code in it being deployed.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
