### PR TITLE
cpu/stm32: fix RAM_LEN for F427, F429, F437, F439 models

### DIFF
--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -159,11 +159,13 @@ ifeq ($(STM32_TYPE), F)
       RAM_LEN = 32K
     else ifneq (, $(filter $(STM32_MODEL), 411 446))
       RAM_LEN = 128K
-    else ifneq (, $(filter $(STM32_MODEL), 412 427 429 437 439))
+    else ifneq (, $(filter $(STM32_MODEL), 412))
       RAM_LEN = 256K
     else ifneq (, $(filter $(STM32_MODEL), 413 423))
       RAM_LEN = 320K
     else ifneq (, $(filter $(STM32_MODEL), 415 417))
+      RAM_LEN = 192K
+    else ifneq (, $(filter $(STM32_MODEL), 427 429 437 439))
       RAM_LEN = 192K
     else ifneq (, $(filter $(STM32_MODEL), 469 479))
       RAM_LEN = 384K


### PR DESCRIPTION
### Contribution description

This PR fixes the `RAM_LEN` setting for STM32 F427, F429, F437, F439 models.

While playing with `bootloader/riotboot_dfu`, I realized that the bootloader hard faults on a `stm32f429i-disc1` board here https://github.com/RIOT-OS/RIOT/blob/2d4c5a43ba8ec218770684b0973a756703d4f3b5/sys/riotboot/usb_dfu.c#L38 because the `RIOTBOOT_MAGIC_ADDR` (which is `RAM_BASE + RAM_LEN - 4`) is not accessible. Although these models have 256 kByte RAM, the upper 64 kByte are used as CCM data RAM accessible at `0x1000 xxxx`. Accessing `0x2003 xxxx` leads to the hard fault

### Testing procedure

Use any `stm32f429i-disc1` board and flash the `bootloader/riotboot_dfu` app:
```
BOARD=stm32f429i-disc1 make -C bootloaders/riotboot_dfu flash
```
Without this PR, the board is not listed with `lsusb` and `dfu-util --list` because it crashes in function riotboot_usb_dfu_init` before the USB interface is initialized. With this PR `lsusb` as well as `dfu-util --list` should work.

### Issues/PRs references
