### PR TITLE
tapsetup: add --loss & --delay option

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -45,6 +45,8 @@ usage() {
     echo "                                 (ignored on OSX and FreeBSD)" >&2
     echo "   -u, --uplink:                 Optional uplink interface" >&2
     echo "                                 (ignored on OSX and FreeBSD)" >&2
+    echo "   --loss:                       Optional loss %" >&2
+    echo "                                 (ignored on OSX and FreeBSD)" >&2
     echo "   -h, --help:                   Prints this text" >&2
 }
 
@@ -320,6 +322,9 @@ create_iface() {
             if [ -z "${TUNNAME}" ]; then
                 ip link set dev ${NAME}${N} master ${BRNAME} || exit 1
             fi
+            if [ -n "${LOSS}" ]; then
+                tc qdisc add dev ${NAME}${N} root netem loss ${LOSS}
+            fi
             ip link set ${NAME}${N} up || exit 1 ;;
         OSX)
             chown ${SUDO_USER} /dev/${NAME}${N} || exit 1
@@ -474,6 +479,15 @@ while true ; do
                     exit 2 ;;
                 *)
                     UPLINK="$2"
+                    shift 2 ;;
+            esac ;;
+        --loss)
+            case "$2" in
+                "")
+                    usage
+                    exit 2 ;;
+                *)
+                    LOSS="$2"
                     shift 2 ;;
             esac ;;
         -t|--tap)

--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -45,7 +45,9 @@ usage() {
     echo "                                 (ignored on OSX and FreeBSD)" >&2
     echo "   -u, --uplink:                 Optional uplink interface" >&2
     echo "                                 (ignored on OSX and FreeBSD)" >&2
-    echo "   --loss:                       Optional loss %" >&2
+    echo "   --loss <loss>%:               Optional loss %" >&2
+    echo "                                 (ignored on OSX and FreeBSD)" >&2
+    echo "   --delay <delay>ms:            Optional delay ms" >&2
     echo "                                 (ignored on OSX and FreeBSD)" >&2
     echo "   -h, --help:                   Prints this text" >&2
 }
@@ -322,9 +324,7 @@ create_iface() {
             if [ -z "${TUNNAME}" ]; then
                 ip link set dev ${NAME}${N} master ${BRNAME} || exit 1
             fi
-            if [ -n "${LOSS}" ]; then
-                tc qdisc add dev ${NAME}${N} root netem loss ${LOSS}
-            fi
+            tc qdisc add dev ${NAME}${N} root netem ${DELAY} ${LOSS}
             ip link set ${NAME}${N} up || exit 1 ;;
         OSX)
             chown ${SUDO_USER} /dev/${NAME}${N} || exit 1
@@ -487,7 +487,16 @@ while true ; do
                     usage
                     exit 2 ;;
                 *)
-                    LOSS="$2"
+                    LOSS="loss random $2"
+                    shift 2 ;;
+            esac ;;
+        --delay)
+            case "$2" in
+                "")
+                    usage
+                    exit 2 ;;
+                *)
+                    DELAY="delay $2"
                     shift 2 ;;
             esac ;;
         -t|--tap)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds an option to simulate loss links with `netdev_tap`


### Testing procedure

Create lossy TAP interfaces

    sudo dist/tools/tapsetup/tapsetup --loss 20% --delay 10ms

Start two `native` instances

    > ping -c 100 -i 10 fe80::58b0:8ff:fe67:ad82   
    12 bytes from fe80::58b0:8ff:fe67:ad82%5: icmp_seq=1 ttl=64 time=20.407 ms
    12 bytes from fe80::58b0:8ff:fe67:ad82%5: icmp_seq=5 ttl=64 time=20.355 ms
    12 bytes from fe80::58b0:8ff:fe67:ad82%5: icmp_seq=6 ttl=64 time=20.357 ms
    …
    12 bytes from fe80::58b0:8ff:fe67:ad82%5: icmp_seq=98 ttl=64 time=20.383 ms

    --- fe80::58b0:8ff:fe67:ad82 PING statistics ---
    100 packets transmitted, 67 packets received, 33% packet loss
    round-trip min/avg/max = 20.233/20.373/20.509 ms

Note that ping measures round-trip-time, so two packets: 10 ms + 10 ms -> 20ms, 80% * 80% -> 64% success


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
