### PR TITLE
makefiles/arch/riscv.inc.mk: Clean up target triple detection

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -7,13 +7,10 @@
 # indicated with "riscv" being used instead of "riscv32/riscv64", but e.g.
 # Ubuntu uses "riscv64-unknown-elf" despite being able to produce both 32 and
 # 64 bit binaries. We'll test all possible combinations from the most correct
-# triple to the least correct triple all that might be able to produce our
-# binaries. Finally, "riscv-none-embed" is also tested for compatibility with
-# an previously popular legacy toolchain.
-# For a CI transition period, it is tested first.
+# and most specific triple to the least correct and least specific triple for
+# the target we want to build.
 
 _TRIPLES_TO_TEST := \
-    riscv-none-embed \
     riscv32-none-elf \
     riscv32-unknown-elf \
     riscv32-elf \
@@ -27,7 +24,7 @@ _TRIPLES_TO_TEST := \
 # Do not test at run time if building with docker: The host may have no
 # RISC-V toolchain installed or a different one
 ifeq (1,$(BUILD_IN_DOCKER))
-  TARGET_ARCH_RISCV := riscv-none-embed
+  TARGET_ARCH_RISCV := riscv64-unknown-elf
 endif
 
 TARGET_ARCH_RISCV ?= \


### PR DESCRIPTION
### Contribution description

`riscv-none-embed` is a technically incorrect target triple that was used in a previously popular legacy toolchain. It is not possible anymore to create a toolchain with that triple from upstream sources and all popular distros have migrated. It should be safe to ditch that now.

### Testing procedure

Since we were basically waiting for the CI to also ditch that legacy toolchain, a green Murdock will be the important part. In addition, it would be nice to check if building RISC-V binaries still works with the toolchain Ubuntu ships.

### Issues/PRs references

None