### PR TITLE
cpu/stm32/periph/usbdev_fs: add support for STM32F3 family

### DIFF
--- a/boards/nucleo-f303ze/Kconfig
+++ b/boards/nucleo-f303ze/Kconfig
@@ -21,6 +21,7 @@ config BOARD_NUCLEO_F303ZE
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT

--- a/boards/nucleo-f303ze/Makefile.features
+++ b/boards/nucleo-f303ze/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/nucleo-f303ze/include/periph_conf.h
+++ b/boards/nucleo-f303ze/include/periph_conf.h
@@ -173,6 +173,32 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @brief USB device FS configuration
+ */
+static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
+    {
+        .base_addr  = (uintptr_t)USB,
+        .rcc_mask   = RCC_APB1ENR_USBEN,
+        .irqn       = USB_LP_CAN_RX0_IRQn,
+        .apb        = APB1,
+        .dm         = GPIO_PIN(PORT_A, 11),
+        .dp         = GPIO_PIN(PORT_A, 12),
+        .af         = GPIO_AF14,
+        .disconn    = GPIO_PIN(PORT_G, 6),
+    },
+};
+
+/**
+ * @brief Interrupt function name mapping
+ */
+#define USBDEV_ISR              isr_usb_lp_can_rx0
+
+/**
+ * @brief Number of available USB device FS peripherals
+ */
+#define USBDEV_NUMOF            ARRAY_SIZE(stm32_usbdev_fs_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -116,6 +116,7 @@ static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
         .dm         = GPIO_PIN(PORT_A, 11),
         .dp         = GPIO_PIN(PORT_A, 12),
         .af         = GPIO_AF10,
+        .disconn    = GPIO_UNDEF,
     },
 };
 

--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -4,7 +4,7 @@
 USEMODULE += periph stm32_clk stm32_vectors
 
 ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
-  ifneq (wb,$(CPU_FAM))
+  ifeq (,$(filter f3 wb,$(CPU_FAM)))
     USEMODULE += usbdev_synopsys_dwc2
   endif
   USEMODULE += ztimer

--- a/cpu/stm32/include/periph/cpu_usbdev.h
+++ b/cpu/stm32/include/periph/cpu_usbdev.h
@@ -50,6 +50,7 @@ typedef struct {
     gpio_t dm;                      /**< Data- gpio */
     gpio_t dp;                      /**< Data+ gpio */
     gpio_af_t af;                   /**< Alternative function */
+    gpio_t disconn;                 /**< GPIO if used for USB disconnect */
 } stm32_usbdev_fs_config_t;
 
 #ifdef __cplusplus

--- a/cpu/stm32/periph/Makefile
+++ b/cpu/stm32/periph/Makefile
@@ -51,7 +51,7 @@ endif
 
 # Select the correct implementation for `periph_usbdev`
 ifneq (,$(filter periph_usbdev,$(USEMODULE)))
-  ifeq (wb,$(CPU_FAM))
+  ifneq (,$(filter f3 wb,$(CPU_FAM)))
     SRC += usbdev_fs.c
   endif
 endif

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -195,7 +195,7 @@ static inline void _usb_attach(stm32_usbdev_fs_t *usbdev)
 #ifdef USB_BCDR_DPPU
     /* Enable DP pullup to signal connection */
     _global_regs(conf)->BCDR |= USB_BCDR_DPPU;
-    while (!(CRS->ISR & CRS_ISR_ESYNCF));
+    while (!(CRS->ISR & CRS_ISR_ESYNCF)) {}
 #else
     /* If configuration uses a GPIO for USB connect/disconnect */
     if (conf->disconn != GPIO_UNDEF) {

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -147,12 +147,11 @@ static void _enable_usb_clk(void)
 
 static void _enable_gpio(const stm32_usbdev_fs_config_t *conf)
 {
-    gpio_init(conf->dp, GPIO_IN);
-    gpio_init(conf->dm, GPIO_IN);
-    /* Configure AF for the pins */
-    gpio_init_af(conf->dp, conf->af);
-    gpio_init_af(conf->dm, conf->af);
-}
+    if (conf->af != GPIO_AF_UNDEF) {
+        /* Configure AF for the pins */
+        gpio_init_af(conf->dp, conf->af);
+        gpio_init_af(conf->dm, conf->af);
+    }
 
 static void _set_ep_in_status(uint16_t *val, uint16_t mask)
 {

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -138,8 +138,11 @@ static void _enable_usb_clk(void)
 #elif defined(RCC_APB1SMENR1_USBSMEN)
     RCC->APB1SMENR1 |= RCC_APB1SMENR1_USBSMEN;
 #endif
+
+#if defined(CRS_CR_AUTOTRIMEN) && defined(CRS_CR_CEN)
     /* Enable CRS with auto trim enabled */
     CRS->CR |=  (CRS_CR_AUTOTRIMEN |  CRS_CR_CEN);
+#endif
 }
 
 static void _enable_gpio(const stm32_usbdev_fs_config_t *conf)

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -135,7 +135,7 @@ static void _enable_usb_clk(void)
 
 #if defined(RCC_APB1SMENR_USBSMEN)
     RCC->APB1SMENR |= RCC_APB1SMENR_USBSMEN;
-#elif defined(RCC_APB1SMENR_USBSMEN)
+#elif defined(RCC_APB1SMENR1_USBSMEN)
     RCC->APB1SMENR1 |= RCC_APB1SMENR1_USBSMEN;
 #endif
     /* Enable CRS with auto trim enabled */


### PR DESCRIPTION
### Contribution description

This PR provides some changes of the `cpu/stm32/periph/usbdev_fs` driver to support STM32F3. In detail, it includes the following changes:
- Small bug fix of the register name (commit 1ed26d83a20fee62b52297682eb781c378d59b27)
- Conditional conpilation of the Clock Recovery System configuration (commit b287a72c7afb8d950abda986b3f67a099a354bfd)
- Defiinition of GPIOs for USB_DM and USB_DP signals as additional function instead of alternative function (commit 332c39908e63b9787425a1e8154a7d8e9d5f1a7d)
- Definition of a GPIO used for USB Connect/Disconnect (commit 3693e16b770cc5f57f6f238f4b1ff028c7ca0713)
- Changes to support STM32F3 family (commit ca9cedb2ac508111c4a2457da10844af88be35b1)
- `periph_usbdev` support for `nucleo-f303ze`

Other boards using STM32F303 MCU such as `stm32f3discovery` should also work with these changes but I don't have the hardware at hand. It should also be possible to enable the `periph_usbdev` support using this driver for other boards using other STM32 families such as `b-l072z-lrwan1` or `lsn50`.

### Testing procedure

1. Compile and flash
  ```
  BOARD=nucleo-f303ze make -C tests/usbus_hid/ flash term
  ```
  The test should work as expected.
2. Compile and flash
  ```
  BOARD=p-nucleo-wb55 make -C tests/usbus_hid/ flash term
  ```
  The test should still work for this board which was the only one that was using this `periph_usbdev` driver before.
  
### Issues/PRs references

