### PR TITLE
pkg/tinyusb: add ULPI and UTMI+ HS PHY support for STM32 USB OTG HS ports

### DIFF
--- a/boards/stm32f746g-disco/Kconfig
+++ b/boards/stm32f746g-disco/Kconfig
@@ -24,6 +24,7 @@ config BOARD_STM32F746G_DISCO
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_PERIPH_USBDEV_HS_ULPI
+    select HAS_TINYUSB_DEVICE
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/boards/stm32f746g-disco/features-shared.mk
+++ b/boards/stm32f746g-disco/features-shared.mk
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 FEATURES_PROVIDED += periph_usbdev_hs_ulpi
+FEATURES_PROVIDED += tinyusb_device
 
 # stm32f746g-disco provides a custom default Kconfig clock configuration
 KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/stm32f746g-disco/clock.config

--- a/boards/stm32f7508-dk/Kconfig
+++ b/boards/stm32f7508-dk/Kconfig
@@ -24,6 +24,7 @@ config BOARD_STM32F7508_DK
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_PERIPH_USBDEV_HS_ULPI
+    select HAS_TINYUSB_DEVICE
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/cpu/stm32/include/tinyusb_hw_defaults.h
+++ b/cpu/stm32/include/tinyusb_hw_defaults.h
@@ -55,6 +55,9 @@ extern "C" {
  * - In all other cases, both the device and the host stack use port 0.
  *   This also applies if only the USB FS controller is used.
  *
+ * @warning
+ * - tinyUSB does not support host mode for STM32 MCUs yet.
+ * - tinyUSB does not support to use multiple ports with device stack
  * @{
  */
 #if defined(DWC2_USB_OTG_HS_ENABLED) && defined(DWC2_USB_OTG_FS_ENABLED)
@@ -67,6 +70,9 @@ extern "C" {
 #define TINYUSB_TUH_RHPORT  1
 #endif
 
+#define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED)
+#define CFG_TUSB_RHPORT1_MODE   (OPT_MODE_HOST | OPT_MODE_HIGH_SPEED)
+
 #elif defined(DWC2_USB_OTG_HS_ENABLED)
 
 #ifndef TINYUSB_TUD_RHPORT
@@ -77,6 +83,13 @@ extern "C" {
 #define TINYUSB_TUH_RHPORT  1
 #endif
 
+/*
+ * Since tinyUSB does not support host mode for STM32 MCUs yet, only
+ * OPT_MODE_DEVICE is enabled for the port. Once tinyUSB supports the host mode,
+ * OPT_MODE_HOST could be added to CFG_TUSB_RHPORT1_MODE
+ */
+#define CFG_TUSB_RHPORT1_MODE   (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+
 #else
 
 #ifndef TINYUSB_TUD_RHPORT
@@ -86,6 +99,13 @@ extern "C" {
 #ifndef TINYUSB_TUH_RHPORT
 #define TINYUSB_TUH_RHPORT  0
 #endif
+
+/*
+ * Since tinyUSB does not support host mode for STM32 MCUs yet, only
+ * OPT_MODE_DEVICE is enabled for the port. Once tinyUSB supports the host mode,
+ * OPT_MODE_HOST could be added to CFG_TUSB_RHPORT0_MODE.
+ */
+#define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED)
 
 #endif
 /** @} */

--- a/pkg/tinyusb/contrib/include/tinyusb_config.h
+++ b/pkg/tinyusb/contrib/include/tinyusb_config.h
@@ -80,10 +80,6 @@
  */
 #define CFG_TUD_ENABLED             MODULE_TINYUSB_DEVICE
 
-#ifndef CFG_TUD_MAX_SPEED
-#define CFG_TUD_MAX_SPEED           OPT_MODE_DEFAULT_SPEED
-#endif
-
 #ifndef CFG_TUD_ENDPOINT0_SIZE
 #define CFG_TUD_ENDPOINT0_SIZE      64
 #endif

--- a/pkg/tinyusb/hw/hw_stm32.c
+++ b/pkg/tinyusb/hw/hw_stm32.c
@@ -122,6 +122,68 @@ static int tinyusb_hw_init_dev(const dwc2_usb_otg_fshs_config_t *conf)
             global_regs->GUSBCFG &= ~USB_OTG_GUSBCFG_ULPIFSLS;
         }
 
+#elif defined(MODULE_PERIPH_USBDEV_HS_UTMI)
+        else if (conf->phy == DWC2_USB_OTG_PHY_UTMI) {
+            /* enable ULPI clock */
+            periph_clk_en(conf->ahb, RCC_AHB1ENR_OTGHSULPIEN);
+            /* enable UTMI HS PHY Controller clock */
+            periph_clk_en(APB2, RCC_APB2ENR_OTGPHYCEN);
+
+#ifdef USB_OTG_GUSBCFG_ULPI_UTMI_SEL
+            /* select UTMI+ PHY */
+            global_regs->GUSBCFG &= ~USB_OTG_GUSBCFG_ULPI_UTMI_SEL;
+#endif /* USB_OTG_GUSBCFG_ULPI_UTMI_SEL */
+#ifdef USB_OTG_GUSBCFG_PHYIF
+            /* use the 8-bit interface and single data rate */
+            global_regs->GUSBCFG &= ~USB_OTG_GUSBCFG_PHYIF;
+#endif /* USB_OTG_GUSBCFG_PHYIF */
+
+            /* disable the on-chip FS transceiver */
+            global_regs->GUSBCFG &= ~USB_OTG_GUSBCFG_PHYSEL;
+
+            /* configure the USB HS PHY Controller (USB_HS_PHYC),
+             * USB_HS_PHYC and GCCFG are STM32 specific */
+#ifdef USB_HS_PHYC
+            /* enable USB HS PHY Controller */
+            global_regs->GCCFG |= USB_OTG_GCCFG_PHYHSEN;
+
+            /* determine the PLL input clock of the USB HS PHY from HSE clock */
+            switch (CLOCK_HSE) {
+                case 12000000:
+                    USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL1_PLLSEL_12MHZ;
+                    break;
+                case 12500000:
+                    USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL1_PLLSEL_12_5MHZ;
+                    break;
+                case 16000000:
+                    USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL1_PLLSEL_16MHZ;
+                    break;
+                case 24000000:
+                    USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL1_PLLSEL_24MHZ;
+                    break;
+                case 25000000:
+                    USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL1_PLLSEL_25MHZ;
+                    break;
+                default:
+                    assert(0);
+            }
+
+            /* configure the tuning interface of the USB HS PHY */
+            USB_HS_PHYC->USB_HS_PHYC_TUNE |= conf->phy_tune;
+
+            /* check whether the LDO regulator is used by on the chip */
+            if (USB_HS_PHYC->USB_HS_PHYC_LDO & USB_HS_PHYC_LDO_USED) {
+                /* enable the LDO */
+                USB_HS_PHYC->USB_HS_PHYC_LDO |= USB_HS_PHYC_LDO_ENABLE;
+                /* wait until the LDO is ready */
+                while (!(USB_HS_PHYC->USB_HS_PHYC_LDO & USB_HS_PHYC_LDO_STATUS)) {}
+            }
+
+            /* enable the PLL of the USB HS PHY */
+            USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL_PLLEN;
+#endif /* USB_HS_PHYC */
+        }
+
 #else /* MODULE_PERIPH_USBDEV_HS_ULPI */
         else {
             /* only on-chip PHY support enabled */


### PR DESCRIPTION
### Contribution description

This PR provides the support of external ULPI and internal UTMI+ HS PHYs for STM32 USB OTG HS ports. The support of these HS PHYs allows the use of the tinyUSB package also for STM32 USB OTG HS ports. The HS PHY is used by enabling either the `periph_usbdev_ulpi_hs` pseudomodule or the `periph_usbdev_ulpi_hs` pseudomodule for boards that have an USB OTG FS as well as an USB OTG  HS port and provide the corresponding feature.


The PR also enables the tinyUSB feature for boards with USB OTG HS ports.

### Testing procedure

1. Use a board with an USB OTG FS port and an USB OTG HS port with external ULPI HS PHY, for example: 
   ```
   USEMODULE=periph_usbdev_ulpi_hs BOARD=stm32f746g-disco make -j8 -C tests/pkg_tinyusb_cdc_msc/
   ```
   With the `periph_usbdev_ulpi_hs` module, the test should work for the USB OTG HS port. Without the `periph_usbdev_ulpi_hs` module, the test should work for the USB OTG FS port.

2. Use a board with an USB OTG FS port and an USB OTG HS port with internal UTMI HS PHY, for example: 
   ```
   USEMODULE=periph_usbdev_utmi_hs BOARD=stm32f723e-disco make -j8 -C tests/pkg_tinyusb_cdc_msc/
   ```
   With the `periph_usbdev_utmi_hs` module, the test should work for the USB OTG HS port. Without the `periph_usbdev_ulpi_hs` module, the test should work for the USB OTG FS port.


### Issues/PRs references

