### PR TITLE
tests/thread_msg_bus: enhance test with non-bus message

### DIFF
--- a/tests/thread_msg_bus/tests/01-run.py
+++ b/tests/thread_msg_bus/tests/01-run.py
@@ -12,12 +12,21 @@ def testfunc(child):
 
     child.expect_exact('Posted event 22 to 0 threads')
 
-    child.expect_exact('T1 recv: Hello Threads! (type=23)')
-    child.expect_exact('T3 recv: Hello Threads! (type=23)')
+    child.expect_exact('T1 recv: Hello Threads! (type=23) from bus')
+    child.expect_exact('T3 recv: Hello Threads! (type=23) from bus')
     child.expect_exact('Posted event 23 to 2 threads')
 
-    child.expect_exact('T2 recv: Hello Threads! (type=24)')
-    child.expect_exact('Posted event 24 to 1 threads')
+    child.expect_exact('T1 recv: Hello Threads! (type=24) from bus')
+    child.expect_exact('T2 recv: Hello Threads! (type=24) from bus')
+    child.expect_exact('Posted event 24 to 2 threads')
+
+    child.expect_exact('Post message to thread 1')
+    child.expect_exact('T1 recv: Hello Thread 1 (type=4919)')
+
+    child.expect_exact('Post shutdown request to all threads')
+    child.expect_exact('T1 recv: shutdown request (type=0) from bus')
+    child.expect_exact('T2 recv: shutdown request (type=0) from bus')
+    child.expect_exact('T3 recv: shutdown request (type=0) from bus')
 
     child.expect_exact('SUCCESS')
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I got a bit confused if mixing bus messages with non-bus messages works, but that is indeed already covered…

So let's extend the test so this is also exercised / demonstrated. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
