### PR TITLE
cpu/saml21: add interaction with pm_layered for peripheral drivers

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2014-2015 Freie Universität Berlin
  *               2015 Kaspar Schleiser <kaspar@schleiser.de>
  *               2015 FreshTemp, LLC.
+ *               2022 SSV Software Systems GmbH
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -29,6 +30,7 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Juergen Fitschen <me@jue.yt>
  *
  * The GPIO implementation here support the PERIPH_GPIO_FAST_READ pseudomodule
  * on the cortex-m0/m23 based devices.  This trades an increase in power
@@ -48,6 +50,7 @@
 
 #include "cpu.h"
 #include "bitarithm.h"
+#include "pm_layered.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -365,6 +368,12 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 #endif
     /* clear interrupt flag and enable the interrupt line and line wakeup */
     _EIC->INTFLAG.reg = (1 << exti);
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_GPIO_PM_BLOCK)
+    /* block pm mode if it hasn't been blocked before */
+    if (!(_EIC->INTENSET.reg & (1 << exti))) {
+        pm_block(SAM0_GPIO_PM_BLOCK);
+    }
+#endif
     _EIC->INTENSET.reg = (1 << exti);
 #ifdef CPU_COMMON_SAMD21
     _EIC->WAKEUP.reg |= (1 << exti);
@@ -456,6 +465,13 @@ void gpio_irq_enable(gpio_t pin)
     /* clear stale interrupt */
     _EIC->INTFLAG.reg = 1 << exti;
 
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_GPIO_PM_BLOCK)
+    /* unblock power mode */
+    if (!(_EIC->INTENSET.reg & (1 << exti))) {
+        pm_block(SAM0_GPIO_PM_BLOCK);
+    }
+#endif
+
     /* enable interrupt */
     _EIC->INTENSET.reg = 1 << exti;
 
@@ -469,6 +485,13 @@ void gpio_irq_disable(gpio_t pin)
     if (exti == -1) {
         return;
     }
+
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_GPIO_PM_BLOCK)
+    /* unblock power mode */
+    if (_EIC->INTENSET.reg & (1 << exti)) {
+        pm_unblock(SAM0_GPIO_PM_BLOCK);
+    }
+#endif
 
     /* disable interrupt */
     _EIC->INTENCLR.reg = 1 << exti;

--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
  *               2015 FreshTemp, LLC.
+ *               2022 SSV Software Systems GmbH
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -20,12 +21,14 @@
  * @author      Baptiste Clenet <bapclenet@gmail.com>
  * @author      FWX <FWX@dialine.fr>
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author      Juergen Fitschen <me@jue.yt>
  *
  * @}
  */
 
 #include <stdint.h>
 #include <string.h>
+#include "pm_layered.h"
 #include "periph/rtc.h"
 #include "periph/rtt.h"
 #include "periph_conf.h"
@@ -61,6 +64,38 @@ typedef struct {
 
 static rtc_state_t alarm_cb;
 static rtc_state_t overflow_cb;
+
+#if (IS_ACTIVE(MODULE_PERIPH_RTC) || IS_ACTIVE(MODULE_PERIPH_RTT)) && \
+    IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_RTCRTT_PM_BLOCK)
+
+static bool _pm_alarm = false;
+#if IS_ACTIVE(MODULE_PERIPH_RTT)
+static bool _pm_overflow = false;
+#endif
+
+static inline void _pm_block(bool *flag)
+{
+    if (!*flag) {
+        pm_block(SAM0_RTCRTT_PM_BLOCK);
+        *flag = true;
+    }
+}
+
+static inline void _pm_unblock(bool *flag)
+{
+    if (*flag) {
+        pm_unblock(SAM0_RTCRTT_PM_BLOCK);
+        *flag = false;
+    }
+}
+
+#else
+
+/* Use empty stubs if pm is disabled */
+#define _pm_block(x)
+#define _pm_unblock(x)
+
+#endif
 
 #if IS_ACTIVE(MODULE_PERIPH_RTC)
 /* At 1Hz, RTC goes till 63 years (2^5, see 17.8.22 in datasheet)
@@ -311,6 +346,9 @@ static void _rtc_init(void)
 
 void rtc_init(void)
 {
+    /* clear previously set pm mode blockers */
+    _pm_unblock(&_pm_alarm);
+
     _poweroff();
     _rtc_clock_setup();
     _poweron();
