### PR TITLE
gnrc_sixlowpan: Various hardening fixes [backport 2022.10]

### DIFF
--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -54,7 +54,7 @@ static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
 
     dst_len = ieee802154_get_dst(mhr, dst, &_pan_tmp);
     src_len = ieee802154_get_src(mhr, src, &_pan_tmp);
-    if ((dst_len < 0) || (src_len < 0)) {
+    if ((dst_len < 0) || (src_len <= 0)) {
         DEBUG("_make_netif_hdr: unable to get addresses\n");
         return NULL;
     }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -236,6 +236,9 @@ static size_t _6lo_frag_size(gnrc_pktsnip_t *pkt, size_t offset, uint8_t *data)
     size_t frag_size;
 
     if (offset == 0) {
+        if (pkt->size < sizeof(sixlowpan_frag_t)) {
+            return 0;
+        }
         frag_size = pkt->size - sizeof(sixlowpan_frag_t);
         if (data[0] == SIXLOWPAN_UNCOMP) {
             /* subtract SIXLOWPAN_UNCOMP byte from fragment size,
@@ -244,6 +247,9 @@ static size_t _6lo_frag_size(gnrc_pktsnip_t *pkt, size_t offset, uint8_t *data)
         }
     }
     else {
+        if (pkt->size < sizeof(sixlowpan_frag_n_t)) {
+            return 0;
+        }
         frag_size = pkt->size - sizeof(sixlowpan_frag_n_t);
     }
     return frag_size;
@@ -306,6 +312,11 @@ static int _rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
     if (IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG) && sixlowpan_frag_is(pkt->data)) {
         data = _6lo_frag_payload(pkt);
         frag_size = _6lo_frag_size(pkt, offset, data);
+        if (frag_size == 0) {
+            DEBUG("6lo rbuf: integer underflow detected.\n");
+            gnrc_pktbuf_release(pkt);
+            return RBUF_ADD_ERROR;
+        }
         datagram_size = sixlowpan_frag_datagram_size(pkt->data);
         datagram_tag = sixlowpan_frag_datagram_tag(pkt->data);
     }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -53,6 +53,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
     gnrc_sixlowpan_frag_vrb_t *vrbe = NULL;
 
     assert(base != NULL);
+    assert(base->src_len != 0);
     assert(out_netif != NULL);
     assert(out_dst != NULL);
     assert(out_dst_len > 0);
@@ -168,6 +169,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
 {
     DEBUG("6lo vrb: trying to get entry for (%s, %u)\n",
           gnrc_netif_addr_to_str(src, src_len, addr_str), src_tag);
+    assert(src_len != 0);
     for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         gnrc_sixlowpan_frag_vrb_t *vrbe = &_vrb[i];
 
@@ -189,6 +191,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_reverse(
 {
     DEBUG("6lo vrb: trying to get entry for reverse label switching (%s, %u)\n",
           gnrc_netif_addr_to_str(src, src_len, addr_str), tag);
+    assert(src_len != 0);
     for (unsigned i = 0; i < CONFIG_GNRC_SIXLOWPAN_FRAG_VRB_SIZE; i++) {
         gnrc_sixlowpan_frag_vrb_t *vrbe = &_vrb[i];
 

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -1650,6 +1650,11 @@ static gnrc_pktsnip_t *_iphc_encode(gnrc_pktsnip_t *pkt,
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC_NHC
     while (_compressible_nh(nh)) {
         ssize_t local_pos = 0;
+        if (pkt->next->next == NULL) {
+            DEBUG("6lo iphc: packet next header missing data");
+            gnrc_pktbuf_release(dispatch);
+            return NULL;
+        }
         switch (nh) {
             case PROTNUM_UDP:
                 local_pos = _nhc_udp_encode_snip(pkt, &iphc_hdr[inline_pos]);

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -843,10 +843,10 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             payload_len = (uint16_t)(rbuf->super.datagram_size - sizeof(ipv6_hdr_t));
         }
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_VRB
-        DEBUG("6lo iphc: VRB present, trying to create entry for dst %s\n",
-              ipv6_addr_to_str(addr_str, &ipv6_hdr->dst, sizeof(addr_str)));
         /* re-assign IPv6 header in case realloc changed the address */
         ipv6_hdr = ipv6->data;
+        DEBUG("6lo iphc: VRB present, trying to create entry for dst %s\n",
+              ipv6_addr_to_str(addr_str, &ipv6_hdr->dst, sizeof(addr_str)));
         /* only create virtual reassembly buffer entry from IPv6 destination if
          * the current first fragment is the only received fragment in the
          * reassembly buffer so far and the hop-limit is larger than 1

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -760,8 +760,9 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
     iface = gnrc_netif_hdr_get_netif(netif->data);
     payload_offset = _iphc_ipv6_decode(iphc_hdr, netif->data, iface,
                                        ipv6->data);
-    if (payload_offset == 0) {
-        /* unable to parse IPHC header */
+    if ((payload_offset == 0) || (payload_offset > sixlo->size)) {
+        /* unable to parse IPHC header or malicious packet */
+        DEBUG("6lo iphc: malformed IPHC header\n");
         _recv_error_release(sixlo, ipv6, rbuf);
         return;
     }
@@ -781,7 +782,9 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
                                                            &prev_nh_offset,
                                                            ipv6,
                                                            &uncomp_hdr_len);
-                    if (payload_offset == 0) {
+                    if ((payload_offset == 0) || (payload_offset > sixlo->size)) {
+                        /* unable to parse IPHC header or malicious packet */
+                        DEBUG("6lo iphc: malformed IPHC NHC IPv6 header\n");
                         _recv_error_release(sixlo, ipv6, rbuf);
                         return;
                     }
@@ -796,7 +799,9 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
                                                           prev_nh_offset,
                                                           ipv6,
                                                           &uncomp_hdr_len);
-                    if (payload_offset == 0) {
+                    if ((payload_offset == 0) || (payload_offset > sixlo->size)) {
+                        /* unable to parse IPHC header or malicious packet */
+                        DEBUG("6lo iphc: malformed IPHC NHC IPv6 header\n");
                         _recv_error_release(sixlo, ipv6, rbuf);
                         return;
                     }
@@ -898,9 +903,11 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
     /* re-assign IPv6 header in case realloc changed the address */
     ipv6_hdr = ipv6->data;
     ipv6_hdr->len = byteorder_htons(payload_len);
-    memcpy(((uint8_t *)ipv6->data) + uncomp_hdr_len,
-           ((uint8_t *)sixlo->data) + payload_offset,
-           sixlo->size - payload_offset);
+    if (sixlo->size > payload_offset) {
+        memcpy(((uint8_t *)ipv6->data) + uncomp_hdr_len,
+               ((uint8_t *)sixlo->data) + payload_offset,
+               sixlo->size - payload_offset);
+    }
     if (rbuf != NULL) {
         rbuf->super.current_size += (uncomp_hdr_len - payload_offset);
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_VRB

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -1613,16 +1613,7 @@ static gnrc_pktsnip_t *_iphc_encode(gnrc_pktsnip_t *pkt,
         else {
             dispatch->next = ptr;
         }
-        if (ptr->type == GNRC_NETTYPE_UNDEF) {
-            /* most likely UDP for now so use that (XXX: extend if extension
-             * headers make problems) */
-            dispatch_size += sizeof(udp_hdr_t);
-            break;  /* nothing special after UDP so quit even if more UNDEF
-                     * come */
-        }
-        else {
-            dispatch_size += ptr->size;
-        }
+        dispatch_size += ptr->size;
         dispatch = ptr; /* use dispatch as temporary point for prev */
         ptr = ptr->next;
     }

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -406,105 +406,108 @@ static void test_ieee802154_set_frame_hdr_dst8_src8_pancomp(void)
 
 static void test_ieee802154_get_frame_hdr_len_dst0_src0(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_VOID |
-                                  IEEE802154_FCF_SRC_ADDR_VOID };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_DST_ADDR_VOID |
+                                                      IEEE802154_FCF_SRC_ADDR_VOID };
 
-    TEST_ASSERT_EQUAL_INT(3, ieee802154_get_frame_hdr_len(mhr));
+    /* either source or destination are required, so expect an error */
+    TEST_ASSERT_EQUAL_INT(0, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dstr(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_RESV };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_DST_ADDR_RESV };
 
     TEST_ASSERT_EQUAL_INT(0, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_srcr(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_RESV };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_DST_ADDR_RESV };
 
     TEST_ASSERT_EQUAL_INT(0, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst2_src0(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_SHORT |
-                                  IEEE802154_FCF_SRC_ADDR_VOID };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_DST_ADDR_SHORT |
+                                                      IEEE802154_FCF_SRC_ADDR_VOID };
 
     TEST_ASSERT_EQUAL_INT(7, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst8_src0(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_LONG };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_DST_ADDR_LONG };
 
     TEST_ASSERT_EQUAL_INT(13, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst0_src2(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_SRC_ADDR_SHORT };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_SRC_ADDR_SHORT };
 
     TEST_ASSERT_EQUAL_INT(7, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst0_src2_pancomp(void)
 {
-    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP, IEEE802154_FCF_SRC_ADDR_SHORT };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_SRC_ADDR_SHORT };
 
     TEST_ASSERT_EQUAL_INT(0, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst0_src8(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_SRC_ADDR_LONG };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA, IEEE802154_FCF_SRC_ADDR_LONG };
 
     TEST_ASSERT_EQUAL_INT(13, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst0_src8_pancomp(void)
 {
-    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP, IEEE802154_FCF_SRC_ADDR_LONG };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_SRC_ADDR_LONG };
 
     TEST_ASSERT_EQUAL_INT(0, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst2_src2(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_SHORT |
-                                  IEEE802154_FCF_SRC_ADDR_SHORT };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA,
+                            IEEE802154_FCF_DST_ADDR_SHORT | IEEE802154_FCF_SRC_ADDR_SHORT };
 
     TEST_ASSERT_EQUAL_INT(11, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst8_src2(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_LONG |
-                                  IEEE802154_FCF_SRC_ADDR_SHORT };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA,
+                            IEEE802154_FCF_DST_ADDR_LONG | IEEE802154_FCF_SRC_ADDR_SHORT };
 
     TEST_ASSERT_EQUAL_INT(17, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst8_src8(void)
 {
-    const uint8_t mhr[] = { 0x00, IEEE802154_FCF_DST_ADDR_LONG |
-                                  IEEE802154_FCF_SRC_ADDR_LONG };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA,
+                            IEEE802154_FCF_DST_ADDR_LONG | IEEE802154_FCF_SRC_ADDR_LONG };
 
     TEST_ASSERT_EQUAL_INT(23, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst2_src2_pancomp(void)
 {
-    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP, IEEE802154_FCF_DST_ADDR_SHORT |
-                                                     IEEE802154_FCF_SRC_ADDR_SHORT };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_DST_ADDR_SHORT | IEEE802154_FCF_SRC_ADDR_SHORT };
 
     TEST_ASSERT_EQUAL_INT(9, ieee802154_get_frame_hdr_len(mhr));
 }
 
 static void test_ieee802154_get_frame_hdr_len_dst8_src8_pancomp(void)
 {
-    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP, IEEE802154_FCF_DST_ADDR_LONG |
-                                                     IEEE802154_FCF_SRC_ADDR_LONG };
+    const uint8_t mhr[] = { IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_DST_ADDR_LONG | IEEE802154_FCF_SRC_ADDR_LONG };
 
     TEST_ASSERT_EQUAL_INT(21, ieee802154_get_frame_hdr_len(mhr));
 }


### PR DESCRIPTION
# Backport of #18817

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Title says everything
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Fragmentation and header compression (e.g. as outlined in Release Specs 4 and 6) should still work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
