### PR TITLE
pkg/lwip: add missing initialization for async_cb

### DIFF
--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -45,6 +45,7 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
                                 NETCONN_RAW)) == 0) {
         sock->base.conn = tmp;
 #if IS_ACTIVE(SOCK_HAS_ASYNC)
+        sock->base.async_cb.gen = NULL;
         netconn_set_callback_arg(sock->base.conn, &sock->base);
 #endif
     }

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -41,6 +41,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
                                 NETCONN_UDP)) == 0) {
         sock->base.conn = tmp;
 #if IS_ACTIVE(SOCK_HAS_ASYNC)
+        sock->base.async_cb.gen = NULL;
         netconn_set_callback_arg(sock->base.conn, &sock->base);
 #endif
     }


### PR DESCRIPTION
### Contribution description

Without initializing async_cb to NULL it might be a value != NULL, which leads to sock->async_cb.gen() being called mistakenly in _netconn_cb.

gnrc_sock already does it with `reg->async_cb.generic = NULL;`

### Issues/PRs references

Dependency for and split out from #16853