### PR TITLE
sys/net/nanocoap: introduce Accept option helper

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -629,6 +629,16 @@ uint8_t *coap_find_option(coap_pkt_t *pkt, unsigned opt_num);
 unsigned coap_get_content_type(coap_pkt_t *pkt);
 
 /**
+ * @brief   Get the Accept option value from a packet if present
+ *
+ * @param[in]   pkt     packet to work on
+ *
+ * @returns     the packet's Accept option value if included,
+ *              COAP_FORMAT_NONE otherwise
+ */
+unsigned coap_get_accept(coap_pkt_t *pkt);
+
+/**
  * @brief   Get a uint32 option value
  *
  * @param[in]   pkt         packet to read from

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -280,9 +280,9 @@ uint8_t *coap_iterate_option(coap_pkt_t *pkt, uint8_t **optpos,
     }
 }
 
-unsigned coap_get_content_type(coap_pkt_t *pkt)
+static unsigned _get_content_format(coap_pkt_t *pkt, unsigned int opt_num)
 {
-    uint8_t *opt_pos = coap_find_option(pkt, COAP_OPT_CONTENT_FORMAT);
+    uint8_t *opt_pos = coap_find_option(pkt, opt_num);
     unsigned content_type = COAP_FORMAT_NONE;
     if (opt_pos) {
         uint16_t delta;
@@ -300,6 +300,16 @@ unsigned coap_get_content_type(coap_pkt_t *pkt)
     }
 
     return content_type;
+}
+
+unsigned coap_get_content_type(coap_pkt_t *pkt)
+{
+    return _get_content_format(pkt, COAP_OPT_CONTENT_FORMAT);
+}
+
+unsigned coap_get_accept(coap_pkt_t *pkt)
+{
+    return _get_content_format(pkt, COAP_OPT_ACCEPT);
 }
 
 ssize_t coap_opt_get_next(const coap_pkt_t *pkt, coap_optpos_t *opt,

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -138,6 +138,7 @@ static void test_nanocoap__put_req(void)
     size_t total_hdr_len = 6;
     size_t uri_opt_len = 6;
     size_t fmt_opt_len = 1;
+    size_t accept_opt_len = 2;
 
     size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
                                 &token[0], 2, COAP_METHOD_PUT, msgid);
@@ -155,8 +156,12 @@ static void test_nanocoap__put_req(void)
     TEST_ASSERT_EQUAL_INT(fmt_opt_len, len);
     TEST_ASSERT_EQUAL_INT(COAP_FORMAT_TEXT, coap_get_content_type(&pkt));
 
+    len = coap_opt_add_uint(&pkt, COAP_OPT_ACCEPT, COAP_FORMAT_CBOR);
+    TEST_ASSERT_EQUAL_INT(accept_opt_len, len);
+    TEST_ASSERT_EQUAL_INT(COAP_FORMAT_CBOR, coap_get_accept(&pkt));
+
     len = coap_opt_finish(&pkt, COAP_OPT_FINISH_PAYLOAD);
-    TEST_ASSERT_EQUAL_INT(total_hdr_len + uri_opt_len + fmt_opt_len + 1, len);
+    TEST_ASSERT_EQUAL_INT(total_hdr_len + uri_opt_len + fmt_opt_len + accept_opt_len + 1, len);
     TEST_ASSERT_EQUAL_INT(0xFF, *(pkt.payload - 1));
     TEST_ASSERT_EQUAL_INT(&buf[0] + _BUF_SIZE - pkt.payload, pkt.payload_len);
 }


### PR DESCRIPTION
### Contribution description

Working with content negotiation in the context of gcoap/nanocoap, I noticed that it would be handy to be able to access the Accept option of a request more easily. Therefore, this PR adds a new helper function `coap_get_accept` that gets the respective option value from a CoAP packet. It reuses most of the code from the existing `coap_get_content_type` helper, moving its logic to a new internal function that is called by both `coap_get_content_type` and `coap_get_accept`.

### Testing procedure

I adjusted the existing unit tests to assert that new the helper works.

### Issues/PRs references

—
