### PR TITLE
github/workflows/release-test: check return code

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -123,6 +123,7 @@ jobs:
         sudo apt-get install lib32asan6
     - name: Run release tests
       timeout-minutes: 350
+      shell: /usr/bin/bash {0}
       run: |
         RIOTBASE="$GITHUB_WORKSPACE/RIOT"
         TOX_ARGS=""
@@ -135,6 +136,8 @@ jobs:
         fi
 
         cd Release-Specs
+        # avoid exiting on non-zero exit code
+        set +e
         # definition in env does not work since $GITHUB_WORKSPACE seems not to
         # be accessible
         ${{ matrix.sudo }} \
@@ -157,6 +160,15 @@ jobs:
           RIOTBASE=${RIOTBASE} \
           $(which tox) -e test -- ${TOX_ARGS} \
             ${K} "${{ github.event.inputs.filter }}" -m "${{ matrix.pytest_mark }}"
+        TEST_RESULT=$?
+        # check for success or empty test selection
+        # https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
+        if [ ${TEST_RESULT} -eq 0 ] || [ ${TEST_RESULT} -eq 5 ]; then
+          exit 0
+        else
+          exit 1
+        fi
+
     - name: junit2html and XML deploy
       if: always()
       run: |


### PR DESCRIPTION
### Contribution description
Whenever no test matches the criteria pytest returns a non-zero exit code (https://docs.pytest.org/en/7.1.x/reference/exit-codes.html), and github detects this as an error, marking the run as a failure. This adds an explicit check for error codes to avoid unnecessary noise.

### Testing procedure
Not sure if this can be tested before merging. But applying a test filter that resolves to an empty test selection should not result in a failed run.

### Issues/PRs references
None
