### PR TITLE
cpu/stm32: fix KConfig modeling for STM32F1 / usbdev_synopsys_dwc2

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -4,8 +4,12 @@
 USEMODULE += periph stm32_clk stm32_vectors
 
 ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
-  # TODO: STM32F105xx and STM32F107xx also use synopsys_dwc2
+  # All STM32 families except for STM32F1, STM32F3 and STM32WG use synopsys_dwc2
   ifeq (,$(filter f1 f3 wb,$(CPU_FAM)))
+    USEMODULE += usbdev_synopsys_dwc2
+  endif
+  # In STM32F1 family STM32F105xx and STM32F107xx also use synopsys_dwc2
+  ifneq (,$(filter stm32f105% stm32f107%,$(CPU_MODEL)))
     USEMODULE += usbdev_synopsys_dwc2
   endif
   USEMODULE += ztimer

--- a/cpu/stm32/periph/Kconfig
+++ b/cpu/stm32/periph/Kconfig
@@ -10,7 +10,12 @@ config MODULE_PERIPH
     default y
     select MODULE_ZTIMER if MODULE_PERIPH_USBDEV
     select MODULE_ZTIMER_MSEC if MODULE_PERIPH_USBDEV
-    select MODULE_USBDEV_SYNOPSYS_DWC2 if MODULE_PERIPH_USBDEV && !HAS_CPU_STM32WB && !HAS_CPU_STM32F3
+    # All STM32 families except for STM32F1, STM32F3 and STM32WG use
+    # MODULE_USBDEV_SYNOPSYS_DWC2
+    select MODULE_USBDEV_SYNOPSYS_DWC2 if MODULE_PERIPH_USBDEV && !HAS_CPU_STM32WB && !HAS_CPU_STM32F3 && !HAS_CPU_STM32F1
+    # NOTE: In STM32F1 family STM32F105xx and STM32F107xx also use
+    #       MODULE_USBDEV_SYNOPSYS_DWC2. Add those MCUs once the are added to
+    #       KConfig
     help
         stm32 common peripheral code.
 


### PR DESCRIPTION
### Contribution description

This fixes incorrect module selection for STM32F1 boards with feature periph_usbdev, a regression introduced by https://github.com/RIOT-OS/RIOT/pull/17812

### Testing procedure

##### In `master`

```
~/Repos/software/RIOT $ BOARD=bluepill TEST_KCONFIG=0 make info-modules -C tests/sys_fido2_ctap > ~/mods-no-k 
~/Repos/software/RIOT $ BOARD=bluepill TEST_KCONFIG=1 make info-modules -C tests/sys_fido2_ctap > ~/mods-k 
~/Repos/software/RIOT $ diff ~/mods-no-k ~/mods-k 
--- /home/maribu/mods-no-k
+++ /home/maribu/mods-k
@@ -1,4 +1,6 @@
 make: Entering directory '/home/maribu/Repos/software/RIOT/tests/sys_fido2_ctap'
+=== [ATTENTION] Testing Kconfig dependency modelling ===
+=== [ATTENTION] Testing Kconfig dependency modelling ===
 auto_init
 auto_init_random
 auto_init_ztimer
@@ -85,6 +87,7 @@
 stm32_vectors
 sys
 tsrb
+usbdev_synopsys_dwc2
 usbus
 usbus_hid
 xtimer
```

##### This PR

```
~/Repos/software/RIOT $ BOARD=bluepill TEST_KCONFIG=0 make info-modules -C tests/sys_fido2_ctap > ~/mods-no-k 
~/Repos/software/RIOT $ BOARD=bluepill TEST_KCONFIG=1 make info-modules -C tests/sys_fido2_ctap > ~/mods-k 
~/Repos/software/RIOT $ diff ~/mods-no-k ~/mods-k 
--- /home/maribu/mods-no-k
+++ /home/maribu/mods-k
@@ -1,4 +1,6 @@
 make: Entering directory '/home/maribu/Repos/software/RIOT/tests/sys_fido2_ctap'
+=== [ATTENTION] Testing Kconfig dependency modelling ===
+=== [ATTENTION] Testing Kconfig dependency modelling ===
 auto_init
 auto_init_random
 auto_init_ztimer
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17812
