### PR TITLE
sys/clif: Fixing out of bounds read under certain conditions

### DIFF
--- a/sys/clif/clif.c
+++ b/sys/clif/clif.c
@@ -107,7 +107,7 @@ ssize_t clif_encode_link(const clif_t *link, char *buf, size_t maxlen)
     size_t pos = 0;
     ssize_t res = 0;
 
-    res = clif_add_target(link->target, buf, maxlen);
+    res = clif_add_target_from_buffer(link->target, link->target_len, buf, maxlen);
     if (res < 0) {
         return res;
     }
@@ -124,12 +124,12 @@ ssize_t clif_encode_link(const clif_t *link, char *buf, size_t maxlen)
     return pos;
 }
 
-ssize_t clif_add_target(const char *target, char *buf, size_t maxlen)
+ssize_t clif_add_target_from_buffer(const char *target, size_t target_len, char *buf, size_t maxlen)
 {
     assert(target);
 
     size_t pos = 0;
-    size_t target_len = strlen(target);
+    DEBUG("Adding target: %.*s, len: %d\n", target_len, target, target_len);
 
     if (!buf) {
         return target_len + 2; /* size after adding '<' and '>' */
@@ -147,6 +147,15 @@ ssize_t clif_add_target(const char *target, char *buf, size_t maxlen)
     buf[pos++] = LF_PATH_END_C;
 
     return pos;
+}
+
+ssize_t clif_add_target(const char *target, char *buf, size_t maxlen)
+{
+    assert(target);
+
+    size_t target_len = strlen(target);
+    assert(target_len > 0);
+    return clif_add_target_from_buffer(target, target_len, buf, maxlen);
 }
 
 ssize_t clif_add_link_separator(char *buf, size_t maxlen)

--- a/sys/include/clif.h
+++ b/sys/include/clif.h
@@ -191,8 +191,28 @@ ssize_t clif_decode_link(clif_t *link, clif_attr_t *attrs, unsigned attrs_len,
  *
  * @pre `target != NULL`
  *
- * @param[in]  target  string containing the path to the resource. Must not be
- *                     NULL.
+ * @param[in]  target       buffer containing the path to the resource.
+ *                          Must not be NULL.
+ * @param[in]  target_len   size of @p target
+ * @param[out] buf          buffer to output the formatted path. Can be NULL
+ * @param[in]  maxlen       size of @p buf
+ *
+ * @note If @p buf is NULL this will return the amount of bytes that would be
+ *       needed
+ *
+ * @return in success the amount of bytes used in the buffer
+ * @return CLIF_NO_SPACE if there is not enough space in the buffer
+ */
+ssize_t clif_add_target_from_buffer(const char *target, size_t target_len,
+                                    char *buf, size_t maxlen);
+
+/**
+ * @brief   Adds a given @p target to a given buffer @p buf using link format
+ *
+ * @pre `target != NULL`
+ *
+ * @param[in]  target  zero terminated string containing the path to the resource.
+ *                     Must not be NULL.
  * @param[out] buf     buffer to output the formatted path. Can be NULL
  * @param[in]  maxlen  size of @p buf
  *


### PR DESCRIPTION
Hi 😈

This fixes a potential out of bounds read in `clif_encode_link`. There is no code in RIOT that can be exploited & and the close by `memcpy` only operates within a safe/length checked buffer.

The fix does not break the current API.
I also added a new test which also acts as an example on how to use clif. 

Run `make -C tests/unittests tests-clif` and `make -C tests/unittests term` to test the fix.

Side note: I did not run uncrustify as this would have filled this PR with a lot of unrelated changes. Somebody should open a separate PR for those cosmetic changes.

cc @leandrolanzieri 