### PR TITLE
boards/hamilton: Add minimal doc

### DIFF
--- a/boards/hamilton/doc.txt
+++ b/boards/hamilton/doc.txt
@@ -1,0 +1,10 @@
+/**
+@defgroup    boards_hamilton HamiltonIoT Hamilton
+@ingroup     boards
+@brief       Support for the HamiltonIoT Hamilton board.
+
+@image html "https://github.com/immesys/baseliner/raw/fa1f224b0a6eaf101dfeb2abe3127ecc5acd0986/misc/hamilton-sm.jpg" "Image of the Hamilton IoT board next to coin" width=80%
+
+See https://github.com/hamilton-mote/hw for more details on the hardware.
+
+ */

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_hamilton HamiltonIoT Hamilton
- * @ingroup     boards
+ * @ingroup     boards_hamilton
  * @brief       Support for the HamiltonIoT Hamilton board.
  * @{
  *


### PR DESCRIPTION
### Contribution description

The doc of the board is still suboptimal, but at least an image to identify what board this is and a link to further information is a starting point.

### Testing procedure

The static tests will do.

### Issues/PRs references

None.