### PR TITLE
pkg/esp32_sdk: bump to v4.4.2 

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -72,6 +72,7 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/platform_port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/heap/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/log/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/newlib/platform_include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/nvs_flash/private_include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/include
 

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -25,11 +25,13 @@ ESP32_SDK_SRC = \
   components/esp_system/port/soc/$(CPU_FAM)/cache_err_int.c \
   components/esp_system/port/soc/$(CPU_FAM)/clk.c \
   components/esp_system/port/soc/$(CPU_FAM)/reset_reason.c \
+  components/esp_system/port/soc/$(CPU_FAM)/system_internal.c \
   components/esp_system/system_time.c \
   components/esp_timer/src/esp_timer.c \
   components/esp_timer/src/system_time.c \
   components/hal/cpu_hal.c \
   components/hal/mpu_hal.c \
+  components/hal/soc_hal.c \
   components/hal/timer_hal.c \
   components/hal/uart_hal.c \
   components/hal/wdt_hal_iram.c \

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -145,6 +145,11 @@ void vTaskSuspend(TaskHandle_t xTaskToSuspend)
     }
 }
 
+void vTaskSuspendAll(void)
+{
+    /* TODO */
+}
+
 void vTaskResume(TaskHandle_t xTaskToResume)
 {
     extern volatile thread_t *sched_active_thread;

--- a/pkg/esp32_sdk/Makefile
+++ b/pkg/esp32_sdk/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk
 PKG_URL=https://github.com/espressif/esp-idf
-# v4.4.1
-PKG_VERSION=1329b19fe494500aeb79d19b27cfd99b40c37aec
+# v4.4.2
+PKG_VERSION=1b16ef6cfc2479a08136782f9dc57effefa86f66
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/esp32_sdk/patches/0001-esp_hw_support-rename-rtc_init.patch
+++ b/pkg/esp32_sdk/patches/0001-esp_hw_support-rename-rtc_init.patch
@@ -1,7 +1,7 @@
-From f3c3f97504da7d0bf25fa1e59d0350d130ca6eec Mon Sep 17 00:00:00 2001
+From e9c07c132c516a6eba1ade311f4fbcb2bdf632cd Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
-Date: Fri, 3 Jun 2022 00:02:07 +0200
-Subject: [PATCH] esp_hw_support: rename rtc_init
+Date: Tue, 18 Oct 2022 19:12:51 +0200
+Subject: [PATCH 1/27] esp_hw_support: rename rtc_init
 
 Rename `rtc_init` to `rtc_init_module` due to name conflicts with RIOT `periph/rtc` module.
 ---
@@ -36,7 +36,7 @@ index e66a493b..7f1d1915 100644
      CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_PVTMON_PU | RTC_CNTL_TXRF_I2C_PU |
              RTC_CNTL_RFRX_PBUS_PU | RTC_CNTL_CKGEN_I2C_PU | RTC_CNTL_PLL_I2C_PU);
 diff --git a/components/esp_hw_support/port/esp32c3/rtc_init.c b/components/esp_hw_support/port/esp32c3/rtc_init.c
-index 388399f1..f6fdc692 100644
+index d0ee4788..332cd901 100644
 --- a/components/esp_hw_support/port/esp32c3/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32c3/rtc_init.c
 @@ -25,7 +25,7 @@ static void set_ocode_by_efuse(int calib_version);
@@ -62,7 +62,7 @@ index 7b684d3d..ff0b5f49 100644
      CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_PVTMON_PU);
      REG_SET_FIELD(RTC_CNTL_TIMER1_REG, RTC_CNTL_PLL_BUF_WAIT, cfg.pll_wait);
 diff --git a/components/esp_hw_support/port/esp32s2/rtc_init.c b/components/esp_hw_support/port/esp32s2/rtc_init.c
-index 7932a89a..8910f7a2 100644
+index 50c6e7e5..43c3ceba 100644
 --- a/components/esp_hw_support/port/esp32s2/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32s2/rtc_init.c
 @@ -24,7 +24,7 @@ __attribute__((unused)) static const char *TAG = "rtc_init";
@@ -75,7 +75,7 @@ index 7932a89a..8910f7a2 100644
      CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_PVTMON_PU);
      REG_SET_FIELD(RTC_CNTL_TIMER1_REG, RTC_CNTL_PLL_BUF_WAIT, cfg.pll_wait);
 diff --git a/components/esp_hw_support/port/esp32s3/rtc_init.c b/components/esp_hw_support/port/esp32s3/rtc_init.c
