### PR TITLE
nanocoap_sock: don't store entire sock in coap_block_request_t

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -527,7 +527,7 @@ int nanocoap_sock_block_request(coap_block_request_t *req,
     pkt.payload = pktpos;
     pkt.payload_len = 0;
 
-    res = nanocoap_sock_request_cb(&req->sock, &pkt, callback, arg);
+    res = nanocoap_sock_request_cb(req->sock, &pkt, callback, arg);
     if (res < 0) {
         return res;
     }

--- a/sys/net/application_layer/nanocoap/vfs.c
+++ b/sys/net/application_layer/nanocoap/vfs.c
@@ -131,7 +131,7 @@ int nanocoap_vfs_put(nanocoap_sock_t *sock, const char *path, const char *src,
         .path = path,
         .method = COAP_METHOD_PUT,
         .blksize = coap_size2szx(work_buf_len - 1),
-        .sock = *sock,
+        .sock = sock,
     };
 
     return _vfs_put(&ctx, src, work_buf);
@@ -146,12 +146,13 @@ int nanocoap_vfs_put_url(const char *url, const char *src,
         return -ENOBUFS;
     }
 
+    nanocoap_sock_t sock;
     coap_block_request_t ctx;
-    int res = nanocoap_block_request_init_url(&ctx, url, COAP_METHOD_PUT,
-                                              coap_size2szx(work_buf_len - 1));
+    int res = nanocoap_block_request_connect_url(&ctx, &sock, url, COAP_METHOD_PUT,
+                                                 coap_size2szx(work_buf_len - 1));
     if (res == 0) {
         res = _vfs_put(&ctx, src, work_buf);
-        nanocoap_block_request_done(&ctx);
+        nanocoap_sock_close(&sock);
     }
 
     return res;

--- a/sys/net/application_layer/nanocoap/vfs.c
+++ b/sys/net/application_layer/nanocoap/vfs.c
@@ -114,8 +114,6 @@ static int _vfs_put(coap_block_request_t *ctx, const char *file, void *buffer)
         vfs_lseek(fd, -1, SEEK_CUR);
     }
 
-    nanocoap_block_request_done(ctx);
-
     vfs_close(fd);
     return res;
 }
@@ -151,9 +149,10 @@ int nanocoap_vfs_put_url(const char *url, const char *src,
     coap_block_request_t ctx;
     int res = nanocoap_block_request_init_url(&ctx, url, COAP_METHOD_PUT,
                                               coap_size2szx(work_buf_len - 1));
-    if (res) {
-        return res;
+    if (res == 0) {
+        res = _vfs_put(&ctx, src, work_buf);
+        nanocoap_block_request_done(&ctx);
     }
 
-    return _vfs_put(&ctx, src, work_buf);
+    return res;
 }

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -268,6 +268,7 @@ static const char song[] =
 int nanotest_client_put_cmd(int argc, char **argv)
 {
     int res;
+    nanocoap_sock_t sock;
     coap_block_request_t ctx;
 
     if (argc < 2) {
@@ -275,8 +276,8 @@ int nanotest_client_put_cmd(int argc, char **argv)
         return 1;
     }
 
-    res = nanocoap_block_request_init_url(&ctx, argv[1],
-                                          COAP_METHOD_PUT, COAP_BLOCKSIZE_32);
+    res = nanocoap_block_request_connect_url(&ctx, &sock, argv[1],
+                                             COAP_METHOD_PUT, COAP_BLOCKSIZE_32);
     if (res < 0) {
         printf("error: %d\n", res);
         return res;
@@ -295,7 +296,7 @@ int nanotest_client_put_cmd(int argc, char **argv)
         pos += res;
     }
 
-    nanocoap_block_request_done(&ctx);
+    nanocoap_sock_close(&sock);
     return res;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I previously thought it would be convenient to store the socket struct inside `coap_block_request_t`. 
This turned out to inhibit flexibility if the socket is to be used outside the blockwise request.
Worse even, in `nanocoap_vfs_put()` it would be copied (which turned out to not be safe for listening sockets).

So get rid of the misguided `nanocoap_block_request_init()` function - it never used in tree and was only added for 'API symmetry'.
Instead add a `sock` parameter to `nanocoap_block_request_init_url()` and since the user is now aware that they have a socket at their hands, just let them call `nanocoap_sock_close()` instead of providing an otherwise useless `nanocoap_block_request_done()` wrapper.


### Testing procedure

`tests/gcoap_fileserver` will ensure that block-wise PUT and GET do still work (via `ncput`/`ncget`).

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
