### PR TITLE
gnrc/tcp: Add support for peeking

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -269,6 +269,7 @@ PSEUDOMODULES += sock_async
 PSEUDOMODULES += sock_aux_local
 PSEUDOMODULES += sock_aux_rssi
 PSEUDOMODULES += sock_aux_timestamp
+PSEUDOMODULES += sock_peek
 PSEUDOMODULES += sock_dtls
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,6 +11,7 @@
  *
  * @file
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 
 #include <assert.h>
@@ -43,11 +44,17 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
     if ((res = lwip_sock_create(&tmp, (struct _sock_tl_ep *)local,
                                 (struct _sock_tl_ep *)remote, proto, flags,
                                 NETCONN_RAW)) == 0) {
+        mutex_init(&(sock->mutex));
+        mutex_lock(&(sock->mutex));
         sock->base.conn = tmp;
+        sock->last_buf = NULL;
+        sock->peek_buf_avail = false;
+
 #if IS_ACTIVE(SOCK_HAS_ASYNC)
         sock->base.async_cb.gen = NULL;
         netconn_set_callback_arg(sock->base.conn, &sock->base);
 #endif
+        mutex_unlock(&(sock->mutex));
     }
 
     return res;
@@ -189,15 +196,31 @@ ssize_t sock_ip_recv_aux(sock_ip_t *sock, void *data, size_t max_len,
     ssize_t res, ret = 0;
     bool nobufs = false;
 
+    bool peek = false;
+    if (aux != NULL) {
+        peek = aux->flags & SOCK_AUX_PEEK;
+    }
+
     assert((sock != NULL) && (data != NULL) && (max_len > 0));
-    while ((res = sock_ip_recv_buf_aux(sock, &pkt, (void **)&ctx, timeout,
-                                       remote, aux)) > 0) {
+    while ((res = sock_ip_recv_buf_aux(sock, &pkt, (void**)&ctx, timeout, remote,
+                                       aux)) > 0) {
         if (ctx->p->tot_len > (ssize_t)max_len) {
+            /* copy everything that fits in to the buffer and return -ENOBUFS
+             * (quite similar to the MSG_TRUNC flag) */
+            memcpy(ptr, pkt, max_len);
+            ret = max_len;
             nobufs = true;
+
+            if (peek) {
+                res = max_len;
+                nobufs = false;
+            }
+
             /* progress context to last element */
             while (netbuf_next(ctx) == 0) {}
             continue;
         }
+
         memcpy(ptr, pkt, res);
         ptr += res;
         ret += res;
@@ -210,40 +233,91 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **ctx,
                              uint32_t timeout, sock_ip_ep_t *remote,
                              sock_ip_aux_rx_t *aux)
 {
-    (void)aux;
     struct netbuf *buf;
     int res;
 
     assert((sock != NULL) && (data != NULL) && (ctx != NULL));
-    buf = *ctx;
+
+    bool peek = false;
+    sock_ip_ep_t *local = NULL;
+
+    if (aux != NULL) {
+        peek = aux->flags & SOCK_AUX_PEEK;
+
+#if IS_USED(MODULE_SOCK_AUX_LOCAL)
+        local = &aux->local;
+        aux->flags &= ~(SOCK_AUX_GET_LOCAL);
+#endif
+    }
+
+    buf = sock->last_buf;
+
+    if (timeout == 0) {
+        if (!mutex_trylock(&sock->mutex)) {
+            return -EAGAIN;
+        }
+    }
+    else {
+        mutex_lock(&sock->mutex);
+    }
 
     if (buf != NULL) {
-        if (netbuf_next(buf) == -1) {
-            *data = NULL;
-            netbuf_delete(buf);
-            *ctx = NULL;
-            return 0;
+        if (netbuf_next(buf) == -1) { /* check for next part in chain */
+            /* this is the last part of the chain (and maybe also the first) */
+
+            if (sock->peek_buf_avail) { /* first element in the chain */
+                /* return data from buffer fetched from sock */
+                sock->peek_buf_avail = false;
+
+                res = _parse_iphdr(buf, data, ctx, remote, local);
+
+                mutex_unlock(&sock->mutex);
+
+                return res;
+            }
+            else {
+                if (peek) {
+                    /* reset to the original starting point for later use and finish */
+                    netbuf_first(buf);
+                    sock->peek_buf_avail = true;
+
+                    mutex_unlock(&sock->mutex);
+
+                    return 0;
+                }
+                else {
+                    /* delete netbuf and finish */
+                    netbuf_delete(buf);
+                    sock->last_buf = NULL;
+                    *data = NULL;
+                    *ctx = NULL;
+
+                    mutex_unlock(&sock->mutex);
+
+                    return 0;
+                }
+            }
         }
         else {
+            /* next part in chain now available */
             *data = buf->ptr->payload;
-            return buf->ptr->len;
+            res = buf->ptr->len;
+
+            mutex_unlock(&sock->mutex);
+
+            return res;
         }
     }
 
     if ((res = lwip_sock_recv(sock->base.conn, timeout, &buf)) < 0) {
+        mutex_unlock(&sock->mutex);
         return res;
     }
 
-    sock_ip_ep_t *local = NULL;
-
-#if IS_USED(MODULE_SOCK_AUX_LOCAL)
-    if (aux != NULL) {
-        local = &aux->local;
-        aux->flags &= ~(SOCK_AUX_GET_LOCAL);
-    }
-#endif
-
+    sock->last_buf = buf;
     res = _parse_iphdr(buf, data, ctx, remote, local);
+
+    mutex_unlock(&sock->mutex);
 
     return res;
 }

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -47,8 +47,11 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
         mutex_init(&(sock->mutex));
         mutex_lock(&(sock->mutex));
         sock->base.conn = tmp;
-        sock->last_buf = NULL;
-        sock->peek_buf_avail = false;
+
+        if (IS_USED(MODULE_SOCK_PEEK)) {
+            sock->last_buf = NULL;
+            sock->peek_buf_avail = false;
+        }
 
 #if IS_ACTIVE(SOCK_HAS_ASYNC)
         sock->base.async_cb.gen = NULL;
@@ -197,7 +200,7 @@ ssize_t sock_ip_recv_aux(sock_ip_t *sock, void *data, size_t max_len,
     bool nobufs = false;
 
     bool peek = false;
-    if (aux != NULL) {
+    if ((aux != NULL) && IS_USED(MODULE_SOCK_PEEK)) {
         peek = aux->flags & SOCK_AUX_PEEK;
     }
 
@@ -211,7 +214,7 @@ ssize_t sock_ip_recv_aux(sock_ip_t *sock, void *data, size_t max_len,
             ret = max_len;
             nobufs = true;
 
-            if (peek) {
+            if (peek && IS_USED(MODULE_SOCK_PEEK)) {
                 res = max_len;
                 nobufs = false;
             }
@@ -242,7 +245,10 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **ctx,
     sock_ip_ep_t *local = NULL;
 
     if (aux != NULL) {
-        peek = aux->flags & SOCK_AUX_PEEK;
+
+        if (IS_USED(MODULE_SOCK_PEEK)) {
+            peek = aux->flags & SOCK_AUX_PEEK;
+        }
 
 #if IS_USED(MODULE_SOCK_AUX_LOCAL)
         local = &aux->local;
@@ -265,7 +271,7 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **ctx,
         if (netbuf_next(buf) == -1) { /* check for next part in chain */
             /* this is the last part of the chain (and maybe also the first) */
 
-            if (sock->peek_buf_avail) { /* first element in the chain */
+            if (sock->peek_buf_avail && IS_USED(MODULE_SOCK_PEEK)) { /* first element in the chain */
                 /* return data from buffer fetched from sock */
                 sock->peek_buf_avail = false;
 
@@ -276,7 +282,7 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **ctx,
                 return res;
             }
             else {
-                if (peek) {
+                if (peek && IS_USED(MODULE_SOCK_PEEK)) {
                     /* reset to the original starting point for later use and finish */
                     netbuf_first(buf);
                     sock->peek_buf_avail = true;

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -298,6 +298,10 @@ ssize_t _tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
     ssize_t recvd = 0;
     ssize_t res = 0;
 
+    if (!IS_USED(MODULE_SOCK_PEEK)) {
+        peek = false;
+    }
+
     assert((sock != NULL) && (data != NULL) && (max_len > 0));
 
     ssize_t recv_left = (max_len <= SSIZE_MAX) ? (ssize_t)max_len : SSIZE_MAX;
@@ -417,7 +421,7 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
     return _tcp_read(sock, data, max_len, timeout, false);
 }
 
-#ifdef MODULE_LWIP
+#if IS_USED(MODULE_SOCK_PEEK)
 ssize_t sock_tcp_peek(sock_tcp_t *sock, void *data, size_t max_len,
                       uint32_t timeout)
 {

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,6 +11,7 @@
  *
  * @file
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 
 #include <assert.h>
@@ -290,8 +291,8 @@ int sock_tcp_accept(sock_tcp_queue_t *queue, sock_tcp_t **sock,
     return res;
 }
 
-ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
-                      uint32_t timeout)
+ssize_t _tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
+                  uint32_t timeout, bool peek)
 {
     struct pbuf *buf;
     ssize_t recvd = 0;
@@ -304,6 +305,7 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
     if (sock->base.conn == NULL) {
         return -ENOTCONN;
     }
+
     if (timeout == 0) {
         if (!mutex_trylock(&sock->mutex)) {
             return -EAGAIN;
@@ -320,13 +322,14 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
     else
 #endif
 
-    if ((timeout == 0) && !mbox_avail(&sock->base.conn->recvmbox.mbox)) {
+    if ((timeout == 0) && !mbox_avail(&sock->base.conn->recvmbox.mbox) && !peek) {
         mutex_unlock(&sock->mutex);
         return -EAGAIN;
     }
 
-    while (recv_left > 0) {
+    do {
         uint16_t copylen, buf_len;
+
         if (sock->last_buf != NULL) {
             buf = sock->last_buf;
         }
@@ -361,6 +364,7 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
             }
             sock->last_buf = buf;
         }
+
         buf_len = buf->tot_len - sock->last_offset;
         copylen = (buf_len > recv_left) ? (uint16_t)recv_left : buf_len;
         pbuf_copy_partial(buf, (uint8_t*)data + recvd, copylen, sock->last_offset);
@@ -371,24 +375,26 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
             res = recvd;   /* in case recvd == 0 */
         }
 
-        /* post-process buf */
-        if (buf_len > copylen) {
-            /* there is still data in the buffer */
-            sock->last_buf = buf;
-            sock->last_offset += copylen;
-        }
-        else {
-            sock->last_buf = NULL;
-            sock->last_offset = 0;
-            pbuf_free(buf);
-            /* Exit the loop only when there's no more data available in the
-             * connection. This allows to copy more data in a single read if
-             * available. */
-            if (!mbox_avail(&sock->base.conn->recvmbox.mbox)) {
-                break;
+        if (!peek) {
+            /* post-process buf */
+            if (buf_len > copylen) {
+                /* there is still data in the buffer */
+                sock->last_buf = buf;
+                sock->last_offset += copylen;
+            }
+            else {
+                sock->last_buf = NULL;
+                sock->last_offset = 0;
+                pbuf_free(buf);
+                /* Exit the loop only when there's no more data available in the
+                 * connection. This allows to copy more data in a single read if
+                 * available. */
+                if (!mbox_avail(&sock->base.conn->recvmbox.mbox)) {
+                    break;
+                }
             }
         }
-    }
+    } while (recv_left > 0 && !peek);
 
     if (recvd > 0) {
         res = recvd;   /* we received data so return it */
@@ -399,9 +405,25 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
     netconn_set_recvtimeout(sock->base.conn, 0);
 #endif
     netconn_set_nonblocking(sock->base.conn, false);
+
     mutex_unlock(&sock->mutex);
+
     return res;
 }
+
+ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
+                      uint32_t timeout)
+{
+    return _tcp_read(sock, data, max_len, timeout, false);
+}
+
+#ifdef MODULE_LWIP
+ssize_t sock_tcp_peek(sock_tcp_t *sock, void *data, size_t max_len,
+                      uint32_t timeout)
+{
+    return _tcp_read(sock, data, max_len, timeout, true);
+}
+#endif
 
 ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len)
 {

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,6 +11,7 @@
  *
  * @file
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 
 #include <assert.h>
@@ -39,11 +40,17 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
     if ((res = lwip_sock_create(&tmp, (struct _sock_tl_ep *)local,
                                 (struct _sock_tl_ep *)remote, 0, flags,
                                 NETCONN_UDP)) == 0) {
+        mutex_init(&(sock->mutex));
+        mutex_lock(&(sock->mutex));
         sock->base.conn = tmp;
+        sock->last_buf = NULL;
+        sock->peek_buf_avail = false;
+
 #if IS_ACTIVE(SOCK_HAS_ASYNC)
         sock->base.async_cb.gen = NULL;
         netconn_set_callback_arg(sock->base.conn, &sock->base);
 #endif
+        mutex_unlock(&(sock->mutex));
     }
 
     return res;
@@ -77,21 +84,36 @@ ssize_t sock_udp_recv_aux(sock_udp_t *sock, void *data, size_t max_len,
                           sock_udp_aux_rx_t *aux)
 {
     void *pkt = NULL;
-    void *ctx = NULL;
+    struct netbuf *ctx = NULL;
     uint8_t *ptr = data;
     ssize_t res, ret = 0;
     bool nobufs = false;
 
+    bool peek = false;
+    if (aux != NULL) {
+        peek = aux->flags & SOCK_AUX_PEEK;
+    }
+
     assert((sock != NULL) && (data != NULL) && (max_len > 0));
-    while ((res = sock_udp_recv_buf_aux(sock, &pkt, &ctx, timeout,
+    while ((res = sock_udp_recv_buf_aux(sock, &pkt, (void**)&ctx, timeout,
                                         remote, aux)) > 0) {
-        struct netbuf *buf = ctx;
-        if (buf->p->tot_len > (ssize_t)max_len) {
+        if (ctx->p->tot_len > (ssize_t)max_len) {
+            /* copy everything that fits in to the buffer and return -ENOBUFS
+             * (quite similar to the MSG_TRUNC flag) */
+            memcpy(ptr, pkt, max_len);
+            ret = max_len;
             nobufs = true;
+
+            if (peek) {
+                res = max_len;
+                nobufs = false;
+            }
+
             /* progress context to last element */
             while (netbuf_next(ctx) == 0) {}
             continue;
         }
+
         memcpy(ptr, pkt, res);
         ptr += res;
         ret += res;
@@ -104,27 +126,78 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
                               uint32_t timeout, sock_udp_ep_t *remote,
                               sock_udp_aux_rx_t *aux)
 {
-    (void)aux;
     struct netbuf *buf;
     int res;
 
     assert((sock != NULL) && (data != NULL) && (ctx != NULL));
-    buf = *ctx;
+
+    bool peek = false;
+    if (aux != NULL) {
+        peek = aux->flags & SOCK_AUX_PEEK;
+    }
+
+    buf = sock->last_buf;
+
+    if (timeout == 0) {
+        if (!mutex_trylock(&sock->mutex)) {
+            return -EAGAIN;
+        }
+    }
+    else {
+        mutex_lock(&sock->mutex);
+    }
 
     if (buf != NULL) {
-        if (netbuf_next(buf) == -1) {
-            *data = NULL;
-            netbuf_delete(buf);
-            *ctx = NULL;
-            return 0;
+        if (netbuf_next(buf) == -1) { /* check for next part in chain */
+            /* this is the last part of the chain (and maybe also the first) */
+
+            if (sock->peek_buf_avail) { /* first element in the chain */
+                /* return data from buffer fetched from sock */
+                sock->peek_buf_avail = false;
+                *ctx = buf;
+                *data = buf->ptr->payload;
+                res = buf->ptr->len;
+
+                mutex_unlock(&sock->mutex);
+
+                return res;
+            }
+            else {
+                if (peek) {
+                    /* reset to the original starting point for later use and finish */
+                    netbuf_first(buf);
+                    sock->peek_buf_avail = true;
+
+                    mutex_unlock(&sock->mutex);
+
+                    return 0;
+                }
+                else {
+                    /* delete netbuf and finish */
+                    netbuf_delete(buf);
+                    sock->last_buf = NULL;
+                    *data = NULL;
+                    *ctx = NULL;
+
+                    mutex_unlock(&sock->mutex);
+
+                    return 0;
+                }
+            }
         }
         else {
+            /* next part in chain now available */
             *data = buf->ptr->payload;
-            return buf->ptr->len;
+            res = buf->ptr->len;
+
+            mutex_unlock(&sock->mutex);
+
+            return res;
         }
     }
 
     if ((res = lwip_sock_recv(sock->base.conn, timeout, &buf)) < 0) {
+        mutex_unlock(&sock->mutex);
         return res;
     }
 
@@ -141,6 +214,7 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
         }
         else if (!IS_ACTIVE(LWIP_IPV4)) {
             netbuf_delete(buf);
+            mutex_unlock(&sock->mutex);
             return -EPROTO;
         }
 
@@ -168,10 +242,15 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
 #endif /* MODULE_SOCK_AUX_LOCAL */
     }
 
-    *data = buf->ptr->payload;
     *ctx = buf;
+    sock->last_buf = buf;
 
-    return (ssize_t)buf->ptr->len;
+    *data = buf->ptr->payload;
+    res = (ssize_t)buf->ptr->len;
+
+    mutex_unlock(&sock->mutex);
+
+    return res;
 }
 
 ssize_t sock_udp_sendv_aux(sock_udp_t *sock, const iolist_t *snips,

--- a/pkg/lwip/include/sock_types.h
+++ b/pkg/lwip/include/sock_types.h
@@ -90,6 +90,9 @@ struct lwip_sock_base {
  */
 struct sock_ip {
     lwip_sock_base_t base;          /**< parent class */
+    mutex_t mutex;                  /**< Mutex to protect the sock */
+    struct netbuf *last_buf;        /**< Last received data */
+    bool peek_buf_avail;            /**< Whether there is a buffer left from a previous peek operation */
 };
 
 /**

--- a/pkg/lwip/include/sock_types.h
+++ b/pkg/lwip/include/sock_types.h
@@ -130,6 +130,9 @@ struct sock_tcp_queue {
  */
 struct sock_udp {
     lwip_sock_base_t base;          /**< parent class */
+    mutex_t mutex;                  /**< Mutex to protect the sock */
+    struct netbuf *last_buf;        /**< Last received data */
+    bool peek_buf_avail;            /**< Whether there is a buffer left from a previous peek operation */
 };
 
 #ifdef __cplusplus

--- a/pkg/openwsn/Makefile.dep
+++ b/pkg/openwsn/Makefile.dep
@@ -112,6 +112,10 @@ ifneq (,$(filter openwsn_sock_async,$(USEMODULE)))
   USEMODULE += sock_async
 endif
 
+ifneq (,$(filter sock_peek,$(USEMODULE)))
+  $(error OpenWSN does not support sock_peek)
+endif
+
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   USEMODULE += l2util
 endif

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -269,6 +269,24 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
                       const uint32_t user_timeout_duration_ms);
 
 /**
+ * @brief Peek at data from the peer.
+ *
+ * This is identical to @ref gnrc_tcp_recv in all except that it only peeks at
+ * the data -- that is, it does not advance the read position, and later calls
+ * to either this or @ref gnrc_tcp_recv will return the same bytes (just maybe
+ * more, when data has been received inbetween) until @ref gnrc_tcp_recv is
+ * called.
+ *
+ * Beware that reading data this way does not free up buffer space: Unlike a
+ * call to @ref gnrc_tcp_recv, which can receive more than the TCP buffer size,
+ * calling this with a @p max_len exceeding the TCP buffer size and a @p
+ * user_timeout_duration_ms of @ref GNRC_TCP_NO_TIMEOUT will just block
+ * indefinitely.
+ */
+ssize_t gnrc_tcp_peek(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
+                      const uint32_t user_timeout_duration_ms);
+
+/**
  * @brief Close a TCP connection.
  *
  * @pre gnrc_tcp_tcb_init() must have been successfully called.

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -318,6 +318,12 @@ enum {
      * @ref sock_dtls_aux_tx_t::local.
      */
     SOCK_AUX_SET_LOCAL = (1LU << 3),
+    /**
+     * @brief   Just peek data and keep it for later use
+     *
+     * @note    Currently only supported for lwIP!
+     */
+    SOCK_AUX_PEEK = (1LU << 4),
 };
 
 /**

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -274,6 +274,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#include "kernel_defines.h"
+
 /* net/sock/async/types.h included by net/sock.h needs to re-typedef the
  * `sock_ip_t` to prevent cyclic includes */
 #if defined (__clang__)
@@ -528,7 +530,7 @@ static inline ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
     return sock_ip_recv_aux(sock, data, max_len, timeout, remote, NULL);
 }
 
-#ifdef MODULE_LWIP
+#if IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN)
 /**
  * @brief   Peeks bytes from a message over IPv4/IPv6 from remote end point. If
  *          no data is available then an attempt is made to receive new data first.
@@ -569,7 +571,7 @@ static inline ssize_t sock_ip_peek(sock_ip_t *sock, void *data, size_t max_len,
 
     return sock_ip_recv_aux(sock, data, max_len, timeout, remote, &flags);
 }
-#endif /* MODULE_LWIP */
+#endif /* IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN) */
 
 /**
  * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
@@ -668,7 +670,7 @@ static inline ssize_t sock_ip_recv_buf(sock_ip_t *sock,
     return sock_ip_recv_buf_aux(sock, data, buf_ctx, timeout, remote, NULL);
 }
 
-#ifdef MODULE_LWIP
+#if IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN)
 /**
  * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
  *          message from remote end point
@@ -722,7 +724,7 @@ static inline ssize_t sock_ip_peek_buf(sock_ip_t *sock,
 
     return sock_ip_recv_buf_aux(sock, data, buf_ctx, timeout, remote, &flags);
 }
-#endif /* MODULE_LWIP */
+#endif /* IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN) */
 
 /**
  * @brief   Sends a message over IPv4/IPv6 to remote end point

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Alexander Aring <aar@pengutronix.de>
+ * Copyright (C) 2021 Alexander Aring <aar@pengutronix.de>
  *                    Freie Universität Berlin
  *                    HAW Hamburg
  *                    Kaspar Schleiser <kaspar@schleiser.de>
@@ -264,6 +264,7 @@
  * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 #ifndef NET_SOCK_IP_H
 #define NET_SOCK_IP_H
@@ -527,6 +528,49 @@ static inline ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
     return sock_ip_recv_aux(sock, data, max_len, timeout, remote, NULL);
 }
 
+#ifdef MODULE_LWIP
+/**
+ * @brief   Peeks bytes from a message over IPv4/IPv6 from remote end point. If
+ *          no data is available then an attempt is made to receive new data first.
+ *
+ * @note    Currently only available for lwIP!
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (max_len > 0)`
+ *
+ * @param[in] sock      A raw IPv4/IPv6 sock object.
+ * @param[out] data     Pointer where the read data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be NULL, if it is not required by the application.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ * @note    This function is only available when using lwIP at the moment.
+ *
+ * @return  The number of bytes read on success.
+ * @return  0, if no read data is available, but everything is in order.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_ip_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+static inline ssize_t sock_ip_peek(sock_ip_t *sock, void *data, size_t max_len,
+                                   uint32_t timeout, sock_ip_ep_t *remote)
+{
+    sock_ip_aux_rx_t flags = { .flags = SOCK_AUX_PEEK };
+
+    return sock_ip_recv_aux(sock, data, max_len, timeout, remote, &flags);
+}
+#endif /* MODULE_LWIP */
+
 /**
  * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
  *          message from remote end point
@@ -623,6 +667,62 @@ static inline ssize_t sock_ip_recv_buf(sock_ip_t *sock,
 {
     return sock_ip_recv_buf_aux(sock, data, buf_ctx, timeout, remote, NULL);
 }
+
+#ifdef MODULE_LWIP
+/**
+ * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
+ *          message from remote end point
+ *
+ * @note    Currently only available for lwIP!
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (buf_ctx != NULL)`
+ *
+ * @param[in] sock      A raw IPv4/IPv6 sock object.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[in,out] buf_ctx  Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space
+ *                      for a new packet. If it does not point to a `NULL`
+ *                      pointer, an existing context is assumed to get a next
+ *                      segment in a buffer.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be NULL, if it is not required by the application.
+ *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ * @note    This function is only available when using lwIP at the moment.
+ *
+ * @return  The number of bytes read on success. May not be the complete
+ *          payload. Continue calling with the returned `buf_ctx` to get more
+ *          buffers until result is 0 or an error.
+ * @return  0, if no read data is available, but everything is in order.
+ *          When not peeking and if @p buf_ctx was provided, it was released.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_ip_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+static inline ssize_t sock_ip_peek_buf(sock_ip_t *sock,
+                                       void **data, void **buf_ctx,
+                                       uint32_t timeout, sock_ip_ep_t *remote)
+{
+    sock_ip_aux_rx_t flags = { .flags = SOCK_AUX_PEEK };
+
+    return sock_ip_recv_buf_aux(sock, data, buf_ctx, timeout, remote, &flags);
+}
+#endif /* MODULE_LWIP */
 
 /**
  * @brief   Sends a message over IPv4/IPv6 to remote end point

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Alexander Aring <aar@pengutronix.de>
+ * Copyright (C) 2021 Alexander Aring <aar@pengutronix.de>
  *                    Freie Universität Berlin
  *                    HAW Hamburg
  *                    Kaspar Schleiser <kaspar@schleiser.de>
@@ -295,6 +295,7 @@
  * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 #ifndef NET_SOCK_TCP_H
 #define NET_SOCK_TCP_H
@@ -518,6 +519,40 @@ int sock_tcp_accept(sock_tcp_queue_t *queue, sock_tcp_t **sock,
  */
 ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
                       uint32_t timeout);
+
+#ifdef MODULE_LWIP
+/**
+ * @brief   Peeks data from an established TCP stream
+ *
+ * @note    Currently only available for lwIP!
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (max_len > 0)`
+ *
+ * @param[in] sock      A TCP sock object.
+ * @param[out] data     Pointer where the read data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and when not peeking and no data is available, the
+ *                      function returns immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ *
+ * @note    Function may block.
+ * @note    This function is only available when using lwIP at the moment.
+ *
+ * @return  The number of bytes read on success.
+ * @return  0, if no read data is available, but everything is in order.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -ECONNABORTED, if the connection is aborted while waiting for the
+ *          next data.
+ * @return  -ECONNRESET, if the connection was forcibly closed by remote end
+ *          point of @p sock.
+ * @return  -ENOTCONN, when @p sock is not connected to a remote end point.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_tcp_peek(sock_tcp_t *sock, void *data, size_t max_len,
+                      uint32_t timeout);
+#endif /* MODULE_LWIP */
 
 /**
  * @brief   Writes data to an established TCP stream

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -305,6 +305,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#include "kernel_defines.h"
+
 /* net/sock/async/types.h included by net/sock.h needs to re-typedef the
  * `sock_tcp_t` and `sock_tcp_queue_t` to prevent cyclic includes */
 #if defined (__clang__)
@@ -520,7 +522,7 @@ int sock_tcp_accept(sock_tcp_queue_t *queue, sock_tcp_t **sock,
 ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
                       uint32_t timeout);
 
-#ifdef MODULE_LWIP
+#if IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN)
 /**
  * @brief   Peeks data from an established TCP stream
  *
@@ -552,7 +554,7 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
  */
 ssize_t sock_tcp_peek(sock_tcp_t *sock, void *data, size_t max_len,
                       uint32_t timeout);
-#endif /* MODULE_LWIP */
+#endif /* IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN) */
 
 /**
  * @brief   Writes data to an established TCP stream

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Alexander Aring <aar@pengutronix.de>
+ * Copyright (C) 2021 Alexander Aring <aar@pengutronix.de>
  *                    Freie Universität Berlin
  *                    HAW Hamburg
  *                    Kaspar Schleiser <kaspar@schleiser.de>
@@ -264,6 +264,7 @@
  * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 #ifndef NET_SOCK_UDP_H
 #define NET_SOCK_UDP_H
@@ -522,6 +523,50 @@ static inline ssize_t sock_udp_recv(sock_udp_t *sock,
     return sock_udp_recv_aux(sock, data, max_len, timeout, remote, NULL);
 }
 
+#ifdef MODULE_LWIP
+/**
+ * @brief   Peeks bytes from a UDP message from a remote end point. If no data
+ *          is available then an attempt is made to receive new data first.
+ *
+ * @note    Currently only available for lwIP!
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (max_len > 0)`
+ *
+ * @param[in] sock      A UDP sock object.
+ * @param[out] data     Pointer where the read data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ * @note    This function is only available when using lwIP at the moment.
+ *
+ * @return  The number of bytes read on success.
+ * @return  0, if no read data is available, but everything is in order.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_udp_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+static inline ssize_t sock_udp_peek(sock_udp_t *sock,
+                                    void *data, size_t max_len,
+                                    uint32_t timeout, sock_udp_ep_t *remote)
+{
+    sock_udp_aux_rx_t flags = { .flags = SOCK_AUX_PEEK };
+
+    return sock_udp_recv_aux(sock, data, max_len, timeout, remote, &flags);
+}
+#endif /* MODULE_LWIP */
+
 /**
  * @brief   Provides stack-internal buffer space containing a UDP message from
  *          a remote end point
@@ -619,6 +664,63 @@ static inline ssize_t sock_udp_recv_buf(sock_udp_t *sock,
 {
     return sock_udp_recv_buf_aux(sock, data, buf_ctx, timeout, remote, NULL);
 }
+
+#ifdef MODULE_LWIP
+/**
+ * @brief   Provides stack-internal buffer space containing a UDP message from
+ *          a remote end point
+ *
+ * @note    Currently only available for lwIP!
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (buf_ctx != NULL)`
+ *
+ * @param[in] sock      A UDP sock object.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[in,out] buf_ctx  Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space
+ *                      for a new packet. If it does not point to a `NULL`
+ *                      pointer, an existing context is assumed to get a next
+ *                      segment in a buffer.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ * @note    This function is only available when using lwIP at the moment.
+ *
+ * @return  The number of bytes read on success. May not be the complete
+ *          payload. Continue calling with the returned `buf_ctx` to get more
+ *          buffers until result is 0 or an error.
+ * @return  0, if no read data is available, but everything is in order.
+ *          When not peeking and if @p buf_ctx was provided, it was released.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_udp_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+static inline ssize_t sock_udp_peek_buf(sock_udp_t *sock,
+                                        void **data, void **buf_ctx,
+                                        uint32_t timeout,
+                                        sock_udp_ep_t *remote)
+{
+    sock_udp_aux_rx_t flags = { .flags = SOCK_AUX_PEEK };
+
+    return sock_udp_recv_buf_aux(sock, data, buf_ctx, timeout, remote, &flags);
+}
+#endif /* MODULE_LWIP */
 
 /**
  * @brief   Sends a UDP message to remote end point with non-continous payload

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -274,6 +274,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#include "kernel_defines.h"
+
 /* net/sock/async/types.h included by net/sock.h needs to re-typedef the
  * `sock_ip_t` to prevent cyclic includes */
 #if defined (__clang__)
@@ -523,7 +525,7 @@ static inline ssize_t sock_udp_recv(sock_udp_t *sock,
     return sock_udp_recv_aux(sock, data, max_len, timeout, remote, NULL);
 }
 
-#ifdef MODULE_LWIP
+#if IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN)
 /**
  * @brief   Peeks bytes from a UDP message from a remote end point. If no data
  *          is available then an attempt is made to receive new data first.
@@ -565,7 +567,7 @@ static inline ssize_t sock_udp_peek(sock_udp_t *sock,
 
     return sock_udp_recv_aux(sock, data, max_len, timeout, remote, &flags);
 }
-#endif /* MODULE_LWIP */
+#endif /* IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN) */
 
 /**
  * @brief   Provides stack-internal buffer space containing a UDP message from
@@ -665,7 +667,7 @@ static inline ssize_t sock_udp_recv_buf(sock_udp_t *sock,
     return sock_udp_recv_buf_aux(sock, data, buf_ctx, timeout, remote, NULL);
 }
 
-#ifdef MODULE_LWIP
+#if IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN)
 /**
  * @brief   Provides stack-internal buffer space containing a UDP message from
  *          a remote end point
@@ -720,7 +722,7 @@ static inline ssize_t sock_udp_peek_buf(sock_udp_t *sock,
 
     return sock_udp_recv_buf_aux(sock, data, buf_ctx, timeout, remote, &flags);
 }
-#endif /* MODULE_LWIP */
+#endif /* IS_USED(MODULE_SOCK_PEEK) || defined(DOXYGEN) */
 
 /**
  * @brief   Sends a UDP message to remote end point with non-continous payload

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -10,6 +10,10 @@ ifneq (,$(filter sock_async,$(USEMODULE)))
   USEMODULE += gnrc_sock_async
 endif
 
+ifneq (,$(filter sock_peek,$(USEMODULE)))
+  $(error GNRC does not support sock_peek)
+endif
+
 ifneq (,$(filter gnrc_mac,$(USEMODULE)))
   USEMODULE += gnrc_priority_pktqueue
   USEMODULE += csma_sender

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -10,10 +10,6 @@ ifneq (,$(filter sock_async,$(USEMODULE)))
   USEMODULE += gnrc_sock_async
 endif
 
-ifneq (,$(filter sock_peek,$(USEMODULE)))
-  $(error GNRC does not support sock_peek)
-endif
-
 ifneq (,$(filter gnrc_mac,$(USEMODULE)))
   USEMODULE += gnrc_priority_pktqueue
   USEMODULE += csma_sender

--- a/sys/net/gnrc/sock/tcp/gnrc_sock_tcp.c
+++ b/sys/net/gnrc/sock/tcp/gnrc_sock_tcp.c
@@ -133,6 +133,21 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len, uint32_t tim
     return gnrc_tcp_recv(sock, data, max_len, timeout);
 }
 
+ssize_t sock_tcp_peek(sock_tcp_t *sock, void *data, size_t max_len, uint32_t timeout)
+{
+    /* Asserts defined by API. */
+    assert(sock != NULL);
+    assert(data != NULL);
+
+    /* Map SOCK_NO_TIMEOUT to GNRC_TCP_NO_TIMEOUT */
+    if (timeout == SOCK_NO_TIMEOUT) {
+        timeout = GNRC_TCP_NO_TIMEOUT;
+    }
+
+    /* Forward call to gnrc_tcp_recv: All error codes share the same semantics */
+    return gnrc_tcp_peek(sock, data, max_len, timeout);
+}
+
 ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len)
 {
     /* Asserts defined by API. */

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_fsm.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_fsm.h
@@ -53,6 +53,7 @@ typedef enum {
     FSM_EVENT_CALL_OPEN,          /* User function call: open */
     FSM_EVENT_CALL_SEND,          /* User function call: send */
     FSM_EVENT_CALL_RECV,          /* User function call: recv */
+    FSM_EVENT_CALL_PEEK,          /* User function call: peek (a no-op in the FSM, see _fsm_call_recv docs) */
     FSM_EVENT_CALL_CLOSE,         /* User function call: close */
     FSM_EVENT_CALL_ABORT,         /* User function call: abort */
     FSM_EVENT_RCVD_PKT,           /* Packet received from peer */

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -354,7 +354,8 @@ int listen(int socket, int backlog);
  * @param[in] length        Specifies the length in bytes of the buffer pointed
  *                          to by the buffer argument.
  * @param[in] flags         Specifies the type of message reception. Support
- *                          for values other than 0 is not implemented yet.
+ *                          for values other than 0 is not implemented yet, but
+ *                          when using lwIP, the MSG_PEEK flag is available.
  * @param[out] address      A null pointer, or points to a sockaddr structure
  *                          in which the sending address is to be stored. The
  *                          length and format of the address depend on the
@@ -391,7 +392,8 @@ ssize_t recvfrom(int socket, void *__restrict buffer, size_t length, int flags,
  * @param[in] length    Specifies the length in bytes of the buffer pointed to
  *                      by the buffer argument.
  * @param[in] flags     Specifies the type of message reception. Support for
- *                      values other than 0 is not implemented yet.
+ *                      values other than 0 is not implemented yet, but when
+ *                      using lwIP, the MSG_PEEK flag is available.
  *
  * @return  Upon successful completion, recv() shall return the length of the
  *          message in bytes. If no messages are available to be received and

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-15 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -25,6 +25,7 @@
  * * sockatmark()
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 #ifndef SYS_SOCKET_H
 #define SYS_SOCKET_H
@@ -116,6 +117,20 @@ extern "C" {
 #define SO_SNDLOWAT     (13)    /**< Send "low water mark". */
 #define SO_SNDTIMEO     (14)    /**< Send timeout. */
 #define SO_TYPE         (15)    /**< Socket type. */
+/** @} */
+
+/**
+ * @name    Flag names
+ * @brief   Flag parameter for recvfrom(), recvmsg(), sendmsg(), or sendto()
+ * @{
+ */
+#define MSG_CTRUNC      (0x01)    /**< Control data truncated. */
+#define MSG_DONTROUTE   (0x02)    /**< Send without using routing tables. */
+#define MSG_EOR         (0x04)    /**< Terminates a record (if supported by the protocol). */
+#define MSG_OOB         (0x08)    /**< Out-of-band data. */
+#define MSG_PEEK        (0x10)    /**< Leave received data in queue. */
+#define MSG_TRUNC       (0x20)    /**< Normal data truncated. */
+#define MSG_WAITALL     (0x40)    /**< Attempt to fill the read buffer. */
 /** @} */
 
 typedef unsigned short sa_family_t;   /**< address family type */

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -27,6 +27,7 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
 USEMODULE += sock_ip
+USEMODULE += sock_peek
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-LWIP_IPV4 ?= 0
+LWIP_IPV4 ?= 1
 LWIP_IPV6 ?= 1
 AUX_LOCAL ?= 1
 

--- a/tests/lwip_sock_ip/Makefile.ci
+++ b/tests/lwip_sock_ip/Makefile.ci
@@ -1,19 +1,25 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    blackpill \
+    bluepill \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    saml10-xpro \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    stm32mp157c-dk2 \
     #

--- a/tests/lwip_sock_ip/README.md
+++ b/tests/lwip_sock_ip/README.md
@@ -5,28 +5,21 @@ This tests the `sock_ip` port of lwIP. There is no network device needed since
 a [virtual device](http://doc.riot-os.org/group__sys__netdev__test.html) is
 provided at the backend.
 
-These tests test both IPv4 and IPv6 capabilities. They can be activated by
-the `LWIP_IPV4` and `LWIP_IPV6` environment variables to a non-zero value.
-IPv6 is activated by default:
+These tests test both IPv4 and IPv6 capabilities. They can be deactivated
+individually by the `LWIP_IPV4` and `LWIP_IPV6` environment variables by setting
+them to zero.
 
-```sh
-make all test
-# or
-LWIP_IPV6=1 make all test
-```
+By default both IPv4 and IPv6 are tested.
 
-To just test IPv4 set the `LWIP_IPV4` to a non-zero value (IPv6 will be
-deactivated automatically):
+    $ make all test
 
-```sh
-LWIP_IPV4=1 make all test
-```
+To test only IPv4 run:
 
-To test both set the `LWIP_IPV4` and `LWIP_IPV6` to a non-zero value:
+    $ LWIP_IPV6=0 make all test
 
-```sh
-LWIP_IPV4=1 LWIP_IPV6=1 make all test
-```
+To test only IPv6 run:
+
+    $ LWIP_IPV4=0 make all test
 
 Since lwIP uses a lot of macro magic to activate/deactivate these capabilities
 it is advisable to **test all three configurations individually** (just IPv4,

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -352,6 +352,7 @@ static void test_sock_ip_recv_buf4__success(void)
     expect(_check_net());
 }
 
+#if IS_USED(MODULE_SOCK_PEEK)
 static void test_sock_ip_peek4__success(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET };
@@ -375,6 +376,7 @@ static void test_sock_ip_peek4__success(void)
 
     expect(_check_net());
 }
+#endif /* IS_USED(MODULE_SOCK_PEEK) */
 
 static void test_sock_ip_send4__EAFNOSUPPORT(void)
 {
@@ -947,6 +949,7 @@ static void test_sock_ip_recv_buf6__success(void)
     expect(_check_net());
 }
 
+#if IS_USED(MODULE_SOCK_PEEK)
 static void test_sock_ip_peek6__success(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
@@ -972,6 +975,7 @@ static void test_sock_ip_peek6__success(void)
 
     expect(_check_net());
 }
+#endif /* IS_USED(MODULE_SOCK_PEEK) */
 
 static void test_sock_ip_send6__EAFNOSUPPORT(void)
 {
@@ -1271,7 +1275,9 @@ int main(void)
     CALL(test_sock_ip_recv4__non_blocking());
     CALL(test_sock_ip_recv4__aux());
     CALL(test_sock_ip_recv_buf4__success());
+#if IS_USED(MODULE_SOCK_PEEK)
     CALL(test_sock_ip_peek4__success());
+#endif
     _prepare_send_checks();
     CALL(test_sock_ip_send4__EAFNOSUPPORT());
     CALL(test_sock_ip_send4__EINVAL_addr());
@@ -1318,7 +1324,9 @@ int main(void)
     CALL(test_sock_ip_recv6__non_blocking());
     CALL(test_sock_ip_recv6__aux());
     CALL(test_sock_ip_recv_buf6__success());
+#if IS_USED(MODULE_SOCK_PEEK)
     CALL(test_sock_ip_peek6__success());
+#endif
     _prepare_send_checks();
     CALL(test_sock_ip_send6__EAFNOSUPPORT());
     CALL(test_sock_ip_send6__EINVAL_addr());

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +14,7 @@
  * @brief       Test for raw IP socks
  *
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @}
  */
 
@@ -348,6 +349,30 @@ static void test_sock_ip_recv_buf4__success(void)
     expect(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
     expect(data == NULL);
     expect(ctx == NULL);
+    expect(_check_net());
+}
+
+static void test_sock_ip_peek4__success(void)
+{
+    static const sock_ip_ep_t local = { .family = AF_INET };
+    static const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
+                                         .family = AF_INET };
+
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+                               SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+                           sizeof("ABCD"), _TEST_NETIF));
+
+    for (ssize_t i = 1; i <= (ssize_t)sizeof("ABCD"); i++) {
+        expect(i == sock_ip_peek(&_sock, _test_buffer, i, 0, NULL));
+    }
+
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+                                          sizeof(_test_buffer), 0, NULL));
+
+    expect(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+                                   0, NULL));
+
     expect(_check_net());
 }
 
@@ -922,6 +947,32 @@ static void test_sock_ip_recv_buf6__success(void)
     expect(_check_net());
 }
 
+static void test_sock_ip_peek6__success(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR6_LOCAL };
+    static const sock_ip_ep_t local = { .family = AF_INET6 };
+    static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
+                                         .family = AF_INET6 };
+
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+                               SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+                           sizeof("ABCD"), _TEST_NETIF));
+
+    for (ssize_t i = 1; i <= (ssize_t)sizeof("ABCD"); i++) {
+        expect(i == sock_ip_peek(&_sock, _test_buffer, i, 0, NULL));
+    }
+
+    expect(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
+                                          sizeof(_test_buffer), 0, NULL));
+
+    expect(-EAGAIN == sock_ip_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+                                   0, NULL));
+
+    expect(_check_net());
+}
+
 static void test_sock_ip_send6__EAFNOSUPPORT(void)
 {
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
@@ -1220,6 +1271,7 @@ int main(void)
     CALL(test_sock_ip_recv4__non_blocking());
     CALL(test_sock_ip_recv4__aux());
     CALL(test_sock_ip_recv_buf4__success());
+    CALL(test_sock_ip_peek4__success());
     _prepare_send_checks();
     CALL(test_sock_ip_send4__EAFNOSUPPORT());
     CALL(test_sock_ip_send4__EINVAL_addr());
@@ -1266,6 +1318,7 @@ int main(void)
     CALL(test_sock_ip_recv6__non_blocking());
     CALL(test_sock_ip_recv6__aux());
     CALL(test_sock_ip_recv_buf6__success());
+    CALL(test_sock_ip_peek6__success());
     _prepare_send_checks();
     CALL(test_sock_ip_send6__EAFNOSUPPORT());
     CALL(test_sock_ip_send6__EINVAL_addr());

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-LWIP_IPV4 ?= 0
+LWIP_IPV4 ?= 1
 LWIP_IPV6 ?= 1
 
 ifneq (0, $(LWIP_IPV4))

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -21,6 +21,7 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
 USEMODULE += sock_tcp
+USEMODULE += sock_peek
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/lwip_sock_tcp/README.md
+++ b/tests/lwip_sock_tcp/README.md
@@ -5,28 +5,21 @@ This tests the `sock_tcp` port of lwIP. There is no network device needed since
 a [virtual device](http://doc.riot-os.org/group__sys__netdev__test.html) is
 provided at the backend.
 
-These tests test both IPv4 and IPv6 capabilities. They can be activated by
-the `LWIP_IPV4` and `LWIP_IPV6` environment variables to a non-zero value.
-IPv6 is activated by default:
+These tests test both IPv4 and IPv6 capabilities. They can be deactivated
+individually by the `LWIP_IPV4` and `LWIP_IPV6` environment variables by setting
+them to zero.
 
-```sh
-make all test
-# or
-LWIP_IPV6=1 make all test
-```
+By default both IPv4 and IPv6 are tested.
 
-To just test IPv4 set the `LWIP_IPV4` to a non-zero value (IPv6 will be
-deactivated automatically):
+    $ make all test
 
-```sh
-LWIP_IPV4=1 make all test
-```
+To test only IPv4 run:
 
-To test both set the `LWIP_IPV4` and `LWIP_IPV6` to a non-zero value:
+    $ LWIP_IPV6=0 make all test
 
-```sh
-LWIP_IPV4=1 LWIP_IPV6=1 make all test
-```
+To test only IPv6 run:
+
+    $ LWIP_IPV4=0 make all test
 
 Since lwIP uses a lot of macro magic to activate/deactivate these capabilities
 it is advisable to **test all three configurations individually** (just IPv4,

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,9 +11,10 @@
  * @{
  *
  * @file
- * @brief       Test for UDP socks
+ * @brief       Test for TCP socks
  *
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @}
  */
 
@@ -484,6 +485,42 @@ static void test_tcp_read4__success_non_blocking(void)
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
+static void test_tcp_peek4__success(void)
+{
+    static const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
+                                          .family = AF_INET,
+                                          .port = _TEST_PORT_REMOTE,
+                                          .netif = SOCK_ADDR_ANY_NETIF };
+    msg_t msg = { .type = _SERVER_MSG_START };
+    static const struct iovec exp_data = { .iov_base = "Hello!",
+            .iov_len = sizeof("Hello!") };
+
+    _server_addr.family = AF_INET;
+    _server_addr.port = _TEST_PORT_REMOTE;
+    _server_addr.netif = SOCK_ADDR_ANY_NETIF;
+
+    msg_send(&msg, _server);        /* start server on _TEST_PORT_LOCAL */
+    msg.type = _SERVER_MSG_ACCEPT;
+    msg_send(&msg, _server);        /* let server accept */
+
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    msg.type = _SERVER_MSG_WRITE;
+    msg.content.ptr = (void *)&exp_data;
+    msg_send(&msg, _server);        /* write expected data at server */
+
+    for (ssize_t i = 1; i <= (ssize_t)exp_data.iov_len; i++) {
+        expect(i == sock_tcp_peek(&_sock, _test_buffer, i, 0));
+    }
+
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+                                                        sizeof(_test_buffer),
+                                                        SOCK_NO_TIMEOUT));
+
+    expect(-EAGAIN == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer), 0));
+
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+}
+
 /* ENOTCONN not applicable since lwIP always tries to send */
 
 static void test_tcp_write4__ENOTCONN(void)
@@ -832,6 +869,7 @@ static void test_tcp_read6__ETIMEDOUT(void)
                                        sizeof(_test_buffer), _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
 }
+
 static void test_tcp_read6__success(void)
 {
     static const sock_tcp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
@@ -913,6 +951,42 @@ static void test_tcp_read6__success_non_blocking(void)
     expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
                                                         sizeof(_test_buffer),
                                                         0));
