### PR TITLE
cpu/stm32/periph/usbdev_fs: support for STM32F1 family

### DIFF
--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -246,9 +246,10 @@ static void _set_ep_in_status(uint16_t *val, uint16_t mask)
 
 static void _set_ep_out_status(uint16_t *val, uint16_t mask)
 {
-       /* status endpoints bits can only be toggled, writing 0
-       as no effect. Thus, check which bits should be set
-       then XOR it with their current value */
+    /* status endpoints bits can only be toggled, writing 0
+     * as no effect. Thus, check which bits should be set
+     * then XOR it with their current value */
+
     if (mask & USB_EPRX_DTOG1) {
         *val ^= USB_EPRX_DTOG1;
     }

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -56,9 +56,12 @@ static stm32_usbdev_fs_t _usbdevs[USBDEV_NUMOF];
 static usbdev_ep_t _ep_in[_ENDPOINT_NUMOF];
 static usbdev_ep_t _ep_out[_ENDPOINT_NUMOF];
 
-static uint8_t* _ep_out_buf[_ENDPOINT_NUMOF];
+/* 16-bit addresses used by the USB IP as endpoint buffers in the PMA SRAM */
+static uint16_t _ep_in_buf[_ENDPOINT_NUMOF];
+static uint16_t _ep_out_buf[_ENDPOINT_NUMOF];
+
+/* Buffers used for receiving packets on OUT EPs. */
 static uint8_t* _app_pbuf[_ENDPOINT_NUMOF];
-static uint32_t _ep_in_buf[_ENDPOINT_NUMOF];
 
 /* Forward declaration for the usb device driver */
 const usbdev_driver_t driver;
@@ -426,7 +429,7 @@ static usbdev_ep_t *_usbdev_new_ep(usbdev_t *dev, usb_ep_type_t type,
             if (dir == USB_EP_DIR_IN) {
                 _ep_in_buf[new_ep->num] = (BUF_BASE_OFFSET + usbdev->used);
             } else {
-                _ep_out_buf[new_ep->num] = (uint8_t*)(BUF_BASE_OFFSET + usbdev->used);
+                _ep_out_buf[new_ep->num] = (BUF_BASE_OFFSET + usbdev->used);
             }
             usbdev->used += len;
             new_ep->len = len;
@@ -533,7 +536,7 @@ static void _usbdev_ep_init(usbdev_ep_t *ep)
         EP_DESC[ep->num].addr_tx = _ep_in_buf[ep->num];
         EP_DESC[ep->num].count_tx = 64;
     } else {
-        EP_DESC[ep->num].addr_rx = (uint32_t)_ep_out_buf[ep->num];
+        EP_DESC[ep->num].addr_rx = _ep_out_buf[ep->num];
         /* Set BLSIZE + NUM_BLOCK (1) */
         EP_DESC[ep->num].count_rx = (1 << 10) | (1 << 15);
     }


### PR DESCRIPTION
### Contribution description

This PR provides the following changes for the USB Device FS driver for STM32 MCUs to support STM32F1 MCUs.

1. Implementation of PMA access schemes:  MCUs with USB Device FS IP cores use two different schemes for the access to the Packet buffer Memory Area (PMA):
    - 2 x 16 bit/word access scheme where two 16-bit half-words per word can be accessed. With this scheme the access can be half-word aligned and the  PMA address offset corresponds therefore to the local USB IP address.  The size of the PMA SRAM is usually 1024 byte.
   - 1 x 16 bit/word access scheme where one 16-bit half word per word can be  accessed. With this scheme the access can only be word-aligned and the  PMA address offset to a half-word is therefore twice the local USB IP  address. The size of the PMA SRAM is usually 512 byte.
   Which access scheme is used depends on the STM32 model.
   
2. Always use 16-bit addresses for PMA: The addressing of the PMA is done locally in the USB IP core in half-words with 16-bit. The `_ep_in_buf` and `_ep_out_buf` arrays which hold these USB IP local addresses in the PMA for initialized EPs therefore now always use `uint16_t`.
 
3.  Implementation of USB clock pre-divider: Depending on the STM32 MCU the 48 MHz USB clock is derived from the PLL clock. This is the case if the `RCC_CFGR_UBPRE` is defined. In this case the PLL clock must be configured and must be either 48 MHz or 72 MHz. If the PLL clock is 72 MHz, it is pre-divided by 1.5, the PLL clock of 48 MHz is used directly. 

4. Simulate USB disconnect/connect: If the MCU does not have an internal D+ pullup and there is no dedicated GPIO to simulate a USB disconnect, the D+ GPIO is temporarily configured as an output and pushed down to simulate a disconnect/connect cycle to allow the host to recognize the device.

### Testing procedure

`tests/usbus_hid` should still work for `nucleo-f303ze` and `p-nucleo-wb55`.

PR #17812 should work on top of this PR.

### Issues/PRs references

Prerequisite for PR #17812