### PR TITLE
boards/common/nrf52: fix timer config

### DIFF
--- a/boards/common/nrf52/include/cfg_timer_default.h
+++ b/boards/common/nrf52/include/cfg_timer_default.h
@@ -40,7 +40,7 @@ extern "C" {
 static const timer_conf_t timer_config[] = {
     {
         .dev      = NRF_TIMER1,
-        .channels = 4,
+        .channels = 3,
         .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER1_IRQn
     },
@@ -50,7 +50,7 @@ static const timer_conf_t timer_config[] = {
          *         networking)!
          */
         .dev      = NRF_TIMER2,
-        .channels = 4,
+        .channels = 3,
         .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER2_IRQn
     },
@@ -60,7 +60,7 @@ static const timer_conf_t timer_config[] = {
 #ifdef NRF_TIMER3
     {
         .dev      = NRF_TIMER3,
-        .channels = 6,
+        .channels = 5,
         .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER3_IRQn
     },
@@ -68,7 +68,7 @@ static const timer_conf_t timer_config[] = {
 #ifdef NRF_TIMER4
     {
         .dev      = NRF_TIMER4,
-        .channels = 6,
+        .channels = 5,
         .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
         .irqn     = TIMER4_IRQn
     }

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -187,7 +187,14 @@ typedef enum {
  */
 typedef struct {
     NRF_TIMER_Type *dev;    /**< timer device */
-    uint8_t channels;       /**< number of channels available */
+    /**
+     * @brief   number of hardware channels ***minus one***
+     *
+     * The last hardware channels is implicitly used by timer_read() and not
+     * available to the user. This value, hence, is the number of channels
+     * available to the user.
+     */
+    uint8_t channels;
     uint8_t bitmode;        /**< counter width */
     uint8_t irqn;           /**< IRQ number of the timer device */
 } timer_conf_t;


### PR DESCRIPTION
### Contribution description

The `channels` member should not be set to the number of hardware channels *n*, but to *n* - 1 instead. The last channel is implicitly used in `timer_read()`. Hence out of *n* hardware channels, only *n* - 1 are available to the application.

This fixes a bug introduced by 4d02e1524732b040f5109adbeed416b38ceb8c19 which incorrectly set the channel number to *n* rather than to *n* - 1.

### Testing procedure

`timer_read()` should work again on nRF52 MCUs.

### Issues/PRs references

Introduced in https://github.com/RIOT-OS/RIOT/pull/18811