### PR TITLE
sys/stdio_uart: fix undefined behavior

### DIFF
--- a/sys/stdio_uart/Makefile
+++ b/sys/stdio_uart/Makefile
@@ -1,4 +1,1 @@
-ifeq (gnu, $(TOOLCHAIN))
-  CFLAGS += -Wno-cast-function-type
-endif
 include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -30,11 +30,11 @@
 #include <errno.h>
 #include <string.h>
 
-#include "stdio_uart.h"
-
 #include "board.h"
-#include "periph/uart.h"
 #include "isrpipe.h"
+#include "kernel_defines.h"
+#include "periph/uart.h"
+#include "stdio_uart.h"
 
 #if MODULE_VFS
 #include "vfs.h"
@@ -43,23 +43,23 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifdef MODULE_STDIO_UART_RX
 static uint8_t _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
 isrpipe_t stdio_uart_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
-#endif
+
+static void _isrpipe_write_one_wrapper(void *arg, uint8_t value)
+{
+    isrpipe_write_one(arg, value);
+}
 
 void stdio_init(void)
 {
-    uart_rx_cb_t cb;
-    void *arg;
+    uart_rx_cb_t cb = NULL;
+    void *arg = NULL;
 
-#ifdef MODULE_STDIO_UART_RX
-    cb = (uart_rx_cb_t) isrpipe_write_one;
-    arg = &stdio_uart_isrpipe;
-#else
-    cb = NULL;
-    arg = NULL;
-#endif
+    if (IS_USED(MODULE_STDIO_UART_RX)) {
+        cb = _isrpipe_write_one_wrapper;
+        arg = &stdio_uart_isrpipe;
+    }
 
     uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, cb, arg);
 
@@ -77,13 +77,10 @@ int stdio_available(void)
 
 ssize_t stdio_read(void* buffer, size_t count)
 {
-#ifdef MODULE_STDIO_UART_RX
-    return (ssize_t)isrpipe_read(&stdio_uart_isrpipe, buffer, count);
-#else
-    (void)buffer;
-    (void)count;
+    if (IS_USED(MODULE_STDIO_UART_RX)) {
+        return (ssize_t)isrpipe_read(&stdio_uart_isrpipe, buffer, count);
+    }
     return -ENOTSUP;
-#endif
 }
 
 ssize_t stdio_write(const void *buffer, size_t len)


### PR DESCRIPTION
### Contribution description

As the title says and slso drop the `-Wno-cast-function-type` hack that allowed the bug to sneak past Murdock.

### Testing procedure

Ideally the compiler notices that the wrapper is not needed for platforms where the calling conventions of the two signatures are indeed compatible and the machine code doesn't change. I didn't test this, though.

In any case, `examples/default` should still work on boards that use UART for stdio.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/18766