### PR TITLE
gnrc & coap: misc minor changes

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -12275,6 +12275,7 @@ sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_REQUEST_ENTITY_TOO_LAR
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_SERVICE_UNAVAILABLE \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_UNAUTHORIZED \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_UNPROCESSABLE_ENTITY \(macro definition\) of group net_coap is not documented\.
+sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_TOO_MANY_REQUESTS \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_UNSUPPORTED_CONTENT_FORMAT \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_CODE_VALID \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_DEFAULT_LEISURE \(macro definition\) of group net_coap is not documented\.

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -150,6 +150,7 @@ extern "C" {
 #define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4 << 5) | 13)
 #define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4 << 5) | 15)
 #define COAP_CODE_UNPROCESSABLE_ENTITY       ((4 << 5) | 22)
+#define COAP_CODE_TOO_MANY_REQUESTS          ((4 << 5) | 29)
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -593,7 +593,7 @@ static inline int gnrc_netif_ipv6_groups_get(const gnrc_netif_t *netif,
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
 static inline int gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif,
-                                             ipv6_addr_t *group)
+                                             const ipv6_addr_t *group)
 {
     assert(netif != NULL);
     assert(group != NULL);
@@ -615,7 +615,7 @@ static inline int gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif,
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
 static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
-                                              ipv6_addr_t *group)
+                                              const ipv6_addr_t *group)
 {
     assert(netif != NULL);
     assert(group != NULL);

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1069,10 +1069,7 @@ bool coap_has_unprocessed_critical_options(const coap_pkt_t *pkt);
  *
  * @returns     SZX value decoded to bytes
  */
-static inline unsigned coap_szx2size(unsigned szx)
-{
-    return (1 << (szx + 4));
-}
+#define coap_szx2size(szx) (1U << ((szx) + 4))
 
 /**
  * @brief   Helper to encode byte size into next equal or smaller SZX value


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Those are some minor changes that have accumulated in a downstream branch.
They are just some minor quality of life improvements, no logic changes.

 - `gnrc_netif_ipv6_group_XXX()` functions don't modify the parameter, allow them to take a `const` pointer
 - add a definition for CoAP code 5.29
 - turn `coap_szx2size()` into a macro so it can be used to initialize byte arrays.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
