### PR TITLE
sys/net/grnc/netreg: avoid freeing wild pointers

### DIFF
--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -177,7 +177,10 @@ void gnrc_netreg_unregister(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
     if (entry->type == GNRC_NETREG_TYPE_MBOX) {
         msg_t msg;
         while (mbox_try_get(entry->target.mbox, &msg)) {
-            gnrc_pktbuf_release_error(msg.content.ptr, EBADF);
+            if ((msg.type == GNRC_NETAPI_MSG_TYPE_RCV) ||
+                (msg.type == GNRC_NETAPI_MSG_TYPE_SND)) {
+                gnrc_pktbuf_release_error(msg.content.ptr, EBADF);
+            }
         }
     }
 #endif


### PR DESCRIPTION
### Contribution description

When freeing any stale pktsnips from stale messages in the mbox, make sure that the messages actually contains a pktsnip before freeing.

### Testing procedure

The test `tests/pkg_edhoc_c` should no longer crash

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/18949