### PR TITLE
sys/print_stack_usage: update MIN_SIZE [backport 2022.10]

### DIFF
--- a/sys/test_utils/print_stack_usage/print_stack_usage.c
+++ b/sys/test_utils/print_stack_usage/print_stack_usage.c
@@ -26,12 +26,7 @@
 #include <stdio.h>
 #endif
 
-#if MODULE_FMT
-/* fmt's `print_str()` needs very little stack. ~200 total was fine on Cortex-M. */
-# define MIN_SIZE   (THREAD_STACKSIZE_TINY)
-#else
 # define MIN_SIZE   (THREAD_STACKSIZE_TINY + THREAD_EXTRA_STACKSIZE_PRINTF)
-#endif
 
 void print_stack_usage_metric(const char *name, void *stack, unsigned max_size)
 {


### PR DESCRIPTION
# Backport of #18917

### Contribution description

Since fmt no longer has a significant advantage in stack consumption, we need to bump the `MIN_SIZE` guard that prevents causing stack overflows due to the printing of the stack consumption.

### Testing procedure

```
$ make BOARD=nucleo-f767zi -C tests/pthread_flood flash test
```

Should no longer print stack usage for the dummy POSIX threads and not result in hard faults due to stack overflows anymore.

### Issues/PRs references

Better alternative to https://github.com/RIOT-OS/RIOT/pull/18916