### PR TITLE
cpu/efm32: preparing introduction of Gecko Series 2 

### DIFF
--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -107,13 +107,14 @@ static void clk_init(void)
 #endif
 
     /* initialize LFXO with board-specific parameters before switching */
-    if (CLOCK_LFA == cmuSelect_LFXO || CLOCK_LFB == cmuSelect_LFXO ||
 #if defined(_SILICON_LABS_32B_SERIES_1)
-        CLOCK_LFE == cmuSelect_LFXO)
+    if (CLOCK_LFA == cmuSelect_LFXO ||
+        CLOCK_LFB == cmuSelect_LFXO ||
+        CLOCK_LFE == cmuSelect_LFXO) {
 #else
-        false)
+    if (CLOCK_LFA == cmuSelect_LFXO ||
+        CLOCK_LFB == cmuSelect_LFXO) {
 #endif
-    {
         CMU_LFXOInit_TypeDef init_lfxo = CMU_LFXOINIT;
 
         CMU_LFXOInit(&init_lfxo);
@@ -131,13 +132,14 @@ static void clk_init(void)
 #endif
 
     /* disable the LFRCO if external crystal is used */
-    if (CLOCK_LFA == cmuSelect_LFXO && CLOCK_LFB == cmuSelect_LFXO &&
 #if defined(_SILICON_LABS_32B_SERIES_1)
-        CLOCK_LFE == cmuSelect_LFXO)
+    if (CLOCK_LFA == cmuSelect_LFXO &&
+        CLOCK_LFB == cmuSelect_LFXO &&
+        CLOCK_LFE == cmuSelect_LFXO) {
 #else
-        true)
+    if (CLOCK_LFA == cmuSelect_LFXO &&
+        CLOCK_LFB == cmuSelect_LFXO) {
 #endif
-    {
         CMU_OscillatorEnable(cmuOsc_LFRCO, false, false);
     }
 }

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -26,6 +26,7 @@
 
 #include "em_chip.h"
 #include "em_cmu.h"
+#include "em_dbg.h"
 #include "em_emu.h"
 
 /**
@@ -159,6 +160,11 @@ static void pm_init(void)
     EMU_EM4Init_TypeDef init_em4 = EMU_EM4INIT;
 
     EMU_EM4Init(&init_em4);
+#endif
+
+#if defined(DEVELHELP) && defined(EMU_CTRL_EM2DBGEN)
+    /* make sure to keep the debug unit active in develhelp */
+    DBG_EM2DebugEnable(true);
 #endif
 }
 

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -41,6 +41,7 @@
 extern "C" {
 #endif
 
+#if (defined(ADC_COUNT) && (ADC_COUNT > 0)) || defined(DOXYGEN)
 /**
  * @brief   Internal macro for combining ADC resolution (x) with number of
  *          shifts (y).
@@ -90,6 +91,7 @@ typedef struct {
     ADC_Ref_TypeDef reference;        /**< channel voltage reference */
     ADC_AcqTime_TypeDef acq_time;     /**< channel acquisition time */
 } adc_chan_conf_t;
+#endif
 
 /**
  * @brief   Length of CPU ID in octets.

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -456,6 +456,15 @@ typedef struct {
 #define PM_NUM_MODES    (3U)
 
 /**
+ * @name   Available power modes
+ * @{
+ */
+#define EFM32_PM_MODE_EM3  (0U)  /**< CPU sleeps, peripherals in EM3 domain are active */
+#define EFM32_PM_MODE_EM2  (1U)  /**< CPU sleeps, peripherals in EM2 + EM3 domain are active */
+#define EFM32_PM_MODE_EM1  (2U)  /**< CPU sleeps, all peripherals are active */
+/** @} */
+
+/**
  * @name    Watchdog timer (WDT) configuration
  * @{
  */

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -22,8 +22,10 @@
  */
 
 #include "cpu.h"
+#include "board.h"
 
 #include "periph/gpio.h"
+#include "pm_layered.h"
 
 #include "em_gpio.h"
 
@@ -115,7 +117,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* just in case, disable the interrupt for this pin */
-    GPIO_IntDisable(_pin_mask(pin));
+    gpio_irq_disable(pin);
 
     /* store interrupt callback */
     isr_ctx[_pin_num(pin)].cb = cb;
@@ -123,7 +125,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 
     /* enable interrupts */
     GPIO_ExtIntConfig(_port_num(pin), _pin_num(pin), _pin_num(pin),
-                      flank & GPIO_RISING, flank & GPIO_FALLING, true);
+                      flank & GPIO_RISING, flank & GPIO_FALLING, false);
 
     NVIC_ClearPendingIRQ(GPIO_EVEN_IRQn);
     NVIC_ClearPendingIRQ(GPIO_ODD_IRQn);
@@ -131,17 +133,38 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     NVIC_EnableIRQ(GPIO_EVEN_IRQn);
     NVIC_EnableIRQ(GPIO_ODD_IRQn);
 
+    /* enable IRQ */
+    gpio_irq_enable(pin);
+
     return 0;
 }
 
 void gpio_irq_enable(gpio_t pin)
 {
-    GPIO_IntEnable(_pin_mask(pin));
+    unsigned pin_extirq = _pin_mask(pin);
+
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(GPIO_INT_PM_BLOCKER)
+    /* block pm mode if the irq is about to be enabled */
+    if (!(GPIO_EnabledIntGet() & pin_extirq)) {
+        pm_block(GPIO_INT_PM_BLOCKER);
+    }
+#endif
+
+    GPIO_IntEnable(pin_extirq);
 }
 
 void gpio_irq_disable(gpio_t pin)
 {
-    GPIO_IntDisable(_pin_mask(pin));
+    unsigned pin_extirq = _pin_mask(pin);
+
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(GPIO_INT_PM_BLOCKER)
+    /* unblock pm mode if the irq is about to be disabled */
+    if (GPIO_EnabledIntGet() & pin_extirq) {
+        pm_unblock(GPIO_INT_PM_BLOCKER);
+    }
+#endif
+
+    GPIO_IntDisable(pin_extirq);
 }
 
 /**

--- a/cpu/efm32/periph/pm.c
+++ b/cpu/efm32/periph/pm.c
@@ -25,14 +25,15 @@
 void pm_set(unsigned mode)
 {
     switch (mode) {
-        case 0:
+        case EFM32_PM_MODE_EM3:
             /* after exiting EM3, clocks are restored */
             EMU_EnterEM3(true);
             break;
-        case 1:
+        case EFM32_PM_MODE_EM2:
             /* after exiting EM2, clocks are restored */
             EMU_EnterEM2(true);
             break;
+        case EFM32_PM_MODE_EM1:
         default:
             /* wait for next event or interrupt */
             EMU_EnterEM1();


### PR DESCRIPTION
### Contribution description

This is split-off #18760 and provides commits that are useful for #18756.

### Testing procedure

1. Compile testing.
2. `tests/periph_gpio` should be able to raise IRQs even with `PM_BLOCKER_INITIAL` set to `{ 0, 0, 0 }`. Make sure to configure `GPIO_INT_PM_BLOCKER` to the lowest power mode that is able to register IRQs.

### Issues/PRs references

#18760 
#18756 