### PR TITLE
boards/hip-badge: fix doc rendering

### DIFF
--- a/boards/hip-badge/doc.txt
+++ b/boards/hip-badge/doc.txt
@@ -1,17 +1,8 @@
-/*
- * Copyright (C) 2023 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- */
-
 /**
- * @defgroup    boards_hip_badge HiP Badge
- * @ingroup     boards_esp32c3
- * @brief       Support for the Hacking in Parallel Badge
- * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
- */
+@defgroup    boards_hip_badge HiP Badge
+@ingroup     boards_esp32c3
+@brief       Support for the Hacking in Parallel Badge
+@author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
 
 The HiP Badge is a board that was given to participants of the 2022 *Hacking in Parallel* event.
 
@@ -60,3 +51,5 @@ The event (and badge) were organized on short notice (6 Weeks), so there are som
 
  - [Badge Clinic](https://wiki.hip-berlin.de/index.php?title=Badge_Clinic)
  - [Design files](https://gitlab.com/tidklaas/hip-badge/)
+
+ */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The [board documentation](https://doc.riot-os.org/group__boards__hip__badge.html) does exclude the entire body of the documentation.

Fix this by removing the faux-comment. 


### Testing procedure

Doc should now render correctly. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
