### PR TITLE
CI: drop obsolete murdock note

### DIFF
--- a/.murdock.yml
+++ b/.murdock.yml
@@ -10,9 +10,6 @@ pr:
   comment_artifacts:
   - name: doc-preview/
     readable_name: Documentation preview
-  comment_footer: >
-    **This only reflects a subset of all builds from https://ci-prod.riot-os.org.
-    Please refer to https://ci.riot-os.org for a complete build for now.**
 
 commit:
   skip_keywords: ["ci_skip", "murdock_skip"]


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We're migrating to the new Murdock frontend, no need for the note anymore.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
