### PR TITLE
gnrc: Fix unused function error when using LLVM

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -137,10 +137,12 @@ static gnrc_pktsnip_t *_offl_to_pio(_nib_offl_entry_t *offl,
     return pio;
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
 static inline uint16_t _nib_abr_entry_valid_offset(const _nib_abr_entry_t *abr)
 {
     return (abr->valid_until_ms - evtimer_now_msec()) / ( MS_PER_SEC * SEC_PER_MIN);
 }
+#endif
 
 static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
                                        _nib_abr_entry_t *abr)


### PR DESCRIPTION
While investigating #18851 I discovered an issue when compiling the gnrc_networking example using LLVM. 
It fails since there is an unused function:
```
sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c:140:24: error: unused function '_nib_abr_entry_valid_offset' [-Werror,-Wunused-function]
static inline uint16_t _nib_abr_entry_valid_offset(const _nib_abr_entry_t *abr)
```

The fix works by only including this function when it is needed. In this case, when the `CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C` option is set. 

### Testing procedure

I'm currently limited to macOS and couldn't test further than "it compiles". 
Help? 🥺

cc @miri64 👀
