### PR TITLE
cpu/stm32: add unused backup RAM as extra heap

### DIFF
--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -78,6 +78,11 @@
 #error Not supported CPU family
 #endif
 
+/* add unused backup RAM as extra heap */
+#if !defined(NUM_HEAPS) && CPU_HAS_BACKUP_RAM
+#define NUM_HEAPS   2
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `tests/malloc` on a supported CPU

```
2022-11-16 13:25:06,756 # Allocated 128 Bytes at 0x0x20001c58, total 128
2022-11-16 13:25:06,757 # Allocated 128 Bytes at 0x0x20001cf0, total 264
2022-11-16 13:25:06,757 # Allocated 128 Bytes at 0x0x20001d88, total 400
2022-11-16 13:25:06,758 # Allocated 128 Bytes at 0x0x20001e20, total 536
2022-11-16 13:25:06,759 # Allocated 128 Bytes at 0x0x20001eb8, total 672
…
2022-11-16 13:25:07,614 # Allocated 128 Bytes at 0x0x2002fef8, total 169312
2022-11-16 13:25:07,615 # Allocated 128 Bytes at 0x0x40024008, total 169448
2022-11-16 13:25:07,615 # Allocated 128 Bytes at 0x0x40024090, total 169584
2022-11-16 13:25:07,616 # Allocated 128 Bytes at 0x0x40024118, total 169720
2022-11-16 13:25:07,616 # Allocated 128 Bytes at 0x0x400241a0, total 169856
…
2022-11-16 13:25:07,630 # Allocated 128 Bytes at 0x0x40024dd8, total 172712
2022-11-16 13:25:07,631 # Allocated 128 Bytes at 0x0x40024e70, total 172848
2022-11-16 13:25:07,632 # Allocated 128 Bytes at 0x0x40024f08, total 172984
2022-11-16 13:25:07,632 # Allocations count: 1272
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

No longer crashes thanks to https://github.com/RIOT-OS/RIOT/pull/18919
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
