### PR TITLE
cpu/stm32/periph_timer: implement timer_set()

### DIFF
--- a/cpu/stm32/include/periph/cpu_timer.h
+++ b/cpu/stm32/include/periph/cpu_timer.h
@@ -35,6 +35,11 @@ extern "C" {
 #define TIMER_CHANNEL_NUMOF (4U)
 
 /**
+ * @brief   The driver provides a relative set function
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
+/**
  * @brief   Define a macro for accessing a timer channel
  */
 #define TIM_CHAN(tim, chan) *(&dev(tim)->CCR1 + chan)


### PR DESCRIPTION
### Contribution description

The fallback implementation of timer_set() in `drivers/periph_common` is known to fail on short relative sets. This adds a robust implementation.

### Testing procedure

Run `tests/periph_timer_short_relative_set` at least a few dozen times (or use https://github.com/RIOT-OS/RIOT/pull/19030 to have a few dozen repetitions of the test case in a single run of the test application). It should now succeed.

### Issues/PRs references

None