### PR TITLE
CI: can_fast_ci_build.py unittests fix

### DIFF
--- a/dist/tools/ci/can_fast_ci_run.py
+++ b/dist/tools/ci/can_fast_ci_run.py
@@ -73,6 +73,12 @@ class ChangeSet:
         while module != "":
             makefile = os.path.join(self._riotbase, module, "Makefile")
             if os.path.isfile(makefile) or module in EXCEPTION_MODULES:
+
+                # map all tests/unittests/* to just tests/unittests
+                # workaround for #18987
+                if module.startswith("tests/unittests/"):
+                    module = "tests/unittests"
+
                 if module in dest:
                     dest[module].append(file)
                 else:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR should fix #18987.

I first started with some sophisticated regex based generic replacement / mapping functionality, then decided to go simple...

The issue is that can_fast_ci_run.py *correctly* classifies any change to `tests/unittests/tests-$foo` to be a change to that module, but unittests are special in our build system - they can be built as one huge binary (`tests/unittests`), or individually (`tests/unittests/tests-*`). The latter are not built by CI and are not listed when doing `make info-applications`.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #18987.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
