### PR TITLE
sys/puf_sram: cleanup header

### DIFF
--- a/sys/include/puf_sram.h
+++ b/sys/include/puf_sram.h
@@ -58,8 +58,9 @@
 extern "C" {
 #endif
 
-#include "hashes.h"
-#include "thread.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * @brief SRAM length considered for seeding

--- a/sys/puf_sram/puf_sram.c
+++ b/sys/puf_sram/puf_sram.c
@@ -16,6 +16,8 @@
  *
  * @}
  */
+#include "cpu_conf.h"
+#include "hashes.h"
 #include "puf_sram.h"
 
 /* Allocation of the PUF seed variable */


### PR DESCRIPTION
### Contribution description

`puf_sram.h` included `thread.h` and `hashes.h` without making use of it. This fixes that and adds includes of `std...h` that are used by it.

### Testing procedure



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
