### PR TITLE
nanocoap_sock: fix handling empty ACKs with separate response

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -251,6 +251,14 @@ extern "C" {
 #define CONFIG_COAP_RANDOM_FACTOR_1000      (1500)
 #endif
 
+/**
+ * @brief    Timeout in milliseconds for a separate (deferred) response
+ *           sent after an empty ACK.
+ */
+#ifndef CONFIG_COAP_SEPARATE_RESPONSE_TIMEOUT_MS
+#define CONFIG_COAP_SEPARATE_RESPONSE_TIMEOUT_MS    (10 * MS_PER_SEC)
+#endif
+
 /** @brief   Maximum number of retransmissions for a confirmable request */
 #ifndef CONFIG_COAP_MAX_RETRANSMIT
 #define CONFIG_COAP_MAX_RETRANSMIT     (4)

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -74,7 +74,7 @@ static int _send_ack(nanocoap_sock_t *sock, coap_pkt_t *pkt)
     unsigned tkl = coap_get_token_len(pkt);
 
     coap_build_hdr(&ack, COAP_TYPE_ACK, coap_get_token(pkt), tkl,
-                   COAP_CODE_VALID, ntohs(pkt->hdr->id));
+                   COAP_CODE_EMPTY, ntohs(pkt->hdr->id));
 
     return sock_udp_send(sock, &ack, sizeof(ack), NULL);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If an empty ACK was received and a payload is expected, wait for the separate response.


### Testing procedure

~~*still untested*~~

As @chrysn suggested: run aiocoap's `./server.py` and `tests/nanocoap_cli`, then fetch `/other/separate`:

```
> ncget coap://[fe80::90a7:a6ff:fe4b:2e32]/other/separate -
Three rings for the elven kings under the sky, seven rings for dwarven lords in their halls of stone, nine rings for mortal men doomed to die, one ring for the dark lord on his dark throne.
```

While on `master` no response is printed:

```
> ncget coap://[fe80::90a7:a6ff:fe4b:2e32]/other/separate -

>
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
