### PR TITLE
cpu/nrf5x_common: clear stale compare event

### DIFF
--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -100,6 +100,9 @@ int timer_set_absolute(tim_t tim, int chan, unsigned int value)
         return -1;
     }
 
+    /* clear stale compare event */
+    dev(tim)->EVENTS_COMPARE[chan] = 0;
+
     ctx[tim].flags |= (1 << chan);
     dev(tim)->CC[chan] = value;
     dev(tim)->INTENSET = (TIMER_INTENSET_COMPARE0_Msk << chan);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This fixes early-firing timer ISRs in `tests/pkg_edhoc_c`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I tested this fix on 2022.10-branch with `tests/pkg_edhoc_c`. I think it needs a bit more testing than that.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
