### PR TITLE
makefiles/arch/avr8.inc.mk: fix detection of GCC 12

### DIFF
--- a/makefiles/arch/avr8.inc.mk
+++ b/makefiles/arch/avr8.inc.mk
@@ -39,7 +39,9 @@ OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
 OPTIONAL_CFLAGS_BLACKLIST += -gz
 
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-ifneq ($(findstring 12.,$(shell $(CC) --version 2>/dev/null)),)
-  CFLAGS += --param=min-pagesize=0
+ifeq ($(TOOLCHAIN),gnu)
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+  ifneq ($(findstring 12.,$(shell $(TARGET_ARCH)-gcc --version 2>/dev/null)),)
+    CFLAGS += --param=min-pagesize=0
+  endif
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

At this point `$(CC)` will evaluate to `cc` which is the host compiler, not `avr-gcc`.

Test explicitly for `avr-gcc` to get the right compiler version.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #18643
