### PR TITLE
cpu/esp32: move ESP32_SDK_DIR definition here

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -1,6 +1,8 @@
 # ESP32x specific flashing options
 FLASH_CHIP  = $(CPU_FAM)
 
+export ESP32_SDK_DIR ?= $(PKGDIRBASE)/esp32_sdk
+
 # Serial flasher config as used by the ESP-IDF, be careful when overriding them.
 # They have to be exported to use same values in subsequent makefiles.
 ifeq (esp32,$(CPU_FAM))

--- a/pkg/esp32_sdk/Makefile.include
+++ b/pkg/esp32_sdk/Makefile.include
@@ -1,3 +1,1 @@
-export ESP32_SDK_DIR ?= $(PKGDIRBASE)/esp32_sdk
-
 PSEUDOMODULES += esp32_sdk


### PR DESCRIPTION
### Contribution description

The definition in `pkg/esp32_sdk/Makefile.include` was evaluated by `make` after the include paths were already set, resulting in `ESP32_SDK_DIR` being empty in

    INCLUDES += -I$(ESP32_SDK_DIR)/components
    [...]

This in turn resulted in

    cc1: error: /components: No such file or directory [-Werror=missing-include-dirs]
    [...]


### Testing procedure

#### In `master`

```
$ make BOARD=esp32-mh-et-live-minikit -C examples/hello-world
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
Building application "hello-world" for "esp32-mh-et-live-minikit" with MCU "esp32".

"make" -C /home/maribu/Repos/software/RIOT/pkg/esp32_sdk/ 
"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/boards/esp32-mh-et-live-minikit
"make" -C /home/maribu/Repos/software/RIOT/boards/common/esp32
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/esp32
cc1: error: /components: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/bootloader_support/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/driver/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_common/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_hw_support/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_hw_support/include/soc: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_rom/esp32: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_rom/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_rom/include/esp32: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_system/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_system/port/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/esp_timer/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/hal/esp32/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/hal/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/hal/platform_port/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/heap/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/log/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/newlib/platform_include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/soc/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/soc/esp32/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/xtensa/include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /components/xtensa/esp32/include: No such file or directory [-Werror=missing-include-dirs]
In file included from /home/maribu/Repos/software/RIOT/cpu/esp32/include/periph_cpu.h:24,
                 from /home/maribu/Repos/software/RIOT/boards/common/esp32/include/periph_conf_common.h:27,
                 from /home/maribu/Repos/software/RIOT/boards/esp32-mh-et-live-minikit/include/periph_conf.h:166,
                 from /home/maribu/Repos/software/RIOT/boards/common/esp32/include/board_common.h:32,
                 from /home/maribu/Repos/software/RIOT/boards/esp32-mh-et-live-minikit/include/board.h:48,
                 from /home/maribu/Repos/software/RIOT/cpu/esp32/startup.c:28:
/home/maribu/Repos/software/RIOT/cpu/esp32/include/sdkconfig.h:42:10: fatal error: soc/soc_caps.h: No such file or directory
   42 | #include "soc/soc_caps.h"
      |          ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
compilation terminated.
make[2]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:146: /home/maribu/Repos/software/RIOT/examples/hello-world/bin/esp32-mh-et-live-minikit/cpu/startup.o] Error 1
make[1]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/cpu/esp32] Error 2
make: *** [/home/maribu/Repos/software/RIOT/examples/hello-world/../../Makefile.include:738: application_hello-world.module] Error 2
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
```

#### This PR:

```
$ make BOARD=esp32-mh-et-live-minikit -C examples/hello-world
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
Building application "hello-world" for "esp32-mh-et-live-minikit" with MCU "esp32".

"make" -C /home/maribu/Repos/software/RIOT/pkg/esp32_sdk/ 
"make" -C /home/maribu/Repos/software/RIOT/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/boards/esp32-mh-et-live-minikit
"make" -C /home/maribu/Repos/software/RIOT/boards/common/esp32
"make" -C /home/maribu/Repos/software/RIOT/core
"make" -C /home/maribu/Repos/software/RIOT/core/lib
"make" -C /home/maribu/Repos/software/RIOT/cpu/esp32
/home/maribu/Repos/software/RIOT/cpu/esp32/startup.c: In function 'system_init':
/home/maribu/Repos/software/RIOT/cpu/esp32/startup.c:243:31: error: implicit conversion from 'enum <anonymous>' to 'esp_log_level_t' [-Werror=enum-conversion]
  243 |     esp_log_level_set("wifi", LOG_DEBUG);
      |                               ^~~~~~~~~
/home/maribu/Repos/software/RIOT/cpu/esp32/startup.c:244:31: error: implicit conversion from 'enum <anonymous>' to 'esp_log_level_t' [-Werror=enum-conversion]
  244 |     esp_log_level_set("gpio", LOG_DEBUG);
      |                               ^~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:146: /home/maribu/Repos/software/RIOT/examples/hello-world/bin/esp32-mh-et-live-minikit/cpu/startup.o] Error 1
make[1]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/cpu/esp32] Error 2
make: *** [/home/maribu/Repos/software/RIOT/examples/hello-world/../../Makefile.include:738: application_hello-world.module] Error 2
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/hello-world'
```

### Issues/PRs references

None