### PR TITLE
rust: Update dependencies, build and test more on stable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,5 @@
 # Cargo.toml, copy this file over, or just use the released versions.
 
 [patch.crates-io]
-riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }
-riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers" }
+#riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }
+#riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers" }

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -183,13 +183,13 @@ dependencies = [
 
 [[package]]
 name = "coap-handler"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a298428323227d55446ff27f05f80655c0e768367451731606e077c4d784793"
+checksum = "16fbe39cc8c18a07e97f3fbf16e6771946f5cded9800db0ab2698c5a2409ddb2"
 dependencies = [
  "byteorder",
  "coap-message",
- "coap-numbers",
+ "coap-numbers 0.2.0",
  "crc",
  "serde",
  "serde_cbor",
@@ -198,13 +198,13 @@ dependencies = [
 
 [[package]]
 name = "coap-handler-implementations"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c38a836121cc920c50ec1f115a967108b7f6cc7c4de3a13cff7d7efee06f476"
+checksum = "620e584e19bd2432640d73fc29b5c8ac0904a903b863f7c3ad5cd989917c55e5"
 dependencies = [
  "coap-handler",
  "coap-message",
- "coap-numbers",
+ "coap-numbers 0.2.0",
  "crc",
  "minicbor",
  "serde",
@@ -214,19 +214,20 @@ dependencies = [
 
 [[package]]
 name = "coap-message"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c4519a5d4e6f04561ffdc926d771cece250a1eff5d69f87f26948745833df8"
+checksum = "7cc888e15f6be910b58fda4f056f673f58fb9348ea45da014283a14e6d2b58ec"
 
 [[package]]
 name = "coap-message-demos"
-version = "0.1.1"
-source = "git+https://gitlab.com/chrysn/coap-message-demos/#e5bc63915a931d397bd69a75c1ae1aba8063dbdf"
+version = "0.2.0"
+source = "git+https://gitlab.com/chrysn/coap-message-demos/#6a55eef795b33765fe50d8aeb9cb8742ad80a63f"
 dependencies = [
  "coap-handler",
  "coap-handler-implementations",
  "coap-message",
- "coap-numbers",
+ "coap-numbers 0.2.0",
+ "heapless",
  "serde",
  "serde_cbor",
 ]
@@ -236,6 +237,12 @@ name = "coap-numbers"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "846c9bba4f1a98e6b3e26f67d96414eb2b1534a702c87d65c3a52c994c690d6a"
+
+[[package]]
+name = "coap-numbers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d4135db61ac9b5fb4266fcd1294abd47c807e63b496882784543940dc3402e9"
 
 [[package]]
 name = "cortex-m"
@@ -271,13 +278,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.11"
+name = "cstr_core"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
- "proc-macro2",
- "quote",
+ "cty",
+ "memchr",
 ]
 
 [[package]]
@@ -416,9 +423,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -547,9 +554,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -588,7 +595,7 @@ dependencies = [
  "coap-handler",
  "coap-handler-implementations",
  "coap-message",
- "coap-numbers",
+ "coap-numbers 0.2.0",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
@@ -602,8 +609,9 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.8"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#1035e93ad24d007effe79a5764d8c307150503e3"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0186f82eb1cf9f9127d7ac4ca7a5d9315dec7d4a24420723d2a3132f73c88b1"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -618,13 +626,14 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.7.23"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#83f15ef7d3504836a889894463608f6a094525d9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
 dependencies = [
  "bare-metal 1.0.0",
  "coap-handler",
  "coap-message",
- "coap-numbers",
- "cstr",
+ "coap-numbers 0.1.2",
+ "cstr_core",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
@@ -815,9 +824,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -13,6 +13,10 @@ crate-type = ["staticlib"]
 # supports no unwinding), but setting it allows builds on native without using
 # the nightly-only lang_items feature.
 panic = "abort"
+# This is a typical set of options that helps Rust binaries stay small
+lto = true
+codegen-units = 1
+opt-level = "s"
 
 [dependencies]
 riot-wrappers = { version = "^0.7.18", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -8,6 +8,12 @@ resolver = "2"
 [lib]
 crate-type = ["staticlib"]
 
+[profile.release]
+# Setting the panic mode has little effect on the built code (as Rust on RIOT
+# supports no unwinding), but setting it allows builds on native without using
+# the nightly-only lang_items feature.
+panic = "abort"
+
 [dependencies]
 riot-wrappers = { version = "^0.7.18", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
 

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -200,13 +200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.11"
+name = "cstr_core"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
- "proc-macro2",
- "quote",
+ "cty",
+ "memchr",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -449,9 +449,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -484,8 +484,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.8"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#1035e93ad24d007effe79a5764d8c307150503e3"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0186f82eb1cf9f9127d7ac4ca7a5d9315dec7d4a24420723d2a3132f73c88b1"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -500,10 +501,11 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.7.23"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#83f15ef7d3504836a889894463608f6a094525d9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
 dependencies = [
  "bare-metal 1.0.0",
- "cstr",
+ "cstr_core",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
@@ -672,9 +674,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/rust-hello-world/Cargo.toml
+++ b/examples/rust-hello-world/Cargo.toml
@@ -8,6 +8,12 @@ resolver = "2"
 [lib]
 crate-type = ["staticlib"]
 
+[profile.release]
+# Setting the panic mode has little effect on the built code (as Rust on RIOT
+# supports no unwinding), but setting it allows builds on native without using
+# the nightly-only lang_items feature.
+panic = "abort"
+
 [dependencies]
 # `default-features = false` can be removed with 0.8, and enables building on stable during the 0.7 series
 riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ], default-features = false }

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -200,13 +200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.11"
+name = "cstr_core"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
- "proc-macro2",
- "quote",
+ "cty",
+ "memchr",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -449,9 +449,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -484,8 +484,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.8"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#1035e93ad24d007effe79a5764d8c307150503e3"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0186f82eb1cf9f9127d7ac4ca7a5d9315dec7d4a24420723d2a3132f73c88b1"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -500,10 +501,11 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.7.23"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#83f15ef7d3504836a889894463608f6a094525d9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
 dependencies = [
  "bare-metal 1.0.0",
- "cstr",
+ "cstr_core",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
@@ -672,9 +674,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/rust_libs/Makefile
+++ b/tests/rust_libs/Makefile
@@ -5,6 +5,10 @@ USEMODULE += shell_democommands
 
 FEATURES_REQUIRED += rust_target
 
+# Testing on stable to ensure that no nightly features are needed when Rust is
+# pulled in through modules.
+CARGO_CHANNEL = stable
+
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation
 BOARD_BLACKLIST := ek-lm4f120xl

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -200,13 +200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.11"
+name = "cstr_core"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
 dependencies = [
- "proc-macro2",
- "quote",
+ "cty",
+ "memchr",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -449,9 +449,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -484,8 +484,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.8"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#1035e93ad24d007effe79a5764d8c307150503e3"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0186f82eb1cf9f9127d7ac4ca7a5d9315dec7d4a24420723d2a3132f73c88b1"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -500,10 +501,11 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.7.23"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#83f15ef7d3504836a889894463608f6a094525d9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
 dependencies = [
  "bare-metal 1.0.0",
- "cstr",
+ "cstr_core",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
@@ -672,9 +674,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/rust_minimal/Makefile
+++ b/tests/rust_minimal/Makefile
@@ -5,9 +5,8 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# This example can, on all platforms, be built with a stable version of Rust.
-# For most advanced features (eg. when using CoAP, SAUL or the shell with
-# Rust), this needs to be set to "nightly" for the time being.
+# Testing on stable to ensure that no nightly features are needed for basic
+# Rust usage.
 CARGO_CHANNEL = stable
 
 # Currently unknown, something related to the LED_PORT definition that doesn't


### PR DESCRIPTION
### Contribution description

This is a bit more than the usual "bump dependencies", as it also reaps the benefits from the latest crate updates:

* The overrides that say "we take riot-sys and riot-wrappers from git" are commented out. This results in builds (especially those of the imminent release) will thus fetch code from crates.io only, and not resort to direct git fetching. I consider this fitting for a release, see also <https://github.com/RIOT-OS/Release-Specs/issues/251>. If updates need to be done during the next release cycle that require quick fixes, the lines can just be enabled again in the same commit that then also does the `cargo update` that is necessary to apply the updates into the Cargo.lock files anyway.
* Tests can be run on stable.
* Examples are prepared to run on stable (which for native means that the panic=abort setting needs to be added to Cargo.toml, for otherwise nightly-only features would be required)
* The hello-world example is run on stable.
  This could have been done before, but was not, because users often build on a simple example when exploring advanced things, and there might have been frustration when the advanced things don't work there. Given that barely any riot-wrappers features require nightly any more, this is fine now.
* rust-gcoap is prepared to be run on stable. It can't right now, but users who have beta installed can already run it.

### Testing procedure

* Green CI (I'm throwing in run-tests too)

### Issue references

By running tests on stable this closes https://github.com/RIOT-OS/RIOT/issues/18500