### PR TITLE
sys/bitfield: add atomic variants of write functions

### DIFF
--- a/cpu/arm7_common/include/VIC.h
+++ b/cpu/arm7_common/include/VIC.h
@@ -8,6 +8,8 @@
 #ifndef VIC_H
 #define VIC_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -76,9 +78,6 @@ extern "C" {
 
 #define VECT_ADDR_INDEX 0x100
 #define VECT_CNTL_INDEX 0x200
-
-#include <stdbool.h>
-#include "cpu.h"
 
 bool cpu_install_irq(int IntNumber, void *HandlerAddr, int Priority);
 

--- a/cpu/lm4f120/include/cpu_conf.h
+++ b/cpu/lm4f120/include/cpu_conf.h
@@ -22,8 +22,6 @@
 #define CPU_CONF_H
 
 #include "cpu_conf_common.h"
-#include <stdio.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -320,7 +320,7 @@ int bf_get_unset(uint8_t field[], size_t len);
  * @brief  Get the index of the first set bit in the field
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  *
  * @return      number of the first set bit
  * @return      -1 if no bit is set
@@ -331,7 +331,7 @@ int bf_find_first_set(const uint8_t field[], size_t size);
  * @brief  Get the index of the zero bit in the field
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  *
  * @return      number of the first unset bit
  * @return      -1 if all bits are set
@@ -342,7 +342,7 @@ int bf_find_first_unset(const uint8_t field[], size_t size);
  * @brief  Set all bits in the bitfield to 1
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  */
 void bf_set_all(uint8_t field[], size_t size);
 
@@ -350,7 +350,7 @@ void bf_set_all(uint8_t field[], size_t size);
  * @brief  Atomically set all bits in the bitfield to 1
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  */
 static inline void bf_set_all_atomic(uint8_t field[], size_t size)
 {
@@ -363,7 +363,7 @@ static inline void bf_set_all_atomic(uint8_t field[], size_t size)
  * @brief  Clear all bits in the bitfield to 0
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  */
 static inline void bf_clear_all(uint8_t field[], size_t size)
 {
@@ -374,7 +374,7 @@ static inline void bf_clear_all(uint8_t field[], size_t size)
  * @brief  Atomically clear all bits in the bitfield to 0
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  */
 static inline void bf_clear_all_atomic(uint8_t field[], size_t size)
 {
@@ -387,7 +387,7 @@ static inline void bf_clear_all_atomic(uint8_t field[], size_t size)
  * @brief  Count set bits in the bitfield
  *
  * @param[in]     field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     size  The number of bits in the bitfield
  *
  * @return number of '1' bits in the bitfield
  */

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 #include "irq.h"
 
 #ifdef __cplusplus
@@ -355,6 +356,30 @@ static inline void bf_set_all_atomic(uint8_t field[], size_t size)
 {
     unsigned state = irq_disable();
     bf_set_all(field, size);
+    irq_restore(state);
+}
+
+/**
+ * @brief  Clear all bits in the bitfield to 0
+ *
+ * @param[in]     field The bitfield
+ * @param[in]     size  The size of the bitfield
+ */
+static inline void bf_clear_all(uint8_t field[], size_t size)
+{
+    memset(field, 0, (size + 7) / 8);
+}
+
+/**
+ * @brief  Atomically clear all bits in the bitfield to 0
+ *
+ * @param[in]     field The bitfield
+ * @param[in]     size  The size of the bitfield
+ */
+static inline void bf_clear_all_atomic(uint8_t field[], size_t size)
+{
+    unsigned state = irq_disable();
+    bf_clear_all(field, size);
     irq_restore(state);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds wrapper functions for all the bitfield functions that write to the bitfield, to allow two (or more) threads to set/clear bits on the bitfield.

This uses `irq_disable()` as the critical section that modifies the bitfield is shorter than a `mutex_lock()`.

### Testing procedure

This just adds a 2nd `_atomic()` variant of each function that wraps the original function within `irq_disable()`/`irq_restore()`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
