### PR TITLE
sys/analog_util/dac_util: fix truncation bug

### DIFF
--- a/sys/analog_util/dac_util.c
+++ b/sys/analog_util/dac_util.c
@@ -24,7 +24,7 @@
 
 uint16_t dac_util_map(int value, int min, int max)
 {
-    return (uint16_t)((value - min) * UINT16_MAX) / (max - min);
+    return (uint16_t)(((value - min) * UINT16_MAX) / (max - min));
 }
 
 uint16_t dac_util_mapf(float value, float min, float max)


### PR DESCRIPTION
### Contribution description

From the commit message:

>  In `dac_util_map(...)` the expression `((value - min) * UINT16_MAX)` was cast to a 16 bit unsigned, then divided by `(max - min)`. This means that anytime `(value - min) != 0` the numerator was truncated prior to being divided and then returned.
> 
>  This patch modifies the expression so that the downcast to 16 bits is performed as the last operation.


### Testing procedure

Should be verifiable by simply analyzing the code.

### Issues/PRs references

none known
