### PR TITLE
drivers/sdcard_spi: make use of crc16_ccitt_false_update()

### DIFF
--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -24,7 +24,7 @@
 #include "sdcard_spi_params.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
-#include "checksum/ucrc16.h"
+#include "checksum/crc16_ccitt.h"
 #include "ztimer.h"
 
 #include <stdio.h>
@@ -622,7 +622,7 @@ static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, uint8_t token,
         if (_transfer_bytes(card, 0, crc_bytes, sizeof(crc_bytes)) == sizeof(crc_bytes)) {
             uint16_t data_crc16 = (crc_bytes[0] << 8) | crc_bytes[1];
 
-            if (ucrc16_calc_be((uint8_t *)data, size, UCRC16_CCITT_POLY_BE, 0) == data_crc16) {
+            if (crc16_ccitt_false_update(0, data, size) == data_crc16) {
                 DEBUG("_read_data_packet: [OK]\n");
                 return SD_RW_OK;
             }
@@ -716,7 +716,7 @@ static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, uint8_t token,
 
     if (_transfer_bytes(card, data, 0, size) == size) {
 
-        uint16_t data_crc16 = ucrc16_calc_be((uint8_t *)data, size, UCRC16_CCITT_POLY_BE, 0);
+        uint16_t data_crc16 = crc16_ccitt_false_update(0, data, size);
         uint8_t crc[sizeof(uint16_t)] = { data_crc16 >> 8, data_crc16 & 0xFF };
 
         if (_transfer_bytes(card, crc, 0, sizeof(crc)) == sizeof(crc)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Use `crc16_ccitt` instead of `ucrc16`.
This can be speed up by using a look-up table if desired and does not use more memory in the default configuration.

In fact, it saves some bytes compared to the generic CRC implementation:

#### before

```
   text	   data	    bss	    dec	    hex	
  62808	    892	  43688	 107388	  1a37c	
```

#### after

```
   text	   data	    bss	    dec	    hex	
  62744	    892	  43688	 107324	  1a33c	
```

### Testing procedure

SD card still works:

```
2022-10-20 00:42:07,483 # main(): This is RIOT! (Version: 2023.01-devel-92-g10296)

> ls /sd0
2022-10-20 00:42:12,533 # test/
2022-10-20 00:42:12,534 # hello.txt	19 B
2022-10-20 00:42:12,536 # total 1 files

> vfs r /sd0/hello.txt
2022-10-20 00:45:13,936 # 00000000: 4865 6c6c 6f20 6672 6f6d 204c 696e 7578  Hello from Linux
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
