### PR TITLE
pseudomodules: document gnrc_netif_cmd_lora as deprecated

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -124,7 +124,14 @@ PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_ipv6
 PSEUDOMODULES += gnrc_netif_mac
 PSEUDOMODULES += gnrc_netif_single
-PSEUDOMODULES += gnrc_netif_cmd_%
+## @defgroup net_gnrc_netif_cmd_lora  gnrc_netif_cmd_lora
+## @ingroup sys_shell_commands
+## @ingroup net_gnrc_netif
+## @{
+## @deprecated  Use module `shell_cmd_gnrc_netif_lorawan` instead;
+##              will be removed after 2023.07 release.
+PSEUDOMODULES += gnrc_netif_cmd_lora
+## @}
 PSEUDOMODULES += gnrc_netif_dedup
 PSEUDOMODULES += gnrc_nettype_%
 PSEUDOMODULES += gnrc_sixloenc


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This adds the deprecation of `gnrc_netif_cmd_lora` that was introduced in https://github.com/RIOT-OS/RIOT/pull/18649 to the documentation list of deprecated things.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make doc` and read doc/doxygen/html/deprecated.html.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/18649 and semantically requires it to be merged.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
