### PR TITLE
boards/nucleo-l4r5zi: doc improvements

### DIFF
--- a/boards/nucleo-l4r5zi/doc.txt
+++ b/boards/nucleo-l4r5zi/doc.txt
@@ -8,6 +8,32 @@
 The Nucleo-L4R5ZI is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32L4R5ZI microcontroller with 640KiB of RAM and 2MiB of ROM Flash.
 
+## Hardware
+
+![Nucleo144 L4R5ZI](https://www.st.com/bin/ecommerce/api/image.PF264781.en.feature-description-include-personalized-no-cpn-large.jpg)
+
+### MCU
+
+| MCU          | STM32L4R5ZI                                        |
+|:-------------|:---------------------------------------------------|
+| Family       | ARM Cortex-M4F                                     |
+| Vendor       | ST Microelectronics                                |
+| RAM          | 640KiB                                             |
+| Flash        | 2MiB                                               |
+| Frequency    | up to 120 MHz                                      |
+| FPU          | yes                                                |
+| Timers       | 16 (2x watchdog, 1 SysTick, 2x 32-bit, 11x 16-bit) |
+| ADC          | 1x 12 bit (16 channels)                            |
+| UARTs        | 6                                                  |
+| SPIs         | 3                                                  |
+| I2Cs         | 4                                                  |
+| CAN          | 1                                                  |
+| USB          | 1                                                  |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l4r5zi.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0432-stm32l4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics-1.pdf)|
+
 ## Flashing the device
 
 ### Flashing the Board Using OpenOCD
@@ -37,10 +63,13 @@ make BOARD=nucleo-l4r5zi PROGRAMMER=cpy2remed flash
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
+## Accessing RIOT shell
 
-### STDIO
+Default RIOT shell access utilize VCP (Virtual COM Port) via USB interface,
+provided by integrated ST-LINK programmer. ST-LINK is connected to the
+microcontroller LPUART1.
 
-STDIO is available via the ST-Link programmer.
+The default baud rate is 115 200.
 
 Use the `term` target to open a terminal:
 


### PR DESCRIPTION
### Contribution description

Improvements to STM Nucleo l4r5zi documentation:

- Add board image,
- Add MCU table - similar to those, for example for, Nucleo F103RB, F302R8 or F446RE,
- Add information concerning accessing RIOT shell (see Issue #17453) 

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo144-l4r5.html
```

### Issues/PRs references

Issue #17453