### PR TITLE
cpu/qn908x/periph_timer: Implement timer_set()

### DIFF
--- a/cpu/qn908x/include/periph_cpu.h
+++ b/cpu/qn908x/include/periph_cpu.h
@@ -335,6 +335,10 @@ typedef uint16_t adc_conf_t;
  */
 #define TIMER_CHANNELS      (4)
 #define TIMER_MAX_VALUE     (0xffffffff)
+/**
+ * @brief   The nRF5x periph_timer implements timer_set()
+ */
+#define PERIPH_TIMER_PROVIDES_SET   1
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This fixes test failures in tests/periph_timer_short_relative_set.

Note: This differs a bit from the implementation in e.g. nRF5x or STM32 in that it always briefly pauses the timer. The issue is that when running the timer can take a few ticks to actually react to the new compare target. So even if the previously written target is still in the future, the timer may not fire anyway. Pausing the timer while setting and setting the target at least one higher than the current count reliably triggers the IRQ.

### Testing procedure

Run `tests/periph_timer_short_relative_set` at least a few dozen times (or use https://github.com/RIOT-OS/RIOT/pull/19030 to have a few dozen repetitions of the test case in a single run of the test application). It should now succeed.

### Issues/PRs references

None