### PR TITLE
[PoC] gnrc_netif: revamp gnrc_netif_ops_t interface

### DIFF
--- a/examples/spectrum-scanner/main.c
+++ b/examples/spectrum-scanner/main.c
@@ -89,18 +89,18 @@ void spectrum_scanner(unsigned long interval_us)
                 for (unsigned int ch = IEEE802154_CHANNEL_MIN; ch <= IEEE802154_CHANNEL_MAX; ++ch) {
                     uint16_t tmp_ch = ch;
                     int res;
-                    res = gnrc_netapi_set(netif->pid, NETOPT_CHANNEL, 0, &tmp_ch, sizeof(uint16_t));
+                    res = gnrc_netif_set(netif->pid, NETOPT_CHANNEL, 0, &tmp_ch, sizeof(uint16_t));
                     if (res < 0) {
                         continue;
                     }
                     netopt_enable_t tmp;
                     /* Perform CCA to update ED level */
-                    res = gnrc_netapi_get(netif->pid, NETOPT_IS_CHANNEL_CLR, 0, &tmp, sizeof(netopt_enable_t));
+                    res = gnrc_netif_get(netif, NETOPT_IS_CHANNEL_CLR, 0, &tmp, sizeof(netopt_enable_t));
                     if (res < 0) {
                         continue;
                     }
                     int8_t level = 0;
-                    res = gnrc_netapi_get(netif->pid, NETOPT_LAST_ED_LEVEL, 0, &level, sizeof(int8_t));
+                    res = gnrc_netif_get(netif, NETOPT_LAST_ED_LEVEL, 0, &level, sizeof(int8_t));
                     if (res < 0) {
                         continue;
                     }

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -462,6 +462,18 @@ gnrc_netif_t *gnrc_netif_iter(const gnrc_netif_t *prev);
  */
 gnrc_netif_t *gnrc_netif_get_by_pid(kernel_pid_t pid);
 
+static inline int gnrc_netif_get(gnrc_netif_t *netif, netopt_t opt, uint16_t context,
+                                 void *value, size_t max_len)
+{
+    return gnrc_netapi_get(netif->pid, opt, context, value, max_len);
+}
+
+static inline int gnrc_netif_set(gnrc_netif_t *netif, netopt_t opt, uint16_t context,
+                                 const void *value, size_t value_len)
+{
+    return gnrc_netapi_set(netif->pid, opt, context, value, value_len);
+}
+
 /**
  * @brief   Gets the (unicast on anycast) IPv6 address of an interface (if IPv6
  *          is supported)
@@ -483,14 +495,14 @@ gnrc_netif_t *gnrc_netif_get_by_pid(kernel_pid_t pid);
  *          May be 0 if no addresses are configured.
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
-static inline int gnrc_netif_ipv6_addrs_get(const gnrc_netif_t *netif,
+static inline int gnrc_netif_ipv6_addrs_get(gnrc_netif_t *netif,
                                             ipv6_addr_t *addrs,
                                             size_t max_len)
 {
     assert(netif != NULL);
     assert(addrs != NULL);
     assert(max_len >= sizeof(ipv6_addr_t));
-    return gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR, 0, addrs, max_len);
+    return gnrc_netif_get(netif, NETOPT_IPV6_ADDR, 0, addrs, max_len);
 }
 
 /**
@@ -514,14 +526,14 @@ static inline int gnrc_netif_ipv6_addrs_get(const gnrc_netif_t *netif,
  *          corresponding solicited-nodes multicast address.
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
-static inline int gnrc_netif_ipv6_addr_add(const gnrc_netif_t *netif,
+static inline int gnrc_netif_ipv6_addr_add(gnrc_netif_t *netif,
                                            const ipv6_addr_t *addr, unsigned pfx_len,
                                            uint8_t flags)
 {
     assert(netif != NULL);
     assert(addr != NULL);
     assert((pfx_len > 0) && (pfx_len <= 128));
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR,
+    return gnrc_netif_set(netif, NETOPT_IPV6_ADDR,
                            ((pfx_len << 8U) | flags), addr,
                            sizeof(ipv6_addr_t));
 }
@@ -539,12 +551,12 @@ static inline int gnrc_netif_ipv6_addr_add(const gnrc_netif_t *netif,
  * @return  sizeof(ipv6_addr_t) on success.
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
-static inline int gnrc_netif_ipv6_addr_remove(const gnrc_netif_t *netif,
+static inline int gnrc_netif_ipv6_addr_remove(gnrc_netif_t *netif,
                                               const ipv6_addr_t *addr)
 {
     assert(netif != NULL);
     assert(addr != NULL);
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR_REMOVE,
+    return gnrc_netif_set(netif, NETOPT_IPV6_ADDR_REMOVE,
                            0, addr, sizeof(ipv6_addr_t));
 }
 
@@ -568,14 +580,14 @@ static inline int gnrc_netif_ipv6_addr_remove(const gnrc_netif_t *netif,
  *          success (including 0).
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
-static inline int gnrc_netif_ipv6_groups_get(const gnrc_netif_t *netif,
+static inline int gnrc_netif_ipv6_groups_get(gnrc_netif_t *netif,
                                              ipv6_addr_t *groups,
                                              size_t max_len)
 {
     assert(netif != NULL);
     assert(groups != NULL);
     assert(max_len >= sizeof(ipv6_addr_t));
-    return gnrc_netapi_get(netif->pid, NETOPT_IPV6_GROUP, 0, groups, max_len);
+    return gnrc_netif_get(netif, NETOPT_IPV6_GROUP, 0, groups, max_len);
 }
 
 /**
@@ -592,12 +604,12 @@ static inline int gnrc_netif_ipv6_groups_get(const gnrc_netif_t *netif,
  * @return  -ENOMEM, if no space is left on @p netif to add @p group.
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
-static inline int gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif,
+static inline int gnrc_netif_ipv6_group_join(gnrc_netif_t *netif,
                                              ipv6_addr_t *group)
 {
     assert(netif != NULL);
     assert(group != NULL);
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_GROUP, 0, group,
+    return gnrc_netif_set(netif, NETOPT_IPV6_GROUP, 0, group,
                            sizeof(ipv6_addr_t));
 }
 
@@ -614,12 +626,12 @@ static inline int gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif,
  * @return  sizeof(ipv6_addr_t) on success.
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
-static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
+static inline int gnrc_netif_ipv6_group_leave(gnrc_netif_t *netif,
                                               ipv6_addr_t *group)
 {
     assert(netif != NULL);
     assert(group != NULL);
-    return gnrc_netapi_set(netif->pid, NETOPT_IPV6_GROUP_LEAVE, 0, group,
+    return gnrc_netif_set(netif, NETOPT_IPV6_GROUP_LEAVE, 0, group,
                            sizeof(ipv6_addr_t));
 }
 

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -47,7 +47,7 @@ unsigned dhcpv6_client_get_duid_l2(unsigned iface, dhcpv6_duid_l2_t *duid)
         netif = gnrc_netif_get_by_pid(iface);
     }
     assert(netif != NULL);
-    if ((res = gnrc_netapi_get(netif->pid, NETOPT_ADDRESS_LONG, 0,
+    if ((res = gnrc_netif_get(netif, NETOPT_ADDRESS_LONG, 0,
                                l2addr, GNRC_NETIF_L2ADDR_MAXLEN)) > 0) {
         duid->l2type = byteorder_htons(ARP_HWTYPE_EUI64);
     }
@@ -61,7 +61,7 @@ unsigned dhcpv6_client_get_duid_l2(unsigned iface, dhcpv6_duid_l2_t *duid)
             case NETDEV_TYPE_ETHERNET:
             case NETDEV_TYPE_BLE:
             case NETDEV_TYPE_ESP_NOW:
-                if ((res = gnrc_netapi_get(netif->pid,
+                if ((res = gnrc_netif_get(netif,
                                            NETOPT_ADDRESS,
                                            0, l2addr,
                                            GNRC_NETIF_L2ADDR_MAXLEN)) > 0) {

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -30,13 +30,13 @@ static void set_interface_roles(void)
 
     while ((netif = gnrc_netif_iter(netif))) {
         kernel_pid_t dev = netif->pid;
-        int is_wired = gnrc_netapi_get(dev, NETOPT_IS_WIRED, 0, NULL, 0);
+        int is_wired = gnrc_netif_get(netif, NETOPT_IS_WIRED, 0, NULL, 0);
         if ((!gnrc_border_interface) && (is_wired == 1)) {
             ipv6_addr_t addr, defroute = IPV6_ADDR_UNSPECIFIED;
             gnrc_border_interface = dev;
 
             ipv6_addr_from_str(&addr, "fe80::2");
-            gnrc_netapi_set(dev, NETOPT_IPV6_ADDR, 64 << 8, &addr,
+            gnrc_netif_set(netif, NETOPT_IPV6_ADDR, 64 << 8, &addr,
                             sizeof(addr));
             ipv6_addr_from_str(&addr, "fe80::1");
             gnrc_ipv6_nib_ft_add(&defroute, IPV6_ADDR_BIT_LEN, &addr, dev, 0);

--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -48,15 +48,15 @@ netif_t *netif_get_by_id(int16_t id)
 int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t max_len)
 {
-    const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
-    return gnrc_netapi_get(netif->pid, opt, context, value, max_len);
+    gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
+    return gnrc_netif_get(netif, opt, context, value, max_len);
 }
 
 int netif_set_opt(netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t value_len)
 {
-    const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
-    return gnrc_netapi_set(netif->pid, opt, context, value, value_len);
+    gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
+    return gnrc_netif_set(netif, opt, context, value, value_len);
 }
 
 /** @} */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -54,20 +54,76 @@ static void _update_l2addr_from_dev(gnrc_netif_t *netif);
 static void _check_netdev_capabilities(netdev_t *dev);
 static void *_gnrc_netif_thread(void *args);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
+static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);
+static int _gnrc_netif_default_init(gnrc_netif_t *netif);
+static void _send_queued_pkt(gnrc_netif_t *netif);
+
+/**
+ * @brief   Call the ISR handler from an event
+ *
+ * @param[in]   evp     pointer to the event
+ */
+static void _event_handler_isr(event_t *evp)
+{
+    gnrc_netif_t *netif = container_of(evp, gnrc_netif_t, event_isr);
+    netif->dev->driver->isr(netif->dev);
+}
+static void _event_dequeue(event_t *evp)
+{
+    gnrc_netif_t *netif = container_of(evp, gnrc_netif_t, event_dequeue);
+    _send_queued_pkt(netif);
+}
 
 typedef struct {
+    event_t event;
     gnrc_netif_t *netif;
     mutex_t init_done;
     int result;
+    char *stack;
+    int stacksize;
+    char priority;
+    const char *name;
+    netdev_t *netdev;
 } _netif_ctx_t;
