### PR TITLE
makefiles/cargo-targets.inc.mk: Fix RISC-V target

### DIFF
--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -28,8 +28,16 @@ $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" APPLICATION_BLOBS="$(BLOBS)" \
 	  "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk compile-commands
 	@# replacement addresses https://github.com/rust-lang/rust-bindgen/issues/1555
+	@# Keep triples in sync with makefiles/arch/riscv.inc.mk
 	$(Q)$(RIOTTOOLS)/compile_commands/compile_commands.py $(CARGO_COMPILE_COMMANDS_FLAGS) $(BINDIR) \
-	  | sed 's/"riscv-none-embed"/"riscv32"/g' \
+	  | sed -e 's/"riscv32-none-elf"/"riscv32"/g' \
+	        -e 's/"riscv-none-elf"/"riscv32"/g' \
+	        -e 's/"riscv32-unknown-elf"/"riscv32"/g' \
+	        -e 's/"riscv32-elf"/"riscv32"/g' \
+	        -e 's/"riscv64-none-elf"/"riscv32"/g' \
+	        -e 's/"riscv64-unknown-elf"/"riscv32"/g' \
+	        -e 's/"riscv64-elf"/"riscv32"/g' \
+	        -e 's/"riscv-none-embed"/"riscv32"/g' \
 	  | $(LAZYSPONGE) $@
 
 


### PR DESCRIPTION
### Contribution description

Update the list of target triples to match
`makefiles/arch/riscv.inc.mk`. This fixes compilation with toolchains other than the obsolete toolchain that uses the incorrect `riscv-none-embed` triple.

### Testing procedure

```
make BOARD=hifive1b -C examples/rust-gcoap
```

Fails on `master` with a recent RISC-V toolchain, but hopefully compiles with this PR.

### Issues/PRs references

None