+    expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
+}
+
+static void test_tcp_peek6__success(void)
+{
+    static const sock_tcp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
+                                          .family = AF_INET6,
+                                          .port = _TEST_PORT_REMOTE,
+                                          .netif = SOCK_ADDR_ANY_NETIF };
+    msg_t msg = { .type = _SERVER_MSG_START };
+    static const struct iovec exp_data = { .iov_base = "Hello!",
+            .iov_len = sizeof("Hello!") };
+
+    _server_addr.family = AF_INET6;
+    _server_addr.port = _TEST_PORT_REMOTE;
+    _server_addr.netif = SOCK_ADDR_ANY_NETIF;
+
+    msg_send(&msg, _server);        /* start server on _TEST_PORT_LOCAL */
+    msg.type = _SERVER_MSG_ACCEPT;
+    msg_send(&msg, _server);        /* let server accept */
+
+    expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
+    msg.type = _SERVER_MSG_WRITE;
+    msg.content.ptr = (void *)&exp_data;
+    msg_send(&msg, _server);        /* write expected data at server */
+
+    for (ssize_t i = 1; i <= (ssize_t)exp_data.iov_len; i++) {
+        expect(i == sock_tcp_peek(&_sock, _test_buffer, i, 0));
+    }
+
+    expect(((ssize_t)exp_data.iov_len) == sock_tcp_read(&_sock, _test_buffer,
+                                                        sizeof(_test_buffer),
+                                                        SOCK_NO_TIMEOUT));
+
+    expect(-EAGAIN == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer), 0));
+
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
@@ -1012,6 +1086,7 @@ int main(void)
     CALL(test_tcp_read4__success());
     CALL(test_tcp_read4__success_with_timeout());
     CALL(test_tcp_read4__success_non_blocking());
