### PR TITLE
gnrc_netif_lorawan: add support for LINK_UP/_DOWN events

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -409,6 +409,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
     res = conf.status;
 
     if (res < 0) {
+        DEBUG("gnrc_netif: unable to send (%s)\n", strerror(-res));
         gnrc_pktbuf_release_error(payload, res);
     }
 

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -16,6 +16,8 @@
 #include <assert.h>
 #include "fmt.h"
 
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/hdr.h"
@@ -69,7 +71,14 @@ void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm)
 
     if (confirm->type == MLME_JOIN) {
         if (confirm->status == 0) {
-            DEBUG("gnrc_lorawan: join succeeded\n");
+            gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
+            gnrc_netif_t *netif = container_of(lw_netif, gnrc_netif_t, lorawan);
+
+            DEBUG("gnrc_lorawan: join succeeded %d\n", netif->pid);
+            if (netif->dev) {
+                netif->flags |= GNRC_NETIF_FLAGS_HAS_L2ADDR;
+                netif->dev->event_callback(netif->dev, NETDEV_EVENT_LINK_UP);
+            }
         }
         else {
             DEBUG("gnrc_lorawan: join failed\n");
@@ -217,6 +226,22 @@ static void _driver_cb(netdev_t *dev, netdev_event_t event)
         case NETDEV_EVENT_TX_COMPLETE:
             gnrc_lorawan_radio_tx_done_cb(mac);
             break;
+        case NETDEV_EVENT_LINK_UP: {
+            if (IS_USED(MODULE_GNRC_IPV6)) {
+                msg_t msg = { .type = GNRC_IPV6_NIB_IFACE_UP, .content = { .ptr = netif } };
+
+                msg_send(&msg, gnrc_ipv6_pid);
+            }
+            break;
+        }
+        case NETDEV_EVENT_LINK_DOWN: {
+            if (IS_USED(MODULE_GNRC_IPV6)) {
+                msg_t msg = { .type = GNRC_IPV6_NIB_IFACE_DOWN, .content = { .ptr = netif } };
+
+                msg_send(&msg, gnrc_ipv6_pid);
+            }
+            break;
+        }
         case NETDEV_EVENT_RX_TIMEOUT:
             gnrc_lorawan_radio_rx_timeout_cb(mac);
             break;
@@ -578,6 +603,8 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
                                       &mlme_confirm);
             res = mlme_confirm.status;
             if (mlme_confirm.status == 0) {
+                netif->flags &= ~GNRC_NETIF_FLAGS_HAS_L2ADDR;
+                netif->dev->event_callback(netif->dev, NETDEV_EVENT_LINK_DOWN);
                 /* reset netif as well */
                 _reset(netif);
             }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -56,7 +56,10 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     bool new_address = false;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
-    gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]);
+    if (gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]) < 0) {
+        DEBUG("nib: Can't get IID on interface %u\n", netif->pid);
+        return;
+    }
     ipv6_addr_init_prefix(&addr, pfx, pfx_len);
     if ((idx = gnrc_netif_ipv6_addr_idx(netif, &addr)) < 0) {
         if ((idx = gnrc_netif_ipv6_addr_add_internal(netif, &addr, pfx_len,

--- a/tests/gnrc_ipv6_nib/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib/mockup_netif.c
@@ -85,6 +85,7 @@ void _tests_init(void)
         );
     _mock_netif = &_netif;
     expect(res == 0);
+    _common_set_up();
     /* we do not want to test for SLAAC here so just assure the configured
      * address is valid */
     expect(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This prepares for SCHC support with LoRaWAN, by adding UP/DOWN events to `gnrc_netif_lorawan`. Since with LoRaWAN there is only a hardware address (and thus an IID) after the device joined the network (which is the UP event), auto-configuration of link-local addresses needs to be done on UP. Since the hardware address (and the IID for that matter, see https://datatracker.ietf.org/doc/html/rfc9011#section-5.3) might change on the next connect, the link-local address needs to be removed on down.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Sadly, there is no IPv6 support for LoRaWAN yet, so only a compile test must suffice for now. However, I need this for SCHC and IPv6 support (i.e. SCHC) for LoRaWAN is needed to test this, so this is somewhat of a hen-and-egg problem...
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
In preparation for #18700.

Requires ~~#18708~~ (merged).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
