### PR TITLE
nanocoap_sock: allow receiving multiple responses to one request

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -293,6 +293,10 @@ typedef int (*coap_blockwise_cb_t)(void *arg, size_t offset, uint8_t *buf, size_
  *                     Buffers point to network stack internal memory.
  *
  * @returns   >=0       on success
+ * @returns   -EAGAIN   receive more responses
+ *                      Only use this if the request was to a multicast address
+ *                      and you expect responses from multiple nodes.
+ *                      Callback will be called again if another response is received
  * @returns    <0       on error
  */
 typedef int (*coap_request_cb_t)(void *arg, coap_pkt_t *pkt);

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -229,6 +229,10 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 /* call user callback */
                 if (cb) {
                     res = cb(arg, pkt);
+                    /* get another response */
+                    if (res == -EAGAIN) {
+                        state = STATE_RESPONSE_RCVD;
+                    }
                 } else {
                     res = _get_error(pkt);
                 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When we do a `nanocoap_sock_request_cb()` to a multicast address, we expect multiple responses back.

Normally `nanocoap_sock_request_cb()` will return after the first response and not listen for any more responses.

This adds the option for the user supplied callback function to return `-EGAIN` when it expects more responses.
We then just continue listening until the next response is received or the timeout occurs.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
