### PR TITLE
makefiles/gnu.inc.mk: fix "extraneous text after 'ifneq' directive"

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -26,7 +26,7 @@ OBJDUMP   ?= $(_OBJDUMP)
 GCC_VERSION := $(shell $(CC) -dumpversion | cut -d . -f 1)
 
 # -fmacro-prefix-map requires GCC 8
-ifneq (8, $(firstword $(shell echo 8 $(GCC_VERSION) | tr ' ' '\n' | sort -n))))
+ifneq (8, $(firstword $(shell echo 8 $(GCC_VERSION) | tr ' ' '\n' | sort -n)))
   OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`make` on Arch rightfully complains about the extra parenthesis

    /home/benpicco/dev/RIOT/makefiles/toolchain/gnu.inc.mk:29: extraneous text after 'ifneq' directive

~~It's the same version that Ubuntu ships, but for some reason that just silently ignores it.~~
It's also there on Ubuntu, I just didn't see it because it scrolled away so fast.


### Testing procedure

[![image](https://user-images.githubusercontent.com/1301112/202906243-48731344-38fd-454f-9123-8329c70101fd.png)](https://xkcd.com/859/)


### Issues/PRs references

follow-up to #18935
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
