### PR TITLE
tests/congure_abe: reset node before starting terminal

### DIFF
--- a/tests/congure_abe/tests/01-run.py
+++ b/tests/congure_abe/tests/01-run.py
@@ -24,10 +24,10 @@ class TestCongUREBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
+        cls.ctrl.reset()
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout
-        cls.ctrl.reset()
         cls.shell = CongureTest(cls.ctrl)
         cls.json_parser = RapidJSONShellInteractionParser()
         cls.json_parser.set_parser_args(


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fixes synchronization issues on stdio_uart. Copied from the setup function in tests/congure_reno/tests/01-run.py.

See https://github.com/RIOT-OS/RIOT/pull/15968#issuecomment-1283456600 ff.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`CI: run tests` should pass on both Murdocks.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up fix on https://github.com/RIOT-OS/RIOT/pull/15968
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
