### PR TITLE
cpu/stm32: fix periph_dma

### DIFF
--- a/cpu/stm32/include/periph/cpu_dma.h
+++ b/cpu/stm32/include/periph/cpu_dma.h
@@ -16,6 +16,7 @@
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author          Vincent Dupont <vincent@otakeys.com>
+ * @author          Joshua DeWeese <jdeweese@primecontrols.com>
  */
 
 #ifndef PERIPH_CPU_DMA_H
@@ -88,10 +89,8 @@ typedef enum {
  * @{
  */
 #define DMA_DATA_WIDTH_BYTE      (0x00) /**< Byte width */
-#define DMA_DATA_WIDTH_HALF_WORD (0x01) /**< Half word width */
-#define DMA_DATA_WIDTH_WORD      (0x02) /**< Word width */
-#define DMA_DATA_WIDTH_MASK      (0x03) /**< Width mask */
-#define DMA_DATA_WIDTH_SHIFT     (0)    /**< Width position */
+#define DMA_DATA_WIDTH_HALF_WORD (0x01) /**< Half word width (2 bytes)*/
+#define DMA_DATA_WIDTH_WORD      (0x02) /**< Word width (4 bytes)*/
 /** @} */
 
 #ifdef MODULE_PERIPH_DMA
@@ -115,7 +114,7 @@ void dma_init(void);
  * @param[in]  chan    DMA channel (on stm32f2/4/7, CxS or unused on others)
  * @param[in]  src     source buffer
  * @param[out] dst     destination buffer
- * @param[in]  len     length to transfer
+ * @param[in]  len     number of transfers to perform
  * @param[in]  mode    DMA mode
  * @param[in]  flags   DMA configuration
  *
@@ -153,7 +152,7 @@ void dma_start(dma_t dma);
  *
  * @param[in] dma     logical DMA stream
  *
- * @return the remaining number of bytes to transfer
+ * @return the remaining number of transfers to perform
  */
 uint16_t dma_suspend(dma_t dma);
 
@@ -161,7 +160,7 @@ uint16_t dma_suspend(dma_t dma);
  * @brief   Resume a suspended DMA transfer on a stream
  *
  * @param[in] dma         logical DMA stream
- * @param[in] reamaining  the remaining number of bytes to transfer
+ * @param[in] reamaining  the remaining number of transfers to perform
  */
 void dma_resume(dma_t dma, uint16_t remaining);
 
@@ -186,7 +185,7 @@ void dma_wait(dma_t dma);
  * @param[in]  chan    DMA channel (on stm32f2/4/7, CxS or unused on others)
  * @param[in]  src     source buffer
  * @param[out] dst     destination buffer
- * @param[in]  len     length to transfer
+ * @param[in]  len     number of transfers to perform
  * @param[in]  mode    DMA mode
  * @param[in]  flags   DMA configuration
  *
@@ -206,7 +205,7 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
  * @param[in]   chan        DMA channel (on stm32f2/4/7, CxS or unused on others)
  * @param[in]   periph_addr Peripheral register address
  * @param[in]   mode        DMA direction mode
- * @param[in]   width       DMA transfer width
+ * @param[in]   width       DMA transfer width (one of DMA_DATA_WIDTH_*)
  * @param[in]   inc_periph  Increment peripheral address after read/write
  */
 void dma_setup(dma_t dma, int chan, void *periph_addr, dma_mode_t mode,
@@ -217,8 +216,8 @@ void dma_setup(dma_t dma, int chan, void *periph_addr, dma_mode_t mode,
  *
  * @param[in]   dma         Logical DMA stream
  * @param[in]   mem         Memory address
- * @param[in]   len         Transfer length
- * @param[in]   inc_mem     Increment the memory address after read/write
+ * @param[in]   len         Number of transfers to perform
+ * @param[in]   inc_mem     Increment the memory address (by the transfer width) after read/write
  */
 void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem);
 

--- a/cpu/stm32/include/periph/cpu_dma.h
+++ b/cpu/stm32/include/periph/cpu_dma.h
@@ -38,7 +38,7 @@ typedef struct {
      *  - 8: DAM2 / Stream0
      *  - ...
      *  - 15: DMA2 / Stream7
-     * STM32F0/1/L0/1/4:
+     * STM32F0/1/3/L0/1/4:
      *  - 0: DMA1 / Channel1
      *  - ...
      *  - 4: DMA1 / Channel5

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -402,7 +402,7 @@ void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem)
     STM32_DMA_Stream_Type *stream = dma_ctx[dma].stream;
     uint32_t ctr_reg = stream->CONTROL_REG;
 
-#if CPU_FAM_STM32F2 || CPU_FAM_STM32F4 || CPU_FAM_STM32F7
+#ifdef DMA_SxCR_MINC
     stream->CONTROL_REG = (ctr_reg & ~(DMA_SxCR_MINC)) |
                           (incr_mem << DMA_SxCR_MINC_Pos);
 #else

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -193,22 +193,28 @@ static IRQn_Type dma_get_irqn(int stream)
         return ((IRQn_Type)((int)DMA1_Channel1_IRQn + stream));
     }
 #if defined(DMA2_BASE)
+    /* stream 7 is invalid for these CPU families */
+    else if (stream == 7) {
+        return -1;
+    }
 #if defined(CPU_FAM_STM32F1)
     else if (stream < 11) {
 #else
     else if (stream < 13 ) {
 #endif
-        return ((IRQn_Type)((int)DMA2_Channel1_IRQn + stream));
+        /* magic number 8 is first DMA2 stream */
+        return ((IRQn_Type)((int)DMA2_Channel1_IRQn + stream - 8));
     }
-#if !defined(CPU_FAM_STM32L1)
+#if !defined(CPU_FAM_STM32L1) && !defined(CPU_FAM_STM32F3)
     else {
 #if defined(CPU_FAM_STM32F1)
         return (DMA2_Channel4_5_IRQn);
 #else
-        return ((IRQn_Type)((int)DMA2_Channel6_IRQn + stream));
+        /* magic number 13 is 8 (first DMA2 stream) + 5 (Channel6) */
+        return ((IRQn_Type)((int)DMA2_Channel6_IRQn + stream - 13));
 #endif
     }
-#endif /* !defined(CPU_FAM_STM32L1) */
+#endif /* !defined(CPU_FAM_STM32L1) && !defined(CPU_FAM_STM32F3) */
 #endif /* defined(DMA2_BASE) */
 #endif
 


### PR DESCRIPTION
### Contribution description

This fixes some bugs I found in the STM32 DMA module. See commit messages for further details.

Perhaps a better fix would have been to add a second parameter to the `dma_conf_t` struct to separately define the DMA controller and stream/channel. This would be similar to the how the ADC module handles the ADC and channel number for ADC lines. Should I have done this instead of fixing the current way of mapping DMA stream 0-7 to DMA controller 1, and streams 8 and beyond to controller 2?


### Testing procedure

On any STM32 based board:
1. initiate a DMA transfer with width not equal to one byte and auto indexing enabled on the destination buffer
1. call `dma_suspend` followed `dma_resume` after some time
1. observe that after the DMA transfer is complete, the write will underflow the destination buffer
1. initiate a DMA transfer with auto indexing disabled on the destination buffer
1. call `dma_suspend` followed `dma_resume` after some time
1. observe that after the DMA transfer is complete, the write will underflow the destination buffer

On any STM32F303 based board with 2 DMA controllers:
1. enable `periph_dma` module
1. observe compiler error about missing `DMA2_Channel6_IRQn` definition
1. observe that even if compiler error is fixed, any transfer using DMA2 will never complete or even crash the processor

### Issues/PRs references

- may relate to issue: #16242
