### PR TITLE
stdio_uart: add stdio_uart_onlcr option to convert LF -> CRLF on output

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -280,6 +280,7 @@ PSEUDOMODULES += stdio_available
 PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_nimble_debug
+PSEUDOMODULES += stdio_uart_onlcr
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += stdio_telnet
 PSEUDOMODULES += stm32_eth

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -87,6 +87,22 @@ ssize_t stdio_read(void* buffer, size_t count)
 
 ssize_t stdio_write(const void* buffer, size_t len)
 {
+#ifdef MODULE_STDIO_ETHOS
+    ethos_send_frame(&ethos, (const uint8_t *)buffer, len, ETHOS_FRAME_TYPE_TEXT);
+#else
+  #ifdef MODULE_STDIO_UART_ONLCR
+    const uint8_t *buf = (const uint8_t *)buffer;
+    const uint8_t cr = '\r';
+    size_t rem = len;
+    while (rem--) {
+            if (*buf == '\n')
+                    uart_write(STDIO_UART_DEV, &cr, 1);
+            uart_write(STDIO_UART_DEV, buf, 1);
+            buf++;
+    }
+  #else
     uart_write(STDIO_UART_DEV, (const uint8_t *)buffer, len);
+  #endif
+#endif
     return len;
 }


### PR DESCRIPTION
Add USE_MODULE += "stdio_uart_onlcr" to enable it. This is named after the "onlcr" stty flag, which does the same thing.

Jim wrote:

This adds an option, enabled by USE_MODULE += "stdio_uart_onlcr", to automatically convert LF to CRLF on stdio UART output. (\n to \r\n). This is named after the "onlcr" stty flag, which does the same thing on a Unix system.

It's an easy global fix for something which has come up a lot before, e.g.:
[Wiki](https://github.com/RIOT-OS/RIOT/wiki/Configure-terminal-programs-for-correct-display-of-newlines)
PR https://github.com/RIOT-OS/RIOT/pull/4899
Issue https://github.com/RIOT-OS/RIOT/issues/3040
Issue https://github.com/RIOT-OS/RIOT/issues/12540

This approach of converting on output is used by many other embedded OSes and lets RIOT output work without needing specific configuration on the other end's terminal software, or any changes to strings throughout the OS and application.

### Contribution description

This is a rebase of https://github.com/RIOT-OS/RIOT/pull/15619

### Testing procedure

I compiled this code for ESP32, and saw that it resulted in an orderly output of console terminal output.

### Issues/PRs references

Fixed #4899, fixes #3040, fixes #12540
fixes #18286