### PR TITLE
.murdock: extend quickbuild boards list

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -5,7 +5,21 @@
 # and / or
 #export APPS="examples/hello-world tests/unittests"
 
-QUICKBUILD_BOARDS="nrf52840dk samr21-xpro esp32-wroom-32 native"
+QUICKBUILD_BOARDS="
+adafruit-itsybitsy-m4
+atmega256rfr2-xpro
+esp32-wroom-32
+esp32s3-devkit
+frdm-k64f
+hifive1b
+msb-430
+msba2
+native
+nrf52840dk
+qn9080dk
+samr21-xpro
+stk3200
+stm32f429i-disc1"
 
 # this configures boards that are available via pifleet
 case "${CI_MURDOCK_PROJECT}" in


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR extends the list of boards used for per PR quickbuilds. In master only 4 are used and they only cover ARM, native and esp32. The list is extended with
- another ARM based board from STM32 because STM32 represent a large part of boards supported by RIOT
- one RISCV with hifive1b
- one AVR with atmega256rfr2-xpro
- one esp32s3 with esp32s3-devkit

Also the list of boards is sorted with one board per line to ease reviews/updates of this variable.

Normally this should almost double the build time of quick builds (which is in the worst case ~5 minutes at the moment).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green Murdock but takes twice the time for quick builds

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
