### PR TITLE
net/ieee802154: make default ack request configurable

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -91,8 +91,10 @@ void at86rf215_reset_and_cfg(at86rf215_t *dev)
     at86rf215_reset(dev);
 
     /* default to requesting ACKs, just like at86rf2xx */
-    const netopt_enable_t enable = NETOPT_ENABLE;
-    netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ, &enable, sizeof(enable));
+    static const netopt_enable_t ack_req =
+            IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;
+    netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
+                          &ack_req, sizeof(ack_req));
 
     /* enable RX start IRQs */
     at86rf215_reg_or(dev, dev->BBC->RG_IRQM, BB_IRQ_RXAM);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -172,9 +172,10 @@ static int _init(netdev_t *netdev)
     at86rf2xx_set_addr_long(dev, (eui64_t *)dev->netdev.long_addr);
     at86rf2xx_set_addr_short(dev, (network_uint16_t *)dev->netdev.short_addr);
     if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
-        static const netopt_enable_t enable = NETOPT_ENABLE;
+        static const netopt_enable_t ack_req =
+            IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;
         netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
-                              &enable, sizeof(enable));
+                              &ack_req, sizeof(ack_req));
     }
 #if IS_USED(MODULE_IEEE802154_SECURITY) && \
     IS_USED(MODULE_AT86RF2XX_AES_SPI)
@@ -370,9 +371,10 @@ static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
             at86rf2xx_set_addr_short(dev, (network_uint16_t *)dev->netdev.short_addr);
 
             if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
-                static const netopt_enable_t enable = NETOPT_ENABLE;
+                static const netopt_enable_t ack_req =
+                    IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;
                 netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
-                                      &enable, sizeof(enable));
+                                      &ack_req, sizeof(ack_req));
             }
             at86rf2xx_reset(dev);
             break;

--- a/drivers/kw41zrf/kw41zrf.c
+++ b/drivers/kw41zrf/kw41zrf.c
@@ -252,9 +252,10 @@ int kw41zrf_reset(kw41zrf_t *dev)
     kw41zrf_set_option(dev, KW41ZRF_OPT_AUTOACK, 1);
     kw41zrf_set_option(dev, KW41ZRF_OPT_CSMA, 1);
 
-    static const netopt_enable_t enable = NETOPT_ENABLE;
+    static const netopt_enable_t ack_req =
+        IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;
     netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
-                          &enable, sizeof(enable));
+                          &ack_req, sizeof(ack_req));
 
     kw41zrf_abort_sequence(dev);
     kw41zrf_set_sequence(dev, dev->idle_seq);

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -356,13 +356,14 @@ static int _init(netdev_t *netdev)
 
     uint16_t chan = submac->channel_num;
     int16_t tx_power = submac->tx_pow;
-    netopt_enable_t enable = NETOPT_ENABLE;
+    static const netopt_enable_t ack_req =
+        IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;
 
     /* Initialise netdev_ieee802154_t struct */
     netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
                           &chan, sizeof(chan));
     netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
-                          &enable, sizeof(enable));
+                          &ack_req, sizeof(ack_req));
 
     netdev_submac->dev.txpower = tx_power;
 

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -321,6 +321,13 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
 #endif
 
 /**
+ * @brief Request ACKs by default
+ */
+#ifndef CONFIG_IEEE802154_DEFAULT_ACK_REQ
+#define CONFIG_IEEE802154_DEFAULT_ACK_REQ          1
+#endif
+
+/**
  * @brief   Initializes an IEEE 802.15.4 MAC frame header in @p buf.
  *
  * @pre Resulting header must fit in memory allocated at @p buf.

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -112,6 +112,10 @@ if KCONFIG_USEMODULE_IEEE802154
         bool "Disable Auto ACK support" if !USEPKG_OPENWSN
         default y if USEPKG_OPENWSN
 
+    config IEEE802154_DEFAULT_ACK_REQ
+        bool "Request ACKs by default"
+        default y
+
 menuconfig KCONFIG_USEMODULE_IEEE802154_SECURITY
     bool "Configure IEEE802.15.4 Security"
     depends on USEMODULE_IEEE802154_SECURITY


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, every IEEE802.15.4 netdev enables `NETOPT_ACK_REQ` by default. For some environments those ACK requests aren't required and can be disabled completely


### Testing procedure

`at86rf2xx`, `at86rf215`, `kw41zrf` and `ieee802154_submac`-based IEEE802.15.4 MACs shall respect this option

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
