### PR TITLE
drivers/usbdev_synopsys_dwc2: add USB OTG HS peripheral support for external ULPI HS PHYs

### DIFF
--- a/boards/common/esp32s2/include/periph_conf_common.h
+++ b/boards/common/esp32s2/include/periph_conf_common.h
@@ -352,6 +352,7 @@ static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
     {
         .periph = USB_OTG_FS_PERIPH_BASE,
         .type = DWC2_USB_OTG_FS,
+        .phy = DWC2_USB_OTG_PHY_BUILTIN,
     }
 };
 

--- a/boards/common/esp32s3/include/periph_conf_common.h
+++ b/boards/common/esp32s3/include/periph_conf_common.h
@@ -352,6 +352,7 @@ static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
     {
         .periph = USB_OTG_FS_PERIPH_BASE,
         .type = DWC2_USB_OTG_FS,
+        .phy = DWC2_USB_OTG_PHY_BUILTIN,
     }
 };
 

--- a/boards/common/stm32/include/cfg_usb_otg_hs_phy_fs.h
+++ b/boards/common/stm32/include/cfg_usb_otg_hs_phy_fs.h
@@ -11,13 +11,17 @@
  * @{
  *
  * @file
- * @brief       Common configuration for STM32 OTG HS peripheral with FS phy
+ * @brief       Common configuration for STM32 OTG HS peripheral with on-chip FS PHY
+ *
+ * All STM32 boards which use the on-chip FS PHY for the USB OTG HS peripheral
+ * use the same configuration. Therefore a common configuration file can be
+ * used for these boards.
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef CFG_USB_OTG_HS_FS_H
-#define CFG_USB_OTG_HS_FS_H
+#ifndef CFG_USB_OTG_HS_PHY_FS_H
+#define CFG_USB_OTG_HS_PHY_FS_H
 
 #include "periph_cpu.h"
 #include "usbdev_synopsys_dwc2.h"
@@ -57,5 +61,5 @@ static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
 }
 #endif
 
-#endif /* CFG_USB_OTG_HS_FS_H */
+#endif /* CFG_USB_OTG_HS_PHY_FS_H */
 /** @} */

--- a/boards/stm32f429i-disc1/include/periph_conf.h
+++ b/boards/stm32f429i-disc1/include/periph_conf.h
@@ -32,7 +32,7 @@
 #include "periph_cpu.h"
 #include "clk_conf.h"
 #include "cfg_timer_tim5.h"
-#include "cfg_usb_otg_hs_fs.h"
+#include "cfg_usb_otg_hs_phy_fs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/stm32f746g-disco/Kconfig
+++ b/boards/stm32f746g-disco/Kconfig
@@ -23,6 +23,7 @@ config BOARD_STM32F746G_DISCO
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_USBDEV_HS_ULPI
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/boards/stm32f746g-disco/doc.txt
+++ b/boards/stm32f746g-disco/doc.txt
@@ -26,7 +26,7 @@ Current hardware support:
 | I2C |  X | I2C1 on PB8/PB9    |
 | Ethernet | X |  |
 | USB OTG FS | X |  |
-| USB OTG HS | - |  |
+| USB OTG HS | X |  |
 | TFT LCD | X |  |
 | Capacitive touch screen | X | |
 | User microphones | - | |

--- a/boards/stm32f746g-disco/features-shared.mk
+++ b/boards/stm32f746g-disco/features-shared.mk
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_usbdev_hs_ulpi
 
 # stm32f746g-disco provides a custom default Kconfig clock configuration
 KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/stm32f746g-disco/clock.config

--- a/boards/stm32f746g-disco/include/periph_conf.h
+++ b/boards/stm32f746g-disco/include/periph_conf.h
@@ -38,7 +38,11 @@
 #include "clk_conf.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
+#if defined(MODULE_PERIPH_USBDEV_HS_ULPI)
+#include "usbdev_synopsys_dwc2.h"
+#else
 #include "cfg_usb_otg_fs.h"
+#endif
 #include "mii.h"
 
 #ifdef __cplusplus
@@ -264,6 +268,56 @@ static const ltdc_conf_t ltdc_config = {
     .vfp        = 2,
 };
 /** @} */
