### PR TITLE
tests/pkg_utensor: increase main threads stack size

### DIFF
--- a/tests/pkg_utensor/Makefile
+++ b/tests/pkg_utensor/Makefile
@@ -11,10 +11,4 @@ EXTERNAL_MODULE_DIRS += external_modules
 
 include $(RIOTBASE)/Makefile.include
 
-# The application requires a little more stacksize on ARM when building with
-# LLVM
-ifneq (,$(filter arch_arm,$(FEATURES_USED)))
-  ifeq (llvm,$(TOOLCHAIN))
-    CFLAGS += -DTHREAD_STACKSIZE_MAIN=2048
-  endif
-endif
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE


### PR DESCRIPTION
### Contribution description

The MPU based stack guard is very unpleased by the stack overflow happening during the test. The increase in stack size makes the MPU stack guard happy again.

### Testing procedure

```
make BOARD=nrf52840dk -C tests/pkg_utensor flash test
```

In `master`, the test fails with a stack overflow being detected. In this PR, it succeeds.

### Issues/PRs references

None