### PR TITLE
boards/nucleo-l* and g*: update doc concerning Vbat

### DIFF
--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -87,22 +87,39 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @brief    ADC configuration
  *
  * Note that we do not configure all ADC channels,
- * and not in the STM32G070 order.  Instead, we
+ * and not in the STM32G070 order. Instead, we
  * just define 6 ADC channels, for the Nucleo
  * Arduino header pins A0-A5 and the internal VBAT channel.
  *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ARD_A[N]_IN[X],
+ * where:
+ * [N] - describes analog pin number,
+ * [X] - describes used channel - indexed from 1,
+ * for example ARD_A5_IN16 is channel 16
+ *
+ * For Nucleo-G070RB this information is in board manual,
+ * Table 12, page 30.
+ *
+ * VBAT is connected to an internal input and voltage divider
+ * is used, so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For Nucleo-G070RB more information is provided in MCU datasheet,
+ * in section 3.14.3 - Vbat battery voltage monitoring, page 22.
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    { .pin = GPIO_PIN(PORT_A,  0), .dev = 0, .chan =  0 },
-    { .pin = GPIO_PIN(PORT_A,  1), .dev = 0, .chan =  1 },
-    { .pin = GPIO_PIN(PORT_A,  4), .dev = 0, .chan =  4 },
-    { .pin = GPIO_PIN(PORT_B,  1), .dev = 0, .chan =  9 },
-    { .pin = GPIO_PIN(PORT_B, 11), .dev = 0, .chan = 15 },
-    { .pin = GPIO_PIN(PORT_B, 12), .dev = 0, .chan = 16 },
+    { .pin = GPIO_PIN(PORT_A,  0), .dev = 0, .chan =  0 }, /* ARD_A0_IN0  */
+    { .pin = GPIO_PIN(PORT_A,  1), .dev = 0, .chan =  1 }, /* ARD_A1_IN1  */
+    { .pin = GPIO_PIN(PORT_A,  4), .dev = 0, .chan =  4 }, /* ARD_A2_IN4  */
+    { .pin = GPIO_PIN(PORT_B,  1), .dev = 0, .chan =  9 }, /* ARD_A3_IN9  */
+    { .pin = GPIO_PIN(PORT_B, 11), .dev = 0, .chan = 15 }, /* ARD_A4_IN15 */
+    { .pin = GPIO_PIN(PORT_B, 12), .dev = 0, .chan = 16 }, /* ARD_A5_IN16 */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 14}, /* VBAT */
 };
 

--- a/boards/nucleo-g071rb/include/periph_conf.h
+++ b/boards/nucleo-g071rb/include/periph_conf.h
@@ -92,15 +92,33 @@ static const uart_conf_t uart_config[] = {
  * just define 6 ADC channels, for the Nucleo
  * Arduino header pins A0-A5 and the internal VBAT channel.
  *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ARD_A[N]_IN[X],
+ * where:
+ * [N] - describes analog pin number,
+ * [X] - describes used channel - indexed from 1,
+ * for example ARD_A5_IN16 is channel 16
+ *
+ * For Nucleo-G071RB this information is in board manual,
+ * Table 12, page 30.
+ *
+ * VBAT is connected to an internal input and voltage divider
+ * is used, so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For Nucleo-G071RB more information is provided in MCU datasheet,
+ * in section 3.14.3 - Vbat battery voltage monitoring, page 26.
+
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    { .pin = GPIO_PIN(PORT_A,  0), .dev = 0, .chan =  0 },
-    { .pin = GPIO_PIN(PORT_A,  1), .dev = 0, .chan =  1 },
-    { .pin = GPIO_PIN(PORT_A,  4), .dev = 0, .chan =  4 },
-    { .pin = GPIO_PIN(PORT_B,  1), .dev = 0, .chan =  9 },
-    { .pin = GPIO_PIN(PORT_B, 11), .dev = 0, .chan = 15 },
-    { .pin = GPIO_PIN(PORT_B, 12), .dev = 0, .chan = 16 },
+    { .pin = GPIO_PIN(PORT_A,  0), .dev = 0, .chan =  0 }, /* ARD_A0_IN0  */
+    { .pin = GPIO_PIN(PORT_A,  1), .dev = 0, .chan =  1 }, /* ARD_A1_IN1  */
+    { .pin = GPIO_PIN(PORT_A,  4), .dev = 0, .chan =  4 }, /* ARD_A2_IN4  */
+    { .pin = GPIO_PIN(PORT_B,  1), .dev = 0, .chan =  9 }, /* ARD_A3_IN9  */
+    { .pin = GPIO_PIN(PORT_B, 11), .dev = 0, .chan = 15 }, /* ARD_A4_IN15 */
+    { .pin = GPIO_PIN(PORT_B, 12), .dev = 0, .chan = 16 }, /* ARD_A5_IN16 */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 14}, /* VBAT */
 };
 

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -207,11 +207,31 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @brief    ADC configuration
  *
