### PR TITLE
dist/tools/flatc: Fix compilation on musl

### DIFF
--- a/dist/tools/flatc/patches/0001-CMakeLists.txt-fix-compilation-on-musl.patch
+++ b/dist/tools/flatc/patches/0001-CMakeLists.txt-fix-compilation-on-musl.patch
@@ -1,0 +1,35 @@
+From e77a8fe4b722ec79bf31b1e855dbf938e900fa60 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Wed, 9 Nov 2022 22:29:07 +0100
+Subject: [PATCH] CMakeLists.txt: fix compilation on musl
+
+For some reason musl does provide `strtof_l()`, but none of the others.
+It shouldn't even provide `strtof_l()`, as musl has zero locale
+support.
+
+This changes the check for a libc with locale support to check for
+`strtoull_l()` rather than for `strtof_l()`, which also works for
+musl.
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 119855a..7ad7636 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,9 +45,9 @@ endif()
+ # Auto-detect locale-narrow 'strtod_l' function.
+ if(NOT DEFINED FLATBUFFERS_LOCALE_INDEPENDENT)
+   if(MSVC)
+-    check_cxx_symbol_exists(_strtof_l stdlib.h FLATBUFFERS_LOCALE_INDEPENDENT)
++    check_cxx_symbol_exists(_strtoull_l stdlib.h FLATBUFFERS_LOCALE_INDEPENDENT)
+   else()
+-    check_cxx_symbol_exists(strtof_l stdlib.h FLATBUFFERS_LOCALE_INDEPENDENT)
++    check_cxx_symbol_exists(strtoull_l stdlib.h FLATBUFFERS_LOCALE_INDEPENDENT)
+   endif()
+ endif()
+ add_definitions(-DFLATBUFFERS_LOCALE_INDEPENDENT=$<BOOL:${FLATBUFFERS_LOCALE_INDEPENDENT}>)
+-- 
+2.38.1
+


### PR DESCRIPTION
### Contribution description

flatc uses `strto<foo>_l()` over `strto<foo>()` when available, so that they behave reproducible. The musl libc has no locale support, which has the added benefit of reproducible behavior being the default.

For some reason a `strtof_l()` compatibility wrapper was added in musl, but the other `strto<foo>_l()` wrappers are missing. This adds a patch to check for `strtoull_l()` instead of `strtof_l()`. This will not make a difference on a libc that supports all of them, but fixes compilation on musl.

### Testing procedure

`tests/pkg_flatbuffers` should still build and pass. (In fact, no changes in the binary in both the `flatc` host utility and the `tests/pkg_flatbuffers` test application are expected.)

### Issues/PRs references

None