### PR TITLE
pkg/paho-mqtt: add support for DNS

### DIFF
--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -17,6 +17,12 @@ QUIET ?= 1
 WIFI_SSID ?= "Your_WiFi_name"
 WIFI_PASS ?= "Your_secure_password"
 
+# Optionally include remoteDNS support. This includes resolution of names at an
+# upstream DNS server and the handling of RDNSS options in Router Advertisements
+# to auto-configure that upstream DNS server.
+# USEMODULE += sock_dns              # include DNS client
+# USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
+
 ifneq (,$(DEFAULT_MQTT_CLIENT_ID))
   CFLAGS += -DDEFAULT_MQTT_CLIENT_ID=\"$(DEFAULT_MQTT_CLIENT_ID)\"
 endif

--- a/examples/paho-mqtt/main.c
+++ b/examples/paho-mqtt/main.c
@@ -166,7 +166,7 @@ static int _cmd_con(int argc, char **argv)
 
     printf("mqtt_example: Connecting to MQTT Broker from %s %d\n",
             remote_ip, port);
-    printf("mqtt_example: Trying to connect to %s , port: %d\n",
+    printf("mqtt_example: Trying to connect to %s, port: %d\n",
             remote_ip, port);
     ret = NetworkConnect(&network, remote_ip, port);
     if (ret < 0) {

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -22,6 +22,7 @@
 #ifdef MODULE_IPV4_ADDR
 #include "net/ipv4/addr.h"
 #endif
+#include "net/dns.h"
 #include "net/sock/tcp.h"
 #include "paho_mqtt.h"
 #include "MQTTClient.h"
@@ -120,6 +121,12 @@ int NetworkConnect(Network *n, char *addr_ip, int port)
 {
     int ret =-1;
     sock_tcp_ep_t remote = SOCK_IPV4_EP_ANY;
+
+    ret = dns_query(addr_ip, &remote.addr, AF_UNSPEC);
+    if (ret > 0) {
+        remote.port = port;
+        remote.family = ret == 4 ? AF_INET : AF_INET6;
+    }
 
     if (IS_USED(MODULE_IPV4_ADDR) && (remote.port == 0) &&
         ipv4_addr_from_str((ipv4_addr_t *)&remote.addr, addr_ip)) {

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -120,18 +120,14 @@ int NetworkConnect(Network *n, char *addr_ip, int port)
 {
     int ret =-1;
     sock_tcp_ep_t remote = SOCK_IPV4_EP_ANY;
-    char _local_ip[IP_MAX_LEN_ADDRESS];
 
-    strncpy(_local_ip, addr_ip, sizeof(_local_ip));
-    if (IS_USED(MODULE_IPV4_ADDR) &&
-        ipv4_addr_from_str((ipv4_addr_t *)&remote.addr, _local_ip)) {
+    if (IS_USED(MODULE_IPV4_ADDR) && (remote.port == 0) &&
+        ipv4_addr_from_str((ipv4_addr_t *)&remote.addr, addr_ip)) {
             remote.port = port;
     }
 
-    /* ipvN_addr_from_str modifies input buffer */
-    strncpy(_local_ip, addr_ip, sizeof(_local_ip));
-    if (IS_USED(MODULE_IPV6_ADDR) && (remote.port == 0)  &&
-        ipv6_addr_from_str((ipv6_addr_t *)&remote.addr, _local_ip)) {
+    if (IS_USED(MODULE_IPV6_ADDR) && (remote.port == 0) &&
+        ipv6_addr_from_str((ipv6_addr_t *)&remote.addr, addr_ip)) {
             remote.port = port;
             remote.family = AF_INET6;
     }

--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -74,6 +74,15 @@ static inline int dns_query(const char *domain_name, void *addr_out, int family)
 {
     int res = -ENOTSUP;
 
+    if (family == AF_UNSPEC) {
+        if (!IS_USED(MODULE_IPV4_ADDR)) {
+            family = AF_INET6;
+        }
+        else if (!IS_USED(MODULE_IPV6_ADDR)) {
+            family = AF_INET;
+        }
+    }
+
     if (res <= 0 && IS_USED(MODULE_GCOAP_DNS)) {
         res = gcoap_dns_query(domain_name, addr_out, family);
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is pretty straightforward, we only need to hook up `dns_query()`.

Since paho supports both IPv4 and IPv6 we use `AF_UNSPEC` in the query.
This can however give us a A record if we only have IPv6 enabled, so translate the request based on what IP address module is enabled in `dns_query()`.
### Testing procedure

connecting by name works

```
> con test.mosquitto.org 1883
mqtt_example: Connecting to MQTT Broker from test.mosquitto.org 1883
mqtt_example: Trying to connect to test.mosquitto.org , port: 1883
user: clientId: password:
mqtt_example: Connection successfully
```

connecting by IP still works

```
> con 2001:41d0:1:925e::1 1883
mqtt_example: Connecting to MQTT Broker from 2001:41d0:1:925e::1 1883
mqtt_example: Trying to connect to 2001:41d0:1:925e::1 , port: 1883
user: clientId: password:
mqtt_example: Connection successfully
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
