### PR TITLE
examples/gnrc_border_router: Restore UHCP conditional default

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -43,7 +43,7 @@ USEMODULE += ps
 #USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 # When using a regular network uplink we should use DHCPv6
-ifneq (,$(filter cdc-ecm wifi ethernet,$(UPLINK)) $(REUSE_TAP))
+ifneq (,$(filter cdc-ecm wifi ethernet,$(UPLINK))$(REUSE_TAP))
   PREFIX_CONF ?= dhcpv6
 else
   PREFIX_CONF ?= uhcp


### PR DESCRIPTION
The space inside the expression made the ifneq always non-equal; the intended behavior is "if we're using any of these interfaces, or REUSE_TAP is set".