### PR TITLE
pkg/tinydtls: add musl_lcg to list of crypto-secure RNGs

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -12,7 +12,7 @@ INCLUDES += -I$(PKG_BUILDDIR)
 CFLAGS += -DDTLSv12 -DWITH_SHA256
 
 # Check that the used PRNG implementation is cryptographically secure
-CRYPTO_SECURE_IMPLEMENTATIONS := prng_sha256prng prng_sha1prng prng_hwrng
+CRYPTO_SECURE_IMPLEMENTATIONS := prng_sha256prng prng_sha1prng prng_hwrng prng_musl_lcg
 USED_PRNG_IMPLEMENTATIONS := $(filter prng_%,$(USEMODULE))
 ifeq (,$(filter $(CRYPTO_SECURE_IMPLEMENTATIONS),$(USEMODULE)))
   $(info TinyDTLS needs a cryptographically secure implementation of the PRNG module.)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In [0] the paper concludes with

> The Knuth LCG is the most efficient general purpose generator that provides decent statistical quality.
> It is simple and lean enough to run on very constrained devices.

So let's add `prng_musl_lcg` to the list of crypto-secure RNGs then.

[0] https://sci-hub.se/10.1145/3453159


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
