### PR TITLE
sys/tiny_strerror: add tiny_strerror_minimal

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -477,6 +477,7 @@ PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
 PSEUDOMODULES += tiny_strerror_as_strerror
+PSEUDOMODULES += tiny_strerror_minimal
 PSEUDOMODULES += vdd_lc_filter_%
 ## @defgroup pseudomodule_vfs_auto_format vfs_auto_format
 ## @brief Format mount points at startup unless they can be mounted

--- a/sys/include/tiny_strerror.h
+++ b/sys/include/tiny_strerror.h
@@ -24,6 +24,13 @@
  * @note        Using module `tiny_strerror_as_strerror` will replace all calls
  *              to `strerror()` by calls to `tiny_strerror()`, which may safe
  *              a bit of ROM.
+ *
+ * @note        Using module `tiny_strerror_minimal` will just print the error
+ *              code value.
+ *              This will save ~1k of ROM, but won't provide much more information.
+ *
+ * @warning     The module `tiny_strerror_minimal` is not thread-safe.
+ *
  * @{
  *
  *

--- a/sys/tiny_strerror/tiny_strerror.c
+++ b/sys/tiny_strerror/tiny_strerror.c
@@ -18,6 +18,7 @@
  */
 
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "kernel_defines.h"
@@ -111,6 +112,12 @@ const char *tiny_strerror(int errnum)
      */
     const char *retval = "-unknown";
     unsigned offset = 1;
+
+    if (IS_USED(MODULE_TINY_STRERROR_MINIMAL)) {
+        static char buf[4];
+        snprintf(buf, sizeof(buf), "%d", errnum);
+        return buf;
+    }
 
     if (errnum <= 0) {
         offset = 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`tiny_strerror` is still quite heavy (1200 bytes on Cortex-M4), so add a more minimal version that only prints the error code.

This allows to use the same code and have pretty error messages if ROM is ample, but still have the option to strip it down easily.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
