### PR TITLE
sys/include: remove kernel_defines.h where not needed

### DIFF
--- a/drivers/sht1x/sht1x.c
+++ b/drivers/sht1x/sht1x.c
@@ -26,6 +26,7 @@
 #include "sht1x.h"
 #include "sht1x_defines.h"
 #include "bitarithm.h"
+#include "container.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/sys/include/auto_init_utils.h
+++ b/sys/include/auto_init_utils.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 #include "xfa.h"
 #include "macros/xtstr.h"
-#include "kernel_defines.h"
+#include "modules.h"
 #if IS_USED(MODULE_PREPROCESSOR_SUCCESSOR)
 #include "preprocessor_successor.h"
 #endif

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -23,7 +23,7 @@
 #define CRYPTO_CIPHERS_H
 
 #include <stdint.h>
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/dbgpin.h
+++ b/sys/include/dbgpin.h
@@ -23,7 +23,7 @@
 #ifndef DBGPIN_H
 #define DBGPIN_H
 
-#include "kernel_defines.h"
+#include "container.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -23,7 +23,6 @@
 #define EMBUNIT_H
 
 #include "embUnit/embUnit.h"
-#include "kernel_defines.h"
 
 #ifdef OUTPUT
 #   define OUTPUT_XML       (1)

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -46,7 +46,7 @@
 #define EVTIMER_H
 
 #include <stdint.h>
-#include "kernel_defines.h"
+#include "modules.h"
 
 #if IS_USED(MODULE_EVTIMER_ON_ZTIMER)
 #include "ztimer.h"

--- a/sys/include/net/credman.h
+++ b/sys/include/net/credman.h
@@ -29,7 +29,7 @@
 
 #include <unistd.h>
 #include <stdint.h>
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -20,7 +20,7 @@
 #ifndef NET_DNS_H
 #define NET_DNS_H
 
-#include "kernel_defines.h"
+#include "modules.h"
 #include "net/sock/dns.h"
 #include "net/sock/dodtls.h"
 #include "net/gcoap/dns.h"

--- a/sys/include/net/dns/cache.h
+++ b/sys/include/net/dns/cache.h
@@ -35,7 +35,7 @@
 
 #include <stdint.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/ipv6/nib/abr.h
+++ b/sys/include/net/gnrc/ipv6/nib/abr.h
@@ -21,7 +21,7 @@
 #ifndef NET_GNRC_IPV6_NIB_ABR_H
 #define NET_GNRC_IPV6_NIB_ABR_H
 
-#include <kernel_defines.h>
+#include "modules.h"
 
 /* prevent cascading include error to xtimer if it is not compiled in or not
  * supported by board */

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -21,7 +21,7 @@
 #ifndef NET_GNRC_IPV6_NIB_CONF_H
 #define NET_GNRC_IPV6_NIB_CONF_H
 
-#include <kernel_defines.h>
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -21,7 +21,7 @@
 #define NET_GNRC_IPV6_NIB_PL_H
 
 #include <stdint.h>
-#include <kernel_defines.h>
+#include "modules.h"
 
 #if IS_USED(MODULE_EVTIMER)
 #include "evtimer.h"

--- a/sys/include/net/gnrc/lorawan/region.h
+++ b/sys/include/net/gnrc/lorawan/region.h
@@ -18,7 +18,7 @@
 #ifndef NET_GNRC_LORAWAN_REGION_H
 #define NET_GNRC_LORAWAN_REGION_H
 
-#include "kernel_defines.h"
+#include "modules.h"
 #include "net/gnrc/lorawan.h"
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/mac/mac.h
+++ b/sys/include/net/gnrc/mac/mac.h
@@ -21,7 +21,7 @@
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifndef NET_GNRC_MAC_MAC_H
 #define NET_GNRC_MAC_MAC_H

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -20,7 +20,7 @@
 #ifndef NET_GNRC_NETIF_CONF_H
 #define NET_GNRC_NETIF_CONF_H
 
-#include <kernel_defines.h>
+#include "modules.h"
 
 #include "net/dhcpv6/client.h"
 #include "net/ieee802154.h"

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -21,7 +21,7 @@
 #ifndef NET_GNRC_NETIF_INTERNAL_H
 #define NET_GNRC_NETIF_INTERNAL_H
 
