### PR TITLE
release-tests: use Ubuntu Jammy runner

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -44,7 +44,7 @@ env:
 # to hit Github Limit of 6h per job.
 jobs:
   tasks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
       if: ${{ matrix.pytest_mark == 'not iotlab_creds' }}
       run: |
         sudo apt-get update
-        sudo apt-get install lib32asan5
+        sudo apt-get install lib32asan6
     - name: Run release tests
       timeout-minutes: 350
       run: |


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
We are using Ubuntu Jammy (22.04) with our docker containers to build the release, but the release tests are still run in `ubuntu-latest`, which, at the moment, is still Ubuntu Focal (20.04): https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources. Because of that, both the libasan used and libc used differ between builder and the test runner which leads to an execution error of the `native` binaries. This moves the Github Action runner to `ubuntu-2204` and installs libasan 6 instead of libasan 5.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I ran the release tests with a representative subset of the tests that are currently failing with master: https://github.com/miri64/RIOT/actions/runs/3209912518/jobs/5246989391 they now succeed. I also started a full run here https://github.com/miri64/RIOT/actions/runs/3209936619/jobs/5247032154, which did not finish yet, but the `not iotlab_creds` tests should still succeed.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
