### PR TITLE
usbus/hid: fix buffer overflow in hid_io [backport 2022.10]

### DIFF
--- a/sys/usb/usbus/hid/hid_io.c
+++ b/sys/usb/usbus/hid/hid_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Nils Ollrogge
+ * Copyright (C) 2021-2022 Nils Ollrogge
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -57,14 +57,13 @@ void usb_hid_io_write(const void *buffer, size_t len)
     while (len) {
         mutex_lock(&hid.in_lock);
         if (len > max_size) {
-            memmove(buffer_ep + offset, (uint8_t *)buffer + offset, max_size);
+            memmove(buffer_ep, (uint8_t *)buffer + offset, max_size);
             offset += max_size;
             hid.occupied = max_size;
             len -= max_size;
         }
         else {
-            memmove(buffer_ep + offset, (uint8_t *)buffer + offset, len);
-            offset += len;
+            memmove(buffer_ep, (uint8_t *)buffer + offset, len);
             hid.occupied = len;
             len = 0;
         }


### PR DESCRIPTION
# Backport of #18860

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR fixes a potential buffer overflow inside `usb_hid_io_write` which occurs when `len > CONFIG_USBUS_HID_INTERRUPT_EP_SIZE`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

