### PR TITLE
makefiles/gnu.inc.mk: set flags based on compiler version

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -52,5 +52,3 @@ LINKFLAGS += -Tesp8266.peripherals.ld
 
 LINKFLAGS += -Wl,-wrap=pp_attach
 LINKFLAGS += -Wl,-wrap=pm_attach
-
-OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=

--- a/makefiles/arch/avr8.inc.mk
+++ b/makefiles/arch/avr8.inc.mk
@@ -38,7 +38,6 @@ endif
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
 OPTIONAL_CFLAGS_BLACKLIST += -gz
-OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=
 
 ifeq ($(TOOLCHAIN),gnu)
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -22,5 +22,13 @@ endif
 # Default to the native (g)objdump, helps when using toolchain from docker
 _OBJDUMP         := $(or $(shell command -v $(PREFIX)objdump || command -v gobjdump),objdump)
 OBJDUMP   ?= $(_OBJDUMP)
+
+GCC_VERSION := $(shell $(CC) -dumpversion | cut -d . -f 1)
+
+# -fmacro-prefix-map requires GCC 8
+ifneq (8, $(firstword $(shell echo 8 $(GCC_VERSION) | tr ' ' '\n' | sort -n))))
+  OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=
+endif
+
 # We use GDB for debugging
 include $(RIOTMAKE)/tools/gdb.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`-fmacro-prefix-map` was introduced in GCC 8, so only set it if the compiler version is 8 or newer.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18913#issuecomment-1320555878
