### PR TITLE
boards/native: Drop backward compatibility code for glibc <= 2.17

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -148,15 +148,6 @@ ifneq ($(shell gcc --version | head -1 | grep -E ' (4.6|4.7)'),)
   CFLAGS += -DHAVE_NO_BUILTIN_BSWAP16
 endif
 
-# backward compatability with glibc <= 2.17 for native
-ifeq ($(CPU),native)
-  ifeq ($(OS),Linux)
-    ifeq ($(shell ldd --version |  awk '/^ldd/{if ($$NF < 2.17) {print "yes"} else {print "no"} }'),yes)
-	  LINKFLAGS += -lrt
-    endif
-  endif
-endif
-
 # clumsy way to enable building native on osx:
 BUILDOSXNATIVE = 0
 ifeq ($(CPU),native)


### PR DESCRIPTION
### Contribution description

Even Debian [oldstable is now at glibc 2.28](https://packages.debian.org/source/buster/glibc), so it is safe to assume that nobody needs this anymore.

This also fixes garbage on the terminal on musl systems, where `ldd --version` is not supported (and output on `stderr` was not redirected to `/dev/null`).

### Testing procedure

The CI will check if this breaks the `native` board.

### Issues/PRs references

None