### PR TITLE
makefiles/tools/serial.inc.mk: Allow detection of debug adapter

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -25,11 +25,11 @@ ARDUINO_MEGA2560_COMPAT_WITH_CLONES ?= 1
 ifeq (1,$(ARDUINO_MEGA2560_COMPAT_WITH_CLONES))
   TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
                     --most-recent \
-                    --format path \
+                    --format path serial \
                     $(TTY_BOARD_FILTER) || \
                     $(RIOTTOOLS)/usb-serial/ttys.py \
                     --most-recent \
-                    --format path \
+                    --format path serial \
                     $(TTY_BOARD_FILTER_CLONE)
 endif
 

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -11,6 +11,10 @@ include $(RIOTMAKE)/boards/stm32.inc.mk
 # USB serials to only select the UART bridge of embedded STLink debuggers.
 TTY_BOARD_FILTER := --model 'STM32 STLink'
 
+# The TTY serial also is the ID of the debug adapter, as the TTY is provided by
+# the debug adapter
+DEBUG_ADAPTER_ID_IS_TTY_SERIAL := 1
+
 # variable needed by cpy2remed PROGRAMMER
 # it contains name of ST-Link removable media
 

--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -25,5 +25,9 @@ endif
 # the UART bridge to the ESP32-SOLO-1 MCU instead of the FE310 MCU on the board.
 TTY_BOARD_FILTER := --model HiFive --iface-num 0
 
+# The TTY serial also is the ID of the debug adapter, as the TTY is provided by
+# the debug adapter
+DEBUG_ADAPTER_ID_IS_TTY_SERIAL := 1
+
 TESTRUNNER_RESET_DELAY = 1
 $(call target-export-variables,test,TESTRUNNER_RESET_DELAY)

--- a/boards/microbit-v2/Makefile.include
+++ b/boards/microbit-v2/Makefile.include
@@ -7,6 +7,10 @@ PROGRAMMERS_SUPPORTED += pyocd
 # programmer firmware revisions "fix" that.
 TTY_BOARD_FILTER := --model ".?BBC micro:bit CMSIS-DAP.?"
 
+# The TTY serial also is the ID of the debug adapter, as the TTY is provided by
+# the debug adapter
+DEBUG_ADAPTER_ID_IS_TTY_SERIAL := 1
+
 # The board is not recognized automatically by pyocd, so the CPU target
 # option is passed explicitly
 PYOCD_FLASH_TARGET_TYPE ?= -t $(CPU)

--- a/boards/nrf52840dk/Makefile.include
+++ b/boards/nrf52840dk/Makefile.include
@@ -2,4 +2,8 @@
 # USB serials to only select the UART bridge of integrated J-Link debugger.
 TTY_BOARD_FILTER := --model J-Link
 
+# The TTY serial also is the ID of the debug adapter, as the TTY is provided by
+# the debug adapter
+DEBUG_ADAPTER_ID_IS_TTY_SERIAL := 1
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/qn9080dk/Makefile.include
+++ b/boards/qn9080dk/Makefile.include
@@ -7,5 +7,9 @@ CFLAGS += \
 QN908X_JLINK ?= $(QN9080DK_JLINK)
 JLINK_DEVICE ?= QN9080A
 
+# The TTY serial also is the ID of the debug adapter, as the TTY is provided by
+# the debug adapter
+DEBUG_ADAPTER_ID_IS_TTY_SERIAL := 1
+
 # Include default QN908x board config
 include $(RIOTBOARD)/common/qn908x/Makefile.include

--- a/dist/tools/usb-serial/README.md
+++ b/dist/tools/usb-serial/README.md
@@ -23,7 +23,19 @@ With the parameter `--format FORMAT` a different format than the default
 markdown table can be selected, e.g. `json` results in JSON output and `path`
 will print the paths of the matching TTYs without any formatting (useful for
 scripting). The full list of formats can be obtained by running the script with
