### PR TITLE
paho: use GNRC instead of lwip

### DIFF
--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -34,24 +34,12 @@ USEMODULE += netdev_default
 USEPKG += paho-mqtt
 
 # paho-mqtt depends on TCP support, choose which stacks you want
+GNRC_IPV6 ?= 1
 LWIP_IPV4 ?= 0
-LWIP_IPV6 ?= 1
+LWIP_IPV6 ?= 0
 
-ifneq (0,$(LWIP_IPV4))
-  USEMODULE += ipv4_addr
-  USEMODULE += lwip_arp
-  USEMODULE += lwip_ipv4
-  USEMODULE += lwip_dhcp_auto
-  CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
-endif
-
-ifneq (0,$(LWIP_IPV6))
-  USEMODULE += ipv6_addr
-  USEMODULE += lwip_ipv6_autoconfig
-endif
-
-USEMODULE += lwip_netdev
-USEMODULE += lwip
+include Makefile.lwip
+include Makefile.gnrc
 
 USEMODULE += sock_async_event
 USEMODULE += sock_ip

--- a/examples/paho-mqtt/Makefile.ci
+++ b/examples/paho-mqtt/Makefile.ci
@@ -1,7 +1,9 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
     blackpill \
+    blackpill-128kib \
     bluepill \
+    bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
     hifive1 \

--- a/examples/paho-mqtt/Makefile.gnrc
+++ b/examples/paho-mqtt/Makefile.gnrc
@@ -1,0 +1,16 @@
+ifneq (0,$(GNRC_IPV6))
+  ifneq (0,$(USE_LWIP))
+    $(error No valid choice: Select either LWIP or GNRC)
+  endif
+  USEMODULE += auto_init_gnrc_netif
+  # Activate ICMPv6 error messages
+  USEMODULE += gnrc_icmpv6_error
+  # Specify the mandatory networking modules for IPv6
+  USEMODULE += gnrc_ipv6_default
+  # Additional networking modules that can be dropped if not needed
+  USEMODULE += gnrc_icmpv6_echo
+else
+  ifeq (0,$(USE_LWIP))
+    $(error No network stack selected. Please choose either GNRC or LWIP)
+  endif
+endif

--- a/examples/paho-mqtt/Makefile.lwip
+++ b/examples/paho-mqtt/Makefile.lwip
@@ -1,0 +1,25 @@
+USE_LWIP := 0
+ifneq (0,$(LWIP_IPV4))
+  USE_LWIP := 1
+endif
+ifneq (0,$(LWIP_IPV6))
+  USE_LWIP := 1
+endif
+
+ifneq (0,$(LWIP_IPV4))
+  USEMODULE += ipv4_addr
+  USEMODULE += lwip_arp
+  USEMODULE += lwip_ipv4
+  USEMODULE += lwip_dhcp_auto
+  CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
+endif
+
+ifneq (0,$(LWIP_IPV6))
+  USEMODULE += ipv6_addr
+  USEMODULE += lwip_ipv6_autoconfig
+endif
+
+ifneq (0,$(USE_LWIP))
+  USEMODULE += lwip_netdev
+  USEMODULE += lwip
+endif

--- a/examples/paho-mqtt/main.c
+++ b/examples/paho-mqtt/main.c
@@ -29,6 +29,9 @@
 #include "paho_mqtt.h"
 #include "MQTTClient.h"
 
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
 #define BUF_SIZE                        1024
 #define MQTT_VERSION_v311               4       /* MQTT v3.1.1 version is 4 */
 #define COMMAND_TIMEOUT_MS              4000
@@ -293,6 +296,9 @@ static unsigned char readbuf[BUF_SIZE];
 
 int main(void)
 {
+    if (IS_USED(MODULE_GNRC_ICMPV6_ECHO)) {
+        msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    }
 #ifdef MODULE_LWIP
     /* let LWIP initialize */
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -39,11 +39,9 @@
 #define TSRB_MAX_SIZE       (1024)
 #endif
 
-#ifdef MODULE_LWIP
 static uint8_t buffer[TSRB_MAX_SIZE];
 static uint8_t _temp_buf[TSRB_MAX_SIZE];
 static tsrb_t tsrb_lwip_tcp;
-#endif
 
 #ifndef PAHO_MQTT_YIELD_MS
 #define PAHO_MQTT_YIELD_MS  (10)
@@ -75,7 +73,7 @@ static int mqtt_read(struct Network *n, unsigned char *buf, int len,
     uint32_t send_time = ztimer_now(ZTIMER_MSEC) + timeout_ms;
     do {
         rc = sock_tcp_read(&n->sock, _buf, _len, _timeout);
-        if (rc == -EAGAIN) {
+        if ((rc == -EAGAIN) || (rc == -ETIMEDOUT)) {
             rc = 0;
         }
 


### PR DESCRIPTION
### Contribution description

The example application for Paho MQTT is using lwip instead of GNRC because at the time of writing no TCP support for GNRC was available. However, in the meantime the situation has changed and with a tiny tweak of the adapter code Paho works like charm on GNRC TCP sockets.

### Testing procedure

Start a MQTT broker, e.g., mosquitto.

On native:
1. Start the example application and add the tab bridge as default route via `nib route add 7 :: <link-local address of the bridge>`

On iotlab-m3 (or similar):
1. Setup a border router (for instance in IoT-Lab following https://www.iot-lab.info/learn/tutorials/riot/riot-public-ipv6-m3/)
2. Start the example application on a second node

Finally, call `con <Broker IPv6 address>` followed by `sub <TOPIC>` and `pub <TOPIC>.