### PR TITLE
CI: no quickbuild on "bors try"

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -184,8 +184,8 @@ fi
 # configurations.
 if [ -z "${QUICK_BUILD}" ]; then
     export QUICK_BUILD=0
-    if [ "${CI_BUILD_BRANCH}" = "staging" ]; then
-        # always do full build for bors' integration branch
+    if [ "${CI_BUILD_BRANCH}" = "staging" ] || [ "${CI_BUILD_BRANCH}" = "trying" ]; then
+        # always do full build for bors' branches
         true
     elif [ ${FULL_BUILD} -eq 1 ]; then
         # full build if building nightly or full build requested by label


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Make "bors try" behave like "bors merge", don't do a quick build.

### Testing procedure

- [x] regular PR build (should be a quickbuild): [build](https://ci.riot-os.org/details/a3d6db6f70624d5aa08d138ca63a702b)
- [x] "bors try" (should be a full build) [build](https://ci.riot-os.org/details/6a994d3894e44fc2a34bcddd676e4e62/builds/examples:default)
- [x] finally, "bors merge"

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes https://github.com/RIOT-OS/murdock-scripts/issues/45
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
