### PR TITLE
rust: Update dependencies

### DIFF
--- a/drivers/lsm303agr/Cargo.toml
+++ b/drivers/lsm303agr/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 
 [dependencies]
 lsm303agr = "^0.2"
-riot-wrappers = "^0.7.17"
+riot-wrappers = "^0.8"
 # Whatever lsm uses
 nb = "*"

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "16fbe39cc8c18a07e97f3fbf16e6771946f5cded9800db0ab2698c5a2409ddb2"
 dependencies = [
  "byteorder",
  "coap-message",
- "coap-numbers 0.2.0",
+ "coap-numbers",
  "crc",
  "serde",
  "serde_cbor",
@@ -204,7 +204,7 @@ checksum = "620e584e19bd2432640d73fc29b5c8ac0904a903b863f7c3ad5cd989917c55e5"
 dependencies = [
  "coap-handler",
  "coap-message",
- "coap-numbers 0.2.0",
+ "coap-numbers",
  "crc",
  "minicbor",
  "serde",
@@ -226,17 +226,11 @@ dependencies = [
  "coap-handler",
  "coap-handler-implementations",
  "coap-message",
- "coap-numbers 0.2.0",
+ "coap-numbers",
  "heapless",
  "serde",
  "serde_cbor",
 ]
-
-[[package]]
-name = "coap-numbers"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "846c9bba4f1a98e6b3e26f67d96414eb2b1534a702c87d65c3a52c994c690d6a"
 
 [[package]]
 name = "coap-numbers"
@@ -278,13 +272,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr_core"
-version = "0.2.6"
+name = "cstr"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
+checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
 dependencies = [
- "cty",
- "memchr",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -590,12 +584,12 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#630a3b0af6dadf10da0583ac2faa54d5297b7bf4"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#75132650a5c8dfe16cd62eb3dcc91f8fd1630648"
 dependencies = [
  "coap-handler",
  "coap-handler-implementations",
  "coap-message",
- "coap-numbers 0.2.0",
+ "coap-numbers",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
@@ -625,15 +619,15 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.23"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
+checksum = "4482b7376de29de4b9d4e5dd8a6bf32da617f93be43dfe1ae5aff24ccc318f4f"
 dependencies = [
  "bare-metal 1.0.0",
  "coap-handler",
  "coap-message",
- "coap-numbers 0.1.2",
- "cstr_core",
+ "coap-numbers",
+ "cstr",
  "embedded-graphics",
  "embedded-hal",
  "heapless",

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -19,7 +19,7 @@ codegen-units = 1
 opt-level = "s"
 
 [dependencies]
-riot-wrappers = { version = "^0.7.18", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
+riot-wrappers = { version = "^0.8", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
 
 coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
 coap-handler-implementations = "0.3"

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -200,13 +200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr_core"
-version = "0.2.6"
+name = "cstr"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
+checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
 dependencies = [
- "cty",
- "memchr",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -500,12 +500,12 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.23"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
+checksum = "4482b7376de29de4b9d4e5dd8a6bf32da617f93be43dfe1ae5aff24ccc318f4f"
 dependencies = [
  "bare-metal 1.0.0",
- "cstr_core",
+ "cstr",
  "embedded-graphics",
  "embedded-hal",
  "heapless",

--- a/examples/rust-hello-world/Cargo.toml
+++ b/examples/rust-hello-world/Cargo.toml
@@ -15,8 +15,7 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-# `default-features = false` can be removed with 0.8, and enables building on stable during the 0.7 series
-riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ], default-features = false }
+riot-wrappers = { version = "0.8", features = [ "set_panic_handler" ] }
 
 # While currently this exmple does not use any RIOT modules implemented in
 # Rust, that may change; it is best practice for any RIOT application that has

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -200,13 +200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr_core"
-version = "0.2.6"
+name = "cstr"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
+checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
 dependencies = [
- "cty",
- "memchr",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -500,12 +500,12 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.23"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
+checksum = "4482b7376de29de4b9d4e5dd8a6bf32da617f93be43dfe1ae5aff24ccc318f4f"
 dependencies = [
  "bare-metal 1.0.0",
- "cstr_core",
+ "cstr",
  "embedded-graphics",
  "embedded-hal",
  "heapless",

--- a/sys/rust_riotmodules_standalone/Cargo.toml
+++ b/sys/rust_riotmodules_standalone/Cargo.toml
@@ -16,6 +16,6 @@ panic = "abort"
 codegen-units = 1
 
 [dependencies]
-riot-wrappers = { version = "0.7", default-features = false, features = [ "set_panic_handler" ] }
+riot-wrappers = { version = "0.8", features = [ "set_panic_handler" ] }
 
 rust_riotmodules = { path = "../rust_riotmodules" }

--- a/sys/shell/democommands/Cargo.toml
+++ b/sys/shell/democommands/Cargo.toml
@@ -11,4 +11,4 @@ license = "LGPL-2.1-only"
 publish = false
 
 [dependencies]
-riot-wrappers = "^0.7.17"
+riot-wrappers = "^0.8"

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -200,13 +200,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr_core"
-version = "0.2.6"
+name = "cstr"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
+checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
 dependencies = [
- "cty",
- "memchr",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -500,12 +500,12 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.23"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b11fc0cd528fb848b4abdefa332f4163052edf0bcc3a2ee9cd95e4256e1edc7"
+checksum = "4482b7376de29de4b9d4e5dd8a6bf32da617f93be43dfe1ae5aff24ccc318f4f"
 dependencies = [
  "bare-metal 1.0.0",
- "cstr_core",
+ "cstr",
  "embedded-graphics",
  "embedded-hal",
  "heapless",

--- a/tests/rust_minimal/Cargo.toml
+++ b/tests/rust_minimal/Cargo.toml
@@ -15,8 +15,7 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-# `default-features = false` can be removed with 0.8, and enables building on stable during the 0.7 series
-riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ], default-features = false }
+riot-wrappers = { version = "0.8", features = [ "set_panic_handler" ] }
 
 # While currently this test does not use any RIOT modules implemented in Rust,
 # that may change; it is best practice for any RIOT application that has its


### PR DESCRIPTION
The change in 399e25cc ([#18678](https://github.com/RIOT-OS/RIOT/pull/18678)) was did not have the intended effect: As the local crates still all defined 0.7 as the riot-wrappers version, that dependency was actually down- rather than upgraded, and thus did not effect the stabilizations.

This went unnoticed for two reasons:
* The stabilizations can not be tested yet, so tests for what used to run on nightly still did run on nighlty.
* The downgrade (from 0.8-to-be to 0.7.23) went unnoticed because all changes were done after a deprecation phase, so 0.8 was not breaking for any code under test (because that had previously been updated not to raise deprecation warnings on the late 0.7 releases).

I only noticed it now when later changes on the riot-wrappers side, being tested there, broke in ways that should long have been fixed.

Asking @maribu for a review as he also reviewed #18678, and (even though there is no CI-observable breakage) this does fix a regression introduced there.