### PR TITLE
sys/stdio_udp: add stdio over UDP

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -7,6 +7,21 @@
  */
 
 /**
+ * @defgroup     stdio_usb_serial_jtag  STDIO over ESP32 Debug Serial/JTAG
+ * @ingroup      sys_stdio
+ * @brief        STDIO via the USB Serial/JTAG debug interface found on some ESP32 SoCs
+ *
+ * Some members of the ESP32 family (ESP32-C3, ESP32-S3, ESP32-H2) provide a on-chip
+ * debug interface that provides a serial console and JTAG via USB.
+ *
+ * To route STDIO to this debug console, enable this module.
+ *
+ *     USEMODULE += stdio_usb_serial_jtag
+ *
+ * @see          cpu_esp32
+ */
+
+/**
 @defgroup   cpu_esp32 ESP32 SoC Series
 @ingroup    cpu
 @brief      Implementation for Espressif ESP32 SoC Series

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -11,6 +11,17 @@
  */
 
 /**
+ * @defgroup    cpu_native_stdio    STDIO for native
+ * @ingroup     sys_stdio
+ * @brief       Standard input/output backend for native
+ *
+ * This will hook up RIOT's stdio to the host's stdio fds. It is the default
+ * stdio implementation of the board `native`.
+ *
+ * @see         cpu_native
+ */
+
+/**
  * @ingroup    cpu_native
  * @{
  * @author  Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -7,6 +7,21 @@
  */
 
 /**
+ * @defgroup    drivers_ethos_stdio   STDIO via ethos
+ * @ingroup     sys_stdio
+ * @brief       Standard input/output backend multiplexed via ethernet-over-serial
+ *
+ * This will multiplex STDIO via ethos.
+ * The shell can be accessed via the `ethos` tool.
+ *
+ * To enable this stdio implementation, select
+ *
+ *     USEMODULE += stdio_ethos
+ *
+ * @see         drivers_ethos
+ */
+
+/**
  * @defgroup    drivers_ethos Ethernet-over-serial driver
  * @ingroup     drivers_netdev
  * @brief       Driver for the ethernet-over-serial module

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -7,6 +7,21 @@
  */
 
 /**
+ * @defgroup    drivers_slipdev_stdio   STDIO via SLIP
+ * @ingroup     sys_stdio
+ * @brief       Standard input/output backend multiplexed via SLIP
+ *
+ * This will multiplex STDIO via the Serial Line Internet Protocol.
+ * The shell can be accessed via the `sliptty` tool.
+ *
+ * To enable this stdio implementation, select
+ *
+ *     USEMODULE += slipdev_stdio
+ *
+ * @see         drivers_slipdev
+ */
+
+/**
  * @defgroup    drivers_slipdev SLIP network device
  * @ingroup     drivers_netdev
  * @brief       SLIP network device over @ref drivers_periph_uart

--- a/makefiles/dependency_resolution.inc.mk
+++ b/makefiles/dependency_resolution.inc.mk
@@ -80,4 +80,17 @@ else
                             "don't run this on public networks!$(COLOR_RESET)" 1>&2)
     endif
   endif
+
+  # Warn about STDIO UDP
+  ifneq (,$(filter stdio_udp,$(USEMODULE)))
+    ifneq (1,$(I_UNDERSTAND_THAT_STDIO_UDP_IS_INSECURE))
+      $(shell $(COLOR_ECHO) "$(COLOR_RED)stdio via UDP will be started automatically,"\
+                            "make sure you understand why this almost certainly"\
+                            "is a REALLY BAD idea before proceeding!$(COLOR_RESET)" 1>&2)
+      $(error I_UNDERSTAND_THAT_STDIO_UDP_IS_INSECURE must be set to 1 to proceed)
+    else
+      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)stdio via UDP will be started automatically,"\
+                            "don't run this on public networks!$(COLOR_RESET)" 1>&2)
+    endif
+  endif
 endif

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -8,6 +8,7 @@ STDIO_MODULES = \
   stdio_rtt \
   stdio_semihosting \
   stdio_uart \
+  stdio_udp \
   stdio_telnet \
   stdio_tinyusb_cdc_acm \
   stdio_usb_serial_jtag \
@@ -73,6 +74,10 @@ endif
 ifneq (,$(filter stdio_telnet,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_telnet
   USEMODULE += telnet
+endif
+
+ifneq (,$(filter stdio_udp,$(USEMODULE)))
+  USEMODULE += sock_udp
 endif
 
 # enable stdout buffering for modules that benefit from sending out buffers in larger chunks

--- a/pkg/tinyusb/doc.txt
+++ b/pkg/tinyusb/doc.txt
@@ -129,3 +129,14 @@
  * [tinyUSB documentation](https://docs.tinyusb.org/en/latest/reference/getting_started.html)
  * for details.
  */
