### PR TITLE
tests: set netdev `event_callback` before calling init

### DIFF
--- a/tests/driver_cc2538_rf/main.c
+++ b/tests/driver_cc2538_rf/main.c
@@ -36,12 +36,12 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     netdev_register(netdev, NETDEV_CC2538, 0);
     netdev_ieee802154_submac_init(&cc2538_rf);
 
+    /* set the application-provided callback */
+    netdev->event_callback = cb;
+
     /* setup and initialize the specific driver */
     cc2538_rf_hal_setup(&cc2538_rf.submac.dev);
     cc2538_init();
-
-    /* set the application-provided callback */
-    netdev->event_callback = cb;
 
     /* initialize the device driver */
     int res = netdev->driver->init(netdev);

--- a/tests/driver_nrf802154/main.c
+++ b/tests/driver_nrf802154/main.c
@@ -36,12 +36,12 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     netdev_register(netdev, NETDEV_CC2538, 0);
     netdev_ieee802154_submac_init(&nrf802154);
 
+    /* set the application-provided callback */
+    netdev->event_callback = cb;
+
     /* setup and initialize the specific driver */
     nrf802154_hal_setup(&nrf802154.submac.dev);
     nrf802154_init();
-
-    /* set the application-provided callback */
-    netdev->event_callback = cb;
 
     /* initialize the device driver */
     int res = netdev->driver->init(netdev);

--- a/tests/driver_sx126x/main.c
+++ b/tests/driver_sx126x/main.c
@@ -325,12 +325,12 @@ int main(void)
 
     netdev->driver = &sx126x_driver;
 
+    netdev->event_callback = _event_cb;
+
     if (netdev->driver->init(netdev) < 0) {
         puts("Failed to initialize SX126X device, exiting");
         return 1;
     }
-
-    netdev->event_callback = _event_cb;
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
                               THREAD_CREATE_STACKTEST, _recv_thread, netdev,

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -545,12 +545,12 @@ int main(void)
 
     netdev->driver = &sx127x_driver;
 
+    netdev->event_callback = _event_cb;
+
     if (netdev->driver->init(netdev) < 0) {
         puts("Failed to initialize SX127x device, exiting");
         return 1;
     }
-
-    netdev->event_callback = _event_cb;
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
                               THREAD_CREATE_STACKTEST, _recv_thread, NULL,

--- a/tests/driver_sx1280/main.c
+++ b/tests/driver_sx1280/main.c
@@ -355,12 +355,12 @@ int main(void)
 
     netdev->driver = &sx1280_driver;
 
+    netdev->event_callback = _event_cb;
+
     if (netdev->driver->init(netdev) < 0) {
         puts("Failed to initialize SX1280 device, exiting");
         return 1;
     }
-
-    netdev->event_callback = _event_cb;
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
                               THREAD_CREATE_STACKTEST, _recv_thread, netdev,

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -55,10 +55,10 @@ static void test_init(void)
     printf("Initializing socket ZEP with (local: [%s]:%s, remote: [%s]:%s)\n",
            p->local_addr, p->local_port, p->remote_addr, p->remote_port);
     netdev_register(&_socket_zep_netdev.dev.netdev, NETDEV_SOCKET_ZEP, 0);
+    netdev->event_callback = _event_cb;
     netdev_ieee802154_submac_init(&_socket_zep_netdev);
     socket_zep_hal_setup(&_dev, &_socket_zep_netdev.submac.dev);
     socket_zep_setup(&_dev, p);
-    netdev->event_callback = _event_cb;
     expect(netdev->driver->init(netdev) >= 0);
     _print_info(netdev);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/17893#issuecomment-1279037495.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
All tests should compile and run as expected.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#17893

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