+
+static void _init_wrapper(event_t *event)
+{
+    _netif_ctx_t *ctx = container_of(event, _netif_ctx_t, event);
+    gnrc_netif_t *netif;
+
+    DEBUG("gnrc_netif: starting thread %i\n", thread_getpid());
+    netif = ctx->netif;
+    gnrc_netif_acquire(netif);
+    netif->pid = thread_getpid();
+
+    netif->event_isr.handler = _event_handler_isr;
+    netif->event_dequeue.handler = _event_dequeue;
+#if IS_USED(MODULE_NETDEV_NEW_API)
+    netif->event_tx_done.handler = _event_handler_tx_done;
+#endif
+
+    /* initialize low-level driver */
+    ctx->result = _gnrc_netif_default_init(netif);
+    /* signal that driver init is done */
+    mutex_unlock(&ctx->init_done);
+    if (ctx->result < 0) {
+        LOG_ERROR("gnrc_netif: init failed: %d\n", ctx->result);
+        return;
+    }
+#ifdef MODULE_NETSTATS_L2
+    memset(&netif->stats, 0, sizeof(netstats_t));
+#endif
+    /* now let rest of GNRC use the interface */
+    gnrc_netif_release(netif);
+#if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
+    uint32_t last_wakeup = ztimer_now(ZTIMER_USEC);
+#endif
+}
 
 int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
                       char priority, const char *name, netdev_t *netdev,
                       const gnrc_netif_ops_t *ops)
 {
-    int res;
-    _netif_ctx_t ctx;
-
     if (IS_ACTIVE(DEVELHELP) && gnrc_netif_highlander() && netif_iter(NULL)) {
         LOG_WARNING("gnrc_netif: gnrc_netif_highlander() returned true but "
                     "more than one interface is being registered.\n");
@@ -78,29 +134,19 @@ int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
         msg_bus_init(&netif->bus[i]);
     }
 #endif
-    rmutex_init(&netif->mutex);
     netif->ops = ops;
+    _netif_ctx_t ctx = {0};
+    ctx.stack = stack;
+    ctx.stacksize = stacksize;
+    ctx.priority = priority;
+    ctx.name = name;
+    ctx.netdev = netdev;
+    ctx.netif = netif;
     assert(netif->dev == NULL);
     netif->dev = netdev;
+    ctx.event.handler = _init_wrapper;
 
-#ifdef MODULE_NETSTATS_NEIGHBOR
-    netstats_nb_init(&netif->netif);
-#endif
-
-    /* prepare thread context */
-    ctx.netif = netif;
-    mutex_init(&ctx.init_done);
-    mutex_lock(&ctx.init_done);
-
-    res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
-                        _gnrc_netif_thread, &ctx, name);
-    assert(res > 0);
-    (void)res;
-
-    /* wait for result of driver init */
-    mutex_lock(&ctx.init_done);
-
-    return ctx.result;
+    return netif->ops->init(netif, &ctx);
 }
 
 bool gnrc_netif_dev_is_6lo(const gnrc_netif_t *netif)
