### PR TITLE
boards: add esp32s3-pros3 support

### DIFF
--- a/boards/common/makefiles/stdio_tinyusb_cdc_acm.dep.mk
+++ b/boards/common/makefiles/stdio_tinyusb_cdc_acm.dep.mk
@@ -8,4 +8,9 @@ ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
   endif
 
   FEATURES_REQUIRED += highlevel_stdio
+
+  # Enforce tests to wait a bit for the serial port after reset
+  TERM_DELAY ?= 2
+  TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
+  $(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
 endif

--- a/boards/esp32s3-pros3/Kconfig
+++ b/boards/esp32s3-pros3/Kconfig
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2023 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32s3-pros3" if BOARD_ESP32S3_PROS3
+
+config BOARD_ESP32S3_PROS3
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3
+    select HAS_ARDUINO
+    select HAS_ESP_JTAG
+    select HAS_ESP_SPI_RAM
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_USBDEV
+    select HAS_TINYUSB_DEVICE
+    select MODULE_USB_BOARD_RESET if TEST_KCONFIG && MODULE_STDIO_USB_SERIAL_JTAG
+
+choice STDIO_IMPLEMENTATION
+    bool "STDIO implementation"
+    depends on TEST_KCONFIG
+    default MODULE_STDIO_CDC_ACM if MODULE_USBUS
+    default MODULE_STDIO_TINYUSB_CDC_ACM if MODULE_TINYUSB_DEVICE
+    default MODULE_STDIO_USB_SERIAL_JTAG if !MODULE_USBUS && !MODULE_TINYUSB_DEVICE
+endchoice
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/esp32s3-pros3/Makefile
+++ b/boards/esp32s3-pros3/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32s3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-pros3/Makefile.dep
+++ b/boards/esp32s3-pros3/Makefile.dep
@@ -1,0 +1,14 @@
+ifeq (,$(filter stdio_% slipdev_stdio usbus tinyusb_device,$(USEMODULE)))
+  # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+  # and neither USBUS nor tinyusb_device are used
+  USEMODULE += stdio_usb_serial_jtag
+  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+  # since there should be a CDC ACM interface in any case. This is necessary,
+  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+  # was previously used.
+  USEMODULE += usb_board_reset
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
+endif
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/esp32s3-pros3/Makefile.features
+++ b/boards/esp32s3-pros3/Makefile.features
@@ -1,0 +1,19 @@
+# the board uses a ESP32-S3 with a 16MB QSPI Flash and a 8MB QSPI PSRAM
+CPU_MODEL = esp32s3
+FEATURES_PROVIDED += esp_spi_ram
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features
+
+# peripherals provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_usbdev
+
+# other features provided by the board
+FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += esp_jtag
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/esp32s3-pros3/Makefile.include
+++ b/boards/esp32s3-pros3/Makefile.include
@@ -1,0 +1,8 @@
+# The board uses a ESP32-S3 with a 16MB QSPI Flash and a 8MB QSPI PSRAM
+FLASH_SIZE ?= 16
+
+PORT_LINUX ?= /dev/ttyACM0
+
+OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/esp32s3-pros3/doc.txt
+++ b/boards/esp32s3-pros3/doc.txt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32s3_pros3 ESP32 ProS3 Board
+ * @ingroup     boards_esp32s3
+ * @brief       Support for the ESP32 ProS3 board
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32s3_pros3 ESP32 ProS3
+
+## Table of Contents {#esp32s3_pros3_toc}
+
+1. [Overview](#esp32s3_pros3_overview)
+2. [Hardware](#esp32s3_pros3_hardware)
+    1. [MCU](#esp32s3_pros3_mcu)
+    2. [Board Configuration](#esp32s3_pros3_board_configuration)
+    3. [Board Pinout](#esp32s3_pros3_pinout)
+3. [Flashing the Device](#esp32s3_pros3_flashing)
+4. [Using STDIO](#esp32s3_pros3_stdio)
+
+## Overview {#esp32s3_pros3_overview}
+
+The ESP32 ProS3 is one of the ESP32-S3 boards from Unexpected Maker.
+\image html https://esp32s3.com/images/main_features_pros3.jpg "ESP32 ProS3" width=800px
+
+The main features of the board are:
+
+- ESP32-S3 SoC with 2.4 GHz WiFi 802.11b/g/n and Bluetooth5, BLE
+- 16 MByte Flash
+- 4 MByte SPI RAM
+- RGB LED WS2812B
+- Native USB and USB Serial JTAG
+- LiPo Battery Charging and PicoBlade connector
+- VBAT and 5V Sensing Pins
+- 3D High Gain Antenna
+
+[Back to table of contents](#esp32s3_pros3_toc)
+
+## Hardware {#esp32s3_pros3_hardware}
+
+This section describes
+
+- the [MCU](#esp32s3_pros3_mcu),
+- the default [board configuration](#esp32s3_pros3_board_configuration),
+- the [board pinout](#esp32s3_pros3_pinout).
+
+[Back to table of contents](#esp32s3_pros3_toc)
+
+### MCU {#esp32s3_pros3_mcu}
+
+Most features of the board are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32s3_pros3_toc)
+
+### Board Configuration {#esp32s3_pros3_board_configuration}
+
+ESP32 ProS3 boards have no special hardware on board with the exception
+of a single pin RGB-LED WS2812B that uses a special bit-oriented protocol to
+control the RGB-LED by 24-bit RGB values which is not supported yet.
+
+Most GPIOs are broken out on the board for flexibility. The default board
+configuration provides:
+
+- 10 x ADC channels at maximum
+- 1 x SPI
+- 1 x I2C
+- 1 x UART
+- 2 x PWM, 4 channels each
+- 1 x RGB-LED
+
+For flexibility, some GPIOs are used in different peripheral configurations,
+but they can only be used for one peripheral at a time. For example, GPIO9
+is used in the ADC channel definition and the definition of the SCL signal
+for I2C_DEV(0).
+
+This is possible because GPIOs are only used for a specific peripheral
+interface when either
+
+- the corresponding peripheral module is used, e.g. `periph_i2c`, or
+- the corresponding init function is called, e.g. `adc_init`.
+
+That is, the purpose for which a GPIO is used depends on which module
+or function is used first.
+
+For example, if module `periph_i2c` is not used, the GPIOs listed in I2C
+configuration can be used for the other purposes, that is, GPIO9 can be
+used as ADC channel.
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks | Configuration
+:---------------|:-------|:--------|:----------------------------------
+BTN0            | GPIO0  | labeled as BOOT button | |
+ADC_LINE(n)     | GPIO1, GPIO2, GPIO3, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO9, GPIO10 | | \ref esp32_adc_channels "ADC Channels"
+PWM_DEV(0)      | GPIO12, GPIO13, GPIO14, GPIO15, GPIO16 | - | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1)      | GPIO6, GPIO7, GPIO21, GPIO38 | - | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0) SCL  | GPIO9  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0) SDA  | GPIO8  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0) CLK  | GPIO36 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MISO | GPIO37 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MOSI | GPIO35 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) CS0  | GPIO34 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0) TxD | GPIO43 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0) RxD | GPIO44 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+\n
+
+For detailed information about the peripheral configurations of ESP32-S3
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32s3_pros3_toc)
+
+### Board Pinout {#esp32s3_pros3_pinout}
+
+The following figure shows the pinout as configured by board definition.
+
+@image html https://esp32s3.com/images/pins_pros3.jpg "ESP32 ProS3C-1 Pinout" width=900px
+
+The corresponding board schematic can be found [here]
+(https://github.com/UnexpectedMaker/esp32s3/raw/main/schematics/schematic-pros3.pdf)
+
+[Back to table of contents](#esp32s3_pros3_toc)
+
+## Flashing the Device {#esp32s3_pros3_flashing}
+
+Since the board does not have a USB-to-Serial chip, the easiest way to flash
+the board is using the USB Serial/JTAG interface. Just connect the board to
+your host computer and use the following command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s3-pros3 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+@note Usually the make system resets the board before flashing to enable the
+USB Serial/JTAG interface. In some special cases this reset does not work so
+that the programmer cannot connect to the board and the flashing is aborted
+with a timeout:
+```
+Serial port /dev/ttyACM0
+Connecting...
+...
+serial.serialutil.SerialTimeoutException: Write timeout
+```
+This can happen for example if the board is not yet flashed with RIOT or the
+USB interface is used for another purpose. In this case, restart the board
+manually in download mode by pressing and releasing the RESET button while
+holding down the BOOT button. In download mode, the USB Serial/JTAG interface is
+always available.
+
+Alternatively, an external USB-to-Serial adapter can be used. In this case,
+the USB-to-Serial adapter has to be connected to TxD (GPIO43) and RxD (GPIO44)
+of the UART0 interface. Before RIOT can be flashed, the board has to be
+switched to download mode. To do this, press and release the RESET button
+while holding down the BOOT button. Once the board is in download mode, use
+the following command to flash RIOT:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s3-pros3 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For detailed information about ESP32-S3 as well as configuring and compiling
+RIOT for ESP32-S3 boards, see \ref esp32_riot.
+
+[Back to table of contents](#esp32s3_pros3_toc)
+
+## Using STDIO {#esp32s3_pros3_stdio}
+
+Since the board does not have a USB-to-Serial chip, the USB Serial/JTAG
+interface is used by default for the STDIO (module `stdio_usb_serial_jtag`)
+which provides an USB CDC ACM interface.
+
+If the USB port is used by the USBUS stack or the tinyUSB stack, implicitly
+the module `stdio_cdc_acm` or `stdio_tinyusb_cdc_acm` is used for the STDIO
+via the USB CDC ACM interface.
+
+Alternatively, the UART interface could be used with an external USB-to-Serial
+adapter. Simply add `stdio_uart` to the list of used modules for this purpose:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s3-pros3 USEMODULE=stdio_uart make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ */

--- a/boards/esp32s3-pros3/include/arduino_board.h
+++ b/boards/esp32s3-pros3/include/arduino_board.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_pros3
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is not available
+ */
+#define ARDUINO_LED         (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/esp32s3-pros3/include/arduino_pinmap.h
+++ b/boards/esp32s3-pros3/include/arduino_pinmap.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C)  2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_pros3
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO44      /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO43      /**< Arduino Uno pin 1 (TxD) */
+#define ARDUINO_PIN_2   GPIO0       /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO12      /**< Arduino Uno pin 3 (PWM) */
+#define ARDUINO_PIN_4   GPIO6       /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO13      /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO14      /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO7       /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO16       /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO15      /**< Arduino Uno pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO34      /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO35      /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO37      /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO36      /**< Arduino Uno pin 13 (SCK)  */
+
+#define ARDUINO_PIN_A0  GPIO1       /**< Arduino Uno pin A0 */
+#define ARDUINO_PIN_A1  GPIO2       /**< Arduino Uno pin A1 */
+#define ARDUINO_PIN_A2  GPIO4       /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO5       /**< Arduino Uno pin A3 */
+
+#define ARDUINO_PIN_A4  GPIO8       /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO9       /**< Arduino Uno pin A5 (SCL) */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/esp32s3-pros3/include/board.h
+++ b/boards/esp32s3-pros3/include/board.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_pros3
+ * @brief       Board definitions for ESP32 ProS3 boards
+ * @{
+ *
+ * The board definitions in this file are valid for the ESP32 ProS3 board.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * ESP32 ProS3 boards have a BOOT button connected to GPIO0, which can be
+ * used as button during normal operation. Since the GPIO0 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * The ESP32 ProS3 board has one 24-bit RGB-LED WS2812B connected to GPIO18.
+ * @{
+ */
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    (GPIO18)  /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)      /**< Number of LEDs chained */
+#endif
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32s3-pros3/include/gpio_params.h
+++ b/boards/esp32s3-pros3/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32s3_pros3
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32s3-pros3/include/periph_conf.h
+++ b/boards/esp32s3-pros3/include/periph_conf.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_pros3
+ * @brief       Peripheral configurations for ESP32 ProS3 boards
+ * @{
+ *
+ * The peripheral configurations in this file can be used for Espressif
+ * ESP32 ProS3x board.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-S3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * All pins of ADC1 are declared as ADC channels. Keep in mind that GPIO10 is
+ * not broken out and used as VBAT signal. GPIO3 is a strapping pin if
+ * `EFUSE_STRAP_JTAG_SEL` is set, see \ref esp32_gpio_pins_esp32s3_strapping.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO1, GPIO2, GPIO3, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO9, GPIO10 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * For generic boards, only one I2C interface I2C_DEV(0) is defined.
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO9           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO8           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * Two PWM devices are configured. These devices can use all GPIOs that are not
+ * defined as I2C, SPI or UART for this board. Generally, all outputs pins
+ * could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO12, GPIO13, GPIO14, GPIO15, GPIO16 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM1_GPIOS
+#define PWM1_GPIOS  { GPIO6, GPIO7, GPIO21, GPIO38 }
+#endif
+
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   FSPI    /**< FSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO36  /**< FSPI SCK (pin FSPICLK) */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO37  /**< FSPI MISO (pin FSPIQ) */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO35  /**< FSPI MOSI (pin FSPID) */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO34  /**< FSPI CS0 (pin FSPICS0) */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S3 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/esp32/doc_esp32s3.txt
+++ b/cpu/esp32/doc_esp32s3.txt
@@ -138,6 +138,8 @@ GPIO48 | In/Out | -   | -    | X       | SPICLK_N           | -
 <b>RTC:</b> Pins that are RTC GPIOs and can be used in deep-sleep mode.<br>
 <b>PU/PD:</b> Pins that have software configurable pull-up/pull-down functionality.<br>
 
+### Strapping pins {#esp32_gpio_pins_esp32s3_strapping}
+
 GPIO0, GPIO3, GPIO45 and GPIO46 are bootstrapping. GPIO0 and GPIO46 pins are
 used to boot ESP32-S3 in different modes:
 

--- a/sys/usb_board_reset/Kconfig
+++ b/sys/usb_board_reset/Kconfig
@@ -8,4 +8,5 @@
 config MODULE_USB_BOARD_RESET
     bool "Trigger a board reset via USB CDC ACM"
     depends on TEST_KCONFIG
-    depends on MODULE_USBUS_CDC_ACM || (MODULE_TINYUSB_DEVICE && MODULE_TINYUSB_CLASS_CDC)
+    depends on MODULE_USBUS_CDC_ACM || (MODULE_TINYUSB_DEVICE && MODULE_TINYUSB_CLASS_CDC) \
+                                    || MODULE_STDIO_USB_SERIAL_JTAG


### PR DESCRIPTION
### Contribution description

This PR provides the support for [ESP32 ProS3](https://esp32s3.com/pros3.html#home) board from Unexpected Maker.

This board doesn't have a USB-to-Serial chip on board. Therefore, USB Serial/JTAG is used for STDIO and the board is flashed via the USB Seral/JTAG interface by default.

### Testing procedure

Flashing `tests/shell` should work.

### Issues/PRs references