### PR TITLE
makefiles: No --fatal-warnings for Cortex-M linker

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -29,7 +29,7 @@ CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 LINKER_SCRIPT ?= $(CPU_MODEL).ld
-LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings
+LINKFLAGS += -T$(LINKER_SCRIPT)
 
 LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 LINKFLAGS += -Wl,--gc-sections


### PR DESCRIPTION
### Contribution description

The linker flag --fatal-warnings was added in #3120 on the premise that linker warnings result in broken binaries.

Issue https://github.com/RIOT-OS/RIOT/issues/18522 has more details on a concrete issue, but the present PR doesn't resolve that issue's root cause -- the issue just serves to illustrate that there are linker warnings that are really just that (warnings), and that the original premise was flawed and introduces failures where there needn't be any.

### Testing procedure

* On Debian sid, this now works:

```
$ make -C examples/hello-world TOOLCHAIN=clang BOARD=microbit-v2
```

### Issues/PRs references

Reverts-Part-Of: https://github.com/RIOT-OS/RIOT/pull/3120
Contributes-To: https://github.com/RIOT-OS/RIOT/issues/18522

Original round of reviewers are the original contributor of that flag, and the last mainitainers who touched RIOT's linker scripts.