### PR TITLE
examples: Remove macOS references in README

### DIFF
--- a/examples/emcute_mqttsn/README.md
+++ b/examples/emcute_mqttsn/README.md
@@ -62,7 +62,7 @@ sudo ./RIOTDIR/dist/tools/tapsetup/tapsetup
 ```
 
 2. Assign a site-global prefix to the `tapbr0` interface (the name could be
-   different on macOS etc):
+   different on your machine etc):
 ```
 sudo ip a a fec0:affe::1/64 dev tapbr0
 ```

--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -46,7 +46,6 @@ to using `esp_now` for the downstream interface.
 
 ## Requirements
 This functionality works only on Linux machines.
-macOS support will be added in the future (lack of native `tap` interface).
 
 If you want to use DHCPv6, you also need a DHCPv6 server configured for prefix
 delegation from the interface facing the border router. With the [KEA] DHCPv6


### PR DESCRIPTION
### Contribution description

Removed references to macOS from two README.md as supporting macOS (native & networking) is no longer in scope for RIOT.

@miri64  I'm assuming the future you were talking about is not going to happen? 😉
