### PR TITLE
core/mbox: fix race condition

### DIFF
--- a/core/mbox.c
+++ b/core/mbox.c
@@ -73,7 +73,7 @@ int _mbox_put(mbox_t *mbox, msg_t *msg, int blocking)
         return 1;
     }
     else {
-        if (cib_full(&mbox->cib)) {
+        while (cib_full(&mbox->cib)) {
             if (blocking) {
                 _wait(&mbox->writers, irqstate);
                 irqstate = irq_disable();


### PR DESCRIPTION
### Contribution description

The mbox code contains a race condition in `mbox_put()`: When it waits for a slot in the queue to become available, it is woken up with IRQs enabled. It disables IRQs again as first thing, but by then another thread may already have preempted the running thread and filled the queue back up. In this case, a message in the queue would be silently overwritten.

### Testing procedure

Actually triggering the race condition would require some effort with a specially crafted test application, which I am unable to currently provide. It should however be quite easy to reason that the change fixes the potential race condition.

In addition, the usual regression tests may make sense.

### Issues/PRs references

None