### PR TITLE
pkg: paho-mqtt: added missing requirement

### DIFF
--- a/pkg/paho-mqtt/Makefile.dep
+++ b/pkg/paho-mqtt/Makefile.dep
@@ -1,3 +1,7 @@
+# PAHO does some comparisons against literals that make certain assumptions
+# about the width of integer types which hold only true for 32 bit platforms
+FEATURES_REQUIRED += arch_32bit
+
 USEMODULE += ztimer
 USEMODULE += ztimer_msec
 USEMODULE += paho-mqtt-contrib


### PR DESCRIPTION
Paho won't compile on platforms where an Integer is smaller than 32 bit.

### Contribution description

This PR adds the corresponding requirement to the package.

### Testing procedure

Build paho_mqtt example application and check if it still building for a 32 bit platform. (It won't build for a 16 bit platform even without this PR because of LWIP having the same requirement.)

Take a look at https://github.com/eclipse/paho.mqtt.embedded-c/blob/master/MQTTPacket/src/MQTTPacket.c#L93 

### Issues/PRs references

#18982 relies on this PR.
