### PR TITLE
makefiles/tools/gdb.inc.mk: prefer $(target)-gdb over gdb-multiarch

### DIFF
--- a/makefiles/tools/gdb.inc.mk
+++ b/makefiles/tools/gdb.inc.mk
@@ -1,7 +1,11 @@
-# new versions of gdb will support all architectures in one binary
-ifeq ($(shell gdb-multiarch -v > /dev/null 2>&1; echo $$?),0)
-export GDB        ?= gdb-multiarch
+export GDBPREFIX ?= $(PREFIX)
+
+# If the user installed a magic single target GDB rather than just using
+# gdb-multiarch, there typically is a reason for it - e.g. missing support for
+# that particular target in gdb-multiarch.
+ifeq ($(shell $(GDBPREFIX)gdb -v > /dev/null 2>&1; echo $$?),0)
+  export GDB ?= $(GDBPREFIX)gdb
 else
-export GDBPREFIX  ?= $(PREFIX)
-export GDB        ?= $(GDBPREFIX)gdb
+  # gdb-multiarch is normally
+  export GDB ?= gdb-multiarch
 endif


### PR DESCRIPTION
### Contribution description

In an ideal world everyone would just install `gdb-multiarch` and be happy. However, some MCUs need magic GDB versions sprinkled with unicorn-stardust-Espressif-patches...

Since there is little reason to have `$(target)-gdb` installed in addition to `gdb-multiarch` if `gdb-multiarch` would work fine, let's assume the user wants to use `$(target)-gdb` when present over `gdb-multiarch`.

### Testing procedure

```
USEMODULE=esp_jtag make BOARD=esp32-ethernet-kit-v1_2 PROGRAMMER=openocd OPENOCD=openocd-esp32 debug -C examples/default
```

In `master`:

```
/home/maribu/Repos/software/RIOT/dist/tools/openocd/openocd.sh debug /home/maribu/Repos/software/RIOT/examples/default/bin/esp32-ethernet-kit-v1_2/default.elf
### Starting Debugging ###
Open On-Chip Debugger v0.11.0-snapshot (2022-10-21-10:40)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /home/maribu/Repos/software/RIOT/examples/default/bin/esp32-ethernet-kit-v1_2/default.elf...
Remote debugging using :3333
Remote 'g' packet reply is too long (expected 180 bytes, got 420 bytes): 00040040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000004004096fec51c2500060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```

With this PR:

```
/home/maribu/Repos/software/RIOT/dist/tools/openocd/openocd.sh debug /home/maribu/Repos/software/RIOT/examples/default/bin/esp32-ethernet-kit-v1_2/default.elf
### Starting Debugging ###
DBG="xtensa-esp32-elf-gdb", GDB="xtensa-esp32-elf-gdb", DBG_FLAGS="-q -ex "tar ext :3333" "
Open On-Chip Debugger v0.11.0-snapshot (2022-10-21-10:40)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /home/maribu/Repos/software/RIOT/examples/default/bin/esp32-ethernet-kit-v1_2/default.elf...
Remote debugging using :3333
0x40000400 in ?? ()
(gdb) start
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Temporary breakpoint 1 at 0x400d0024: file /data/riotbuild/riotbase/examples/default/main.c, line 37.
Note: automatically using hardware breakpoints for read-only addresses.
Starting program: /home/maribu/Repos/software/RIOT/examples/default/bin/esp32-ethernet-kit-v1_2/default.elf 
[esp32.cpu0] Target halted, PC=0x400D0024, debug_reason=00000001
Set GDB target to 'esp32.cpu0'

Temporary breakpoint 1, main () at /data/riotbuild/riotbase/examples/default/main.c:37
37	{
(gdb) show arch
The target architecture is set to "auto" (currently "xtensa").
(gdb) 

quit
A debugging session is active.

	Inferior 1 [Remote target] will be detached.

Quit anyway? (y or n) y

Detaching from program: /home/maribu/Repos/software/RIOT/examples/default/bin/esp32-ethernet-kit-v1_2/default.elf, Remote target
[Inferior 1 (Remote target) detached]
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18359#issuecomment-1285444608