-index ed44fd7b..f0b7f5c8 100644
+index d878d2a9..04c07096 100644
 --- a/components/esp_hw_support/port/esp32s3/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32s3/rtc_init.c
 @@ -31,7 +31,7 @@ static const char *TAG = "rtcinit";
@@ -101,11 +101,11 @@ index 3b3f2b73..c891224a 100644
  #if (CONFIG_ESP32_COMPATIBLE_PRE_V2_1_BOOTLOADERS || CONFIG_ESP32_APP_INIT_CLK)
      /* Check the bootloader set the XTAL frequency.
 diff --git a/components/esp_system/port/soc/esp32c3/clk.c b/components/esp_system/port/soc/esp32c3/clk.c
-index d2181b58..36ab8a40 100644
+index 5f867751..868c04db 100644
 --- a/components/esp_system/port/soc/esp32c3/clk.c
 +++ b/components/esp_system/port/soc/esp32c3/clk.c
-@@ -72,7 +72,7 @@ static const char *TAG = "clk";
-     if (rst_reas == RESET_REASON_CHIP_POWER_ON) {
+@@ -76,7 +76,7 @@ static const char *TAG = "clk";
+         ) {
          cfg.cali_ocode = 1;
      }
 -    rtc_init(cfg);
@@ -127,12 +127,12 @@ index 7ea2dde1..0061e39b 100644
      assert(rtc_clk_xtal_freq_get() == RTC_XTAL_FREQ_32M);
  
 diff --git a/components/esp_system/port/soc/esp32s2/clk.c b/components/esp_system/port/soc/esp32s2/clk.c
-index 68ad39c1..4fa1aac0 100644
+index f1eb0bee..0c70bd0e 100644
 --- a/components/esp_system/port/soc/esp32s2/clk.c
 +++ b/components/esp_system/port/soc/esp32s2/clk.c
-@@ -72,7 +72,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
-     if (rst_reas == RESET_REASON_CHIP_POWER_ON) {
-         cfg.cali_ocode = 1;
+@@ -78,7 +78,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
+             esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
+         }
      }
 -    rtc_init(cfg);
 +    rtc_init_module(cfg);
@@ -140,7 +140,7 @@ index 68ad39c1..4fa1aac0 100644
      rtc_clk_fast_freq_set(RTC_FAST_FREQ_8M);
  
 diff --git a/components/esp_system/port/soc/esp32s3/clk.c b/components/esp_system/port/soc/esp32s3/clk.c
-index 15610ae9..a5b2ddf3 100644
+index ca2f2828..ebe579ec 100644
 --- a/components/esp_system/port/soc/esp32s3/clk.c
 +++ b/components/esp_system/port/soc/esp32s3/clk.c
 @@ -73,7 +73,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
@@ -153,10 +153,10 @@ index 15610ae9..a5b2ddf3 100644
      assert(rtc_clk_xtal_freq_get() == RTC_XTAL_FREQ_40M);
  
 diff --git a/components/soc/esp32/include/soc/rtc.h b/components/soc/esp32/include/soc/rtc.h
-index bbbf3c75..3b983466 100644
+index b336cb2a..5b3cd8c9 100644
 --- a/components/soc/esp32/include/soc/rtc.h
 +++ b/components/soc/esp32/include/soc/rtc.h
-@@ -685,7 +685,7 @@ typedef struct rtc_config_s {
+@@ -674,7 +674,7 @@ typedef struct rtc_config_s {
   * Initialize RTC clock and power control related functions
   * @param cfg configuration options as rtc_config_t
   */
@@ -166,10 +166,10 @@ index bbbf3c75..3b983466 100644
  #define RTC_VDDSDIO_TIEH_1_8V 0 //!< TIEH field value for 1.8V VDDSDIO
  #define RTC_VDDSDIO_TIEH_3_3V 1 //!< TIEH field value for 3.3V VDDSDIO
 diff --git a/components/soc/esp32c3/include/soc/rtc.h b/components/soc/esp32c3/include/soc/rtc.h
-index dccd7a07..f4b4aa44 100644
+index 5222da63..7308b669 100644
 --- a/components/soc/esp32c3/include/soc/rtc.h
 +++ b/components/soc/esp32c3/include/soc/rtc.h
