### PR TITLE
tools/backport_pr: finally fix running outside of repo's root

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -240,7 +240,7 @@ def main():
     if new_branch in repo.branches:
         print(f"ERROR: Branch {new_branch} already exists")
         sys.exit(1)
-    worktree_dir = os.path.join(args.gitdir, WORKTREE_SUBDIR)
+    worktree_dir = os.path.join(repo.working_dir, WORKTREE_SUBDIR)
     repo.git.worktree(
         "add",
         "-b",


### PR DESCRIPTION
### Contribution description

It turned out that 4983f8bb6042018ce762c0d64b21ca09ccb00ceb was not enough to allow the tool to be executed from within `dist/tools/backport_pr`. With this, I successfully tested it :)

### Testing procedure

Run `./backport_pr --comment <NUM>` inside `<RIOT_DIR>/dist/tools/backport_pr`. In `master`, it still fails, with this, it succeeds.

### Issues/PRs references

First attempt (that only partially succeeded) to do this was https://github.com/RIOT-OS/RIOT/pull/18866