### PR TITLE
sys/pm_layered: align pm_blocker_t for speed

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include "periph_cpu.h"
+#include "architecture.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,7 +56,7 @@ extern "C" {
  */
 typedef struct {
     uint8_t blockers[PM_NUM_MODES];     /**< number of blockers for the mode */
-} pm_blocker_t;
+} WORD_ALIGNED pm_blocker_t;
 
 /**
  * @brief   Block a power mode

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -75,6 +75,7 @@ void pm_set_lowest(void)
     irq_restore(state);
 }
 
+__attribute__((optimize(3)))
 void pm_block(unsigned mode)
 {
     DEBUG("[pm_layered] pm_block(%d)\n", mode);
@@ -85,6 +86,7 @@ void pm_block(unsigned mode)
     irq_restore(state);
 }
 
+__attribute__((optimize(3)))
 void pm_unblock(unsigned mode)
 {
     DEBUG("[pm_layered] pm_unblock(%d)\n", mode);

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -19,7 +19,6 @@
  */
 
 #include <assert.h>
-#include <string.h>
 
 #include "board.h"
 #include "irq.h"
@@ -102,7 +101,7 @@ pm_blocker_t pm_get_blocker(void)
     pm_blocker_t result;
 
     unsigned state = irq_disable();
-    memcpy(&result, &pm_blocker, sizeof(result));
+    result = pm_blocker;
     irq_restore(state);
 
     return result;


### PR DESCRIPTION
pm_(un)block add attribute optimize(3) - shortens hotpath by moving the jump to panic behind return

pm_get_blocker `=` instead of memcpy to ease readability

### Contribution description

this PR aligns pm_blocker_t that enables the compiler to use word loads instead of byte loads with 
cortexm0: whole struct access (pm_get_blocker and pm_set_lowest used memcpy or bytewise access to read pm_blocker) with this it is ldr (word) and some register operations

### Testing procedure

read 

### Issues/PRs references

#17607 started the journey
#18821 opened the rabbit hole 
#18842 