@@ -332,6 +370,9 @@ void rtc_init(void)
 #ifdef MODULE_PERIPH_RTT
 void rtt_init(void)
 {
+    /* clear previously set pm mode blockers */
+    _pm_unblock(&_pm_alarm);
+    _pm_unblock(&_pm_overflow);
 
     _rtt_clock_setup();
     _poweron();
@@ -579,6 +620,11 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     RTC->MODE2.INTFLAG.reg  = RTC_MODE2_INTFLAG_ALARM0;
     RTC->MODE2.INTENSET.reg = RTC_MODE2_INTENSET_ALARM0;
 
+    /* block power mode if callback function is present */
+    if (alarm_cb.cb) {
+        _pm_block(&_pm_alarm);
+    }
+
     return 0;
 }
 
@@ -608,6 +654,8 @@ void rtc_clear_alarm(void)
 {
     /* disable alarm interrupt */
     RTC->MODE2.INTENCLR.reg = RTC_MODE2_INTENCLR_ALARM0;
+
+    _pm_unblock(&_pm_alarm);
 }
 
 void rtc_poweron(void)
@@ -633,11 +681,18 @@ void rtt_set_overflow_cb(rtt_cb_t cb, void *arg)
 
     /* enable overflow interrupt */
     RTC->MODE0.INTENSET.reg = RTC_MODE0_INTENSET_OVF;
+
+    /* block power mode if callback function is present */
+    if (overflow_cb.cb) {
+        _pm_block(&_pm_overflow);
+    }
 }
 void rtt_clear_overflow_cb(void)
 {
     /* disable overflow interrupt */
     RTC->MODE0.INTENCLR.reg = RTC_MODE0_INTENCLR_OVF;
+
+    _pm_unblock(&_pm_overflow);
 }
 
 uint32_t rtt_get_counter(void)
@@ -674,12 +729,19 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     /* enable compare interrupt and clear flag */
     RTC->MODE0.INTFLAG.reg = RTC_MODE0_INTFLAG_CMP0;
     RTC->MODE0.INTENSET.reg = RTC_MODE0_INTENSET_CMP0;
+
+    /* block power mode if callback function is present */
+    if (alarm_cb.cb) {
+        _pm_block(&_pm_alarm);
+    }
 }
 
 void rtt_clear_alarm(void)
 {
     /* disable compare interrupt */
     RTC->MODE0.INTENCLR.reg = RTC_MODE0_INTENCLR_CMP0;
+
+    _pm_unblock(&_pm_alarm);
 }
 
 void rtt_poweron(void)
@@ -727,6 +789,7 @@ static void _isr_rtt(void)
         /* disable interrupt */
         RTC->MODE0.INTENCLR.reg = RTC_MODE0_INTENCLR_CMP0;
         if (alarm_cb.cb) {
+            _pm_unblock(&_pm_alarm);
             alarm_cb.cb(alarm_cb.arg);
         }
     }

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2014-2016 Freie Universität Berlin
  *               2015 Kaspar Schleiser <kaspar@schleiser.de>
  *               2015 FreshTemp, LLC.
+ *               2022 SSV Software Systems GmbH
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -22,6 +23,7 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author      Juergen Fitschen <me@jue.yt>
  *
  * @}
  */
@@ -459,15 +461,15 @@ static void _blocking_transfer(spi_t bus, const void *out, void *in, size_t len)
 
 static void _dma_execute(spi_t bus)
 {
-#if defined(CPU_COMMON_SAMD21)
-    pm_block(SAMD21_PM_IDLE_1);
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_SPI_PM_BLOCK)
+    pm_block(SAM0_SPI_PM_BLOCK);
 #endif
     dma_start(_dma_state[bus].rx_dma);
     dma_start(_dma_state[bus].tx_dma);
 
     dma_wait(_dma_state[bus].rx_dma);