+
+/**
+ * @defgroup     pkg_tinyusb_stdio_cdc_acm STDIO over USB CDC-ACM (tinyUSB)
+ * @ingroup      sys_stdio
+ * @brief        Standard input/output backend using tinyUSB CDC ACM
+ * @see          pkg_tinyusb
+ *
+ * To enable this, select the `tinyusb_stdio_cdc_acm` module:
+ *
+ *     USEMODULE += stdio_tinyusb_cdc_acm
+ */

--- a/sys/include/net/telnet.h
+++ b/sys/include/net/telnet.h
@@ -7,6 +7,26 @@
  */
 
 /**
+ * @defgroup    net_telnet_stdio    STDIO over telnet
+ * @ingroup     sys_stdio
+ * @brief       Standard input/output via telnet
+ *
+ * This will make RIOT's stdio available over telnet.
+ *
+ * To enable it, add
+ *
+ *     USEMODULE += stdio_telnet
+ *
+ * to your application.
+ * You will also have to set `I_UNDERSTAND_THAT_TELNET_IS_INSECURE = 1` to
+ * acknowledge that you will only use this for debugging in an isolated network.
+ *
+ * You can then use any standard `telnet` client to connect to your node.
+ *
+ * @see         net_telnet
+ */
+
+/**
  * @defgroup    net_telnet basic Telnet server implementation
  * @ingroup     net_ipv6
  * @brief       Telnet server functions

--- a/sys/include/stdio_nimble.h
+++ b/sys/include/stdio_nimble.h
@@ -8,7 +8,11 @@
 
 /**
  * @defgroup     sys_stdio_nimble STDIO over NimBLE
- * @ingroup      sys
+ * @ingroup      sys_stdio
+ *
+ * To enable stdio over nimBLE, add the module `stdio_nimble`:
+ *
+ *     USEMODULE += stdio_nimble
  *
  * @experimental This feature is experimental as some use-cases, such as examples/twr_aloha, show
  *               unexpected behaviour.

--- a/sys/include/stdio_rtt.h
+++ b/sys/include/stdio_rtt.h
@@ -9,9 +9,16 @@
 
 /**
  * @defgroup    sys_stdio_rtt STDIO over SEGGER RTT
- * @ingroup     sys
+ * @ingroup     sys_stdio
  *
  * @brief       STDIO mapping for running the STDIO over SEGGER's RTT interface
+ *
+ * To enable stdio over SEGGER's RTT, enable the module `stdio_rtt`:
+ *
+ *     USEMODULE += stdio_rtt
+ *
+ * @note    Currently, `stdio_rtt` is only supported when OpenOCD or J-Link is
+ *          used as programmer.
  *
  * @{
  * @file

--- a/sys/include/stdio_semihosting.h
+++ b/sys/include/stdio_semihosting.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    sys_stdio_semihosting STDIO over Semihosting
- * @ingroup     sys
+ * @ingroup     sys_stdio
  *
  * @brief       Standard input/output backend using ARM Semihosting
  *

--- a/sys/include/stdio_uart.h
+++ b/sys/include/stdio_uart.h
@@ -9,9 +9,16 @@
 
 /**
  * @defgroup    sys_stdio_uart STDIO over UART
- * @ingroup     sys
+ * @ingroup     sys_stdio
  *
  * @brief       Standard input/output backend using UART
+ *
+ * To enable stdio over UART, enable the `stdio_uart` module:
+ *
+ *     USEMODULE += stdio_uart
+ *
+ * @note    For many board, `stdio_uart` is already the default stdio backend
+ *          and therefore already enabled.
  *
  * ## Input
  *

--- a/sys/include/usb/usbus/cdc/acm.h
+++ b/sys/include/usb/usbus/cdc/acm.h
@@ -7,6 +7,19 @@
  */
 
 /**
+ * @defgroup    usbus_cdc_acm_stdio  STDIO over CDC ACM (usbus)
+ * @ingroup     sys_stdio
+ * @brief       Standard input/output backend using usbus CDC ACM.
+ *
+ * This will provide STDIO via a virtual COM port over USB.
+ * It can be enabled with
+ *
+ *    USEMODULE += stdio_cdc_acm
+ *
+ * @see         usbus_cdc_acm
+ */
+
+/**
  * @defgroup    usbus_cdc_acm USBUS CDC ACM - USBUS CDC abstract control model
  * @ingroup     usb
  * @brief       USBUS CDC ACM interface module

--- a/sys/net/application_layer/telnet/stdio_telnet.c
+++ b/sys/net/application_layer/telnet/stdio_telnet.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     sys
+ * @defgroup    net_telnet_stdio    STDIO via telnet
+ * @ingroup     sys_stdio
  * @{
  *
  * @file

--- a/sys/stdio_null/doc.txt
+++ b/sys/stdio_null/doc.txt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_stdio_null  STDIO null driver
+ * @ingroup     sys_stdio
+ *
+ * @brief       Dummy implementation of the stdio interface.
+ *
+ * This provides a null driver for STDIO that does not depend on anything.
+ * It is a mock implementation that will never output / read anything.
+ *
+ * To enable it use
+ *
+ *     USEMODULE += stdio_null
+ */

