### PR TITLE
shell/gnrc_icmpv6_echo: acquire ZTIMER_USEC clock for time measurement

### DIFF
--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -99,8 +99,10 @@ static int _gnrc_icmpv6_ping(int argc, char **argv)
     };
     int res;
 
+    ztimer_acquire(ZTIMER_USEC);
+
     if ((res = _configure(argc, argv, &data)) != 0) {
-        return res;
+        goto ret;
     }
     gnrc_netreg_register(GNRC_NETTYPE_ICMPV6, &data.netreg);
     _pinger(&data);
@@ -143,6 +145,8 @@ finish:
             msg_send(&msg, thread_getpid());
         }
     }
+ret:
+    ztimer_release(ZTIMER_USEC);
     return res;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With the introduction of #17607, applications using `ztimer_now()` have to tell `ztimer` that it mustn't disable underlying clocks.

### Testing procedure

Ping should work. No warnings shall be displayed if `ztimer_ondemand` is active.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
