### PR TITLE
sys/checksum: add CRC-32 checksum 

### DIFF
--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -147,3 +147,6 @@ nam
 
 # donot (part of bloom filter test vector) => do not
 donot
+
+# Didi (Ayman El Didi) => Did
+didi

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -45,6 +45,7 @@ PSEUDOMODULES += cortexm_fpu
 PSEUDOMODULES += cortexm_svc
 PSEUDOMODULES += cpp
 PSEUDOMODULES += cpu_check_address
+PSEUDOMODULES += crc32_fast
 PSEUDOMODULES += credman_load
 PSEUDOMODULES += dbgpin
 PSEUDOMODULES += devfs_%

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -49,6 +49,10 @@ ifneq (,$(filter congure_reno_methods,$(USEMODULE)))
   USEMODULE += seq
 endif
 
+ifneq (,$(filter crc32_fast,$(USEMODULE)))
+  USEMODULE += checksum
+endif
+
 ifneq (,$(filter eepreg,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eeprom
 endif

--- a/sys/checksum/crc32.c
+++ b/sys/checksum/crc32.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2020 Ayman El Didi
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * domain worldwide. This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this software. If not, see http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author      Ayman El Didi <ayman@eldidi.org>
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include "kernel_defines.h"
+#include "checksum/crc32.h"
+
+const uint32_t crc32_tab[] = {
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+    0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+    0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
+    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
+    0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+    0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
+    0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
+    0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
+    0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
+    0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+    0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
+    0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+    0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
+    0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
+    0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+    0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
+    0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+    0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
+    0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+};
+
+static inline uint32_t crc32_for_byte(uint32_t result)
+{
+    if (IS_USED(MODULE_CRC32_FAST)) {
+        return crc32_tab[result & 0xFF] ^ (result >> 8);
+    }
+
+    const uint32_t polynomial = 0xEDB88320L;
+
+    for (unsigned i = 0; i < 8; i++) {
+        /* IMPLEMENTATION: the code below always shifts result right by
+         * 1, but only XORs it by the polynomial if we're on the lowest
+         * bit.
+         *
+         * This is because 1 in binary is 00000001, so ANDing the
+         * result by 1 will always give 0 unless the lowest bit is set.
+         * And since XOR by zero does nothing, the other half only
+         * occurs when we're on the lowest bit.
+         *
+         * I didn't leave the above implementation in, despite being
+         * faster on my machine since it is a more complex operation
+         * which may be slower on less sophisticated processors. It can
+         * be added in in place of the loop code below.
+         */
+
+        result = (result >> 1) ^ (result & 1) * polynomial;
+
+        /* Here is the code I replaced with the branch I tried to
+         * remove:
+        if (result & 1) {
+            result = (result >> 1) ^ polynomial;
+            continue;
+        }
+        result >>= 1;
+         */
+    }
+    return result;
+}
+
+uint32_t crc32(const void *buf, size_t size)
+{
+    const uint8_t *p = buf;
+    uint32_t crc = ~0U;
+
+    for (unsigned i = 0; i < size; ++i) {
+        crc ^= *p++;
+        crc = crc32_for_byte(crc);
+
+    }
+
+    return ~crc;
+}
+
+/** @} */

--- a/sys/include/checksum/crc32.h
+++ b/sys/include/checksum/crc32.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_checksum_crc32 CRC32
+ * @ingroup     sys_checksum
+ *
+ * @brief       CRC32 checksum algorithm implementation according to IEEE standards
+ * @{
+ *
+ * @file
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef CHECKSUM_CRC32_H
+#define CHECKSUM_CRC32_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   CRC-32 checksum
+ *
+ * Uses the `0xedb88320` polynomial
+ *
+ * @note enable the `crc32_fast` module for a look-up table based implementation
+ *       that trades code size for speed.
+ *
+ * @param[in] buf   The data to checksum
+ * @param[in] size  Length of the data in bytes
+ *
+ * @return 32 bit sized hash in the interval [0..2^32]
+ */
+uint32_t crc32(const void *buf, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CHECKSUM_CRC32_H */
+
+/** @} */

--- a/tests/unittests/tests-checksum/tests-checksum-crc32.c
+++ b/tests/unittests/tests-checksum/tests-checksum-crc32.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "checksum/crc32.h"
+#include "tests-checksum.h"
+
+static void test_checksum_crc32_sequence_empty(void)
+{
+    unsigned char buf[] = "";
+    uint32_t expect = 0x0;
+
+    TEST_ASSERT_EQUAL_INT(expect, crc32(buf, sizeof(buf) - 1));
+}
+
+static void test_checksum_crc32_sequence_1a(void)
+{
+    unsigned char buf[] = "A";
+    uint32_t expect = 0xd3d99e8b;
+
+    TEST_ASSERT_EQUAL_INT(expect, crc32(buf, sizeof(buf) - 1));
+}
+
+static void test_checksum_crc32_sequence_256a(void)
+{
+    unsigned char buf[] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    uint32_t expect = 0x49975b13;
+
+    TEST_ASSERT_EQUAL_INT(expect, crc32(buf, sizeof(buf) - 1));
+}
+
+static void test_checksum_crc32_sequence_1to9(void)
+{
+    unsigned char buf[] = "123456789";
+    uint32_t expect = 0xcbf43926;
+
+    TEST_ASSERT_EQUAL_INT(expect, crc32(buf, sizeof(buf) - 1));
+}
+
+static void test_checksum_crc32_sequence_4bytes(void)
+{
+    unsigned char buf[] = { 0x12, 0x34, 0x56, 0x78 };
+    uint32_t expect = 0x4a090e98;
+
+    TEST_ASSERT_EQUAL_INT(expect, crc32(buf, sizeof(buf)));
+}
+
+Test *tests_checksum_crc32_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_checksum_crc32_sequence_empty),
+        new_TestFixture(test_checksum_crc32_sequence_1a),
+        new_TestFixture(test_checksum_crc32_sequence_256a),
+        new_TestFixture(test_checksum_crc32_sequence_1to9),
+        new_TestFixture(test_checksum_crc32_sequence_4bytes),
+    };
+
+    EMB_UNIT_TESTCALLER(checksum_crc32_tests, NULL, NULL, fixtures);
+
+    return (Test *)&checksum_crc32_tests;
+}

--- a/tests/unittests/tests-checksum/tests-checksum.c
+++ b/tests/unittests/tests-checksum/tests-checksum.c
@@ -15,6 +15,7 @@ void tests_checksum(void)
     TESTS_RUN(tests_checksum_crc16_ccitt_mcrf4xx_tests());
     TESTS_RUN(tests_checksum_crc16_ccitt_aug_tests());
     TESTS_RUN(tests_checksum_crc16_ccitt_false_tests());
+    TESTS_RUN(tests_checksum_crc32_tests());
     TESTS_RUN(tests_checksum_fletcher16_tests());
     TESTS_RUN(tests_checksum_fletcher32_tests());
     TESTS_RUN(tests_checksum_ucrc16_tests());

--- a/tests/unittests/tests-checksum/tests-checksum.h
+++ b/tests/unittests/tests-checksum/tests-checksum.h
@@ -65,6 +65,13 @@ Test *tests_checksum_crc16_ccitt_false_tests(void);
 Test *tests_checksum_crc16_ccitt_aug_tests(void);
 
 /**
+ * @brief   Generates tests for checksum/crc32.h
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_checksum_crc32_tests(void);
+
+/**
  * @brief   Generates tests for checksum/fletcher16.h
  *
  * @return  embUnit tests if successful, NULL if not.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The CRC-32 checksum algorithm was previously absent in RIOT, so add it.
This is with the polynomial used by e.g. Ethernet, SATA, PNG, etc.

### Testing procedure

A new unit test was added to `tests-checksum`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
