### PR TITLE
cpu/qn908x: use bitarithm_test_and_clear() & fix cb

### DIFF
--- a/cpu/qn908x/periph/timer.c
+++ b/cpu/qn908x/periph/timer.c
@@ -66,9 +66,9 @@ static const clock_ip_name_t ctimers_clocks[FSL_FEATURE_SOC_CTIMER_COUNT] =
 #error "ERROR in board timer configuration: too many timers defined"
 #endif
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    DEBUG("timer_init(%u, %lu)\n", tim, freq);
+    DEBUG("timer_init(%u, %" PRIu32 ")\n", tim, freq);
     if (tim >= TIMER_NUMOF) {
         return -1;
     }
@@ -84,7 +84,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     uint32_t core_freq = CLOCK_GetFreq(kCLOCK_ApbClk);
     uint32_t prescale = (core_freq + freq / 2) / freq - 1;
     if (prescale == (uint32_t)(-1)) {
-        DEBUG("timer_init: Frequency %lu is too fast for core_freq=%lu",
+        DEBUG("timer_init: Frequency %" PRIu32 " is too fast for core_freq=%" PRIu32,
               freq, core_freq);
         return -1;
     }


### PR DESCRIPTION
### Contribution description

Previously, the callback was incorrectly passed a channel of zero as argument regardless of the channel that triggered the IRQ. This fixes the issue and also uses `bitarithm_test_and_clear()` to only iterate over the channels that actually have an IRQ flag set, rather than all channels.

### Testing procedure

```
$ make BOARD=qn9080dk flash test -C tests/periph_timer
```

for the test application pimped up by https://github.com/RIOT-OS/RIOT/pull/18963

#### With `master`

```
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2023.01-devel-473-g496ab-tests/periph_timer)

Test for peripheral TIMERs

Available timers: 4

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: set channel 1 to 10000
TIMER_0: set channel 2 to 15000
TIMER_0: set channel 3 to 20000
TIMER_0: starting
TIMER_0: channel 0 fired at SW count    39971 - init:    39971
TIMER_0: ERROR callback argument mismatch


Testing TIMER_1:
TIMER_1: initialization successful
TIMER_1: stopped
TIMER_1: set channel 0 to 5000
TIMER_1: set channel 1 to 10000
TIMER_1: set channel 2 to 15000
TIMER_1: set channel 3 to 20000
TIMER_1: starting
TIMER_1: channel 0 fired at SW count    39970 - init:    39970
TIMER_1: ERROR callback argument mismatch


Testing TIMER_2:
TIMER_2: initialization successful
TIMER_2: stopped
TIMER_2: set channel 0 to 5000
TIMER_2: set channel 1 to 10000
TIMER_2: set channel 2 to 15000
TIMER_2: set channel 3 to 20000
TIMER_2: starting
TIMER_2: channel 0 fired at SW count    39972 - init:    39972
TIMER_2: ERROR callback argument mismatch


Testing TIMER_3:
TIMER_3: initialization successful
TIMER_3: stopped
TIMER_3: set channel 0 to 5000
TIMER_3: set channel 1 to 10000
TIMER_3: set channel 2 to 15000
TIMER_3: set channel 3 to 20000
TIMER_3: starting
TIMER_3: channel 0 fired at SW count    39970 - init:    39970
TIMER_3: ERROR callback argument mismatch


TEST FAILED
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 408 }]}
Timeout in expect script at "child.expect('TEST SUCCEEDED')" (tests/periph_timer/tests/01-run.py:21)

make: *** [/home/maribu/Repos/software/RIOT/makefiles/tests/tests.inc.mk:26: test] Error 1
```

#### This PR

```
READY
s
START
main(): This is RIOT! (Version: 2023.01-devel-474-g1df0f56-cpu/qn908x)

Test for peripheral TIMERs

Available timers: 4

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: set channel 1 to 10000
TIMER_0: set channel 2 to 15000
TIMER_0: set channel 3 to 20000
TIMER_0: starting
TIMER_0: channel 0 fired at SW count    10000 - init:    10000
TIMER_0: channel 1 fired at SW count    19993 - diff:     9993
TIMER_0: channel 2 fired at SW count    29986 - diff:     9993
TIMER_0: channel 3 fired at SW count    39979 - diff:     9993

Testing TIMER_1:
TIMER_1: initialization successful
TIMER_1: stopped
TIMER_1: set channel 0 to 5000
TIMER_1: set channel 1 to 10000
TIMER_1: set channel 2 to 15000
TIMER_1: set channel 3 to 20000
TIMER_1: starting
TIMER_1: channel 0 fired at SW count     9999 - init:     9999
TIMER_1: channel 1 fired at SW count    19992 - diff:     9993
TIMER_1: channel 2 fired at SW count    29985 - diff:     9993
TIMER_1: channel 3 fired at SW count    39978 - diff:     9993

Testing TIMER_2:
TIMER_2: initialization successful
TIMER_2: stopped
TIMER_2: set channel 0 to 5000
TIMER_2: set channel 1 to 10000
TIMER_2: set channel 2 to 15000
TIMER_2: set channel 3 to 20000
TIMER_2: starting
TIMER_2: channel 0 fired at SW count     9999 - init:     9999
TIMER_2: channel 1 fired at SW count    19992 - diff:     9993
TIMER_2: channel 2 fired at SW count    29985 - diff:     9993
TIMER_2: channel 3 fired at SW count    39978 - diff:     9993

Testing TIMER_3:
TIMER_3: initialization successful
TIMER_3: stopped
TIMER_3: set channel 0 to 5000
TIMER_3: set channel 1 to 10000
TIMER_3: set channel 2 to 15000
TIMER_3: set channel 3 to 20000
TIMER_3: starting
TIMER_3: channel 0 fired at SW count     9999 - init:     9999
TIMER_3: channel 1 fired at SW count    19992 - diff:     9993
TIMER_3: channel 2 fired at SW count    29985 - diff:     9993
TIMER_3: channel 3 fired at SW count    39978 - diff:     9993

TEST SUCCEEDED
```

### Issues/PRs references

Found well testing for https://github.com/RIOT-OS/RIOT/issues/18976