### PR TITLE
test-on-iotlab: several fixes to make it runnable again [backport 2022.10]

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install iotlabcli pexpect riotctrl[rapidjson] junit-xml
+          pip install iotlabcli pexpect riotctrl[rapidjson] junit-xml scapy
       - name: Configure credentials
         run: echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
       - name: Setup SSH agent

--- a/tests/gnrc_rpl/Makefile
+++ b/tests/gnrc_rpl/Makefile
@@ -9,9 +9,6 @@ USEMODULE += gnrc_rpl
 USEMODULE += shell
 USEMODULE += shell_cmds_default
 
-# automated test only works on native
-TEST_ON_CI_WHITELIST += native
-
 ifeq (native, $(BOARD))
   USEMODULE += socket_zep
   USEMODULE += socket_zep_hello
@@ -19,6 +16,8 @@ ifeq (native, $(BOARD))
   TERMFLAGS += -z 127.0.0.1:17754 # Murdock has no IPv6 support
 else
   USEMODULE += netdev_default
+  # automated test only works on native
+  TESTS=
 endif
 
 .PHONY: host-tools


### PR DESCRIPTION
# Backport of #18722

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Adds a few fixes, so that some of the tests currently failing in the test-on-iotlab action run again.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I will start a manual run of the action.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
