### PR TITLE
pkg/gecko_sdk: Bump to version 4.1.2

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -3,6 +3,9 @@ include $(RIOTCPU)/efm32/efm32-features.mk
 
 CPU_CORE = $(EFM32_ARCHITECTURE)
 
+# allow CPU families to add features individually
+-include $(RIOTCPU)/efm32/families/$(CPU_FAM)/Makefile.features
+
 # families without MPU
 ifeq (,$(filter efm32zg efm32hg, $(CPU_FAM)))
   FEATURES_PROVIDED += cortexm_mpu
@@ -21,6 +24,9 @@ FEATURES_PROVIDED += periph_wdt
 
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware peripheral."
+
+FEATURES_CONFLICT += cortexm_fpu:gecko_sdk_librail_nonfpu
+FEATURES_CONFLICT_MSG += "Using librail with the FPU enabled is not supported on this CPU."
 
 ifeq (1,$(EFM32_TRNG))
   FEATURES_PROVIDED += periph_hwrng

--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -6,6 +6,9 @@ include $(RIOTCPU)/efm32/efm32-info.mk
 # `cpu_$(CPU_FAM)` for something that is MODULE related.
 include $(RIOTCPU)/efm32/families/$(CPU_FAM)/Makefile.include
 
+# Export vars for Gecko SDK librail Makefile
+export EFM32_LIBRAIL_BLOB_NAME
+
 ifeq (,$(EFM32_HEADER))
   $(error Header file for $(CPU_MODEL) is missing)
 endif

--- a/cpu/efm32/families/efr32mg12p/Kconfig
+++ b/cpu/efm32/families/efr32mg12p/Kconfig
@@ -11,6 +11,7 @@ config CPU_FAM_EFR32MG12P
     select CPU_EFM32_SERIES1
     select HAS_PERIPH_HWRNG
     select HAS_CORTEXM_MPU
+    select HAS_GECKO_SDK_LIBRAIL_NONFPU
 
 config MODULE_CPU_EFR32MG12P
     bool

--- a/cpu/efm32/families/efr32mg12p/Makefile.features
+++ b/cpu/efm32/families/efr32mg12p/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += gecko_sdk_librail_nonfpu

--- a/cpu/efm32/families/efr32mg12p/Makefile.include
+++ b/cpu/efm32/families/efr32mg12p/Makefile.include
@@ -3,5 +3,10 @@
 # as easy as adding the header file only.
 EFM32_HEADER = $(wildcard $(RIOTCPU)/efm32/families/efr32mg12p/include/vendor/$(CPU_MODEL).h)
 
+# Names of librail related files
+EFM32_LIBRAIL_BLOB_NAME = efr32xg12
+EFM32_LIBRAIL_HEADER_NAME = efr32xg1x
+EFM32_LIBRAIL_PA_HEADER_NAME = efr32xg1x
+
 # include vendor device headers
 INCLUDES += -I$(RIOTCPU)/efm32/families/efr32mg12p/include/vendor

--- a/cpu/efm32/families/efr32mg1b/Kconfig
+++ b/cpu/efm32/families/efr32mg1b/Kconfig
@@ -10,6 +10,7 @@ config CPU_FAM_EFR32MG1B
     select CPU_COMMON_EFM32
     select CPU_EFM32_SERIES1
     select HAS_CORTEXM_MPU
+    select HAS_GECKO_SDK_LIBRAIL_NONFPU
 
 config MODULE_CPU_EFR32MG1B
     bool

--- a/cpu/efm32/families/efr32mg1b/Makefile.features
+++ b/cpu/efm32/families/efr32mg1b/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += gecko_sdk_librail_nonfpu

--- a/cpu/efm32/families/efr32mg1b/Makefile.include
+++ b/cpu/efm32/families/efr32mg1b/Makefile.include
@@ -3,5 +3,10 @@
 # as easy as adding the header file only.
 EFM32_HEADER = $(wildcard $(RIOTCPU)/efm32/families/efr32mg1b/include/vendor/$(CPU_MODEL).h)
 
+# Names of librail related files
+EFM32_LIBRAIL_BLOB_NAME = efr32xg1
+EFM32_LIBRAIL_HEADER_NAME = efr32xg1x
+EFM32_LIBRAIL_PA_HEADER_NAME = efr32xg1x
+
 # include vendor device headers
 INCLUDES += -I$(RIOTCPU)/efm32/families/efr32mg1b/include/vendor

--- a/cpu/efm32/families/efr32mg1p/Kconfig
+++ b/cpu/efm32/families/efr32mg1p/Kconfig
@@ -10,6 +10,7 @@ config CPU_FAM_EFR32MG1P
     select CPU_COMMON_EFM32
     select CPU_EFM32_SERIES1
     select HAS_CORTEXM_MPU
+    select HAS_GECKO_SDK_LIBRAIL_NONFPU
 
 config MODULE_CPU_EFR32MG1P
     bool

--- a/cpu/efm32/families/efr32mg1p/Makefile.features
+++ b/cpu/efm32/families/efr32mg1p/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += gecko_sdk_librail_nonfpu

--- a/cpu/efm32/families/efr32mg1p/Makefile.include
+++ b/cpu/efm32/families/efr32mg1p/Makefile.include
@@ -3,5 +3,10 @@
 # as easy as adding the header file only.
 EFM32_HEADER = $(wildcard $(RIOTCPU)/efm32/families/efr32mg1p/include/vendor/$(CPU_MODEL).h)
 
+# Names of librail related files
+EFM32_LIBRAIL_BLOB_NAME = efr32xg1
+EFM32_LIBRAIL_HEADER_NAME = efr32xg1x
+EFM32_LIBRAIL_PA_HEADER_NAME = efr32xg1x
+
 # include vendor device headers
 INCLUDES += -I$(RIOTCPU)/efm32/families/efr32mg1p/include/vendor

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -122,8 +122,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     isr_ctx[_pin_num(pin)].arg = arg;
 
     /* enable interrupts */