@@ -166,7 +212,26 @@ gnrc_netif_t *gnrc_netif_get_by_type(netdev_type_t type, uint8_t index)
     return NULL;
 }
 
-int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
+static void _gnrc_netif_get_from_netdev_wrapper(event_t *event);
+
+int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, netopt_t opt, uint16_t context,
+                                 void *value, size_t max_len)
+{
+    gnrc_netif_opt_ctx_t ctx = {0};
+    ctx.opt.opt = opt;
+    ctx.opt.context = context;
+    ctx.opt.data = (void*) value;
+    ctx.opt.data_len = max_len;
+    ctx.pid = thread_getpid();
+    ctx.event.handler = _gnrc_netif_get_from_netdev_wrapper;
+    ctx.netif = netif;
+    thread_flags_clear(0x1);
+    event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &ctx.event);
+    thread_flags_wait_one(0x1);
+    return ctx.res;
+}
+
+int _gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
 {
     int res = -ENOTSUP;
 
@@ -315,7 +380,61 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
     return res;
 }
 
-int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
+static void _gnrc_netif_set_from_netdev_wrapper(event_t *event)
+{
+    gnrc_netif_opt_ctx_t *ctx = container_of(event, gnrc_netif_opt_ctx_t, event);
+    assert(ctx->pid != thread_getpid());
+    ctx->res = _gnrc_netif_set_from_netdev(ctx->netif, &ctx->opt);
+    thread_flags_set((thread_t*) thread_get(ctx->pid), 0x1);
+}
+
+static void _gnrc_netif_send_wrapper(event_t *event)
+{
+
+    gnrc_netif_schedule_ctx_t *ctx = container_of(event, gnrc_netif_schedule_ctx_t, event);
+    DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_SND received\n");
+    assert(ctx->pid != thread_getpid());
+    _send(ctx->netif, ctx->pkt, false);
+    ctx->res = 1;
+    thread_flags_set((thread_t*) thread_get(ctx->pid), 0x1);
+#if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
+    ztimer_periodic_wakeup(
+            ZTIMER_USEC,
+            &last_wakeup,
+            CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US
+        );
+    /* override last_wakeup in case last_wakeup +
+     * CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US was in the past */
+    last_wakeup = ztimer_now(ZTIMER_USEC);
+#endif
+}
+
+static void _gnrc_netif_get_from_netdev_wrapper(event_t *event)
+{
+    gnrc_netif_opt_ctx_t *ctx = container_of(event, gnrc_netif_opt_ctx_t, event);
+    assert(ctx->pid != thread_getpid());
+    ctx->res = _gnrc_netif_get_from_netdev(ctx->netif, &ctx->opt);
+    thread_flags_set((thread_t*) thread_get(ctx->pid), 0x1);
+}
+
+int gnrc_netif_set_from_netdev(gnrc_netif_t *netif, netopt_t opt, uint16_t context,
+                                 const void *value, size_t value_len)
+{
+    gnrc_netif_opt_ctx_t ctx = {0};
+    ctx.opt.opt = opt;
+    ctx.opt.context = context;
+    ctx.opt.data = (void*) value;
+    ctx.opt.data_len = value_len;
+    ctx.pid = thread_getpid();
+    ctx.event.handler = _gnrc_netif_set_from_netdev_wrapper;
+    ctx.netif = netif;
+    thread_flags_clear(0x1);
+    event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &ctx.event);
+    thread_flags_wait_one(0x1);
+    return ctx.res;
+}
+
+int _gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
                                const gnrc_netapi_opt_t *opt)
 {
     int res = -ENOTSUP;
@@ -802,12 +921,7 @@ gnrc_netif_t *gnrc_netif_get_by_prefix(const ipv6_addr_t *prefix)
 static int _netif_ops_set_helper(gnrc_netif_t *netif, netopt_t opt,
                                  void *data, uint16_t data_len)
 {
-    gnrc_netapi_opt_t netapi_opt = {
-        .opt = opt,
-        .data = data,
-        .data_len = data_len,
-    };
-    return netif->ops->set(netif, &netapi_opt);
+    return netif->ops->set(netif, opt, 0, data, data_len);
 }
 
 int gnrc_netif_ipv6_group_join_internal(gnrc_netif_t *netif,
@@ -1610,7 +1724,30 @@ static void _test_options(gnrc_netif_t *netif)
 }
 #endif /* DEVELHELP */
 
-int gnrc_netif_default_init(gnrc_netif_t *netif)
+int gnrc_netif_default_init(gnrc_netif_t *netif, void *ctx)
+{
+    _netif_ctx_t *_ctx = ctx;
+    int res = thread_create(_ctx->stack, _ctx->stacksize, _ctx->priority, THREAD_CREATE_STACKTEST,
+                        _gnrc_netif_thread, _ctx->netif, _ctx->name);
+    assert(res > 0);
+    (void)res;
+    rmutex_init(&netif->mutex);
+
+#ifdef MODULE_NETSTATS_NEIGHBOR
+    netstats_nb_init(&netif->netif);
+#endif
+
+    /* prepare thread context */
+    mutex_init(&_ctx->init_done);
+    mutex_lock(&_ctx->init_done);
+    event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &_ctx->event);
+    /* wait for result of driver init */
+    mutex_lock(&_ctx->init_done);
+
+    return _ctx->result;
+}
+
+int _gnrc_netif_default_init(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     /* register the event callback with the device driver */
@@ -1637,19 +1774,6 @@ int gnrc_netif_default_init(gnrc_netif_t *netif)
     assert(options_tested);
 #endif
     return 0;
-}
-
-static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);
-
-/**
- * @brief   Call the ISR handler from an event
- *
- * @param[in]   evp     pointer to the event
- */
-static void _event_handler_isr(event_t *evp)
-{
-    gnrc_netif_t *netif = container_of(evp, gnrc_netif_t, event_isr);
-    netif->dev->driver->isr(netif->dev);
 }
 
 static void _process_receive_stats(gnrc_netif_t *netdev, gnrc_pktsnip_t *pkt)
