### PR TITLE
SUBSYSTEMS.md: migrate subsystem list from wiki

### DIFF
--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -1,0 +1,110 @@
+# RIOT Subsystem Maintainers
+
+This file gives an overview about the maintainers of RIOT subsystems. Whenever
+you submit an issue or a Pull Request, please assign one of the maintainers of
+the affected modules as an assignee in the issue tracker. The maintainer takes
+care of either fixing/merging the issue/PR herself or re-assign the issue to a
+qualified developer.
+
+**Note**: A developer might maintain more than one subsystem and an issue might
+affect more than one module.
+
+# CPU
+## ESP32, ESP8266
+
+## MSP430
+
+## ARM7
+
+## ARM Cortex-M
+
+## Atmel AVR (Atmega)
+
+## Native
+
+# Hardware modules
+
+## Network devices
+### IEEE 802.15.4
+
+### BLE
+
+### LoRa
+
+### CC110X
+
+### ESP-NOW
+
+## Peripherals
+
+## Other drivers
+
+# Kernel (core)
+
+# System libraries
+
+## High-level timer API (xtimer, ztimer)
+
+## Power Management
+
+## File Systems
+
+## USB support
+
+## POSIX support
+
+## Scripting languages
+
+## RUST support
+
+## C++ support
+
+## Crypto
+
+# Networking
+
+## Network stacks
+### GNRC
+
+### CCN-Lite
+
+### OpenThread
+
+### LWIP
+
+### OpenWSN
+
+## Physical/Link Layer
+### LoRaWAN
+
+### BLE (nimble)
+
+### IEEE 802.15.4
+
+## Interfaces
+### Sock
+
+### Netif
+
+### Netdev
+
+## 6LowPAN
+
+## Application protocols
+### CoAP
+
+### MQTT
+
+### LWM2M
+
+## Others
+
+### DTLS
+
+### RPL
+
+# Build System
+
+# Documentation
+
+# Testing/CI


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR migrate the [existing list of subsystems](https://github.com/RIOT-OS/RIOT/wiki/Maintainers) to the RIOT repo.
I also updated the list to represent the actual state of the system.

The list is definitely not perfect and may need several iterations. Feel free to add commits on demand.
We should definitely add more descriptions though, at least for the top headings (CPU, Core, etc).

The original entry included boards as well, but IMO it doesn't really make sense, as they are not a subsystem.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read. Make sure that the list makes sense.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discussed during the Virtual Maintainer Assembly
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
