### PR TITLE
gnrc_ipv6_nib: handle iface_up/iface_down in IPv6 thread

### DIFF
--- a/examples/telnet_server/Makefile.ci
+++ b/examples/telnet_server/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     slstk3400a \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -233,6 +233,16 @@ extern "C" {
  * @note    Only handled with @ref CONFIG_GNRC_IPV6_NIB_DNS != 0
  */
 #define GNRC_IPV6_NIB_RDNSS_TIMEOUT         (0x4fd3U)
+
+/**
+ * @brief   Interface up event
+ */
+#define GNRC_IPV6_NIB_IFACE_UP              (0x4fd4U)
+
+/**
+ * @brief   Interface down event
+ */
+#define GNRC_IPV6_NIB_IFACE_DOWN            (0x4fd5U)
 /** @} */
 
 /**

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -25,10 +25,8 @@
 #include "net/ethernet.h"
 #include "net/ipv6.h"
 #include "net/gnrc.h"
-#if IS_USED(MODULE_GNRC_IPV6_NIB)
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/ipv6.h"
-#endif /* IS_USED(MODULE_GNRC_IPV6_NIB) */
 #if IS_USED(MODULE_GNRC_NETIF_PKTQ)
 #include "net/gnrc/netif/pktq.h"
 #endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
@@ -2052,14 +2050,20 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
         DEBUG("gnrc_netif: event triggered -> %i\n", event);
         gnrc_pktsnip_t *pkt = NULL;
         switch (event) {
-#if IS_USED(MODULE_GNRC_IPV6_NIB)
             case NETDEV_EVENT_LINK_UP:
-                gnrc_ipv6_nib_iface_up(netif);
+                if (IS_USED(MODULE_GNRC_IPV6)) {
+                    msg_t msg = { .type = GNRC_IPV6_NIB_IFACE_UP, .content = { .ptr = netif } };
+
+                    msg_send(&msg, gnrc_ipv6_pid);
+                }
                 break;
             case NETDEV_EVENT_LINK_DOWN:
-                gnrc_ipv6_nib_iface_down(netif, false);
+                if (IS_USED(MODULE_GNRC_IPV6)) {
+                    msg_t msg = { .type = GNRC_IPV6_NIB_IFACE_DOWN, .content = { .ptr = netif } };
+
+                    msg_send(&msg, gnrc_ipv6_pid);
+                }
                 break;
-#endif
             case NETDEV_EVENT_RX_COMPLETE:
                 pkt = netif->ops->recv(netif);
                 /* send packet previously queued within netif due to the lower

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -244,6 +244,12 @@ static void *_event_loop(void *args)
                 DEBUG("ipv6: NIB timer event received\n");
                 gnrc_ipv6_nib_handle_timer_event(msg.content.ptr, msg.type);
                 break;
+            case GNRC_IPV6_NIB_IFACE_UP:
+                gnrc_ipv6_nib_iface_up(msg.content.ptr);
+                break;
+            case GNRC_IPV6_NIB_IFACE_DOWN:
+                gnrc_ipv6_nib_iface_down(msg.content.ptr, false);
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The main motivation for this was, that I observed that with #18700 the LoRaWAN thread suddenly used a huge amount of stack space. Given that `gnrc_ipv6_nib_iface_up` accumulated already uses over 100 bytes on the board I was using (`b-l072z-lrwan1`), the function is called very deep in the stack, and since it is really weird, that the netif calls a function that configures an IPv6 component, I decided to decouple this call into the `gnrc_ipv6` handler, which is actually a cleaner approach.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I do not have a device that supports this currently in master, but I confirmed that the up-event is still executed when merging this PR (and the changes I will push to #18699 in a moment) by checking if the link-local address was configured, using `ifconfig`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #17893
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
