### PR TITLE
CI: implement quick build logic

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -5,6 +5,8 @@
 # and / or
 #export APPS="examples/hello-world tests/unittests"
 
+QUICKBUILD_BOARDS="nrf52840dk samr21-xpro esp32-wroom-32 native"
+
 # this configures boards that are available via pifleet
 case "${CI_MURDOCK_PROJECT}" in
     riot)
@@ -154,7 +156,44 @@ export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}
 export MURDOCK_REDIS_HOST=${MURDOCK_REDIS_HOST:-127.0.0.1}
 
 NIGHTLY=${NIGHTLY:-0}
-FULL_BUILD=${FULL_BUILD:-${NIGHTLY}}
+
+check_label() {
+    local label="${1}"
+    [ -z "${CI_PULL_LABELS}" ] && return 1
+    echo "${CI_PULL_LABELS}" | grep -q "${label}"
+    return $?
+}
+
+# fullbuild logic
+# non-full-builds are those where can_fast_ci_run might reduce the build
+# automatically
+if [ -z "${FULL_BUILD}" ]; then
+    if [ "${NIGHTLY}" = 1 ]; then
+        FULL_BUILD=1
+    elif check_label "CI: full build"; then
+        # full build if requested by label
+        FULL_BUILD=1
+    else
+        FULL_BUILD=0
+    fi
+    export FULL_BUILD
+fi
+
+# quickbuild logic
+# a "quickbuild" is only building a representative subset of all build
+# configurations.
+if [ -z "${QUICK_BUILD}" ]; then
+    export QUICK_BUILD=0
+    if [ "${CI_BUILD_BRANCH}" = "staging" ]; then
+        # always do full build for bors' integration branch
+        true
+    elif [ ${FULL_BUILD} -eq 1 ]; then
+        # full build if building nightly or full build requested by label
+        true
+    else
+        export QUICK_BUILD=1
+    fi
+fi
 
 # This is a work around for a bug in CCACHE which interacts very badly with
 # some features of RIOT and of murdock. The result is that ccache is
@@ -176,7 +215,7 @@ export OPTIONAL_CFLAGS_BLACKLIST="-gz"
 DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE
          -E TEST_HASH -E CI_PULL_LABELS -ECI_BASE_BRANCH -ECI_BASE_COMMIT
          -EPKG_USE_MIRROR -EAPPS_CHANGED -EBOARDS_CHANGED -ESTATIC_TESTS
-         -E CI_MURDOCK_PROJECT"
+         -E CI_MURDOCK_PROJECT -EFULL_BUILD -EQUICK_BUILD"
 
 if [ ${NIGHTLY} -eq 1 ]; then
     export PKG_USE_MIRROR=0
@@ -230,13 +269,6 @@ kconfig_module_packages_diff() {
 
 
     bash -c "diff <(echo \"${mmp}\") <(echo \"${kmp}\")"
-}
-
-check_label() {
-    local label="${1}"
-    [ -z "${CI_PULL_LABELS}" ] && return 1
-    echo "${CI_PULL_LABELS}" | grep -q "${label}"
-    return $?
 }
 
 # if RUN_TESTS is unset (e.g., not passed from the outside),
@@ -345,9 +377,14 @@ get_supported_boards() {
         fi
     fi
 
+    BOARDS_=${BOARDS}
     if [ $only_changed -eq 1 ]; then
-        BOARDS_=${BOARDS}
+        # if can_fast_ci_run figured out changes to specific boards,
+        # only consider those
         export BOARDS="$BOARDS_CHANGED"
+    elif [ -z "${BOARDS}" -a ${QUICK_BUILD} -eq 1 ]; then
+        # quickbuild board filter is applied here
+        export BOARDS="${QUICKBUILD_BOARDS}"
     fi
 
     local boards="$(make --no-print-directory -C$appdir info-boards-supported 2>/dev/null || echo broken)"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR implements "quick builds" (subset builds).

The logic is as following (checkmark for what was tested):

- [x] if the "CI: full build" label is set, [result](https://ci.riot-os.org/details/15e489f7a3f346bdb49a84080329f3d6)
- [x]   or NIGHTLY=1 [result](https://ci.riot-os.org/details/d741a174bbbc437eb1972e87688098fb)
- [x]   or if building bors' ~~"trying"~~"staging" branch, do a full build. [result](https://ci.riot-os.org/details/692362fd0e594bdeb190ea99a6de2479)
- [x] otherwise, if BOARDS was supplied, build those: [result](https://ci-staging.riot-os.org/details/2034f3ed656c4b37b573732517334cfd) (ci-staging hard-sets BOARDS="samr21-xpro native")
- [x] otherwise, if can_fast_ci_build.py figured out boards that have changes, build those [result](https://ci.riot-os.org/details/ab92ec61cb7040b18d9789c05831eb86)
- [x] otherwise, only consider boards listed in QUICKBUILD_BOARDS [result](https://ci.riot-os.org/details/fca366441e0341d79af52200365d298d)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

TBD: actual list of QUICKBUILD_BOARDS

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

bors tracking issue: https://github.com/RIOT-OS/RIOT/issues/18911
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
