### PR TITLE
tests/gcoap_fileserver: add test for PUT

### DIFF
--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -275,7 +275,13 @@ static ssize_t _put_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
         if ((ret = vfs_lseek(fd, 0, SEEK_END)) < 0) {
             goto close_on_error;
         }
-        if (block1.offset != (unsigned)ret) {
+        if (block1.offset < (unsigned)ret) {
+            /* ignore duplicate packet */
+            create = false; /* don't delete file */
+            ret = COAP_CODE_CONTINUE;
+            goto close_on_error;
+        }
+        if (block1.offset > (unsigned)ret) {
             /* expect block to be in the correct order during initial creation */
             ret = COAP_CODE_REQUEST_ENTITY_INCOMPLETE;
             goto close_on_error;

--- a/tests/gcoap_fileserver/Makefile
+++ b/tests/gcoap_fileserver/Makefile
@@ -10,6 +10,8 @@ USEMODULE += shell
 USEMODULE += shell_commands
 
 USEMODULE += gcoap_fileserver
+USEMODULE += gcoap_fileserver_put
+
 USEMODULE += nanocoap_vfs
 
 USEMODULE += constfs

--- a/tests/gcoap_fileserver/Makefile.ci
+++ b/tests/gcoap_fileserver/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     atmega328p-xplained-mini \
+    atxmega-a1-xplained \
     atxmega-a3bu-xplained \
     blackpill \
     bluepill \

--- a/tests/gcoap_fileserver/main.c
+++ b/tests/gcoap_fileserver/main.c
@@ -28,7 +28,18 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/const", COAP_GET | COAP_MATCH_SUBTREE, gcoap_fileserver_handler, "/const" },
+    {
+        .path = "/const",
+        .methods = COAP_GET | COAP_MATCH_SUBTREE,
+        .handler = gcoap_fileserver_handler,
+        .context = "/const"
+    },
+    {
+        .path = "/vfs",
+        .methods = COAP_GET | COAP_PUT | COAP_MATCH_SUBTREE,
+        .handler = gcoap_fileserver_handler,
+        .context = VFS_DEFAULT_DATA
+    },
 };
 
 static gcoap_listener_t _listener = {

--- a/tests/gcoap_fileserver/tests/01-run.py
+++ b/tests/gcoap_fileserver/tests/01-run.py
@@ -98,10 +98,17 @@ def test_linear_topology(factory, zep_dispatch):
 
     # Download file from CoAP server
     B.cmd("vfs rm /nvm0/song.txt")
+    B.cmd("vfs rm /nvm0/song2.txt")
     B.cmd("ncget coap://[2001:db8::1]/const/song.txt", timeout=60)
 
     # make sure the content matches
     assert A.cmd("md5sum /const/song.txt").split()[2] == B.cmd("md5sum /nvm0/song.txt").split()[2]
+
+    # upload the file to node B (only one node should write MEMORY.bin)
+    A.cmd("ncput /const/song.txt coap://[" + global_addr(B.cmd("ifconfig 7"))[1] + "]/vfs/song2.txt", timeout=60)
+
+    # make sure the content matches
+    assert B.cmd("md5sum /nvm0/song.txt").split()[2] == B.cmd("md5sum /nvm0/song2.txt").split()[2]
 
     # terminate nodes
     for n in nodes:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a test for blockwise PUT to `tests/gcoap_fileserver`.

Doing so uncovered a bug: When a block would be transmitted, but the ACK got lost, the sender would re-transmit the block.

This triggered the `block1.offset != (unsigned)ret` check in the GCoAP fileserver which considered this an error and aborted the transmission.

To fix this, simply ignore old blocks and send a `COAP_CODE_CONTINUE` anyway.


### Testing procedure

CI will run `tests/gcoap_fileserver`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
