### PR TITLE
build system: Fix parallel build with clean

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -708,6 +708,11 @@ BUILDDEPS += pkg-prepare
 BUILDDEPS += $(APPDEPS)
 BUILDDEPS += $(MODULE_LIST_DIR)
 
+# Build dependencies depend on clean (if a make goal), as clean may wipe them.
+# Without them depending on clean parallel builds occasionally fail due to
+# clean removing dependencies that make previously considered as up to date.
+$(BUILDDEPS): $(CLEAN)
+
 # Save value to verify it is not modified later
 _BASELIBS_VALUE_BEFORE_USAGE := $(BASELIBS)
 


### PR DESCRIPTION
### Contribution description

It turns out that `make clean all -j 16` previously failed every second time, as a dependency to a generated header (`preprocessor_succesor.h` in this case) is checked and considered to be up to date before running the `clean` target. However, after the `clean` target it is removed.

This fixes:

```
$ BOARD=nrf52840dk make -C examples/emcute_mqttsn clean all --jobs 16
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/emcute_mqttsn'
make: Circular clean <- clean dependency dropped.
Building application "emcute_mqttsn" for "nrf52840dk" with MCU "nrf52".
[...]
cc1: error: /home/maribu/Repos/software/RIOT/examples/emcute_mqttsn/bin/nrf52840dk/preprocessor: No such file or directory [-Werror=missing-include-dirs]
[...]
```

### Testing procedure

Run

```
$ BOARD=nrf52840dk make -C examples/emcute_mqttsn clean all --jobs 16
```

a few times. For me it fails every second time on `master`, but succeeds with this PR every time.

### Issues/PRs references

I was too lazy to open an issue for this :)