### PR TITLE
tests/shell: add test for preemption

### DIFF
--- a/tests/sys/shell/Makefile
+++ b/tests/sys/shell/Makefile
@@ -4,6 +4,7 @@ include ../Makefile.sys_common
 USEMODULE += app_metadata
 USEMODULE += shell_cmds_default
 USEMODULE += ps
+USEMODULE += ztimer_msec
 
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
@@ -12,6 +13,9 @@ APP_SHELL_FMT ?= NONE
 
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
+
+# requires #19005
+TEST_ON_CI_BLACKLIST += native native64
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/sys/shell/Makefile.ci
+++ b/tests/sys/shell/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    atmega328p-xplained-mini \
     atmega8 \
     #

--- a/tests/sys/shell/main.c
+++ b/tests/sys/shell/main.c
@@ -20,13 +20,14 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+
+#include "thread.h"
+#include "string_utils.h"
+#include "ztimer.h"
 
 #include "architecture.h"
 #include "shell.h"
-
-#if MODULE_STDIO_RTT
-#include "xtimer.h"
-#endif
 
 /* define buffer to be used by the shell. Note: This is intentionally
  * smaller than 64 bytes, as the EDBG integrated UART bridge of the samr21-xpro
@@ -100,12 +101,48 @@ static int print_empty(int argc, char **argv)
     return 0;
 }
 
+static char _stack[THREAD_STACKSIZE_TINY];
+static struct {
+    uint16_t period_ms;
+    uint16_t reps;
+} _periodic_ctx;
+
+static void *_func(void *arg)
+{
+    (void)arg;
+
+    while (_periodic_ctx.reps--) {
+        ztimer_sleep(ZTIMER_MSEC, _periodic_ctx.period_ms);
+        puts("test");
+    }
+
+    return NULL;
+}
+
+/* test to make sure that waiting for stdin does not block other threads */
+static int print_periodic(int argc, char **argv)
+{
+    if (argc > 1) {
+        _periodic_ctx.reps = atoi(argv[1]);
+    } else {
+        _periodic_ctx.reps = 5;
+    }
+
+    _periodic_ctx.period_ms = 500;
+
+    thread_create(_stack, sizeof(_stack), THREAD_PRIORITY_MAIN, THREAD_CREATE_STACKTEST,
+                  _func, NULL, "periodic");
+
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
     { "bufsize", "Get the shell's buffer size", print_shell_bufsize },
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
     { "echo", "prints the input command", print_echo },
     { "empty", "print nothing on command", print_empty },
+    { "periodic", "periodically print command", print_periodic },
     { NULL, NULL, NULL }
 };
 

--- a/tests/sys/shell/tests/01-run.py
+++ b/tests/sys/shell/tests/01-run.py
@@ -19,6 +19,7 @@ EXPECTED_HELP = (
     'end_test             ends a test',
     'echo                 prints the input command',
     'empty                print nothing on command',
+    'periodic             periodically print command',
     'app_metadata         Returns application metadata',
     'pm                   interact with layered PM subsystem',
     'ps                   Prints information about running threads.',
@@ -205,6 +206,18 @@ def check_control_d(child):
         child.expect_exact(PROMPT)
 
 
+def check_preempt(child):
+    child.expect(PROMPT)
+    child.sendline('periodic 5')
+
+    child.expect_exact('test')
+    child.expect_exact('test')
+    child.expect_exact('test')
+    child.expect_exact('test')
+    child.expect_exact('test')
+    child.sendline('')
+
+
 def testfunc(child):
     # avoid sending an extra empty line on native.
     if BOARD in ['native', 'native64']:
@@ -223,6 +236,8 @@ def testfunc(child):
     check_erase_long_line(child, longline)
 
     check_control_d(child)
+
+    check_preempt(child)
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This tests if a blocking stdio read will allow other threads to be scheduled.



### Testing procedure

`periodic test 5` should print `test` 5 times from a separate thread

```
> periodic test 5
> test
test
test
test
test
```


### Issues/PRs references

requires #19002 to work on `native`
