### PR TITLE
cpu/cortexm: clear FPU state in `cpu_switch_context_exit()`

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -282,6 +282,16 @@ void *thread_isr_stack_start(void)
 
 void NORETURN cpu_switch_context_exit(void)
 {
+#ifdef MODULE_CORTEXM_FPU
+    /* An exiting thread won't need it's FPU state anymore, so clear it here.
+     * This is important, as `sched_task_exit` clears `sched_active_thread`,
+     * which in turn causes `isr_pendsv` to skip all FPU storing/restoring.
+     * That might lead to this thread's FPU lazy stacking / FPCAR to stay active.
+     */
+    __set_FPSCR(0);
+    __set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));
+#endif
+
     /* enable IRQs to make sure the PENDSV interrupt is reachable */
     irq_enable();
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When an exiting thread that was using the FPU would cause a context switch to a non-FPU-using thread, the lazy stacking could stay activated with outdated info, causing memory corruption:

1. fpu using thread exits, lands in `sched_task_exit`
2. `sched_active_thread` is set to NULL
3. `cpu_switch_context_exit` triggers pendsv
4. pendsv exception entry creates an extended stack frame, configures lazy stacking with FPCAR pointing to the exiting thread's reserved space
5. isr_pendsv *skips storing the thread context* because sched_active_thread is NULL
6. isr_pendsv, when jumping to a thread that didn't use fpu (thus the restored EXC_RETURN[4] is set), *doesn't restore FPU context
8. note that lazy stacking was activated due to the thread using FPU, but in ISR, no fpu is used, and the VSTR/VLDR were skipped
9. next time any fpu is used, the lazy stacking takes place -> the FPU registers get stored to the old thread's reserved space -> memory corruption

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The new test in https://github.com/RIOT-OS/RIOT/pull/18641 triggers this.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18641

Alternative to https://github.com/RIOT-OS/RIOT/pull/18691.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
