### PR TITLE
boards/hifive1b: minor improvements

### DIFF
--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -1,16 +1,22 @@
-# Set default programmer as jlink
-PROGRAMMER ?= jlink
 PROGRAMMERS_SUPPORTED += jlink openocd
 
-ifeq (openocd,$(PROGRAMMER))
-  OPENOCD_DEBUG_ADAPTER = jlink
-  OPENOCD_TRANSPORT = jtag
-  OPENOCD_PRE_FLASH_CMDS += "-c flash protect 0 1 last off"
-else ifeq (jlink,$(PROGRAMMER))
-  # setup JLink for flashing
-  JLINK_DEVICE = FE310
-  JLINK_IF = JTAG
-  FLASH_ADDR = 0x20010000
+# OpenOCD parameters
+OPENOCD_DEBUG_ADAPTER := jlink
+OPENOCD_TRANSPORT := jtag
+OPENOCD_PRE_FLASH_CMDS += "-c flash protect 0 1 last off"
+
+# setup JLink for flashing
+JLINK_DEVICE := FE310
+JLINK_IF := JTAG
+FLASH_ADDR := 0x20010000
+
+# keep name of `JLINK` in sync with script jlink.sh in $(RIOTTOOLS)/jlink
+# Default to J-Link as programmer when installed, otherwise go for OpenOCD
+JLINK ?= JLinkExe
+ifneq (,$(shell command -v $(JLINK)))
+  PROGRAMMER ?= jlink
+else
+  PROGRAMMER ?= openocd
 endif
 
 TESTRUNNER_RESET_DELAY = 1

--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -19,5 +19,11 @@ else
   PROGRAMMER ?= openocd
 endif
 
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the first UART bridge of integrated J-Link
+# debugger (that identifies as "HiFive" as model). Use --iface-num 2 to select
+# the UART bridge to the ESP32-SOLO-1 MCU instead of the FE310 MCU on the board.
+TTY_BOARD_FILTER := --model HiFive --iface-num 0
+
 TESTRUNNER_RESET_DELAY = 1
 $(call target-export-variables,test,TESTRUNNER_RESET_DELAY)


### PR DESCRIPTION
### Contribution description

- Cleaning up flash config
    - Only defaulting to J-Link as flasher when actually installed
- Add TTY_BOARD_FILTER to more reliably select the TTY of the HiFive1b board

### Testing procedure

- Flashing should still work
- Flashing should prefer J-Link over OpenOCD when both are available
- Flashing should prefer OpenOCD over J-Link when J-Link is not found

### Issues/PRs references

None