### PR TITLE
build-system: add capability to execute scripts with custom executor

### DIFF
--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -17,10 +17,14 @@ TESTS ?= $(foreach file,$(wildcard $(APPDIR)/tests/*[^~]),\
 # this. In order to make local builds behave similar, add the term deps here.
 # See #11762.
 TEST_DEPS += $(TERMDEPS)
+# these variables can be used to use e.g. pytest to execute the tests instead of
+# executing them as a script
+TEST_EXECUTOR ?=
+TEST_EXECUTOR_FLAGS ?=
 
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
-		$$t || exit 1; \
+		$(TEST_EXECUTOR) $(TEST_EXECUTOR_FLAGS) $$t || exit 1; \
 	done
 
 test/available:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
I sometimes find it more convenient to use `pytest` to execute and debug my more complex tests (it shows output in order of test execution, in color, you can filter tests and has flags to step in with `pdb`, ...). However, for that I either need to define all the RIOT environment in my shell, or touch `makefile/tests/tests.mk` to execute the test with `pytest`. Since I do not want to enforce `pytest` on everyone and the CI, this amends that file with two optional macros `TEST_EXECUTOR` and `TEST_EXECUTOR_FLAGS`, so the executor for the tests can be selected from the environment.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Sadly, not all tests are able to be run this way: when the `test...` function has an argument, `pytest` thinks that argument is a fixture and gets confused (another reason why I made `pytest` optional). However, all tests that are based on unittest classes (so either `unittests.TestCase` or `testrunner.unittest.PexpectTestCase` (e.g. `tests/turo` can now be executed this way):

```console
$ TEST_EXECUTOR=pytest TEST_EXECUTOR_FLAGS="-v -s" QUIETER=1 make -C tests/turo/ --no-print-directory -j flash test
Building application "tests_turo" for "native" with MCU "native".

/usr/bin/ld: warning: /home/mlenders/Repositories/RIOT-OS/RIOT/tests/turo/bin/native/tests_turo.elf has a LOAD segment with RWX permissions
   text	   data	    bss	    dec	    hex	filename
  39098	    704	  47800	  87602	  15632	/home/mlenders/Repositories/RIOT-OS/RIOT/tests/turo/bin/native/tests_turo.elf
============================= test session starts ==============================
platform linux -- Python 3.10.8, pytest-7.1.3, pluggy-1.0.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/mlenders/Repositories/RIOT-OS/RIOT/tests/turo
plugins: cov-4.0.0, anyio-3.6.1
collected 13 items                                                             

tests/01-run.py::TestTuro::test_test_multi_element_dict PASSED
tests/01-run.py::TestTuro::test_test_netif PASSED
tests/01-run.py::TestTuro::test_turo_simple_array_s32 PASSED
tests/01-run.py::TestTuro::test_turo_simple_array_s32_fail PASSED
tests/01-run.py::TestTuro::test_turo_simple_array_u8 PASSED
tests/01-run.py::TestTuro::test_turo_simple_array_u8_fail PASSED
tests/01-run.py::TestTuro::test_turo_simple_dict_s32 PASSED
tests/01-run.py::TestTuro::test_turo_simple_dict_s32_fail PASSED
tests/01-run.py::TestTuro::test_turo_simple_dict_string PASSED
tests/01-run.py::TestTuro::test_turo_simple_dict_string_fail PASSED
tests/01-run.py::TestTuro::test_turo_simple_exit_status PASSED
tests/01-run.py::TestTuro::test_turo_simple_s32 PASSED
tests/01-run.py::TestTuro::test_turo_simple_s32_fail PASSED

============================== 13 passed in 4.52s ==============================
```

Of course, the normal approach should also still work:

```console
$ QUIETER=1 make -C tests/turo/ --no-print-directory -j flash test
Building application "tests_turo" for "native" with MCU "native".

/usr/bin/ld: warning: /home/mlenders/Repositories/RIOT-OS/RIOT/tests/turo/bin/native/tests_turo.elf has a LOAD segment with RWX permissions
   text	   data	    bss	    dec	    hex	filename
  39098	    704	  47800	  87602	  15632	/home/mlenders/Repositories/RIOT-OS/RIOT/tests/turo/bin/native/tests_turo.elf
.............
----------------------------------------------------------------------
Ran 13 tests in 4.453s

OK
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but got the idea while debugging #18769.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
