### PR TITLE
boards/qn9080dk: add default OPENOCD_DEBUG_ADAPTER

### DIFF
--- a/boards/qn9080dk/Makefile.include
+++ b/boards/qn9080dk/Makefile.include
@@ -4,5 +4,7 @@ CFLAGS += \
   -DCONFIG_BOARD_HAS_XTAL_32M \
   #
 
+OPENOCD_DEBUG_ADAPTER ?= dap
+
 # Include default QN908x board config
 include $(RIOTBOARD)/common/qn908x/Makefile.include


### PR DESCRIPTION
### Contribution description

The board has integrated debugger:

    1fc9:0090 NXP Semiconductors LPC-LINK2 CMSIS-DAP V5.173

This commit changes the default debug adapter to this one.

### Testing procedure

Connect the board via USB to the connector labeled `DFU Link` (rather than the one labeled `Target`) and set the jumper JP2 to use the internal debugger (for me, this is how the board came out of the box). Then, in any RIOT app, run:

```
make BOARD=qn9080dk flash
```

This yields on `master`:

```
### Flashing Target ###
Open On-Chip Debugger 0.12.0-rc2+dev-snapshot (2022-11-28-13:26)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
Error: No J-Link device found
```

With this PR it yields:

```
### Flashing Target ###
Open On-Chip Debugger 0.12.0-rc2+dev-snapshot (2022-11-28-13:26)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
Info : CMSIS-DAP: SWD supported
Info : CMSIS-DAP: JTAG supported
Info : CMSIS-DAP: FW Version = 1.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : [qn908x.cpu] Cortex-M4 r0p1 processor detected
Info : [qn908x.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for qn908x.cpu on 0
Info : Listening on port 34559 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* qn908x.cpu         cortex_m   little qn908x.cpu         running

[qn908x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x03000738 msp: 0x04010000
Info : Detected flash size: 512 Kb
Info : Padding image section 0 at 0x01000114 with 12 bytes
auto erase enabled
wrote 14336 bytes from file /home/maribu/Repos/software/RIOT/tests/periph_timer/bin/qn9080dk/tests_periph_timer-checksum.elf in 0.432092s (32.401 KiB/s)

verified 13628 bytes in 0.183026s (72.714 KiB/s)

Info : SWD DPIDR 0x2ba01477
shutdown command invoked
Done flashing
```

***Beware***: This requires a patched verion of OpenOCD, refer to the board docs. I rebased the patch on top of current `master` in https://github.com/maribu/openocd/tree/qn908x - if this helps in getting OpenOCD

### Issues/PRs references

None