--- a/sys/stdio_null/stdio_null.c
+++ b/sys/stdio_null/stdio_null.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     sys
+ * @ingroup     sys_stdio_null
  * @{
  *
  * @file

--- a/sys/stdio_udp/Makefile
+++ b/sys/stdio_udp/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_udp/doc.txt
+++ b/sys/stdio_udp/doc.txt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_stdio_udp   STDIO over UDP
+ * @ingroup     sys_stdio
+ * @brief       STDIO over UDP implementation
+ *
+ * This file implements STDIO via a UDP that can be used with e.g. netcat:
+ *
+ *      nc -u fe80::7837:fcff:fe7d:1aaf%tapbr0 2323
+ *
+ * It can be enabled with
+ *
+ *      USEMODULE += stdio_udp
+ *
+ * and will listen on `CONFIG_STDIO_UDP_PORT` for incoming connections.
+ *
+ * You will also have to set `I_UNDERSTAND_THAT_STDIO_UDP_IS_INSECURE = 1` to
+ * acknowledge that you will only use this for debugging in an isolated network.
+ *
+ * @warning     This is entirely unsecured, only use this for debugging in
+ *              an isolated network!
+ */

--- a/sys/stdio_udp/stdio_udp.c
+++ b/sys/stdio_udp/stdio_udp.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_stdio_udp
+ * @{
+ *
+ * @file
+ * @brief       STDIO over UDP implementation
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <errno.h>
+
+#include "macros/utils.h"
+#include "net/sock/udp.h"
+
+#ifndef CONFIG_STDIO_UDP_PORT
+#define CONFIG_STDIO_UDP_PORT       2323
+#endif
+
+#ifndef CONFIG_STDIO_UDP_RX_BUF_LEN
+#define CONFIG_STDIO_UDP_RX_BUF_LEN 64
+#endif
+
+static sock_udp_t sock;
+static sock_udp_ep_t remote;
+
+void stdio_init(void)
+{
+    const sock_udp_ep_t local = {
+        .family = AF_INET6,
+        .netif = SOCK_ADDR_ANY_NETIF,
+        .port = CONFIG_STDIO_UDP_PORT,
+    };
+
+    sock_udp_create(&sock, &local, NULL, 0);
+}
+
+ssize_t stdio_read(void* buffer, size_t count)
+{
+    static uint8_t rx_buf[CONFIG_STDIO_UDP_RX_BUF_LEN];
+    static uint8_t *pos;
+    static size_t left;
+
+    /* shell will only read one byte at a time, so we buffer the input */
+    if (left == 0) {
+        int res = sock_udp_recv(&sock, rx_buf, sizeof(rx_buf),
+                                SOCK_NO_TIMEOUT, &remote);
+        if (res > 0) {
+            left = res;
+            pos = rx_buf;
+        } else {
+            return res;
+        }
+    }
+
+    count = MIN(left, count);
+    memcpy(buffer, pos, count);
+
+    left -= count;
+    pos  += count;
+
+    return count;
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    if (remote.port == 0) {
+        return -ENOTCONN;
+    }
+    if (len == 0) {
+        return 0;
+    }
+
+    return sock_udp_send(&sock, buffer, len, &remote);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`stdio_telnet` can sometimes be slow and also a bit heavy when TCP is otherwise not used.
When doing remote debugging, a lost packet isn't usually so bad, so we don't need the reliability we get from telnet.

This adds a stdio via UDP module that can be used with `nc` or `socat`:


### Testing procedure

Enable the module in e.g. `gnrc_networking`:

    USEMODULE += stdio_udp

You will not see any output unless you connect to the instance from a 2nd terminal:

```
$ nc -u fe80::7837:fcff:fe7d:1aaf%tapbr0 2323
help
Command              Description
---------------------------------------
ifconfig             Configure network interfaces
nib                  Configure neighbor information base
ping                 Ping via ICMPv6
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
reboot               Reboot the node
rpl                  rpl configuration tool ('rpl help' for more information)
udp                  send data over UDP and listen on UDP ports
version              Prints current RIOT_VERSION
> 
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
