### PR TITLE
pkg/tinydtls: only build debug log when tinydtls_debug is enabled 

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/eclipse/tinydtls.git
-PKG_VERSION=297fced854b652591b78113f0ba8d57ad9f934d9
+PKG_VERSION=c84e36ff60a283ee1953458239828477cd4e98ec
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -11,6 +11,11 @@ INCLUDES += -I$(PKG_BUILDDIR)
 # Mandatory for tinyDTLS
 CFLAGS += -DDTLSv12 -DWITH_SHA256
 
+PSEUDOMODULES += tinydtls_debug
+ifeq (,$(filter tinydtls_debug, $(USEMODULE)))
+  CFLAGS += -DNDEBUG=1
+endif
+
 # Check that the used PRNG implementation is cryptographically secure
 CRYPTO_SECURE_IMPLEMENTATIONS := prng_sha256prng prng_sha1prng prng_hwrng
 USED_PRNG_IMPLEMENTATIONS := $(filter prng_%,$(USEMODULE))

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -822,7 +822,9 @@ void sock_dtls_close(sock_dtls_t *sock)
 void sock_dtls_init(void)
 {
     dtls_init();
-    dtls_set_log_level(TINYDTLS_LOG_LVL);
+    if (IS_USED(MODULE_TINYDTLS_DEBUG)) {
+        dtls_set_log_level(TINYDTLS_LOG_LVL);
+    }
 }
 
 static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)

--- a/pkg/tinydtls/patches/0001-RIOT-make-use-of-log.h-for-dsrv_log.patch
+++ b/pkg/tinydtls/patches/0001-RIOT-make-use-of-log.h-for-dsrv_log.patch
@@ -1,0 +1,67 @@
+From 2335c1410102b8f35f45018b15d91f3d8bbfe701 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Tue, 15 Nov 2022 01:50:59 +0100
+Subject: [PATCH 1/2] RIOT: make use of log.h for dsrv_log()
+
+Signed-off-by: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+---
+ dtls_debug.c | 2 ++
+ dtls_debug.h | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/dtls_debug.c b/dtls_debug.c
+index 70c88ff..b33b453 100644
+--- a/dtls_debug.c
++++ b/dtls_debug.c
+@@ -278,6 +278,7 @@ static dtls_mutex_t static_mutex = DTLS_MUTEX_INITIALIZER;
+ static char message[DTLS_DEBUG_BUF_SIZE];
+ #endif /* DTLS_CONSTRAINED_STACK */
+ 
++#ifndef RIOT_VERSION
+ /*
+  * Caution. If DTLS_CONSTRAINED_STACK is set, then the same mutex will get
+  * locked in dtls_log() and/or dtls_dsrv_hexdump_log() so these functions
+@@ -310,6 +311,7 @@ dsrv_log(log_t level, const char *format, ...) {
+   dtls_mutex_unlock(&static_mutex);
+ #endif /* DTLS_CONSTRAINED_STACK */
+ }
++#endif /* !RIOT_VERSION */
+ 
+ #elif defined (HAVE_VPRINTF) /* WITH_CONTIKI */
+ void
+diff --git a/dtls_debug.h b/dtls_debug.h
+index cf8e193..8769774 100644
+--- a/dtls_debug.h
++++ b/dtls_debug.h
+@@ -28,6 +28,10 @@
+ #include <logging/log.h>
+ #endif /* WITH_ZEPHYR */
+ 
++#ifdef RIOT_VERSION
++#include "log.h"
++#endif
++
+ #ifdef WITH_CONTIKI
+ # ifndef DEBUG
+ #  define DEBUG DEBUG_PRINT
+@@ -95,6 +99,9 @@ void dtls_set_log_handler(dtls_log_handler_t app_handler);
+  * Writes the given text to \c stdout. The text is output only when \p
+  * level is below or equal to the log level that set by
+  * set_log_level(). */
++#ifdef RIOT_VERSION
++#define dsrv_log(level, ...) LOG((unsigned)level, __VA_ARGS__)
++#else
+ #ifdef HAVE_VPRINTF
+ #if (defined(__GNUC__) && !defined(__MINGW32__))
+ void dsrv_log(log_t level, const char *format, ...) __attribute__ ((format(printf, 2, 3)));
+@@ -104,6 +111,7 @@ void dsrv_log(log_t level, const char *format, ...);
+ #else
+ #define dsrv_log(level, format, ...) PRINTF(format, ##__VA_ARGS__)
+ #endif
++#endif
+ 
+ /** dumps packets in usual hexdump format */
+ void hexdump(const unsigned char *packet, int length);
+-- 
+2.34.1
+