+
+#if defined(MODULE_PERIPH_USBDEV_HS_ULPI) || DOXYGEN
+/**
+ * @name USB OTG FS configuration using ULPI HS PHY
+ *
+ * The USB OTG HS peripheral uses a ULPI HS PHY. The configuration of the
+ * ULPI HS PHY interface is board-specific.
+ *
+ * @{
+ */
+
+/**
+ * @brief Enable the high speed USB OTG peripheral
+ */
+#define DWC2_USB_OTG_HS_ENABLED
+
+/**
+ * @brief Common USB OTG HS configuration with ULPI HS PHY
+ */
+static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
+    {
+        .periph   = USB_OTG_HS_PERIPH_BASE,
+        .type     = DWC2_USB_OTG_HS,
+        .phy      = DWC2_USB_OTG_PHY_ULPI,
+        .rcc_mask = RCC_AHB1ENR_OTGHSEN,
+        .irqn     = OTG_HS_IRQn,
+        .ahb      = AHB1,
+        .ulpi_af  = GPIO_AF10,
+        .ulpi_clk = GPIO_PIN(PORT_A, 5),
+        .ulpi_d0  = GPIO_PIN(PORT_A, 3),
+        .ulpi_d1  = GPIO_PIN(PORT_B, 0),
+        .ulpi_d2  = GPIO_PIN(PORT_B, 1),
+        .ulpi_d3  = GPIO_PIN(PORT_B, 10),
+        .ulpi_d4  = GPIO_PIN(PORT_B, 11),
+        .ulpi_d5  = GPIO_PIN(PORT_B, 12),
+        .ulpi_d6  = GPIO_PIN(PORT_B, 13),
+        .ulpi_d7  = GPIO_PIN(PORT_B, 5),
+        .ulpi_dir = GPIO_PIN(PORT_C, 2),
+        .ulpi_stp = GPIO_PIN(PORT_C, 0),
+        .ulpi_nxt = GPIO_PIN(PORT_H, 4),
+    }
+};
+
+/**
+ * @brief Number of available USB OTG peripherals
+ */
+#define USBDEV_NUMOF           ARRAY_SIZE(dwc2_usb_otg_fshs_config)
+
+/** @} */
+#endif /* defined(MODULE_PERIPH_USBDEV_HS_ULPI) || DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/boards/stm32f7508-dk/Kconfig
+++ b/boards/stm32f7508-dk/Kconfig
@@ -23,6 +23,7 @@ config BOARD_STM32F7508_DK
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_USBDEV_HS_ULPI
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -141,6 +141,10 @@ ifneq (,$(filter periph_usbdev,$(USEMODULE)))
   USEMODULE += periph_usbdev_clk
 endif
 
