### PR TITLE
tests/pbkdf2: remove unused #include

### DIFF
--- a/tests/pbkdf2/main.c
+++ b/tests/pbkdf2/main.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "container.h"
 #include "fmt.h"
 #include "hashes/pbkdf2.h"
 #include "hashes/sha256.h"


### PR DESCRIPTION
### Contribution description

What the title says.

### Testing procedure

Should not result in changes in binaries. And Murdock should give green light.

### Issues/PRs references

The removed `#include` caused issues in [a backport](https://github.com/RIOT-OS/RIOT/pull/18941), but it is actually uneeded in `master` as well. I cannot recall why it was there in the first place - maybe a leftover from the flaky test?