### PR TITLE
examples/timer_periodic_wakeup: switch to ztimer

### DIFF
--- a/examples/timer_periodic_wakeup/Makefile
+++ b/examples/timer_periodic_wakeup/Makefile
@@ -1,8 +1,9 @@
 APPLICATION = timer_periodic_wakeup
 RIOTBASE ?= $(CURDIR)/../..
+
 BOARD ?= native
-USEMODULE += xtimer
-QUIET ?= 1
+
+USEMODULE += ztimer_msec
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/timer_periodic_wakeup/main.c
+++ b/examples/timer_periodic_wakeup/main.c
@@ -19,19 +19,19 @@
  */
 
 #include <stdio.h>
-#include "xtimer.h"
+#include "ztimer.h"
 #include "timex.h"
 
 /* set interval to 1 second */
-#define INTERVAL (1U * US_PER_SEC)
+#define INTERVAL_MS (1U * MS_PER_SEC)
 
 int main(void)
 {
-    xtimer_ticks32_t last_wakeup = xtimer_now();
+    uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
 
-    while(1) {
-        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
-        printf("slept until %" PRIu32 "\n", xtimer_usec_from_ticks(xtimer_now()));
+    while (1) {
+        ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, INTERVAL_MS);
+        printf("slept until %" PRIu32 "\n", ztimer_now(ZTIMER_MSEC));
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`ztimer_msec` is entirely sufficient for this test.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
