### PR TITLE
pkg/wamr: Update to WAMR-1.1.1

### DIFF
--- a/pkg/wamr/Makefile
+++ b/pkg/wamr/Makefile
@@ -3,8 +3,8 @@ PKG_URL=https://github.com/bytecodealliance/wasm-micro-runtime.git
 ifeq ($(PKG_BLEADING),1)
   PKG_VERSION=main
 else
-  PKG_VERSION=d7a2888b18c478d87ce8094e1419b4e061db289f
-  #release tag: WAMR-05-18-2022
+  PKG_VERSION=dc4dcc3d6fba42dbe93cf9050fad8e0cfa4b88d0
+  #release tag: WAMR-1.1.1
 endif
 PKG_LICENSE=Apache-2.0
 


### PR DESCRIPTION
### Contribution description

Update WAMR pkg to new release `WAMR-1.1.1` (2022-10-18)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
