### PR TITLE
rust: Use stable Rust

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -106,26 +106,21 @@ Toolchain {#toolchain}
 
 To install the necessary Rust components, it is easiest use [**rustup**, installed as described on its website].
 
-Using Rust on RIOT needs the latest stable or nightly version of Rust,
-depending on the precise example used.
-(Currently, it's mainly the CoAP parts that use nightly features, and some native builds;
-until stable is universally available, only tests are run on stable by default).
+Using Rust on RIOT needs the latest stable version of Rust.
 
-Make sure you have both the nightly and stable **toolchains**
+Make sure you have the stable **toolchain**
 and the core library for the CPU (**target**) of your choice available:
 
 ```
-$ rustup toolchain add nightly
 $ rustup toolchain add stable
-$ rustup target add thumbv7m-none-eabi --toolchain nightly
 $ rustup target add thumbv7m-none-eabi --toolchain stable
 ```
 
 Substitute thumbv7m-none-eabi with the value of `RUST_TARGET`
-in the output of `make info-build` of an application that has your current board selected,
-or just add it later whenever the Rust compiler complains about not finding the core library for a given target).
-Installing only nightly will work just as well,
-but you may need to remove the `CARGO_CHANNEL = stable` line to run tests.
+in the output of `make info-build` of an application that has your current board selected
+(or just add it later whenever the Rust compiler complains about not finding the core library for a given target).
+Using a beta or nightly will work just as well,
+but you may need to set `CARGO_CHANNEL=nightly` on your shell or in your Makefiles.
 
 
 While Rust comes with its own [cargo] dependency tracker for any Rust code,

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -41,8 +41,7 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# This example requires a nightly version because of the CoAP dependencies
-CARGO_CHANNEL ?= ${CARGO_CHANNEL_NIGHTLY}
+CARGO_CHANNEL ?= stable
 
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation

--- a/examples/rust-hello-world/Makefile
+++ b/examples/rust-hello-world/Makefile
@@ -21,10 +21,10 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# While this example can be built with stable Rust on many platforms, the
-# nightly channel is selected to smoothly transition from running this example
-# to experimenting with it (which might easily lead into nightly territory).
-CARGO_CHANNEL ?= $(CARGO_CHANNEL_NIGHTLY)
+# All Rust components RIOT uses work on stable Rust. If any extra libraries
+# were to require a more recent version, switch to `CARGO_CHANNEL =
+# $(CARGO_CHANNEL_NIGHTLY)` to use whichever nightly version is available.
+CARGO_CHANNEL ?= stable
 
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation


### PR DESCRIPTION
### Contribution description

Since Rust 1.65, we don't depend on anything nightly any more. This changes the examples and documentation to use stable.

### Testing procedure

* Green CI with tests enabled
* Look at changed documentation ([rendered](https://ci.riot-os.org/results/2923b30a4ba04dbface1ed38fb6aae12/doc-preview/using-rust.html#toolchain))

<del>Note that these will *not* pass yet: This needs a CI update (no PR associated: Any CI image built from now on will do).</del>

### Issues/PRs references

A follow-up will simplify things a bit further, but that will depend on CI to have made stable the default, which is a later step in what is a bit of a lock-step game:

* [x] CI rebuilds riotdocker -- no PR, then stable=1.65
* [ ] Use stable in examples -- this PR, then examples use stable
* [ ] CI removes nightly and makes stable the default -- https://github.com/RIOT-OS/riotdocker/pull/214, then default=stable
* [ ] Use the new default to simplify makefiles -- https://github.com/RIOT-OS/RIOT/pull/18840