### PR TITLE
gnrc_sock_udp: style fix in sock_udp_recv_buf_aux()

### DIFF
--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -206,8 +206,8 @@ ssize_t sock_udp_recv_aux(sock_udp_t *sock, void *data, size_t max_len,
     return (nobufs) ? -ENOBUFS : ((res < 0) ? res : ret);
 }
 
-static bool _remote_accept(const sock_udp_t *sock, const udp_hdr_t *hdr,
-                             const sock_ip_ep_t *remote)
+static bool _accept_remote(const sock_udp_t *sock, const udp_hdr_t *hdr,
+                           const sock_ip_ep_t *remote)
 {
     if ((sock->flags & SOCK_FLAGS_CONNECT_REMOTE) == 0) {
         /* socket is not bound to a remote */
@@ -286,7 +286,7 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
         memcpy(remote, &tmp, sizeof(tmp));
         remote->port = byteorder_ntohs(hdr->src_port);
     }
-    if (!_remote_accept(sock, hdr, &tmp)) {
+    if (!_accept_remote(sock, hdr, &tmp)) {
         gnrc_pktbuf_release(pkt);
         return -EPROTO;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Indentation was wrong and function name reversed.


### Testing procedure

Just style fix.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