+ifneq (,$(filter periph_usbdev_hs_ulpi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_usbdev_hs_ulpi
+endif
+
 ifneq (,$(filter pn532_i2c,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += pn532

--- a/drivers/include/usbdev_synopsys_dwc2.h
+++ b/drivers/include/usbdev_synopsys_dwc2.h
@@ -41,18 +41,30 @@ typedef enum {
     DWC2_USB_OTG_HS = 1,   /**< High speed peripheral */
 } dwc2_usb_otg_fshs_type_t;
 
-#if defined(MCU_STM32)
 /**
- * @brief Type of USB OTG peripheral phy.
+ * @brief Device speed used
+ */
+enum {
+    DWC2_USB_OTG_DSPD_HS = 0,           /**< High speed */
+    DWC2_USB_OTG_DSPD_FS_PHY_HS = 1,    /**< Full speed on HS PHY */
+    DWC2_USB_OTG_DSPD_LS = 2,           /**< Low speed */
+    DWC2_USB_OTG_DSPD_FS = 3,           /**< Full speed */
+};
+
+/**
+ * @brief Type of USB OTG peripheral PHY.
  *
- * The FS type only supports the built-in type, the HS phy can have either the
- * FS built-in phy enabled or the HS ULPI interface enabled.
+ * The FS type only supports the built-in PHY, the HS type can have enabled
+ * either
+ * - the on-chip FS PHY,
+ * - the external ULPI HS PHY interface, or
+ * - the internal UTMI HS PHY.
  */
 typedef enum {
-    DWC2_USB_OTG_PHY_BUILTIN,
-    DWC2_USB_OTG_PHY_ULPI,
+    DWC2_USB_OTG_PHY_BUILTIN,   /**< on-chip FS PHY */
+    DWC2_USB_OTG_PHY_ULPI,      /**< ULPI for external HS PHY */
+    DWC2_USB_OTG_PHY_UTMI,      /**< UTMI for internal HS PHY */
 } dwc2_usb_otg_fshs_phy_t;
-#endif
 
 /**
  * @brief stm32 USB OTG configuration
@@ -60,15 +72,30 @@ typedef enum {
 typedef struct {
     uintptr_t periph;               /**< USB peripheral base address */
     dwc2_usb_otg_fshs_type_t type;  /**< FS or HS type */
-#if defined(MCU_STM32)
-    dwc2_usb_otg_fshs_phy_t phy;    /**< Built-in or ULPI phy */
+    dwc2_usb_otg_fshs_phy_t phy;    /**< on-chip FS, ULPI HS or UTMI HS PHY */
+#if defined(MODULE_PERIPH_USBDEV_HS_ULPI) || DOXYGEN
+    gpio_t ulpi_clk;                /**< ULPI CLK gpio */
+    gpio_t ulpi_d0;                 /**< ULPI D0 gpio */
+    gpio_t ulpi_d1;                 /**< ULPI D1 gpio */
+    gpio_t ulpi_d2;                 /**< ULPI D2 gpio */
+    gpio_t ulpi_d3;                 /**< ULPI D3 gpio */
+    gpio_t ulpi_d4;                 /**< ULPI D4 gpio */
+    gpio_t ulpi_d5;                 /**< ULPI D5 gpio */
+    gpio_t ulpi_d6;                 /**< ULPI D6 gpio */
+    gpio_t ulpi_d7;                 /**< ULPI D7 gpio */
+    gpio_t ulpi_dir;                /**< ULPI DIR gpio */
+    gpio_t ulpi_stp;                /**< ULPI STP gpio */
+    gpio_t ulpi_nxt;                /**< ULPI NXT gpio */
+    gpio_af_t ulpi_af;              /**< Alternative function for ULPI */
+#endif
+#if defined(MCU_STM32) || DOXYGEN
     uint32_t rcc_mask;              /**< bit in clock enable register */
     uint8_t irqn;                   /**< IRQ channel */
     uint8_t ahb;                    /**< AHB bus */
     gpio_t dm;                      /**< Data- gpio */
     gpio_t dp;                      /**< Data+ gpio */
     gpio_af_t af;                   /**< Alternative function */
-#endif /* defined(MCU_STM32) */
+#endif /* defined(MCU_STM32) || DOXYGEN */
 } dwc2_usb_otg_fshs_config_t;
 
 #ifdef __cplusplus

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -168,6 +168,17 @@ config MODULE_PERIPH_INIT_USBDEV
     default y if MODULE_PERIPH_INIT
     depends on MODULE_PERIPH_USBDEV
 
+config MODULE_PERIPH_USBDEV_HS_ULPI
+    bool "Use USB HS pripheral with UPLI HS PHY"
+    depends on HAS_PERIPH_USBDEV_HS_ULPI
+    depends on MODULE_PERIPH_USBDEV
+
+config MODULE_PERIPH_INIT_USBDEV_HS_ULPI
+    bool
+    default y if MODULE_PERIPH_INIT && MODULE_PERIPH_USBDEV_HS_ULPI
+    depends on HAS_PERIPH_USBDEV_HS_ULPI
+    depends on MODULE_PERIPH_USBDEV
+
 config MODULE_PERIPH_USBDEV_CLK
     bool
     depends on HAS_PERIPH_USBDEV

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -392,11 +392,11 @@ static void _ep_deactivate(usbdev_ep_t *ep)
 
     if (ep->dir == USB_EP_DIR_IN) {
         _ep_in_disable(conf, ep->num);
-        _in_regs(conf, ep->num)->DIEPCTL &= USB_OTG_DIEPCTL_USBAEP;
+        _in_regs(conf, ep->num)->DIEPCTL &= ~USB_OTG_DIEPCTL_USBAEP;
     }
     else {
         _ep_out_disable(conf, ep->num);
-        _out_regs(conf, ep->num)->DOEPCTL &= USB_OTG_DOEPCTL_USBAEP;
+        _out_regs(conf, ep->num)->DOEPCTL &= ~USB_OTG_DOEPCTL_USBAEP;
     }
 }
 
@@ -690,17 +690,74 @@ static void _usbdev_init(usbdev_t *dev)
 #error "MCU not supported"
 #endif
 
-    /* TODO: implement ULPI mode when a board is available */
 #ifdef DWC2_USB_OTG_HS_ENABLED
     if (conf->type == DWC2_USB_OTG_HS) {
-        /* Disable the ULPI clock in low power mode, this is essential for the
-         * peripheral when using the built-in phy */
-        periph_lpclk_dis(conf->ahb, RCC_AHB1LPENR_OTGHSULPILPEN);
-        /* Only the built-in phy supported for now */
-        assert(conf->phy == DWC2_USB_OTG_PHY_BUILTIN);
-        _global_regs(conf)->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
+        if (conf->phy == DWC2_USB_OTG_PHY_BUILTIN) {
+            /* Disable the ULPI clock in low power mode, this is essential for the
+             * peripheral when using the built-in phy or UTMI phy */
+            periph_lpclk_dis(conf->ahb, RCC_AHB1LPENR_OTGHSULPILPEN);
+            /* select on-chip builtin PHY */
+            _global_regs(usbdev->config)->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
+        }
+#ifdef MODULE_PERIPH_USBDEV_HS_ULPI
+        else if (conf->phy == DWC2_USB_OTG_PHY_ULPI) {
+            /* initialize ULPI interface */
+            gpio_init(conf->ulpi_clk, GPIO_IN);
+            gpio_init(conf->ulpi_d0, GPIO_IN);
+            gpio_init(conf->ulpi_d1, GPIO_IN);
+            gpio_init(conf->ulpi_d2, GPIO_IN);
+            gpio_init(conf->ulpi_d3, GPIO_IN);
+            gpio_init(conf->ulpi_d4, GPIO_IN);
+            gpio_init(conf->ulpi_d5, GPIO_IN);
+            gpio_init(conf->ulpi_d6, GPIO_IN);
+            gpio_init(conf->ulpi_d7, GPIO_IN);
+            gpio_init(conf->ulpi_stp, GPIO_IN);
+            gpio_init(conf->ulpi_dir, GPIO_IN);
+            gpio_init(conf->ulpi_nxt, GPIO_IN);
+            gpio_init_af(conf->ulpi_clk, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d0, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d1, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d2, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d3, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d4, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d5, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d6, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_d7, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_stp, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_dir, conf->ulpi_af);
+            gpio_init_af(conf->ulpi_nxt, conf->ulpi_af);
+
+            /* enable ULPI clock */
+            periph_clk_en(conf->ahb, RCC_AHB1ENR_OTGHSULPIEN);
+
+#if !defined(MCU_STM32)
+            /* TODO following settings are required for DWC2 HS but are not
+             * defined for STM32 MCUs where these settings correspond to the
+             * reset value of the GUSBCFG register */
+            /* select ULPI PHY */
+            _global_regs(usbdev->config)->GUSBCFG |= USB_OTG_GUSBCFG_ULPI_UTMI_SEL
+            /* use the 8-bit interface and single data rate */
+            _global_regs(usbdev->config)->GUSBCFG &= ~(USB_OTG_GUSBCFG_PHYIF16 |
+                                                       USB_OTG_GUSBCFG_DDRSEL);
+#endif /* !defined(MCU_STM32) */
+
+            /* disable the on-chip FS transceiver */
+            _global_regs(usbdev->config)->GUSBCFG &= ~USB_OTG_GUSBCFG_PHYSEL;
+
+            /* use internal V_BUS valid indicator and internal charge pump */
+            _global_regs(usbdev->config)->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD |
+                                                       USB_OTG_GUSBCFG_ULPIEVBUSI);
+            /* disable ULPI FS/LS serial interface */
+            _global_regs(usbdev->config)->GUSBCFG &= ~USB_OTG_GUSBCFG_ULPIFSLS;
+        }
+#else /* MODULE_PERIPH_USBDEV_HS_ULPI */
+        else {
+            /* only on-chip PHY support enabled */
+            assert(conf->phy == DWC2_USB_OTG_PHY_BUILTIN);
+        }
+#endif /* MODULE_PERIPH_USBDEV_HS_ULPI */
     }
-#endif
+#endif /* DWC2_USB_OTG_HS_ENABLED */
 
     /* Reset the peripheral after phy selection */
     _reset_periph(usbdev);
@@ -711,20 +768,31 @@ static void _usbdev_init(usbdev_t *dev)
     /* Force the peripheral to device mode */
     _set_mode_device(usbdev);
 
+#if defined(MCU_STM32)
+
     /* Disable Vbus detection and force the pull-up on, GCCFG is STM32 specific */
 #if defined(STM32_USB_OTG_CID_1x)
-    /* Enable no Vbus sensing and enable 'Power Down Disable */
-    _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS |
-                                           USB_OTG_GCCFG_PWRDWN;
+    /* Enable no Vbus sensing */
+    _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
 #elif defined(STM32_USB_OTG_CID_2x)
     /* Enable no Vbus Detect enable  and enable 'Power Down Disable */
-    _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_VBDEN |
-                                           USB_OTG_GCCFG_PWRDWN;
+    _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_VBDEN;
     /* Force Vbus Detect values and ID detect values to device mode */
     _global_regs(usbdev->config)->GOTGCTL |= USB_OTG_GOTGCTL_VBVALOVAL |
                                              USB_OTG_GOTGCTL_VBVALOEN |
                                              USB_OTG_GOTGCTL_BVALOEN |
                                              USB_OTG_GOTGCTL_BVALOVAL;
+#endif /* defined(STM32_USB_OTG_CID_1x) */
+
+    if (conf->phy == DWC2_USB_OTG_PHY_BUILTIN) {
+        /* set `Power Down Disable` to activate the on-chip FS transceiver */
+        _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+    }
+    else if (IS_USED(MODULE_PERIPH_USBDEV_HS_ULPI) && (conf->phy == DWC2_USB_OTG_PHY_ULPI)) {
+        /* clear `Power Down Disable` to deactivate the on-chip FS transceiver */
+        _global_regs(usbdev->config)->GCCFG &= USB_OTG_GCCFG_PWRDWN;
+    }
+
 #elif defined(MCU_ESP32)
     /* Force Vbus Detect values and ID detect values to device mode */
     _global_regs(usbdev->config)->GOTGCTL |= USB_OTG_GOTGCTL_VBVALOVAL |
@@ -739,8 +807,19 @@ static void _usbdev_init(usbdev_t *dev)
     _global_regs(conf)->GUSBCFG &=
         ~(USB_OTG_GUSBCFG_HNPCAP | USB_OTG_GUSBCFG_SRPCAP);
 
+#ifdef DWC2_USB_OTG_HS_ENABLED
+    if ((conf->type == DWC2_USB_OTG_FS) || (conf->phy == DWC2_USB_OTG_PHY_BUILTIN)) {
+        /* Device mode init */
+        _device_regs(conf)->DCFG |= DWC2_USB_OTG_DSPD_FS;  /* Full speed is */
+    }
+    else {
+        /* Device mode init */
+        _device_regs(conf)->DCFG |= DWC2_USB_OTG_DSPD_HS;  /* High speed! */
+    }
+#else
     /* Device mode init */
-    _device_regs(conf)->DCFG |= USB_OTG_DCFG_DSPD_Msk;  /* Full speed! */
+    _device_regs(conf)->DCFG |= DWC2_USB_OTG_DSPD_FS;  /* Full speed! */
+#endif
 
     _configure_fifo(usbdev);
 

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -424,6 +424,11 @@ config HAS_PERIPH_USBDEV
     help
         Indicates that an USBDEV peripheral is present.
 
+config HAS_PERIPH_USBDEV_HS_ULPI
+    bool
+    help
+        Indicates that an USBDEV HS peripheral with ULPI HS PHY is present.
+
 config HAS_PERIPH_VBAT
     bool
     help


### PR DESCRIPTION
### Contribution description

This PR adds the support for external ULPI HS PHYs.

Boards whose USB OTG HS peripherals use an external HS-PHY via the ULPI interface, such as the board `stm32f746g-disco`, can be used with this PR in USB HS mode. For this purpose, the USB OTG configuration structure has been extended by the ULPI interface configuration. ULPI HS PHY support is enabled by the `periph_usbdev_hs_ulpi` module, which requires the `periph_usbdev_hs_ulpi` feature.

Boards whose USB OTG HS peripherals use an external HS-PHY via the ULPI interface must define the ULPI interface configuration and provide the `periph_usbdev_hs_ulpi` feature. The application can then enable the USB OTG HS port by enabling the `periph_usbdev_hs_ulpi` module.

### Testing procedure

The best way to test the PR is to use a board with two USB OTG ports (one FS port and one HS port connected to a ULPI PHY, such as the board "stm32f746g-disco") connected to the host with two USB cables.

1. Compile and flash application `tests/usbus_hid`
    ```
    BOARD=stm32f746g-disco make -C tests/usbus_hid flash term
    ```
    The FS port should still work.
    ```python
    Oct  2 14:12:52 gunny8 kernel: [1906145.745440] usb 1-4.4: new full-speed USB device number 91 using xhci_hcd
    Oct  2 14:12:52 gunny8 kernel: [1906145.851446] usb 1-4.4: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 1.00
    Oct  2 14:12:52 gunny8 kernel: [1906145.851449] usb 1-4.4: New USB device strings: Mfr=3, Product=2, SerialNumber=4
    Oct  2 14:12:52 gunny8 kernel: [1906145.851451] usb 1-4.4: Product: stm32f746g-disco
    Oct  2 14:12:52 gunny8 kernel: [1906145.851452] usb 1-4.4: Manufacturer: RIOT-os.org
    Oct  2 14:12:52 gunny8 kernel: [1906145.851453] usb 1-4.4: SerialNumber: BF52913CA9DB6BE8
    Oct  2 14:12:52 gunny8 kernel: [1906145.858630] hid-generic 0003:1209:7D01.013C: hiddev2,hidraw5: USB HID v1.10 Device [RIOT-os.org stm32f
    ```
2. Compile and flash application `tests/usbus_hid` with module `periph_usbdev_hs_ulpi`
    ```
    USEMODULE=periph_usbdev_hs_ulpi BOARD=stm32f746g-disco make -C tests/usbus_hid flash term
    ```
    In that case, the HS port should work and recognized as HS device.
    ```python
    Oct  2 14:14:40 gunny8 kernel: [1906254.288780] usb 1-4.4: new high-speed USB device number 96 using xhci_hcd
    Oct  2 14:14:40 gunny8 kernel: [1906254.390195] usb 1-4.4: New USB device found, idVendor=1209, idProduct=7d01,  bcdDevice= 1.00
    Oct  2 14:14:40 gunny8 kernel: [1906254.390199] usb 1-4.4: New USB device strings: Mfr=3, Product=2, SerialNumber=4
    Oct  2 14:14:40 gunny8 kernel: [1906254.390201] usb 1-4.4: Product: stm32f746g-disco
    Oct  2 14:14:40 gunny8 kernel: [1906254.390202] usb 1-4.4: Manufacturer: RIOT-os.org
    Oct  2 14:14:40 gunny8 kernel: [1906254.390204] usb 1-4.4: SerialNumber: BF52913CA9DB6BE8
    Oct  2 14:14:40 gunny8 kernel: [1906254.392899] hid-generic 0003:1209:7D01.013D: hiddev2,hidraw5: USB HID v1.10 Device [RIOT-os.org stm32f746g-disco] on usb-0000:00:14.0-4.4/input0
    ```
3. A board with USB OTG HS peripheral that uses the on-chip FS PHY, such as `stm32f429i-disc1` should still work.
    ```
    BOARD=stm32f429i-disco make -C tests/usbus_hid flash term
    ```
4. A board with only USB OTG FS peripheral should still work.
    ```
    BOARD=nucleo-f767zi make -C tests/usbus_hid flash term
    ```

### Issues/PRs references
