### PR TITLE
core/lib/xfa: fix parameter documentation

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -64,7 +64,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *     error: ISO C forbids empty initializer braces
  *     error: ISO C forbids zero-size array ‘xfatest_const_end’
  *
- * @param[in]   type    name of the cross-file array
+ * @param[in]   type    type of the cross-file array
  * @param[in]   name    name of the cross-file array
  */
 #define XFA_INIT_CONST(type, name) \
@@ -86,7 +86,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *     error: ISO C forbids empty initializer braces
  *     error: ISO C forbids zero-size array ‘xfatest_end’
  *
- * @param[in]   type    name of the cross-file array
+ * @param[in]   type    type of the cross-file array
  * @param[in]   name    name of the cross-file array
  */
 #define XFA_INIT(type, name) \
@@ -105,7 +105,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * It is supposed to be used in compilation units where the cross file array is
  * being accessed, but not defined using XFA_INIT.
  *
- * @param[in]   type    name of the cross-file array
+ * @param[in]   type    type of the cross-file array
  * @param[in]   name    name of the cross-file array
  */
 #define XFA_USE_CONST(type, name) \
@@ -120,7 +120,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * It is supposed to be used in compilation units where the cross file array is
  * being accessed, but not defined using XFA_INIT.
  *
- * @param[in]   type    name of the cross-file array
+ * @param[in]   type    type of the cross-file array
  * @param[in]   name    name of the cross-file array
  */
 #define XFA_USE(type, name) \


### PR DESCRIPTION
### Contribution description

This PR is a very small fix of the documentation of parameters in `core/lib/include/xfa.h`. I guess this was just a copy&paste bug.

### Testing procedure

Green CI and correct documentation of the `XFA_{INIT|USE}*` macros in https://doc.riot-os.org/xfa_8h.html.

### Issues/PRs references

