### PR TITLE
core/init: add early_init()

### DIFF
--- a/core/lib/include/kernel_init.h
+++ b/core/lib/include/kernel_init.h
@@ -56,6 +56,15 @@ void kernel_init(void);
  */
 void board_init(void);
 
+/**
+ * @brief   Initialize debug LEDs and stdio
+ */
+#ifdef MODULE_CORE_INIT
+void early_init(void);
+#else
+static inline void early_init(void) {}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "periph/pm.h"
 #include "thread.h"
+#include "stdio_base.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -101,4 +102,15 @@ void kernel_init(void)
     }
 
     cpu_switch_context_exit();
+}
+
+void early_init(void)
+{
+    /* initialize leds */
+    if (IS_USED(MODULE_PERIPH_INIT_LEDS)) {
+        extern void led_init(void);
+        led_init();
+    }
+
+    stdio_init();
 }

--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -31,6 +31,10 @@
 #include "thread.h"
 #include "stdio_base.h"
 
+#if IS_USED(MODULE_VFS)
+#include "vfs.h"
+#endif
+
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -113,4 +117,8 @@ void early_init(void)
     }
 
     stdio_init();
+
+#if MODULE_VFS
+    vfs_bind_stdio();
+#endif
 }

--- a/cpu/avr8_common/avr_libc_extra/avr8_stdio.c
+++ b/cpu/avr8_common/avr_libc_extra/avr8_stdio.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <avr/io.h>
 
+#include "kernel_init.h"
 #include "stdio_uart.h"
 
 static int _uart_putchar(char c, FILE *stream);
@@ -45,7 +46,7 @@ static int _uart_getchar(FILE *stream)
 
 void avr8_stdio_init(void)
 {
-    stdio_init();
+    early_init();
 
     stdout = &_uart_stdout;
     stdin = &_uart_stdin;

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -20,6 +20,7 @@
 #include "stdio_base.h"
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 #include "periph_conf.h"
 
@@ -37,7 +38,7 @@ void cpu_init(void)
     /* initialize the clock system */
     cpu_clock_init();
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/cc26x0_cc13x0/cpu.c
+++ b/cpu/cc26x0_cc13x0/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph_conf.h"
 #include "periph/init.h"
 #include "stdio_base.h"
@@ -46,7 +47,7 @@ void cpu_init(void)
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/cc26x2_cc13x2/cpu.c
+++ b/cpu/cc26x2_cc13x2/cpu.c
@@ -19,6 +19,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph_conf.h"
 #include "periph/init.h"
 #include "stdio_base.h"
@@ -37,7 +38,7 @@ void cpu_init(void)
     setup_trim_device();
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -22,6 +22,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph_conf.h"
 #include "periph/init.h"
 #include "stdio_base.h"
@@ -231,7 +232,7 @@ void cpu_init(void)
     pm_init();
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -149,7 +149,7 @@ static NORETURN void IRAM system_startup_cpu0(void)
 
     /* initialize stdio */
     esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
-    stdio_init();
+    early_init();
 
     RESET_REASON reset_reason = rtc_get_reset_reason(PRO_CPU_NUM);
 

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -106,7 +106,7 @@ void esp_riot_init(void)
 
     /* initialize stdio*/
     extern int stdio_is_initialized;
-    stdio_init();
+    early_init();
     stdio_is_initialized = 1;
 
     /* trigger static peripheral initialization */

--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -19,6 +19,7 @@
 
 #include "clk.h"
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 #include "periph_conf.h"
 
@@ -108,7 +109,7 @@ void cpu_init(void)
     riscv_init();
 
     /* Initialize stdio */
-    stdio_init();
+    early_init();
 
     /* Initialize static peripheral */
     periph_init();

--- a/cpu/gd32v/cpu.c
+++ b/cpu/gd32v/cpu.c
@@ -14,6 +14,7 @@
  *
  * @author          Koen Zandberg <koen@bergzand.net>
  */
+#include "kernel_init.h"
 #include "stdio_uart.h"
 #include "periph/init.h"
 #include "irq_arch.h"
@@ -30,6 +31,6 @@ void cpu_init(void)
     gd32vf103_clock_init();
     /* Common RISC-V initialization */
     riscv_init();
-    stdio_init();
+    early_init();
     periph_init();
 }

--- a/cpu/kinetis/cpu.c
+++ b/cpu/kinetis/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 #include "stdio_base.h"
 #ifdef MODULE_PERIPH_MCG
@@ -44,7 +45,7 @@ void cpu_init(void)
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/lm4f120/cpu.c
+++ b/cpu/lm4f120/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "irq.h"
 #include "sched.h"
 #include "thread.h"
@@ -38,7 +39,7 @@ void cpu_init(void)
     cpu_clock_init(CLOCK_SOURCE);
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/lpc1768/cpu.c
+++ b/cpu/lpc1768/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 #include "stdio_base.h"
 
@@ -29,7 +30,7 @@ void cpu_init(void)
     /* initialize the Cortex-M core */
     cortexm_init();
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/lpc23xx/cpu.c
+++ b/cpu/lpc23xx/cpu.c
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include "cpu.h"
+#include "kernel_init.h"
 #include "irq.h"
 #include "VIC.h"
 
