### PR TITLE
sys/fmt: add print_bytes_hex()

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -550,6 +550,15 @@ void print_byte_hex(uint8_t byte)
     print(buf, sizeof(buf));
 }
 
+void print_bytes_hex(const void *bytes, size_t num)
+{
+    const uint8_t *b = bytes;
+
+    while (num--) {
+        print_byte_hex(*b++);
+    }
+}
+
 void print_u32_hex(uint32_t val)
 {
     char buf[8];

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -451,6 +451,14 @@ void print_s32_dec(int32_t val);
 void print_byte_hex(uint8_t byte);
 
 /**
+ * @brief Print bytes as hex to stdout
+ *
+ * @param[in]  bytes Byte array to print
+ * @param[in]  n     Number of bytes to print
+ */
+void print_bytes_hex(const void *bytes, size_t n);
+
+/**
  * @brief Print uint32 value as hex to stdout
  *
  * @param[in]   val  Value to print

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -45,6 +45,8 @@ int main(void)
     print_str("\n");
     print_float(1.2345, 5);
     print_str("\n");
+    print_bytes_hex("0123456789", 10);
+    print_str("\n");
     /* test mixing of printf() and fmt's print() works fine */
     printf("%s", "Test");
     /* test fmt's print indeed only honors the length parameter and doesn't

--- a/tests/fmt_print/tests/01-run.py
+++ b/tests/fmt_print/tests/01-run.py
@@ -15,6 +15,7 @@ def testfunc(child):
     child.expect_exact('18446744073709551615')
     child.expect_exact('-9223372036854775808')
     child.expect_exact('1.23450')
+    child.expect_exact('30313233343536373839')
     child.expect_exact('Test successful.')
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Pretty straightforward function to print a byte buffer 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
