### PR TITLE
tests/pkg_emlearn: fix compilation

### DIFF
--- a/tests/pkg_emlearn/Makefile
+++ b/tests/pkg_emlearn/Makefile
@@ -10,4 +10,4 @@ include $(RIOTBASE)/Makefile.include
 
 model.h: $(CURDIR)/model
 	$(Q)$(CURDIR)/generate_model.py
-	$(Q)echo "/* fix for no newline at eof */\n" >> model.h
+	$(Q)echo "/* fix for no newline at eof */" >> model.h


### PR DESCRIPTION
### Contribution description

It turns out that the fix for the missing terminating newline is not robust. This hopefully fixes the issue and resolves the following error message:

    In file included from /home/maribu/Repos/software/RIOT/tests/pkg_emlearn/main.c:25:
    /home/maribu/Repos/software/RIOT/tests/pkg_emlearn/model.h:7221:36: error: stray '\' in program
     7221 |     /* fix for no newline at eof */\n
          |                                    ^
    /home/maribu/Repos/software/RIOT/tests/pkg_emlearn/model.h:7221:38: error: expected ';' before '_Alignas'
     7221 |     /* fix for no newline at eof */\n
          |                                      ^
          |                                      ;

### Testing procedure

```
$ make BOARD=samr21-xpro -j 8 -C tests/pkg_emlearn/
```

Should succeed consistently, rather than fail when the `\n` is not being turned into a newline on some systems. Just omitting it should cause no issues, as the append operator (`>>`) will always create a terminating newline afterwards anyway, so if the `\n` is turned into a newline two newlines get added.

### Issues/PRs references

Mone