### PR TITLE
makefiles/libc/picolibc.mk: fix compilation with modern binutils [backport 2022.10]

### DIFF
--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -27,6 +27,14 @@ ifeq (1,$(USE_PICOLIBC))
     CFLAGS += -DPICOLIBC_INTEGER_PRINTF_SCANF
     LINKFLAGS += -DPICOLIBC_INTEGER_PRINTF_SCANF
   endif
+  # For some reason segments with RWX permissions will be created with
+  # picolibc. But since (as of now) RIOT only supports disabling the execute of
+  # all RAM via the `mpu_noexec_ram` module, permissions of the segments are
+  # ignored anyway. So for now, we just simply disable the warning.
+  LINKER_SUPPORTS_NOWARNRWX ?= $(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(LINK) -xc - -o /dev/null -lc -Wall -Wextra -pedantic -Wl,--no-warn-rwx-segments 2> /dev/null && echo 1 || echo 0)
+  ifeq (1,$(LINKER_SUPPORTS_NOWARNRWX))
+    LINKFLAGS += -Wl,--no-warn-rwx-segments
+  endif
 endif
 
 LINKFLAGS += -lc


### PR DESCRIPTION
# Backport of #18893

### Contribution description

Modern binutils complain about segments with RWX permissions. While this is indeed a bad habit, RIOT ignores segments permissions anyway. (We do have a `mpu_noexec_ram` module to disable execution of all of RAM, which would do so regardless of the segment permission.) So for now, we can safely just disable the warning.

This fixes:

    /usr/lib/gcc/arm-none-eabi/12.2.0/../../../../arm-none-eabi/bin/ld: warning: /home/maribu/Repos/software/RIOT/examples/default/bin/nucleo-f767zi/default.elf has a LOAD segment with RWX permissions
    collect2: error: ld returned 1 exit status

### Testing procedure

```
$ FEATURES_REQUIRED=picolibc make BOARD=nucleo-f767zi -C examples/default
```

With `master`, the above warning pops up with `binutils` 2.39. With this PR, it is disabled.

### Issues/PRs references

None