### PR TITLE
makefiles/cflags.inc.mk: don't include absolute path in __FILE__ macro

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -52,3 +52,5 @@ LINKFLAGS += -Tesp8266.peripherals.ld
 
 LINKFLAGS += -Wl,-wrap=pp_attach
 LINKFLAGS += -Wl,-wrap=pm_attach
+
+OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=

--- a/makefiles/arch/avr8.inc.mk
+++ b/makefiles/arch/avr8.inc.mk
@@ -38,6 +38,7 @@ endif
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
 OPTIONAL_CFLAGS_BLACKLIST += -gz
+OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=
 
 ifeq ($(TOOLCHAIN),gnu)
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -95,6 +95,9 @@ OPTIONAL_CFLAGS += -Wformat=2
 OPTIONAL_CFLAGS += -Wformat-overflow
 OPTIONAL_CFLAGS += -Wformat-truncation
 
+# Don't include absolute path in __FILE__ macro
+OPTIONAL_CFLAGS += -fmacro-prefix-map=$(RIOTBASE)/=
+
 # Warn about casts that increase alignment requirements
 OPTIONAL_CFLAGS += -Wcast-align
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`__FILE__` will resolve to the absolute path of the file.
This adds a lot of noise (and ROM size) when debugging with tracer macros.

Luckily, starting with GCC 8 we can drop the common `$(RIOTBASE)` prefix, this makes for much nicer output.


### Testing procedure

Used in e.g. #18795


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
