### PR TITLE
pkg/tinyusb: Note distinction from USBUS

### DIFF
--- a/pkg/tinyusb/doc.txt
+++ b/pkg/tinyusb/doc.txt
@@ -10,6 +10,10 @@
  * tinyUSB is an open-source cross-platform USB Host/Device stack for
  * embedded systems.
  *
+ * @note This package is distinct from (and incompatible with) the USB stack
+ * provided around USBUS in RIOT (see @ref usb). They differ in the level of
+ * abstraction and in the set of supported devices.
+ *
  * # Usage
  *
  * Add the following entries to your application makefile:


### PR DESCRIPTION
### Contribution description

Users who find tinyusb in the documentation might be misled into thinking that this is what backs the USB features advertised around RIOT, or think that one of the stacks can use the other. This adds text to the docs to say that they are distinct and incompatible.

### Testing procedure

* Look at text: Is it correct?
* Look at rendered documentation to see whether it looks nice.