### PR TITLE
release-tests: add capability to run on PR comment

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -12,6 +12,9 @@ name: release-tests
 # dispatch.
 
 on:
+  pull_request_review:
+    types:
+      - submitted
   schedule:
     - cron: '0 3 * * 6'
   push:
@@ -45,6 +48,7 @@ env:
 jobs:
   tasks:
     runs-on: ubuntu-22.04
+    if: ${{ !github.event.review || (contains(github.event.review.body, '@riot-ci do release tests'))}}
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -132,6 +136,10 @@ jobs:
         fi
         if [ -n "${{ github.event.inputs.filter }}" ]; then
           K="-k"
+          FILTER="${{ github.event.inputs.filter }}"
+        elif echo '${{ github.event.review.body }}' | tr '\n' ' ' | grep -i '@riot-ci do release tests with "[^"]\+"'; then
+          K="-k"
+          FILTER="$(echo '${{ github.event.review.body }}' | tr '\n' ' ' | sed 's/.*@riot-ci do release tests with "\([^"]\+\)".*/\1/i')"
         fi
 
         cd Release-Specs
@@ -154,9 +162,10 @@ jobs:
           TTN_APP_ID="release-tests" \
           TTN_DEV_ID="eui-70b3d57ed00463e7-otaa" \
           TTN_DEV_ID_ABP="eui-70b3d57ed0046d5d-abp" \
+          PULL_REQUEST="${{ github.event.issue.pull_request.html_url }}" \
           RIOTBASE=${RIOTBASE} \
           $(which tox) -e test -- ${TOX_ARGS} \
-            ${K} "${{ github.event.inputs.filter }}" -m "${{ matrix.pytest_mark }}"
+            ${K} "${FILTER}" -m "${{ matrix.pytest_mark }}"
     - name: junit2html and XML deploy
       if: always()
       run: |


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This adds the capability to trigger a `release-tests` run when a member or owner of the RIOT-OS organization leaves a review that contains "@riot-ci do release tests" (case insensitive).

I decided to go for a review rather than comments, since

1. the comments trigger would also include issue comments and it would spin up the action every time a comment is made (it is then however canceled early, but it would just clutter our already full Actions tab)
2. the comment trigger would not add the results to the checks for the PR.

Additionally, a pytest filter can be used by commenting '@riot-ci do release tests with "\<pytest filter>"' instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I did extensive testing of this functionality here: https://github.com/miri64/RIOT/pull/37. AFAIK for this to work in main RIOT, this PR has to be merged first.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
