### PR TITLE
tests/periph_uart: only exclude STDIO_UART_DEV if stdio_uart is used

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -46,6 +46,11 @@
 
 #define POWEROFF_DELAY      (250U * US_PER_MS)      /* quarter of a second */
 
+/* if stdio is not done via UART, allow to use the stdio UART for the test */
+#ifndef MODULE_STDIO_UART
+#undef STDIO_UART_DEV
+#endif
+
 #ifndef STDIO_UART_DEV
 #define STDIO_UART_DEV      (UART_UNDEF)
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a board uses e.g. stdio via CDC ACM or RTT there is no reason to exclude the stdio uart from being used in `tests/periph_uart`.

In fact, the UART that can be used for stdio may well be the only UART that is exposed by the device. 

### Testing procedure

Without this patch

```
2023-01-06 16:10:20,282 # > init 0 9600
2023-01-06 16:10:20,285 # Error: The selected UART_DEV(0) is used for the shell!
```

With this patch

```
2023-01-06 16:18:08,291 # > init 0 9600
2023-01-06 16:18:08,295 # Success: Initialized UART_DEV(0) at BAUD 9600
2023-01-06 16:18:08,549 # UARD_DEV(0): test uart_poweron() and uart_poweroff()  ->  [OK]
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
