### PR TITLE
cpu/esp32c3: fix SDK configuration for USB PHY

### DIFF
--- a/cpu/esp32/include/sdkconfig_esp32c3.h
+++ b/cpu/esp32/include/sdkconfig_esp32c3.h
@@ -95,6 +95,11 @@ extern "C" {
 #define CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND  1
 
 /**
+ * ESP32-C3 specific USB configuration
+ */
+#define CONFIG_ESP_PHY_ENABLE_USB               1
+
+/**
  * ESP32-C3 BLE driver configuration (DO NOT CHANGE)
  */
 #ifdef MODULE_ESP_BLE

--- a/cpu/esp32/include/sdkconfig_esp32s3.h
+++ b/cpu/esp32/include/sdkconfig_esp32s3.h
@@ -109,8 +109,8 @@ extern "C" {
 /**
  * ESP32-S3 specific USB configuration
  */
-#ifdef MODULE_ESP_IDF_USB
 #define CONFIG_ESP_PHY_ENABLE_USB               1
+#ifdef MODULE_ESP_IDF_USB
 #define CONFIG_USB_OTG_SUPPORTED                1
 #endif
 


### PR DESCRIPTION
### Contribution description

This PR provides a fix for the USB Serial/JTAG interface for ESP32C3.

When using USB Serial/JTAG/OTG/CDC, USB should be enabled in `phy_init`, otherwise the USB interface is not working properly. The problem was described https://github.com/espressif/esp-idf/issues/8046 and fixed with https://github.com/espressif/esp-idf/commit/93be7d5192a33df8bc97c5ebc6cb3b06b054a213:
```
#if CONFIG_ESP_PHY_ENABLE_USB
    phy_bbpll_en_usb(true);
#endif
```
However, to work correctly, `CONFIG_ESP_PHY_ENABLE_USB` which was not the case for ESP32-C3.

### Testing procedure

Without this PR the USB Serial/JTAG interface is not working correctly when WiFi is used:
```
CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' USEMODULE=esp_wifi BOARD=esp32c3-devkit make -j8 -C examples/gnrc_networking flash
```
Using OpenOCD then fails:
```
Open On-Chip Debugger  v0.11.0-esp32-20211220 (2021-12-20-15:42)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'jtag'
Info : esp_usb_jtag: VID set to 0x303a and PID to 0x1001
Info : esp_usb_jtag: capabilities descriptor set to 0x2000
Warn : Transport "jtag" was already selected
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Error: libusb_get_string_descriptor_ascii() failed with -9
```
Another effect is that
```
dist/tools/esptools/espreset.py --port /dev/ttyACM0
```
leads to endless warnings in `/var/log/syslog` and the board does not reset:
```
Jan  5 02:03:32 gunny8 kernel: [3466923.746827] xhci_hcd 0000:00:14.0: WARN Cannot submit Set TR Deq Ptr
Jan  5 02:03:32 gunny8 kernel: [3466923.746829] xhci_hcd 0000:00:14.0: A Set TR Deq Ptr command is pending.
```
With this PR, OpenOCD works also with WiFi and the board resets.

### Issues/PRs references
