### PR TITLE
dist/tools/usb-serial: fix exception on missing entries [backport 2022.10]

### DIFF
--- a/dist/tools/usb-serial/ttys.py
+++ b/dist/tools/usb-serial/ttys.py
@@ -47,6 +47,9 @@ def filters_match(filters, tty):
     """
 
     for key, regex in filters:
+        if tty[key] is None:
+            return False
+
         if not regex.match(tty[key]):
             return False
 


### PR DESCRIPTION
# Backport of #19011

### Contribution description

For some TTY interfaces no DB entry exists, which is reflected by having a `None` in `tty[key]`. Trying to match a regex against `None` in turn resulted then in an exception.

This fixes the issue by treating a filter applied on a non-existing entry as not matching.

### Testing procedure

With the following TTYs attached:

```
$ ./dist/tools/usb-serial/ttys.py
```

path         | driver  | vendor                   | model                      | model_db               | serial               | ctime    | iface_num
-------------|---------|--------------------------|----------------------------|------------------------|----------------------|----------|----------
/dev/ttyACM1 | cdc_acm | Arduino (www.arduino.cc) | 0042                       | Mega 2560 R3 (CDC ACM) | 857353134333519002C1 | 10:43:21 | 0        
/dev/ttyACM2 | cdc_acm | NXP Semiconductors       | LPC-LINK2 CMSIS-DAP V5.173 | None                   | NRA1AQCQ             | 10:43:31 | 1        
/dev/ttyACM0 | cdc_acm | Valve Software           | Steam Deck Controller      | None                   | MEDA20927049         | 10:28:36 | 3

In `master`

```
$ ./dist/tools/usb-serial/ttys.py --vendor 'Arduino' --model-db 'Mega 2560'
Traceback (most recent call last):
  File "/home/maribu/Repos/software/RIOT/examples/default/../../dist/tools/usb-serial/ttys.py", line 229, in <module>
    print_ttys(sys.argv)
  File "/home/maribu/Repos/software/RIOT/examples/default/../../dist/tools/usb-serial/ttys.py", line 212, in print_ttys
    if tty["serial"] not in args.exclude_serial and filters_match(filters, tty):
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maribu/Repos/software/RIOT/examples/default/../../dist/tools/usb-serial/ttys.py", line 50, in filters_match
    if not regex.match(tty[key]):
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```

With this PR:

```
$ ./dist/tools/usb-serial/ttys.py --vendor 'Arduino' --model-db 'Mega 2560'
```
path         | driver  | vendor                   | model | model_db               | serial               | ctime    | iface_num
-------------|---------|--------------------------|-------|------------------------|----------------------|----------|----------
/dev/ttyACM1 | cdc_acm | Arduino (www.arduino.cc) | 0042  | Mega 2560 R3 (CDC ACM) | 857353134333519002C1 | 10:43:21 | 0        

### Issues/PRs references

None