### PR TITLE
cpu/riscv_common/periph_timer: Fix timer_clear()

### DIFF
--- a/cpu/riscv_common/periph/coretimer.c
+++ b/cpu/riscv_common/periph/coretimer.c
@@ -131,6 +131,7 @@ int timer_clear(tim_t dev, int channel)
         return -1;
     }
 
+    clear_csr(mie, MIP_MTIP);
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

Previously, timer_clear() was a no-op, resulting in spurious IRQs from already canceled timeouts. This fixes the issue.

### Testing procedure

```
$ make BOARD=hifive1b flash test -C tests/periph_timer
[...]
Welcome to pyterm!
Bench Clock Reset Complete

ATE0-->ATE0
OK
AT+BLEINIT=0-->OK
AT+CWMODE=0-->OK

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2023.01-devel-773-g441b69)

Test for peripheral TIMERs

Available timers: 1

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: starting
TIMER_0: channel 0 fired at SW count  3164199 - init:  3164199

TEST SUCCEEDED
```

(In `master`, the test fails with a spurious IRQ.)

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/18976