### PR TITLE
examples/wasm/wasm_sample: fix linking with new wasm-ld

### DIFF
--- a/examples/wasm/wasm_sample/Makefile
+++ b/examples/wasm/wasm_sample/Makefile
@@ -45,7 +45,6 @@ LINK_FLAGS := -z stack-size=4096 \
 		--export=__heap_base \
 		--export=__data_end \
 		--allow-undefined \
-		--no-entry \
 		--strip-all \
 		--export-dynamic \
 		-error-limit=0 \
@@ -53,6 +52,8 @@ LINK_FLAGS := -z stack-size=4096 \
 		-O3 \
 		--gc-sections\
 		--initial-memory=65536 \
+		--no-entry \
+		#
 
 # --initial-memory may only be set in 64kB steps (pagesize of WASM)
 # even though this one page is 64kB


### PR DESCRIPTION
### Contribution description

Apparently the order of the flags now became significant. This fixes:

    wasm-ld: error: entry symbol not defined (pass --no-entry to suppress)

### Testing procedure

This fixes https://github.com/maribu/riot-test-results/blob/main/2022.10-branch-bf7e4f6ca8096de94c7f2274d4406de7263e9493/samr21-xpro/examples/wasm/compilation.failed

### Issues/PRs references

None