### PR TITLE
pkg/tinyusb: add support for SAM0-based boards

### DIFF
--- a/boards/common/arduino-zero/Kconfig
+++ b/boards/common/arduino-zero/Kconfig
@@ -18,6 +18,7 @@ config BOARD_COMMON_ARDUINO_ZERO
     select HAS_PERIPH_USBDEV
     select HAS_ARDUINO
     select HAS_ARDUINO_PWM
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_SAUL_GPIO
 

--- a/boards/common/arduino-zero/Makefile.features
+++ b/boards/common/arduino-zero/Makefile.features
@@ -15,3 +15,4 @@ FEATURES_PROVIDED += periph_usbdev
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += arduino_pwm
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/samd21-xpro/Kconfig
+++ b/boards/samd21-xpro/Kconfig
@@ -21,5 +21,6 @@ config BOARD_SAMD21_XPRO
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_SAUL_GPIO

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -12,3 +12,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/same54-xpro/Kconfig
+++ b/boards/same54-xpro/Kconfig
@@ -23,6 +23,7 @@ config BOARD_SAME54_XPRO
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_SAUL_GPIO
     select HAVE_MTD_SPI_NOR

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -16,3 +16,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/saml21-xpro/Kconfig
+++ b/boards/saml21-xpro/Kconfig
@@ -22,5 +22,6 @@ config BOARD_SAML21_XPRO
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_SAUL_GPIO

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -15,3 +15,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/samr21-xpro/Kconfig
+++ b/boards/samr21-xpro/Kconfig
@@ -22,6 +22,7 @@ config BOARD_SAMR21_XPRO
     select HAS_PERIPH_UART_HW_FC
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_EDBG_EUI
     select HAVE_SAUL_GPIO

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -15,3 +15,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/samr30-xpro/Kconfig
+++ b/boards/samr30-xpro/Kconfig
@@ -20,6 +20,7 @@ config BOARD_SAMR30_XPRO
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_AT86RF212B
     select HAVE_SAUL_GPIO

--- a/boards/samr30-xpro/Makefile.features
+++ b/boards/samr30-xpro/Makefile.features
@@ -13,3 +13,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/samr34-xpro/Kconfig
+++ b/boards/samr34-xpro/Kconfig
@@ -20,6 +20,7 @@ config BOARD_SAMR34_XPRO
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
 
     select HAVE_SX1276
     select HAVE_SAUL_GPIO

--- a/boards/samr34-xpro/Makefile.features
+++ b/boards/samr34-xpro/Makefile.features
@@ -14,3 +14,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += tinyusb_device

--- a/pkg/tinyusb/Kconfig
+++ b/pkg/tinyusb/Kconfig
@@ -35,6 +35,8 @@ menuconfig PACKAGE_TINYUSB
     select MODULE_TINYUSB_PORTABLE_STM32_FSEDV if CPU_STM32 && CPU_FAM_G4
     select MODULE_TINYUSB_PORTABLE_STM32_FSEDV if CPU_STM32 && CPU_FAM_L0
     select MODULE_TINYUSB_PORTABLE_STM32_FSEDV if CPU_STM32 && CPU_FAM_WB
+    select MODULE_TINYUSB_PORTABLE_MICROCHIP if CPU_FAM_SAMD21 || CPU_FAM_SAMR21 \
+           || CPU_COMMON_SAMD5X || CPU_FAM_SAML21
     select MODULE_ZTIMER_MSEC
     help
         tinyUSB is an open-source cross-platform USB Host/Device stack for
@@ -92,6 +94,11 @@ config MODULE_TINYUSB_PORTABLE_STM32_FSDEV
     bool
     help
         tinyUSB STM32 FS device driver is used
+
+config MODULE_TINYUSB_PORTABLE_MICROCHIP
+    bool
+    help
+        tinyUSB Microchip SAM0 driver is used
 
 menu "Device Classes"
     config MODULE_TINYUSB_CLASS_AUDIO

--- a/pkg/tinyusb/Makefile
+++ b/pkg/tinyusb/Makefile
@@ -71,6 +71,9 @@ tinyusb_host:
 tinyusb_portable_espressif:
 	$(QQ)"$(MAKE)" -C $(PSRC)/portable/espressif/esp32sx -f $(RIOTBASE)/Makefile.base MODULE=$@
 
+tinyusb_portable_microchip:
+	$(QQ)"$(MAKE)" -C $(PSRC)/portable/microchip/samd -f $(RIOTBASE)/Makefile.base MODULE=$@
+
 tinyusb_portable_stm32_fsdev:
 	$(QQ)"$(MAKE)" -C $(PSRC)/portable/st/stm32_fsdev -f $(RIOTBASE)/Makefile.base MODULE=$@
 

--- a/pkg/tinyusb/Makefile.dep
+++ b/pkg/tinyusb/Makefile.dep
@@ -54,6 +54,8 @@ endif
 # tinyUSB hardware driver selection
 ifneq (,$(filter esp32s2 esp32s3,$(CPU_FAM)))
   USEMODULE += tinyusb_portable_espressif
+else ifneq (,$(filter saml21 samd5x samd21,$(CPU)))
+  USEMODULE += tinyusb_portable_microchip
 else ifeq (stm32,$(CPU))
   ifneq (,$(filter f2 f4 f7 h7 l4,$(CPU_FAM)))
     USEMODULE += tinyusb_portable_synopsys_dwc2

--- a/pkg/tinyusb/Makefile.include
+++ b/pkg/tinyusb/Makefile.include
@@ -12,6 +12,12 @@ else ifeq (esp32s3,$(CPU_FAM))
   CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_ESP32S3
 else ifeq (stm32,$(CPU))
   CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_STM32$(call uppercase_and_underscore,$(CPU_FAM))
