### PR TITLE
sys/shell: fix deprecated shell_command in examples and tests

### DIFF
--- a/examples/sniffer/Makefile
+++ b/examples/sniffer/Makefile
@@ -13,7 +13,7 @@ USEMODULE += gnrc
 USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += shell
-USEMODULE += shell_commands
+USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += ztimer64_usec
 

--- a/tests/gcoap_fileserver/Makefile
+++ b/tests/gcoap_fileserver/Makefile
@@ -7,7 +7,7 @@ USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_rpl
 
 USEMODULE += shell
-USEMODULE += shell_commands
+USEMODULE += shell_cmds_default
 
 USEMODULE += gcoap_fileserver
 USEMODULE += gcoap_fileserver_put
@@ -18,7 +18,8 @@ USEMODULE += constfs
 USEMODULE += vfs_default
 USEMODULE += vfs_auto_format
 
-USEMODULE += md5sum
+USEMODULE += hashes
+USEMODULE += shell_cmd_md5sum
 
 # automated test only works on native
 TEST_ON_CI_WHITELIST += native

--- a/tests/nimble_esp_wifi_coexist/Makefile
+++ b/tests/nimble_esp_wifi_coexist/Makefile
@@ -37,10 +37,10 @@ USEMODULE += gnrc_rpl
 USEMODULE += auto_init_gnrc_rpl
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
-USEMODULE += gnrc_udp_cmd
+USEMODULE += shell_cmd_gnrc_udp
 # Add also the shell, some shell commands
 USEMODULE += shell
-USEMODULE += shell_commands
+USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6


### PR DESCRIPTION
### Contribution description

PR #18355 adds submodules for dedicated commands. However, there are few examples and tests, which still used deprecated modules:

- examples/sniffer
- tests/gcoap_fileserver
- tests/nimble_esp_wifi_coexist

This PR changes configuration to use new submodules for dedicated commands.

### Testing procedure

Without this PR during compilation makefile prints some warnings, respectively for listed programs:
```
Deprecated modules are in use: shell_commands
Deprecated modules are in use: md5sum shell_commands
Deprecated modules are in use: gnrc_udp_cmd shell_commands
```
With this  PR this warnings are not presented. I tested first two programs with `native`  board, and PR works. The last one uses `xtensa-esp32-elf-gcc` - tests are needed.

### Issues/PRs references

PR #18355