### PR TITLE
tests/shell: fix failure on samr21-xpro [backport 2022.10]

### DIFF
--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -16,5 +16,7 @@ TEST_ON_CI_BLACKLIST += microbit
 
 include $(RIOTBASE)/Makefile.include
 
+CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_SMALL+THREAD_EXTRA_STACKSIZE_PRINTF)'
+
 # the test script skips tests if socat is not used
 $(call target-export-variables,$(RIOT_TERMINAL),RIOT_TERMINAL)

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -27,6 +27,12 @@
 #include "xtimer.h"
 #endif
 
+/* define buffer to be used by the shell. Note: This is intentionally
+ * smaller than 64 bytes, as the EDBG integrated UART bridge of the samr21-xpro
+ * (and likely all other EDBG boards) drops chars when sending more than 64
+ * bytes at a time. This results in the buffer overflow test failing. */
+static char line_buf[60];
+
 #if MODULE_SHELL_HOOKS
 void shell_post_readline_hook(void)
 {
@@ -81,7 +87,7 @@ static int print_shell_bufsize(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-    printf("%d\n", SHELL_DEFAULT_BUFSIZE);
+    printf("%d\n", sizeof(line_buf));
 
     return 0;
 }
@@ -130,20 +136,17 @@ int main(void)
 {
     printf("test_shell.\n");
 
-    /* define buffer to be used by the shell */
-    char line_buf[SHELL_DEFAULT_BUFSIZE];
-
     /* define own shell commands */
-    shell_run_once(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run_once(shell_commands, line_buf, sizeof(line_buf));
 
     puts("shell exited");
 
     /* Restart the shell after the previous one exits, so that we can test
      * Ctrl-D exit */
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(shell_commands, line_buf, sizeof(line_buf));
 
     /* or use only system shell commands */
-    /* shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE); */
+    /* shell_run(NULL, line_buf, sizeof(line_buf)); */
 
     return 0;
 }

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -211,7 +211,7 @@ def testfunc(child):
         child.crlf = '\n'
 
     bufsize = check_and_get_bufsize(child)
-    longline = "_"*bufsize + "verylong"
+    longline = "_" * (bufsize - len("verylong")) + "verylong"
 
     check_line_exceeded(child, longline)
 


### PR DESCRIPTION
# Backport of #18891

### Contribution description

The test (at least locally) fails on the long shell line detection in `master`, as the EDBG UART adapter drops chars when more than 64 bytes are send at a time. This works around the issue:

- The line buffer in the test is reduced to 60 bytes, so that overflowing it becomes possible with sending less than 64 bytes.
- The test script is adapted to exceed the shell buffer size by one byte only (due to linefeed char), rather than significantly. - Sending more than 64 bytes would result in the linefeed being dropped by the EDBG adapter and the test failing

Finally, the shell buffer is no longer allocated on the stack and, hence, the main stack size could be reduced a bit. The test still passes on the Nucleo-F767ZI which is notorious in failing on tight stacks due to the MPU stack guard - so the stack size reduction is expected to work for all boards.

### Testing procedure

```
make BOARD=samr21-xpro -C tests/shell
```

Should now pass, while it fails on `master` on the test for graceful buffer overflow handling.

### Issues/PRs references

None