### PR TITLE
native: Remove code used for __MACH__ target

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -26,7 +26,7 @@
  * check here for more:
  * http://sourceforge.net/p/predef/wiki/OperatingSystems/
  */
-#if (defined(__FreeBSD__) || defined(__MACH__))
+#ifdef __FreeBSD__
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
 #include <ucontext.h>
@@ -136,10 +136,7 @@ extern mode_t (*real_umask)(mode_t cmask);
 extern ssize_t (*real_writev)(int fildes, const struct iovec *iov, int iovcnt);
 extern ssize_t (*real_send)(int sockfd, const void *buf, size_t len, int flags);
 
-#ifdef __MACH__
-#else
 extern int (*real_clock_gettime)(clockid_t clk_id, struct timespec *tp);
-#endif
 
 /**
  * data structures

--- a/cpu/native/include/netdev_tap.h
+++ b/cpu/native/include/netdev_tap.h
@@ -30,11 +30,7 @@ extern "C" {
 
 #include "net/ethernet/hdr.h"
 
-#ifdef __MACH__
-#include "net/if_var.h"
-#else
 #include "net/if.h"
-#endif
 
 /**
  * @brief tap interface state

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -345,15 +345,7 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     /* disable interrupts in context */
     isr_set_sigmask((ucontext_t *)context);
     _native_in_isr = 1;
-    /*
-     * For register access on new platforms see:
-     * http://google-glog.googlecode.com/svn/trunk/m4/pc_from_ucontext.m4
-     * (URL added on Fri Aug 29 17:17:45 CEST 2014)
-     */
-#ifdef __MACH__
-    _native_saved_eip = ((ucontext_t *)context)->uc_mcontext->__ss.__eip;
-    ((ucontext_t *)context)->uc_mcontext->__ss.__eip = (unsigned int)&_native_sig_leave_tramp;
-#elif defined(__FreeBSD__)
+#if defined(__FreeBSD__)
     _native_saved_eip = ((struct sigcontext *)context)->sc_eip;
     ((struct sigcontext *)context)->sc_eip = (unsigned int)&_native_sig_leave_tramp;
 #else /* Linux */

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -69,10 +69,7 @@ char __end_stack[SIGSTKSZ];
  */
 static void _native_mod_ctx_leave_sigh(ucontext_t *ctx)
 {
-#ifdef __MACH__
-    _native_saved_eip = ((ucontext_t *)ctx)->uc_mcontext->__ss.__eip;
-    ((ucontext_t *)ctx)->uc_mcontext->__ss.__eip = (unsigned int)&_native_sig_leave_handler;
-#elif defined(__FreeBSD__)
+#if defined(__FreeBSD__)
     _native_saved_eip = ((struct sigcontext *)ctx)->sc_eip;
     ((struct sigcontext *)ctx)->sc_eip = (unsigned int)&_native_sig_leave_handler;
 #else /* Linux */

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -32,12 +32,7 @@
 /* needs to be included before native's declarations of ntohl etc. */
 #include "byteorder.h"
 
-#ifdef __MACH__
-#include <net/if.h>
-#include <sys/types.h>
-#include <ifaddrs.h>
-#include <net/if_dl.h>
-#elif defined(__FreeBSD__)
+#ifdef __FreeBSD__
 #include <sys/socket.h>
 #include <net/if.h>
 #include <ifaddrs.h>

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -203,21 +203,11 @@ unsigned int timer_read(tim_t dev)
     DEBUG("timer_read()\n");
 
     _native_syscall_enter();
-#ifdef __MACH__
-    clock_serv_t cclock;
-    mach_timespec_t mts;
-    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-    clock_get_time(cclock, &mts);
-    mach_port_deallocate(mach_task_self(), cclock);
-    t.tv_sec = mts.tv_sec;
-    t.tv_nsec = mts.tv_nsec;
-#else
 
     if (real_clock_gettime(CLOCK_MONOTONIC, &t) == -1) {
         err(EXIT_FAILURE, "timer_read: clock_gettime");
     }
 
-#endif
     _native_syscall_leave();
 
     return ts2ticks(&t) - time_null;

--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -9,33 +9,7 @@
 
 .text
 
-#ifdef __MACH__
-.globl __native_sig_leave_tramp
-__native_sig_leave_tramp:
-    pushl __native_saved_eip
-    pushfl
-    pushal
-
-    pushl __native_isr_ctx
-    pushl __native_cur_ctx
-    call _swapcontext
-    addl $8, %esp
-
-    call _irq_enable
-
-    movl $0x0, __native_in_isr
-    popal
-    popfl
-
-    ret
-
-.globl __native_sig_leave_handler
-__native_sig_leave_handler:
-    pushl __native_saved_eip
-    movl $0x0, __native_in_isr
-    ret
-
-#elif __arm__
+#ifdef __arm__
 
 .globl _native_sig_leave_tramp
 _native_sig_leave_tramp:


### PR DESCRIPTION
### Contribution description

This PR removes code that was used to support macOS as native target. 
macOS / `__MACH__` is no longer supported by RIOT on master.

### Testing procedure

If murdock is happy, that should be enough.
