### PR TITLE
boards/dwm1001: add saul_gpio support

### DIFF
--- a/boards/dwm1001/Kconfig
+++ b/boards/dwm1001/Kconfig
@@ -18,5 +18,6 @@ config BOARD_DWM1001
     select HAS_VDD_LC_FILTER_REG1
 
     select HAVE_LIS2DH12_SPI
+    select HAVE_SAUL_GPIO
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/dwm1001/Makefile.dep
+++ b/boards/dwm1001/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis2dh12_spi
+  USEMODULE += saul_gpio
 endif
 
 # include common nrf52 dependencies

--- a/boards/dwm1001/include/gpio_params.h
+++ b/boards/dwm1001/include/gpio_params.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 Gregory Holder <gregory.holder@orange.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_dwm1001
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Gregory Holder <gregory.holder@orange.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED0 (Green)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED1 (Red)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED2 (Red)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED3 (Blue)",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Button 1 (USER)",
+        .pin   = BTN0_PIN,
+        .mode  = GPIO_IN_PU,
+        .flags = (SAUL_GPIO_INVERTED),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Add saul support for the dwm1001-dev's LEDs and "USER" button.
The pin macros were already present for this board, all that remained was to add the `gpio_params.h` header and include the `saul_gpio` pseudomodule in the board's `Makefile.dep`.

#### Added LEDs:
- LED0 - Green
- LED1 - Red
- LED2 - Red
- LED3 - Blue

#### Added button:
- Button 1 - Labelled as "USER"

| <img src="https://user-images.githubusercontent.com/30503300/198588724-356e6b44-58a6-4fbb-ae38-939da2ec3f51.jpg"> |  <img src="https://user-images.githubusercontent.com/30503300/198588735-5828e155-2539-4e37-b7cb-095578fe0fde.jpg"> |
| ----- | ----- |
| dwm1001 front | blurry leds - the bokeh actually helps with seeing each LED color |

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Below is the terminal output where each LED has been toggled by shell command, and a before/after of pressing the "USER" button.

```
main(): This is RIOT! (Version: 2023.01-devel-182-gbfc8c-pr/board/dwm1001_gpio_params)
> saul
saul
ID      Class           Name
#0      ACT_SWITCH      LED0 (Green)
#1      ACT_SWITCH      LED1 (Red)
#2      ACT_SWITCH      LED2 (Red)
#3      ACT_SWITCH      LED3 (Blue)
#4      SENSE_BTN       Button 1 (USER)
#5      SENSE_TEMP      NRF_TEMP
> saul write 0 1
saul write 0 1
Writing to device #0 - LED0 (Green)
Data:                 1 
data successfully written to device #0
> saul write 1 1
saul write 1 1
Writing to device #1 - LED1 (Red)
Data:                 1 
data successfully written to device #1
> saul write 2 1
saul write 2 1
Writing to device #2 - LED2 (Red)
Data:                 1 
data successfully written to device #2
> saul write 3 1
saul write 3 1
Writing to device #3 - LED3 (Blue)
Data:                 1 
data successfully written to device #3
> saul read 4
saul read 4
Reading from #4 (Button 1 (USER)|SENSE_BTN)
Data:                 0 
<---  pressing "USER" button --->
> saul read 4
saul read 4
Reading from #4 (Button 1 (USER)|SENSE_BTN)
Data:                 1 
> 
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

