### PR TITLE
sys/event: add event sources

### DIFF
--- a/sys/include/event/source.h
+++ b/sys/include/event/source.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_event
+ * @brief       Provides functionality to trigger multiple events at once
+ *
+ * @{
+ *
+ * @file
+ * @brief       Event Source API
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ */
+
+#ifndef EVENT_SOURCE_H
+#define EVENT_SOURCE_H
+
+#include "event.h"
+#include "list.h"
+#include "irq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Event source struct
+ */
+typedef struct {
+    list_node_t list;       /**< event source list node */
+} event_source_t;
+
+/**
+ * @brief   Subscriber of an event source
+ */
+typedef struct {
+    list_node_t node;       /**< event subscriber list node  */
+    event_t *event;         /**< pointer to event that should be triggered */
+    event_queue_t *queue;   /**< event queue to be used for the event */
+} event_source_subscriber_t;
+
+/**
+ * @brief   Initialize an event source
+ */
+#define EVENT_SOURCE_INIT  { 0 }
+
+/**
+ * @brief   Initialize an event source subscriber
+ *
+ * @param[in]   e       The event to trigger
+ * @param[in]   q       The event queue to use for the event
+ */
+#define EVENT_SOURCE_SUBSCRIBER_INIT(e, q) { .event = (event_t *)e, .queue = q }
+
+/**
+ * @brief   Attach an event to an event source
+ *
+ * @param[in]   source  The event list to attach the event to
+ * @param[in]   event   The new event subscription
+ */
+static inline void event_source_attach(event_source_t *source,
+                                       event_source_subscriber_t *event)
+{
+    unsigned state = irq_disable();
+
+    list_add(&source->list, &event->node);
+
+    irq_restore(state);
+}
+
+/**
+ * @brief   Remove a subscription from the event source
+ *
+ * @param[in]   source  The event list to remove the event from
+ * @param[in]   event   The event to remove
+ */
+static inline void event_source_detach(event_source_t *source,
+                                       event_source_subscriber_t *event)
+{
+    unsigned state = irq_disable();
+
+    list_remove(&source->list, &event->node);
+
+    irq_restore(state);
+}
+
+/**
+ * @brief   Trigger all events registered on the event source
+ *
+ * @param[in]   source  The event list to trigger
+ */
+static inline void event_source_trigger(event_source_t *source)
+{
+    unsigned state = irq_disable();
+
+    event_source_subscriber_t *event = container_of(source->list.next,
+                                                    event_source_subscriber_t,
+                                                    node);
+    while (event) {
+        event_post(event->queue, event->event);
+        event = container_of(event->node.next, event_source_subscriber_t, node);
+    }
+
+    irq_restore(state);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* EVENT_SOURCE_H */
+/** @} */

--- a/tests/event_source/Makefile
+++ b/tests/event_source/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += event_callback
+USEMODULE += event_thread
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/event_source/Makefile.ci
+++ b/tests/event_source/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/event_source/main.c
+++ b/tests/event_source/main.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Event Source test application
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "event/callback.h"
+#include "event/source.h"
+#include "event/thread.h"
+
+static void _event_cb(void *ctx)
+{
+    puts(ctx);
+}
+
+int main(void)
+{
+    event_source_t source = EVENT_SOURCE_INIT;
+    event_callback_t a, b, c;
+
+    event_source_subscriber_t ba = EVENT_SOURCE_SUBSCRIBER_INIT(&a, EVENT_PRIO_MEDIUM);
+    event_source_subscriber_t bb = EVENT_SOURCE_SUBSCRIBER_INIT(&b, EVENT_PRIO_MEDIUM);
+    event_source_subscriber_t bc = EVENT_SOURCE_SUBSCRIBER_INIT(&c, EVENT_PRIO_MEDIUM);
+
+    event_callback_init(&a, _event_cb, "event A");
+    event_callback_init(&b, _event_cb, "event B");
+    event_callback_init(&c, _event_cb, "event C");
+
+    puts("empty event source");
+    event_source_trigger(&source);
+
+    event_source_attach(&source, &ba);
+    event_source_attach(&source, &bb);
+    event_source_attach(&source, &bc);
+
+    puts("occupied event source");
+    event_source_trigger(&source);
+
+    return 0;
+}

--- a/tests/event_source/tests/01-run.py
+++ b/tests/event_source/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("empty event source")
+    child.expect_exact("occupied event source")
+    child.expect_exact("event C")
+    child.expect_exact("event B")
+    child.expect_exact("event A")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The idea is similar to the message bus, but instead of registering threads to which we send messages, instead we have a list of event handlers that can all be triggered at once.

The advantage is of course that as opposed to messages, events can't be lost.


### Testing procedure

A very simple test application has been added to `tests/event_bus`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
