### PR TITLE
nanocoap: add coap_next_msg_id()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1099,6 +1099,15 @@ static inline unsigned coap_size2szx(unsigned len)
  * full.
  */
 /**@{*/
+
+/**
+ * @brief   Get next consecutive message ID for use when building a new
+ *          CoAP request.
+ *
+ * @return  A new message ID that can be used for a request or response.
+ */
+uint16_t coap_next_msg_id(void);
+
 /**
  * @brief   Add block option in descriptive use from a slicer object
  *

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -45,7 +45,6 @@ typedef struct {
     event_t event;
 } client_ep_t;
 
-extern uint16_t gcoap_next_msg_id(void);
 extern void gcoap_forward_proxy_post_event(void *arg);
 
 static uint8_t proxy_req_buf[CONFIG_GCOAP_PDU_BUF_SIZE];
@@ -238,7 +237,7 @@ static void _set_response_type(coap_pkt_t *pdu, uint8_t resp_type)
 {
     coap_hdr_set_type(pdu->hdr, resp_type);
     if (resp_type == COAP_TYPE_CON) {
-        pdu->hdr->id = htons(gcoap_next_msg_id());
+        pdu->hdr->id = htons(coap_next_msg_id());
     }
 }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -26,11 +26,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "auto_init_utils.h"
 #include "atomic_utils.h"
 #include "bitarithm.h"
 #include "net/nanocoap.h"
-#include "random.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -48,21 +46,12 @@ static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);
 
-__attribute__((section(".noinit")))
-static uint16_t _msg_id;
 uint16_t coap_next_msg_id(void)
 {
-    return atomic_fetch_add_u16(&_msg_id, 1);
+    __attribute__((section(".noinit")))
+    static uint16_t id;
+    return atomic_fetch_add_u16(&id, 1);
 }
-
-static void auto_init_coap_random(void)
-{
-    if (_msg_id == 0) {
-        _msg_id = random_uint32();
-    }
-}
-
-AUTO_INIT(auto_init_coap_random, AUTO_INIT_PRIORITY_AFTER(AUTO_INIT_PRIO_MOD_RANDOM));
 
 /* http://tools.ietf.org/html/rfc7252#section-3
  *  0                   1                   2                   3

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "atomic_utils.h"
 #include "bitarithm.h"
 #include "net/nanocoap.h"
 
@@ -44,6 +45,13 @@
 static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);
+
+uint16_t coap_next_msg_id(void)
+{
+    __attribute__((section(".noinit")))
+    static uint16_t id;
+    return atomic_fetch_add_u16(&id, 1);
+}
 
 /* http://tools.ietf.org/html/rfc7252#section-3
  *  0                   1                   2                   3

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -26,9 +26,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "auto_init_utils.h"
 #include "atomic_utils.h"
 #include "bitarithm.h"
 #include "net/nanocoap.h"
+#include "random.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -46,12 +48,21 @@ static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);
 
+__attribute__((section(".noinit")))
+static uint16_t _msg_id;
 uint16_t coap_next_msg_id(void)
 {
-    __attribute__((section(".noinit")))
-    static uint16_t id;
-    return atomic_fetch_add_u16(&id, 1);
+    return atomic_fetch_add_u16(&_msg_id, 1);
 }
+
+static void auto_init_coap_random(void)
+{
+    if (_msg_id == 0) {
+        _msg_id = random_uint32();
+    }
+}
+
+AUTO_INIT(auto_init_coap_random, AUTO_INIT_PRIORITY_AFTER(AUTO_INIT_PRIO_MOD_RANDOM));
 
 /* http://tools.ietf.org/html/rfc7252#section-3
  *  0                   1                   2                   3


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Both nanoCoAP and GCoAP have the need for getting (somewhat) monotonic message IDs.
Currently both implement this as an internal function that they then kinda need to re-repose after all.

Clean this up by just adding a single public `coap_next_msg_id()` function that can be used by anyone needing CoAP message IDs.


### Testing procedure

CoAP should function as before.
(`tests/gcoap_fileserver` will run integration test on CI)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