@@ -1696,7 +1820,7 @@ static event_t *_gnrc_netif_fetch_event(gnrc_netif_t *netif)
  *
  * @return >0 if msg contains a new message
  */
-static void _process_events_await_msg(gnrc_netif_t *netif, msg_t *msg)
+static void _process_events_await_msg(gnrc_netif_t *netif)
 {
     while (1) {
         /* Using messages for external IPC, and events for internal events */
@@ -1713,14 +1837,9 @@ static void _process_events_await_msg(gnrc_netif_t *netif, msg_t *msg)
                 evp->handler(evp);
             }
         }
-        /* non-blocking msg check */
-        int msg_waiting = msg_try_receive(msg);
-        if (msg_waiting > 0) {
-            return;
-        }
         DEBUG("gnrc_netif: waiting for events\n");
         /* Block the thread until something interesting happens */
-        thread_flags_wait_any(THREAD_FLAG_MSG_WAITING | THREAD_FLAG_EVENT);
+        thread_flags_wait_any(THREAD_FLAG_EVENT);
     }
 }
 
@@ -1908,114 +2027,11 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
 
 static void *_gnrc_netif_thread(void *args)
 {
-    _netif_ctx_t *ctx = args;
-    gnrc_netapi_opt_t *opt;
-    gnrc_netif_t *netif;
-    int res;
-    msg_t reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-
-    DEBUG("gnrc_netif: starting thread %i\n", thread_getpid());
-    netif = ctx->netif;
-    gnrc_netif_acquire(netif);
-    netif->pid = thread_getpid();
-
-    netif->event_isr.handler = _event_handler_isr;
-#if IS_USED(MODULE_NETDEV_NEW_API)
-    netif->event_tx_done.handler = _event_handler_tx_done;
-#endif
-    /* set up the event queue */
+    gnrc_netif_t *netif = args;
+    /* set up thstatic e event queue */
     event_queues_init(netif->evq, GNRC_NETIF_EVQ_NUMOF);
-
-    /* setup the link-layer's message queue */
-    msg_init_queue(netif->msg_queue, ARRAY_SIZE(netif->msg_queue));
-    /* initialize low-level driver */
-    ctx->result = netif->ops->init(netif);
-    /* signal that driver init is done */
-    mutex_unlock(&ctx->init_done);
-    if (ctx->result < 0) {
-        LOG_ERROR("gnrc_netif: init failed: %d\n", ctx->result);
-        return NULL;
-    }
-#ifdef MODULE_NETSTATS_L2
-    memset(&netif->stats, 0, sizeof(netstats_t));
-#endif
-    /* now let rest of GNRC use the interface */
-    gnrc_netif_release(netif);
-#if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
-    uint32_t last_wakeup = ztimer_now(ZTIMER_USEC);
-#endif
-
     while (1) {
-        msg_t msg;
-        /* msg will be filled by _process_events_await_msg.
-         * The function will not return until a message has been received. */
-        _process_events_await_msg(netif, &msg);
-
-        /* dispatch netdev, MAC and gnrc_netapi messages */
-        DEBUG("gnrc_netif: message %u\n", (unsigned)msg.type);
-        switch (msg.type) {
-#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
-            case GNRC_NETIF_PKTQ_DEQUEUE_MSG:
-                DEBUG("gnrc_netif: send from packet send queue\n");
-                _send_queued_pkt(netif);
-                break;
-#endif  /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-            case GNRC_NETAPI_MSG_TYPE_SND:
-                DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_SND received\n");
-                _send(netif, msg.content.ptr, false);
-#if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
-                ztimer_periodic_wakeup(
-                        ZTIMER_USEC,
-                        &last_wakeup,
-                        CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US
-                    );
-                /* override last_wakeup in case last_wakeup +
-                 * CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US was in the past */
-                last_wakeup = ztimer_now(ZTIMER_USEC);
-#endif
-                break;
-            case GNRC_NETAPI_MSG_TYPE_SET:
-                opt = msg.content.ptr;
-#ifdef MODULE_NETOPT
-                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_SET received. opt=%s\n",
-                      netopt2str(opt->opt));
-#else
-                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_SET received. opt=%d\n",
-                      opt->opt);
-#endif
-                /* set option for device driver */
-                res = netif->ops->set(netif, opt);
-                DEBUG("gnrc_netif: response of netif->ops->set(): %i\n", res);
-                reply.content.value = (uint32_t)res;
-                msg_reply(&msg, &reply);
-                break;
-            case GNRC_NETAPI_MSG_TYPE_GET:
-                opt = msg.content.ptr;
-#ifdef MODULE_NETOPT
-                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_GET received. opt=%s\n",
-                      netopt2str(opt->opt));
-#else
-                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_GET received. opt=%d\n",
-                      opt->opt);
-#endif
-                /* get option from device driver */
-                res = netif->ops->get(netif, opt);
-                DEBUG("gnrc_netif: response of netif->ops->get(): %i\n", res);
-                reply.content.value = (uint32_t)res;
-                msg_reply(&msg, &reply);
-                break;
-            default:
-                if (netif->ops->msg_handler) {
-                    DEBUG("gnrc_netif: delegate message of type 0x%04x to "
-                          "netif->ops->msg_handler()\n", msg.type);
-                    netif->ops->msg_handler(netif, &msg);
-                }
-                else {
-                    DEBUG("gnrc_netif: unknown message type 0x%04x"
-                          "(no message handler defined)\n", msg.type);
-                }
-                break;
-        }
+        _process_events_await_msg(netif);
     }
     /* never reached */
     return NULL;
@@ -2030,6 +2046,19 @@ static void _pass_on_packet(gnrc_pktsnip_t *pkt)
         gnrc_pktbuf_release(pkt);
         return;
     }
