### PR TITLE
sys/bitfield: add bf_find_first_{set, unset}()

### DIFF
--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 #include "bitfield.h"
 #include "irq.h"
 
@@ -79,4 +80,15 @@ int bf_find_first_unset(const uint8_t field[], size_t size)
     }
 
     return -1;
+}
+
+void bf_set_all(uint8_t field[], size_t size)
+{
+    unsigned bytes = size >> 3;
+    unsigned bits = size & 0x7;
+
+    memset(field, 0xff, bytes);
+    if (bits) {
+        field[bytes] = ~((1U << (8 - bits)) - 1);
+    }
 }

--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -13,6 +13,7 @@
  * @brief       Bitfield auxiliary functions
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  * @}
  */
@@ -21,18 +22,24 @@
 #include "bitfield.h"
 #include "irq.h"
 
+static inline unsigned _skip_bytes(const uint8_t field[], unsigned nbytes, uint8_t byte)
+{
+    unsigned i = 0;
+    for (unsigned j = 0; (j < nbytes) && (field[j] == byte); j++) {
+        i += 8;
+    }
+    return i;
+}
+
 int bf_get_unset(uint8_t field[], size_t size)
 {
     int result = -1;
-    int nbytes = (size + 7) / 8;
-    size_t i = 0;
+    unsigned nbytes = (size + 7) / 8;
 
     unsigned state = irq_disable();
 
     /* skip full bytes */
-    for (int j = 0; (j < nbytes) && (field[j] == 255); j++) {
-        i += 8;
-    }
+    unsigned i = _skip_bytes(field, nbytes, 0xff);
 
     for (; i < size; i++) {
         if (!bf_isset(field, i)) {
@@ -44,4 +51,32 @@ int bf_get_unset(uint8_t field[], size_t size)
 
     irq_restore(state);
     return result;
+}
+
+int bf_find_first_set(const uint8_t field[], size_t size)
+{
+    unsigned nbytes = (size + 7) / 8;
+    unsigned i = _skip_bytes(field, nbytes, 0);
+
+    for (; i < size; i++) {
+        if (bf_isset(field, i)) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+int bf_find_first_unset(const uint8_t field[], size_t size)
+{
+    unsigned nbytes = (size + 7) / 8;
+    unsigned i = _skip_bytes(field, nbytes, 0xff);
+
+    for (; i < size; i++) {
+        if (!bf_isset(field, i)) {
+            return i;
+        }
+    }
+
+    return -1;
 }

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -211,6 +211,14 @@ int bf_find_first_set(const uint8_t field[], size_t size);
  */
 int bf_find_first_unset(const uint8_t field[], size_t size);
 
+/**
+ * @brief  Set all bits in the bitfield to 1
+ *
+ * @param[in]     field The bitfield
+ * @param[in]     size  The size of the bitfield
+ */
+void bf_set_all(uint8_t field[], size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -84,7 +84,7 @@ static inline void bf_toggle(uint8_t field[], size_t idx)
  * @param[in,out] field The bitfield
  * @param[in]     idx   The number of the bit to check
  */
-static inline bool bf_isset(uint8_t field[], size_t idx)
+static inline bool bf_isset(const uint8_t field[], size_t idx)
 {
     return (field[idx / 8] & (1u << (7 - (idx % 8))));
 }
@@ -188,6 +188,28 @@ static inline void bf_inv(uint8_t out[], const uint8_t a[], size_t len)
  * @return      -1 if no bit was unset
  */
 int bf_get_unset(uint8_t field[], size_t len);
+
+/**
+ * @brief  Get the index of the first set bit in the field
+ *
+ * @param[in]     field The bitfield
+ * @param[in]     size  The size of the bitfield
+ *
+ * @return      number of the first set bit
+ * @return      -1 if no bit is set
+ */
+int bf_find_first_set(const uint8_t field[], size_t size);
+
+/**
+ * @brief  Get the index of the zero bit in the field
+ *
+ * @param[in]     field The bitfield
+ * @param[in]     size  The size of the bitfield
+ *
+ * @return      number of the first unset bit
+ * @return      -1 if all bits are set
+ */
+int bf_find_first_unset(const uint8_t field[], size_t size);
 
 #ifdef __cplusplus
 }

--- a/tests/unittests/tests-bitfield/tests-bitfield.c
+++ b/tests/unittests/tests-bitfield/tests-bitfield.c
@@ -222,6 +222,58 @@ static void test_bf_ops(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(c, b, sizeof(c)));
 }
 
+static void test_bf_find_first_set(void)
+{
+    int res;
+    uint8_t field[5];
+    memset(field, 0, sizeof(field));
+
+    res = bf_find_first_set(field, 40);
+    TEST_ASSERT_EQUAL_INT(-1, res);
+
+    bf_set(field, 23);
+    res = bf_find_first_set(field, 40);
+    TEST_ASSERT_EQUAL_INT(23, res);
+
+    bf_set(field, 24);
+    res = bf_find_first_set(field, 40);
+    TEST_ASSERT_EQUAL_INT(23, res);
+
+    bf_set(field, 13);
+    res = bf_find_first_set(field, 40);
+    TEST_ASSERT_EQUAL_INT(13, res);
+
+    bf_set(field, 3);
+    res = bf_find_first_set(field, 40);
+    TEST_ASSERT_EQUAL_INT(3, res);
+}
+
+static void test_bf_find_first_unset(void)
+{
+    int res;
+    uint8_t field[5];
+    memset(field, 0xff, sizeof(field));
+
+    res = bf_find_first_unset(field, 40);
+    TEST_ASSERT_EQUAL_INT(-1, res);
+
+    bf_unset(field, 23);
+    res = bf_find_first_unset(field, 40);
+    TEST_ASSERT_EQUAL_INT(23, res);
+
+    bf_unset(field, 24);
+    res = bf_find_first_unset(field, 40);
+    TEST_ASSERT_EQUAL_INT(23, res);
+
+    bf_unset(field, 13);
+    res = bf_find_first_unset(field, 40);
+    TEST_ASSERT_EQUAL_INT(13, res);
+
+    bf_unset(field, 3);
+    res = bf_find_first_unset(field, 40);
+    TEST_ASSERT_EQUAL_INT(3, res);
+}
+
 Test *tests_bitfield_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -234,6 +286,8 @@ Test *tests_bitfield_tests(void)
         new_TestFixture(test_bf_get_unset_middle),
         new_TestFixture(test_bf_get_unset_lastbyte),
         new_TestFixture(test_bf_ops),
+        new_TestFixture(test_bf_find_first_set),
+        new_TestFixture(test_bf_find_first_unset),
     };
 
     EMB_UNIT_TESTCALLER(bitfield_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-bitfield/tests-bitfield.c
+++ b/tests/unittests/tests-bitfield/tests-bitfield.c
@@ -274,8 +274,32 @@ static void test_bf_find_first_unset(void)
     TEST_ASSERT_EQUAL_INT(3, res);
 }
 
-Test *tests_bitfield_tests(void)
+static void test_bf_set_all(void)
 {
+    uint8_t field[5];
+
+    memset(field, 0, sizeof(field));
+    bf_set_all(field, 5);
+    TEST_ASSERT_EQUAL_INT(0xf8, field[0]);
+    TEST_ASSERT_EQUAL_INT(0, field[1]);
+
+    memset(field, 0, sizeof(field));
+    bf_set_all(field, 24);
+    TEST_ASSERT_EQUAL_INT(0xff, field[0]);
+    TEST_ASSERT_EQUAL_INT(0xff, field[1]);
+    TEST_ASSERT_EQUAL_INT(0xff, field[2]);
+    TEST_ASSERT_EQUAL_INT(0, field[3]);
+
+    memset(field, 0, sizeof(field));
+    bf_set_all(field, 30);
+    TEST_ASSERT_EQUAL_INT(0xff, field[0]);
+    TEST_ASSERT_EQUAL_INT(0xff, field[1]);
+    TEST_ASSERT_EQUAL_INT(0xff, field[2]);
+    TEST_ASSERT_EQUAL_INT(0xfc, field[3]);
+    TEST_ASSERT_EQUAL_INT(0, field[4]);
+}
+
+Test *tests_bitfield_tests(void) {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_bf_set),
         new_TestFixture(test_bf_unset),
@@ -288,6 +312,7 @@ Test *tests_bitfield_tests(void)
         new_TestFixture(test_bf_ops),
         new_TestFixture(test_bf_find_first_set),
         new_TestFixture(test_bf_find_first_unset),
+        new_TestFixture(test_bf_set_all),
     };
 
     EMB_UNIT_TESTCALLER(bitfield_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I noticed that I needed these functions independent from #17045 and just as I was about to re-implement them, stale bot reminded me that I already did so a year ago.

So let's try to salvage them from that PR.


### Testing procedure

Unittests are provided an can be build with

    make -C tests/unittests tests-bitfield


### Issues/PRs references

split from #17045