### PR TITLE
tests/pkg_tinyusb*: add a BOARD to make make build

### DIFF
--- a/tests/pkg_tinyusb_cdc_acm_stdio/Makefile
+++ b/tests/pkg_tinyusb_cdc_acm_stdio/Makefile
@@ -1,3 +1,4 @@
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 USB_VID ?= $(USB_VID_TESTING)
@@ -6,7 +7,7 @@ USB_PID ?= $(USB_PID_TESTING)
 USEMODULE += stdio_tinyusb_cdc_acm
 
 USEMODULE += shell
-USEMODULE += shell_commands
+USEMODULE += shell_cmds_default
 USEMODULE += ps
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_tinyusb_cdc_msc/Makefile
+++ b/tests/pkg_tinyusb_cdc_msc/Makefile
@@ -1,3 +1,4 @@
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 USB_VID ?= $(USB_VID_TESTING)


### PR DESCRIPTION
### Contribution description

`tests/pkg_tinyusb*` did not build because no BOARD was set and native has no USB for tinyusb
this sets a board enabling default buildability. 

this also changes the deprecated `shell_commands` to the new `shell_cmds_default'

### Testing procedure

```
tests/pkg_tinyusb_cdc_acm_stdio$ make
```

```
tests/pkg_tinyusb_cdc_msc$ make
```

### Issues/PRs references
