### PR TITLE
boards/dwm1001: use lis2dh12_i2c instead of lis2dh12_spi

### DIFF
--- a/boards/dwm1001/Kconfig
+++ b/boards/dwm1001/Kconfig
@@ -17,7 +17,7 @@ config BOARD_DWM1001
     select HAS_PERIPH_UART
     select HAS_VDD_LC_FILTER_REG1
 
-    select HAVE_LIS2DH12_SPI
+    select HAVE_LIS2DH12_I2C
     select HAVE_SAUL_GPIO
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/dwm1001/Makefile.dep
+++ b/boards/dwm1001/Makefile.dep
@@ -1,5 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
-  USEMODULE += lis2dh12_spi
+  USEMODULE += lis2dh12_i2c
   USEMODULE += saul_gpio
 endif
 


### PR DESCRIPTION
### Contribution description

Use the i2c version of the lis2df12 driver instead of the spi one for the dwm1001.

When including saul, I get the following error:
```
[auto_init_saul] error initializing lis2dh12 #0
```

As I understand it, the lis2df12 is capable of both i2c and spi communication, however I believe with the dwm1001, it is only connected by i2c. 

|<img src="https://user-images.githubusercontent.com/30503300/200798135-77778835-1527-48dc-a5c1-fae8cd96c394.png" width=50%>|
|-----|
| *Page 7, 2. DWM1001 MODULE* - [DWM data sheet](https://www.qorvo.com/products/d/da007952) |



When switching to the i2c implementation, the error disappears, and the previously un-detected sensors now show up (`6` and `7`):

```
> saul
saul
ID      Class           Name
#0      ACT_SWITCH      LED0 (Green)
#1      ACT_SWITCH      LED1 (Red)
#2      ACT_SWITCH      LED2 (Red)
#3      ACT_SWITCH      LED3 (Blue)
#4      SENSE_BTN       Button 1 (USER)
#5      SENSE_TEMP      NRF_TEMP
#6      SENSE_ACCEL     lis2dh12
#7      SENSE_TEMP      lis2dh12
> saul read 6
saul read 6
Reading from #6 (lis2dh12|SENSE_ACCEL)
Data:   [0]        -100 mg
        [1]           8 mg
        [2]        -996 mg
> 
```


