### PR TITLE
drivers/ethos: Fix off-by-one bug [backport 2022.10]

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -373,16 +373,17 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void* info)
                 DEBUG("ethos _recv(): inbuf doesn't contain enough bytes.\n");
                 return -EIO;
             }
-            tmp = ethos_unstuff_readbyte(ptr, (uint8_t)byte, &escaped, &frametype);
-            ptr += tmp;
-            res += tmp;
-            if ((unsigned)res > len) {
-                while (byte != (int)ETHOS_FRAME_DELIMITER) {
+            if ((unsigned)res >= len) {
+                while (byte != (int)ETHOS_FRAME_DELIMITER && byte >= 0) {
                     /* clear out unreceived packet */
                     byte = tsrb_get_one(&dev->inbuf);
                 }
                 return -ENOBUFS;
             }
+
+            tmp = ethos_unstuff_readbyte(ptr, (uint8_t)byte, &escaped, &frametype);
+            ptr += tmp;
+            res += tmp;
         } while (byte != ETHOS_FRAME_DELIMITER);
 
         switch (frametype) {


### PR DESCRIPTION
# Backport of #18823

The ethernet over serial driver `_recv` function checks the buffer size after writing the data.
To fix this I moved the bounds check before the function writing to the buffer.