### PR TITLE
cpu/nrf5x_common: implement timer_set()

### DIFF
--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -199,6 +199,11 @@ typedef struct {
     uint8_t irqn;           /**< IRQ number of the timer device */
 } timer_conf_t;
 
+/**
+ * @brief   The nRF5x periph_timer implements timer_set()
+ */
+#define PERIPH_TIMER_PROVIDES_SET   1
+
 #ifndef DOXYGEN
 /**
  * @brief   Override SPI mode values

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -101,6 +101,7 @@ int timer_set_absolute(tim_t tim, int chan, unsigned int value)
     }
 
     ctx[tim].flags |= (1 << chan);
+    ctx[tim].is_periodic &= ~(1 << chan);
     dev(tim)->CC[chan] = value;
 
     /* clear spurious IRQs */

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -117,6 +117,55 @@ int timer_set_absolute(tim_t tim, int chan, unsigned int value)
     return 0;
 }
 
+int timer_set(tim_t tim, int chan, unsigned int timeout)
+{
+    static const uint32_t max_mask[] = {
+        [TIMER_BITMODE_BITMODE_08Bit] = 0x000000ff,
+        [TIMER_BITMODE_BITMODE_16Bit] = 0x0000ffff,
+        [TIMER_BITMODE_BITMODE_24Bit] = 0x00ffffff,
+        [TIMER_BITMODE_BITMODE_32Bit] = 0xffffffff,
+    };
+    /* see if channel is valid */
+    if (chan >= timer_config[tim].channels) {
+        return -1;
+    }
+
+    unsigned value = timer_read(tim) + timeout;
+
+    unsigned irq_state = irq_disable();
+    ctx[tim].flags |= (1 << chan);
+    ctx[tim].is_periodic &= ~(1 << chan);
+    dev(tim)->CC[chan] = value;
+
+    /* clear spurious IRQs */
+    dev(tim)->EVENTS_COMPARE[chan] = 0;
+    (void)dev(tim)->EVENTS_COMPARE[chan];
+
+    /* enable IRQ */
+    dev(tim)->INTENSET = (TIMER_INTENSET_COMPARE0_Msk << chan);
+
+    unsigned expires = value - timer_read(tim);
+    expires &= max_mask[timer_config[tim].bitmode];
+    if (expires > timeout) {
+        /* timer already expired, check if IRQ flag is set */
+        if (!dev(tim)->EVENTS_COMPARE[chan]) {
+            /* timer has expired but IRQ flag is not set. The only way to not
+             * wait *a full period* is now to set a new target to the next tick.
+             * (Setting it to the current timer value will not trigger the IRQ
+             * flag.) We briefly stop the timer to avoid a race, losing one
+             * timer tick in accuracy. But that is better than a timer firing
+             * a whole period too late */
+            dev(tim)->TASKS_STOP = 1;
+            dev(tim)->CC[chan] = timer_read(tim) + 1;
+            dev(tim)->TASKS_START = 1;
+        }
+    }
+
+    irq_restore(irq_state);
+
+    return 0;
+}
+
 int timer_set_periodic(tim_t tim, int chan, unsigned int value, uint8_t flags)
 {
     /* see if channel is valid */


### PR DESCRIPTION
### Contribution description

The fallback implementation of timer_set() in `drivers/periph_common` is known to fail on short relative sets. This adds a robust implementation.

### Testing procedure

Run `tests/periph_timer_short_relative_set` at least a few dozen times (or use https://github.com/RIOT-OS/RIOT/pull/19030 to have a few dozen repetitions of the test case in a single run of the test application). It should now succeed.

### Issues/PRs references

None