### PR TITLE
examples/gnrc_border_router: add option to re-use existing TAP interface

### DIFF
--- a/dist/tools/zep_dispatch/start_network.sh
+++ b/dist/tools/zep_dispatch/start_network.sh
@@ -25,7 +25,9 @@ remove_tap() {
 
 cleanup() {
     echo "Cleaning up..."
-    remove_tap
+    if [ "${CREATE_TAP}" -eq 1 ]; then
+        remove_tap
+    fi
     if [ -n "${UHCPD_PID}" ]; then
         kill "${UHCPD_PID}"
     fi
@@ -64,6 +66,13 @@ start_zep_dispatch() {
     ZEP_DISPATCH_PID=$!
 }
 
+if [ "$1" = "-c" ] || [ "$1" = "--create-tap" ]; then
+    CREATE_TAP=1
+    shift 1
+else
+    CREATE_TAP=0
+fi
+
 if [ "$1" = "-d" ] || [ "$1" = "--use-dhcpv6" ]; then
     USE_DHCPV6=1
     shift 1
@@ -101,7 +110,9 @@ for TAP in "$@"; do :; done
 
 trap "cleanup" INT QUIT TERM EXIT
 
-create_tap
+if [ ${CREATE_TAP} -eq 1 ]; then
+    create_tap
+fi
 
 if [ ${USE_ZEP_DISPATCH} -eq 1 ]; then
     start_zep_dispatch

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -43,7 +43,7 @@ USEMODULE += ps
 #USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 # When using a regular network uplink we should use DHCPv6
-ifneq (,$(filter cdc-ecm wifi ethernet,$(UPLINK)))
+ifneq (,$(filter cdc-ecm wifi ethernet,$(UPLINK)) $(REUSE_TAP))
   PREFIX_CONF ?= dhcpv6
 else
   PREFIX_CONF ?= uhcp

--- a/examples/gnrc_border_router/Makefile.ethos.conf
+++ b/examples/gnrc_border_router/Makefile.ethos.conf
@@ -1,14 +1,21 @@
 CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
 
-STATIC_ROUTES ?= 1
-
 ifeq (dhcpv6,$(PREFIX_CONF))
   FLAGS_EXTRAS=--use-dhcpv6
 else ifeq (auto_subnets,$(PREFIX_CONF))
   FLAGS_EXTRAS=--use-radvd
 endif
 
-# Configure terminal parameters
+ifeq (1, $(REUSE_TAP))
+  # Use ethos directly
+  TERMPROG ?= $(RIOTTOOLS)/ethos/ethos
+  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+else
+  STATIC_ROUTES ?= 1
+
+  # Set up network, ethos started by start_network.sh
+  TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= $(FLAGS_EXTRAS) $(PORT) $(TAP) $(IPV6_PREFIX) $(ETHOS_BAUDRATE)
+endif
+
 TERMDEPS += host-tools
-TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
-TERMFLAGS ?= $(FLAGS_EXTRAS) $(PORT) $(TAP) $(IPV6_PREFIX) $(ETHOS_BAUDRATE)

--- a/examples/gnrc_border_router/Makefile.native.conf
+++ b/examples/gnrc_border_router/Makefile.native.conf
@@ -34,3 +34,6 @@ TERMFLAGS ?= $(patsubst %,-z [::1]:%, $(shell seq $(ZEP_PORT_BASE) $(ZEP_PORT_MA
 ifneq (,$(ZEP_MAC))
   TERMFLAGS += --eui64=$(ZEP_MAC)
 endif
+
+# native uses $PORT to specify the TAP interface
+PORT ?= $(TAP)

--- a/examples/gnrc_border_router/Makefile.native.conf
+++ b/examples/gnrc_border_router/Makefile.native.conf
@@ -9,10 +9,14 @@ CFLAGS += -DASYNC_READ_NUMOF=$(shell expr $(ZEP_DEVICES) + 1)
 # Set CFLAGS if not being set via Kconfig
 CFLAGS += $(if $(CONFIG_KCONFIG_MODULE_DHCPV6),,-DCONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX=$(ZEP_DEVICES))
 
-ifeq (dhcpv6,$(PREFIX_CONF))
-  FLAGS_EXTRAS += --use-dhcpv6
-else ifeq (auto_subnets,$(PREFIX_CONF))
-  FLAGS_EXTRAS += --use-radvd
+# create a new TAP interface if not re-using an existing one
+ifneq (1, $(REUSE_TAP))
+  FLAGS_EXTRAS += --create-tap
+  ifeq (dhcpv6,$(PREFIX_CONF))
+    FLAGS_EXTRAS += --use-dhcpv6
+  else ifeq (auto_subnets,$(PREFIX_CONF))
+    FLAGS_EXTRAS += --use-radvd
+  endif
 endif
 
 # enable the ZEP dispatcher

--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -44,6 +44,21 @@ credentials. You can alternatively edit the `Makefile`.
 Currently, `wifi` requires an esp8266 or esp32 for the border router and will default
 to using `esp_now` for the downstream interface.
 
+### Connection sharing with host
+
+If the host (Linux) computer has an IPv6 uplink that can be shard with the RIOT border
+router to provide it with an uplink.
+
+This requires the host network to be bridged with the TAP network by connecting it to
+the TAP bridge:
+
+    sudo dist/tools/tapsetup/tapsetup -u eno1
+
+where `eno1` is the host's uplink interface.
+
+Then specify `REUSE_TAP=1` when building / running the border router application.
+This works with both `native` and the `ethos` uplink.
+
 ## Requirements
 This functionality works only on Linux machines.
 macOS support will be added in the future (lack of native `tap` interface).


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When using `gnrc_border_router` on `native` the build system will take care of creating a TAP interface and running UHCP/DHCPv6 on it.

This is not always the desired behavior.
e.g. when a TAP bridge was created with a real interface to provide an uplink to `native` or `ethos`, we actually want to use that instead of creating a new one.

We then also want to use the real DHCPv6 server instead of starting our own one.

This adds the `REUSE_TAP=1` option to skip network setup and just use the provided TAP interface as the uplink.


### Testing procedure

 - create a bridge with your Ethernet adapter (interface name may vary)

       sudo dist/tools/tapsetup/tapsetup -u eno1

 - start the border router with the `tap` uplink

       make REUSE_TAP=1 -C examples/gnrc_border_router all term

  - the border router should receive a global address and can reach internet hosts

```
Iface  6  HWaddr: 7A:37:FC:7D:1A:AF 
          L2-PDU:1500  MTU:1492  HL:255  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::7837:fcff:fe7d:1aaf  scope: link  VAL
          inet6 addr: 2001:9e8:140f:fc00:7837:fcff:fe7d:1aaf  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff7d:1aaf
          
Iface  7  HWaddr: 44:28  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: AA:78:BF:FD:E1:06:C4:28 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::a878:bffd:e106:c428  scope: link  VAL
          inet6 addr: 2001:9e8:140f:fcf4:a878:bffd:e106:c428  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff06:c428
          
> ping riot-os.org
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=0 ttl=60 time=25.104 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=1 ttl=60 time=147.904 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=2 ttl=60 time=50.646 ms

--- riot-os.org PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 25.104/74.551/147.904 ms
```

 - *Bonus*: virtual 802.15.4 nodes can also reach the internet

       make USE_ZEP=1 -C examples/gnrc_networking all term

```
Iface  7  HWaddr: 61:B3  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: 5E:AF:98:F2:44:49:E1:B3 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::5caf:98f2:4449:e1b3  scope: link  VAL
          inet6 addr: 2001:9e8:140f:fcf4:5caf:98f2:4449:e1b3  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff49:e1b3
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 3  bytes 246
            TX packets 3 (Multicast: 2)  bytes 0
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 2  bytes 248
            TX packets 3 (Multicast: 2)  bytes 210
            TX succeeded 3 errors 0

> ping riot-os.org
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=0 ttl=59 rssi=0 dBm time=24.319 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=1 ttl=59 rssi=0 dBm time=23.516 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=2 ttl=59 rssi=0 dBm time=147.707 ms

--- riot-os.org PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 23.516/65.180/147.707 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
