### PR TITLE
Fix kconfig mismatch breaking nightlies

### DIFF
--- a/boards/blackpill-128kib/Kconfig
+++ b/boards/blackpill-128kib/Kconfig
@@ -17,4 +17,11 @@ config BOARD_BLACKPILL_128KIB
 
     select HAS_HIGHLEVEL_STDIO
 
+# HACK: This is added due to the make resolution
+# make will select timer backend, probably due to the USBUS
+# and kconfig cannot select if something is already selected like make
+choice ZTIMER_MSEC_BACKEND
+    default ZTIMER_MSEC_BACKEND_TIMER if MODULE_PERIPH_RTC
+endchoice
+
 source "$(RIOTBOARD)/common/blxxxpill/Kconfig"

--- a/boards/bluepill-128kib/Kconfig
+++ b/boards/bluepill-128kib/Kconfig
@@ -17,4 +17,11 @@ config BOARD_BLUEPILL_128KIB
 
     select HAS_HIGHLEVEL_STDIO
 
+# HACK: This is added due to the make resolution
+# make will select timer backend, probably due to the USBUS
+# and kconfig cannot select if something is already selected like make
+choice ZTIMER_MSEC_BACKEND
+    default ZTIMER_MSEC_BACKEND_TIMER if MODULE_PERIPH_RTC
+endchoice
+
 source "$(RIOTBOARD)/common/blxxxpill/Kconfig"

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -59,7 +59,7 @@ config MODULE_ZTIMER_MSEC
     bool "Milliseconds"
     select MODULE_ZTIMER
 
-choice
+choice ZTIMER_MSEC_BACKEND
     bool "Backend"
     depends on MODULE_ZTIMER_MSEC
     default ZTIMER_MSEC_BACKEND_RTT if !MODULE_ZTIMER_NO_PERIPH_RTT


### PR DESCRIPTION
### Contribution description

Nightlies are failing due to kconfig mismatch.
It would seem this is a result of bringing in the USB stuff. I assume that this uses ztimer periph_timer as a backend as periph_timer is already selected. However, kconfig only resolves one and not recursively making it hard to match. For not a hack is added to override for these boards.

### Testing procedure

Fixed in murdock with NIGHTLY=1

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