+}
+
+int gnrc_netif_schedule_netapi_default(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
+{
+    gnrc_netif_schedule_ctx_t ctx = {0};
+    ctx.pkt = pkt;
+    ctx.pid = thread_getpid();
+    ctx.event.handler = _gnrc_netif_send_wrapper;
+    ctx.netif = netif;
+    thread_flags_clear(0x1);
+    event_post(&netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW], &ctx.event);
+    thread_flags_wait_one(0x1);
+    return ctx.res;
 }
 
 static void _event_cb(netdev_t *dev, netdev_event_t event)

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1284,7 +1284,7 @@ int gnrc_netif_ipv6_add_prefix(gnrc_netif_t *netif,
     assert(netif != NULL);
     DEBUG("gnrc_netif: (re-)configure prefix %s/%d\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)), pfx_len);
-    if (gnrc_netapi_get(netif->pid, NETOPT_IPV6_IID, 0, &iid,
+    if (gnrc_netif_get(netif, NETOPT_IPV6_IID, 0, &iid,
                         sizeof(eui64_t)) >= 0) {
         ipv6_addr_set_aiid(&addr, iid.uint8);
     }

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -105,13 +105,13 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif)
         case NETDEV_TYPE_IEEE802154: {
             /* see https://tools.ietf.org/html/rfc6775#section-5.2 */
             uint16_t src_len = IEEE802154_LONG_ADDRESS_LEN;
-            gnrc_netapi_opt_t opt = { .opt = NETOPT_SRC_LEN,
-                                      .data = &src_len,
-                                      .data_len = sizeof(src_len) };
 
             /* XXX we are supposed to be in interface context here, so use driver
              * directly everything else would deadlock anyway */
-            netif->ops->set(netif, &opt);
+            gnrc_netapi_opt_t opt = { .opt = NETOPT_SRC_LEN,
+                                      .data = &src_len,
+                                      .data_len = sizeof(src_len) };
+            _gnrc_netif_set_from_netdev(netif, &opt);
         }
         /* intentionally falls through */
         case NETDEV_TYPE_BLE:

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -31,6 +31,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
 static const gnrc_netif_ops_t ieee802154_ops = {
     .init = gnrc_netif_default_init,
+    .schedule = gnrc_netif_schedule_netapi_default,
     .send = _send,
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,

--- a/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
+++ b/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
@@ -87,10 +87,7 @@ void gnrc_netif_pktq_sched_get(gnrc_netif_t *netif)
     irq_restore(state);
 #elif CONFIG_GNRC_NETIF_PKTQ_TIMER_US == 0
     assert(netif != NULL);
-    netif->send_queue.dequeue_msg.type = GNRC_NETIF_PKTQ_DEQUEUE_MSG;
-    if (msg_send(&netif->send_queue.dequeue_msg, netif->pid) < 0) {
-        DEBUG("gnrc_netif_pktq: couldn't schedule packet (msg queue is full)\n");
-    }
+    event_post(&netif->evq, &netif->event_dequeue);
 #else
     (void)netif;
 #endif  /* CONFIG_GNRC_NETIF_PKTQ_TIMER_US >= 0 */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -102,21 +102,21 @@ static bool _try_l2addr_reconfiguration(gnrc_netif_t *netif)
     uint8_t hwaddr[GNRC_NETIF_L2ADDR_MAXLEN];
     uint16_t hwaddr_len;
 
-    if (gnrc_netapi_get(netif->pid, NETOPT_SRC_LEN, 0, &hwaddr_len,
+    if (gnrc_netif_get(netif, NETOPT_SRC_LEN, 0, &hwaddr_len,
                         sizeof(hwaddr_len)) < 0) {
         return false;
     }
     luid_get(hwaddr, hwaddr_len);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     if (hwaddr_len == IEEE802154_LONG_ADDRESS_LEN) {
-        if (gnrc_netapi_set(netif->pid, NETOPT_ADDRESS_LONG, 0, hwaddr,
+        if (gnrc_netif_set(netif, NETOPT_ADDRESS_LONG, 0, hwaddr,
                             hwaddr_len) < 0) {
             return false;
         }
     }
     else
 #endif
-    if (gnrc_netapi_set(netif->pid, NETOPT_ADDRESS, 0, hwaddr,
+    if (gnrc_netif_set(netif, NETOPT_ADDRESS, 0, hwaddr,
                         hwaddr_len) < 0) {
         return false;
     }
@@ -132,7 +132,7 @@ static bool _try_addr_reconfiguration(gnrc_netif_t *netif)
         remove_old = true;
     }
     /* seize netif to netif thread since _try_l2addr_reconfiguration uses
-     * gnrc_netapi_get()/gnrc_netapi_set(). Since these are synchronous this is
+     * gnrc_netif_get()/gnrc_netif_set(). Since these are synchronous this is
      * safe */
     gnrc_netif_release(netif);
     /* reacquire netif for IPv6 address reconfiguraton */

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -728,7 +728,7 @@ static void test_ipv6_get_iid(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ieee802154_ipv6_ll_long.u64[1],
                 sizeof(res)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_SRC_LEN, 0,
                 &ieee802154_l2addr_len,
                 sizeof(ieee802154_l2addr_len)));
@@ -738,7 +738,7 @@ static void test_ipv6_get_iid(void)
     /* reset to source length 8 */
     ieee802154_l2addr_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_SRC_LEN, 0,
                 &ieee802154_l2addr_len,
                 sizeof(ieee802154_l2addr_len)));
@@ -752,7 +752,7 @@ static void test_netapi_get__HOP_LIMIT(void)
     uint8_t value;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_get(netifs[0].pid, NETOPT_HOP_LIMIT,
+            gnrc_netif_get(&netifs[0], NETOPT_HOP_LIMIT,
                 0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(netifs[0].cur_hl, value);
 }
@@ -763,7 +763,7 @@ static void test_netapi_get__IPV6_ADDR(void)
     ipv6_addr_t value[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
     test_ipv6_addr_add__success();
-    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netapi_get(netifs[0].pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netif_get(&netifs[0],
                 NETOPT_IPV6_ADDR,
                 0, &value,
                 sizeof(value)));
@@ -775,7 +775,7 @@ static void test_netapi_get__IPV6_ADDR_FLAGS(void)
     uint8_t value[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
     test_ipv6_addr_add__success();
-    TEST_ASSERT_EQUAL_INT(sizeof(uint8_t), gnrc_netapi_get(netifs[0].pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint8_t), gnrc_netif_get(&netifs[0],
                 NETOPT_IPV6_ADDR_FLAGS,
                 0, &value,
                 sizeof(value)));
@@ -788,7 +788,7 @@ static void test_netapi_get__IPV6_GROUP(void)
     ipv6_addr_t value[GNRC_NETIF_IPV6_GROUPS_NUMOF];
 
     test_ipv6_group_join__success();
-    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netapi_get(netifs[0].pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t), gnrc_netif_get(&netifs[0],
                 NETOPT_IPV6_GROUP,
                 0, &value,
                 sizeof(value)));
@@ -804,22 +804,22 @@ static void test_netapi_get__IPV6_IID(void)
     eui64_t value;
     uint16_t ieee802154_l2addr_len = 2U;
 
-    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ethernet_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netif_get(&ethernet_netif,
                 NETOPT_IPV6_IID,
                 0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ethernet_ipv6_ll.u64[1],
                 sizeof(value)));
-    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netif_get(&ieee802154_netif,
                 NETOPT_IPV6_IID,
                 0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ieee802154_ipv6_ll_long.u64[1],
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_SRC_LEN, 0,
                 &ieee802154_l2addr_len,
                 sizeof(ieee802154_l2addr_len)));
-    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netif_get(&ieee802154_netif,
                 NETOPT_IPV6_IID,
                 0, &value,
                 sizeof(value)));
@@ -828,11 +828,11 @@ static void test_netapi_get__IPV6_IID(void)
     /* reset to source length 8 */
     ieee802154_l2addr_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_SRC_LEN, 0,
                 &ieee802154_l2addr_len,
                 sizeof(ieee802154_l2addr_len)));
-    TEST_ASSERT_EQUAL_INT(-ENOTSUP, gnrc_netapi_get(netifs[0].pid,
+    TEST_ASSERT_EQUAL_INT(-ENOTSUP, gnrc_netif_get(&netifs[0],
                 NETOPT_IPV6_IID,
                 0, &value, sizeof(value)));
 }
@@ -841,32 +841,32 @@ static void test_netapi_get__MAX_PACKET_SIZE(void)
 {
     uint16_t value;
 
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ethernet_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(&ethernet_netif,
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_IPV6,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(ETHERNET_DATA_LEN, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ethernet_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(&ethernet_netif,
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_NETIF,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(ETHERNET_DATA_LEN, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ieee802154_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(&ieee802154_netif,
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_IPV6,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(IPV6_MIN_MTU, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(ieee802154_netif.pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(&ieee802154_netif,
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_NETIF,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(TEST_IEEE802154_MAX_FRAG_SIZE, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(netifs[0].pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(&netifs[0],
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_IPV6,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(IPV6_MIN_MTU, value);
-    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netapi_get(netifs[0].pid,
+    TEST_ASSERT_EQUAL_INT(sizeof(uint16_t), gnrc_netif_get(&netifs[0],
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_NETIF,
                 &value, sizeof(value)));
@@ -878,17 +878,17 @@ static void test_netapi_get__6LO_IPHC(void)
     netopt_enable_t value;
 
     TEST_ASSERT_EQUAL_INT(sizeof(netopt_enable_t),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_6LO_IPHC, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(NETOPT_DISABLE, value);
     TEST_ASSERT_EQUAL_INT(sizeof(netopt_enable_t),
-            gnrc_netapi_get(ieee802154_netif.pid,
+            gnrc_netif_get(&ieee802154_netif,
                 NETOPT_6LO_IPHC, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(NETOPT_ENABLE, value);
     TEST_ASSERT_EQUAL_INT(sizeof(netopt_enable_t),
-            gnrc_netapi_get(netifs[0].pid,
+            gnrc_netif_get(&netifs[0],
                 NETOPT_6LO_IPHC, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(NETOPT_DISABLE, value);
@@ -901,12 +901,12 @@ static void test_netapi_get__ADDRESS(void)
     uint8_t value[GNRC_NETIF_L2ADDR_MAXLEN];
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_ADDRESS, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ethernet, value, sizeof(exp_ethernet)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-            gnrc_netapi_get(ieee802154_netif.pid,
+            gnrc_netif_get(&ieee802154_netif,
                 NETOPT_ADDRESS, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ieee802154, value,
@@ -919,17 +919,17 @@ static void test_netapi_get__ADDRESS_LONG(void)
     uint8_t value[GNRC_NETIF_L2ADDR_MAXLEN];
 
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-            gnrc_netapi_get(ieee802154_netif.pid,
+            gnrc_netif_get(&ieee802154_netif,
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ieee802154, value,
                 sizeof(exp_ieee802154)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_get(netifs[0].pid,
+            gnrc_netif_get(&netifs[0],
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
 }
@@ -941,21 +941,21 @@ static void test_netapi_set_get__L2_GROUP(void)
     uint8_t value[2][ETHERNET_ADDR_LEN];
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp_group1),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &exp_group1, sizeof(exp_group1)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_group2),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &exp_group2, sizeof(exp_group2)));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_group1, value[0], sizeof(exp_group1)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_group2, value[1], sizeof(exp_group2)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_get(ieee802154_netif.pid,
+            gnrc_netif_get(&ieee802154_netif,
                 NETOPT_L2_GROUP, 0,
                 &value, sizeof(value)));
 }
@@ -968,17 +968,17 @@ static void test_netapi_set__L2_GROUP_LEAVE(void)
 
     test_netapi_set_get__L2_GROUP();
     TEST_ASSERT_EQUAL_INT(sizeof(exp_group1),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_L2_GROUP_LEAVE, 0,
                 &exp_group1, sizeof(exp_group1)));
     /* exp_group1 was removed */
     TEST_ASSERT_EQUAL_INT(sizeof(exp_group2),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_group2, value[0], sizeof(exp_group2)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_get(ieee802154_netif.pid,
+            gnrc_netif_get(&ieee802154_netif,
                 NETOPT_L2_GROUP_LEAVE, 0,
                 &value, sizeof(value)));
 }
@@ -988,7 +988,7 @@ static void test_netapi_set__HOP_LIMIT(void)
     uint8_t value = 89;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_HOP_LIMIT, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, netifs[0].cur_hl);
@@ -1002,7 +1002,7 @@ static void test_netapi_set__IPV6_ADDR(void)
 
     TEST_ASSERT(0 > gnrc_netif_ipv6_addr_idx(&netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_IPV6_ADDR, context,
                 &value, sizeof(value)));
     TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_idx(&netifs[0], &value));
@@ -1015,7 +1015,7 @@ static void test_netapi_set__IPV6_ADDR_REMOVE(void)
     test_ipv6_addr_add__success();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_idx(&netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_IPV6_ADDR_REMOVE, 0,
                 &value, sizeof(value)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_addr_idx(&netifs[0], &value));
@@ -1027,7 +1027,7 @@ static void test_netapi_set__IPV6_GROUP(void)
 
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(&netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_IPV6_GROUP, 0,
                 &value, sizeof(value)));
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(&netifs[0], &value));
@@ -1045,12 +1045,12 @@ static void test_netapi_set__IPV6_GROUP__ethernet(void)
                                                             exp_ethernet));
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(&ethernet_netif, &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_IPV6_GROUP, 0,
                 &value, sizeof(value)));
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(&ethernet_netif, &value));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ethernet, l2_value[0],
@@ -1064,7 +1064,7 @@ static void test_netapi_set__IPV6_GROUP_LEAVE(void)
     test_ipv6_group_join__success();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(&netifs[0], &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_IPV6_GROUP_LEAVE, 0,
                 &value, sizeof(value)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(&netifs[0], &value));
@@ -1077,20 +1077,20 @@ static void test_netapi_set__IPV6_GROUP_LEAVE__ethernet(void)
 
     /* no L2 group assigned */
     TEST_ASSERT_EQUAL_INT(0,
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
     /* join a group */
     test_netapi_set__IPV6_GROUP__ethernet();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(&ethernet_netif, &value));
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_IPV6_GROUP_LEAVE, 0,
                 &value, sizeof(value)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(&ethernet_netif, &value));
     /* no L2 group assigned */
     TEST_ASSERT_EQUAL_INT(0,
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
 }
@@ -1104,7 +1104,7 @@ static void test_netapi_set__IPV6_GROUP_LEAVE__ethernet_two_same(void)
 
     /* no L2 group assigned */
     TEST_ASSERT_EQUAL_INT(0,
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
@@ -1116,37 +1116,37 @@ static void test_netapi_set__IPV6_GROUP_LEAVE__ethernet_two_same(void)
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(&ethernet_netif, &value1));
     /* join another IPv6 group with same suffix */
     TEST_ASSERT_EQUAL_INT(sizeof(value2),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_IPV6_GROUP, 0,
                 &value2, sizeof(value2)));
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(&ethernet_netif, &value2));
     /* only one link layer group joined due to the same suffix */
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ethernet, l2_value[0],
                                     sizeof(exp_ethernet)));
     TEST_ASSERT_EQUAL_INT(sizeof(value1),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_IPV6_GROUP_LEAVE, 0,
                 &value1, sizeof(value1)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(&ethernet_netif, &value1));
     /* still in link layer group due to other IPv6 group */
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_ethernet, l2_value[0],
                                     sizeof(exp_ethernet)));
     TEST_ASSERT_EQUAL_INT(sizeof(value2),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_IPV6_GROUP_LEAVE, 0,
                 &value2, sizeof(value2)));
     TEST_ASSERT(0 > gnrc_netif_ipv6_group_idx(&ethernet_netif, &value2));
     /* no L2 group assigned */
     TEST_ASSERT_EQUAL_INT(0,
-            gnrc_netapi_get(ethernet_netif.pid,
+            gnrc_netif_get(&ethernet_netif,
                 NETOPT_L2_GROUP, 0,
                 &l2_value, sizeof(l2_value)));
 }
@@ -1156,13 +1156,13 @@ static void test_netapi_set__MAX_PACKET_SIZE(void)
     uint16_t value = 57194;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_MAX_PDU_SIZE,
                 GNRC_NETTYPE_IPV6,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, netifs[0].ipv6.mtu);
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_MAX_PDU_SIZE, 0,
                 &value, sizeof(value)));
 }
@@ -1172,7 +1172,7 @@ static void test_netapi_set__6LO_IPHC(void)
     netopt_enable_t value = NETOPT_ENABLE;
 
     TEST_ASSERT_EQUAL_INT(sizeof(value),
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_6LO_IPHC, 0,
                 &value, sizeof(value)));
     TEST_ASSERT(netifs[0].flags & GNRC_NETIF_FLAGS_6LO_HC);
@@ -1186,14 +1186,14 @@ static void test_netapi_set__ADDRESS(void)
     uint8_t value[] = { LA1 + 1, LA2 + 2, LA3 + 3, LA4 + 4, LA5 + 5, LA6 + 6 };
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_ADDRESS, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ethernet_netif.l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(value, ethernet_netif.l2addr,
                 ETHERNET_ADDR_LEN));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_ADDRESS, 0,
                 &value, sizeof(uint16_t)));
     /* we did not change NETOPT_SRC_LEN, so this field shouldn't change */