+    CALL(test_tcp_peek4__success());
     /* ECONNABORTED can't be tested in this setup */
     /* ENOTCONN not applicable since lwIP always tries to send */
     CALL(test_tcp_write4__ENOTCONN());
@@ -1055,6 +1130,7 @@ int main(void)
     CALL(test_tcp_read6__success());
     CALL(test_tcp_read6__success_with_timeout());
     CALL(test_tcp_read6__success_non_blocking());
+    CALL(test_tcp_peek6__success());
     /* ECONNABORTED can't be tested in this setup */
     /* ENOTCONN not applicable since lwIP always tries to send */
     CALL(test_tcp_write6__ENOTCONN());

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -485,6 +485,7 @@ static void test_tcp_read4__success_non_blocking(void)
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
+#if IS_USED(MODULE_SOCK_PEEK)
 static void test_tcp_peek4__success(void)
 {
     static const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
@@ -520,6 +521,7 @@ static void test_tcp_peek4__success(void)
 
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
+#endif /* IS_USED(MODULE_SOCK_PEEK) */
 
 /* ENOTCONN not applicable since lwIP always tries to send */
 
@@ -954,6 +956,7 @@ static void test_tcp_read6__success_non_blocking(void)
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
 
+#if IS_USED(MODULE_SOCK_PEEK)
 static void test_tcp_peek6__success(void)
 {
     static const sock_tcp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
@@ -989,6 +992,7 @@ static void test_tcp_peek6__success(void)
 
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
 }
+#endif /* IS_USED(MODULE_SOCK_PEEK) */
 
 /* ENOTCONN not applicable since lwIP always tries to send */
 
@@ -1086,7 +1090,9 @@ int main(void)
     CALL(test_tcp_read4__success());
     CALL(test_tcp_read4__success_with_timeout());
     CALL(test_tcp_read4__success_non_blocking());
+#if IS_USED(MODULE_SOCK_PEEK)
     CALL(test_tcp_peek4__success());
+#endif
     /* ECONNABORTED can't be tested in this setup */
     /* ENOTCONN not applicable since lwIP always tries to send */
     CALL(test_tcp_write4__ENOTCONN());
@@ -1130,7 +1136,9 @@ int main(void)
     CALL(test_tcp_read6__success());
     CALL(test_tcp_read6__success_with_timeout());
     CALL(test_tcp_read6__success_non_blocking());
+#if IS_USED(MODULE_SOCK_PEEK)
     CALL(test_tcp_peek6__success());
+#endif
     /* ECONNABORTED can't be tested in this setup */
     /* ENOTCONN not applicable since lwIP always tries to send */
     CALL(test_tcp_write6__ENOTCONN());

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -27,6 +27,7 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
 USEMODULE += sock_udp
+USEMODULE += sock_peek
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-LWIP_IPV4 ?= 0
+LWIP_IPV4 ?= 1
 LWIP_IPV6 ?= 1
 AUX_LOCAL ?= 1
 

--- a/tests/lwip_sock_udp/Makefile.ci
+++ b/tests/lwip_sock_udp/Makefile.ci
@@ -1,19 +1,25 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    blackpill \
+    bluepill \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    saml10-xpro \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    stm32mp157c-dk2 \
     #

--- a/tests/lwip_sock_udp/README.md
+++ b/tests/lwip_sock_udp/README.md
@@ -5,28 +5,21 @@ This tests the `sock_udp` port of lwIP. There is no network device needed since
 a [virtual device](http://doc.riot-os.org/group__sys__netdev__test.html) is
 provided at the backend.
 
-These tests test both IPv4 and IPv6 capabilities. They can be activated by
-the `LWIP_IPV4` and `LWIP_IPV6` environment variables to a non-zero value.
-IPv6 is activated by default:
+These tests test both IPv4 and IPv6 capabilities. They can be deactivated
+individually by the `LWIP_IPV4` and `LWIP_IPV6` environment variables by setting
+them to zero.
 
-```sh
-make all test
-# or
-LWIP_IPV6=1 make all test
-```
+By default both IPv4 and IPv6 are tested.
 
-To just test IPv4 set the `LWIP_IPV4` to a non-zero value (IPv6 will be
-deactivated automatically):
+    $ make all test
 
-```sh
-LWIP_IPV4=1 make all test
-```
+To test only IPv4 run:
 
-To test both set the `LWIP_IPV4` and `LWIP_IPV6` to a non-zero value:
+    $ LWIP_IPV6=0 make all test
 
-```sh
-LWIP_IPV4=1 LWIP_IPV6=1 make all test
-```
+To test only IPv6 run:
+
+    $ LWIP_IPV4=0 make all test
 
 Since lwIP uses a lot of macro magic to activate/deactivate these capabilities
 it is advisable to **test all three configurations individually** (just IPv4,

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -447,6 +447,7 @@ static void test_sock_udp_recv_buf4__success(void)
     expect(_check_net());
 }
 
+#if IS_USED(MODULE_SOCK_PEEK)
 static void test_sock_udp_peek4__success(void)
 {
     static const sock_udp_ep_t local = { .family = AF_INET,
@@ -473,6 +474,7 @@ static void test_sock_udp_peek4__success(void)
 
     expect(_check_net());
 }
+#endif /* IS_USED(MODULE_SOCK_PEEK) */
 
 static void test_sock_udp_send4__EAFNOSUPPORT(void)
 {
@@ -1170,6 +1172,7 @@ static void test_sock_udp_recv_buf6__success(void)
     expect(_check_net());
 }
 
+#if IS_USED(MODULE_SOCK_PEEK)
 static void test_sock_udp_peek6__success(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
@@ -1198,6 +1201,7 @@ static void test_sock_udp_peek6__success(void)
 
     expect(_check_net());
 }
+#endif /* IS_USED(MODULE_SOCK_PEEK) */
 
 static void test_sock_udp_send6__EAFNOSUPPORT(void)
 {
@@ -1560,7 +1564,9 @@ int main(void)
     CALL(test_sock_udp_recv4__non_blocking());
     CALL(test_sock_udp_recv4__aux());
     CALL(test_sock_udp_recv_buf4__success());
+#if IS_USED(MODULE_SOCK_PEEK)
     CALL(test_sock_udp_peek4__success());
+#endif
     _prepare_send_checks();
     CALL(test_sock_udp_send4__EAFNOSUPPORT());
     CALL(test_sock_udp_send4__EINVAL_addr());
@@ -1610,7 +1616,9 @@ int main(void)
     CALL(test_sock_udp_recv6__non_blocking());
     CALL(test_sock_udp_recv6__aux());
     CALL(test_sock_udp_recv_buf6__success());
+#if IS_USED(MODULE_SOCK_PEEK)
     CALL(test_sock_udp_peek6__success());
+#endif
     _prepare_send_checks();
     CALL(test_sock_udp_send6__EAFNOSUPPORT());
     CALL(test_sock_udp_send6__EINVAL_addr());

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +14,7 @@
  * @brief       Test for UDP socks
  *
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @}
  */
 
@@ -443,6 +444,33 @@ static void test_sock_udp_recv_buf4__success(void)
     expect(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
     expect(data == NULL);
     expect(ctx == NULL);
+    expect(_check_net());
+}
+
+static void test_sock_udp_peek4__success(void)
+{
+    static const sock_udp_ep_t local = { .family = AF_INET,
+                                         .port = _TEST_PORT_LOCAL };
+    static const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = _TEST_ADDR4_REMOTE },
+                                          .family = AF_INET,
+                                          .port = _TEST_PORT_REMOTE };
+
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
+                           _TEST_NETIF));
+
+    for (ssize_t i = 1; i <= (ssize_t)sizeof("ABCD"); i++) {
+        expect(i == sock_udp_peek(&_sock, _test_buffer, i, SOCK_NO_TIMEOUT, NULL));
+    }
+
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+                                           sizeof(_test_buffer),
+                                           SOCK_NO_TIMEOUT, NULL));
+
+    expect(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+                                    0, NULL));
+
     expect(_check_net());
 }
 