-#if defined(CPU_COMMON_SAMD21)
-    pm_unblock(SAMD21_PM_IDLE_1);
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_SPI_PM_BLOCK)
+    pm_unblock(SAM0_SPI_PM_BLOCK);
 #endif
 }
 

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
  *               2015 FreshTemp, LLC.
+ *               2022 SSV Software Systems GmbH
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -20,11 +21,13 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Dylan Laduranty <dylanladuranty@gmail.com>
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author      Juergen Fitschen <me@jue.yt>
  *
  * @}
  */
 
 #include "cpu.h"
+#include "pm_layered.h"
 
 #include "periph/uart.h"
 #include "periph/gpio.h"
@@ -165,6 +168,20 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     /* enable peripheral clock */
     sercom_clk_en(dev(uart));
 
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
+    /* clear previously blocked power modes */
+    if (dev(uart)->CTRLA.bit.ENABLE) {
+        /* RX IRQ is enabled */
+        if (dev(uart)->INTENSET.bit.RXC) {
+            pm_unblock(SAM0_UART_PM_BLOCK);
+        }
+        /* data reg empty IRQ is enabled -> sending data was in progress */
+        if (dev(uart)->INTENSET.bit.DRE) {
+            pm_unblock(SAM0_UART_PM_BLOCK);
+        }
+    }
+#endif
+
     /* must disable here first to ensure idempotency */
     dev(uart)->CTRLA.reg = 0;
 
@@ -236,6 +253,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 #endif /* UART_HAS_TX_ISR */
         dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_RXEN;
         dev(uart)->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
+        /* block power mode for rx IRQs */
+        pm_block(SAM0_UART_PM_BLOCK);
+#endif
         /* set wakeup receive from sleep if enabled */
         if (uart_config[uart].flags & UART_FLAG_WAKEUP) {
             dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_SFDE;
@@ -320,7 +341,20 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         else {
             while (tsrb_add_one(&uart_tx_rb[uart], *data) < 0) {}
         }
+        /* check and enable DRE IRQs atomically */
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
+        unsigned state = irq_disable();
+        /* tsrb_add_one() is blocking the thread. It may happen that
+         * the corresponding ISR has turned off DRE IRQs and, thus,
+         * unblocked the corresponding power mode. */
+        if (!dev(uart)->INTENSET.bit.DRE) {
+            pm_block(SAM0_UART_PM_BLOCK);
+        }
         dev(uart)->INTENSET.reg = SERCOM_USART_INTENSET_DRE;
+        irq_restore(state);
+#else
+        dev(uart)->INTENSET.reg = SERCOM_USART_INTENSET_DRE;
+#endif
     }
 #else
     for (const void* end = data + len; data != end; ++data) {
@@ -334,13 +368,48 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 void uart_poweron(uart_t uart)
 {
     sercom_clk_en(dev(uart));
+
+    /* the enable bit must be read and written atomically */
+    unsigned state = irq_disable();
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
+    /* block required power modes */
+    if (!dev(uart)->CTRLA.bit.ENABLE) {
+        /* RX IRQ is enabled */
+        if (dev(uart)->INTENSET.bit.RXC) {
+            pm_block(SAM0_UART_PM_BLOCK);
+        }
+        /* data reg empty IRQ is enabled -> sending data was in progress */
+        if (dev(uart)->INTENSET.bit.DRE) {
+            pm_block(SAM0_UART_PM_BLOCK);
+        }
+    }
+#endif
     dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
+    irq_restore(state);
+
     _syncbusy(dev(uart));
 }
 
 void uart_poweroff(uart_t uart)
 {
+    /* the enable bit must be read and written atomically */
+    unsigned state = irq_disable();
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
+    /* clear blocked power modes */
+    if (dev(uart)->CTRLA.bit.ENABLE) {
+        /* RX IRQ is enabled */
+        if (dev(uart)->INTENSET.bit.RXC) {
+            pm_unblock(SAM0_UART_PM_BLOCK);
+        }
+        /* data reg empty IRQ is enabled -> sending data is in progress */
+        if (dev(uart)->INTENSET.bit.DRE) {
+            pm_unblock(SAM0_UART_PM_BLOCK);
+        }
+    }
+#endif
     dev(uart)->CTRLA.reg &= ~(SERCOM_USART_CTRLA_ENABLE);
+    irq_restore(state);
+
     sercom_clk_dis(dev(uart));
 }
 
@@ -504,6 +573,11 @@ static inline void irq_handler_tx(unsigned uartnum)
     /* disable the interrupt if there are no more bytes to send */
     if (tsrb_empty(&uart_tx_rb[uartnum])) {
         dev(uartnum)->INTENCLR.reg = SERCOM_USART_INTENSET_DRE;
+#if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
+        /* we really should be in IRQ context! */
+        assert(irq_is_in());
+        pm_unblock(SAM0_UART_PM_BLOCK);
+#endif
     }
 }
 #endif

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -162,6 +162,9 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         return UART_NODEV;
     }
 