-@@ -831,7 +831,7 @@ typedef struct {
+@@ -820,7 +820,7 @@ typedef struct {
   * Initialize RTC clock and power control related functions
   * @param cfg configuration options as rtc_config_t
   */
@@ -179,10 +179,10 @@ index dccd7a07..f4b4aa44 100644
  /**
   * Structure describing vddsdio configuration
 diff --git a/components/soc/esp32h2/include/soc/rtc.h b/components/soc/esp32h2/include/soc/rtc.h
-index 5585986e..7a1dd718 100644
+index 596e1305..c41d4325 100644
 --- a/components/soc/esp32h2/include/soc/rtc.h
 +++ b/components/soc/esp32h2/include/soc/rtc.h
-@@ -925,7 +925,7 @@ typedef struct {
+@@ -913,7 +913,7 @@ typedef struct {
  * Initialize RTC clock and power control related functions
  * @param cfg configuration options as rtc_config_t
  */
@@ -192,10 +192,10 @@ index 5585986e..7a1dd718 100644
  /**
   * Structure describing vddsdio configuration
 diff --git a/components/soc/esp32s2/include/soc/rtc.h b/components/soc/esp32s2/include/soc/rtc.h
-index 11b13fb6..73caf339 100644
+index 12cb8ba1..07d65474 100644
 --- a/components/soc/esp32s2/include/soc/rtc.h
 +++ b/components/soc/esp32s2/include/soc/rtc.h
-@@ -854,7 +854,7 @@ typedef struct {
+@@ -845,7 +845,7 @@ typedef struct {
   * Initialize RTC clock and power control related functions
   * @param cfg configuration options as rtc_config_t
   */
@@ -205,10 +205,10 @@ index 11b13fb6..73caf339 100644
  /**
   * Structure describing vddsdio configuration
 diff --git a/components/soc/esp32s3/include/soc/rtc.h b/components/soc/esp32s3/include/soc/rtc.h
-index aa09874f..eb8bbed6 100644
+index 479e2c20..4b1c7289 100644
 --- a/components/soc/esp32s3/include/soc/rtc.h
 +++ b/components/soc/esp32s3/include/soc/rtc.h
-@@ -849,7 +849,7 @@ typedef struct {
+@@ -842,7 +842,7 @@ typedef struct {
   * Initialize RTC clock and power control related functions
   * @param cfg configuration options as rtc_config_t
   */

--- a/pkg/esp32_sdk/patches/0006-compilation-include-missing-header-files.patch
+++ b/pkg/esp32_sdk/patches/0006-compilation-include-missing-header-files.patch
@@ -1,7 +1,7 @@
-From 0647c9d01c3e433d1b3abaf4774523ac0ef90a3c Mon Sep 17 00:00:00 2001
+From f1703a742dc3c5ee251cd5bae46197d8bbcfb603 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
 Date: Thu, 2 Jun 2022 23:45:01 +0200
-Subject: [PATCH] compilation: include missing header files
+Subject: [PATCH 06/27] compilation: include missing header files
 
 ---
  components/efuse/src/esp_efuse_api.c                 | 1 +
@@ -11,7 +11,7 @@ Subject: [PATCH] compilation: include missing header files
  4 files changed, 4 insertions(+)
 
 diff --git a/components/efuse/src/esp_efuse_api.c b/components/efuse/src/esp_efuse_api.c
-index a89205fc..1b90deaf 100644
+index 968d9543..bb11377d 100644
 --- a/components/efuse/src/esp_efuse_api.c
 +++ b/components/efuse/src/esp_efuse_api.c
 @@ -19,6 +19,7 @@ const static char *TAG = "efuse";
@@ -35,7 +35,7 @@ index 6ce93cc5..a40b821e 100644
  #include "esp_attr.h"
  #include <stdint.h>
 diff --git a/components/esp_hw_support/sleep_modes.c b/components/esp_hw_support/sleep_modes.c
-index f5a6b292..6f9fd2b1 100644
+index 9ef2c72c..a0550389 100644
 --- a/components/esp_hw_support/sleep_modes.c
 +++ b/components/esp_hw_support/sleep_modes.c
 @@ -26,6 +26,7 @@
@@ -47,16 +47,16 @@ index f5a6b292..6f9fd2b1 100644
  #include "soc/soc_caps.h"
  #include "regi2c_ctrl.h"
 diff --git a/components/nvs_flash/src/nvs_encrypted_partition.cpp b/components/nvs_flash/src/nvs_encrypted_partition.cpp
-index 26e8a331..4de077b9 100644
+index 653fbefa..d614fa61 100644
 --- a/components/nvs_flash/src/nvs_encrypted_partition.cpp
 +++ b/components/nvs_flash/src/nvs_encrypted_partition.cpp
-@@ -13,6 +13,7 @@
- // limitations under the License.
- 
+@@ -7,6 +7,7 @@
  #include <cstring>
-+#include "nvs.hpp"
  #include "nvs_encrypted_partition.hpp"
  #include "nvs_types.hpp"
++#include "nvs.hpp"
+ 
+ namespace nvs {
  
 -- 
 2.34.1

--- a/pkg/esp32_sdk/patches/0015-driver-i2c-remove-the-include-gpio.h-in-i2c.h-header.patch
+++ b/pkg/esp32_sdk/patches/0015-driver-i2c-remove-the-include-gpio.h-in-i2c.h-header.patch
@@ -1,7 +1,7 @@
-From 25509b8b61b329d3c4ae5b3874704dae55d62ccd Mon Sep 17 00:00:00 2001
-From: Gunar Schorcht <gunar@schorcht.net>
-Date: Tue, 8 Mar 2022 11:34:13 +0100
-Subject: [PATCH 15/17] driver/i2c: remove the include gpio.h in i2c.h header
+From 30efe1c3049b34bba70d6496d3d5f6d0489433ae Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Tue, 18 Oct 2022 19:17:28 +0200
+Subject: [PATCH 15/27] driver/i2c: remove the include gpio.h in i2c.h header
 
 Including driver/i2c.h by RIOT code leads to type conflicts with RIOT gpio_t type.
 ---
@@ -10,19 +10,19 @@ Including driver/i2c.h by RIOT code leads to type conflicts with RIOT gpio_t typ
  2 files changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/driver/i2c.c b/components/driver/i2c.c
-index 438d1efc12d..be26fdeffc3 100644
+index d7bf4b95..072d039f 100644
 --- a/components/driver/i2c.c
 +++ b/components/driver/i2c.c
-@@ -21,6 +21,7 @@
- #include "hal/i2c_hal.h"
- #include "hal/gpio_hal.h"
- #include "soc/i2c_periph.h"
-+#include "driver/gpio.h"
- #include "driver/i2c.h"
- #include "driver/periph_ctrl.h"
+@@ -26,6 +26,7 @@
  #include "esp_rom_gpio.h"
+ #include "esp_rom_sys.h"
+ #include <sys/param.h>
++#include "driver/gpio.h"
+ 
+ static const char *I2C_TAG = "i2c";
+ 
 diff --git a/components/driver/include/driver/i2c.h b/components/driver/include/driver/i2c.h
-index 22dcc8ab241..e668bba2acd 100644
+index 57d9091e..c55e5f4f 100644
 --- a/components/driver/include/driver/i2c.h
 +++ b/components/driver/include/driver/i2c.h
 @@ -19,7 +19,6 @@ extern "C" {
@@ -34,5 +34,5 @@ index 22dcc8ab241..e668bba2acd 100644
  #include "hal/i2c_types.h"
  
 -- 
-2.17.1
+2.34.1
 

--- a/pkg/esp32_sdk/patches/0016-driver-i2c.h-expose-i2c_hw_fsm_reset-to-RIOT-code.patch
+++ b/pkg/esp32_sdk/patches/0016-driver-i2c.h-expose-i2c_hw_fsm_reset-to-RIOT-code.patch
@@ -1,34 +1,34 @@
-From cd8688a55e62094cb6605ee8594985f862d57a95 Mon Sep 17 00:00:00 2001
-From: Gunar Schorcht <gunar@schorcht.net>
-Date: Tue, 8 Mar 2022 11:35:11 +0100
-Subject: [PATCH 16/17] driver/i2c.h: expose i2c_hw_fsm_reset to RIOT code
+From 716cd97fba672809fd007d70b5f43b5dc4eda039 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Tue, 18 Oct 2022 19:20:41 +0200
+Subject: [PATCH 16/27] driver/i2c.h: expose i2c_hw_fsm_reset to RIOT code
 
 ---
  components/driver/i2c.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/components/driver/i2c.c b/components/driver/i2c.c
-index be26fdeffc3..cff410b9d1b 100644
+index d7bf4b95..946d1e12 100644
 --- a/components/driver/i2c.c
 +++ b/components/driver/i2c.c
-@@ -209,7 +209,7 @@ static i2c_clk_alloc_t i2c_clk_alloc[I2C_SCLK_MAX] = {
+@@ -208,7 +208,7 @@ static i2c_clk_alloc_t i2c_clk_alloc[I2C_SCLK_MAX] = {
  static i2c_obj_t *p_i2c_obj[I2C_NUM_MAX] = {0};
  static void i2c_isr_handler_default(void *arg);
  static void IRAM_ATTR i2c_master_cmd_begin_static(i2c_port_t i2c_num);
--static esp_err_t IRAM_ATTR i2c_hw_fsm_reset(i2c_port_t i2c_num);
-+esp_err_t IRAM_ATTR i2c_hw_fsm_reset(i2c_port_t i2c_num);
+-static esp_err_t i2c_hw_fsm_reset(i2c_port_t i2c_num);
++esp_err_t i2c_hw_fsm_reset(i2c_port_t i2c_num);
  
  static void i2c_hw_disable(i2c_port_t i2c_num)
  {
-@@ -595,7 +595,7 @@ static esp_err_t i2c_master_clear_bus(i2c_port_t i2c_num)
+@@ -605,7 +605,7 @@ static esp_err_t i2c_master_clear_bus(i2c_port_t i2c_num)
   * If we remove the power supply for the slave during I2C is reading, or directly connect SDA or SCL to ground,
   * this would cause the I2C FSM get stuck in wrong state, all we can do is to reset the I2C hardware in this case.
   **/
 -static esp_err_t i2c_hw_fsm_reset(i2c_port_t i2c_num)
 +esp_err_t i2c_hw_fsm_reset(i2c_port_t i2c_num)
  {
- #if !SOC_I2C_SUPPORT_HW_FSM_RST
-     int scl_low_period, scl_high_period;
+ // A workaround for avoiding cause timeout issue when using
+ // hardware reset.
 -- 
-2.17.1
+2.34.1
 

--- a/pkg/esp32_sdk_lib_bt_esp32/Makefile
+++ b/pkg/esp32_sdk_lib_bt_esp32/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk_lib_bt_esp32
 PKG_URL=https://github.com/espressif/esp32-bt-lib
-# This is a version in the v4.4.1 release branch
-PKG_VERSION=b877f7e1fc98dccfcf4dbf31f215c5cb44ec3f0d
+# This is a version in the v4.4.2 release branch
+PKG_VERSION=9bc3e81aa1b556c23d4ef6933042bfd24b86d1ab
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/esp32_sdk_lib_bt_esp32c3/Makefile
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk_lib_bt_esp32c3
 PKG_URL=https://github.com/espressif/esp32c3-bt-lib
-# This is a version in the v4.4.1 release branch
-PKG_VERSION=98dcc9591365b5ac486a9f0b474c36bf8c4ca97b
+# This is a version in the v4.4.2 release branch
+PKG_VERSION=d1c2082e5633a89c6fd6051c7761c1e697cb7a2e
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/esp32_sdk_lib_phy/Makefile
+++ b/pkg/esp32_sdk_lib_phy/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk_lib_phy
 PKG_URL=https://github.com/espressif/esp-phy-lib
-# This is a version in the v4.4.1 release branch
-PKG_VERSION=dcbe6085e0215e2ea6a2e43b1106bdb15807f398
+# This is a version in the v4.4.2 release branch
+PKG_VERSION=ff0d771b8e33e320e11634567ee53b9cd78e6be1
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/esp32_sdk_lib_wifi/Makefile
+++ b/pkg/esp32_sdk_lib_wifi/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk_lib_wifi
 PKG_URL=https://github.com/espressif/esp32-wifi-lib
-# This is a version in the v4.4.1 release branch
-PKG_VERSION=5a0d2aee49633b1a0c0374c2a01ed8c2a10e2fe4
+# This is a version in the v4.4.2 release branch
+PKG_VERSION=85d6197b8f4271f51a409c0cd7e293ae2694145c
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

[v4.4.2](https://github.com/espressif/esp-idf/releases/tag/v4.4.2) is a bugfix release, it should work with only minor changes.

The restart procedure now involves `esp_restart_noos()` and `vTaskSuspendAll()`, so add `system_internal.c ` for the former and a dummy implementation for the latter.


### Testing procedure

Only tested `examples/gnrc_border_router` on `esp32-wroom-32` so far.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
