### PR TITLE
nanocoap_sock: implement nanocoap_sock_delete()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -290,6 +290,27 @@ ssize_t nanocoap_sock_post_url(const char *url,
                                void *response, size_t len_max);
 
 /**
+ * @brief   Simple synchronous CoAP (confirmable) DELETE
+ *
+ * @param[in]   sock    socket to use for the request
+ * @param[in]   path    remote path to delete
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_delete(nanocoap_sock_t *sock, const char *path);
+
+/**
+ * @brief   Simple synchronous CoAP (confirmable) DELETE for URL
+ *
+ * @param[in]   url     URL of the resource that should be deleted
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_delete_url(const char *url);
+
+/**
  * @brief    Performs a blockwise coap get request on a socket.
  *
  * This function will fetch the content of the specified resource path via

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -391,6 +391,38 @@ ssize_t nanocoap_sock_post_url(const char *url,
     return _sock_put_post_url(url, COAP_METHOD_POST, request, len, response, len_max);
 }
 
+ssize_t nanocoap_sock_delete(nanocoap_sock_t *sock, const char *path)
+{
+    /* buffer for CoAP header */
+    uint8_t buffer[CONFIG_NANOCOAP_BLOCK_HEADER_MAX];
+    uint8_t *pktpos = buffer;
+
+    coap_pkt_t pkt = {
+        .hdr = (void *)pktpos,
+    };
+
+    pktpos += coap_build_hdr(pkt.hdr, COAP_TYPE_CON, NULL, 0, COAP_METHOD_DELETE, _get_id());
+    pktpos += coap_opt_put_uri_path(pktpos, 0, path);
+
+    pkt.payload = pktpos;
+
+    return nanocoap_sock_request_cb(sock, &pkt, NULL, NULL);
+}
+
+ssize_t nanocoap_sock_delete_url(const char *url)
+{
+    nanocoap_sock_t sock;
+    int res = nanocoap_sock_url_connect(url, &sock);
+    if (res) {
+        return res;
+    }
+
+    res = nanocoap_sock_delete(&sock, sock_urlpath(url));
+    nanocoap_sock_close(&sock);
+
+    return res;
+}
+
 ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
                          const sock_udp_ep_t *remote, size_t len)
 {

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -183,7 +183,7 @@ static int _blockwise_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int
 int nanotest_client_url_cmd(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
-    const char *method_codes[] = {"get", "post", "put"};
+    const char *method_codes[] = { "get", "post", "put", "delete" };
     int res;
 
     if (argc < 3) {
@@ -202,11 +202,12 @@ int nanotest_client_url_cmd(int argc, char **argv)
     }
 
     switch (code_pos) {
-    case 0:
-        return nanocoap_get_blockwise_url(argv[2], COAP_BLOCKSIZE_32,
-                                          _blockwise_cb, NULL);
-    case 1:
-    case 2:
+    case COAP_METHOD_GET - 1:
+        res = nanocoap_get_blockwise_url(argv[2], COAP_BLOCKSIZE_32,
+                                         _blockwise_cb, NULL);
+        break;
+    case COAP_METHOD_POST - 1:
+    case COAP_METHOD_PUT - 1:
         ;
         char response[32];
         nanocoap_sock_t sock;
@@ -229,6 +230,9 @@ int nanotest_client_url_cmd(int argc, char **argv)
             printf("response: %s\n", response);
         }
         break;
+    case COAP_METHOD_DELETE - 1:
+        res = nanocoap_sock_delete_url(argv[2]);
+        break;
     default:
         printf("TODO: implement %s request\n", method_codes[code_pos]);
         return -1;
@@ -240,7 +244,7 @@ int nanotest_client_url_cmd(int argc, char **argv)
     return res;
 
 error:
-    printf("usage: %s <get|post|put> <url> [data]\n", argv[0]);
+    printf("usage: %s <get|post|put|delete> <url> [data]\n", argv[0]);
     return -1;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We support GET, PUT and POST, so also implement DELETE.

### Testing procedure

This can be tested with `examples/gcoap_fileserver`:

```
main(): This is RIOT! (Version: 2022.10-devel-1142-gbec06-nanocoap_sock_delete)
nanocoap test app
All up, running the shell now

> url delete coap://[fe80::58b0:8ff:fe67:ad82]/vfs/core
nanocoap: send 13 bytes (5 tries left)
nanocoap: waiting for response (timeout: 2125925 µs)
nanocoap: response code=202

> url delete coap://[fe80::58b0:8ff:fe67:ad82]/vfs/core
nanocoap: send 13 bytes (5 tries left)
nanocoap: waiting for response (timeout: 2772702 µs)
nanocoap: response code=404
res: Unknown error -6
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
