### PR TITLE
.vscode: import initial RIOT-OS style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ cachegrind.out*
 # Codelite (among others) project files
 *.project
 # Visual Studio Code user settings
-.vscode/
+.vscode/*
+!.vscode/settings.json
 # ctags index files
 tags
 # GDB initialization scripts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "editor.rulers": [
+        80,
+        120
+    ],
+    "editor.detectIndentation": false,
+    "files.insertFinalNewline": true,
+    "files.associations": {
+        "Makefile.*": "makefile",
+        "*.mk": "makefile"
+    },
+    "[shellscript][c][cpp]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true,
+    },
+    "[makefile]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+    },
+}


### PR DESCRIPTION
### Contribution description

This PR adds initial RIOT-OS style for Vscode like editor.
By default, vscode tries to auto-detect the file settings but it can easily be biaised. Thus, let's fix it by creating a few rules.


### Testing procedure

Open RIOT-OS folder inside vscode or vscodium, open any .c, .h or Makefiles files and check if defaults settings are correct.


### Issues/PRs references
Trying to fix @maribu frustration here :)
