### PR TITLE
cpu/nrf5x/timer: fix high current consumption in powered off state

### DIFF
--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -165,7 +165,29 @@ void timer_start(tim_t tim)
 
 void timer_stop(tim_t tim)
 {
-    dev(tim)->TASKS_STOP = 1;
+    /* Errata: [78] TIMER: High current consumption when using
+     *                     timer STOP task only
+     *
+     * # Symptoms
+     *
+     * Increased current consumption when the timer has been running and the
+     * STOP task is used to stop it.
+     *
+     * # Conditions
+     * The timer has been running (after triggering a START task) and then it is
+     * stopped using a STOP task only.
+     *
+     * # Consequences
+     *
+     * Increased current consumption.
+     *
+     * # Workaround
+     *
+     * Use the SHUTDOWN task after the STOP task or instead of the STOP task
+     *
+     * cf. https://infocenter.nordicsemi.com/pdf/nRF52833_Engineering_A_Errata_v1.4.pdf
+     */
+    dev(tim)->TASKS_SHUTDOWN = 1;
 }
 
 static inline void irq_handler(int num)


### PR DESCRIPTION
### Contribution description

While testing #17607 I realized that the timer peripheral consumes significant amounts of current even in stopped state. I had a look into the [implementation of our Zephyr friends](https://github.com/zephyrproject-rtos/zephyr/blob/178bdc4afcd54e2bd5b986d0de4591a6f888d874/drivers/counter/counter_nrfx_timer.c#L67) and found this [Errata PDF](https://infocenter.nordicsemi.com/pdf/nRF52833_Engineering_A_Errata_v1.4.pdf).

### Testing procedure

TBD

### Issues/PRs references

