### PR TITLE
utils/uncrustify: display warning instead of error

### DIFF
--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -32,7 +32,7 @@ check () {
 _annotate_diff() {
     if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
         MSG="Uncrustify proposes the following patch:\n\n$3"
-        IFS="${OLD_IFS}" github_annotate_error "$1" "$2" "${MSG}"
+        IFS="${OLD_IFS}" github_annotate_warning "$1" "$2" "${MSG}"
     fi
 }
 


### PR DESCRIPTION
### Contribution description

we treat uncrustify comment like warnings (failed uncrustify does not fail static tests) -> we should display them as that.

### Testing procedure

read

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
