### PR TITLE
boards/hamilton: Fix TMP00x parameters

### DIFF
--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -110,14 +110,14 @@ extern "C" {
 /** @} */
 
 /**
- * @name TMP006 configuration
- * Note that two other tmp006 operation options, TMP006_USE_LOW_POWER and
- * TMP006_USE_RAW_VALUES, need to be set according to the application purpose
+ * @name TMP00X configuration
+ * Note that two other tmp006 operation options, TMP00X_USE_LOW_POWER and
+ * TMP00X_USE_RAW_VALUES, need to be set according to the application purpose
  * @{
  */
-#define TMP006_PARAM_I2C            I2C_DEV(0)
-#define TMP006_PARAM_ADDR           (0x44)
-#define TMP006_PARAM_RATE           TMP006_CONFIG_CR_AS2
+#define TMP00X_PARAM_I2C            I2C_DEV(0)
+#define TMP00X_PARAM_ADDR           (0x44)
+#define TMP00X_PARAM_RATE           TMP00X_CONFIG_CR_AS2
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

The TMP006 driver has been renamed to TMP00x, as it (now) supports both TMP006 and TMP007 infrared thermopile sensors. However, the board configuration was never updated to match the new names. This fixes the issue.

### Testing procedure

Someone with the board could test if the TMP006 driver now starts to work again. Otherwise, it should be relatively straight forward to "test this by code review" (tm).

### Issues/PRs references

None