### PR TITLE
gnrc_udp: use small stack-size

### DIFF
--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -11,23 +11,15 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \
-    calliope-mini \
     derfmega128 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
-    im880b \
     mega-xplained \
-    microbit \
     microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
-    nucleo-f070rb \
-    nucleo-f072rb \
-    nucleo-f103rb \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
@@ -38,7 +30,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml10-xpro \
     saml11-xpro \
     slstk3400a \
-    spark-core \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -59,7 +59,7 @@ extern "C" {
  * @brief   Default stack size to use for the UDP thread
  */
 #ifndef GNRC_UDP_STACK_SIZE
-#define GNRC_UDP_STACK_SIZE     (THREAD_STACKSIZE_DEFAULT)
+#define GNRC_UDP_STACK_SIZE     (THREAD_STACKSIZE_SMALL)
 #endif
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
I don't remember the stack for UDP ever being fuller than half full. So let's use half the stack size.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Sending UDP packets should still work without crashes on all supported boards.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Taken out of #18700 to discuss separately.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
