### PR TITLE
tools/vagrant: fix Ubuntu version in README

### DIFF
--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -3,7 +3,7 @@
 
 ## About
 This repository includes a [Vagrantfile](https://github.com/RIOT-OS/RIOT/blob/master/Vagrantfile)
-to download and control a pre-configured Linux virtual machine (VM) based on an Ubuntu 16.04 (64-bit) image that contains all necessary toolchains and dependencies to build and flash compatible devices with RIOT.
+to download and control a pre-configured Linux virtual machine (VM) based on an Ubuntu 18.04 (64-bit) image that contains all necessary toolchains and dependencies to build and flash compatible devices with RIOT.
 The advantage of using this VM is to have a reproducible, portable and even disposable environment
 that can be used to develop for RIOT with decreased setup times and without the requirement of
 making changes to the underlying host system.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As [reported on the forum](https://forum.riot-os.org/t/reproducible-developer-setup-for-riot/3830/12), the README is not in sync with the current state of the VM, which is [based on 18.04](https://github.com/RIOT-OS/RIOT/blob/268e931f1c07e30c9ce87c92e3e352376556d424/Vagrantfile#L10).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read and compare the version. The brave could also try the vagrant image and check the ubuntu version using `lsb_release`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://forum.riot-os.org/t/reproducible-developer-setup-for-riot/3830/12

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
