### PR TITLE
sys/uri_parser: fixing potential out of bounds read when consuming ports

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1006,4 +1006,8 @@ ifneq (,$(filter auto_init%,$(USEMODULE)))
   USEMODULE += preprocessor_successor
 endif
 
+ifneq (,$(filter uri_parser,$(USEMODULE)))
+  USEMODULE += fmt
+endif
+
 include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/uri_parser/Kconfig
+++ b/sys/uri_parser/Kconfig
@@ -7,4 +7,5 @@
 
 config MODULE_URI_PARSER
     bool "URI parser"
+    select MODULE_FMT
     depends on TEST_KCONFIG

--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -21,6 +21,8 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "fmt.h"
+
 #include "uri_parser.h"
 
 #define MAX_PORT_STR_LEN    (5)
@@ -129,15 +131,8 @@ bool _consume_port(uri_parser_result_t *result, const char *ipv6_end,
             }
         }
 
-        /* Verify that the next character, after the port, is an invalid
-         * character for the atol function. Preventing it from reading out-
-         * side of the port section */
-        if ((authority_end[0] >= '0') && (authority_end[0] <= '9')) {
-            return false;
-        }
-
         /* Verify that the port is smaller or equal to UINT16_MAX. */
-        uint32_t port = atol(port_begin);
+        uint32_t port = scn_u32_dec(port_begin, port_str_len);
         if (port > UINT16_MAX) {
             return false;
         }


### PR DESCRIPTION
### Contribution description
The uri_parser has a bug where exactly one byte is read past the end of the buffer.
There are no security implications.

This PR switches the way a port as uint16 is parsed from a given string / buffer. 
The fmt module's `scn_u32_dec(buffer, len)` is now used instead of manual length check + `atoi(buffer)`

### Testing procedure

The Unit tests still run fine. How ever, the newly added dependency of fmt required changes to the modules Kconfig file as well as `sys/Makefile.dep`. I was unsure how to test them beside "it builds".

### Issues/PRs references

See #18702 

