### PR TITLE
riotctrl_shell.cord_ep: remove regif parameter

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/cord_ep.py
+++ b/dist/pythonlibs/riotctrl_shell/cord_ep.py
@@ -117,11 +117,8 @@ class CordEp(ShellInteraction):
     def cord_ep_info(self, timeout=-1, async_=False):
         return self.cord_ep_cmd(self.INFO, None, timeout, async_)
 
-    def cord_ep_register(self, uri, regif=None, timeout=-1, async_=False):
-        args = [uri]
-        if regif is not None:
-            args.append(regif)
-        return self.cord_ep_cmd(self.REGISTER, args, timeout, async_)
+    def cord_ep_register(self, uri, timeout=-1, async_=False):
+        return self.cord_ep_cmd(self.REGISTER, (uri,), timeout, async_)
 
     def cord_ep_discover(self, uri, timeout=-1, async_=False):
         return self.cord_ep_cmd(self.DISCOVER, (uri,), timeout, async_)

--- a/dist/pythonlibs/riotctrl_shell/tests/test_cord_ep.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_cord_ep.py
@@ -55,18 +55,18 @@ def test_cord_ep_parser_empty():
 
 
 @pytest.mark.parametrize(
-    "uri,regif,expected",
+    "uri,expected",
     [
-        ("[fe80::1]", None, "cord_ep register [fe80::1]"),
-        ("[fe80::1%iface0]", None, "cord_ep register [fe80::1%iface0]"),
-        ("[fe80::1]:5684", None, "cord_ep register [fe80::1]:5684"),
-        ("[fe80::1]", "/regif", "cord_ep register [fe80::1] /regif"),
+        ("coap://[fe80::1]", "cord_ep register coap://[fe80::1]"),
+        ("coap://[fe80::1%iface0]", "cord_ep register coap://[fe80::1%iface0]"),
+        ("coap://[fe80::1]:5684", "cord_ep register coap://[fe80::1]:5684"),
+        ("coap://[fe80::1]/regif", "cord_ep register coap://[fe80::1]/regif"),
     ]
 )
-def test_cord_ep_register(uri, regif, expected):
+def test_cord_ep_register(uri, expected):
     rc = init_ctrl()
     si = riotctrl_shell.cord_ep.CordEp(rc)
-    res = si.cord_ep_register(uri, regif)
+    res = si.cord_ep_register(uri)
     assert res == expected
 
 
@@ -108,5 +108,5 @@ def test_cord_ep_error(error_msg):
     rc = init_ctrl(error_msg)
     si = riotctrl_shell.cord_ep.CordEp(rc)
     with pytest.raises(RuntimeError):
-        si.cord_ep_register("[abcde]:1234", "lalala")
-    assert rc.term.last_command == "cord_ep register [abcde]:1234 lalala"
+        si.cord_ep_register("coap://[abcde]:1234")
+    assert rc.term.last_command == "cord_ep register coap://[abcde]:1234"


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The argument regif was removed from the shell command in https://github.com/RIOT-OS/RIOT/pull/18053, so there is not much need to keep it in the ShellInteraction for that command.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
cd dist/pythonlibs/riotctrl_shell; tox
```
should still succeed 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/18053

Also see https://github.com/RIOT-OS/Release-Specs/pull/260 for the fix of release spec 9.1 and the test for it.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
