### PR TITLE
cpu/esp_common/periph_uart: fix call to _uart_set_mode

### DIFF
--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -391,8 +391,8 @@ static void _uart_config(uart_t uart)
     }
 
     /* set number of data bits, stop bits and parity mode */
-    if (_uart_set_mode(uart, _uarts[uart].data, _uarts[uart].stop,
-                             _uarts[uart].parity) != UART_OK) {
+    if (_uart_set_mode(uart, _uarts[uart].data, _uarts[uart].parity,
+                             _uarts[uart].stop) != UART_OK) {
         return;
     }
 


### PR DESCRIPTION
### Contribution description

The parameters for parity and stop bits was confused, resulting in the following compilation error with GCC 12.2.0:

    /home/maribu/Repos/software/RIOT/cpu/esp_common/periph/uart.c: In function '_uart_config':
    /home/maribu/Repos/software/RIOT/cpu/esp_common/periph/uart.c:394:61: error: implicit conversion from 'uart_stop_bits_t' to 'uart_parity_t' -Werror=enum-conversion]
      394 |     if (_uart_set_mode(uart, _uarts[uart].data, _uarts[uart].stop,
          |                                                 ~~~~~~~~~~~~^~~~~
    /home/maribu/Repos/software/RIOT/cpu/esp_common/periph/uart.c:395:42: error: implicit conversion from 'uart_parity_t' to 'uart_stop_bits_t' -Werror=enum-conversion]
      395 |                              _uarts[uart].parity) != UART_OK) {
          |                              ~~~~~~~~~~~~^~~~~~~
    cc1: all warnings being treated as errors

This swaps the parameters.

### Testing procedure

The output of e.g. `examples/hello_world` on ESP boards connected via UART should still be readable after this change.

I am not sure why UART works correctly. Maybe there is a second parameter order confusion somewhere that negates the bug?

**BEWARE: This is untested**

### Issues/PRs references

None