-#include <kernel_defines.h>
+#include "modules.h"
 
 #include "net/gnrc/netif.h"
 #include "net/l2util.h"

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -18,7 +18,7 @@
 #ifndef NET_GNRC_NETIF_IPV6_H
 #define NET_GNRC_NETIF_IPV6_H
 
-#include <kernel_defines.h>
+#include "modules.h"
 
 #include "evtimer_msg.h"
 #include "net/ipv6/addr.h"

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -35,7 +35,7 @@
 
 #include <inttypes.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 #include "net/ethertype.h"
 #include "net/protnum.h"
 

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -143,7 +143,7 @@
 
 #include <string.h>
 #include <stdint.h>
-#include "kernel_defines.h"
+#include "modules.h"
 #include "net/gnrc.h"
 #include "net/gnrc/ipv6.h"
 #include "net/ipv6/addr.h"

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -21,7 +21,7 @@
 #ifndef NET_GNRC_SIXLOWPAN_CONFIG_H
 #define NET_GNRC_SIXLOWPAN_CONFIG_H
 
-#include "kernel_defines.h"
+#include "modules.h"
 #include "timex.h"
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -31,7 +31,7 @@
 
 #include "net/ipv6/addr.h"
 #include "timex.h"
-#include <kernel_defines.h>
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 
 #include "congure.h"
-#include "kernel_defines.h"
+#include "modules.h"
 #include "net/gnrc/sixlowpan/frag/sfr.h"
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr_types.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr_types.h
@@ -24,7 +24,7 @@
 #include "clist.h"
 #include "congure.h"
 #include "evtimer_msg.h"
-#include "kernel_defines.h"
+#include "modules.h"
 #include "msg.h"
 #include "xtimer.h"
 

--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -25,7 +25,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/sixlowpan/config.h"
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -26,7 +26,7 @@
 
 #include "byteorder.h"
 #include "net/eui64.h"
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -31,7 +31,6 @@
 #define NET_IEEE802154_SECURITY_H
 
 #include <stdint.h>
-#include "kernel_defines.h"
 #include "ieee802154.h"
 #include "crypto/ciphers.h"
 

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -37,7 +37,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/senml.h
+++ b/sys/include/senml.h
@@ -40,7 +40,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include "periph/pm.h"
 
-#include "kernel_defines.h"
+#include "modules.h"
 #include "xfa.h"
 
 #ifdef __cplusplus

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -25,7 +25,7 @@
 
 #include <unistd.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -30,7 +30,7 @@
 #include <strings.h>
 #include <sys/types.h>
 
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifndef STRING_UTILS_H
 #define STRING_UTILS_H

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -21,8 +21,6 @@
 #include <sys/time.h>
 #include <stdint.h>
 
-#include "kernel_defines.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -29,7 +29,7 @@
 #include "clist.h"
 #include "event.h"
 #include "sched.h"
-#include "kernel_defines.h"
+#include "modules.h"
 #include "msg.h"
 #include "thread.h"
 

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -33,6 +33,7 @@
 #include "net/loramac.h"
 #include "net/netif.h"
 #include "shell.h"
+#include "container.h"
 
 #ifdef MODULE_NETSTATS
 #include "net/netstats.h"

--- a/sys/shell/cmds/openwsn.c
+++ b/sys/shell/cmds/openwsn.c
@@ -27,6 +27,7 @@
 #include "net/ipv6/addr.h"
 #include "net/l2util.h"
 #include "net/netif.h"
+#include "container.h"
 
 #include "openwsn.h"
 #include "opendefs.h"

--- a/sys/shell/cmds/sht1x.c
+++ b/sys/shell/cmds/sht1x.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "shell.h"
+#include "container.h"
 #include "sht1x.h"
 #include "sht1x_params.h"
 

--- a/tests/can_trx/main.c
+++ b/tests/can_trx/main.c
@@ -21,8 +21,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "kernel_defines.h"
 #include "can/can_trx.h"
-
 #include "shell.h"
 
 #ifdef MODULE_TJA1042

--- a/tests/driver_dynamixel/main.c
+++ b/tests/driver_dynamixel/main.c
@@ -11,6 +11,7 @@
 #include "stdio_uart.h"
 #include "board.h"
 #include "periph/gpio.h"
