### PR TITLE
cpu/stm32/periph_timer: fix spurious IRQs and race conditions [backport 2022.10]

### DIFF
--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -136,6 +136,10 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     }
 #endif
 
+    /* clear spurious IRQs */
+    dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
+
+    /* enable IRQ */
     dev(tim)->DIER |= (TIM_DIER_CC1IE << channel);
     irq_restore(irqstate);
 
@@ -166,6 +170,11 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
     }
 
     TIM_CHAN(tim, channel) = value;
+
+    /* clear spurious IRQs */
+    dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
+
+    /* enable IRQ */
     dev(tim)->DIER |= (TIM_DIER_CC1IE << channel);
 
     if (flags & TIM_FLAG_RESET_ON_MATCH) {


### PR DESCRIPTION
# Backport of #18969

### Contribution description

This fixes in the `periph_timer` implementation of STM32:

- race conditions when two threads share the same timer peripheral, but distinct sets of timer channel
- spurious IRQs

### Testing procedure

The test in https://github.com/RIOT-OS/RIOT/pull/18963 should now pass

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18963