### PR TITLE
boards/cc1350: add info concerning shell access

### DIFF
--- a/boards/cc1350-launchpad/doc.txt
+++ b/boards/cc1350-launchpad/doc.txt
@@ -9,6 +9,8 @@
 2. [Hardware](#cc1350_launchpad_hardware)
 3. [Board pinout](#cc1350_launchpad_pinout)
 4. [Flashing the Device](#cc1350_launchpad_flashing)
+5. [Accessing RIOT shell](#cc1350_launchpad_shell)
+6. [More information](#cc1350_launchpad_moreinfo)
 
 ## <a name="cc1350_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
 
@@ -63,8 +65,26 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-For detailed information about CC1312 MCUs as well as configuring, compiling
-RIOT and installation of flashing tools for CC1312 boards,
+## <a name="cc1350_launchpad_shell"> Accessing RIOT shell </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+
+Default RIOT shell access utilize XDS110 debug probe integrated with launchpad
+board. It provides virtual serials via USB interface - for connecting to RIOT
+shell, use the first one (with TI drivers for Windows named
+"Class Application/User UART").
+
+If a physical connection to UART is needed, disconnect jumpers RXD and TXD 
+joining cc1350 microcontroller with XDS110 and connect UART to pin RXD/DIO2 
+and TXD/DIO3.
+
+The default baud rate is 115 200 - in both connection types.
+
+@warning Launchpad cc1350 board is not 5V tolerant. Use voltage divider or logic
+level shifter when connecting to 5V UART.
+
+## <a name="cc1350_launchpad_moreinfo"> More information </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+
+For detailed information about CC1350 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1350 boards,
 see \ref cc26xx_cc13xx_riot.
 
 */

--- a/boards/cc1350-launchpad/doc.txt
+++ b/boards/cc1350-launchpad/doc.txt
@@ -72,8 +72,8 @@ board. It provides virtual serials via USB interface - for connecting to RIOT
 shell, use the first one (with TI drivers for Windows named
 "Class Application/User UART").
 
-If a physical connection to UART is needed, disconnect jumpers RXD and TXD 
-joining cc1350 microcontroller with XDS110 and connect UART to pin RXD/DIO2 
+If a physical connection to UART is needed, disconnect jumpers RXD and TXD
+joining cc1350 microcontroller with XDS110 and connect UART to pin RXD/DIO2
 and TXD/DIO3.
 
 The default baud rate is 115 200 - in both connection types.


### PR DESCRIPTION
### Contribution description

This PR adds to TI CC1350 Launchpad board documentation section concerning accessing RIOT shell.
The description is provided according to the Issue [#17453](https://github.com/RIOT-OS/RIOT/issues/17453).

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__cc1350__launchpad.html
```

### Issues/PRs references
See also #17453 