### PR TITLE
boards/lora-e5-dev: add arduino feature

### DIFF
--- a/boards/lora-e5-dev/Kconfig
+++ b/boards/lora-e5-dev/Kconfig
@@ -23,6 +23,7 @@ config BOARD_LORA_E5_DEV
     select HAS_PERIPH_UART
 
     # Put other features for this board (in alphabetical order)
+    select HAS_ARDUINO
     select HAS_RIOTBOOT
 
     # Clock configuration

--- a/boards/lora-e5-dev/Makefile.features
+++ b/boards/lora-e5-dev/Makefile.features
@@ -11,4 +11,5 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += riotboot

--- a/boards/lora-e5-dev/include/arduino_board.h
+++ b/boards/lora-e5-dev/include/arduino_board.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lora-e5-dev
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 11 on this board
+ */
+#define ARDUINO_LED         (11)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    GPIO_UNDEF,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_16,
+    ARDUINO_PIN_17,
+    ARDUINO_PIN_18,
+    ARDUINO_PIN_19,
+    ARDUINO_PIN_20,
+    ARDUINO_PIN_21,
+    ARDUINO_PIN_22,
+    ARDUINO_PIN_23,
+    ARDUINO_PIN_24,
+    ARDUINO_PIN_25,
+    ARDUINO_PIN_26,
+    ARDUINO_PIN_27,
+    ARDUINO_PIN_28,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/lora-e5-dev/include/arduino_pinmap.h
+++ b/boards/lora-e5-dev/include/arduino_pinmap.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lora-e5-dev
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ *
+ * @warning Beware: Despite an Arduino pin mapping being available, Arduino shields
+ *          are mechanically not compatible with the board. Check header file
+ *          https://github.com/RIOT-OS/RIOT/blob/master/boards/lora-e5-dev/include/arduino_pinmap.h#L42
+ *          for the exact mapping.
+ *
+ * @{
+ */
+
+#define ARDUINO_PIN_1           GPIO_UNDEF           /**< VCC: Supply voltage for the module */
+#define ARDUINO_PIN_2           GPIO_UNDEF           /**< GND: Ground */
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_A, 13) /**< SWDIO of SWIM for program download */
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_A, 14) /**< SWCLK of SWIM for program download */
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 15) /**< SCL of I2C2 from MCU */
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_A, 15) /**< SDA of I2C2 from MCU */
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_B, 4)  /**< MCU GPIO */
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_B, 3)  /**< MCU GPIO */
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_B, 7)  /**< UART1_RX from MCU */
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_B, 6)  /**< UART1_TX from MCU */
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_B, 5)  /**< MCU GPIO */
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_C, 1)  /**< MCU GPIO; LPUART1_TX from MCU */
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_C, 0)  /**< MCU GPIO; LPUART1_RX from MCU */
+#define ARDUINO_PIN_14          GPIO_UNDEF           /**< GND: Ground */
+#define ARDUINO_PIN_15          GPIO_UNDEF           /**< RFIO: RF input/output */
+#define ARDUINO_PIN_16          GPIO_UNDEF           /**< GND: Ground */
+#define ARDUINO_PIN_17          GPIO_UNDEF           /**< RST: Reset trigger input for MCU */
+#define ARDUINO_PIN_18          GPIO_PIN(PORT_A, 3)  /**< MCU GPIO; USART2_RX from MCU */
+#define ARDUINO_PIN_19          GPIO_PIN(PORT_A, 2)  /**< MCU GPIO; USART2_TX from MCU */
+#define ARDUINO_PIN_20          GPIO_PIN(PORT_B, 10) /**< MCU GPIO */
+#define ARDUINO_PIN_21          GPIO_PIN(PORT_A, 9)  /**< MCU GPIO */
+#define ARDUINO_PIN_22          GPIO_UNDEF           /**< GND: Ground */
+#define ARDUINO_PIN_23          GPIO_PIN(PORT_A, 0)  /**< MCU GPIO */
+#define ARDUINO_PIN_24          GPIO_PIN(PORT_B, 13) /**< SPI2_SCK from MCU; Boot pin(Active low) */
+#define ARDUINO_PIN_25          GPIO_PIN(PORT_B, 9)  /**< SPI2_NSS from MCU */
+#define ARDUINO_PIN_26          GPIO_PIN(PORT_B, 14) /**< SPI2_MISO from MCU */
+#define ARDUINO_PIN_27          GPIO_PIN(PORT_A, 10) /**< SPI2_MOSI from MCU */
+#define ARDUINO_PIN_28          GPIO_PIN(PORT_B, 0)  /**< Unavailable；Suspended treatment */
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

Adds the arduino feature to the `lora-e5-dev` board.

The board is not compatible with Arduino shields. The pin definition comes from the LoRa-E5 datasheet, see https://files.seeedstudio.com/products/317990687/res/LoRa-E5%20module%20datasheet_V1.0.pdf page 6.


### Testing procedure

I've tested the following programs:

- examples/arduino_hello-world
- tests/periph_gpio_arduino
- tests/sys_arduino
- tests/sys_arduino_lib


### Issues/PRs references

None.