### PR TITLE
gnrc_ipv6_nib: clean up _resolve_addr()

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
@@ -249,7 +249,7 @@ bool _is_reachable(_nib_onl_entry_t *entry);
 #define _set_reachable(netif, nce)                  (void)netif; (void)nce
 
 #define _get_nud_state(nbr)                 (GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNMANAGED)
-#define _set_nud_state(netif, nce, state)   (void)netif; (void)nbr; (void)state
+#define _set_nud_state(netif, nce, state)   (void)netif; (void)nce; (void)state
 #define _is_reachable(entry)                (true)
 #endif  /* CONFIG_GNRC_IPV6_NIB_ARSM || defined(DOXYGEN) */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I'm still trying to find a proper fix for #16988 (border router does ARSM on the 6lo interface) but still no avail.

But as a first step, clean up `_resolve_addr()` by getting rid of unececary pre-processor conditionals and moving logic blocks to separate functions. 

This makes it easier to figure out what's actually going on.

There should be no changes to the logic.

### Testing procedure

All tests should continue yielding the same results as before.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