@@ -130,7 +131,7 @@ void cpu_init(void)
     board_init();
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/msp430_common/cpu.c
+++ b/cpu/msp430_common/cpu.c
@@ -9,6 +9,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "irq.h"
 #include "sched.h"
 #include "thread.h"

--- a/cpu/msp430_common/startup.c
+++ b/cpu/msp430_common/startup.c
@@ -51,7 +51,7 @@ __attribute__((constructor)) static void startup(void)
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
     /* trigger static peripheral initialization */
     periph_init();
     /* continue with kernel initialization */

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -466,7 +466,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
 {
     _native_init_syscalls();
     /* initialize stdio as early as possible */
-    stdio_init();
+    early_init();
 
     _native_argv = argv;
     _progname = argv[0];

--- a/cpu/native/stdio_native/stdio_native.c
+++ b/cpu/native/stdio_native/stdio_native.c
@@ -15,15 +15,11 @@
 
 #include "kernel_defines.h"
 #include "native_internal.h"
-#include "vfs.h"
 
 #include "stdio_base.h"
 
 void stdio_init(void)
 {
-    if (IS_USED(MODULE_VFS)) {
-        vfs_bind_stdio();
-    }
 }
 
 ssize_t stdio_read(void* buffer, size_t max_len)

--- a/cpu/nrf51/cpu.c
+++ b/cpu/nrf51/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "nrf_clock.h"
 #include "nrfx_riot.h"
 #include "periph_conf.h"
@@ -36,7 +37,7 @@ void cpu_init(void)
     /* setup the HF clock */
     clock_init_hf();
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -23,6 +23,7 @@
 #define DONT_OVERRIDE_NVIC
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "nrfx_riot.h"
 #include "nrf_clock.h"
 #include "periph_conf.h"
@@ -75,7 +76,7 @@ void cpu_init(void)
     SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/nrf9160/cpu.c
+++ b/cpu/nrf9160/cpu.c
@@ -19,6 +19,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "nrf_clock.h"
 #include "periph_conf.h"
 #include "periph/init.h"
@@ -44,7 +45,7 @@ void cpu_init(void)
     SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/qn908x/cpu.c
+++ b/cpu/qn908x/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 
 #include "stdio_base.h"
@@ -51,7 +52,7 @@ void cpu_init(void)
     cpu_clock_init();
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/rpx0xx/cpu.c
+++ b/cpu/rpx0xx/cpu.c
@@ -19,6 +19,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "macros/units.h"
 #include "periph/init.h"
 #include "periph_cpu.h"
@@ -87,7 +88,7 @@ void cpu_init(void)
     _cpu_reset();
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     DEBUG_PUTS("[rpx0xx] GPOUT0 (GPIO pin 21) is clocked from XOSC (typically 12 MHz)");
 

--- a/cpu/sam3/cpu.c
+++ b/cpu/sam3/cpu.c
@@ -18,6 +18,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph_conf.h"
 #include "periph/init.h"
 #include "stdio_base.h"
@@ -104,7 +105,7 @@ void cpu_init(void)
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -19,6 +19,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph_conf.h"
 #include "periph/init.h"
 #include "stdio_base.h"
@@ -281,7 +282,7 @@ void cpu_init(void)
     dma_init();
 #endif
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "macros/units.h"
 #include "periph_conf.h"
 #include "periph/init.h"
@@ -383,7 +384,7 @@ void cpu_init(void)
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -19,6 +19,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 #include "periph_conf.h"
 #include "board.h"
@@ -183,7 +184,7 @@ void cpu_init(void)
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "periph/init.h"
 #include "periph_conf.h"
 #include "stdio_base.h"
@@ -312,7 +313,7 @@ void cpu_init(void)
     dma_init();
 #endif
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -33,6 +33,7 @@
  */
 
 #include "cpu.h"
+#include "kernel_init.h"
 #include "stdio_base.h"
 #include "stmclk.h"
 #include "periph_cpu.h"
@@ -359,7 +360,7 @@ void cpu_init(void)
     dma_init();
 #endif
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
-    stdio_init();
+    early_init();
 
 #ifdef STM32F1_DISABLE_JTAG
     RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;

--- a/drivers/ethos/stdio.c
+++ b/drivers/ethos/stdio.c
@@ -24,9 +24,6 @@
 #include "ethos.h"
 #include "isrpipe.h"
 #include "stdio_uart.h"
-#if IS_USED(MODULE_VFS)
-#include "vfs.h"
-#endif
 
 extern ethos_t ethos;
 
@@ -41,10 +38,6 @@ static void _isrpipe_write(void *arg, uint8_t data)
 void stdio_init(void)
 {
     uart_init(ETHOS_UART, ETHOS_BAUDRATE, _isrpipe_write, &ethos_stdio_isrpipe);
-
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }
 
 extern unsigned ethos_unstuff_readbyte(uint8_t *buf, uint8_t byte,

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -58,11 +58,6 @@
 void periph_init(void)
 {
 #ifdef MODULE_PERIPH_INIT
-    /* initialize leds */
-    if (IS_USED(MODULE_PERIPH_INIT_LEDS)) {
-        extern void led_init(void);
-        led_init();
-    }
     /* initialize buttonss */
     if (IS_USED(MODULE_PERIPH_INIT_BUTTONS)) {
         extern void button_init(void);

--- a/pkg/tinyusb/cdc_acm_stdio/cdc_acm_stdio.c
+++ b/pkg/tinyusb/cdc_acm_stdio/cdc_acm_stdio.c
@@ -28,18 +28,10 @@
 #include "tusb.h"
 #include "tinyusb.h"
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 static mutex_t data_lock = MUTEX_INIT_LOCKED;
 
 void stdio_init(void)
 {
-    /* Initialize this side of the CDC ACM pipe */
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }
 
 #if IS_USED(MODULE_STDIO_AVAILABLE)

--- a/sys/net/application_layer/telnet/stdio_telnet.c
+++ b/sys/net/application_layer/telnet/stdio_telnet.c
@@ -29,9 +29,6 @@
 #include "stdio_uart.h"
 #include "periph/uart.h"
 #endif
-#if IS_USED(MODULE_VFS)
-#include "vfs.h"
-#endif
 #ifdef CPU_NATIVE
 #include "native_internal.h"
 #endif
@@ -62,10 +59,6 @@ static inline int _write_fallback(const void* buffer, size_t len)
 void stdio_init(void)
 {
     _init_fallback();
-
-#if IS_USED(MODULE_VFS)
-    vfs_bind_stdio();
-#endif
 }
 
 ssize_t stdio_read(void* buffer, size_t count)

--- a/sys/stdio_nimble/stdio_nimble.c
+++ b/sys/stdio_nimble/stdio_nimble.c
@@ -39,10 +39,6 @@
 #include "periph/uart.h"
 #endif /* IS_USED(MODULE_STDIO_NIMBLE_DEBUG) */
 
-#if IS_USED(MODULE_VFS)
-#include "vfs.h"
-#endif
-
 #include "tsrb.h"
 #include "isrpipe.h"
 #include "stdio_nimble.h"
@@ -312,10 +308,6 @@ static int gatt_svr_chr_access_stdin(
 
 void stdio_init(void)
 {
-#if IS_USED(MODULE_VFS)
-    vfs_bind_stdio();
-#endif
-
 #if IS_USED(MODULE_STDIO_NIMBLE_DEBUG)
     uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, NULL, NULL);
 #endif

--- a/sys/stdio_null/stdio_null.c
+++ b/sys/stdio_null/stdio_null.c
@@ -22,18 +22,11 @@
 
 #include "stdio_base.h"
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
 void stdio_init(void)
 {
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }
 
 ssize_t stdio_read(void* buffer, size_t count)

--- a/sys/stdio_rtt/stdio_rtt.c
+++ b/sys/stdio_rtt/stdio_rtt.c
@@ -82,10 +82,6 @@
 #include "thread.h"
 #include "ztimer.h"
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 /* This parameter affects the bandwidth of both input and output. Decreasing
    it will significantly improve bandwidth at the cost of CPU time. */
 #ifndef STDIO_POLL_INTERVAL_MS
@@ -281,10 +277,6 @@ void stdio_init(void) {
     #ifdef STDIO_RTT_ENABLE_BLOCKING_STDOUT
     blocking_stdout = 1;
     #endif
-
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 
     /* the mutex should start locked */
     mutex_lock(&_rx_mutex);

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -27,10 +27,6 @@
 #include "stdio_semihosting.h"
 #include "ztimer.h"
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 /**
  * @brief Rate at which the stdin read polls (breaks) the debugger for input
  * data in milliseconds
@@ -149,9 +145,6 @@ static ssize_t _semihosting_read(uint8_t *buffer, size_t len)
 
 void stdio_init(void)
 {
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }
 
 ssize_t stdio_read(void* buffer, size_t count)

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -36,10 +36,6 @@
 #include "periph/uart.h"
 #include "stdio_uart.h"
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -62,10 +58,6 @@ void stdio_init(void)
     }
 
     uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, cb, arg);
-
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }
 
 #if IS_USED(MODULE_STDIO_AVAILABLE)

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -30,10 +30,6 @@
 #include "usb/usbus.h"
 #include "usb/usbus/cdc/acm.h"
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 static usbus_cdcacm_device_t cdcacm;
 static uint8_t _cdc_tx_buf_mem[CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE];
 static uint8_t _cdc_rx_buf_mem[CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE];
@@ -41,10 +37,6 @@ static isrpipe_t _cdc_stdio_isrpipe = ISRPIPE_INIT(_cdc_rx_buf_mem);
 
 void stdio_init(void)
 {
-    /* Initialize this side of the CDC ACM pipe */
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }
 
 #if IS_USED(MODULE_STDIO_AVAILABLE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently each stdio implementation has to call `vfs_bind_stdio()` and LEDs are initialized *after* stdio.

Fix this by introducing a new `early_init()` function that takes care of initializing debug LEDs and stdio as well as binding it to VFS.


### Testing procedure

stdio should function as before - the call was just moved behind LED init.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
