### PR TITLE
gh-actions: move actions/checkout to main

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         check: [commit-msg, pr_check]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
       with:
         # Use the SHA of the PR branch as-is, not the PR branch merged
         # in master (default behavior in GH actions)

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -88,14 +88,14 @@ jobs:
         ssh -oStrictHostKeyChecking=accept-new \
           ${IOTLAB_USER}@lille.iot-lab.info exit
     - name: Checkout Release-Specs
-      uses: actions/checkout@v2
+      uses: actions/checkout@main
       with:
         repository: RIOT-OS/Release-Specs
         path: Release-Specs
         fetch-depth: 1
         ref: ${{ github.event.inputs.release_specs_version }}
     - name: Checkout RIOT
-      uses: actions/checkout@v2
+      uses: actions/checkout@main
       with:
         repository: RIOT-OS/RIOT
         path: RIOT

--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -16,7 +16,7 @@ jobs:
   static-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
       with:
         fetch-depth: 0
     - name: Setup git

--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           docker pull riot/riotbuild:latest
       - name: Checkout RIOT
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           ref: ${{ github.event.inputs.riot_version }}
       - name: Launch IoT-LAB experiment

--- a/.github/workflows/test-on-ryot.yml
+++ b/.github/workflows/test-on-ryot.yml
@@ -85,7 +85,7 @@ jobs:
       APPLICATIONS_EXCLUDE: 'tests/periph_timer_short_relative_set'
     steps:
       - name: Checkout RIOT
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           ref: ${{ github.event.inputs.riot_version }}
           # Make sure it runs git clean -xdff before fetching

--- a/.github/workflows/tools-buildtest.yml
+++ b/.github/workflows/tools-buildtest.yml
@@ -14,7 +14,7 @@ jobs:
   tools-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Build flatc standalone
       uses: aabadie/riot-action@v1
       with:

--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -14,7 +14,7 @@ jobs:
   python-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Github is complaining about deprecation of Node.js 12 deprecation in our Github Actions (one example can be found here: https://github.com/RIOT-OS/RIOT/actions/runs/3235426917) this is due to us using an outdated version of the actions/checkout Action. This bumps all of them to follow the master branch (as some already do, e.g. tools-buildtests).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See if the Node.js deprecation warning disappears.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