@@ -1142,6 +1170,35 @@ static void test_sock_udp_recv_buf6__success(void)
     expect(_check_net());
 }
 
+static void test_sock_udp_peek6__success(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR6_LOCAL };
+    static const sock_udp_ep_t local = { .family = AF_INET6,
+                                         .port = _TEST_PORT_LOCAL };
+    static const sock_udp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
+                                          .family = AF_INET6,
+                                          .port = _TEST_PORT_REMOTE };
+
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
+                           _TEST_NETIF));
+
+    for (ssize_t i = 1; i <= (ssize_t)sizeof("ABCD"); i++) {
+        expect(i == sock_udp_peek(&_sock, _test_buffer, i, SOCK_NO_TIMEOUT, NULL));
+    }
+
+    expect(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
+                                           sizeof(_test_buffer),
+                                           SOCK_NO_TIMEOUT, NULL));
+
+    expect(-EAGAIN == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+                                    0, NULL));
+
+    expect(_check_net());
+}
+
 static void test_sock_udp_send6__EAFNOSUPPORT(void)
 {
     static const sock_udp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
@@ -1503,6 +1560,7 @@ int main(void)
     CALL(test_sock_udp_recv4__non_blocking());
     CALL(test_sock_udp_recv4__aux());
     CALL(test_sock_udp_recv_buf4__success());
+    CALL(test_sock_udp_peek4__success());
     _prepare_send_checks();
     CALL(test_sock_udp_send4__EAFNOSUPPORT());
     CALL(test_sock_udp_send4__EINVAL_addr());
@@ -1552,6 +1610,7 @@ int main(void)
     CALL(test_sock_udp_recv6__non_blocking());
     CALL(test_sock_udp_recv6__aux());
     CALL(test_sock_udp_recv_buf6__success());
+    CALL(test_sock_udp_peek6__success());
     _prepare_send_checks();
     CALL(test_sock_udp_send6__EAFNOSUPPORT());
     CALL(test_sock_udp_send6__EINVAL_addr());


### PR DESCRIPTION
### Contribution description

In #16850, socket support for peeking is established, initially for lwIP. This adds GNRC support for this on TCP sockets.

### Open questions

* Am I using the FSM mechanism right? The peek function doesn't really participate in state transitions, so rather than going through _gnrc_tcp_fsm feels a bit wrong, but then again, that does provide the locking setup around the FSM ... or should I just make _fsm_peek a non-static internal function inside the FSM that's called from gnrc_tcp.c and locks the FSM on its own?
* I think that due to peeking not freeing anything up, _fsm_call_peek can (compared to _fsm_call_recv) save the if-ringbuffer-free > MSS, is that right?

Semi-related (as peeking itself doesn't cause it):

* As _fsm_call_recv is implemented now, it will only send out a new ACK if we have room for yet another MSS. Does this mean that if, say, the buffer is full and 50 bytes are read, and then the receiving process waits until the buffer is full to read in one go, this would starve? (One might argue correctly that this situation could not previously happen, because without peeking there is no way for the application to know when sufficient data is available). Would it be reasonable to have some sort of "flush receive" call by which the program can tell the stack that it won't read as things are, but that the TCP implementation should acknowledge everything that has been received so far, so that the buffer can be filled up? (Otherwise, a program that wants to spool some amount of data up in the TCP buffer would need to size its TCP buffer larger than the required amount of data by almost an MSS, so that it can be sure that enough data becomes available).

### Testing procedure

TBD

### PR references

This PR being based on #16850, please consider only the top commits in this PR.