-the `--help` parameter
+the `--help` parameter.
+
+Note: Formats other than `json` and `table` can be combined. A script that
+required both path and serial of TTYs could use:
+
+```
+./ttys.py --format path serial
+```
+
+This will output one TTY per line with the selected fields separated by space.
+To use a different separator than space (e.g. to create CSV files), the option
+`--format-sep` can be used. If a field value contains the separator, it will
+be quoted and quotation chars inside will be escaped.
 
 ### Filtering
 

--- a/doc/doxygen/src/flashing.md
+++ b/doc/doxygen/src/flashing.md
@@ -478,20 +478,20 @@ In most cases, just adding a simple `TTY_BOARD_FILTER` is sufficient. If we
 however have wildly different flavors of the same board (e.g. genuine Arduino
 Mega 2560 with an ATmega16U2 and clones with a cheap USB to UART bridge) that we
 all want to support, we have to instead provide a `TTY_SELECT_CMD` that prints
-the path to the TTY and exists with `0` if a TTY was found, or that exists with
-`1` and prints nothing when no TTY was found. We can still use the `ttys.py`
-script to detect all Arduino Mega 2560 versions: We first try to detect a
-genuine Arduino Mega and fall back to selecting cheap USB UART bridges when that
-fails using the `||` shell operator:
+the path to and the serial of the TTY (separated by a space) and exists with
+`0` if a TTY was found, or that exists with `1` and prints nothing when no TTY
+was found. We can still use the `ttys.py` script to detect all Arduino Mega
+2560 versions: We first try to detect a genuine Arduino Mega and fall back to
+selecting cheap USB UART bridges when that fails using the `||` shell operator:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
                     --most-recent \
-                    --format path \
+                    --format path serial \
                     --vendor 'Arduino' \
                     --model-db 'Mega 2560|Mega ADK' || \
                     $(RIOTTOOLS)/usb-serial/ttys.py \
                     --most-recent \
-                    --format path \
+                    --format path serial \
                     --driver 'cp210x'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -5,10 +5,15 @@ ifeq (1,$(MOST_RECENT_PORT))
   endif
   TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
                     --most-recent \
-                    --format path \
+                    --format path serial \
                     $(TTY_BOARD_FILTER)
-  PORT_DETECTED := $(shell $(TTY_SELECT_CMD) || echo 'no-tty-detected')
-  PORT ?= $(PORT_DETECTED)
+  TTY_DETECTED := $(shell $(TTY_SELECT_CMD) || echo 'no-tty-detected no-serial-detected')
+  PORT_DETECTED := $(firstword $(TTY_DETECTED))
+  PORT_SERIAL_DETECTED := $(lastword $(TTY_DETECTED))
+  PORT ?= $(firstword $(TTY_DETECTED))
+  ifeq (1,$(DEBUG_ADAPTER_ID_IS_TTY_SERIAL))
+    DEBUG_ADAPTER_ID ?= $(PORT_SERIAL_DETECTED)
+  endif
 endif
 # Otherwise, use as default the most commonly used ports on Linux and OSX
 PORT_LINUX ?= /dev/ttyACM0


### PR DESCRIPTION
### Contribution description

This PR adds the ability to automatically detect the debug adapter for boards with an integrated programmer/debugger, if that debugger also provides the TTY.

This extends the TTY detection that can be enabled with `MOST_RECENT_PORT=1` to set `DEBUG_ADAPTER_ID` to the TTY's serial, but only if `DEBUG_ADAPTER_ID_IS_TTY_SERIAL` is set to `1` by the board (as not all boards have an integrated programmer/debugger).

### Testing procedure

Connect a HiFive-1B and a nRF52840DK at the same time and try `make BOARD=<nrf52840dk|hifive1b> MOST_RECENT_PORT=1 -C examples/default flash term` for both. The programmer will not reliably select the correct programmer in `master`. With this PR, it will.

### Issues/PRs references

None