### PR TITLE
pkg/nimble: signal LINK_UP on initialisation [backport 2022.10]

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -207,6 +207,10 @@ static inline int _netdev_init(netdev_t *dev)
     (void)res;
 
     bluetil_addr_swapped_cp(tmp, _netif.l2addr);
+
+    /* signal link UP */
+    dev->event_callback(dev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 


### PR DESCRIPTION
# Backport of #18979

### Contribution description

Since commit ab32ad50 netifs are required to signal NETDEV_EVENT_LINK_UP at least once; commit 838a5e4b adds this to all netifs except nimble_netif, which basically breaks all of the usage scenarios for 6LoWPAN over BLE; this is a fix of this issue.

### Testing procedure

Compile gnrc_networking for nrf52dk, then run ifconfig; a link-local address should be available.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/18923
