### PR TITLE
cpu/atmega_common/periph_timer: fix spurious IRQs [backport 2022.10]

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -158,7 +158,9 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     unsigned state = irq_disable();
 
     ctx[tim].dev->OCR[channel] = (uint16_t)value;
-    *ctx[tim].flag &= ~(1 << (channel + OCF1A));
+    /* clear spurious IRQs, if any */
+    *ctx[tim].flag = (1 << (channel + OCF1A));
+    /* unmask IRQ */
     *ctx[tim].mask |= (1 << (channel + OCIE1A));
     set_oneshot(tim, channel);
 
@@ -177,6 +179,9 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
     unsigned absolute = ctx[tim].dev->CNT + timeout;
 
     ctx[tim].dev->OCR[channel] = absolute;
+    /* clear spurious IRQs, if any */
+    *ctx[tim].flag = (1 << (channel + OCF1A));
+    /* unmask IRQ */
     *ctx[tim].mask |= (1 << (channel + OCIE1A));
     set_oneshot(tim, channel);
 
@@ -210,7 +215,9 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
 
     ctx[tim].dev->OCR[channel] = (uint16_t)value;
 
-    *ctx[tim].flag &= ~(1 << (channel + OCF1A));
+    /* clear spurious IRQs, if any */
+    *ctx[tim].flag = (1 << (channel + OCF1A));
+    /* unmask IRQ */
     *ctx[tim].mask |=  (1 << (channel + OCIE1A));
 
     clear_oneshot(tim, channel);


### PR DESCRIPTION
# Backport of #18978

### Contribution description

As the tile says

### Testing procedure

`tests/periph_timer` from https://github.com/RIOT-OS/RIOT/pull/18963 and `tests/periph_timer_periodic` should pass. (They do on the `arduino-mega2560`.)

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/18976