### PR TITLE
dist/tools/pyterm: avoid deprecated .setDaemon

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -285,8 +285,7 @@ class SerCmd(cmd.Cmd):
             self.onecmd(self.precmd(command))
 
         # start serial->console thread
-        receiver_thread = threading.Thread(target=self.reader)
-        receiver_thread.setDaemon(1)
+        receiver_thread = threading.Thread(target=self.reader, daemon=True)
         receiver_thread.start()
 
     def precmd(self, line):


### PR DESCRIPTION
pyterm uses a (now) deprecated method `threading.setDaemon()`
```
        receiver_thread = threading.Thread(target=self.reader)
        receiver_thread.setDaemon(1)
        receiver_thread.start()
```

With Python 3.10 the `setDaemon` method is deprecated. You get a warning each time `pyterm` is used.
To avoid the warning we should set the property `daemon` instead.
```
        receiver_thread.daemon = True
```
I've checked this syntax with 3.6 and it is supported at least since that version.