### PR TITLE
treewide: fix typos found by recent codespell

### DIFF
--- a/boards/common/particle-mesh/bootloader.c
+++ b/boards/common/particle-mesh/bootloader.c
@@ -47,7 +47,7 @@ ISR_VECTOR(50) const uint32_t particle_monofirmware_padding[64] = {0, };
 
 #ifdef PARTICLE_MONOFIRMWARE_CHECKSUMLIMIT
 /* Watch the ISR vector sequence here: This is placed *after* the module_info
- * in the flash (52 > 51), but placed before it in the code to be referencable
+ * in the flash (52 > 51), but placed before it in the code to be referenceable
  * from there.
  *
  * The actual value is replaced by monofirmware-tool.py.

--- a/boards/esp32-mh-et-live-minikit/include/board_modules.h
+++ b/boards/esp32-mh-et-live-minikit/include/board_modules.h
@@ -82,7 +82,7 @@ extern "C" {
 #define SDCARD_SPI_PARAM_POWER  GPIO_UNDEF   /**< power control is not used (fixed) */
 
 #ifndef SDCARD_SPI_PARAM_CS
-#define SDCARD_SPI_PARAM_CS     SPI0_CS0     /**< SD-Card CS signal (overridde it) */
+#define SDCARD_SPI_PARAM_CS     SPI0_CS0     /**< SD-Card CS signal (override it) */
 #endif
 /** @} */
 #endif /* MODULE_SDCARD_SPI || DOXYGEN */

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -73,7 +73,7 @@ typedef struct __attribute__((packed)) {
     /**
      * @brief version control flags and Fragment Offset.
      *
-     * @details The flags are the 3 most significant bits, and the remaining 13 bits are the fragment offfset
+     * @details The flags are the 3 most significant bits, and the remaining 13 bits are the fragment offset
      *
      * This module provides helper functions to set, get, and check these
      * fields accordingly:

--- a/sys/posix/pthread/include/pthread_cleanup.h
+++ b/sys/posix/pthread/include/pthread_cleanup.h
@@ -81,7 +81,7 @@ void __pthread_cleanup_pop(__pthread_cleanup_datum_t *datum, int execute);
             do { } while (0)
 
 /**
- * @brief       Closes a cleaup frame
+ * @brief       Closes a cleanup frame
  * @details     Must be paired with pthread_cleanup_push().
  * @param[in]   EXECUTE   Iff `!= 0` call cleanup handler.
  */

--- a/tests/driver_mcp47xx/main.c
+++ b/tests/driver_mcp47xx/main.c
@@ -12,7 +12,7 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  *
- * This test appliation demonstrates the usage of the MCP47xx driver.
+ * This test application demonstrates the usage of the MCP47xx driver.
  * It can be used to test each MCP47xx DAC channel with shell commands.
  *
  * Functions `init`, `set`, `poweron`, `poweroff` demonstrate the usage of

--- a/tests/driver_pca9685/README.md
+++ b/tests/driver_pca9685/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This test appliation demonstrates the usage of the PCA9685 driver interface
+This test application demonstrates the usage of the PCA9685 driver interface
 and can be used to test each PCA9685 PWM device with shell commands.
 
 The application bases on the test application for PWM peripheral drivers

--- a/tests/driver_pca9685/main.c
+++ b/tests/driver_pca9685/main.c
@@ -14,7 +14,7 @@
  *
  * ## Overview
  *
- * This test appliation demonstrates the usage of the PCA9685 driver interface
+ * This test application demonstrates the usage of the PCA9685 driver interface
  * and can be used to test each PCA9685 PWM device with shell commands.
  *
  * The application bases on the test application for PWM peripheral drivers

--- a/tests/driver_pcf857x/README.md
+++ b/tests/driver_pcf857x/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This test appliation demonstrates the usage of the PCF857X driver interface
+This test application demonstrates the usage of the PCF857X driver interface
 and can be used to test each PCF857X expander I/O pin with shell commands.
 
 ## Compilation

--- a/tests/driver_pcf857x/main.c
+++ b/tests/driver_pcf857x/main.c
@@ -14,7 +14,7 @@
  *
  * ## Overview
  *
- * This test appliation demonstrates the usage of the PCF857X driver interface
+ * This test application demonstrates the usage of the PCF857X driver interface
  * and can be used to test each PCF857X expander I/O pin with shell commands.
  *
  * The application bases on the test application for GPIO peripheral drivers


### PR DESCRIPTION
### Contribution description

Static tests are currently failing on master.

### Testing procedure

Green static tests.

### Issues/PRs references

