### PR TITLE
tests/bitarithm_timings: shorten timeout from 5s to 200ms

### DIFF
--- a/tests/bitarithm_timings/main.c
+++ b/tests/bitarithm_timings/main.c
@@ -37,8 +37,8 @@
 #include "test_utils/expect.h"
 #include "xtimer.h"
 
-#define TIMEOUT_S (5ul)
-#define TIMEOUT (TIMEOUT_S * US_PER_SEC)
+#define TIMEOUT_MS (200ul)
+#define TIMEOUT (TIMEOUT_MS * US_PER_MS)
 #define PER_ITERATION (4)
 
 #if ARCH_32_BIT
@@ -91,7 +91,7 @@ static void run_test(const char *name, unsigned (*test)(unsigned))
         ++count;
     } while (atomic_load(&done) == false);
 
-    printf("+ %s: %lu iterations per second\r\n", name, (4*PER_ITERATION) * count / TIMEOUT_S);
+    printf("+ %s: %lu iterations per second\r\n", name, (4*PER_ITERATION) * count / TIMEOUT_MS * 1000);
 }
 
 static unsigned do_test_and_clear(unsigned state)
@@ -121,7 +121,7 @@ static void run_test_test_and_clear(void)
         ++count;
     } while (atomic_load(&done) == false);
 
-    printf("+ %s: %lu iterations per second\r\n", "bitarithm_test_and_clear", 2 * count / TIMEOUT_S);
+    printf("+ %s: %lu iterations per second\r\n", "bitarithm_test_and_clear", 2 * count / TIMEOUT_MS * 1000);
 }
 
 #define run_test(test) run_test(#test, test)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This test eats 25 whole seconds at 100% of one CI core for the native test, for each build.
The results on an actual MCU won't change, whether it runs for 25s or 1s.
So, reduce the test timeout for each test from 5s to 200ms.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
