### PR TITLE
shell_cmd_gnrc_udp: add missing netutils dependency

### DIFF
--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -208,6 +208,7 @@ endif
 ifneq (,$(filter shell_cmd_gnrc_udp,$(USEMODULE)))
   USEMODULE += gnrc_udp
   USEMODULE += gnrc_pktdump
+  USEMODULE += netutils
 endif
 ifneq (,$(filter shell_cmd_i2c_scan,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The `gnrc_udp` shell command uses the function `netutils_get_ipv6()` but does not include the corresponding module `netutils`. The only reason most applications that use `shell_cmd_gnrc_udp` link is because they also include the `shell_cmd_gnrc_icmpv6_echo` module (e.g. implicit via `gnrc_ipcmpv6_echo`), which includes this dependency.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Remove the `gnrc_icmpv6_echo` module from `examples/gnrc_networking`:

```patch
diff --git a/examples/gnrc_networking/Makefile b/examples/gnrc_networking/Makefile
index df2cb0ddcc..e2f766d264 100644
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -21,3 +21,2 @@ USEMODULE += auto_init_gnrc_rpl
 # Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
 USEMODULE += shell_cmd_gnrc_udp
```

Now try to build this application for a platform of your choice. On current master, it will fail to link:

```
/usr/bin/ld: examples/gnrc_networking/bin/native/shell_cmds/gnrc_udp.o: in function `_send':
sys/shell/cmds/gnrc_udp.c:54: undefined reference to `netutils_get_ipv6'
collect2: error: ld returned 1 exit status
```

with this PR, it will link again.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Noticed while trying to port the test of #16158 to using `shell_cmd_gnrc_udp`.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
