### PR TITLE
sys/checksum: add CRC-16 implementation without lookup table

### DIFF
--- a/drivers/dose/Kconfig
+++ b/drivers/dose/Kconfig
@@ -28,6 +28,7 @@ menuconfig MODULE_DOSE
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
     depends on HAS_PERIPH_UART
+    select MODULE_CHECKSUM
     select MODULE_CHUNKED_RINGBUFFER
     select MODULE_EUI_PROVIDER
     select MODULE_IOLIST

--- a/drivers/dose/Makefile.dep
+++ b/drivers/dose/Makefile.dep
@@ -7,6 +7,7 @@ ifneq (,$(filter dose_watchdog,$(USEMODULE)))
   FEATURES_REQUIRED += periph_timer_periodic
 endif
 
+USEMODULE += checksum
 USEMODULE += chunked_ringbuffer
 USEMODULE += eui_provider
 USEMODULE += iolist

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -45,6 +45,7 @@ PSEUDOMODULES += cortexm_fpu
 PSEUDOMODULES += cortexm_svc
 PSEUDOMODULES += cpp
 PSEUDOMODULES += cpu_check_address
+PSEUDOMODULES += crc16_fast
 PSEUDOMODULES += crc32_fast
 PSEUDOMODULES += credman_load
 PSEUDOMODULES += dbgpin

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -49,6 +49,10 @@ ifneq (,$(filter congure_reno_methods,$(USEMODULE)))
   USEMODULE += seq
 endif
 
+ifneq (,$(filter crc16_fast,$(USEMODULE)))
+  USEMODULE += checksum
+endif
+
 ifneq (,$(filter crc32_fast,$(USEMODULE)))
   USEMODULE += checksum
 endif

--- a/sys/include/checksum/crc16_ccitt.h
+++ b/sys/include/checksum/crc16_ccitt.h
@@ -18,6 +18,9 @@
  *              do (and is thus also far more memory efficient). Its caveat
  *              however is that it is slower by about factor 8 than these versions.
  *
+ *              @note enable the `crc32_fast` module for a look-up table based
+ *              implementation that trades code size for speed.
+ *
  * @{
  * @file
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The look-up table for CRC-16 can be quite heavy, so also provide an implementation without it.
The look-up table can be enabled with the `crc16_fast` pseudo-module.

Since this removes @jue89's concern with the common implementation, also use it in DOSE instead of re-implementing CRC-16 there. (DOSE's CRC-16 implementation is now the common one without the look-up table).


### Testing procedure

The `tests-checksum` unittest still works with and without `crc16_fast`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
