### PR TITLE
gnrc_sock_udp: accept response from any address if remote is multicast

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -143,7 +143,8 @@ extern "C" {
  * @anchor      net_sock_flags
  * @{
  */
-#define SOCK_FLAGS_REUSE_EP     (0x0001)    /**< allow to reuse end point on bind */
+#define SOCK_FLAGS_REUSE_EP         (0x0001)    /**< allow to reuse end point on bind */
+#define SOCK_FLAGS_CONNECT_REMOTE   (0x0002)    /**< restrict responses to remote address */
 /** @} */
 
 /**

--- a/tests/gnrc_sock_udp/main.c
+++ b/tests/gnrc_sock_udp/main.c
@@ -255,6 +255,25 @@ static void test_sock_udp_recv__EPROTO(void)
     expect(_check_net());
 }
 
+static void test_sock_udp_recv__multicast(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR_WRONG };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR_LOCAL };
+    static const sock_udp_ep_t local = { .family = AF_INET6,
+                                         .port = _TEST_PORT_LOCAL };
+    static const sock_udp_ep_t remote = { .addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL,
+                                          .family = AF_INET6,
+                                          .port = _TEST_PORT_REMOTE };
+
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+                          _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
+                          _TEST_NETIF));
+    expect(5 == sock_udp_recv(&_sock, _test_buffer, sizeof(_test_buffer),
+                                    SOCK_NO_TIMEOUT, NULL));
+    expect(_check_net());
+}
+
 static void test_sock_udp_recv__ETIMEDOUT(void)
 {
     static const sock_udp_ep_t local = { .family = AF_INET6, .netif = _TEST_NETIF,
@@ -819,6 +838,7 @@ int main(void)
     CALL(test_sock_udp_recv__EAGAIN());
     CALL(test_sock_udp_recv__ENOBUFS());
     CALL(test_sock_udp_recv__EPROTO());
+    CALL(test_sock_udp_recv__multicast());
     CALL(test_sock_udp_recv__ETIMEDOUT());
     CALL(test_sock_udp_recv__socketed());
     CALL(test_sock_udp_recv__socketed_with_remote());


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`sock_udp_create()` with a set remote is not just a convenient way to not having to keep the remote around when calling `sock_udp_send()` it actually binds the socket to that remote and will drop any response from a different address.

This is of course not very practical when the remote is a multicast address as this means all unicast responses are dropped.

This adds a new `SOCK_FLAGS_BIND_REMOTE` flag that gets set automatically for unicast remotes to retain current behavior.

This also moves the remote-checking code `sock_udp_recv_buf_aux()` to make it more readable as this was not so straightforward to debug. 


### Testing procedure

A new test case was added to `tests/gnrc_sock_udp`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
