### PR TITLE
drivers/at86rf2xx: define caps in macros

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -124,7 +124,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t
     dev->state = AT86RF2XX_STATE_P_ON;
     dev->pending_tx = 0;
 
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     (void) params;
     /* set all interrupts off */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK, 0x00);
@@ -140,7 +140,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t
 
 static void at86rf2xx_disable_clock_output(at86rf2xx_t *dev)
 {
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     (void) dev;
 #else
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_0);
@@ -210,7 +210,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
 #endif
 
-#if !defined(MODULE_AT86RFA1) && !defined(MODULE_AT86RFR2)
+#if !AT86RF2XX_IS_PERIPH
     /* don't populate masked interrupt flags to IRQ_STATUS register */
     tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);
     tmp &= ~(AT86RF2XX_TRX_CTRL_1_MASK__IRQ_MASK_MODE);

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -206,7 +206,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
                         AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
 #endif
 

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -228,7 +228,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
                         AT86RF2XX_IRQ_STATUS_MASK__TRX_END);
 
     /* enable TX start interrupt for retry counter */
-#ifdef AT86RF2XX_REG__IRQ_MASK1
+#if AT86RF2XX_HAVE_TX_START_IRQ
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK1,
                              AT86RF2XX_IRQ_STATUS_MASK1__TX_START);
 #endif

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -524,7 +524,7 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
             /* Discard all IRQ flags, framebuffer is lost anyway */
             at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
             /* Go to SLEEP mode from TRX_OFF */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
             /* reset interrupts states in device */
             dev->irq_status = 0;
             /* Setting SLPTR bit brings radio transceiver to sleep in in TRX_OFF*/

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -151,7 +151,7 @@ void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t channel)
 
 uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev)
 {
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     return dev->page;
 #else
     (void) dev;
@@ -161,7 +161,7 @@ uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
 {
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     if ((page == 0) || (page == 2)) {
         dev->page = page;
         at86rf2xx_configure_phy(dev);
@@ -174,7 +174,7 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
 
 uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev)
 {
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     uint8_t ctrl2;
     ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
     if (ctrl2 & AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK) {
@@ -230,7 +230,7 @@ void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
 
 int16_t at86rf2xx_get_txpower(const at86rf2xx_t *dev)
 {
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR);
     DEBUG("txpower value: %x\n", txpower);
     return _tx_pow_to_dbm_212b(dev->netdev.chan, dev->page, txpower);
@@ -251,7 +251,7 @@ void at86rf2xx_set_txpower(const at86rf2xx_t *dev, int16_t txpower)
     else if (txpower > AT86RF2XX_TXPOWER_MAX) {
         txpower = AT86RF2XX_TXPOWER_MAX;
     }
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     if (dev->netdev.chan == 0) {
         at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_TX_PWR,
                             dbm_to_tx_pow_868[txpower]);
@@ -389,7 +389,7 @@ int8_t at86rf2xx_get_ed_level(at86rf2xx_t *dev)
 {
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_ED_LEVEL);
 
-#if MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     /* AT86RF212B has different scale than the other variants */
     int8_t ed = (int8_t)(((int16_t)tmp * 103) / 100) + RSSI_BASE_VAL;
 #else

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -25,7 +25,7 @@
 #include "at86rf2xx_internal.h"
 #include "at86rf2xx_registers.h"
 
-#if !defined(MODULE_AT86RFA1) && !defined(MODULE_AT86RFR2)
+#if !AT86RF2XX_IS_PERIPH
 #include "periph/spi.h"
 #include "periph/gpio.h"
 
@@ -120,7 +120,7 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 {
     if (at86rf2xx_get_status(dev) == AT86RF2XX_STATE_SLEEP) {
         /* wake up and wait for transition to TRX_OFF */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
         /* Setting SLPTR bit in TRXPR to 0 returns the radio transceiver
          * to the TRX_OFF state */
         *AT86RF2XX_REG__TRXPR &= ~(AT86RF2XX_TRXPR_SLPTR);
@@ -144,7 +144,7 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
 {
     /* trigger hardware reset */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     /* set reset Bit */
     *(AT86RF2XX_REG__TRXPR) |= AT86RF2XX_TRXPR_TRXRST;
 #else

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -169,7 +169,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
     /* we must be in TRX_OFF before changing the PHY configuration */
     uint8_t prev_state = at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
 
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     /* The TX power register must be updated after changing the channel if
      * moving between bands. */
     int16_t txpower = at86rf2xx_get_txpower(dev);
@@ -211,7 +211,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
     phy_cc_cca |= (dev->netdev.chan & AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_CC_CCA, phy_cc_cca);
 
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
     /* Update the TX power register to achieve the same power (in dBm) */
     at86rf2xx_set_txpower(dev, txpower);
 #endif

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -669,7 +669,7 @@ static void _isr_send_complete(at86rf2xx_t *dev, uint8_t trac_status)
         return;
     }
 /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
-#if AT86RF2XX_HAVE_RETRIES && defined(AT86RF2XX_REG__XAH_CTRL_2)
+#if AT86RF2XX_HAVE_RETRIES_REG
     dev->tx_retries = (at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_2)
                        & AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK) >>
                       AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -62,7 +62,7 @@ const netdev_driver_t at86rf2xx_driver = {
     .set = _set,
 };
 
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 /* SOC has radio interrupts, store reference to netdev */
 static netdev_t *at86rfmega_dev;
 #else
@@ -78,7 +78,7 @@ static int _init(netdev_t *netdev)
                           netdev_ieee802154_t, netdev);
     at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
 
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     at86rfmega_dev = netdev;
 #else
     /* initialize GPIOs */
@@ -161,7 +161,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     at86rf2xx_fb_start(dev);
 
     /* get the size of the received packet */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     phr = TST_RX_LENGTH;
 #else
     at86rf2xx_fb_read(dev, &phr, 1);
@@ -223,7 +223,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         netdev_ieee802154_rx_info_t *radio_info = info;
         at86rf2xx_fb_read(dev, &(radio_info->lqi), 1);
 
-#if defined(MODULE_AT86RF231) || defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if defined(MODULE_AT86RF231) || IS_ACTIVE(AT86RF2XX_PERIPH)
         /* AT86RF231 does not provide ED at the end of the frame buffer, read
          * from separate register instead */
         at86rf2xx_fb_stop(dev);
@@ -752,7 +752,7 @@ static void _isr(netdev_t *netdev)
     }
 
     /* read (consume) device status */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     irq_mask = dev->irq_status;
     dev->irq_status = 0;
 #else
@@ -802,7 +802,7 @@ static void _isr(netdev_t *netdev)
     }
 }
 
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 
 /**
  * @brief ISR for transceiver's TX_START interrupt
@@ -1010,4 +1010,4 @@ ISR(TRX24_AWAKE_vect, ISR_BLOCK)
     avr8_exit_isr();
 }
 
-#endif /* MODULE_AT86RFA1 || MODULE_AT86RFR2 */
+#endif /* AT86RF2XX_IS_PERIPH */

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -533,7 +533,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_CHANNEL_PAGE:
             assert(len == sizeof(uint16_t));
             uint8_t page = (((const uint16_t *)val)[0]) & UINT8_MAX;
-#ifdef MODULE_AT86RF212B
+#if AT86RF2XX_HAVE_SUBGHZ
             if ((page != 0) && (page != 2)) {
                 res = -EINVAL;
             }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -223,7 +223,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         netdev_ieee802154_rx_info_t *radio_info = info;
         at86rf2xx_fb_read(dev, &(radio_info->lqi), 1);
 
-#if defined(MODULE_AT86RF231) || IS_ACTIVE(AT86RF2XX_PERIPH)
+#if AT86RF2XX_HAVE_ED_REGISTER
         /* AT86RF231 does not provide ED at the end of the frame buffer, read
          * from separate register instead */
         at86rf2xx_fb_stop(dev);

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -28,7 +28,7 @@
 
 #include "at86rf2xx.h"
 
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 #include <string.h>
 #include "at86rf2xx_registers.h"
 #endif
@@ -85,7 +85,7 @@ extern "C" {
  *
  * @return              the value of the specified register
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, volatile uint8_t *addr) {
     (void) dev;
     return *addr;
@@ -101,7 +101,7 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, uint8_t addr);
  * @param[in] addr      address of the register to write
  * @param[in] value     value to write to the given register
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline void at86rf2xx_reg_write(const at86rf2xx_t *dev, volatile uint8_t *addr,
                                        const uint8_t value) {
     (void) dev;
@@ -119,7 +119,7 @@ void at86rf2xx_reg_write(const at86rf2xx_t *dev, uint8_t addr, uint8_t value);
  * @param[out] data     buffer to read data into
  * @param[in]  len      number of bytes to read from SRAM
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline void at86rf2xx_sram_read(const at86rf2xx_t *dev, uint8_t offset,
                                        uint8_t *data, size_t len) {
     (void)dev;
@@ -137,7 +137,7 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev, uint8_t offset,
  * @param[in] data      data to copy into SRAM
  * @param[in] len       number of bytes to write to SRAM
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
                                         const uint8_t *data, size_t len) {
     (void)dev;
@@ -155,7 +155,7 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
  *
  * @param[in]  dev      device to start read
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline void at86rf2xx_fb_start(const at86rf2xx_t *dev) {
     (void) dev;
 }
@@ -171,7 +171,7 @@ void at86rf2xx_fb_start(const at86rf2xx_t *dev);
  * @param[out] data     buffer to copy the data to
  * @param[in]  len      number of bytes to read from the frame buffer
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline void at86rf2xx_fb_read(const at86rf2xx_t *dev, uint8_t *data, size_t len) {
     (void)dev;
     memcpy(data, (void*)AT86RF2XX_REG__TRXFBST, len);
@@ -186,7 +186,7 @@ void at86rf2xx_fb_read(const at86rf2xx_t *dev, uint8_t *data, size_t len);
  *
  * @param[in]  dev      device to stop read
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static inline void at86rf2xx_fb_stop(const at86rf2xx_t *dev) {
     (void) dev;
 }

--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -63,7 +63,7 @@ extern "C" {
 /**
  * @brief   AT86RF231 configuration
  */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 static const uint8_t at86rf2xx_params[] =
 {
     0 /* dummy value */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -116,6 +116,15 @@ extern "C" {
 #define AT86RF2XX_IS_PERIPH (0)
 #endif
 
+/**
+ * @brief   Support for SubGHz bands
+ */
+#ifdef MODULE_AT86RF212B
+#define AT86RF2XX_HAVE_SUBGHZ (1)
+#else
+#define AT86RF2XX_HAVE_SUBGHZ (0)
+#endif
+
 #if defined(DOXYGEN) || defined(MODULE_AT86RF232) || defined(MODULE_AT86RF233) || defined(MODULE_AT86RFR2)
 /**
  * @brief   Frame retry counter reporting

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -107,6 +107,15 @@ extern "C" {
 #   define MIN_RX_SENSITIVITY              (-101)
 #endif
 
+/**
+ * @brief   Whether there is a periph version of the radio
+ */
+#if IS_USED(MODULE_AT86RFA1) || IS_USED(MODULE_AT86RFR2)
+#define AT86RF2XX_IS_PERIPH (1)
+#else
+#define AT86RF2XX_IS_PERIPH (0)
+#endif
+
 #if defined(DOXYGEN) || defined(MODULE_AT86RF232) || defined(MODULE_AT86RF233) || defined(MODULE_AT86RFR2)
 /**
  * @brief   Frame retry counter reporting
@@ -209,7 +218,7 @@ extern "C" {
 #define AT86RF2XX_PHY_STATE_TX_BUSY  AT86RF2XX_STATE_BUSY_TX_ARET
 #endif /* IS_ACTIVE(AT86RF2XX_BASIC_MODE) */
 
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
 /**
  * @brief   memory mapped radio needs no parameters
  */
@@ -235,7 +244,7 @@ typedef struct at86rf2xx_params {
  */
 typedef struct {
     netdev_ieee802154_t netdev;             /**< netdev parent struct */
-#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+#if AT86RF2XX_IS_PERIPH
     /* ATmega256rfr2 signals transceiver events with different interrupts
      * they have to be stored to mimic the same flow as external transceiver
      * Use irq_status to map saved interrupts of SOC transceiver,

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -139,13 +139,23 @@ extern "C" {
  * @brief   Frame retry counter reporting
  *
  * The AT86RF2XX_HAVE_RETRIES flag enables support for NETOPT_TX_RETRIES NEEDED
- * operation. Required for this functionality is the XAH_CTRL_2 register which
- * contains the frame retry counter. Only the at86rf232 and the at86rf233
- * support this register.
+ * operation.
  */
 #define AT86RF2XX_HAVE_RETRIES             (1)
 #else
 #define AT86RF2XX_HAVE_RETRIES             (0)
+#endif
+
+/**
+ * @brief   Frame retry counter register
+ *
+ * Some radios include the XAH_CTRL_2 register which contains the frame retry
+ * counter. Only the at86rf232 and the at86rf233 support this register.
+ */
+#if AT86RF2XX_HAVE_RETRIES && defined(AT86RF2XX_REG__XAH_CTRL_2)
+#define AT86RF2XX_HAVE_RETRIES_REG         (1)
+#else
+#define AT86RF2XX_HAVE_RETRIES_REG         (0)
 #endif
 
 /**

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -131,6 +131,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   TX Start IRQ
+ */
+#ifdef AT86RF2XX_REG__IRQ_MASK1
+#define AT86RF2XX_HAVE_TX_START_IRQ        (1)
+#else
+#define AT86RF2XX_HAVE_TX_START_IRQ        (0)
+#endif
+
+/**
  * @brief   Random Number Generator
  *
  * Most AT86RF radios have the option to use the highest bits of the RSSI

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -117,6 +117,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   ED Register
+ */
+#if defined(MODULE_AT86RF231) || IS_ACTIVE(AT86RF2XX_PERIPH)
+#define AT86RF2XX_HAVE_ED_REGISTER (1)
+#else
+#define AT86RF2XX_HAVE_ED_REGISTER (0)
+#endif
+
+/**
  * @brief   Support for SubGHz bands
  */
 #ifdef MODULE_AT86RF212B


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
It has been [very hard](https://github.com/RIOT-OS/RIOT/pull/16535) to port AT86RF based radios to the Radio HAL because the presentation layer is mixed with the interface layer (netdev). Even more, variant specific stuff are scattered everywhere, which makes it hard to write a compatible Radio HAL interface. Therefore, I think the only way to move forward is to clean-up the driver a bit.

This PR tries to define variant specific caps (e.g `HAVE_ED_REGISTER`, `HAVE_SUBGHZ` , `AT86RF2XX_PERIPH`) based on the variant.
In a follow up, I plan to move the PERIPH parts to its own file and separate the SPI implementation with the PERIPH version. The idea is to have provide a common abstraction for the hardware interface layer, so it becomes relatively straight forward to replace `at86rf2xx_netdev.c` with `at86rf2xx_rf_ops.c`. With some tweaks, it should be also possible to run multiple variants on the same firmware.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check that AT86RF2XX variants still work as expected.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/16535
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