- * configure only  ADC channels for the Arduino header pins A0-A5
- * and the internal VBAT channel
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32L476RG order. Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5 and the internal VBAT channel.
  *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC1_IN10 is device 0,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC1_IN10 is channel 10
+ *
+ * For Nucleo-L476RG this information is in board manual,
+ * Table 23, page 52.
+ *
+ * VBAT is connected ADC1_IN18 or ADC3_IN18 and a voltage divider
+ * is used, so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For Nucleo-L476RG more information is provided in MCU datasheet,
+ * in section 3.15.3 - Vbat battery voltage monitoring, page 42.
  * @{
  */
 static const adc_conf_t adc_config[] = {
@@ -219,8 +239,8 @@ static const adc_conf_t adc_config[] = {
     {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC12_IN6 */
     {GPIO_PIN(PORT_A, 4), 1, 9},  /*< ADC12_IN9 */
     {GPIO_PIN(PORT_B, 0), 1, 15}, /*< ADC12_IN15 */
-    {GPIO_PIN(PORT_C, 1), 2, 2},  /*< ADC123_IN_2 */
-    {GPIO_PIN(PORT_C, 0), 2, 1},  /*< ADC123_IN_1 */
+    {GPIO_PIN(PORT_C, 1), 2, 2},  /*< ADC123_IN2 */
+    {GPIO_PIN(PORT_C, 0), 2, 1},  /*< ADC123_IN1 */
     {GPIO_UNDEF, 0, 18}, /* VBAT */
 };
 

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -176,6 +176,12 @@ static const spi_conf_t spi_config[] = {
  * For Nucleo-L496ZG this information is in board manual,
  * Table 11, page 38.
  *
+ * VBAT is connected ADC1_IN18 or ADC3_IN18 and a voltage divider
+ * is used, so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For Nucleo-L496ZG more information is provided in MCU datasheet,
+ * in section 3.17.3 - Vbat battery voltage monitoring, page 43.
  * @{
  */
 static const adc_conf_t adc_config[] = {
@@ -185,13 +191,6 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_PIN(PORT_C, 1), .dev = 0, .chan =  2 }, /* ADC123_IN2  */
     { .pin = GPIO_PIN(PORT_C, 4), .dev = 0, .chan = 13 }, /* ADC12_IN13  */
     { .pin = GPIO_PIN(PORT_C, 5), .dev = 0, .chan = 14 }, /* ADC12_IN14  */
-    /* VBAT is connected ADC1_IN18 or ADC3_IN18 and a voltage divider
-     * is used, so that only 1/3 of the actual VBAT is measured. This
-     * allows for a supply voltage higher than the reference voltage.
-     *
-     * For Nucleo-L496ZG more information is provided in MCU datasheet,
-       in section 3.17.3 - Vbat battery voltaga monioring, page 43.
-     */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 18 },
 };
 

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -136,6 +136,13 @@ static const spi_conf_t spi_config[] = {
  *
  * For Nucleo-L4R5ZI this information is in board manual,
  * Table 11, page 38.
+ *
+ * VBAT is connected ADC1_IN18 and a voltage divider is used,
+ * so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For Nucleo-L4R5ZI more information is provided in MCU datasheet,
+ * in section 3.19.3 - Vbat battery voltage monitoring, page 46.
  * @{
  */
 static const adc_conf_t adc_config[] = {


### PR DESCRIPTION
### Contribution description

In PR #18940 @maribu point out that vbat ADC channel for nucleo-l496zg has voltage divider.
I checked datasheets for other nucleo boards with configured ADC and find that this behavior is 
documented only on few L and G family MCUs. 

This PR improves documentation adding such information. Moreover, I moved doxygen section 
from the middle of   `adc_config[]` as it do not appear in the generated HTML documentation.

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/boards_2nucleo-l496zg_2include_2periph__conf_8h.html
xdg-open doc/doxygen/html/boards_2nucleo-l476rg_2include_2periph__conf_8h.html
xdg-open doc/doxygen/html/boards_2nucleo-l4r5zi_2include_2periph__conf_8h.html
xdg-open doc/doxygen/html/boards_2nucleo-g070rb_2include_2periph__conf_8h.html
xdg-open doc/doxygen/html/boards_2nucleo-g071rb_2include_2periph__conf_8h.html
```

### Issues/PRs references

PR #18940 