### PR TITLE
examples/gcoap/server: allow ECC when using dtls

### DIFF
--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -42,6 +42,21 @@
 /* Example credential tag for credman. Tag together with the credential type needs to be unique. */
 #define GCOAP_DTLS_CREDENTIAL_TAG 10
 
+#ifdef CONFIG_DTLS_ECC
+static const credman_credential_t credential = {
+    .type = CREDMAN_TYPE_ECDSA,
+    .tag = GCOAP_DTLS_CREDENTIAL_TAG,
+    .params = {
+        .ecdsa = {
+            .private_key = ecdsa_priv_key,
+            .public_key = {
+                .x = ecdsa_pub_key_x,
+                .y = ecdsa_pub_key_y,
+            },
+        },
+    },
+};
+#else /* use PSK if not configured for ECC */
 static const uint8_t psk_id_0[] = PSK_DEFAULT_IDENTITY;
 static const uint8_t psk_key_0[] = PSK_DEFAULT_KEY;
 static const credman_credential_t credential = {
@@ -54,7 +69,8 @@ static const credman_credential_t credential = {
         }
     },
 };
-#endif
+#endif /* CONFIG_DTLS_ECC */
+#endif /* IS_USED(MODULE_GCOAP_DTLS) */
 
 static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context);

--- a/examples/gcoap_dtls/Makefile
+++ b/examples/gcoap_dtls/Makefile
@@ -56,6 +56,8 @@ ifeq (1,$(GCOAP_ENABLE_DTLS))
   USEMODULE += gcoap_dtls
   # tinydtls needs crypto secure PRNG
   USEMODULE += prng_sha1prng
+  ## Uncomment to use TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 instead of PSK
+  # CFLAGS += -DCONFIG_DTLS_ECC
 endif
 
 # Instead of simulating an Ethernet connection, we can also simulate


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds credential declaration of ECC (ECDSA) to the gcoap example when compiled with DTLS and ECC.
The credentials are in fact already provided in the [respective header file](https://github.com/RIOT-OS/RIOT/blob/master/examples/gcoap_dtls/tinydtls_keys.h) but were not used yet. 
With master the example compiles fine with `CONFIG_DTLS_ECC` but coap requests fail with a timeout. With this PR it works as expected, which is in line with other dtls examples that [explicitly allow this config](https://github.com/RIOT-OS/RIOT/tree/master/examples/dtls-sock#cipher-suite).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

To reproduce the issue run two RIOT instances. In the first term:
```
sudo dist/tools/tapsetup/tapsetup
CFLAGS+=-DCONFIG_DTLS_ECC BUILD_IN_DOCKER=1 BOARD=native PORT=tap0 make -C examples/gcoap_dtls all term
> ifconfig
*copy <IP1>*
```

second term:
```
CFLAGS+=-DCONFIG_DTLS_ECC BUILD_IN_DOCKER=1 BOARD=native PORT=tap1 make -C examples/gcoap_dtls all term
> coap get <IP1> 5684 /.well-known/core
gcoap_cli: sending msg ID 7605, 23 bytes
gcoap: timeout for msg ID 7605
```

With this PR it will work just as if the default PSK config was used:
> coap get fe80::e43a:a5ff:feba:b8cc 5684 /.well-known/core
coap get fe80::e43a:a5ff:feba:b8cc 5684 /.well-known/core
gcoap_cli: sending msg ID 49600, 23 bytes
> gcoap: response Success, code 2.05, 46 bytes
</cli/stats>;ct=0;rt="count";obs,</riot/board>

(To test this on an MCU you probably need to tweak `CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_MSEC` and `GCOAP_STACK_SIZE`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
