### PR TITLE
treewide: replace RIOT_FILE_RELATIVE with __FILE__

### DIFF
--- a/core/lib/include/assert.h
+++ b/core/lib/include/assert.h
@@ -44,10 +44,6 @@ extern "C" {
 #define DEBUG_ASSERT_VERBOSE
 #endif
 
-#ifndef RIOT_FILE_RELATIVE
-#define RIOT_FILE_RELATIVE  (__FILE__)
-#endif
-
 /**
  * @def __NORETURN
  * @brief hidden (__) NORETURN definition
@@ -110,8 +106,7 @@ __NORETURN void _assert_failure(const char *file, unsigned line);
  *
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/assert.html
  */
-#define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, \
-                                                          __LINE__))
+#define assert(cond) ((cond) ? (void)0 :  _assert_failure(__FILE__, __LINE__))
 #else /* DEBUG_ASSERT_VERBOSE */
 __NORETURN void _assert_panic(void);
 #define assert(cond) ((cond) ? (void)0 : _assert_panic())

--- a/core/msg.c
+++ b/core/msg.c
@@ -105,18 +105,18 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
     thread_t *me = thread_get_active();
 
     DEBUG("msg_send() %s:%i: Sending from %" PRIkernel_pid " to %" PRIkernel_pid
-          ". block=%i src->state=%i target->state=%i\n", RIOT_FILE_RELATIVE,
+          ". block=%i src->state=%i target->state=%i\n", __FILE__,
           __LINE__, thread_getpid(), target_pid,
           block, (int)me->status, (int)target->status);
 
     if (target->status != STATUS_RECEIVE_BLOCKED) {
         DEBUG(
             "msg_send() %s:%i: Target %" PRIkernel_pid " is not RECEIVE_BLOCKED.\n",
-            RIOT_FILE_RELATIVE, __LINE__, target_pid);
+            __FILE__, __LINE__, target_pid);
 
         if (queue_msg(target, m)) {
             DEBUG("msg_send() %s:%i: Target %" PRIkernel_pid
-                  " has a msg_queue. Queueing message.\n", RIOT_FILE_RELATIVE,
+                  " has a msg_queue. Queueing message.\n", __FILE__,
                   __LINE__, target_pid);
             irq_restore(state);
             if (me->status == STATUS_REPLY_BLOCKED

--- a/cpu/lpc23xx/mci/lpc23xx-mci.c
+++ b/cpu/lpc23xx/mci/lpc23xx-mci.c
@@ -534,7 +534,7 @@ diskio_sta_t mci_initialize(void)
             /* Wait while card is busy state (use ACMD41 with HCS bit) */
             /* This loop will take a time. Insert wai_tsk(1) here for multitask envilonment. */
             if (ztimer_now(ZTIMER_USEC) > (start + 1 * US_PER_SEC /* !Timer[0] */)) {
-                DEBUG("%s, %d: Timeout #1\n", RIOT_FILE_RELATIVE, __LINE__);
+                DEBUG("%s, %d: Timeout #1\n", __FILE__, __LINE__);
                 goto di_fail;
             }
         }
@@ -556,13 +556,13 @@ diskio_sta_t mci_initialize(void)
 
         do {
             /* Wait while card is busy state (use ACMD41 or CMD1) */
-            DEBUG("%s, %d: %lX\n", RIOT_FILE_RELATIVE, __LINE__, resp[0]);
+            DEBUG("%s, %d: %lX\n", __FILE__, __LINE__, resp[0]);
 
             /* This loop will take a time. Insert wai_tsk(1) here for multitask envilonment. */
             if (ztimer_now(ZTIMER_USEC) > (start + 1 * US_PER_SEC/* !Timer[0] */)) {
                 DEBUG("now: %" PRIu32 "us, started at: %" PRIu32 "\n",
                       (uint32_t) ztimer_now(ZTIMER_USEC), start);
-                DEBUG("%s, %d: Timeout #2\n", RIOT_FILE_RELATIVE, __LINE__);
+                DEBUG("%s, %d: Timeout #2\n", __FILE__, __LINE__);
                 goto di_fail;
             }
         }
@@ -575,7 +575,7 @@ diskio_sta_t mci_initialize(void)
     /*---- Card is 'ready' state ----*/
 
     if (!send_cmd(CMD2, 0, 2, resp)) {
-        DEBUG("%s, %d: Failed entering ident state", RIOT_FILE_RELATIVE,
+        DEBUG("%s, %d: Failed entering ident state", __FILE__,
               __LINE__);
         goto di_fail;   /* Enter ident state */
     }
@@ -588,7 +588,7 @@ diskio_sta_t mci_initialize(void)
 
     if (ty & CT_SDC) {                      /* SDC: Get generated RCA and save it */
         if (!send_cmd(CMD3, 0, 1, resp)) {
-            DEBUG("%s, %d: Failed generating RCA\n", RIOT_FILE_RELATIVE, __LINE__);
+            DEBUG("%s, %d: Failed generating RCA\n", __FILE__, __LINE__);
             goto di_fail;
         }
 

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -330,7 +330,7 @@ static void _tap_isr(int fd, void *arg) {
 
 static int _init(netdev_t *netdev)
 {
-    DEBUG("%s:%s:%u\n", RIOT_FILE_RELATIVE, __func__, __LINE__);
+    DEBUG("%s:%s:%u\n", __FILE__, __func__, __LINE__);
 
     netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
 

--- a/sys/include/embUnit/AssertImpl.h
+++ b/sys/include/embUnit/AssertImpl.h
@@ -49,7 +49,7 @@ void assertImplementationCStr(const char *expected,const char *actual, long line
         const char *____expected__ = expected_; \
         const char *____actual__ = actual_; \
         if (stdimpl_strcmp(____expected__, ____actual__) != 0) { \
-            assertImplementationCStr(____expected__, ____actual__, __LINE__, RIOT_FILE_RELATIVE); \
+            assertImplementationCStr(____expected__, ____actual__, __LINE__, __FILE__); \
             return; \
         } \
     } while (0)
@@ -60,7 +60,7 @@ void assertImplementationCStr(const char *expected,const char *actual, long line
         long long ____actual__ = (long long) (actual_); \
         if (____expected__ != ____actual__) { \
             assertImplementationLongLong(____expected__, ____actual__, \
-                                         __LINE__, RIOT_FILE_RELATIVE); \
+                                         __LINE__, __FILE__); \
             return; \
         } \
     } while (0)
@@ -92,7 +92,7 @@ void assertImplementationCStr(const char *expected,const char *actual, long line
 
 #define TEST_FAIL(message) \
     do { \
-        addFailure((message), __LINE__, RIOT_FILE_RELATIVE); \
+        addFailure((message), __LINE__, __FILE__); \
         return; \
     } while (0)
 

--- a/sys/include/test_utils/expect.h
+++ b/sys/include/test_utils/expect.h
@@ -32,10 +32,6 @@
 extern "C" {
 #endif
 
-#ifndef RIOT_FILE_RELATIVE
-#define RIOT_FILE_RELATIVE  (__FILE__)
-#endif
-
 /**
  * @brief   Function to handle failed expectation
  *
@@ -80,8 +76,7 @@ NORETURN static inline void _expect_failure(const char *file, unsigned line)
  * the condition failed in.
  *
  */
-#define expect(cond) ((cond) ? (void)0 :  _expect_failure(RIOT_FILE_RELATIVE, \
-                                                          __LINE__))
+#define expect(cond) ((cond) ? (void)0 :  _expect_failure(__FILE__, __LINE__))
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
@@ -120,7 +120,7 @@ extern "C" {
  * @note Compilation units using TCP_DEBUG_ENTER must set ENABLE_DEBUG and include debug.h.
  */
 #define TCP_DEBUG_ENTER DEBUG("GNRC_TCP: Enter \"%s\", File: %s(%d)\n", \
-                              DEBUG_FUNC, RIOT_FILE_RELATIVE, __LINE__)
+                              DEBUG_FUNC, __FILE__, __LINE__)
 
 /**
  * @brief Helper macro used to create debug message on function exit.
@@ -128,7 +128,7 @@ extern "C" {
  * @note Compilation units using TCP_DEBUG_LEAVE must set ENABLE_DEBUG and include debug.h.
  */
 #define TCP_DEBUG_LEAVE DEBUG("GNRC_TCP: Leave \"%s\", File: %s(%d)\n", \
-                              DEBUG_FUNC, RIOT_FILE_RELATIVE, __LINE__)
+                              DEBUG_FUNC, __FILE__, __LINE__)
 
 /**
  * @brief Helper macro used to create debug message on error.
@@ -136,7 +136,7 @@ extern "C" {
  * @note Compilation units using TCP_DEBUG_ERROR must set ENABLE_DEBUG and include debug.h.
  */
 #define TCP_DEBUG_ERROR(msg) DEBUG("GNRC_TCP: Error: \"%s\", Func: %s, File: %s(%d)\n", \
-                                   msg, DEBUG_FUNC, RIOT_FILE_RELATIVE, __LINE__)
+                                   msg, DEBUG_FUNC, __FILE__, __LINE__)
 
 /**
  * @brief Helper macro used to create informational debug message.
@@ -144,7 +144,7 @@ extern "C" {
  * @note Compilation units using TCP_DEBUG_INFO must set ENABLE_DEBUG and include debug.h.
  */
 #define TCP_DEBUG_INFO(msg) DEBUG("GNRC_TCP: Info: \"%s\", Func: %s, File: %s(%d)\n", \
-                                  msg, DEBUG_FUNC, RIOT_FILE_RELATIVE, __LINE__)
+                                  msg, DEBUG_FUNC, __FILE__, __LINE__)
 
 /**
  * @brief TCB list type.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With a recent compiler (GCC ≥ 8) we can define `__FILE__` to be relative to the RIOT base directory, so there is no more need for the custom (and fragile) `RIOT_FILE_RELATIVE` macro.

### Testing procedure

Output should stay the same.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18913#issuecomment-1320647678
