### PR TITLE
drivers/usbdev_synopsys_dwc2: add support for internal UTMI HS PHY

### DIFF
--- a/boards/common/stm32/include/cfg_usb_otg_hs_phy_utmi.h
+++ b/boards/common/stm32/include/cfg_usb_otg_hs_phy_utmi.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 Koen Zandberg
+ *               2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Common configuration for STM32 OTG HS peripheral with internal UTMI HS PHY
+ *
+ * All STM32 boards which use the internal UTMI HS PHY for the USB OTG HS
+ * peripheral use the same configuration. Therefore a common configuration file
+ * can be used for these boards.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef CFG_USB_OTG_HS_PHY_UTMI_H
+#define CFG_USB_OTG_HS_PHY_UTMI_H
+
+#include "periph_cpu.h"
+#include "usbdev_synopsys_dwc2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable the high speed USB OTG peripheral
+ */
+#define DWC2_USB_OTG_HS_ENABLED
+
+#ifndef USBPHYC_TUNE_VALUE
+/**
+ * @brief Default value of USBPHYC tuning control register
+ *
+ * The value of the USBPHYC tuning control register (USBPHYC_TUNE) is used by
+ * the USB HS PHY controller for the tuning interface of the internal
+ * USB HS PHY, please refer the Reference Manual for STM32F72xxx and STM32F73xxx
+ * for details.
+ *
+ * The value as defined in the [STM32CubeF7 HAL Driver MCU Component for F7]
+ * (https://bit.ly/3es9eFA) is used as default value.
+ * If necessary, it can be overridden by the board configuration in
+ * `periph_conf.h` by defining the value before this file is included.
+ */
+#define USBPHYC_TUNE_VALUE  0x00000f13U
+#endif
+
+/**
+ * @brief Common USB OTG HS configuration
+ */
+static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
+    {
+        .periph   = USB_OTG_HS_PERIPH_BASE,
+        .type     = DWC2_USB_OTG_HS,
+        .phy      = DWC2_USB_OTG_PHY_UTMI,
+        .rcc_mask = RCC_AHB1ENR_OTGHSEN,
+        .irqn     = OTG_HS_IRQn,
+        .ahb      = AHB1,
+        .dm       = GPIO_PIN(PORT_B, 14),
+        .dp       = GPIO_PIN(PORT_B, 15),
+        .af       = GPIO_AF10,
+        .phy_tune = USBPHYC_TUNE_VALUE,
+    }
+};
+
+/**
+ * @brief Number of available USB OTG peripherals
+ */
+#define USBDEV_NUMOF           ARRAY_SIZE(dwc2_usb_otg_fshs_config)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_USB_OTG_HS_PHY_UTMI_H */
+/** @} */

--- a/boards/stm32f723e-disco/Kconfig
+++ b/boards/stm32f723e-disco/Kconfig
@@ -22,6 +22,7 @@ config BOARD_STM32F723E_DISCO
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_HW_FC
     select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_USBDEV_HS_UTMI
 
     # Put other features for this board (in alphabetical order)
     select HAS_TINYUSB_DEVICE

--- a/boards/stm32f723e-disco/Makefile.features
+++ b/boards/stm32f723e-disco/Makefile.features
@@ -11,6 +11,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_uart_hw_fc
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_usbdev_hs_utmi
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/stm32f723e-disco/doc.txt
+++ b/boards/stm32f723e-disco/doc.txt
@@ -28,4 +28,10 @@ Use the `term` target to open a terminal:
 
     make BOARD=stm32f723e-disco -C examples/hello-world term
 
+### USB OTG Peripheral Device Driver
+
+By default, the USB OTG FS port is used. To use the USB OTG HS port with the
+internal UTMI+ HS PHY, enable the module `periph_usbdev_hs_utmi`:
+
+    make BOARD=stm32f723e-disco USEMODULE=periph_usbdev_hs_utmi -C examples/usbus_minimal
  */

--- a/boards/stm32f723e-disco/include/periph_conf.h
+++ b/boards/stm32f723e-disco/include/periph_conf.h
@@ -35,7 +35,11 @@
 #include "periph_cpu.h"
 #include "clk_conf.h"
 #include "cfg_rtt_default.h"
