### PR TITLE
makefiles/tests/tests.inc.mk: fix test/available target

### DIFF
--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -28,6 +28,16 @@ test: $(TEST_DEPS)
 	done
 
 test/available:
+ifneq (,$(TEST_ON_CI_WHITELIST))
+  ifeq (,$(filter $(BOARD),$(TEST_ON_CI_WHITELIST)))
+	@echo "Board $(BOARD) not in TEST_ON_CI_WHITELIST"
+	$(Q)false
+  endif
+endif
+ifneq (,$(filter $(BOARD) all,$(TEST_ON_CI_BLACKLIST)))
+	@echo "Board $(BOARD) is in TEST_ON_CI_BLACKLIST"
+	$(Q)false
+endif
 	$(Q)test -n "$(strip $(TESTS))"
 
 # Tests that require root privileges


### PR DESCRIPTION
### Contribution description

`dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` relies on `make test/available` to check if a test if available. However, this so far did not take `TEST_ON_CI_BLACKLIST` and `TEST_ON_CI_WHITELIST` into account, resulting in tests being executed for boards which they are not available. This should fix the issue.

### Testing procedure


#### Expected to fail

```
$ make BOARD=nrf52840dk -C tests/gcoap_fileserver test/available
$ make BOARD=microbit -C tests/log_color test/available
```

(On `master`, they succeed, but fail in this PR.)

#### Expected to succeed

```
$ make BOARD=native -C tests/gcoap_fileserver test/available
$ make BOARD=nrf52840dk -C tests/pkg_edhoc_c test/available
$ make BOARD=nrf52840dk -C tests/log_color test/available
```

(Succeed in both `master` and this PR.)

### Issues/PRs references

None