### PR TITLE
tests/mpu_stack_guard: Fix compilation on modern GCC (>= 12.x)

### DIFF
--- a/tests/mpu_stack_guard/main.c
+++ b/tests/mpu_stack_guard/main.c
@@ -38,6 +38,16 @@ static struct {
     char stack[THREAD_STACKSIZE_MAIN];
 } buf;
 
+/* Tell modern GCC (12.x) to not complain that this infinite recursion is
+ * bound to overflow the stack - this is exactly what this test wants to do :)
+ *
+ * Also, tell older versions of GCC that do not know about -Winfinit-recursion
+ * that it is safe to ignore `GCC diagnostics ignored "-Winfinit-recursion"`.
+ * They behave as intended in this case :)
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
 static int recurse(int counter)
 {
     printf("counter =%4d, SP = 0x%08x, canary = 0x%08x\n", counter, (unsigned int)__get_PSP(), buf.canary);
@@ -55,6 +65,7 @@ static int recurse(int counter)
     /* Recursing twice here prevents the compiler from optimizing-out the recursion. */
     return recurse(counter) + recurse(counter);
 }
+#pragma GCC diagnostic pop
 
 static void *thread(void *arg)
 {


### PR DESCRIPTION
### Contribution description

The `mpu_stack_guard` test intentionally overflows the stack with a stupid infinite recursion. Newer versions of GCC started to dislike this, so this disables the corresponding diagnostics to get the intentional stack overflow still compiled.

### Testing procedure

The test application should now compile on both older toolchains (e.g. the one used by Murdock) and modern toolchains (e.g. the one provided by Arch Linux or Alpine).

### Issues/PRs references

None