### PR TITLE
pkg/cryptoauthlib: Pass ATCA_NO_HEAP Flag to library

### DIFF
--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -24,6 +24,7 @@ CFLAGS += -Wno-unused-function
 CFLAGS += -Wno-unused-parameter
 CFLAGS += -Wno-unused-variable
 CFLAGS += -Wno-format-nonliteral
+CFLAGS += -Wno-maybe-uninitialized
 
 TOOLCHAIN_FILE=$(PKG_SOURCE_DIR)/xcompile-toolchain.cmake
 
@@ -40,6 +41,7 @@ cryptoauth: $(PKG_BUILD_DIR)/Makefile
 $(PKG_BUILD_DIR)/Makefile: $(TOOLCHAIN_FILE)
 	cmake -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
 		  -Wno-dev \
+		  -DATCA_NO_HEAP:BOOL=TRUE \
 		  -B$(PKG_BUILD_DIR) \
 		  -H$(PKG_SOURCE_DIR)/lib
 


### PR DESCRIPTION
### Contribution description
ATCA_NO_HEAP must be passed to cryptoauthlib build system in order to not use dynamic memory allocation.
Build fails when using KCONFIG for dependency resolution, because ATCA_NO_HEAP is not defined.
This fixes the problem.

### Testing procedure
Build `tests/pkg_cryptoauthlib_compare_sha256/` using KCONFIG dependency resolution.