### PR TITLE
dist/tools: add "RESET_PIN" value for the dwm1001

### DIFF
--- a/dist/tools/nrf52_resetpin_cfg/Makefile
+++ b/dist/tools/nrf52_resetpin_cfg/Makefile
@@ -14,6 +14,9 @@ USEMODULE += stdin
 ifeq (nrf52dk,$(BOARD))
   RESET_PIN ?= 21
 endif
+ifeq (dwm1001,$(BOARD))
+  RESET_PIN ?= 21
+endif
 ifeq (nrf52840dk,$(BOARD))
   RESET_PIN ?= 18
 endif


### PR DESCRIPTION
Set "RESET_PIN" to 21 if the selected board is "dwm1001".

The data sheet linked below confirms that this is the cannonical reset pin. 

[DWM1001C Data Sheet](https://www.qorvo.com/products/d/da007950)

![image](https://user-images.githubusercontent.com/30503300/198581106-160ec6d5-1256-4de5-ad25-607a08f40448.png)
*Section 3: DWM1001 Pin Connections, page 9*