### PR TITLE
tools/backport_pr.py: improve usability

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -224,7 +224,7 @@ def main():
             sys.exit(5)
     print(f"Backport based on branch {release_fullname}")
 
-    repo = git.Repo(args.gitdir)
+    repo = git.Repo(args.gitdir, search_parent_directories=True)
     # Fetch current upstream
     upstream_remote = _get_upstream(repo)
     if not upstream_remote:


### PR DESCRIPTION
### Contribution description

Add `search_parent_directories=True` to `git.Repo()` so that `backport_pr.py` can be called anywhere within the RIOT git repo without manually passing the repo root path via `--gitdir`.

Previously the tool had to be called from the RIOT base repo.

### Testing procedure

The script should no longer throw

```
$ ./backport_pr.py --comment <num>
[...]
Traceback (most recent call last):
  File "/home/maribu/Repos/software/RIOT/dist/tools/backport_pr/./backport_pr.py", line 314, in <module>
    main()
  File "/home/maribu/Repos/software/RIOT/dist/tools/backport_pr/./backport_pr.py", line 227, in main
    repo = git.Repo(args.gitdir)
  File "/usr/lib/python3.10/site-packages/git/repo/base.py", line 224, in __init__
    self.working_dir: Optional[PathLike] = self._working_tree_dir or self.common_dir
  File "/usr/lib/python3.10/site-packages/git/repo/base.py", line 307, in common_dir
    raise InvalidGitRepositoryError()
git.exc.InvalidGitRepositoryError
```

when called from a subfolder withing the RIOT git repo and not passing the path to the repo's root via `--gitdir`.

### Issues/PRs references

None