+else ifeq (saml21,$(CPU))
+  CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_SAML21
+else ifeq (samd21,$(CPU))
+  CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_SAMD21
+else ifeq (samd5x,$(CPU))
+  CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_SAME5X
 else
   $(error CPU $(CPU) or CPU family $(CPU_FAM) not supported)
 endif

--- a/pkg/tinyusb/hw/Makefile
+++ b/pkg/tinyusb/hw/Makefile
@@ -1,5 +1,9 @@
 MODULE = tinyusb_hw
 
-SRC = hw_$(CPU).c
+ifneq (,$(filter saml21 samd5x samd21,$(CPU)))
+  SRC = hw_sam0.c
+else
+  SRC = hw_$(CPU).c
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/tinyusb/hw/hw_sam0.c
+++ b/pkg/tinyusb/hw/hw_sam0.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_tinyusb
+ * @brief
+ * @{
+ *
+ * @brief       tinyUSB hardware driver for SAM0 MCUs
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#include <errno.h>
+
+#include "periph_conf.h"
+#include "periph/gpio.h"
+#include "pm_layered.h"
+#include "log.h"
+#include "tusb.h"
+#include "device/usbd.h"
+#include "host/usbh.h"
+
+int tinyusb_hw_init(void)
+{
+    /* Initialize GPIO pins */
+    gpio_init(sam_usbdev_config[0].dp, GPIO_IN);
+    gpio_init(sam_usbdev_config[0].dm, GPIO_IN);
+    gpio_init_mux(sam_usbdev_config[0].dm, sam_usbdev_config[0].d_mux);
+    gpio_init_mux(sam_usbdev_config[0].dp, sam_usbdev_config[0].d_mux);
+
+    /* Initialize clocks */
+    sam0_gclk_enable(sam_usbdev_config[0].gclk_src);
+
+#if defined(MCLK)
+    MCLK->AHBMASK.reg |= MCLK_AHBMASK_USB;
+    MCLK->APBBMASK.reg |= MCLK_APBBMASK_USB;
+#else
+    PM->AHBMASK.reg |= PM_AHBMASK_USB;
+    PM->APBBMASK.reg |= PM_APBBMASK_USB;
+#endif
+
+#if defined(CPU_COMMON_SAMD21)
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN
+                        | GCLK_CLKCTRL_GEN(sam_usbdev_config[0].gclk_src)
+                        | GCLK_CLKCTRL_ID(USB_GCLK_ID);
+    pm_block(SAMD21_PM_IDLE_1);
+#else
+    GCLK->PCHCTRL[USB_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
+                                   | GCLK_PCHCTRL_GEN(sam_usbdev_config[0].gclk_src);
+#endif
+
+    return 0;
+}
+
+void isr_usb(void)
+{
+    /* call device interrupt handler with the first device */
+    if (IS_USED(MODULE_TINYUSB_DEVICE)) {
+        tud_int_handler(TINYUSB_TUD_RHPORT);
+    }
+
+    /* call host interrupt handler with the first device */
+    if (IS_USED(MODULE_TINYUSB_HOST)) {
+        tuh_int_handler(TINYUSB_TUH_RHPORT);
+    }
+
+    cortexm_isr_end();
+}
+
+void isr_usb0(void)
+{
+    isr_usb();
+}
+
+void isr_usb1(void)
+{
+    isr_usb();
+}
+void isr_usb2(void)
+{
+    isr_usb();
+}
+void isr_usb3(void)
+{
+    isr_usb();
+}

--- a/pkg/tinyusb/patches/0003-src-portable-microchip-update-header-file-for-RIOT-s.patch
+++ b/pkg/tinyusb/patches/0003-src-portable-microchip-update-header-file-for-RIOT-s.patch
@@ -1,0 +1,27 @@
+From 87051385205f8bf4829bfbb8309c8141a6108481 Mon Sep 17 00:00:00 2001
+From: Dylan Laduranty <dylan.laduranty@mesotic.com>
+Date: Fri, 30 Sep 2022 22:07:24 +0200
+Subject: [PATCH 3/3] src/portable/microchip: update header file for RIOT
+ support
+
+Signed-off-by: Dylan Laduranty <dylan.laduranty@mesotic.com>
+---
+ src/portable/microchip/samd/dcd_samd.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/portable/microchip/samd/dcd_samd.c b/src/portable/microchip/samd/dcd_samd.c
+index 22fe32407..cf9c1af69 100644
+--- a/src/portable/microchip/samd/dcd_samd.c
++++ b/src/portable/microchip/samd/dcd_samd.c
+@@ -31,7 +31,7 @@
+      CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X || \
+      CFG_TUSB_MCU == OPT_MCU_SAML22 || CFG_TUSB_MCU == OPT_MCU_SAML21)
+ 
+-#include "sam.h"
++#include "cpu_conf.h"
+ #include "device/dcd.h"
+ 
+ /*------------------------------------------------------------------*/
+-- 
+2.17.1
+


### PR DESCRIPTION
### Contribution description

This PR add tinyusb pkg support for SAM0-based MCUs.
I used `usbdev` support as pattern to enable tinyusb on them.
I tested this PR on `same54-xpro`, `samr21-xpro` and `saml21-xpro`

### Testing procedure
Use any SAM0-based board declare in this PR with tinyusb:
`BOARD=samr21-xpro make -C tests/pkg_tinyusb_cdc_msc flash`
tinyusb should works as expected.


### Issues/PRs references
None.
