### PR TITLE
cpu/sam0_common/periph: Fix compilation with LLVM 

### DIFF
--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -161,6 +161,7 @@ static void _poweroff(void)
 #endif
 }
 
+MAYBE_UNUSED
 static inline void _rtc_set_enabled(bool on)
 {
 #ifdef REG_RTC_MODE2_CTRLA


### PR DESCRIPTION
Related to #18851 

This fixes an unused function error when compiling the gnrc_networking_mac example using LLVM as toolchain.
The fix works by only including the function when it is actually needed.
