### PR TITLE
drivers/ws281x: fix out-of-bounds read on native

### DIFF
--- a/drivers/ws281x/vt100.c
+++ b/drivers/ws281x/vt100.c
@@ -26,10 +26,10 @@ void ws281x_write_buffer(ws281x_t *dev, const void *buf, size_t size)
     (void) dev;
     const uint8_t *src = buf;
 
-    for (unsigned i = 0; i < size; ++i) {
-        int r = src[WS281X_BYTES_PER_DEVICE * i + WS281X_OFFSET_R];
-        int g = src[WS281X_BYTES_PER_DEVICE * i + WS281X_OFFSET_G];
-        int b = src[WS281X_BYTES_PER_DEVICE * i + WS281X_OFFSET_B];
+    for (unsigned i = 0; i < size; i += WS281X_BYTES_PER_DEVICE) {
+        int r = src[i + WS281X_OFFSET_R];
+        int g = src[i + WS281X_OFFSET_G];
+        int b = src[i + WS281X_OFFSET_B];
         printf("\033[48;2;%d;%d;%dm ", r, g, b);
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The VT100 backend had a little confusion between array size and size in bytes, leading to a read beyond the end of the buffer.

This produced garbage colors on the terminal.

### Testing procedure

    make -C tests/driver_ws281x BOARD=native all term

no longer prints garbage colors at the end of the line


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
