### PR TITLE
cpu/cortexm_common: disable saving FPU state on IRQ

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -97,6 +97,10 @@ static inline void cortexm_init_fpu(void)
 #if (defined(CPU_CORE_CORTEX_M33) || defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)) && defined(MODULE_CORTEXM_FPU)
     /* give full access to the FPU */
     SCB->CPACR |= (uint32_t)CORTEXM_SCB_CPACR_FPU_ACCESS_FULL;
+    /* Disable hardware backup of FPU registers. As a result, the FPU must not
+     * be used in ISRs. During context switch registers are saved and restored
+     * in software, so threads can safely use the FPU. */
+    FPU->FPCCR = 0x0;
 #endif
 }
 


### PR DESCRIPTION
### Contribution description

The context switching code for Cortex M is a bit of a strange in beast in regard to the FPU state: It will only save it on the stack if the FPU actually was in use and only restore it if a backup is found on the stack being switched to.

When switching from a thread that did use the FPU to a thread that did not yet, the FPU state is consequently not restored and the FPU will be left in whatever state the previous thread left it. This can have severe side effects if the new thread starts using the FPU. Especially with the lazy backup / restore feature of the FPU: If the FPU has saved registers on the stack (of the old thread) but not yet restored, it will "restore" it on the next use of the FPU, which corrupts the stack.

Simply disabling backup and restore of the FPU state upon ISR entry and return avoids this potential memory corruption foot gun. The trade-off is a FPU state corruption bug whenever an ISR does start using the FPU.

### Testing procedure

The test provided in https://github.com/RIOT-OS/RIOT/pull/18641 should now pass

### Issues/PRs references

None opened yet
