### PR TITLE
core/macros: rewrite DIV_ROUND add DIV_ROUND_UINT

### DIFF
--- a/core/include/macros/math.h
+++ b/core/include/macros/math.h
@@ -31,11 +31,16 @@ extern "C" {
                               unsigned int: 1,           \
                               unsigned long: 1,          \
                               unsigned long long: 1,     \
-                              default: (long long)(a) < 0 ? -1 : 1)
+                              default: ((a) <= 0 ? ((a) == 0 ? 1L : -1L ): 1L))
 /**
  * @brief Calculates @p a/ @p b with arithmetic rounding
  */
-#define DIV_ROUND(a, b) (((a) + SIGNOF(a) * (b) / 2) / (b))
+#define DIV_ROUND(a, b) (((long long)(a) + SIGNOF(a) * SIGNOF(b) * (long long)(b) / 2) / (b))
+
+/**
+ * @brief Calculates @p a/ @p b with arithmetic rounding for natural numbers (unsigned)
+ */
+#define DIV_ROUND_UINT(a, b) (((a) + (b) / 2) / (b))
 
 /**
  * @brief Calculates @p a/ @p b, always rounding up to the


### PR DESCRIPTION
with #18853 i had hope to remove `SIGNOF` from `DIV_ROUND` but tests showed that types and negative numbers had some false results, so this makes `DIV_ROUND` deliver what it promisses (math rounded division for integers that don't reach to high into the rage)

There are some variants to implement such thing at https://godbolt.org/z/TsKcnPoYx sadly most of them either fail in a specific range or if divisor or dividend is negative or unsigned are typical, so i choose the one that worked across the test range (DIV_ROUNDb) please feel free to find a better one. 

Condition: 
Working for either `i` or `j` or both being `uint` and for negative an positive values of `i` and `j`

### Contribution description

This `DIV_ROUND` works for:
- either `a` or `b` or both being `uint` and 
- for negative an positive values of `a` and `b` as expected 

current upstream  tells me -15 / -5 = rounded to nearest is 2  (that is wrong)
with this PR i get 3  (see the godbolt)

Oh and i shall not forget i added `DIV_ROUND_UINT` for the most likely usecases

this also circumvents the `-Wtype-limits` warning by having the same result for positive and 0 but 2 checks (thatat ar optimized away) an alternative would be to have 3 result 1,0,-1 or
```
#if defined(__GNUC__)
_Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
#endif
```

### Testing procedure

read, run tests, look at that linked compiler explorer 

### Issues/PRs references

this fixes the issue of #18849 

#18853 was my first atempt on this 

https://godbolt.org/z/TsKcnPoYx