### PR TITLE
boards/nucleo-f207zg:  support for ADC

### DIFF
--- a/boards/nucleo-f207zg/Kconfig
+++ b/boards/nucleo-f207zg/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_F207ZG
     select CPU_MODEL_STM32F207ZG
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32f207zg
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -228,20 +228,46 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @brief   ADC configuration
  *
- * We need to define the following fields:
- * PIN, device (ADCx), channel
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F207ZG order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5 and the internal VBAT channel.
+ *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC1_IN10 is device 0,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC1_IN10 is channel 10
+ *
+ * For Nucleo-F207ZG this information is in board manual,
+ * Table 13, page 37.
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    {GPIO_PIN(PORT_A, 3), 0, 3},
-    {GPIO_PIN(PORT_C, 0), 1, 0},
-    {GPIO_UNDEF, 0, 18}, /* VBAT */
+    { .pin = GPIO_PIN(PORT_A, 3), .dev = 0, .chan =  3 }, /* ADC123_IN3  */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 0, .chan = 10 }, /* ADC123_IN10 */
+    { .pin = GPIO_PIN(PORT_C, 3), .dev = 0, .chan = 13 }, /* ADC123_IN13 */
+    { .pin = GPIO_PIN(PORT_F, 3), .dev = 2, .chan =  9 }, /* ADC3_IN9  */
+    { .pin = GPIO_PIN(PORT_F, 5), .dev = 2, .chan = 15 }, /* ADC3_IN15   */
+    { .pin = GPIO_PIN(PORT_F, 10), .dev = 2, .chan = 8 }, /* ADC3_IN8    */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 18 }, /* VBAT */
 };
 
-#define VBAT_ADC            ADC_LINE(2) /**< VBAT ADC line */
+/**
+ * @brief VBAT ADC line
+ */
+#define VBAT_ADC            ADC_LINE(6)
+
+/**
+ * @brief Number of ADC devices
+ */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
 /** @} */
 
 /**

--- a/cpu/stm32/include/periph/f2/periph_cpu.h
+++ b/cpu/stm32/include/periph/f2/periph_cpu.h
@@ -28,7 +28,11 @@ extern "C" {
 /**
  * @brief   Available number of ADC devices
  */
+#if defined (ADC3)
+#define ADC_DEVS            (3U)
+#else
 #define ADC_DEVS            (2U)
+#endif
 
 #ifndef DOXYGEN
 


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-f207zg ADC configuration.

### Testing procedure

Flash the board using `tests/periph_adc` program. Check if measured values changes when A0-A5 pins are
connected to the 3,3V, GND or to the potentiometer. 

### Issues/PRs references

None