@@ -1204,7 +1204,7 @@ static void test_netapi_set__ADDRESS(void)
     /* return addresses to previous state for further testing */
     memcpy(value, exp_ethernet, sizeof(exp_ethernet));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ethernet),
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_ADDRESS, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ethernet_netif.l2addr_len);
@@ -1212,7 +1212,7 @@ static void test_netapi_set__ADDRESS(void)
                 sizeof(value)));
     memcpy(value, exp_ieee802154, sizeof(exp_ieee802154));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_ADDRESS, 0,
                 &value, sizeof(uint16_t)));
 }
@@ -1224,24 +1224,24 @@ static void test_netapi_set__ADDRESS_LONG(void)
         LA7 + 1, LA8 + 2 };
 
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_set(ethernet_netif.pid,
+            gnrc_netif_set(&ethernet_netif,
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ieee802154_netif.l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(value, ieee802154_netif.l2addr,
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_set(netifs[0].pid,
+            gnrc_netif_set(&netifs[0],
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
     /* return addresses to previous state for further testing */
     memcpy(value, exp_ieee802154, sizeof(exp_ieee802154));
     TEST_ASSERT_EQUAL_INT(sizeof(exp_ieee802154),
-            gnrc_netapi_set(ieee802154_netif.pid,
+            gnrc_netif_set(&ieee802154_netif,
                 NETOPT_ADDRESS_LONG, 0,
                 &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(value), ieee802154_netif.l2addr_len);
@@ -1256,21 +1256,21 @@ static void test_netapi_set__SRC_LEN(void)
     uint16_t value = 2U;
 
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_set(ethernet_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ethernet_netif, NETOPT_SRC_LEN,
                 0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(uint16_t),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, ieee802154_netif.l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp_l2addr, ieee802154_netif.l2addr,
                 sizeof(exp_l2addr)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP,
-            gnrc_netapi_set(netifs[0].pid, NETOPT_SRC_LEN, 0,
+            gnrc_netif_set(&netifs[0], NETOPT_SRC_LEN, 0,
                 &value, sizeof(value)));
     /* return addresses to previous state for further testing */
     value = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(uint16_t),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(value, ieee802154_netif.l2addr_len);
     TEST_ASSERT_EQUAL_INT(0, memcmp(orig_ieee802154, ieee802154_netif.l2addr,
@@ -1329,7 +1329,7 @@ static void test_netif_get_by_name_buffer(void)
 
 static void test_netif_get_opt(void)
 {
-    /* just repeat one of the gnrc_netapi_get tests, just with netif_get_opt */
+    /* just repeat one of the gnrc_netif_get tests, just with netif_get_opt */
     static const uint8_t exp_ethernet[] = ETHERNET_SRC;
     uint8_t value[GNRC_NETIF_L2ADDR_MAXLEN];
 
@@ -1342,7 +1342,7 @@ static void test_netif_get_opt(void)
 
 static void test_netif_set_opt(void)
 {
-    /* just repeat one of the gnrc_netapi_set tests, just with netif_set_opt */
+    /* just repeat one of the gnrc_netif_set tests, just with netif_set_opt */
     static const uint8_t exp_ethernet[] = ETHERNET_SRC;
     uint8_t value[] = { LA1 + 1, LA2 + 2, LA3 + 3, LA4 + 4, LA5 + 5, LA6 + 6 };
 
@@ -1429,7 +1429,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
@@ -1438,7 +1438,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &src_len, sizeof(src_len)));
 }
 
@@ -1467,7 +1467,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
@@ -1476,7 +1476,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &src_len, sizeof(src_len)));
 }
 
@@ -1505,7 +1505,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
 
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     TEST_ASSERT_NOT_NULL(netif);
@@ -1516,7 +1516,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
     /* reset src_len */
     src_len = 8U;
     TEST_ASSERT_EQUAL_INT(sizeof(src_len),
-            gnrc_netapi_set(ieee802154_netif.pid, NETOPT_SRC_LEN,
+            gnrc_netif_set(&ieee802154_netif, NETOPT_SRC_LEN,
                 0, &src_len, sizeof(src_len)));
 }
 

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -119,7 +119,7 @@ static void _init_interface(void)
     addr.u8[15] = 0x01;
 
     xtimer_usleep(500); /* wait for thread to start */
-    if (gnrc_netapi_set(_netif.pid, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
+    if (gnrc_netif_set(&_netif, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
                         sizeof(addr)) < 0) {
         printf("error: unable to add IPv6 address fd01::1/64 to interface %u\n",
                _netif.pid);

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -93,14 +93,14 @@ static int _list_all_inet6(int argc, char **argv)
     while ((netif = gnrc_netif_iter(netif))) {
         ipv6_addr_t ipv6_addrs[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
-        int res = gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
+        int res = gnrc_netif_get(netif, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
                                   sizeof(ipv6_addrs));
         if (res >= 0) {
             uint8_t ipv6_addrs_flags[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
 
             memset(ipv6_addrs_flags, 0, sizeof(ipv6_addrs_flags));
             /* assume it to succeed (otherwise array will stay 0) */
-            gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR_FLAGS, 0,
+            gnrc_netif_get(netif, NETOPT_IPV6_ADDR_FLAGS, 0,
                             ipv6_addrs_flags, sizeof(ipv6_addrs_flags));
             /* yes, the res of NETOPT_IPV6_ADDR is meant to be here ;-) */
             for (unsigned i = 0; i < (res / sizeof(ipv6_addr_t)); i++) {

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -72,7 +72,7 @@ static int test_get_addr(void)
 {
     uint8_t tmp[sizeof(_dev_addr)];
 
-    if (gnrc_netapi_get(_mac_pid, NETOPT_ADDRESS, 0, tmp, sizeof(tmp)) != sizeof(_dev_addr)) {
+    if (gnrc_netif_get(gnrc_netif_get_by_pid(_mac_pid), NETOPT_ADDRESS, 0, tmp, sizeof(tmp)) != sizeof(_dev_addr)) {
         puts("Error getting device address");
         return 0;
     }
@@ -232,12 +232,12 @@ static int test_set_addr(void)
     static const uint8_t new_addr[] = { 0x71, 0x29, 0x5b, 0xc8, 0x52, 0x65 };
     uint8_t tmp[sizeof(new_addr)];
 
-    if (gnrc_netapi_set(_mac_pid, NETOPT_ADDRESS, 0, (void *)new_addr,
+    if (gnrc_netif_set(gnrc_netif_get_by_pid(_mac_pid), NETOPT_ADDRESS, 0, (void *)new_addr,
                         sizeof(new_addr)) != sizeof(new_addr)) {
         puts("Error setting device address");
         return 0;
     }
-    if (gnrc_netapi_get(_mac_pid, NETOPT_ADDRESS, 0, tmp,
+    if (gnrc_netif_get(gnrc_netif_get_by_pid(_mac_pid), NETOPT_ADDRESS, 0, tmp,
                         sizeof(tmp)) != sizeof(tmp)) {
         puts("Error setting device address");
         return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PoC revamps the GNRC Network Interface to make it independent of the source of events and adapt it better to slotted MAC layers.

The reason for doing this are:
1. It allows any other mechanism besides IPC messages to interact with the network interface. For example, it is possible to implement an interface using `event_thread`, which **may** enable running multiple interfaces on a single thread.
2. It decouples IRQ processing from the interface. Each link layer technology can decide what's the best way to process their events. Note that since we use the same thread to process IRQ and netif events, a relatively long `get` or `set` function will postpone IRQ offloading, which can be fatal for slotted MAC layers.
3. It gives the freedom to each layer to implement the send mechanism. E.g some MACs may simple put a frame in the queue, while other may try to send immediately. E.g as it is now, `gnrc_netif_pktq` is redundant with the openDSME MAC queue.
4. It simplifies migration of gnrc_netif to non-netdev devices. We can move the gnrc_netif thread to a separate file and use it as legacy code, while new link layers implement the new API.
 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Proposed changes

1. Use the `gnrc_netif_ops_t` interface ( `netif->ops->xxx` functions) to interact with the network interface, instead of `gnrc_netapi`. I propose to use `gnrc_netif_xxx` functions as a wrapper, in case we need to structure common code.
2. Rename `netif->ops->send` to `netif->ops->schedule` and adapt documentation to indicate the function schedules a transmission to be as soon as possible.
3. Add a `ctx` parameter to the init function, which can be used to pass link layer specific information (e.g thread stacksize for current netdev implementations).
4. Stop identifying an interface by the PID and simply use a fixed ID. In the PoC I kept `kernel_pid_t` for simplicity, but this could be any identifier.

### PoC

To showcase the proposed changes, I wrote the new `gnrc_netif_ops_t` interface to use event loops instead of IPC messages. The implementation saves ~100 bytes of RAM and seems to perform slightly better than the current master:
This PR
```
2022-11-23 17:59:52,179 # 2000 packets transmitted, 2000 packets received, 0% packet loss
2022-11-23 17:59:52,183 # round-trip min/avg/max = 122.322/134.179/145.675 ms
```
Master
```
OLD:
2022-11-23 18:07:48,686 # 2000 packets transmitted, 2000 packets received, 0% packet loss
2022-11-23 18:07:48,691 # round-trip min/avg/max = 124.255/134.208/148.003 ms
```

### Testing procedure
I only implemented the changes to `gnrc_netif_ieee802154`. Feel free to try e.g ` gnrc_networking` with a IEEE 802.15.4 transceiver.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
There have been long discussions in the past with @miri64 in order to make `gnrc_netif` independent of the source of events. But now that #18156 and future MAC layers are very close, this makes IMO the transition smoother.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
