### PR TITLE
native: Explicitly opt in to GNUisms rather than setting std=gnu11

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -25,16 +25,17 @@ CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG) $(CFLAGS_OPT)
 CFLAGS += -U_FORTIFY_SOURCE
 CFLAGS_DBG ?= -g3
 
+# This allows using functions like `kill()` that are not in the C but in the
+# POSIX standard, sigwait requires at least this version
+CFLAGS += -D_POSIX_C_SOURCE=200112L
+# F_SETOWN is a Linux extension only available in -std=c11 mode with:
+CFLAGS += -D_GNU_SOURCE
+
 ifneq (,$(filter backtrace,$(USEMODULE)))
   $(warning module backtrace is used, do not omit frame pointers)
   CFLAGS_OPT ?= -Og -fno-omit-frame-pointer
 else
   CFLAGS_OPT ?= -Og
-endif
-
-# default std set to gnu11 if not overwritten by user
-ifeq (,$(filter -std=%, $(CFLAGS)))
-  CFLAGS += -std=gnu11
 endif
 
 ifeq ($(OS_ARCH),x86_64)


### PR DESCRIPTION
Native used to default to std=gnu11 rather than std=c11 like the rest of RIOT. This changes the makefiles to use the same std as other boards, and sets (and documents) the relevant defines to keep using the GNU features that native (esp. async_read; the rest would be POSIX only) needs.

This eases experimentation with newer standards, as setting std=c2x now works consistently across boards, for example as needed to test #18650.