### PR TITLE
Documentation: Document PWM and other Peripherals for Weact STM32F4x1Cx boards

### DIFF
--- a/boards/weact-f401cc/doc.txt
+++ b/boards/weact-f401cc/doc.txt
@@ -33,6 +33,19 @@ It is available on sites like AliExpress for less than 3€.
 | Datasheet        | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f401cc.pdf) |
 | Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/9b/53/39/1c/f7/01/4a/79/DM00119316.pdf/files/DM00119316.pdf/jcr:content/translations/en.DM00119316.pdf) |
 
+## Implementation Status
+
+| Device            | ID            | Supported                 | Comments                                                  |
+|:----------------- |:------------- |:------------------------- |:--------------------------------------------------------- |
+| MCU               | STM32F401CC   | partly                    | Energy saving modes not fully utilized                    |
+| Low-level driver  | GPIO          | yes                       |                                                           |
+|                   | PWM           | yes (4 pins available))   |                                                           |
+|                   | UART          | 2 UARTs                   | USART2 via  PA3(RX)/PA2(TX), USART1 on PA10(RX)/PA9(TX)   |
+|                   | I2C           | 1 I2C                     |                                                           |
+|                   | SPI           | 1 SPI                     |                                                           |
+|                   | USB           | yes                       |                                                           |
+|                   | Timer         | 1 32 bit timer (TIM5)     |                                                           |
+
 ## Flashing the device
 The device comes with a bootloader that allows flashing via `dfu-util`.
 

--- a/boards/weact-f401ce/doc.txt
+++ b/boards/weact-f401ce/doc.txt
@@ -33,6 +33,19 @@ It is available on sites like AliExpress for less than 3€.
 | Datasheet        | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f401ce.pdf) |
 | Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/9b/53/39/1c/f7/01/4a/79/DM00119316.pdf/files/DM00119316.pdf/jcr:content/translations/en.DM00119316.pdf) |
 
+## Implementation Status
+
+| Device            | ID            | Supported                 | Comments                                                  |
+|:----------------- |:------------- |:------------------------- |:--------------------------------------------------------- |
+| MCU               | STM32F401CE   | partly                    | Energy saving modes not fully utilized                    |
+| Low-level driver  | GPIO          | yes                       |                                                           |
+|                   | PWM           | yes (4 pins available))   |                                                           |
+|                   | UART          | 2 UARTs                   | USART2 via  PA3(RX)/PA2(TX), USART1 on PA10(RX)/PA9(TX)   |
+|                   | I2C           | 1 I2C                     |                                                           |
+|                   | SPI           | 1 SPI                     |                                                           |
+|                   | USB           | yes                       |                                                           |
+|                   | Timer         | 1 32 bit timer (TIM5)     |                                                           |
+
 ## Flashing the device
 The device comes with a bootloader that allows flashing via `dfu-util`.
 

--- a/boards/weact-f411ce/doc.txt
+++ b/boards/weact-f411ce/doc.txt
@@ -15,7 +15,7 @@ It is available on sites like AliExpress for less than 4€.
 ![WeAct-F411CE](https://user-images.githubusercontent.com/1301112/69389644-eb5fb080-0ccc-11ea-8002-67d3db851250.png)
 
 ### MCU
-| MCU              | STM32F411CE           |
+| MCU              | STM32F411CEU6           |
 |:---------------- |:--------------------- |
 | Family           | ARM Cortex-M4F        |
 | Vendor           | ST Microelectronics   |
@@ -32,6 +32,19 @@ It is available on sites like AliExpress for less than 4€.
 | Vcc              | 2.0V - 3.6V           |
 | Datasheet        | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f411ce.pdf) |
 | Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/9b/53/39/1c/f7/01/4a/79/DM00119316.pdf/files/DM00119316.pdf/jcr:content/translations/en.DM00119316.pdf) |
+
+## Implementation Status
+
+| Device            | ID            | Supported                 | Comments                                                  |
+|:----------------- |:------------- |:------------------------- |:--------------------------------------------------------- |
+| MCU               | STM32F411CE   | partly                    | Energy saving modes not fully utilized                    |
+| Low-level driver  | GPIO          | yes                       |                                                           |
+|                   | PWM           | yes (4 pins available))   |                                                           |
+|                   | UART          | 2 UARTs                   | USART2 via  PA3(RX)/PA2(TX), USART1 on PA10(RX)/PA9(TX)   |
+|                   | I2C           | 1 I2C                     |                                                           |
+|                   | SPI           | 1 SPI                     |                                                           |
+|                   | USB           | yes                       |                                                           |
+|                   | Timer         | 1 32 bit timer (TIM5)     |                                                           |
 
 ## Flashing the device
 The device comes with a bootloader that allows flashing via `dfu-util`.


### PR DESCRIPTION
### Contribution description
The  Weact boards with STM32F4x1Cx MCU's have their PWM outputs enabled. But these currently do not show in the the documentation. This PR updates the documentation for these 3 boards.  

### Testing procedure
I rebuild the documentation with `make doc` and checked the resulting 3 html files. 

### Issues/PRs references
Fixes this issue: https://github.com/jhaand/RIOT/issues/1
Also referred to in this issue: https://github.com/RIOT-OS/RIOT/issues/19103

### Context
Discussed @maribu and @benpicco on matrix [link](https://matrix.to/#/!pqHdpanAvkJvlCwUDE:matrix.org/$lEMfOAG5rGGrkEjfJcsg0nC1Ebj4vlitvH9zm8uP-NM?via=matrix.org&via=rubdos.be&via=schleiser.de)
