### PR TITLE
boards/arduino-mega2560: add TTY_BOARD_FILTER

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -3,4 +3,34 @@ BAUD        ?= 9600
 
 ARDUINO_MEGA2560_BOOTLOADER ?= stk500v2
 
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select boards that identify as Arduino Mega 2560 or
+# ad Arduino Mega ADK (a special official Mega flavor that is compatible)
+TTY_BOARD_FILTER := --vendor 'Arduino' --model-db 'Mega 2560|Mega ADK'
+
+# Same, but for clones using a cheap USB <--> UART chip rather than the
+# ATmega16U2
+TTY_BOARD_FILTER_CLONE := --driver 'cp210x|ch341'
+
+# If set to 1, auto-detection of TTYs will also allow clones. This has a slight
+# disadvantage for users of genuine Arduino Mega 2560: If the board is not
+# plugged in, it will fall back to a detection that may yield false positives.
+# However, most people will plug in their boards correctly prior to typing
+# `make term`, so this is only a small loss for users of genuine
+# Arduino Mega 2560 but a big win for users of cheap clones. Still, users that
+# only will ever use genuine Arduino Mega 2560 boards can disable this via their
+# .profile or .bashrc if they want.
+ARDUINO_MEGA2560_COMPAT_WITH_CLONES ?= 1
+
+ifeq (1,$(ARDUINO_MEGA2560_COMPAT_WITH_CLONES))
+  TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
+                    --most-recent \
+                    --format path \
+                    $(TTY_BOARD_FILTER) || \
+                    $(RIOTTOOLS)/usb-serial/ttys.py \
+                    --most-recent \
+                    --format path \
+                    $(TTY_BOARD_FILTER_CLONE)
+endif
+
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/dist/tools/usb-serial/ttys.py
+++ b/dist/tools/usb-serial/ttys.py
@@ -176,7 +176,7 @@ def generate_filters(args):
     Generate filters for use in the filters_match function from the command
     line arguments
     """
-    result = list()
+    result = []
     if args.serial is not None:
         result.append(("serial", re.compile(r"^" + re.escape(args.serial)
                        + r"$")))
@@ -224,6 +224,9 @@ def print_ttys(args):
             ttys = [most_recent]
         else:
             ttys = []
+
+    if len(ttys) == 0:
+        sys.exit(1)
 
     print_results(args, ttys)
 

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -3,8 +3,11 @@ ifeq (1,$(MOST_RECENT_PORT))
   ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
     TTY_BOARD_FILTER ?= --model $(BOARD) --vendor 'RIOT-os\.org'
   endif
-  TTYS_FLAGS := --most-recent --format path $(TTY_BOARD_FILTER)
-  PORT_DETECTED := $(shell $(RIOTTOOLS)/usb-serial/ttys.py $(TTYS_FLAGS))
+  TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
+                    --most-recent \
+                    --format path \
+                    $(TTY_BOARD_FILTER)
+  PORT_DETECTED := $(shell $(TTY_SELECT_CMD) || echo 'no-tty-detected')
   PORT ?= $(PORT_DETECTED)
 endif
 # Otherwise, use as default the most commonly used ports on Linux and OSX


### PR DESCRIPTION
### Contribution description

This allows automatically selecting TTY actually belonging to an
Arduino Mega2560 if `MOST_RECENT_PORT=1` is set.

### Testing procedure

```
make BOARD=arduino-mega2560 MOST_RECENT_PORT=1 -C examples/default flash term
```

Should automatically select the TTY of the most recently connected Arduino Mega2560, even if a board of a different type is connect more recently.

### Issues/PRs references

- [x] depends on (and includes) https://github.com/RIOT-OS/RIOT/pull/19011