### PR TITLE
boards/nucleo-l496zg: add ADC support

### DIFF
--- a/boards/nucleo-l496zg/Kconfig
+++ b/boards/nucleo-l496zg/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_L496ZG
     select CPU_MODEL_STM32L496ZG
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_LPUART
     select HAS_PERIPH_PWM

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l496zg
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -156,6 +156,57 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @brief ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32L496ZG order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5 and the internal VBAT channel.
+ *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC1_IN10 is device 0,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC1_IN10 is channel 10
+ *
+ * For Nucleo-L496ZG this information is in board manual,
+ * Table 11, page 38.
+ *
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 3), .dev = 0, .chan =  8 }, /* ADC12_IN8   */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 0, .chan =  1 }, /* ADC123_IN1  */
+    { .pin = GPIO_PIN(PORT_C, 3), .dev = 0, .chan =  4 }, /* ADC123_IN4  */
+    { .pin = GPIO_PIN(PORT_C, 1), .dev = 0, .chan =  2 }, /* ADC123_IN2  */
+    { .pin = GPIO_PIN(PORT_C, 4), .dev = 0, .chan = 13 }, /* ADC12_IN13  */
+    { .pin = GPIO_PIN(PORT_C, 5), .dev = 0, .chan = 14 }, /* ADC12_IN14  */
+    /* VBAT is connected ADC1_IN18 or ADC3_IN18 and a voltage divider
+     * is used, so that only 1/3 of the actual VBAT is measured. This
+     * allows for a supply voltage higher than the reference voltage.
+     *
+     * For Nucleo-L496ZG more information is provided in MCU datasheet,
+       in section 3.17.3 - Vbat battery voltaga monioring, page 43.
+     */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 18 },
+};
+
+/**
+ * @brief Number of ADC devices
+ */
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+/**
+ * @brief VBAT ADC line
+ */
+#define VBAT_ADC            ADC_LINE(6)
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -27,7 +27,8 @@ extern "C" {
 /**
  * @brief   Available number of ADC devices
  */
-#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG) || \
+    defined(CPU_MODEL_STM32L496ZG)
 #define ADC_DEVS            (3U)
 #elif defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC) || \
  defined(CPU_MODEL_STM32L4R5ZI)
@@ -36,7 +37,7 @@ extern "C" {
 
 #if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG) || \
     defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC) || \
-    defined(CPU_MODEL_STM32L4R5ZI)
+    defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI)
 /**
  * @brief   ADC voltage regulator start-up time [us]
  */

--- a/cpu/stm32/periph/adc_l4.c
+++ b/cpu/stm32/periph/adc_l4.c
@@ -42,7 +42,8 @@
 /**
  * @brief map CPU specific register/value names
  */
-#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L4R5ZI)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L4R5ZI) || \
+    defined(CPU_MODEL_STM32L496ZG)
 #define ADC_CR_REG      CR
 #define ADC_ISR_REG     ISR
 #define ADC_PERIPH_CLK  AHB2


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-l496zg ADC configuration.

### Testing procedure

Flash the board using `tests/periph_adc` program. Check if measured values changes when A0-A5 pins are
connected to the 3,3V, GND or to the potentiometer. 

### Issues/PRs references

None