### PR TITLE
pkg/lwip: Force loglevel when using log module

### DIFF
--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -29,6 +29,7 @@
 #include "mutex.h"
 
 #ifdef MODULE_LOG
+#define LOG_LEVEL LOG_INFO
 #include "log.h"
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

lwIP has already used its own log level when deciding what to print. If we reach the LWIP_PLATFORM_DIAG macro no further filtering should happen, so set the log level to match the macro used.
I am not sure where the log level got set to something else than `LOG_INFO` causing me to get no IP addresses shown (maybe esp32 logging magic?).

A nicer solution is hard to do since lwIP passes the variable part of the log in a separate set of parenthesis, like
`LWIP_DEBUGF(ICMP_DEBUG, ("icmp_input: ip_output_if returned an error: %s\n", lwip_strerr(ret)));`
so vprintf things are needed to add a new log level back to match the log module interface. If `log_write` was printf-like and didn't have the log_level argument it would be easy.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Flash an app using lwIP, I tested with `examples/paho-mqtt`

This fixes the missing IP addresses from ifconfig I was seeing. 
Before:

```
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f Link: up State: up
        Link type: wired
        inet addr:  mask:  gw:
        inet6 addr:  scope: link state: valid preferred
        inet6 addr:  scope: global state: valid preferred
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c Link: up State: up
        Link type: wireless
        inet addr:  mask:  gw:
        inet6 addr:  scope: link state: valid preferred
        inet6 addr:  scope: global state: valid preferred
>
```

With this change:
```
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f Link: up State: up
        Link type: wired
        inet addr: 10.4.4.81 mask: 255.255.254.0 gw: 10.4.4.1
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9f scope: link state: valid preferred
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9f scope: global state: valid preferred
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c Link: up State: up
        Link type: wireless
        inet addr: 10.4.4.86 mask: 255.255.254.0 gw: 10.4.4.1
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9c scope: link state: valid preferred
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9c scope: global state: valid preferred
>
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
