### PR TITLE
nanocoap_sock: deprecate nanocoap_get()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -442,6 +442,9 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
 /**
  * @brief   Simple synchronous CoAP (confirmable) get
  *
+ * @deprecated  Will be removed after the 2023.04 release.
+ *              Please use @ref nanocoap_sock_get instead.
+ *
  * @param[in]   remote  remote UDP endpoint
  * @param[in]   path    remote path
  * @param[out]  buf     buffer to write response to


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is an old holdover, all in-tree users have been converted to use `nanocoap_sock_get()` or similar functions.

Should we also drop `nanocoap_request()` in favor of `nanocoap_sock_request()`?

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
