### PR TITLE
pkg/tinyusb: fix Kconfig problems

### DIFF
--- a/boards/arduino-zero/Kconfig
+++ b/boards/arduino-zero/Kconfig
@@ -11,6 +11,7 @@ config BOARD
 config BOARD_ARDUINO_ZERO
     bool
     default y
+    select HAS_TINYUSB_DEVICE
     select BOARD_COMMON_ARDUINO_ZERO
 
 source "$(RIOTBOARD)/common/arduino-zero/Kconfig"

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -1,1 +1,3 @@
 include $(RIOTBOARD)/common/arduino-zero/Makefile.features
+
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/common/arduino-zero/Kconfig
+++ b/boards/common/arduino-zero/Kconfig
@@ -18,7 +18,6 @@ config BOARD_COMMON_ARDUINO_ZERO
     select HAS_PERIPH_USBDEV
     select HAS_ARDUINO
     select HAS_ARDUINO_PWM
-    select HAS_TINYUSB_DEVICE
 
     select HAVE_SAUL_GPIO
 

--- a/boards/common/arduino-zero/Makefile.features
+++ b/boards/common/arduino-zero/Makefile.features
@@ -15,4 +15,3 @@ FEATURES_PROVIDED += periph_usbdev
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += arduino_pwm
-FEATURES_PROVIDED += tinyusb_device

--- a/boards/stm32f429i-disc1/Kconfig
+++ b/boards/stm32f429i-disc1/Kconfig
@@ -23,7 +23,7 @@ config BOARD_STM32F429I_DISC1
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
-    select HAS_TINYUSB_DEVICE
+    select HAS_TINYUSB_DEVICE if !BOARD_STM32F429I_DISCO
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -11,4 +11,7 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
-FEATURES_PROVIDED += tinyusb_device
+
+ifneq (,$(filter stm32f429i-disc1,$(BOARD)))
+  FEATURES_PROVIDED += tinyusb_device
+endif


### PR DESCRIPTION
### Contribution description

This PR tries to fix the [problems with `tinyUSB` in nightlies](https://ci.riot-os.org/details/d11b383ba0cd45048ed6f8d98abbc0de).
- The `tinyusb_device` feature had to be moved from `boards/common/arduino-zero` definition to the `boards/arduino-zero` definition because the common `arduino-zero` features are also used by `wemos-zero` which uses the `highlevel_stdio` feature via the `stdio_cdc_acm` module.
- The `tinyusb_device` feature had to be removed from Kconfig of board `stm32f429i-disco` since it uses the `highlevel_stdio` feature via the `stdio_cdc_acm` module.

### Testing procedure

Green CI

### Issues/PRs references
