### PR TITLE
cpu/efm32/pm: fix blocking EM1

### DIFF
--- a/cpu/efm32/periph/pm.c
+++ b/cpu/efm32/periph/pm.c
@@ -34,9 +34,12 @@ void pm_set(unsigned mode)
             EMU_EnterEM2(true);
             break;
         case EFM32_PM_MODE_EM1:
-        default:
             /* wait for next event or interrupt */
             EMU_EnterEM1();
+            break;
+        default:
+            /* no sleep at all  */
+            break;
     }
 }
 

--- a/cpu/efm32/periph/pm.c
+++ b/cpu/efm32/periph/pm.c
@@ -22,18 +22,24 @@
 
 #include "em_emu.h"
 
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
 void pm_set(unsigned mode)
 {
     switch (mode) {
         case EFM32_PM_MODE_EM3:
+            DEBUG_PUTS("[pm] enter EFM32_PM_MODE_EM3");
             /* after exiting EM3, clocks are restored */
             EMU_EnterEM3(true);
             break;
         case EFM32_PM_MODE_EM2:
+            DEBUG_PUTS("[pm] enter EFM32_PM_MODE_EM2");
             /* after exiting EM2, clocks are restored */
             EMU_EnterEM2(true);
             break;
         case EFM32_PM_MODE_EM1:
+            DEBUG_PUTS("[pm] enter EFM32_PM_MODE_EM1");
             /* wait for next event or interrupt */
             EMU_EnterEM1();
             break;


### PR DESCRIPTION
### Contribution description

This PR enable users to block `EFM32_PM_MODE_EM1` if required.

### Testing procedure

Programming `tests/periph_pm` to an EFM32-based board:

```
2022-10-19 17:56:56,151 # main(): This is RIOT! (Version: 2023.01-devel-93-g345af-feature/efm32-series2)
2022-10-19 17:56:56,157 # This application allows you to test the CPU power management.
2022-10-19 17:56:56,214 # The available power modes are 0 - 2. Lower-numbered power modes
2022-10-19 17:56:56,217 # save more power, but may require an event/interrupt to wake up
2022-10-19 17:56:56,218 # the CPU. Reset the CPU if needed.
2022-10-19 17:56:56,218 # mode 0 blockers: 0 
2022-10-19 17:56:56,218 # mode 1 blockers: 1 
2022-10-19 17:56:56,218 # mode 2 blockers: 0 
2022-10-19 17:56:56,219 # Lowest allowed mode: 2
2022-10-19 17:56:56,219 # [pm] enter EFM32_PM_MODE_EM1
> pm block 2
2022-10-19 17:57:28,977 # pm block 2
2022-10-19 17:57:28,978 # Blocking power mode 2.
> pm show
2022-10-19 17:57:42,618 # pm show
2022-10-19 17:57:42,619 # mode 0 blockers: 0 
2022-10-19 17:57:42,620 # mode 1 blockers: 1 
2022-10-19 17:57:42,620 # mode 2 blockers: 1 
2022-10-19 17:57:42,621 # Lowest allowed mode: 3
> pm unblock 2
2022-10-19 17:57:58,481 # pm unblock 2
2022-10-19 17:57:58,482 # Unblocking power mode 2.
2022-10-19 17:57:58,485 # [pm] enter EFM32_PM_MODE_EM1
```

### Issues/PRs references

#13475 yielded #17895, which already preparing the EFM32 CPUs to take the IDLE pm into account.
#17883 implements the same logic for the `samd5x` cpu family.