### PR TITLE
sys/net: add Size1 and Size2 option numbers

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -51,6 +51,17 @@ extern "C" {
 #define COAP_OPT_LOCATION_QUERY (20)
 #define COAP_OPT_BLOCK2         (23)
 #define COAP_OPT_BLOCK1         (27)
+/**
+ * @brief Size2 option
+ *
+ * Used by clients to request an estimate of a resource's
+ * total size from a server during block-wise transfer and by
+ * servers to inform clients about the size.
+ *
+ * @see [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959)
+ * @see [RFC 8613](https://datatracker.ietf.org/doc/html/rfc8613)
+ */
+#define COAP_OPT_SIZE2          (28)
 #define COAP_OPT_PROXY_URI      (35)
 #define COAP_OPT_PROXY_SCHEME   (39)
 /**

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -65,6 +65,19 @@ extern "C" {
 #define COAP_OPT_PROXY_URI      (35)
 #define COAP_OPT_PROXY_SCHEME   (39)
 /**
+ * @brief Size1 option
+ *
+ * Used by clients to give servers an estimate of the total request
+ * payload size during block-wise server and by servers to indicate
+ * the maximum acceptable payload size in a 4.13 ("Request Entity
+ * Too Large") response.
+ *
+ * @see [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252)
+ * @see [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959)
+ * @see [RFC 8613](https://datatracker.ietf.org/doc/html/rfc8613)
+ */
+#define COAP_OPT_SIZE1          (60)
+/**
  * @brief suppress CoAP response
  * @see [RFC 7968](https://datatracker.ietf.org/doc/html/rfc7967)
  */


### PR DESCRIPTION
### Contribution description

This PR expands the `coap.h` header file with macro definitions for the Size2 and Size1 option numbers, making it a bit more convenient to use these two options. The PR does not contain any actual new logic, but it could be a first step for reviving https://github.com/RIOT-OS/RIOT/issues/10169 and augmenting either nanocoap or gcoap.

### Testing procedure

Since there is no new logic introduced, comparing the numbers with the [IANA registry](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml) and proofreading the documentation should suffice for this PR.

### Issues/PRs references

—