### PR TITLE
sys/net/network_layer/ipv4/addr: add ipv4_addr_print function

### DIFF
--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -101,6 +101,13 @@ ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr);
 ipv4_addr_t *ipv4_addr_from_buf(ipv4_addr_t *result, const char *addr,
                                 size_t addr_len);
 
+/**
+ * @brief Print IPv4 address to stdout
+ *
+ * @param[in]   addr  Pointer to ipv6_addr_t to print
+ */
+void ipv4_addr_print(const ipv4_addr_t *addr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/network_layer/ipv4/addr/ipv4_addr.c
+++ b/sys/net/network_layer/ipv4/addr/ipv4_addr.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ *
+ * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "fmt.h"
+#include "kernel_defines.h"
+#include "net/ipv4/addr.h"
+
+void ipv4_addr_print(const ipv4_addr_t *addr)
+{
+    assert(addr);
+    char addr_str[IPV4_ADDR_MAX_STR_LEN];
+    ipv4_addr_to_str(addr_str, addr, sizeof(addr_str));
+
+    if (IS_USED(MODULE_FMT)) {
+        print_str(addr_str);
+    } else {
+        printf("%s", addr_str);
+    }
+}
+
+/**
+ * @}
+ */


### PR DESCRIPTION
### Contribution description

Adds the function `ipv4_addr_print`, similar to the already existing to `ipv6_addr_print`.

### Issues/PRs references

Dependency for and split out from #16853