--- a/pkg/tinydtls/patches/0002-RIOT-only-include-dtls_debug.c-when-tinydtls_debug-i.patch
+++ b/pkg/tinydtls/patches/0002-RIOT-only-include-dtls_debug.c-when-tinydtls_debug-i.patch
@@ -1,0 +1,126 @@
+From 6f29262638357f5885554b32997e04745581426e Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Tue, 15 Nov 2022 01:51:56 +0100
+Subject: [PATCH 2/2] RIOT: only include dtls_debug.c when tinydtls_debug is
+ enabled
+
+This saves ~20k ROM.
+
+Signed-off-by: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+---
+ Makefile.riot |  6 ++++--
+ dtls_debug.c  | 31 -------------------------------
+ dtls_debug.h  | 34 ++++++++++++++++++++++++++++++++++
+ 3 files changed, 38 insertions(+), 33 deletions(-)
+
+diff --git a/Makefile.riot b/Makefile.riot
+index 6d5593b..5071010 100644
+--- a/Makefile.riot
++++ b/Makefile.riot
+@@ -1,7 +1,9 @@
+ MODULE = tinydtls
+ 
+-CFLAGS += -DDTLSv12 -DWITH_SHA256
++SRC := ccm.c  crypto.c  dtls.c  dtls_time.c  hmac.c  netq.c  peer.c  session.c dtls_prng.c
+ 
+-SRC := ccm.c  crypto.c  dtls.c  dtls_debug.c  dtls_time.c  hmac.c  netq.c  peer.c  session.c dtls_prng.c
++ifneq (,$(filter tinydtls_debug, $(USEMODULE)))
++  SRC += dtls_debug.c
++endif
+ 
+ include $(RIOTBASE)/Makefile.base
+diff --git a/dtls_debug.c b/dtls_debug.c
+index b33b453..3166b2a 100644
+--- a/dtls_debug.c
++++ b/dtls_debug.c
+@@ -496,35 +496,4 @@ dtls_dsrv_hexdump_log(log_t level, const char *name, const unsigned char *buf, s
+   PRINTF("\n");
+ }
+ #endif /* WITH_CONTIKI */
+-
+-#else /* NDEBUG */
+-
+-void
+-hexdump(const unsigned char *packet, int length) {
+-  (void)packet;
+-  (void)length;
+-}
+-
+-void
+-dump(unsigned char *buf, size_t len) {
+-  (void)buf;
+-  (void)len;
+-}
+-
+-void
+-dtls_dsrv_hexdump_log(log_t level, const char *name, const unsigned char *buf, size_t length, int extend) {
+-  (void)level;
+-  (void)name;
+-  (void)buf;
+-  (void)length;
+-  (void)extend;
+-}
+-
+-void
+-dtls_dsrv_log_addr(log_t level, const char *name, const session_t *addr) {
+-  (void)level;
+-  (void)name;
+-  (void)addr;
+-}
+-
+ #endif /* NDEBUG */
+diff --git a/dtls_debug.h b/dtls_debug.h
+index 8769774..e80ebac 100644
+--- a/dtls_debug.h
++++ b/dtls_debug.h
+@@ -113,6 +113,7 @@ void dsrv_log(log_t level, const char *format, ...);
+ #endif
+ #endif
+ 
++#ifndef NDEBUG
+ /** dumps packets in usual hexdump format */
+ void hexdump(const unsigned char *packet, int length);
+ 
+@@ -122,6 +123,39 @@ void dump(unsigned char *buf, size_t len);
+ void dtls_dsrv_hexdump_log(log_t level, const char *name, const unsigned char *buf, size_t length, int extend);
+ 
+ void dtls_dsrv_log_addr(log_t level, const char *name, const session_t *addr);
++#else
++static inline
++void hexdump(const unsigned char *packet, int length)
++{
++  (void)packet;
++  (void)length;
++}
++
++static inline
++void dump(unsigned char *buf, size_t len)
++{
++  (void)buf;
++  (void)len;
++}
++
++static inline
++void dtls_dsrv_hexdump_log(log_t level, const char *name, const unsigned char *buf, size_t length, int extend)
++{
++  (void)level;
++  (void)name;
++  (void)buf;
++  (void)length;
++  (void)extend;
++}
++
++static inline
++void dtls_dsrv_log_addr(log_t level, const char *name, const session_t *addr)
++{
++  (void)level;
++  (void)name;
++  (void)addr;
++}
++#endif /* NDEBUG */
+ 
+ /* A set of convenience macros for common log levels. */
+ #ifdef WITH_ZEPHYR
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

tinydtls allows to switch the log level at run-time, which means all debug strings have to be present in ROM.
This is pretty wasteful, so define a `tinydtls_debug` module without which those debug facilities are dropped, saving ~20k ROM on Cortex-M0.

This also hooks the tinydtls log into RIOT's log facility, so even with `tinydtls_debug` enabled messages below the log level set in RIOT are dropped.

Dynamic log level switching does no longer work, but we don't have this in RIOT so we don't need it for this module.


### Testing procedure

Build `examples/dtls-sock`

#### master

```
   text	   data	    bss	    dec	    hex	filename
 120412	    376	  23356	 144144	  23310	examples/dtls-sock/bin/samr21-xpro/dtls_sock.elf

```

#### this PR

```
   text	   data	    bss	    dec	    hex	filename
  98088	    272	  23236	 121596	  1dafc	examples/dtls-sock/bin/samr21-xpro/dtls_sock.elf
```

### Issues/PRs references

Upstream PR: https://github.com/eclipse/tinydtls/pull/177
