### PR TITLE
sys/fmt: directly use stdio_write() 

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -25,8 +25,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "kernel_defines.h"
 #include "fmt.h"
+#include "kernel_defines.h"
+#include "stdio_base.h"
 
 static const char _hex_chars[16] = "0123456789ABCDEF";
 
@@ -517,7 +518,7 @@ void print(const char *s, size_t n)
 
     while (n > 0) {
         ssize_t written;
-        written = fwrite(s, 1, n, stdout);
+        written = stdio_write(s, n);
         if (written < 0) {
             break;
         }

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -24,31 +24,31 @@
  * @}
  */
 
-#include <unistd.h>
-#include <reent.h>
 #include <errno.h>
 #include <malloc.h>
+#include <reent.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/times.h>
 #include <sys/unistd.h>
-#include <stdint.h>
+#include <unistd.h>
 
-#include "cpu.h"
 #include "board.h"
-#include "sched.h"
-#include "thread.h"
+#include "cpu.h"
 #include "irq.h"
+#include "kernel_defines.h"
 #include "log.h"
 #include "periph/pm.h"
+#include "sched.h"
+#include "stdio_base.h"
+#include "thread.h"
+
 #if MODULE_VFS
 #include "vfs.h"
 #endif
-
-#include "stdio_base.h"
-
-#include <sys/times.h>
 
 #ifdef MODULE_XTIMER
 #include <sys/time.h>
@@ -149,7 +149,9 @@ static const struct heap heaps[NUM_HEAPS] = {
  */
 void _init(void)
 {
-    /* nothing to do here */
+    if (IS_USED(MODULE_FMT)) {
+        setvbuf(stdout, NULL, _IONBF, 0);
+    }
 }
 
 /**

--- a/sys/test_utils/print_stack_usage/print_stack_usage.c
+++ b/sys/test_utils/print_stack_usage/print_stack_usage.c
@@ -26,7 +26,12 @@
 #include <stdio.h>
 #endif
 
+#if MODULE_FMT
+/* fmt's `print_str()` needs very little stack. ~200 total was fine on Cortex-M. */
+# define MIN_SIZE   (THREAD_STACKSIZE_TINY)
+#else
 # define MIN_SIZE   (THREAD_STACKSIZE_TINY + THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
 
 void print_stack_usage_metric(const char *name, void *stack, unsigned max_size)
 {


### PR DESCRIPTION
### Contribution description

- directly use `stdio_write()` instead of `fwrite()` in `fmt`'s `print()` to reduce stack consumption significantly
- disable buffered stdio output when `fmt` is used in newlib to avoid surprises when mixing stdio and `fmt`'s output.
    - Note: `tests/fmt_print` tests for sane interaction between `stdio` and `fmt`.
- revert https://github.com/RIOT-OS/RIOT/pull/18917

### Testing procedure

`tests/fmt_print`

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18917