### PR TITLE
CI: update murdock yml [backport 2022.10]

### DIFF
--- a/.murdock.yml
+++ b/.murdock.yml
@@ -1,8 +1,8 @@
 push:
   branches:
     # these two enable potential bors support:
-    - staging
-    - trying
+    - '^staging$'
+    - '^trying$'
 
 pr:
   enable_comments: true

--- a/.murdock.yml
+++ b/.murdock.yml
@@ -15,7 +15,7 @@ pr:
     Please refer to https://ci.riot-os.org for a complete build for now.**
 
 commit:
-  skip_keywords: ["ci_skip", "murdock_skip"]
+  skip_keywords: ["ci_skip", "murdock_skip", "[ci skip]" ]
 
 artifacts:
   - output.txt


### PR DESCRIPTION
# Backport of #19022

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Debugging the weird "trying.tmp" / "staging.tmp" builds in https://github.com/RIOT-OS/RIOT/pull/18910, I think I realize what's happening:

1. PR changes .murdock.yml, changing the .murdock.yml to not built .tmp branches
2. bors pushes master to .tmp (causing a build) -> murdock schedules a build
3. bors merges the PR commits
4. bors pushes the merged branch to .tmp

So, there's a push event that does not yet include the .murdock.yml changes, so the spurious build gets scheduled.

This PR cuts out those .murdock.yml changs commits from #18910, so that one can be built with the configuration in place.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

#18910 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
