### PR TITLE
drivers/slipdev: fix off-by-one error in _recv()

### DIFF
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -201,16 +201,19 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                 /* something went wrong, return error */
                 return -EIO;
             }
-            tmp = slipdev_unstuff_readbyte(ptr, byte, &escaped);
-            ptr += tmp;
-            res += tmp;
-            if ((unsigned)res > len) {
+
+            /* frame is larger than expected - lost end marker */
+            if ((unsigned)res >= len) {
                 while (byte != SLIPDEV_END) {
                     /* clear out unreceived packet */
                     byte = tsrb_get_one(&dev->inbuf);
                 }
                 return -ENOBUFS;
             }
+
+            tmp = slipdev_unstuff_readbyte(ptr, byte, &escaped);
+            ptr += tmp;
+            res += tmp;
         } while (byte != SLIPDEV_END);
 
         if (++dev->rx_done != dev->rx_queued) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This fixes the off-by-one error in SLIP the same way as it was fixed in ethos.

Previously I tried to make SLIP use the chunked ringbuffer to handle this with common code or clean up the driver while fixing the bug, but neither reached consensus.

So this minimal solution should fix the bug while not touching the driver otherwise.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #18229, #18066
same as #18823
