### PR TITLE
nanocoap_sock: implement DTLS socket

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -713,6 +713,11 @@ ifneq (,$(filter luid,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_cpuid
 endif
 
+ifneq (,$(filter nanocoap_dtls,$(USEMODULE)))
+  USEMODULE += sock_dtls
+  USEPKG += tinydtls
+endif
+
 ifneq (,$(filter nanocoap_sock,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += sock_util

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -31,6 +31,11 @@ extern "C" {
  */
 #define COAP_PORT               (5683)
 
+/**
+ * @brief   Default CoAP DTLS port
+ */
+#define COAPS_PORT              (5684)
+
 #define COAP_V1                 (1)     /**< Identifier for CoAP version 1 (RFC 7252) */
 
 /**

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -142,9 +142,10 @@ extern "C" {
 
 /**
  * @brief   nanocoap socket type
- *
  */
-typedef sock_udp_t nanocoap_sock_t;
+typedef struct {
+    sock_udp_t udp;                 /**< UDP socket */
+} nanocoap_sock_t;
 
 /**
  * @brief Blockwise request helper struct
@@ -185,7 +186,7 @@ static inline int nanocoap_sock_connect(nanocoap_sock_t *sock,
                                         const sock_udp_ep_t *local,
                                         const sock_udp_ep_t *remote)
 {
-    return sock_udp_create(sock, local, remote, 0);
+    return sock_udp_create(&sock->udp, local, remote, 0);
 }
 
 /**
@@ -206,7 +207,7 @@ int nanocoap_sock_url_connect(const char *url, nanocoap_sock_t *sock);
  */
 static inline void nanocoap_sock_close(nanocoap_sock_t *sock)
 {
-    sock_udp_close(sock);
+    sock_udp_close(&sock->udp);
 }
 
 /**
@@ -441,7 +442,7 @@ ssize_t nanocoap_sock_request(nanocoap_sock_t *sock, coap_pkt_t *pkt, size_t len
  * @returns     length of response on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_sock_request_cb(sock_udp_t *sock, coap_pkt_t *pkt,
+ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                                  coap_request_cb_t cb, void *arg);
 
 /**

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -777,6 +777,19 @@ void ztimer_set_timeout_flag(ztimer_clock_t *clock, ztimer_t *timer,
                              uint32_t timeout);
 
 /**
+ * @brief    Unlock mutex after @p timeout
+ *
+ * This function will unlock the given mutex after the timeout has passed.
+ *
+ * @param[in]   clock           ztimer clock to operate on
+ * @param[in]   timer           timer struct to use
+ * @param[in]   timeout         timeout in ztimer_clock's ticks
+ * @param[in]   mutex           mutex to unlock after timeout
+ */
+void ztimer_mutex_unlock(ztimer_clock_t *clock, ztimer_t *timer,
+                         uint32_t timeout, mutex_t *mutex);
+
+/**
  * @brief   Try to lock the given mutex, but give up after @p timeout
  *
  * @param[in]       clock       ztimer clock to operate on

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -76,7 +76,7 @@ static int _send_ack(nanocoap_sock_t *sock, coap_pkt_t *pkt)
     coap_build_hdr(&ack, COAP_TYPE_ACK, coap_get_token(pkt), tkl,
                    COAP_CODE_EMPTY, ntohs(pkt->hdr->id));
 
-    return sock_udp_send(sock, &ack, sizeof(ack), NULL);
+    return sock_udp_send(&sock->udp, &ack, sizeof(ack), NULL);
 }
 
 static bool _id_or_token_missmatch(const coap_pkt_t *pkt, unsigned id,
@@ -149,7 +149,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
             DEBUG("nanocoap: send %u bytes (%u tries left)\n",
                   (unsigned)iolist_size(&head), tries_left);
 
-            res = sock_udp_sendv(sock, &head, NULL);
+            res = sock_udp_sendv(&sock->udp, &head, NULL);
             if (res <= 0) {
                 DEBUG("nanocoap: error sending coap request, %d\n", (int)res);
                 return res;
@@ -170,7 +170,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                       _deadline_left_us(deadline));
             }
             const void *old_ctx = ctx;
-            tmp = sock_udp_recv_buf(sock, &payload, &ctx, _deadline_left_us(deadline), NULL);
+            tmp = sock_udp_recv_buf(&sock->udp, &payload, &ctx, _deadline_left_us(deadline), NULL);
             /* sock_udp_recv_buf() is supposed to return multiple packet fragments
              * when called multiple times with the same context.
              * In practise, this is not implemented and it will always return a pointer
@@ -271,7 +271,7 @@ static int _request_cb(void *arg, coap_pkt_t *pkt)
     return pkt_len;
 }
 
-ssize_t nanocoap_sock_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len)
+ssize_t nanocoap_sock_request(nanocoap_sock_t *sock, coap_pkt_t *pkt, size_t len)
 {
     struct iovec buf = {
         .iov_base = pkt->hdr,
@@ -693,13 +693,13 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
         local->port = COAP_PORT;
     }
 
-    ssize_t res = sock_udp_create(&sock, local, NULL, 0);
+    ssize_t res = sock_udp_create(&sock.udp, local, NULL, 0);
     if (res != 0) {
         return -1;
     }
 
     while (1) {
-        res = sock_udp_recv(&sock, buf, bufsize, -1, &remote);
+        res = sock_udp_recv(&sock.udp, buf, bufsize, -1, &remote);
         if (res < 0) {
             DEBUG("error receiving UDP packet %d\n", (int)res);
         }
@@ -710,7 +710,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
                 continue;
             }
             if ((res = coap_handle_req(&pkt, buf, bufsize, &ctx)) > 0) {
-                sock_udp_send(&sock, buf, res, &remote);
+                sock_udp_send(&sock.udp, buf, res, &remote);
             }
             else {
                 DEBUG("error handling request %d\n", (int)res);

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -438,7 +438,8 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
 
     if (0) {}
 #ifdef MODULE_SUIT_TRANSPORT_COAP
-    else if (strncmp(manifest->urlbuf, "coap://", 7) == 0) {
+    else if ((strncmp(manifest->urlbuf, "coap://", 7) == 0) ||
+             (IS_USED(MODULE_NANOCOAP_DTLS) && strncmp(manifest->urlbuf, "coaps://", 8) == 0)) {
         res = nanocoap_get_blockwise_url(manifest->urlbuf, CONFIG_SUIT_COAP_BLOCKSIZE,
                                          _storage_helper,
                                          manifest);

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -87,7 +87,8 @@ int suit_handle_url(const char *url)
 
     if (0) {}
 #ifdef MODULE_SUIT_TRANSPORT_COAP
-    else if (strncmp(url, "coap://", 7) == 0) {
+    else if ((strncmp(url, "coap://", 7) == 0) ||
+             (IS_USED(MODULE_NANOCOAP_DTLS) && strncmp(url, "coaps://", 8) == 0)) {
         size = nanocoap_get_blockwise_url_to_buf(url,
                                                  CONFIG_SUIT_COAP_BLOCKSIZE,
                                                  _manifest_buf,

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -144,6 +144,18 @@ void ztimer_set_timeout_flag(ztimer_clock_t *clock, ztimer_t *t,
 }
 #endif
 
+void ztimer_mutex_unlock(ztimer_clock_t *clock, ztimer_t *timer, uint32_t offset,
+                         mutex_t *mutex)
+{
+    unsigned state = irq_disable();
+
+    timer->callback = _callback_unlock_mutex;
+    timer->arg = (void *)mutex;
+
+    irq_restore(state);
+    ztimer_set(clock, timer, offset);
+}
+
 static void _callback_wakeup(void *arg)
 {
     thread_wakeup((kernel_pid_t)((intptr_t)arg));

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -22,22 +22,27 @@ LOW_MEMORY_BOARDS := \
   blackpill-stm32f103c8 \
   bluepill-stm32f103c8 \
   derfmega128 \
+  im880b \
   nucleo-f302r8 \
   saml10-xpro \
   saml11-xpro \
+  spark-core \
   stm32f7508-dk \
   stm32mp157c-dk2 \
   #
 
-# Don't enable VFS functions on small boards
+# Don't enable VFS, DTLS functions on small boards
 ifeq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+  USEMODULE += nanocoap_dtls
+  USEMODULE += prng_sha256prng
+
   USEMODULE += nanocoap_vfs
   USEMODULE += vfs_default
   # USEMODULE += vfs_auto_format
   USEMODULE += shell_cmds_default
 
-  # VFS operations require more stack on the main thread
-  CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
+  # DTLS and VFS operations require more stack on the main thread
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
 
   # always enable auto-format for native
   ifeq ($(BOARD),native)

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -21,12 +21,32 @@
 #include <stdio.h>
 #include "msg.h"
 
+#include "net/nanocoap_sock.h"
 #include "net/gnrc/netif.h"
 #include "net/ipv6/addr.h"
 #include "shell.h"
 
 #define MAIN_QUEUE_SIZE (4)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+#if IS_USED(MODULE_NANOCOAP_DTLS)
+#include "net/credman.h"
+#include "net/dsm.h"
+#include "tinydtls_keys.h"
+
+static const uint8_t psk_id_0[] = PSK_DEFAULT_IDENTITY;
+static const uint8_t psk_key_0[] = PSK_DEFAULT_KEY;
+static const credman_credential_t credential = {
+    .type = CREDMAN_TYPE_PSK,
+    .tag = CONFIG_NANOCOAP_SOCK_DTLS_TAG,
+    .params = {
+        .psk = {
+            .key = { .s = psk_key_0, .len = sizeof(psk_key_0) - 1, },
+            .id = { .s = psk_id_0, .len = sizeof(psk_id_0) - 1, },
+        }
+    },
+};
+#endif
 
 extern int nanotest_client_cmd(int argc, char **argv);
 extern int nanotest_client_url_cmd(int argc, char **argv);
@@ -120,6 +140,14 @@ int main(void)
     /* for the thread running the shell */
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     puts("nanocoap test app");
+
+#if IS_USED(MODULE_NANOCOAP_DTLS)
+    int res = credman_add(&credential);
+    if (res < 0 && res != CREDMAN_EXIST) {
+        printf("nanocoap: cannot add credential to system: %d\n", res);
+        return res;
+    }
+#endif
 
     /* start shell */
     puts("All up, running the shell now");

--- a/tests/nanocoap_cli/tinydtls_keys.h
+++ b/tests/nanocoap_cli/tinydtls_keys.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       PSK and RPK keys for the dtls-sock example.
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef TINYDTLS_KEYS_H
+#define TINYDTLS_KEYS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  Default keys examples for tinyDTLS (for RIOT, Linux and Contiki)
+ */
+#define PSK_DEFAULT_IDENTITY "Client_identity"
+#define PSK_DEFAULT_KEY "secretPSK"
+#define PSK_OPTIONS "i:k:"
+#define PSK_ID_MAXLEN 32
+#define PSK_MAXLEN 32
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TINYDTLS_KEYS_H */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This implements DTLS support for NanoCoAP.

When the `nanocoap_dtls` module is used, the `nanocoap_sock_t` struct is extended with session information.

All NanoCoAP API functions will automatically handle the new transport type, `nanocoap_sock_url_connect()` will automatically select the DTLS socket when a `coaps://` URL is used.

I'm a bit confused by credman. I now define a `CONFIG_NANOCOAP_SOCK_DTLS_TAG` by which NanoCoAP can get the credential tag to select the right credential for the connection without having to add new parameter to the API. This is convenient, but it only allows a single credential to be used with NanoCoAP (which is probably fine for the use case, there is only ever a single endpoint).

### Testing procedure

The `tests/nanocoap_cli` application works without modification. I used `examples/gcoap_dtls` for the server:

<details><summary>log of a nanocoap_cli session</summary>

```
# CoAP request
> ncget coap://[fe80::58b0:8ff:fe67:ad82]/vfs/
/vfs/core
/vfs/fw/
/vfs/main.c

# CoAPS request
> ncget coaps://[fe80::58b0:8ff:fe67:ad82]/vfs/
/vfs/core
/vfs/fw/
/vfs/main.c

# block-wise CoAPS request
> ncget coaps://[fe80::58b0:8ff:fe67:ad82]/vfs/main.c -
/*
 * Copyright (C) 2022 ML!PA Consulting GmbH
 *
 * This file is subject to the terms and conditions of the GNU Lesser
 * General Public License v2.1. See the file LICENSE in the top level
 * directory for more details.
 */

/**
 * @ingroup     examples
 * @{
 *
 * @file
 * @brief       Example application for demonstrating the GCoAP file server
 *
 * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
 * @}
 */

#include "kernel_defines.h"
#include "net/gcoap.h"
#include "net/gcoap/fileserver.h"
#include "shell.h"
#include "vfs_default.h"

#define MAIN_QUEUE_SIZE (4)
static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];

/* CoAP resources. Must be sorted by path (ASCII order). */
static const coap_resource_t _resources[] = {
    { "/vfs",
      COAP_GET |
#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
      COAP_PUT |
#endif
#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
      COAP_DELETE |
#endif
      COAP_MATCH_SUBTREE,
      gcoap_fileserver_handler, VFS_DEFAULT_DATA },
};

static gcoap_listener_t _listener = {
    .resources = _resources,
    .resources_len = ARRAY_SIZE(_resources),
};

int main(void)
{
    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
    gcoap_register_listener(&_listener);

    char line_buf[SHELL_DEFAULT_BUFSIZE];
    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

    return 0;
}
```
</details>

<details><summary>add fileserver to gcoap_dtls</summary>

```patch
diff --git a/examples/gcoap/server.c b/examples/gcoap/server.c
index bf2315cd01..ff00d67d53 100644
--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -29,6 +29,9 @@
 #include "net/utils.h"
 #include "od.h"
 
+#include "net/gcoap/fileserver.h"
+#include "vfs_default.h"
+
 #include "gcoap_example.h"
 
 #define ENABLE_DEBUG 0
@@ -65,6 +68,16 @@ static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, co
 static const coap_resource_t _resources[] = {
     { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },
+    { "/vfs",
+      COAP_GET |
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
+      COAP_PUT |
+#endif
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
+      COAP_DELETE |
+#endif
+      COAP_MATCH_SUBTREE,
+      gcoap_fileserver_handler, VFS_DEFAULT_DATA },
 };
 
 static const char *_link_params[] = {
diff --git a/examples/gcoap_dtls/Makefile b/examples/gcoap_dtls/Makefile
index 078c224838..9241c0f268 100644
--- a/examples/gcoap_dtls/Makefile
+++ b/examples/gcoap_dtls/Makefile
@@ -16,6 +16,9 @@ USEMODULE += netdev_default
 # use GNRC by default
 LWIP ?= 0
 
+USEMODULE += gcoap_fileserver
+USEMODULE += vfs_default
+
 ifeq (0,$(LWIP))
   USEMODULE += auto_init_gnrc_netif
   # Specify the mandatory networking modules
```
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
