### PR TITLE
boards/common/nrf52: improve default clock config

### DIFF
--- a/boards/common/nrf52/include/cfg_timer_default.h
+++ b/boards/common/nrf52/include/cfg_timer_default.h
@@ -20,6 +20,7 @@
 #ifndef CFG_TIMER_DEFAULT_H
 #define CFG_TIMER_DEFAULT_H
 
+#include "kernel_defines.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
@@ -30,34 +31,45 @@ extern "C" {
  * @name    Timer configuration
  * @{
  */
+/**
+ * @brief   Configuration of the exposed timers
+ *
+ * @warning The timer `NRF802154_TIMER`, which by default is `TIMER_DEV(1)`,
+ *          is used for the IEEE 802.15.4 driver
+ */
 static const timer_conf_t timer_config[] = {
     {
         .dev      = NRF_TIMER1,
-        .channels = 3,
+        .channels = 4,
         .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER1_IRQn
     },
     {
+        /* BEWARE: This timer is allocated to the nRF52 IEEE 802.15.4 driver.
+         *         Do not use this timer (unless you do not use IEEE 802.15.4
+         *         networking)!
+         */
         .dev      = NRF_TIMER2,
-        .channels = 3,
-        .bitmode  = TIMER_BITMODE_BITMODE_08Bit,
+        .channels = 4,
+        .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER2_IRQn
     },
     /* The later timers are only present on the larger NRF52 CPUs like NRF52840
-     * or NRF52833, but not small ones like NRF52810 */
+     * or NRF52833, but not small ones like NRF52810. They do have 2 channels
+     * more (CC registers [0..5] instead of CC registers [0..3]). */
 #ifdef NRF_TIMER3
     {
         .dev      = NRF_TIMER3,
-        .channels = 3,
-        .bitmode  = TIMER_BITMODE_BITMODE_08Bit,
+        .channels = 6,
+        .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER3_IRQn
     },
 #endif
 #ifdef NRF_TIMER4
     {
         .dev      = NRF_TIMER4,
-        .channels = 3,
-        .bitmode  = TIMER_BITMODE_BITMODE_08Bit,
+        .channels = 6,
+        .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER4_IRQn
     }
 #endif


### PR DESCRIPTION
### Contribution description

- All nRF52 timers support 32 bit mode, so use that
- All nRF52 timers support at least 4 channels, the timers NRF_TIMER3 and NRF_TIMER4 even support 6 channels.
- Add a warning that `TIMER_DEV(1)` is used by the IEEE 802.15.4 driver

### Testing procedure

Use a timer other than `TIMER_DEV(0)` (that is used by ztimer) and set a timeout that cannot be represented in 8 bits. This should now work.

### Issues/PRs references

Needed for https://github.com/RIOT-OS/RIOT/pull/18392 to work