### PR TITLE
llvm: Fix unused function warning

### DIFF
--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -161,6 +161,7 @@ static void _gpio_init_ain(void)
  * This very teniously avoids optimization, even optimized it's better than
  * nothing but periodic review should establish that it doesn't get optimized.
  */
+MAYBE_UNUSED
 __attribute__((always_inline))
 static inline uint32_t _multi_read_reg32(volatile uint32_t *addr, bool *glitch)
 {


### PR DESCRIPTION
Related to #18851 

When building example/gnrc_lorawan using LLVM two unused function error are raised. Those are fixed by only include said functions when they are needed. 

~~Additionally, LLVM complains about lorawan struct being not packed correctly. I believe this is because GCC applies the given attribute(packed) to all elements of a given struct including the anonymous struct and unions if present. Clang on the other does not seem to do that. The fix works by adding the packed attribute to the anonymous union as well.~~