### PR TITLE
cpu/native: fix build with musl

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -171,15 +171,18 @@ void thread_add_to_list(list_node_t *list, thread_t *thread)
     list->next = new_node;
 }
 
-uintptr_t thread_measure_stack_free(const char *stack)
+uintptr_t measure_stack_free_internal(const char *stack, size_t size)
 {
     /* Alignment of stack has been fixed (if needed) by thread_create(), so
      * we can silence -Wcast-align here */
     uintptr_t *stackp = (uintptr_t *)(uintptr_t)stack;
+    uintptr_t end = (uintptr_t)stack + size;
 
-    /* assume that the comparison fails before or after end of stack */
+    /* better be safe than sorry: align end of stack just in case */
+    end &= (sizeof(uintptr_t) - 1);
+
     /* assume that the stack grows "downwards" */
-    while (*stackp == (uintptr_t)stackp) {
+    while (((uintptr_t)stackp < end) && (*stackp == (uintptr_t)stackp)) {
         stackp++;
     }
 

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -197,7 +197,7 @@ UBaseType_t uxTaskGetStackHighWaterMark(TaskHandle_t xTask)
     thread_t *thread = thread_get((xTask == NULL) ? (uint32_t)thread_getpid()
                                                   : (uint32_t)xTask);
     assert(thread != NULL);
-    return thread_measure_stack_free(thread->stack_start);
+    return thread_measure_stack_free(thread);
 }
 
 void *pvTaskGetThreadLocalStoragePointer(TaskHandle_t xTaskToQuery,

--- a/cpu/esp_common/thread_arch.c
+++ b/cpu/esp_common/thread_arch.c
@@ -92,10 +92,9 @@ void thread_isr_stack_init(void)
 
 int thread_isr_stack_usage(void)
 {
-    /* cppcheck-suppress comparePointers
-     * (reason: comes from ESP-SDK, so should be valid) */
-    return &port_IntStackTop - &port_IntStack -
-           thread_measure_stack_free((char*)&port_IntStack);
+    size_t stack_size = (uintptr_t)&port_IntStackTop - (uintptr_t)&port_IntStack;
+    return stack_size -
+           measure_stack_free_internal((char *)&port_IntStack, stack_size);
 }
 
 void *thread_isr_stack_pointer(void)

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -19,3 +19,10 @@ ifeq ($(OS) $(OS_ARCH),Linux x86_64)
 endif
 
 include $(RIOTMAKE)/arch/native.inc.mk
+
+USE_LIBUCONTEXT := $(shell pkg-config libucontext 2> /dev/null && echo 1 || echo 0)
+
+ifeq ($(USE_LIBUCONTEXT),1)
+  CFLAGS += $(pkg-config libucontext --cflags) -DUSE_LIBUCONTEXT=1
+  LINKFLAGS += $(shell pkg-config libucontext --libs)
+endif

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -172,7 +172,7 @@ extern volatile int _native_in_isr;
 extern volatile int _native_in_syscall;
 
 extern char __isr_stack[];
-extern char __end_stack[];
+extern const size_t __isr_stack_size;
 extern ucontext_t native_isr_context;
 extern ucontext_t end_context;
 extern ucontext_t *_native_cur_ctx, *_native_isr_ctx;

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -143,7 +143,7 @@ void _native_syscall_leave(void)
          * stacks are manually word aligned in thread_static_init() */
         _native_cur_ctx = (ucontext_t *)(uintptr_t)thread_get_active()->sp;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
-        native_isr_context.uc_stack.ss_size = SIGSTKSZ;
+        native_isr_context.uc_stack.ss_size = __isr_stack_size;
         native_isr_context.uc_stack.ss_flags = 0;
         native_interrupts_enabled = 0;
         makecontext(&native_isr_context, native_irq_handler, 0);

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -98,7 +98,7 @@ void ps(void)
 #ifdef DEVELHELP
             int stacksz = thread_get_stacksize(p);                          /* get stack size */
             overall_stacksz += stacksz;
-            int stack_free = thread_measure_stack_free(thread_get_stackstart(p));
+            int stack_free = thread_measure_stack_free(p);
             stacksz -= stack_free;
             overall_used += stacksz;
 #endif

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/sys/test_utils/print_stack_usage/print_stack_usage.c
+++ b/sys/test_utils/print_stack_usage/print_stack_usage.c
@@ -34,7 +34,7 @@
 
 void print_stack_usage_metric(const char *name, void *stack, unsigned max_size)
 {
-    unsigned free = thread_measure_stack_free(stack);
+    unsigned free = measure_stack_free_internal(stack, max_size);
 
     if ((LOG_LEVEL >= LOG_INFO) &&
         (thread_get_stacksize(thread_get_active()) >= MIN_SIZE)) {

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",


### PR DESCRIPTION
### Contribution description

This changes a bunch of things that allows building with `BOARD=native` on 32-bit arches with the musl C lib, provided that `libucontext-dev` and `pkg-config` is installed.

Note that installing libucontext makes absolutely zero sense on C libs that do natively provide this deprecated System V API, such as glibc. Hence, it no sane glibc setup is expected to ever have libucontext installed.

### Testing procedure

```
make BOARD=native -C examples/default
```

On a 32 bit system with musl as C lib and `pkg-config` as well as `libucontext-dev` installed should now succeed. The generated binary on glibc based 32 bit or multiarch systems should not change compared to `master`.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/18937