### PR TITLE
boards/qn9080dk: add TTY_BOARD_FILTER

### DIFF
--- a/boards/qn9080dk/Makefile.include
+++ b/boards/qn9080dk/Makefile.include
@@ -6,5 +6,9 @@ CFLAGS += \
 
 OPENOCD_DEBUG_ADAPTER ?= dap
 
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of embedded NXP debuggers.
+TTY_BOARD_FILTER := --vendor NXP --model LPC-LINK2
+
 # Include default QN908x board config
 include $(RIOTBOARD)/common/qn908x/Makefile.include


### PR DESCRIPTION
### Contribution description

With `MOST_RECENT_PORT=1` the TTY interface of the most recently connected board with an embedded NXP debugger is selected. If only a single board with an embedded NXP debugger is selected, this will automatically connect to the correct board using:

```
make term MOST_RECENT_PORT=1
```

### Testing procedure

Run `make term MOST_RECENT_PORT=1` with a qn9080dk board and some non-NXP boards attached. It should reliably select the qn9080dk regardless of TTY names and order they were connected.

### Issues/PRs references

None