### PR TITLE
riscv: Reduce reset trampoline code size by 2 bytes

### DIFF
--- a/cpu/riscv_common/start.S
+++ b/cpu/riscv_common/start.S
@@ -19,8 +19,7 @@ _start:
 .option norelax
     csrc CSR_MSTATUS, MSTATUS_MIE
     lui a0, %hi(_start_real)
-    addi a0, a0, %lo(_start_real)
-    jr a0
+    jalr x0, a0, %lo(_start_real)
 
 _start_real:
     la gp, __global_pointer$


### PR DESCRIPTION
`addi` with 20 bit immediate does not have a compressed representation, so using `jalr` with immediate offset uncompressed is smaller than using `addi`+`c.jr`