+    /* enable peripheral clock */
+    sercom_clk_en(dev(uart));
+
     /* must disable here first to ensure idempotency */
     dev(uart)->CTRLA.reg = 0;
 
@@ -172,9 +175,6 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
     /* configure pins */
     _configure_pins(uart);
-
-    /* enable peripheral clock */
-    sercom_clk_en(dev(uart));
 
     /* reset the UART device */
     _reset(dev(uart));

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -303,6 +303,10 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         return;
     }
 
+    if (!dev(uart)->CTRLA.bit.ENABLE) {
+        return;
+    }
+
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     for (const void* end = data + len; data != end; ++data) {
         if (irq_is_in() || __get_PRIMASK()) {

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -54,6 +54,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @name   SPI configuration
+ * @{
+ */
+#define SAM0_SPI_PM_BLOCK        SAMD21_PM_IDLE_1 /**< Stay in Idle 0 mode */
+/** @} */
+
+/**
  * @name   USB configuration
  * @{
  */

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -54,6 +54,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @name   USB configuration
+ * @{
+ */
+#define SAM0_USB_ACTIVE_PM_BLOCK SAMD21_PM_IDLE_1 /**< Stay in Idle 0 mode */
+/** @} */
+
+/**
  * @name   SAMD21 GCLK definitions
  * @{
  */

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -42,6 +42,27 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Peripheral power mode requirements
+ * @{
+ */
+#define SAM0_GPIO_PM_BLOCK        SAML21_PM_MODE_BACKUP   /**< GPIO IRQs require STANDBY mode */
+#define SAM0_RTCRTT_PM_BLOCK      SAML21_PM_MODE_BACKUP   /**< RTC/TRR require STANDBY mode */
+#define SAM0_SPI_PM_BLOCK         SAML21_PM_MODE_STANDBY  /**< SPI in DMA mode require IDLE mode */
+#define SAM0_TIMER_PM_BLOCK       SAML21_PM_MODE_STANDBY  /**< Timers require IDLE mode */
+#define SAM0_UART_PM_BLOCK        SAML21_PM_MODE_STANDBY  /**< UART RX IRQ require IDLE mode */
+#define SAM0_USB_IDLE_PM_BLOCK    SAML21_PM_MODE_BACKUP   /**< Idle USB require STANDBY mode */
+#define SAM0_USB_ACTIVE_PM_BLOCK  SAML21_PM_MODE_STANDBY  /**< Active USB require IDLE mode */
+/** @} */
+
+/**
+ * @brief   Override the default initial PM blocker
+ *          All peripheral drivers ensure required pm modes are blocked
+ */
+#ifndef PM_BLOCKER_INITIAL
+#define PM_BLOCKER_INITIAL      { 0, 0, 0 }
+#endif
+
+/**
  * @name   SAML21 GCLK definitions
  * @{
  */


### PR DESCRIPTION
### Contribution description

Currently, RIOT just runs with by-default blocked power modes. This PR changes this for the saml21 family: All peripheral drivers now block and unblock pm modes depending on whether they are used or nor. In combination with #17607 this will get us near to *seamless power management*

Current state of this PR:

* [x] `periph_timer`
* [x] `periph_uart`
* [x] `periph_gpio`
* [x] `periph_usbdev`
* [x] `periph_rtc`
* [x] `periph_rtt`
* [x] `periph_spi` (DMA transfers ...)

Affected boards (using `saml21`):
- bastwan
- saml21-xpro
- samr30-xpro
- samr34-xpro
- yarm

### Testing procedure

#### `periph_timer`

Flash `test/periph_timer` on a `saml21` board:

<details>

```
make -C tests/periph_timer BOARD=samr30-xpro flash term
2022-10-31 22:43:18,356 # Help: Press s to start test, r to print it is ready
s
2022-10-31 22:43:20,390 # START
2022-10-31 22:43:20,397 # main(): This is RIOT! (Version: 2023.01-devel-225-gd564e-feature/saml21_pheriph_pm)
2022-10-31 22:43:20,397 # 
2022-10-31 22:43:20,399 # Test for peripheral TIMERs
2022-10-31 22:43:20,399 # 
2022-10-31 22:43:20,401 # Available timers: 1
2022-10-31 22:43:20,401 # 
2022-10-31 22:43:20,403 # Testing TIMER_0:
2022-10-31 22:43:20,405 # [pm_layered] pm_block(1)
(STANDBY has been blocked by timer_init)
2022-10-31 22:43:20,408 # TIMER_0: initialization successful
2022-10-31 22:43:20,411 # [pm_layered] pm_unblock(1)
(STANDBY has been unblocked by timer_stop)
2022-10-31 22:43:20,412 # TIMER_0: stopped
2022-10-31 22:43:20,415 # TIMER_0: set channel 0 to 5000
2022-10-31 22:43:20,418 # TIMER_0: set channel 1 to 10000
2022-10-31 22:43:20,420 # TIMER_0: starting
2022-10-31 22:43:20,422 # [pm_layered] pm_block(1)
(STANDBY has been unblocked by timer_start)
2022-10-31 22:43:20,438 # TIMER_0: channel 0 fired at SW count    24003 - init:    24003
2022-10-31 22:43:20,443 # TIMER_0: channel 1 fired at SW count    47984 - diff:    23981
2022-10-31 22:43:20,443 # 
2022-10-31 22:43:20,445 # TEST SUCCEEDED
2022-10-31 22:43:20,451 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 492 }]}
```

</details>

#### `periph_gpio`

Flash `test/periph_gpio` on a `saml21` board:

<details>

```
2022-10-31 22:34:54,582 # main(): This is RIOT! (Version: 2023.01-devel-225-gd564e-feature/saml21_pheriph_pm)
2022-10-31 22:34:54,584 # GPIO peripheral driver test
2022-10-31 22:34:54,584 # 
2022-10-31 22:34:54,590 # In this test, pins are specified by integer port and pin numbers.
2022-10-31 22:34:54,596 # So if your platform has a pin PA01, it will be port=0 and pin=1,
2022-10-31 22:34:54,599 # PC14 would be port=2 and pin=14 etc.
2022-10-31 22:34:54,599 # 
2022-10-31 22:34:54,604 # NOTE: make sure the values you use exist on your platform! The
2022-10-31 22:34:54,610 #       behavior for not existing ports/pins is not defined!
> pm show
2022-10-31 22:35:06,747 # pm show
2022-10-31 22:35:06,749 # mode 0 blockers: 0 
2022-10-31 22:35:06,751 # mode 1 blockers: 2     (one blocker from periph_timer used by ztimer and periph_uart used by stdio)
2022-10-31 22:35:06,753 # mode 2 blockers: 0 
2022-10-31 22:35:06,755 # Lowest allowed mode: 2
> init_int 0 28 0 1
2022-10-31 22:37:34,359 # init_int 0 28 0 1
2022-10-31 22:37:34,364 # GPIO_PIN(0, 28) successfully initialized as ext int
> pm show
2022-10-31 22:37:38,150 # pm show
2022-10-31 22:37:38,152 # mode 0 blockers: 1     (init_int added one blocker)   
2022-10-31 22:37:38,154 # mode 1 blockers: 2
2022-10-31 22:37:38,156 # mode 2 blockers: 0 
2022-10-31 22:37:38,158 # Lowest allowed mode: 2
> init_int 0 28 0 1
2022-10-31 22:37:57,024 # init_int 0 28 0 1
2022-10-31 22:37:57,027 # INT: external interrupt from pin 28
2022-10-31 22:37:57,032 # GPIO_PIN(0, 28) successfully initialized as ext int
> pm show
2022-10-31 22:38:00,304 # pm show
2022-10-31 22:38:00,305 # mode 0 blockers: 1     (second init didn't added a second blocker!)   
2022-10-31 22:38:00,307 # mode 1 blockers: 2 
2022-10-31 22:38:00,309 # mode 2 blockers: 0 
2022-10-31 22:38:00,311 # Lowest allowed mode: 2
> enable_int 0 28 0
2022-10-31 22:39:49,058 # enable_int 0 28 0
2022-10-31 22:39:49,061 # disabling GPIO interrupt
> pm show
2022-10-31 22:39:53,106 # pm show
2022-10-31 22:39:53,108 # mode 0 blockers: 0     (blocker removed)  
2022-10-31 22:39:53,110 # mode 1 blockers: 2 
2022-10-31 22:39:53,111 # mode 2 blockers: 0 
2022-10-31 22:39:53,113 # Lowest allowed mode: 2
> enable_int 0 28 0
2022-10-31 22:40:21,355 # enable_int 0 28 0
2022-10-31 22:40:21,357 # disabling GPIO interrupt
> pm show
2022-10-31 22:40:24,890 # pm show
2022-10-31 22:40:24,892 # mode 0 blockers: 0     (second call hasn't changed anything)  
2022-10-31 22:40:24,894 # mode 1 blockers: 2 
2022-10-31 22:40:24,896 # mode 2 blockers: 0 
2022-10-31 22:40:24,898 # Lowest allowed mode: 2
> enable_int 0 28 1
2022-10-31 22:40:51,460 # enable_int 0 28 1
2022-10-31 22:40:51,463 # enabling GPIO interrupt
> pm show
2022-10-31 22:40:56,635 # pm show
2022-10-31 22:40:56,637 # mode 0 blockers: 1     (re-enabling ints added one blocker)
2022-10-31 22:40:56,638 # mode 1 blockers: 2 
2022-10-31 22:40:56,640 # mode 2 blockers: 0 
2022-10-31 22:40:56,642 # Lowest allowed mode: 2
> enable_int 0 28 1
2022-10-31 22:41:30,373 # enable_int 0 28 1
2022-10-31 22:41:30,375 # enabling GPIO interrupt
> pm show
2022-10-31 22:41:32,411 # pm show
2022-10-31 22:41:32,413 # mode 0 blockers: 1     (no further blockers are added)
2022-10-31 22:41:32,415 # mode 1 blockers: 2 
2022-10-31 22:41:32,417 # mode 2 blockers: 0 
2022-10-31 22:41:32,419 # Lowest allowed mode: 2
```

</details>

#### `periph_usbdev`

Flash `tests/usbus_cdc_ecm` on a `saml21` board:

<details>

```
make -C tests/usbus_cdc_ecm BOARD=samr30-xpro flash term
2022-10-31 22:47:04,378 # [pm_layered] pm_block(1)
(timer_init called by ztimer)
2022-10-31 22:47:04,381 # [pm_layered] pm_block(0)
2022-10-31 22:47:04,384 # [pm_layered] pm_block(1)
(blocked by _usbdev_init)
2022-10-31 22:47:04,386 # [pm_layered] pm_unblock(1)
(unblocked because no USB cable is connceted)
2022-10-31 22:47:04,395 # main(): This is RIOT! (Version: 2023.01-devel-225-gd564e-feature/saml21_pheriph_pm)
2022-10-31 22:47:04,399 # Test application for the USBUS CDC ECM interface
2022-10-31 22:47:04,399 # 
2022-10-31 22:47:04,405 # This test pulls in parts of the GNRC network stack, use the
2022-10-31 22:47:04,410 # provided shell commands (i.e. ifconfig, ping) to interact with
2022-10-31 22:47:04,413 # the CDC ECM based network interface.
2022-10-31 22:47:04,413 # 
2022-10-31 22:47:04,416 # Starting the shell now...
> pm show
2022-10-31 22:47:15,339 # pm show
2022-10-31 22:47:15,341 # mode 0 blockers: 1 
2022-10-31 22:47:15,343 # mode 1 blockers: 2 
2022-10-31 22:47:15,344 # mode 2 blockers: 0 
2022-10-31 22:47:15,346 # Lowest allowed mode: 2
(connect USB cable)
2022-10-31 22:49:20,413 # [pm_layered] pm_block(1)
2022-10-31 22:49:20,417 # [pm_layered] pm_unblock(1)
2022-10-31 22:49:20,558 # [pm_layered] pm_block(1)
(Ethernet devices shows up on USB host)
> pm show
2022-10-31 22:50:17,422 # pm show
2022-10-31 22:50:17,424 # mode 0 blockers: 1 
2022-10-31 22:50:17,426 # mode 1 blockers: 3 
2022-10-31 22:50:17,428 # mode 2 blockers: 0 
2022-10-31 22:50:17,430 # Lowest allowed mode: 2
(disconnect USB cable)
2022-10-31 22:50:36,785 # [pm_layered] pm_unblock(1)
```

</details>

#### `periph_uart`

Flash `tests/periph_uart` on the `samr30-xpro` board:

<details>

Changes to the `periph_conf.h`:

```diff
diff --git a/boards/samr30-xpro/include/periph_conf.h b/boards/samr30-xpro/include/periph_conf.h
index dfa9f624dd..47ef6f3018 100644
--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -70,11 +70,22 @@ static const uart_conf_t uart_config[] = {
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {    /* EXT1 & EXT3 Pin Header */
+        .dev      = &(SERCOM5->USART),
+        .rx_pin   = GPIO_PIN(PB, 3),
+        .tx_pin   = GPIO_PIN(PB, 22),
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom0
+#define UART_1_ISR          isr_sercom5
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
@@ -100,23 +111,6 @@ static const spi_conf_t spi_config[] = {
         .rx_trigger = SERCOM4_DMAC_ID_RX,
 #endif
     },
-    {    /* EXT1 & EXT3 Pin Header */
-        .dev      = &(SERCOM5->SPI),
-        .miso_pin = GPIO_PIN(PB, 2),
-        .mosi_pin = GPIO_PIN(PB, 22),
-        .clk_pin  = GPIO_PIN(PB, 23),
-        .miso_mux = GPIO_MUX_D,
-        .mosi_mux = GPIO_MUX_D,
-        .clk_mux  = GPIO_MUX_D,
-        .miso_pad = SPI_PAD_MISO_0,
-        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
-        .gclk_src = SAM0_GCLK_MAIN,
-#ifdef MODULE_PERIPH_DMA
-        /* The SAML21 doesn't support DMA triggers on SERCOM5 */
-        .tx_trigger = DMA_TRIGGER_DISABLED,
-        .rx_trigger = DMA_TRIGGER_DISABLED,
-#endif
-    }
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
```

Bridge PB03 + PB22.

```
make -C tests/periph_uart BOARD=samr30-xpro flash term
> init 1 115200
2022-11-01 23:45:41,625 # init 1 115200
2022-11-01 23:45:41,627 # [pm_layered] pm_block(1)
2022-11-01 23:45:41,632 # Success: Initialized UART_DEV(1) at BAUD 115200
2022-11-01 23:45:41,639 # UARD_DEV(1): test uart_poweron() and uart_poweroff()  ->  [pm_layered] pm_unblock(1)
2022-11-01 23:45:41,892 # [pm_layered] pm_block(1)
2022-11-01 23:45:41,892 # [OK]
> init 1 115200
2022-11-01 23:45:43,721 # init 1 115200
2022-11-01 23:45:43,724 # [pm_layered] pm_unblock(1)
2022-11-01 23:45:43,726 # [pm_layered] pm_block(1)
2022-11-01 23:45:43,730 # Success: Initialized UART_DEV(1) at BAUD 115200
2022-11-01 23:45:43,738 # UARD_DEV(1): test uart_poweron() and uart_poweroff()  ->  [pm_layered] pm_unblock(1)
2022-11-01 23:45:43,990 # [pm_layered] pm_block(1)
2022-11-01 23:45:43,991 # [OK]
(Second init unblock STANDBY mode ...)
> test 1
2022-11-01 23:46:20,138 # test 1
2022-11-01 23:46:20,139 # [START]
2022-11-01 23:46:20,141 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,143 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,183 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,186 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,207 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,209 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,224 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,226 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,238 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,241 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,251 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,253 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,262 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,264 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,272 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,274 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,281 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,283 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,290 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,292 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,299 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,301 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,307 # [pm_layered] pm_unblock(1)
2022-11-01 23:46:20,309 # [pm_layered] pm_block(1)
2022-11-01 23:46:20,313 # [SUCCESS]
(Switching baud rates caused 12 pm_unblock/pm_block pairs)
```

</details>

#### `periph_spi`

Flash `tests/periph_spi` with DMA support on the `samr30-xpro` board:

<details>

```
USEMODULE=periph_dma make -C tests/periph_spi BOARD=samr30-xpro flash term
2022-11-02 00:00:27,823 # [pm_layered] pm_block(0)
2022-11-02 00:00:27,825 # [pm_layered] pm_block(1)
2022-11-02 00:00:27,833 # main(): This is RIOT! (Version: 2023.01-devel-241-ge2c7b-feature/saml21_pheriph_pm)
2022-11-02 00:00:27,838 # Manual SPI peripheral driver test (see README.md)
2022-11-02 00:00:27,842 # There are 2 SPI devices configured for your platform.
> init 0 0 2 2 0
2022-11-02 00:00:35,171 # init 0 0 2 2 0
2022-11-02 00:00:35,178 # Trying to initialize SPI_DEV(0): mode: 0, clk: 2, cs_port: 2, cs_pin: 0
2022-11-02 00:00:35,183 # Note: Failed assertion (crash) means configuration not supported
> send HELLOWORLDHELLOWORLD
2022-11-02 00:00:40,525 # send HELLOWORLDHELLOWORLD
2022-11-02 00:00:40,527 # [pm_layered] pm_block(1)
2022-11-02 00:00:40,530 # [pm_layered] pm_unblock(1)
2022-11-02 00:00:40,531 # Sent bytes
2022-11-02 00:00:40,541 #    0    1    2    3    4    5    6    7    8    9   10   11   12   13   14   15   16   17   18   19 
2022-11-02 00:00:40,550 #   0x48 0x45 0x4c 0x4c 0x4f 0x57 0x4f 0x52 0x4c 0x44 0x48 0x45 0x4c 0x4c 0x4f 0x57 0x4f 0x52 0x4c 0x44
2022-11-02 00:00:40,560 #     H    E    L    L    O    W    O    R    L    D    H    E    L    L    O    W    O    R    L    D 
2022-11-02 00:00:40,560 # 
2022-11-02 00:00:40,561 # Received bytes
2022-11-02 00:00:40,571 #    0    1    2    3    4    5    6    7    8    9   10   11   12   13   14   15   16   17   18   19 
2022-11-02 00:00:40,581 #   0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xff
2022-11-02 00:00:40,590 #    ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ??   ?? 
2022-11-02 00:00:40,590 # 
> pm show
2022-11-02 00:02:09,843 # pm show
2022-11-02 00:02:09,845 # mode 0 blockers: 1 (periph_rtt (used by ztimer_sec))
2022-11-02 00:02:09,846 # mode 1 blockers: 2 (periph_uart + periph_timer (used by ztimer_uec))
2022-11-02 00:02:09,848 # mode 2 blockers: 0 
2022-11-02 00:02:09,850 # Lowest allowed mode: 2
```

</details>

### Issues/PRs references

My talk from the last RIOT summit: https://www.youtube.com/watch?v=N2etFVR5mfg

Waiting for #18825 