### PR TITLE
sys/ztimer: model ztimer_periph_lptimer for Kconfig

### DIFF
--- a/boards/xg23-pk6068a/Kconfig
+++ b/boards/xg23-pk6068a/Kconfig
@@ -20,3 +20,4 @@ config BOARD_XG23_PK6068A
 
     # Put other features for this board (in alphabetical order)
     select HAVE_SAUL_GPIO
+    select HAVE_ZTIMER_PERIPH_LPTIMER

--- a/boards/xg23-pk6068a/Makefile.dep
+++ b/boards/xg23-pk6068a/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+ifneq (,$(filter ztimer_msec ztimer_sec,$(USEMODULE)))
+  USEMODULE += ztimer_periph_lptimer
+endif

--- a/boards/xg23-pk6068a/include/board.h
+++ b/boards/xg23-pk6068a/include/board.h
@@ -36,6 +36,16 @@ extern "C" {
 #define PM_BLOCKER_INITIAL { 0, 0, 0 }
 
 /**
+ * @name    ztimer configuration
+ * @{
+ */
+#define CONFIG_ZTIMER_LPTIMER_DEV            TIMER_DEV(1)
+#define CONFIG_ZTIMER_LPTIMER_FREQ           LFXO_FREQ
+#define CONFIG_ZTIMER_LPTIMER_WIDTH          24
+#define CONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE  EFM32_PM_MODE_EM3
+/** @} */
+
+/**
  * @brief   Power mode required for GPIO IRQs
  *
  * If all GPIO IRQs are expected on port A or B, EM3 is the lowest allowed

--- a/sys/include/ztimer/config.h
+++ b/sys/include/ztimer/config.h
@@ -62,6 +62,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default width of ZTIMER_LPTIMER
+ */
+#ifndef CONFIG_ZTIMER_LPTIMER_WIDTH
+#define CONFIG_ZTIMER_LPTIMER_WIDTH     (32)
+#endif
+
+/**
  * @brief   ZTIMER_USEC optimal minimum value for ztimer_set()
  *
  * When scheduling an ISR every timer will be set to:
@@ -112,6 +119,13 @@ extern "C" {
 #  else
 #    define CONFIG_ZTIMER_TIMER_BLOCK_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
 #  endif
+#endif
+
+/**
+ * @brief   The minimum pm mode required for ZTIMER_LPTIMER to run
+ */
+#ifndef CONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE
+#  define CONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
 #endif
 
 /**

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -5,6 +5,11 @@
 # directory for more details.
 #
 
+config HAVE_ZTIMER_PERIPH_LPTIMER
+    bool
+    help
+        Indicates that ZTIMER_PERIPH_LPTIMER configuration is available.
+
 menu "ztimer - High level timer abstraction layer"
 
 config ZTIMER_CUSTOM_BACKEND_CONFIGURATION
@@ -39,6 +44,10 @@ config MODULE_ZTIMER_PERIPH_TIMER
     depends on HAS_PERIPH_TIMER
     select MODULE_PERIPH_TIMER
 
+config MODULE_ZTIMER_PERIPH_LPTIMER
+    bool "Low-power Timer peripheral"
+    select MODULE_ZTIMER_PERIPH_TIMER
+
 endmenu # Backends
 
 menu "Clocks"
@@ -62,7 +71,9 @@ config MODULE_ZTIMER_MSEC
 choice
     bool "Backend"
     depends on MODULE_ZTIMER_MSEC
+    default ZTIMER_MSEC_BACKEND_LPTIMER if HAVE_ZTIMER_PERIPH_LPTIMER
     default ZTIMER_MSEC_BACKEND_RTT if !MODULE_ZTIMER_NO_PERIPH_RTT
+    default ZTIMER_MSEC_BACKEND_TIMER
 
 config ZTIMER_MSEC_BACKEND_TIMER
     bool "Timer"
@@ -73,6 +84,11 @@ config ZTIMER_MSEC_BACKEND_RTT
     depends on HAS_PERIPH_RTT
     select MODULE_ZTIMER_PERIPH_RTT
 
+config ZTIMER_MSEC_BACKEND_LPTIMER
+    bool "Low Power Timer"
+    depends on HAVE_ZTIMER_PERIPH_LPTIMER
+    select MODULE_ZTIMER_PERIPH_LPTIMER
+
 endchoice
 
 config MODULE_ZTIMER_SEC
@@ -82,7 +98,9 @@ config MODULE_ZTIMER_SEC
 choice
     bool "Backend"
     depends on MODULE_ZTIMER_SEC
+    default ZTIMER_SEC_BACKEND_LPTIMER if HAVE_ZTIMER_PERIPH_LPTIMER
     default ZTIMER_SEC_BACKEND_RTT if !MODULE_ZTIMER_NO_PERIPH_RTT
+    default ZTIMER_SEC_BACKEND_TIMER
 
 config ZTIMER_SEC_BACKEND_TIMER
     bool "Timer"
@@ -97,6 +115,11 @@ config ZTIMER_SEC_BACKEND_RTC
     bool "RTC"
     depends on HAS_PERIPH_RTC
     select MODULE_ZTIMER_PERIPH_RTC
+
+config ZTIMER_SEC_BACKEND_LPTIMER
+    bool "Low Power Timer"
+    depends on HAVE_ZTIMER_PERIPH_LPTIMER
+    select MODULE_ZTIMER_PERIPH_LPTIMER
 
 endchoice
 

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -41,6 +41,10 @@ ifneq (,$(filter ztimer_convert_%,$(USEMODULE)))
   USEMODULE += ztimer_convert
 endif
 
+ifneq (,$(filter ztimer_periph_lptimer,$(USEMODULE)))
+  USEMODULE += ztimer_periph_timer
+endif
+
 ifneq (,$(filter ztimer_periph_timer,$(USEMODULE)))
   FEATURES_REQUIRED += periph_timer
 endif


### PR DESCRIPTION
### Contribution description

While working on #18760, I realized that #17654 hasn't modeled the module `ztimer_periph_lptimer`.

This PR tries to fix that. For that I added the feature `HAS_ZTIMER_PERIPH_LPTIMER_CONFIG` which should be selected by boards that has the required configuration for `ztimer_periph_lptimer`.

### Testing procedure

```diff
diff --git a/tests/ztimer_msg/Makefile b/tests/ztimer_msg/Makefile
index 247bbc2030..0d53a02304 100644
--- a/tests/ztimer_msg/Makefile
+++ b/tests/ztimer_msg/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-USEMODULE += ztimer_usec
+USEMODULE += ztimer_msec
 
 # uncomment this to test using ztimer msec
 #USEMODULE += ztimer_msec
diff --git a/tests/ztimer_msg/app.config.test b/tests/ztimer_msg/app.config.test
index 2fc4266478..1857316235 100644
--- a/tests/ztimer_msg/app.config.test
+++ b/tests/ztimer_msg/app.config.test
@@ -1,4 +1,4 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_ZTIMER=y
-CONFIG_ZTIMER_USEC=y
+CONFIG_MODULE_ZTIMER_MSEC=y
```

#### With Kconfig support

```
TEST_KCONFIG=1 make -C tests/ztimer_msg  BOARD=xg23-pk6068a LOG_LEVEL=LOG_DEBUG flash term
2022-10-26 22:28:56,539 # ztimer_init(): ZTIMER_LPTIMER using periph timer 1, freq 32768, width 24
2022-10-26 22:28:56,549 # ztimer_init(): ZTIMER_LPTIMER setting block_pm_mode to 255
2022-10-26 22:28:56,549 # ztimer_init(): ZTIMER_MSEC convert_frac from 32768 to 1000
2022-10-26 22:28:56,557 # Help: Press s to start test, r to print it is ready
s
2022-10-26 22:28:59,319 # START
2022-10-26 22:28:59,324 # main(): This is RIOT! (Version: 2023.01-devel-155-g3662e-fix/ztimer_lptimer_kconfig)
2022-10-26 22:28:59,324 # This is thread 2
2022-10-26 22:28:59,324 # sending 1st msg
2022-10-26 22:28:59,329 # now=514:656 -> every 2.0s: Hello World
2022-10-26 22:28:59,329 # sending 2nd msg
2022-10-26 22:28:59,332 # now=514:661 -> every 5.0s: This is a Test
2022-10-26 22:28:59,337 # This is thread 3
2022-10-26 22:29:00,337 # sec=515 min=8 hour=0
2022-10-26 22:29:01,332 # now=516:660 -> every 2.0s: Hello World
(...)
```

#### Without Kconfig support

```
TEST_KCONFIG=0 make -C tests/ztimer_msg  BOARD=xg23-pk6068a LOG_LEVEL=LOG_DEBUG flash term
2022-10-26 22:22:00,617 # ztimer_init(): ZTIMER_LPTIMER using periph timer 1, freq 32768, width 24
2022-10-26 22:22:00,622 # ztimer_init(): ZTIMER_LPTIMER setting block_pm_mode to 255
2022-10-26 22:22:00,627 # ztimer_init(): ZTIMER_MSEC convert_frac from 32768 to 1000
2022-10-26 22:22:00,630 # Help: Press s to start test, r to print it is ready
s
2022-10-26 22:22:03,712 # START
2022-10-26 22:22:03,717 # main(): This is RIOT! (Version: 2023.01-devel-155-g3662e-fix/ztimer_lptimer_kconfig)
2022-10-26 22:22:03,717 # This is thread 2
2022-10-26 22:22:03,721 # sending 1st msg
2022-10-26 22:22:03,722 # now=514:983 -> every 2.0s: Hello World
2022-10-26 22:22:03,727 # sending 2nd msg
2022-10-26 22:22:03,727 # now=514:988 -> every 5.0s: This is a Test
2022-10-26 22:22:03,730 # This is thread 3
2022-10-26 22:22:04,735 # sec=515 min=8 hour=0
2022-10-26 22:22:05,730 # now=516:987 -> every 2.0s: Hello World
(...)
```

### Issues/PRs references

- #18780 
- #17654 