### PR TITLE
cpu/saml21/pm: allow blocking IDLE mode

### DIFF
--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -35,7 +35,10 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (3)
+#define PM_NUM_MODES           (3)
+#define SAML21_PM_MODE_BACKUP  (0)  /**< Wakeup by some IRQs possible, but no RAM retention */
+#define SAML21_PM_MODE_STANDBY (1)  /**< Just peripherals clocked by 32K OSC are active */
+#define SAML21_PM_MODE_IDLE    (2)  /**< CPU sleeping, peripherals are active */
 /** @} */
 
 /**

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -30,18 +30,18 @@ void pm_set(unsigned mode)
     uint32_t _mode;
 
     switch (mode) {
-        case 0:
+        case SAML21_PM_MODE_BACKUP:
             DEBUG_PUTS("pm_set(): setting BACKUP mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
             deep  = 1;
             break;
-        case 1:
+        case SAML21_PM_MODE_STANDBY:
             DEBUG_PUTS("pm_set(): setting STANDBY mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
             deep  = 1;
             break;
         default: /* Falls through */
-        case 2:
+        case SAML21_PM_MODE_IDLE:
             DEBUG_PUTS("pm_set(): setting IDLE mode.");
 #if !defined(PM_SLEEPCFG_SLEEPMODE_IDLE2)
             _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -40,7 +40,6 @@ void pm_set(unsigned mode)
             _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
             deep  = 1;
             break;
-        default: /* Falls through */
         case SAML21_PM_MODE_IDLE:
             DEBUG_PUTS("pm_set(): setting IDLE mode.");
 #if !defined(PM_SLEEPCFG_SLEEPMODE_IDLE2)
@@ -49,6 +48,9 @@ void pm_set(unsigned mode)
             _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
 #endif
             break;
+        default:
+            /* don't sleep at all */
+            return;
     }
 
     /* write sleep configuration */

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -79,6 +79,8 @@ void pm_block(unsigned mode)
 {
     assert(pm_blocker.blockers[mode] != 255);
 
+    DEBUG("[pm_layered] pm_block(%d)\n", mode);
+
     unsigned state = irq_disable();
     pm_blocker.blockers[mode]++;
     irq_restore(state);
@@ -87,6 +89,8 @@ void pm_block(unsigned mode)
 void pm_unblock(unsigned mode)
 {
     assert(pm_blocker.blockers[mode] > 0);
+
+    DEBUG("[pm_layered] pm_unblock(%d)\n", mode);
 
     unsigned state = irq_disable();
     pm_blocker.blockers[mode]--;


### PR DESCRIPTION
### Contribution description

This PR allow to block the IDLE mode on the `saml21` cpu.

### Testing procedure

Programming `tests/periph_pm` to a saml21-based board:

```
make -C tests/periph_pm BOARD=samr30-xpro flash term
2022-10-31 22:24:23,596 # main(): This is RIOT! (Version: 2023.01-devel-216-g4b802-fix/saml21-pm-modes)
2022-10-31 22:24:23,601 # This application allows you to test the CPU power management.
2022-10-31 22:24:23,607 # The available power modes are 0 - 2. Lower-numbered power modes
2022-10-31 22:24:23,612 # save more power, but may require an event/interrupt to wake up
2022-10-31 22:24:23,615 # the CPU. Reset the CPU if needed.
2022-10-31 22:24:23,617 # mode 0 blockers: 1 
2022-10-31 22:24:23,619 # mode 1 blockers: 1 
2022-10-31 22:24:23,621 # mode 2 blockers: 0 
2022-10-31 22:24:23,623 # Lowest allowed mode: 2
2022-10-31 22:24:23,626 # using BTN0 as wake-up source
2022-10-31 22:24:23,628 # pm_set(): setting IDLE mode.
> pm block 2
2022-10-31 22:24:55,455 # pm block 2
2022-10-31 22:24:55,457 # Blocking power mode 2.
> pm show
2022-10-31 22:24:59,751 # pm show
2022-10-31 22:24:59,752 # mode 0 blockers: 1 
2022-10-31 22:24:59,754 # mode 1 blockers: 1 
2022-10-31 22:24:59,756 # mode 2 blockers: 1 
2022-10-31 22:24:59,758 # Lowest allowed mode: 3
> pm unblock 2
2022-10-31 22:25:17,447 # pm unblock 2
2022-10-31 22:25:17,450 # Unblocking power mode 2.
2022-10-31 22:25:17,453 # pm_set(): setting IDLE mode.
> pm unblock 1
2022-10-31 22:25:20,823 # pm unblock 1
2022-10-31 22:25:20,826 # Unblocking power mode 1.
2022-10-31 22:25:20,829 # pm_set(): setting STANDBY mode.
```

### Issues/PRs references

#13475 yielded #17895, which already prepared the saml21 CPUs to take the IDLE pm into account.
#17883 implements the same logic for the samd5x cpu family.
