### PR TITLE
boards/native: set -z noexecstack

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -68,6 +68,8 @@ else
   LINKFLAGS += -ldl
 endif
 
+LINKFLAGS += -z noexecstack
+
 # XFA (cross file array) support
 LINKFLAGS += -T$(RIOTBASE)/cpu/native/ldscripts/xfa.ld
 


### PR DESCRIPTION
### Contribution description

This gets rid of the annoying

    /usr/bin/ld: warning: bin/native/cpu/tramp.o: missing .note.GNU-stack section implies executable stack

with recent toolchains.
I'm pretty sure we don't want to have an exectuable stack.

We still get

    /usr/bin/ld: warning: bin/native/gnrc_networking.elf has a LOAD segment with RWX permissions

I'm also pretty sure we don't want that, but I can't find the actual segment that causes that.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->




<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`native` should still work as before (CI will test this for the most part)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
