### PR TITLE
boards/common/nrf52: Fix detection of JLinkExe

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -12,10 +12,10 @@ endif
 PROGRAMMERS_SUPPORTED += openocd bmp
 # keep name of `JLINK` in sync with script jlink.sh in $(RIOTTOOLS)/jlink
 JLINK ?= JLinkExe
-ifneq (,$(command -v $(JLINK)))
-PROGRAMMER ?= jlink
+ifneq (,$(shell command -v $(JLINK)))
+  PROGRAMMER ?= jlink
 else
-PROGRAMMER ?= openocd
+  PROGRAMMER ?= openocd
 endif
 
 # setup JLink for flashing


### PR DESCRIPTION
### Contribution description

For nRF52 J-Link was intended to be preferred as programmer over OpenOCD when both are available, but falling back to OpenOCD when JLinkExe is not found in `$PATH`. However, there was call the shell missing to actually detect `JLinkExe`.

### Testing procedure

E.g. `make BOARD=nrf52840dk -C examples/default flash` should use J-Link again as default when both are installed.

### Issues/PRs references

None