### PR TITLE
Ensure C locale when querying the compiler for compile commands

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -27,9 +27,11 @@ def detect_includes_and_version_gcc(compiler):
     :rtype: tuple
     """
     try:
+        process_env = dict(os.environ)
+        process_env["LC_MESSAGES"] = "C"
         with subprocess.Popen([compiler, "-v", "-E", "-"],
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE) as proc:
+                              stderr=subprocess.PIPE, env=process_env) as proc:
             inputdata = b"typedef int dont_be_pedantic;"
             _, stderrdata = proc.communicate(input=inputdata)
     except FileNotFoundError:


### PR DESCRIPTION
### Contribution description

This fixes generating the compile commands with localization enabled GCC and non-English shell locale. The python script uses regexes to extract the required information. These only match on the default English output. GCC supports localized output messages which break the regexes used. Instead of matching any possible localization, this fix forces the C locale for message output on the compiler invocation, thus ensuring the regexes can match.

### Testing procedure

Needed: arm-none-eabi.gcc with localization support and non-English system locale.
Invoke the compile-commands make target (`make compile-commands`).

It should generate the `compile_commands.json` file correctly.

### Issues/PRs references

None found, fix was trivial enough to fix it directly.
