### PR TITLE
ieee802154_submac: migrate to ztimer

### DIFF
--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -30,12 +30,11 @@ extern "C" {
 #include "net/netdev/ieee802154.h"
 #include "net/ieee802154/submac.h"
 #include "net/ieee802154/radio.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "od.h"
 #include "event/thread.h"
 #include "event/callback.h"
-#include "xtimer.h"
 
 #define NETDEV_SUBMAC_FLAGS_ACK_TIMEOUT (1 << 0)    /**< Flag for ACK Timeout event */
 #define NETDEV_SUBMAC_FLAGS_TX_DONE     (1 << 1)    /**< Flag for TX Done event */
@@ -49,7 +48,7 @@ extern "C" {
 typedef struct {
     netdev_ieee802154_t dev;            /**< IEEE 802.15.4 netdev descriptor */
     ieee802154_submac_t submac;         /**< IEEE 802.15.4 SubMAC descriptor */
-    xtimer_t ack_timer;                 /**< xtimer descriptor for the ACK timeout timer */
+    ztimer_t ack_timer;                 /**< ztimer descriptor for the ACK timeout timer */
     int isr_flags;                      /**< netdev submac @ref NETDEV_EVENT_ISR flags */
     int8_t retrans;                     /**< number of frame retransmissions of the last TX */
     bool dispatch;                      /**< whether an event should be dispatched or not */

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -141,7 +141,7 @@ void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac, uint16_t us)
                                                              netdev_ieee802154_submac_t,
                                                              submac);
 
-    xtimer_set(&netdev_submac->ack_timer, us);
+    ztimer_set(ZTIMER_USEC, &netdev_submac->ack_timer, us);
 }
 
 void ieee802154_submac_ack_timer_cancel(ieee802154_submac_t *submac)
@@ -150,7 +150,7 @@ void ieee802154_submac_ack_timer_cancel(ieee802154_submac_t *submac)
                                                              netdev_ieee802154_submac_t,
                                                              submac);
 
-    xtimer_remove(&netdev_submac->ack_timer);
+    ztimer_remove(ZTIMER_USEC, &netdev_submac->ack_timer);
     /* Prevent a race condition between the RX_DONE event and the ACK timeout */
     netdev_submac->isr_flags &= ~NETDEV_SUBMAC_FLAGS_ACK_TIMEOUT;
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -188,6 +188,7 @@ ifneq (,$(filter netdev_ieee802154_submac,$(USEMODULE)))
   USEMODULE += netdev_legacy_api
   USEMODULE += ieee802154
   USEMODULE += ieee802154_submac
+  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter uhcpc,$(USEMODULE)))
@@ -231,7 +232,7 @@ ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ieee802154_submac,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer_usec
   USEMODULE += random
 endif
 

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -18,7 +18,7 @@
 #include <string.h>
 #include "net/ieee802154/submac.h"
 #include "net/ieee802154.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "random.h"
 #include "luid.h"
 #include "kernel_defines.h"
@@ -229,7 +229,7 @@ static ieee802154_fsm_state_t _fsm_state_prepare(ieee802154_submac_t *submac,
             uint32_t bp = (random_uint32() & submac->backoff_mask) *
                           CSMA_SENDER_BACKOFF_PERIOD_UNIT_US;
 
-            xtimer_usleep(bp);
+            ztimer_sleep(ZTIMER_USEC, bp);
             /* Prepare for next iteration */
             uint8_t curr_be = (submac->backoff_mask + 1) >> 1;
             if (curr_be < submac->be.max) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Migrate `ieee802154_submac` and `netdev_ieee802154_submac` to `ztimer`.


### Testing procedure

If it compiles, everything should be fine ... `ztimer_xtimer_compat` already did the same thing.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