+#if defined(MODULE_PERIPH_USBDEV_HS_UTMI)
+#include "cfg_usb_otg_hs_phy_utmi.h"
+#else
 #include "cfg_usb_otg_fs.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -145,6 +145,10 @@ ifneq (,$(filter periph_usbdev_hs_ulpi,$(USEMODULE)))
   FEATURES_REQUIRED += periph_usbdev_hs_ulpi
 endif
 
+ifneq (,$(filter periph_usbdev_hs_utmi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_usbdev_hs_utmi
+endif
+
 ifneq (,$(filter pn532_i2c,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += pn532

--- a/drivers/include/usbdev_synopsys_dwc2.h
+++ b/drivers/include/usbdev_synopsys_dwc2.h
@@ -67,7 +67,7 @@ typedef enum {
 } dwc2_usb_otg_fshs_phy_t;
 
 /**
- * @brief stm32 USB OTG configuration
+ * @brief USB OTG configuration
  */
 typedef struct {
     uintptr_t periph;               /**< USB peripheral base address */
@@ -95,6 +95,11 @@ typedef struct {
     gpio_t dm;                      /**< Data- gpio */
     gpio_t dp;                      /**< Data+ gpio */
     gpio_af_t af;                   /**< Alternative function */
+#if defined(MODULE_PERIPH_USBDEV_HS_UTMI) || DOXYGEN
+    uint32_t phy_tune;              /**< USB HS PHY controller tuning register
+                                      *  value (STM32-specific), see USBPHYC_TUNE
+                                      *  register in STM32 Reference Manual */
+#endif /* defined(MODULE_PERIPH_USBDEV_HS_UTMI) */
 #endif /* defined(MCU_STM32) || DOXYGEN */
 } dwc2_usb_otg_fshs_config_t;
 

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -156,39 +156,7 @@ config MODULE_PERIPH_INIT_TEMPERATURE
     depends on MODULE_PERIPH_TEMPERATURE
 
 rsource "Kconfig.uart"
-
-config MODULE_PERIPH_USBDEV
-    bool "USBDEV peripheral driver"
-    depends on HAS_PERIPH_USBDEV
-    select MODULE_PERIPH_COMMON
-    select MODULE_PERIPH_USBDEV_CLK
-
-config MODULE_PERIPH_INIT_USBDEV
-    bool "Auto initialize USBDEV peripheral"
-    default y if MODULE_PERIPH_INIT
-    depends on MODULE_PERIPH_USBDEV
-
-config MODULE_PERIPH_USBDEV_HS_ULPI
-    bool "Use USB HS pripheral with UPLI HS PHY"
-    depends on HAS_PERIPH_USBDEV_HS_ULPI
-    depends on MODULE_PERIPH_USBDEV
-
-config MODULE_PERIPH_INIT_USBDEV_HS_ULPI
-    bool
-    default y if MODULE_PERIPH_INIT && MODULE_PERIPH_USBDEV_HS_ULPI
-    depends on HAS_PERIPH_USBDEV_HS_ULPI
-    depends on MODULE_PERIPH_USBDEV
-
-config MODULE_PERIPH_USBDEV_CLK
-    bool
-    depends on HAS_PERIPH_USBDEV
-    help
-        Enable the USB device specific clock settings, if there are any
-
-config MODULE_PERIPH_INIT_USBDEV_CLK
-    bool
-    default y if MODULE_PERIPH_INIT && MODULE_PERIPH_USBDEV_CLK
-    depends on HAS_PERIPH_USBDEV
+rsource "Kconfig.usbdev"
 
 endif # TEST_KCONFIG
 

--- a/drivers/periph_common/Kconfig.usbdev
+++ b/drivers/periph_common/Kconfig.usbdev
@@ -31,6 +31,15 @@ config MODULE_PERIPH_INIT_USBDEV_HS_ULPI
     depends on MODULE_PERIPH_USBDEV_HS_ULPI
     default y if MODULE_PERIPH_INIT
 
+config MODULE_PERIPH_USBDEV_HS_UTMI
+    bool "Use USB HS peripheral with internal UTMI+ HS PHY"
+    depends on HAS_PERIPH_USBDEV_HS_UTMI
+
+config MODULE_PERIPH_INIT_USBDEV_HS_UTMI
+    bool
+    depends on MODULE_PERIPH_USBDEV_HS_UTMI
+    default y if MODULE_PERIPH_INIT
+
 endif
 
 config MODULE_PERIPH_USBDEV_CLK

--- a/drivers/periph_common/Kconfig.usbdev
+++ b/drivers/periph_common/Kconfig.usbdev
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+menuconfig MODULE_PERIPH_USBDEV
+    bool "USBDEV peripheral driver"
+    depends on HAS_PERIPH_USBDEV
+    select MODULE_PERIPH_COMMON
+    select MODULE_PERIPH_USBDEV_CLK
+
+if MODULE_PERIPH_USBDEV
+
+# TODO: the 'init' modules are actually just artifacts from the way
+# periph_init_% modules are handled in Makefile. We need to define them to keep
+# the list the same for now. We should be able to remove them later on.
+
+config MODULE_PERIPH_INIT_USBDEV
+    bool "Auto initialize USBDEV peripheral"
+    default y if MODULE_PERIPH_INIT
+
+config MODULE_PERIPH_USBDEV_HS_ULPI
+    bool "Use USB HS peripheral with ULPI HS PHY"
+    depends on HAS_PERIPH_USBDEV_HS_ULPI
+
+config MODULE_PERIPH_INIT_USBDEV_HS_ULPI
+    bool
+    depends on MODULE_PERIPH_USBDEV_HS_ULPI
+    default y if MODULE_PERIPH_INIT
+
+endif
+
+config MODULE_PERIPH_USBDEV_CLK
+    bool
+    depends on HAS_PERIPH_USBDEV
+    help
+        Enable the USB device specific clock settings, if there are any
+
+config MODULE_PERIPH_INIT_USBDEV_CLK
+    bool
+    depends on MODULE_PERIPH_USBDEV_CLK
+    default y if MODULE_PERIPH_INIT

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -634,14 +634,17 @@ static void _reset_periph(dwc2_usb_otg_fshs_t *usbdev)
 #ifdef MCU_STM32
 static void _enable_gpio(const dwc2_usb_otg_fshs_config_t *conf)
 {
+    (void)conf;
+#ifndef MODULE_PERIPH_USBDEV_HS_ULPI
     /* Enables clock on the GPIO bus */
     gpio_init(conf->dp, GPIO_IN);
     gpio_init(conf->dm, GPIO_IN);
     /* Configure AF for the pins */
     gpio_init_af(conf->dp, conf->af);
     gpio_init_af(conf->dm, conf->af);
+#endif /* MODULE_PERIPH_USBDEV_HS_ULPI */
 }
-#endif
+#endif /* MCU_STM32 */
 
 static void _set_mode_device(dwc2_usb_otg_fshs_t *usbdev)
 {

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -730,16 +730,18 @@ static void _usbdev_init(usbdev_t *dev)
             /* enable ULPI clock */
             periph_clk_en(conf->ahb, RCC_AHB1ENR_OTGHSULPIEN);
 
-#if !defined(MCU_STM32)
-            /* TODO following settings are required for DWC2 HS but are not
-             * defined for STM32 MCUs where these settings correspond to the
-             * reset value of the GUSBCFG register */
+#ifdef USB_OTG_GUSBCFG_ULPI_UTMI_SEL
             /* select ULPI PHY */
-            _global_regs(usbdev->config)->GUSBCFG |= USB_OTG_GUSBCFG_ULPI_UTMI_SEL
-            /* use the 8-bit interface and single data rate */
-            _global_regs(usbdev->config)->GUSBCFG &= ~(USB_OTG_GUSBCFG_PHYIF16 |
-                                                       USB_OTG_GUSBCFG_DDRSEL);
-#endif /* !defined(MCU_STM32) */
+            _global_regs(usbdev->config)->GUSBCFG |= USB_OTG_GUSBCFG_ULPI_UTMI_SEL;
+#endif
+#ifdef USB_OTG_GUSBCFG_PHYIF
+            /* use the 8-bit interface */
+            _global_regs(usbdev->config)->GUSBCFG &= ~USB_OTG_GUSBCFG_PHYIF;
+#endif /* USB_OTG_GUSBCFG_PHYIF */
+#ifdef USB_OTG_GUSBCFG_DDRSEL
+            /* use single data rate */
+            _global_regs(usbdev->config)->GUSBCFG &= ~USB_OTG_GUSBCFG_DDRSEL;
+#endif /* USB_OTG_GUSBCFG_DDRSEL */
 
             /* disable the on-chip FS transceiver */
             _global_regs(usbdev->config)->GUSBCFG &= ~USB_OTG_GUSBCFG_PHYSEL;

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -424,6 +424,11 @@ config HAS_PERIPH_USBDEV
     help
         Indicates that an USBDEV peripheral is present.
 
+config HAS_PERIPH_USBDEV_HS_UTMI
+    bool
+    help
+        Indicates that an USBDEV HS peripheral with internal UTMI+ HS PHY is present.
+
 config HAS_PERIPH_USBDEV_HS_ULPI
     bool
     help


### PR DESCRIPTION
### Contribution description

This PR adds the support for internal UTMI+ HS PHYs.

Boards whose MCU integrate an UMTI+ HS PHY for their USB OTG HS peripherals, such as the STM32F723xx used on board `stm32f723e-disco`, can be used in USB HS mode with this PR. The UTMI+ HS PHY support is enabled by the `periph_usbdev_hs_utmi` module, which requires the `periph_usbdev_hs_utmi` feature.

### Testing procedure

The best way to test the PR is to use a board with two USB OTG ports (one FS port and one HS port with internal UTMI+ HS PHY, such as the board "stm32f723e-disco") connected to the host with two USB cables.

1. Compile and flash application `tests/usbus_hid`
    ```
    BOARD=stm32f723e-disco make -C tests/usbus_hid flash term
    ```
    The FS port should still work.
    ```python
    Oct  9 17:14:16 gunny8 kernel: [2342975.208076] usb 1-2.2: new full-speed USB device number 86 using xhci_hcd
    Oct  9 17:14:16 gunny8 kernel: [2342975.310550] usb 1-2.2: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 1.00
    Oct  9 17:14:16 gunny8 kernel: [2342975.310552] usb 1-2.2: New USB device strings: Mfr=3, Product=2, SerialNumber=4
    Oct  9 17:14:16 gunny8 kernel: [2342975.310554] usb 1-2.2: Product: stm32f723e-disco
    Oct  9 17:14:16 gunny8 kernel: [2342975.310556] usb 1-2.2: Manufacturer: RIOT-os.org
    Oct  9 17:14:16 gunny8 kernel: [2342975.310557] usb 1-2.2: SerialNumber: A7BAC4E1B1E0806B
    Oct  9 17:14:16 gunny8 kernel: [2342975.318366] hid-generic 0003:1209:7D01.01A5: hiddev2,hidraw5: USB HID v1.10 Device [RIOT-os.org stm32f723e-disco] on usb-0000:00:14.0-2.2/input0
    ```
2. Compile and flash application `tests/usbus_hid` with module `periph_usbdev_hs_utmi`
    ```
    USEMODULE=periph_usbdev_hs_utmi BOARD=stm32f723e-disco make -C tests/usbus_hid flash term
    ```
    In that case, the HS port should work and should be recognized as HS device.
    ```python
    Oct  9 16:59:10 gunny8 kernel: [2342069.036905] usb 1-2.4: new high-speed USB device number 84 using xhci_hcd
    Oct  9 16:59:10 gunny8 kernel: [2342069.141739] usb 1-2.4: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 1.00
    Oct  9 16:59:10 gunny8 kernel: [2342069.141742] usb 1-2.4: New USB device strings: Mfr=3, Product=2, SerialNumber=4
    Oct  9 16:59:10 gunny8 kernel: [2342069.141743] usb 1-2.4: Product: stm32f723e-disco
    Oct  9 16:59:10 gunny8 kernel: [2342069.141745] usb 1-2.4: Manufacturer: RIOT-os.org
    Oct  9 16:59:10 gunny8 kernel: [2342069.141746] usb 1-2.4: SerialNumber: A7BAC4E1B1E0806B
    Oct  9 16:59:10 gunny8 kernel: [2342069.144525] hid-generic 0003:1209:7D01.01A4: hiddev2,hidraw5: USB HID v1.10 Device [RIOT-os.org stm32f723e-disco] on usb-0000:00:14.0-2.4/input0
    ```
3. A board with USB OTG HS peripheral that uses the on-chip FS PHY, such as `stm32f429i-disc1` should still work.
    ```
    BOARD=stm32f429i-disco make -C tests/usbus_hid flash term
    ```
4. A board with only USB OTG FS peripheral should still work.
    ```
    BOARD=nucleo-f767zi make -C tests/usbus_hid flash term
    ```

### Issues/PRs references