-    GPIO_IntConfig(_port_num(pin), _pin_num(pin),
-                   flank & GPIO_RISING, flank & GPIO_FALLING, true);
+    GPIO_ExtIntConfig(_port_num(pin), _pin_num(pin), _pin_num(pin),
+                      flank & GPIO_RISING, flank & GPIO_FALLING, true);
 
     NVIC_ClearPendingIRQ(GPIO_EVEN_IRQn);
     NVIC_ClearPendingIRQ(GPIO_ODD_IRQn);

--- a/pkg/gecko_sdk/Kconfig
+++ b/pkg/gecko_sdk/Kconfig
@@ -1,11 +1,29 @@
 # Copyright (c) 2021 HAW Hamburg
+#               2022 SSV Software Systems GmbH
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
 
-config PACKAGE_GECKO_SDK
+## Definition of Gecko SDK specific features
+config HAS_GECKO_SDK_LIBRAIL_NONFPU
+    bool
+    help
+        Indicates that the CPU offers librail support if the FPU is disabled.
+        Librail is shipped as pre-compiled blobs. Thus, we have to adapt to
+        their choice how to process floats.
+
+config HAS_GECKO_SDK_LIBRAIL_FPU
+    bool
+    help
+        Indicates that the CPU offers librail support if the FPU is enabled.
+        Librail is shipped as pre-compiled blobs. Thus, we have to adapt to
+        their choice how to process floats.
+
+
+## Provided modules
+menuconfig PACKAGE_GECKO_SDK
     bool "Vendor library for EFM/EFR/EZR32 MCUs"
     depends on TEST_KCONFIG
     help
@@ -26,5 +44,19 @@ config MODULE_GECKO_SDK_EMLIB_EXTRA
     default y
     help
         Extra utility methods from EMBLIB vendor library.
+
+config MODULE_GECKO_SDK_LIBRAIL
+    bool "Radio Abstraction Interface Layer (RAIL)"
+    depends on (HAS_GECKO_SDK_LIBRAIL_NONFPU && !MODULE_CORTEXM_FPU) || (HAS_GECKO_SDK_LIBRAIL_FPU && MODULE_CORTEXM_FPU)
+    help
+        The Silicon Labs Radio Abstraction Interface Layer (RAIL) is required
+        to use the integrated radio offered by the EFR32 families.
+
+config MODULE_GECKO_SDK_LIBRAIL_PA
+    bool "Power Amplifier Power Conversion Functions"
+    depends on MODULE_GECKO_SDK_LIBRAIL
+    help
+        Helper to convert between transmission power in dBm and the
+        chip- and circuit-specific raw power level.
 
 endif # PACKAGE_GECKO_SDK

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=e291e7e0bb56d3f51f03ef7c0b8af138a8d1301a
+PKG_VERSION=944639a57adce84fb110fe89e54f50e161607918
 PKG_LICENSE=Zlib
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/gecko_sdk/Makefile.dep
+++ b/pkg/gecko_sdk/Makefile.dep
@@ -1,2 +1,6 @@
 USEMODULE += gecko_sdk_emlib
 USEMODULE += gecko_sdk_emlib_extra
+
+ifneq (,$(filter gecko_sdk_librail_pa,$(USEMODULE)))
+  USEMODULE += gecko_sdk_librail
+endif

--- a/pkg/gecko_sdk/Makefile.include
+++ b/pkg/gecko_sdk/Makefile.include
@@ -1,3 +1,14 @@
 INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/common/inc
 INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/emlib/inc
 INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/emlib-extra/inc
+
+ifneq (,$(filter gecko_sdk_librail,$(USEMODULE)))
+  ARCHIVES += $(BINDIR)/gecko_sdk_librail.a
+  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/common
+  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/chip/efr32/$(EFM32_LIBRAIL_HEADER_NAME)
+endif
+
+ifneq (,$(filter gecko_sdk_librail_pa,$(USEMODULE)))
+  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/plugin/pa-conversions
+  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/plugin/pa-conversions/$(EFM32_LIBRAIL_PA_HEADER_NAME)/config
+endif

--- a/pkg/gecko_sdk/Makefile.include
+++ b/pkg/gecko_sdk/Makefile.include
@@ -1,2 +1,3 @@
+INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/common/inc
 INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/emlib/inc
 INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/emlib-extra/inc


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR updates the SDK to the latest release.

The update is required to bring back SiLabs' RAIL lib support to RIOT.

### Testing procedure

I've run buildtests for all EFM32-based boards that are present in RIOT:

```
jue@baxxter ~/P/s/RIOT (feature/pkg-gecko_sdk_41)> BOARDS="ikea-tradfri e180-zg120b-tb slstk3400a stk3200 slstk3401a slwstk6220a stk3700 slstk3402a sltb001a stk3600 slstk3400a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a" make -C examples/default buildtest
make: Entering directory '/home/jue/Projects/ssv/RIOT/examples/default'
Building for ikea-tradfri ... success.
Building for e180-zg120b-tb ... success.
Building for slstk3400a ... success.
Building for stk3200 ... success.
Building for slstk3401a ... success.
Building for slwstk6220a ... success.
Building for stk3700 ... success.
Building for slstk3402a ... success.
Building for sltb001a ... success.
Building for stk3600 ... success.
Building for slstk3400a ... success.
Building for slwstk6000b-slwrb4150a ... success.
Building for slwstk6000b-slwrb4162a ... success.
make: Leaving directory '/home/jue/Projects/ssv/RIOT/examples/default'
```

### Issues/PRs references

*none*
