### PR TITLE
sys/stdio_uart: add stdio_uart_onlcr (pseudo-) module

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -371,8 +371,15 @@ PSEUDOMODULES += stdio_available
 PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_nimble_debug
-PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += stdio_telnet
+## @defgroup sys_stdio_uart_onlcr   Support for DOS line endings in STDIO-UART
+## @ingroup sys_stdio_uart
+## @{
+## Enable this (pseudo-) module to emit DOS style line endings (`\r\n`) instead
+## of UNIX style line endings (`\n`) via STDIO over UART.
+PSEUDOMODULES += stdio_uart_onlcr
+## @}
+PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += stm32_eth
 PSEUDOMODULES += stm32_eth_auto
 PSEUDOMODULES += stm32_eth_link_up

--- a/sys/Kconfig.stdio
+++ b/sys/Kconfig.stdio
@@ -34,6 +34,10 @@ config MODULE_STDIO_UART
     depends on HAS_PERIPH_UART
     select MODULE_PERIPH_UART
 
+config MODULE_STDIO_UART_ONLCR
+    bool "Emit DOS line endings for STDIO output via UART"
+    depends on MODULE_STDIO_UART
+
 config MODULE_STDIO_NATIVE
     bool "Native"
     depends on CPU_ARCH_NATIVE

--- a/sys/include/stdio_uart.h
+++ b/sys/include/stdio_uart.h
@@ -13,11 +13,36 @@
  *
  * @brief       Standard input/output backend using UART
  *
+ * ## Input
+ *
  * @warning Standard input is disabled by default on UART. To enable it, load
  *          the `stdin` module in your application:
  * ```
  * USEMODULE += stdin
  * ```
+ *
+ * ## UART Configuration
+ *
+ * @note    Running `make BOARD=<your_board> term` will launch `pyterm` with the
+ *          correct parameters, so mostly you do not really need to care about
+ *          the UART configuration.
+ *
+ * By convention RIOT boards used 8N1 encoding with a symbol rate of 115200 Bd
+ * for the UART used as stdio. However, some boards may have a different
+ * configuration due to hardware limitations. Most notably, many AVR boards use
+ * 9600 Bd as symbol rate instead, as they otherwise frequently loose an input
+ * character due to losing interrupts.
+ *
+ * By default UNIX style line endings (`\n`) are used. However, some terminal
+ * programs default to DOS style line endings (`\r\n`). It usually is better to
+ * configure the terminal program on the host to use UNIX style line endings.
+ * In scenarios this is not possible/desired, you can enable the (pseudo-)
+ * module @ref sys_stdio_uart_onlcr to emit DOS style line endings instead.
+ *
+ * RIOT's shell happily accepts both DOS and UNIX style line endings in any
+ * case, so typically no line ending conversion is needed on the input.
+ *
+ * ## STDIO from ISR
  *
  * @attention   Using STDIO over UART from interrupt context should be avoided,
  *              except for debugging purposes


### PR DESCRIPTION
### Contribution description

Add USE_MODULE += "stdio_uart_onlcr" to enable it. This is named after the "onlcr" stty flag, which does the same thing.

### Testing procedure

```
USEMODULE=stdio_uart_onlcr make BOARD=<board-with-stdio_uart> -C examples/default
```

The shell should now work with a terminal that expects DOS line endings.

### Issues/PRs references

Alternative to: https://github.com/RIOT-OS/RIOT/pull/18703 and https://github.com/RIOT-OS/RIOT/pull/15619

This is basically picking up https://github.com/RIOT-OS/RIOT/pull/15619 and polishing it a bit.