### PR TITLE
cpu/esp{32,8266}/periph_timer: allow changing callback or freq [backport 2022.10]

### DIFF
--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -230,11 +230,6 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     assert(clk_div >= 2 && clk_div <= 65536);
     assert(cb != NULL);
 
-    if (_timers[dev].initialized) {
-        DEBUG("%s timer dev=%u is already initialized (used)\n", __func__, dev);
-        return -1;
-    }
-
     /* initialize timer data structure */
     _timers[dev].initialized = true;
     _timers[dev].started     = false;

--- a/cpu/esp8266/periph/timer.c
+++ b/cpu/esp8266/periph/timer.c
@@ -124,11 +124,6 @@ int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     CHECK_PARAM_RET (freq == HW_TIMER_FREQUENCY, -1);
     CHECK_PARAM_RET (cb   != NULL, -1);
 
-    if (timers[dev].initialized) {
-        DEBUG("%s timer dev=%u is already initialized (used)\n", __func__, dev);
-        return -1;
-    }
-
     timers[dev].initialized = true;
     timers[dev].started     = false;
     timers[dev].isr_ctx.cb  = cb;


### PR DESCRIPTION
# Backport of #18971

### Contribution description

Allow multiple calls to `timer_init()`, as this is the only way to change the timer frequency or the callback function.

### Testing procedure

The test in https://github.com/RIOT-OS/RIOT/pull/18963 should now pass.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18963