### PR TITLE
core/lib: define MAYBE_UNUSED

### DIFF
--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -30,10 +30,12 @@ extern "C" {
  * @brief The *NORETURN* keyword tells the compiler to assume that the function
  *        cannot return.
  */
+#ifndef NORETURN
 #ifdef __GNUC__
 #define NORETURN  __attribute__((noreturn))
 #else
 #define NORETURN
+#endif
 #endif
 
 /**
@@ -43,10 +45,12 @@ extern "C" {
  *        function can be subject to common subexpression elimination and loop
  *        optimization just as an arithmetic operator would be.
  */
+#ifndef PURE
 #ifdef __GNUC__
 #define PURE  __attribute__((pure))
 #else
 #define PURE
+#endif
 #endif
 
 /**

--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -54,6 +54,19 @@ extern "C" {
 #endif
 
 /**
+ * @def MAYBE_UNUSED
+ * @brief tell the compiler something may be unused
+ *        static functions, function arguments, local variables
+ */
+#ifndef MAYBE_UNUSED
+#ifdef __GNUC__
+#define MAYBE_UNUSED  __attribute__((unused))
+#else
+#define MAYBE_UNUSED
+#endif
+#endif
+
+/**
  * @def       UNREACHABLE()
  * @brief     Tell the compiler that this line of code cannot be reached.
  * @details   Most useful in junction with #NORETURN.


### PR DESCRIPTION
There are static functions and variables that may be unused if certain modules are used or not used.
Instead of adding a guard around these marking them as "maybe unused" is much clearer C23 seems to add a stadat attribute system where [[maybe_unused]]  would be that mark

### Contribution description

this adds a`MAYBE_UNUSED` define that uses the badly name `__attribute((unused))__` to mark such `maybe unused` cases

### Testing procedure

read

### Issues/PRs references

this contains #18882

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
