### PR TITLE
drivers/ds3231 fix docs, alarms are supported

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -7266,7 +7266,6 @@ drivers/ds18/include/ds18_params\.h:[0-9]+: warning: Member DS18_PARAMS_DEFAULT 
 drivers/ds18/include/ds18_params\.h:[0-9]+: warning: Member DS18_PARAM_PULL \(macro definition\) of file ds18_params\.h is not documented\.
 drivers/ds3231/include/ds3231_params\.h:[0-9]+: warning: Member DS3231_PARAMS \(macro definition\) of file ds3231_params\.h is not documented\.
 drivers/ds3231/include/ds3231_params\.h:[0-9]+: warning: Member DS3231_PARAM_I2C \(macro definition\) of file ds3231_params\.h is not documented\.
-drivers/ds3231/include/ds3231_params\.h:[0-9]+: warning: Member DS3231_PARAM_INT_PIN \(macro definition\) of file ds3231_params\.h is not documented\.
 drivers/ds3231/include/ds3231_params\.h:[0-9]+: warning: Member DS3231_PARAM_OPT \(macro definition\) of file ds3231_params\.h is not documented\.
 drivers/ds3234/include/ds3234_params\.h:[0-9]+: warning: Member DS3234_PARAMS \(macro definition\) of file ds3234_params\.h is not documented\.
 drivers/ds3234/include/ds3234_params\.h:[0-9]+: warning: Member DS3234_PARAM_CLK \(macro definition\) of file ds3234_params\.h is not documented\.

--- a/drivers/ds3231/include/ds3231_params.h
+++ b/drivers/ds3231/include/ds3231_params.h
@@ -33,7 +33,7 @@ extern "C" {
 #define DS3231_PARAM_OPT        (DS3231_OPT_BAT_ENABLE)
 #endif
 #ifndef DS3231_PARAM_INT_PIN
-#define DS3231_PARAM_INT_PIN    (GPIO_UNDEF)
+#define DS3231_PARAM_INT_PIN    (GPIO_UNDEF)    /**< Interrupt pin */
 #endif
 
 #ifndef DS3231_PARAMS

--- a/drivers/include/ds3231.h
+++ b/drivers/include/ds3231.h
@@ -19,7 +19,7 @@
  * registers as well as reading the temperature register and configuring the
  * aging offset.
  *
- * Setting alarms and configuring the square wave output is not yet supported.
+ * Configuring the square wave output is not yet supported.
  *
  * @{
  * @file


### PR DESCRIPTION
### Contribution description

Two changes:

- Remove the text stating that setting alarms is not yet supported, because it is, since PR #16180
- Document DS3231_PARAM_INT_PIN

### Testing procedure

This is only a documentation fix, so there is not code to test.

### Issues/PRs references

Support for setting alarms was implemented in PR #16180
