### PR TITLE
build system: fix compilation with LLVM [backport 2022.10]

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -57,6 +57,25 @@ ifeq ($(LTO),1)
   LINKFLAGS += $(LTOFLAGS) -ffunction-sections -fdata-sections
 endif
 
+# Cannot test with `BUILD_IN_DOCKER=1`, as this is only the case when the
+# actual build is done in the docker container and we are still running in the
+# host's context.
+ifeq (1,$(BUILD_IN_DOCKER))
+  LINKER_SUPPORTS_NOEXECSTACK := determine-later-inside-docker
+endif
+
+# Check if linker supports `-z noexecstack`. Handle BUILD_IN_DOCKER separately,
+# as this is run in the host environment rather than inside the container. We
+# just hardcode this in the BUILD_IN_DOCKER case for now.
+LINKER_SUPPORTS_NOEXECSTACK ?= $(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(LINK) -xc - -o /dev/null -lc -Wall -Wextra -pedantic -z noexecstack 2> /dev/null && echo 1 || echo 0)
+
+# As we do not use nested functions or other stuff requiring trampoline code,
+# we can safely mark the stack as not executable. This avoids warnings on newer
+# toolchains.
+ifeq (1,$(LINKER_SUPPORTS_NOEXECSTACK))
+  LINKFLAGS += -z noexecstack
+endif
+
 # Forbid common symbols to prevent accidental aliasing.
 CFLAGS += -fno-common
 

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -2,7 +2,7 @@ ifneq (,$(filter newlib_nano,$(USEMODULE)))
   # Test if nano.specs is available
   ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
     USE_NEWLIB_NANO = 1
-    ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(CC) -xc - -o /dev/null -lc -specs=nano.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
+    ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(LINK) -xc - -o /dev/null -lc -specs=nano.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
         CFLAGS += -fshort-wchar
         LINKFLAGS += -Wl,--no-wchar-size-warning
     endif

--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -2,7 +2,7 @@ ifneq (,$(filter picolibc,$(USEMODULE)))
   # Test if picolibc.specs is available
   ifeq ($(shell $(LINK) -specs=picolibc.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
     USE_PICOLIBC = 1
-    ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(CC) -xc - -o /dev/null -lc -specs=picolibc.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
+    ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(LINK) -xc - -o /dev/null -lc -specs=picolibc.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
         CFLAGS += -fshort-wchar
         LINKFLAGS += -Wl,--no-wchar-size-warning
     endif


### PR DESCRIPTION
# Backport of #18845

### Contribution description

- makefiles/cflags.inc.mk: add `-z noexecstack` to link flags
    - GCC on some platforms does need an executable stack to generate trampoline code, but use of nested functions is not allowed in RIOT's code base anyway.
- makefiles/libc: fix wchar_t size warnings on LLVM
    - The test for the requirement of disabling wchar_t size warnings assumed that `$(CC)` is used for linking, instead of `$(LINK)`. With GCC `$(LINK)` and `$(CC)` happen to be (in most cases) identical, but with LLVM they are not. This results in issues with compiling with LLVM.

### Testing procedure

No change in binaries and everything should still compile.

### Issues/PRs references

Inspired by https://github.com/RIOT-OS/RIOT/pull/18844