### PR TITLE
makefiles/arch/cortexm.inc.mk: fix ASMFLAGS

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -26,7 +26,7 @@ CFLAGS_OPT  ?= -Os
 
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
-ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+ASFLAGS += $(CFLAGS_CPU)
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
 LINKER_SCRIPT ?= $(CPU_MODEL).ld
 LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings


### PR DESCRIPTION
### Contribution description

Drop `CFLAGS_DBG` from `ASFLAGS` to fix

    make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C /home/maribu/Repos/software/RIOT/tests/pkg_qdsa clean all
    rm -rf /home/maribu/Repos/software/RIOT/tests/pkg_qdsa/bin/samr21-xpro/pkg-build/qdsa
    Building application "tests_pkg_qdsa" for "samr21-xpro" with MCU "samd21".

    Assembler messages:
    Fatal error: unknown option `-ggdb'
    make[3]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:176: /home/maribu/Repos/software/RIOT/tests/pkg_qdsa/bin/samr21-xpro/qdsa_asm/bigint_red.o] Error 1
    make[2]: *** [/home/maribu/Repos/software/RIOT/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/build/pkg/qdsa/arm/asm] Error 2
    make[1]: *** [Makefile:11: all] Error 2
    make: *** [/home/maribu/Repos/software/RIOT/tests/pkg_qdsa/../../Makefile.include:803: pkg-build] Error 2

    Return value: 2

### Testing procedure

With this PR, the compilation failure is gone:

```
$ make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C /home/maribu/Repos/softwar
e/RIOT/tests/pkg_qdsa clean all
rm -rf /home/maribu/Repos/software/RIOT/tests/pkg_qdsa/bin/nucleo-f767zi/pkg-build/qdsa
Building application "tests_pkg_qdsa" for "nucleo-f767zi" with MCU "stm32".

   text	  data	   bss	   dec	   hex	filename
  27000	   132	  5172	 32304	  7e30	/home/maribu/Repos/software/RIOT/tests/pkg_qdsa/bin/nucleo-f767zi/tests_pkg_qdsa.elf
```

### Issues/PRs references

None