### PR TITLE
cpu/sam0_common: ADC keep muxpos as legacy define

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -772,7 +772,11 @@ static inline bool cpu_woke_from_backup(void)
  * @brief ADC Channel Configuration
  */
 typedef struct {
-    uint32_t inputctrl;      /**< ADC channel pin multiplexer value */
+    union {
+        uint32_t inputctrl; /**< ADC channel pin multiplexer value  */
+        uint32_t muxpos;    /**< ADC channel pin multiplexer value
+                                 @deprecated, use inputctrl instead */
+    };
 #ifdef ADC0
     Adc *dev;               /**< ADC device descriptor */
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `.muxpos` member was renamed to `.inputctrl` to make clearer that it can contain more than just the positive mux.

This however makes working with external boards much more painful, especially when bisecting something.

The semantics of the field did not change, so also provide the old name in a `union` to make the transition less painful. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

follow-up to #18658