+#include "container.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/driver_feetech/main.c
+++ b/tests/driver_feetech/main.c
@@ -9,6 +9,7 @@
 #include "feetech.h"
 #include "shell.h"
 #include "stdio_uart.h"
+#include "container.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/driver_sdcard_spi/main.c
+++ b/tests/driver_sdcard_spi/main.c
@@ -22,6 +22,7 @@
 #include "sdcard_spi_internal.h"
 #include "sdcard_spi_params.h"
 #include "fmt.h"
+#include "container.h"
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/driver_sht1x/main.c
+++ b/tests/driver_sht1x/main.c
@@ -20,9 +20,11 @@
  */
 
 #include <stdio.h>
+#include <stddef.h>
 
 #include "shell.h"
 #include "sht1x_params.h"
+#include "container.h"
 
 #define SHT1X_NUM     ARRAY_SIZE(sht1x_params)
 extern sht1x_dev_t sht1x_devs[SHT1X_NUM];

--- a/tests/gnrc_dhcpv6_client_6lbr/main.c
+++ b/tests/gnrc_dhcpv6_client_6lbr/main.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <stddef.h>
 #include "shell.h"
 
 int main(void)

--- a/tests/gnrc_dhcpv6_client_stateless/main.c
+++ b/tests/gnrc_dhcpv6_client_stateless/main.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <stddef.h>
 #include "shell.h"
 
 int main(void)

--- a/tests/gnrc_dhcpv6_relay/main.c
+++ b/tests/gnrc_dhcpv6_relay/main.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <stddef.h>
 #include "shell.h"
 
 int main(void)

--- a/tests/periph_flashpage_unittest/main.c
+++ b/tests/periph_flashpage_unittest/main.c
@@ -23,6 +23,7 @@
 #include "cpu.h"
 #include "embUnit.h"
 #include "embUnit/embUnit.h"
+#include "modules.h"
 
 /* need to define these values before including the header */
 #ifndef FLASHPAGE_SIZE

--- a/tests/phydat_dump/main.c
+++ b/tests/phydat_dump/main.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "phydat.h"
+#include "container.h"
 
 typedef struct {
     phydat_t dat;

--- a/tests/pkg_fatfs/main.c
+++ b/tests/pkg_fatfs/main.c
@@ -24,6 +24,7 @@
 #include "mtd.h"
 #include "fatfs_diskio_mtd.h"
 #include "shell.h"
+#include "container.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/tests/pkg_tinycbor/main.c
+++ b/tests/pkg_tinycbor/main.c
@@ -25,6 +25,7 @@
 #include "embUnit/embUnit.h"
 #include "fmt.h"
 #include "cbor.h"
+#include "container.h"
 
 const char *tests[] = {
     "00",                  /* 0                       */

--- a/tests/unittests/tests-clif/tests-clif.c
+++ b/tests/unittests/tests-clif/tests-clif.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include "embUnit.h"
 #include "tests-clif.h"
+#include "container.h"
 
 #include "clif.h"
 

--- a/tests/unittests/tests-core/tests-core-macros.c
+++ b/tests/unittests/tests-core/tests-core-macros.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <limits.h>
 #include "embUnit.h"

--- a/tests/unittests/tests-core/tests-core-priority-queue.c
+++ b/tests/unittests/tests-core/tests-core-priority-queue.c
@@ -7,6 +7,8 @@
  */
 #include <string.h>
 
+#include "container.h"
+
 #include "embUnit.h"
 
 #include "priority_queue.h"

--- a/tests/unittests/tests-sht1x/tests-sht1x.c
+++ b/tests/unittests/tests-sht1x/tests-sht1x.c
@@ -8,6 +8,7 @@
 
 #include <sht1x.h>
 #include <stdlib.h>
+#include "container.h"
 #include "embUnit/embUnit.h"
 #include "tests-sht1x.h"
 

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include "container.h"
 #include "embUnit.h"
 
 #include "uri_parser.h"


### PR DESCRIPTION

### Contribution description

based of #18882 I cleaned `kernel_defines.h` from `sys/includes` and fixed missing includes

### Testing procedure

read

### Issues/PRs references

#18882 and #18884