### PR TITLE
socket_zep: make use of crc16_ccitt_false_update()

### DIFF
--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -27,7 +27,7 @@
 
 #include "async_read.h"
 #include "byteorder.h"
-#include "checksum/ucrc16.h"
+#include "checksum/crc16_ccitt.h"
 #include "native_internal.h"
 
 #include "net/ieee802154/radio.h"
@@ -400,8 +400,7 @@ static int _write(ieee802154_dev_t *dev, const iolist_t *iolist)
 
     for (unsigned i = 0; i < n; i++) {
         memcpy(out, iolist->iol_base, iolist->iol_len);
-        chksum = ucrc16_calc_le(iolist->iol_base, iolist->iol_len,
-                                UCRC16_CCITT_POLY_LE, chksum);
+        chksum = crc16_ccitt_false_update(chksum, iolist->iol_base, iolist->iol_len);
         out += iolist->iol_len;
         iolist = iolist->iol_next;
     }
@@ -484,7 +483,7 @@ static void _send_ack(socket_zep_t *zepdev, const void *frame)
     ack[2] = rxbuf[2];  /* SeqNum */
 
     /* calculate checksum */
-    uint16_t chksum = ucrc16_calc_le(ack, 3, UCRC16_CCITT_POLY_LE, 0);
+    uint16_t chksum = crc16_ccitt_false_update(0, ack, 3);
 
     real_send(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_MORE);
     real_send(zepdev->sock_fd, ack, sizeof(ack), MSG_MORE);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Use `crc16_ccitt` instead of `ucrc16` as it is faster and smaller than the generic CRC16 implementation.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
ZEP can still communicate with an unmodified instance.

```
Iface  7  HWaddr: 50:3C  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: E6:DF:AB:47:75:1A:50:3C 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::e4df:ab47:751a:503c  scope: link  VAL
          inet6 addr: 2001:db8::e4df:ab47:751a:503c  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff1a:503c
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 3  bytes 222
            TX packets 3 (Multicast: 2)  bytes 0
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 2  bytes 224
            TX packets 3 (Multicast: 2)  bytes 210
            TX succeeded 3 errors 0

> ping ff02::1
ping ff02::1
12 bytes from fe80::e8c8:a4b0:2429:4113%7: icmp_seq=0 ttl=64 rssi=0 dBm time=0.682 ms
12 bytes from fe80::e8c8:a4b0:2429:4113%7: icmp_seq=1 ttl=64 rssi=0 dBm time=0.657 ms
12 bytes from fe80::e8c8:a4b0:2429:4113%7: icmp_seq=2 ttl=64 rssi=0 dBm time=0.715 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.657/0.684/0.715 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
