### PR TITLE
sys/net/sock_util: fix _find_hoststart()

### DIFF
--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -98,7 +98,6 @@ static char* _find_hoststart(const char *url)
             }
             break;
         }
-        urlpos++;
     }
     return NULL;
 }

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -90,7 +90,7 @@ static char* _find_hoststart(const char *url)
      */
     size_t remaining = CONFIG_SOCK_SCHEME_MAXLEN + 1;
     char *urlpos = (char*)url;
-    while(*urlpos && remaining) {
+    while (*urlpos && remaining) {
         remaining--;
         if (*urlpos++ == ':') {
             if (strncmp(urlpos, "//", 2) == 0) {
@@ -106,7 +106,7 @@ static char* _find_pathstart(const char *url)
 {
     size_t remaining = CONFIG_SOCK_HOSTPORT_MAXLEN;
     char *urlpos = (char*)url;
-    while(*urlpos && remaining) {
+    while (*urlpos && remaining) {
         remaining--;
         if (*urlpos == '/') {
             return urlpos;
@@ -183,7 +183,7 @@ int _parse_netif(sock_udp_ep_t *ep_out, char *netifstart)
     char netifbuf[NETIF_STR_LEN + 1] = {0};
 
     for (netifend = netifstart; *netifend && *netifend != ']';
-         netifend++);
+         netifend++) {}
     netiflen = netifend - netifstart;
     if (!*netifend || (netiflen >= NETIF_STR_LEN) || (netiflen == 0)) {
         /* no netif found, bail out */
@@ -212,7 +212,7 @@ int sock_tl_str2ep(struct _sock_tl_ep *ep_out, const char *str)
         brackets_flag = 1;
         for (hostend = ++hoststart;
              *hostend && *hostend != ']' && *hostend != '%';
-             hostend++);
+             hostend++) {}
         if (! *hostend || ((size_t)(hostend - hoststart) >= sizeof(hostbuf))) {
             /* none found, bail out */
             return -EINVAL;

--- a/tests/unittests/tests-sock_util/tests-sock_util.c
+++ b/tests/unittests/tests-sock_util/tests-sock_util.c
@@ -47,7 +47,7 @@
 #define TEST_URL_DNS_HOSTPART       "test.local"
 #define TEST_URL_INVALID            "[2001:db8::1]://local"
 #define TEST_URL_INVALID2           "[2001:db8::1]/local"
-#define TEST_URL_LONG_HOSTPORT      "http://veryveryvery.long.hostname.that." \
+#define TEST_URL_LONG_HOSTPORT      "https://veryveryvery.long.hostname.that." \
                                     "doesnt.fit.inside.sixtyfour.characters." \
                                     "of.buffer.space/localpart"
 #define TEST_URL_LONG_URLPATH       "http://shorthostname/very/very/long/ " \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`_find_hoststart()` would increment `urlpos` twice on each iteration, making it impossible to work with schemas of uneven length (e.g. `https://` or `coaps://`).


### Testing procedure

I modified the `sock_util` test case to also test for a schema of uneven length.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
