### PR TITLE
pkg/tflite-micro: fix compilation with GCC >= 12.x

### DIFF
--- a/pkg/tflite-micro/patches/0002-Compare-names-without-over-reading-in-micro_allocati.patch
+++ b/pkg/tflite-micro/patches/0002-Compare-names-without-over-reading-in-micro_allocati.patch
@@ -1,0 +1,38 @@
+From 027ec148ae13362c00fb9f539f359a9cd8c70af4 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 11 Nov 2022 08:57:01 +0100
+Subject: [PATCH] Compare names without over-reading in
+ micro_allocation_info.cc
+
+This fixes:
+
+    /home/maribu/Repos/software/RIOT/build/pkg/tflite-micro/tensorflow/lite/micro/micro_allocation_info.cc: In member function 'TfLiteStatus tflite::AllocationInfoBuilder::GetOfflinePlannedOffsets(const int32_t**)':
+    /home/maribu/Repos/software/RIOT/build/pkg/tflite-micro/tensorflow/lite/micro/micro_allocation_info.cc:294:18: error: 'int strncmp(const char*, const char*, size_t)' specified bound 23 exceeds source size 0 [-Werror=stringop-overread]
+      294 |       if (strncmp(metadata->name()->c_str(), kOfflineMemAllocMetadata,
+          |           ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      295 |                   strlen(kOfflineMemAllocMetadata)) == 0) {
+          |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+ tensorflow/lite/micro/micro_allocation_info.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tensorflow/lite/micro/micro_allocation_info.cc b/tensorflow/lite/micro/micro_allocation_info.cc
+index ab313e6..1e61135 100644
+--- a/tensorflow/lite/micro/micro_allocation_info.cc
++++ b/tensorflow/lite/micro/micro_allocation_info.cc
+@@ -291,8 +291,10 @@ TfLiteStatus AllocationInfoBuilder::GetOfflinePlannedOffsets(
+   if (model_->metadata()) {
+     for (size_t i = 0; i < model_->metadata()->size(); ++i) {
+       auto metadata = model_->metadata()->Get(i);
+-      if (strncmp(metadata->name()->c_str(), kOfflineMemAllocMetadata,
+-                  strlen(kOfflineMemAllocMetadata)) == 0) {
++      const size_t len_b = sizeof(kOfflineMemAllocMetadata) - 1;
++      size_t len_a = metadata->name()->size();
++      if ((len_a == len_b) &&
++          !memcmp(kOfflineMemAllocMetadata, metadata->name()->c_str(), len_b)) {
+         const flatbuffers::Vector<flatbuffers::Offset<Buffer>>* buffers =
+             model_->buffers();
+         auto* buffer = (*buffers)[metadata->buffer()];
+-- 
+2.38.1
+


### PR DESCRIPTION
### Contribution description

Use C++ style string comparison instead of `strncmp()` to get rid of the following warning:

    /home/maribu/Repos/software/RIOT/build/pkg/tflite-micro/tensorflow/lite/micro/micro_allocation_info.cc: In member function 'TfLiteStatus tflite::AllocationInfoBuilder::GetOfflinePlannedOffsets(const int32_t**)':
    /home/maribu/Repos/software/RIOT/build/pkg/tflite-micro/tensorflow/lite/micro/micro_allocation_info.cc:294:18: error: 'int strncmp(const char*, const char*, size_t)' specified bound 23 exceeds source size 0 [-Werror=stringop-overread]
      294 |       if (strncmp(metadata->name()->c_str(), kOfflineMemAllocMetadata,
          |           ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      295 |                   strlen(kOfflineMemAllocMetadata)) == 0) {
          |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

### Testing procedure

```
$ BOARD=nucleo-f767zi make flash test -C tests/pkg_tflite-micro
[...]

READY
s
START
main(): This is RIOT! (Version: 2023.01-devel-302-g24262)
Digit prediction: 7
```

### Issues/PRs references

None
