### PR TITLE
boards/cc13xx_cc26xx: remove broken HTML links and headings in doc

### DIFF
--- a/boards/cc1312-launchpad/doc.txt
+++ b/boards/cc1312-launchpad/doc.txt
@@ -3,20 +3,13 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1312 Wireless MCU LaunchPad(TM) Kit
 
-## <a name="cc1312_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
-
-1. [Overview](#cc1312_launchpad_overview)
-2. [Hardware](#cc1312_launchpad_hardware)
-3. [Board pinout](#cc1312_launchpad_pinout)
-4. [Flashing the Device](#cc1312_launchpad_flashing)
-
-## <a name="cc1312_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
+## Overview
 
 The [LAUNCHXL-CC1312R1](http://www.ti.com/tool/LAUNCHXL-CC1312R1) is a Texas
 Instrument's development kit for the CC1312R1 SoC MCU which combines a
 Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 
-## <a name="cc1312_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
+## Hardware
 
 ![LAUNCHXL-CC1312R1](http://www.ti.com/diagrams/launchxl-cc1312r1_cc1312r1-top-prof1.jpg)
 
@@ -37,12 +30,12 @@ Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 | Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1312r.pdf) (pdf file) |
 | Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
 
-## <a name="cc1312_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
+## Board pinout
 
 The [LAUNXHL-CC1312R Quick Start Guide](http://www.ti.com/lit/ml/swru535c/swru535c.pdf)
 provides the default pinout for the board.
 
-## <a name="cc1312_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
+## Flashing the Device
 
 Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
 debug probe that provides programming, flashing and debugging capabilities

--- a/boards/cc1350-launchpad/doc.txt
+++ b/boards/cc1350-launchpad/doc.txt
@@ -3,22 +3,13 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1350 Wireless MCU LaunchPad(TM) Kit
 
-## <a name="cc1350_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
-
-1. [Overview](#cc1350_launchpad_overview)
-2. [Hardware](#cc1350_launchpad_hardware)
-3. [Board pinout](#cc1350_launchpad_pinout)
-4. [Flashing the Device](#cc1350_launchpad_flashing)
-5. [Accessing RIOT shell](#cc1350_launchpad_shell)
-6. [More information](#cc1350_launchpad_moreinfo)
-
-## <a name="cc1350_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+## Overview
 
 The [LAUNCHXL-CC1350](https://www.ti.com/tool/LAUNCHXL-CC1350) is a Texas
 Instrument's development kit for the CC1350 SoC MCU which combines a Cortex-M3
 microcontroller alonside a dedicated Cortex-M0 to control a dual-band radio.
 
-## <a name="cc1350_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+## Hardware
 
 ![LAUNCHXL-CC1350](https://www.ti.com/diagrams/launchxl-cc1350_launchxl-cc1350.jpg)
 
@@ -39,12 +30,12 @@ microcontroller alonside a dedicated Cortex-M0 to control a dual-band radio.
 | Datasheet         | [Datasheet](https://www.ti.com/lit/ds/swrs183b/swrs183b.pdf) |
 | Reference Manual  | [Reference Manual](https://www.ti.com/lit/ug/swcu117i/swcu117i.pdf) |
 
-## <a name="cc1350_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+## Board pinout
 
 The [CC1350 Quick Start Guide](https://www.ti.com/lit/ug/swru478b/swru478b.pdf)
 provides the default pinout for the board.
 
-## <a name="cc1350_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+## Flashing the Device
 
 Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
 debug probe that provides programming, flashing and debugging capabilities
@@ -65,7 +56,7 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-## <a name="cc1350_launchpad_shell"> Accessing RIOT shell </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+## Accessing RIOT shell
 
 Default RIOT shell access utilize XDS110 debug probe integrated with launchpad
 board. It provides virtual serials via USB interface - for connecting to RIOT
@@ -74,14 +65,13 @@ shell, use the first one (with TI drivers for Windows named
 
 If a physical connection to UART is needed, disconnect jumpers RXD and TXD
 joining cc1350 microcontroller with XDS110 and connect UART to pin RXD/DIO2
-and TXD/DIO3.
 
 The default baud rate is 115 200 - in both connection types.
 
 @warning Launchpad cc1350 board is not 5V tolerant. Use voltage divider or logic
 level shifter when connecting to 5V UART.
 
-## <a name="cc1350_launchpad_moreinfo"> More information </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+## More information
 
 For detailed information about CC1350 MCUs as well as configuring, compiling
 RIOT and installation of flashing tools for CC1350 boards,

--- a/boards/cc1352-launchpad/doc.txt
+++ b/boards/cc1352-launchpad/doc.txt
@@ -3,22 +3,13 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1352 Wireless MCU LaunchPad(TM) Kit
 
-## <a name="cc1352_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
-
-1. [Overview](#cc1352_launchpad_overview)
-2. [Hardware](#cc1352_launchpad_hardware)
-3. [Board pinout](#cc1352_launcpad_pinout)
-4. [Flashing the Device](#cc1352_launchpad_flashing)
-5. [Accessing RIOT shell](#cc1352_launchpad_shell)
-6. [More information](#cc1352_launchpad_moreinfo)
-
-## <a name="cc1352_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+## Overview
 
 The [LAUNCHXL-CC1352R1](https://www.ti.com/tool/LAUNCHXL-CC1352R1) is a Texas
 Instrument's development kit for the CC1352R1 SoC MCU which combines a
 Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 
-## <a name="cc1352_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+## Hardware
 
 ![LAUNCHXL-CC1352R1](https://www.ti.com/diagrams/launchxl-cc1352r1_launchxl-cc1352r1-angled.jpg)
 
@@ -39,12 +30,12 @@ Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 | Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352r.pdf) (pdf file) |
 | Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
 
-## <a name="cc1352_launcpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+## Board pinout
 
 The [LAUNCHXL-CC1352R1 Quick Start Guide](https://www.ti.com/lit/ml/swru525e/swru525e.pdf)
 provides the default pinout for the board.
 
-## <a name="cc1352_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+## Flashing the Device
 
 Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
 debug probe that provides programming, flashing and debugging capabilities
@@ -65,7 +56,7 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-## <a name="cc1352_launchpad_shell"> Accessing RIOT shell </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+## Accessing RIOT shell
 
 Default RIOT shell access utilize XDS110 debug probe integrated with launchpad board.
 It provides virtual serials via USB interface - for connecting to RIOT shell, use
@@ -79,7 +70,7 @@ The default baud rate is 115 200 - in both connection types.
 @warning Launchpad cc1352 board is not 5V tolerant. Use voltage divider or logic
 level shifter when connecting to 5V UART.
 
-## <a name="cc1352_launchpad_moreinfo"> More information </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+## More information
 
 For detailed information about CC1352R1 MCUs as well as configuring, compiling
 RIOT and installation of flashing tools for CC1352R1 boards,

--- a/boards/cc1352p-launchpad/doc.txt
+++ b/boards/cc1352p-launchpad/doc.txt
@@ -61,8 +61,8 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-For detailed information about CC1312 MCUs as well as configuring, compiling
-RIOT and installation of flashing tools for CC1312 boards,
+For detailed information about CC1352P MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1352P boards,
 see \ref cc26xx_cc13xx_riot.
 
 

--- a/boards/cc1352p-launchpad/doc.txt
+++ b/boards/cc1352p-launchpad/doc.txt
@@ -3,20 +3,13 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1352P Wireless MCU LaunchPad(TM) Kit
 
-## <a name="cc1352p_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
-
-1. [Overview](#cc1352p_launchpad_overview)
-2. [Hardware](#cc1352p_launchpad_hardware)
-3. [Board pinout](#cc1352p_launcpad_pinout)
-4. [Flashing the Device](#cc1352p_launchpad_flashing)
-
-## <a name="cc1352p_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
+## Overview
 
 The [LAUNCHXL-CC1352P](http://www.ti.com/tool/LAUNCHXL-CC1352P) is a Texas
 Instrument's development kit for the CC1352P SoC which combines dual-band wireless MCU
 with integrated power amplifier.
 
-## <a name="cc1352p_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
+## Hardware
 
 ![LAUNCHPAD-CC1352P](http://www.ti.com/diagrams/launchxl-cc1352p_launchxl-cc1352p_mcu041a_cc1352p1.jpg)
 
@@ -42,12 +35,12 @@ The board comes in two variants with different RF matching network on the 20 dBm
 - LAUNCHXL-CC1352P1: 868/915 MHz up to 20 dBm, 2.4 GHz up to 5 dBm
 - LAUNCHXL-CC1352P-2: 868/915 MHz up to 14 dBm, 2.4 GHz up to 20 dBm.
 
-## <a name="cc1352p_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
+## Board pinout
 
 The [LAUNCHXL-CC1352P1 Quick Start Guide](https://www.ti.com/lit/ug/swau108a/swau108a.pdf)
 provides the default pinout for the board.
 
-## <a name="cc1352p_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
+## Flashing the Device
 
 Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
 debug probe that provides programming, flashing and debugging capabilities

--- a/boards/cc2650-launchpad/doc.txt
+++ b/boards/cc2650-launchpad/doc.txt
@@ -56,8 +56,8 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-For detailed information about CC1312 MCUs as well as configuring, compiling
-RIOT and installation of flashing tools for CC1312 boards,
+For detailed information about CC2650 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC2650 boards,
 see \ref cc26xx_cc13xx_riot.
 
 */

--- a/boards/cc2650-launchpad/doc.txt
+++ b/boards/cc2650-launchpad/doc.txt
@@ -3,20 +3,13 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC2650 Wireless MCU LaunchPad(TM) Kit
 
-## <a name="cc2650_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
-
-1. [Overview](#cc2650_launchpad_overview)
-2. [Hardware](#cc2650_launchpad_hardware)
-3. [Board pinout](#cc2650_launchpad_pinout)
-4. [Flashing the Device](#cc2650_launchpad_flashing)
-
-## <a name="cc2650_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+## Overview
 
 The [LAUNCHXL-CC2650](https://www.ti.com/tool/LAUNCHXL-CC2650) is a Texas
 Instrument's development kit for the CC2650 SoC MCU which combines a Cortex-M3
 microcontroller alonside a dedicated Cortex-M0 to control the radio.
 
-## <a name="cc2650_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+## Hardware
 
 ![LAUNCHXL-CC2650](https://www.ti.com/diagrams/launchxl-cc2650_launchxl-cc2650.jpg)
 
@@ -37,12 +30,12 @@ microcontroller alonside a dedicated Cortex-M0 to control the radio.
 | Datasheet         | [Datasheet](https://www.ti.com/lit/ds/symlink/cc2650.pdf) |
 | Reference Manual  | [Reference Manual](https://www.ti.com/lit/ug/swcu117i/swcu117i.pdf) |
 
-## <a name="cc2650_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+## Board pinout
 
 The [CC2650 Quick Start Guide](https://www.ti.com/lit/ml/swru451/swru451.pdf)
 provides the default pinout for the board.
 
-## <a name="cc2650_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+## Flashing the Device
 
 Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
 debug probe that provides programming, flashing and debugging capabilities

--- a/cpu/cc26xx_cc13xx/doc.txt
+++ b/cpu/cc26xx_cc13xx/doc.txt
@@ -8,15 +8,7 @@ supported by RIOT: @ref cpu_cc26x0_cc13x0, @ref cpu_cc26x2_cc13x2
 
 \section cc26xx_cc13xx_riot RIOT-OS on CC26xx/CC13xx boards
 
-## <a name="cc26xx_cc13xx_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
-
-1. [Overview](#cc26xx_cc13xx_overview)
-2. [Flashing the CCFG](#cc26xx_cc13xx_ccfg)
-3. [Debugging](#cc26xx_cc13xx_debugging)
-    1. [Using OpenOCD](#cc26xx_cc13xx_openocd)
-    1. [Using Uniflash](#cc26xx_cc13xx_uniflash)
-
-# <a name="cc26xx_cc13xx_overview"> Overview </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+# Overview
 
 The CC26xx/C13xx is a family of micro controllers fabricated by Texas Instruments
 for low-power communications, using protocols such as BLE, IEEE 802.15.4g-2012,
@@ -34,7 +26,7 @@ and improvements on various peripherals.
 @note The actual flash size is the flash size minus 88 bytes, these 88 bytes are
 reserved for the CCFG, see also [Flashing the CCFG](#cc26xx_cc13xx_ccfg).
 
-# <a name="cc26xx_cc13xx_ccfg"> Flashing the CCFG </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+# Flashing the CCFG
 
 @warning Setting an incorrect CCFG configuration may lock out yourself
 out of the device.
@@ -69,14 +61,14 @@ make -C examples/hello-world flash BOARD=cc1350-launchpad
 @note Once flashed, there's no need to flash it again, unless the configuration
 needs to be changed.
 
-# <a name="cc26xx_cc13xx_debugging"> Debugging </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+# Debugging
 
 Development kits from Texas Instruments come with an XDS110 on-board debug probe
 that provides programming, flashing and debugging capabilities.
 
 It can either use proprietary Texas Instruments tools for programming, or OpenOCD.
 
-### <a name="cc26xx_cc13xx_openocd"> Using OpenOCD </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+### Using OpenOCD
 
 To use OpenOCD with the XDS110 you need to use the an special version of
 OpenOCD made by TI (upstream version is not _yet_ compatible). You can
@@ -107,7 +99,7 @@ To flash a board using OpenOCD you can use do it so by setting the `PROGRAMMER`
 environment variable directly in the make command line or in your shell
 nitialization
 
-### <a name="cc26xx_cc13xx_uniflash"> Using Uniflash </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+### Using Uniflash
 
 The TI's Code Composer Studio provides the necessary tools to use the debug
 features of the XDS110; Uniflash provides flashing tools. Both programs can


### PR DESCRIPTION
### Contribution description

Currently used by CI doxygen version, which generates public documentation for RIOT OS webpage, do not handle HTML tags in headings. In effect, documentation for TI boards shows some "strange" HTML tags in heading [example for cc1315](https://doc.riot-os.org/group__boards__cc1312__launchpad.html).

This PR removes all HTML tags from headings as well as TOC with HTML links. Changes could be `git revert`-ed when doxygen version in the CI will be changed.

### Testing procedure

See current version of the doc in RIOT OS webpage - [example for cc1315](https://doc.riot-os.org/group__boards__cc1312__launchpad.html).

And doc generated by this PR.
```
make doc
xdg-open doc/doxygen/html/group__boards__cc1312__launchpad.html
```
### Issues/PRs references
none