### PR TITLE
.github/tools-buildtest: use latest version of riot-action and fix build issue with mosquitto.rsmb

### DIFF
--- a/.github/workflows/tools-buildtest.yml
+++ b/.github/workflows/tools-buildtest.yml
@@ -18,66 +18,66 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Build flatc standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/flatc
     - name: Build mosquitto_rsmb standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/mosquitto_rsmb
     - name: Build bossa-1.8 standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/bossa-1.8
     - name: Build bossa-1.9 standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/bossa-1.9
     - name: Build bossa-nrf52 standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/bossa-nrf52
     - name: Build edbg standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/edbg
     - name: Build setsid standalone
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/setsid
     - name: Build ethos
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/ethos
     - name: Build uhcpd
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/uhcpd
     - name: Build UDP Benchmark
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/benchmark_udp
     - name: Build stm32 clk_conf
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C cpu/stm32/dist/clk_conf
     - name: Build kinetis calc_spi_scalers
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C cpu/kinetis/dist/calc_spi_scalers
     - name: Build fixdep tool
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/fixdep
     - name: Build lpc2k_pgm tool
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/lpc2k_pgm
     - name: Build riotboot_serial tool
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/riotboot_serial
     - name: Build ZEP dispatcher & topology generator
-      uses: aabadie/riot-action@v1
+      uses: aabadie/riot-action@main
       with:
         cmd: make -C dist/tools/zep_dispatch

--- a/dist/tools/mosquitto_rsmb/Makefile
+++ b/dist/tools/mosquitto_rsmb/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME     = mosquitto_rsmb
 PKG_URL      = https://github.com/eclipse/mosquitto.rsmb
-PKG_VERSION  = 9b99a3be9a26635b93aec8fa2ed744e8c49e7262
+PKG_VERSION  = 36fd4ba9433da172f0af580eb6c1a3139b63c355
 PKG_LICENSE  = EPL-1.0
 
 # manually set some RIOT env vars, so this Makefile can be called stand-alone


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR updates the riot-action used to build the tools. This action is based on a Docker image that is still using Ubuntu 18.04. The [action was updated to use 22.04](https://github.com/aabadie/riot-action/commits/main).

Updating the Ubuntu version to 22.04 revealed a build issue with mosquitto.rsmb that is fixed by d0319304ae5ccc9d0547d8cade6505d8e74f538e. The issue was fixed upstream so just a version bump is enough.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green CI, especially the tools-buildtest action.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
