### PR TITLE
socket_zep: only report size of single datagram

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -94,6 +94,7 @@ extern int (*real_accept)(int socket, ...);
 /* The ... is a hack to save includes: */
 extern int (*real_bind)(int socket, ...);
 extern int (*real_connect)(int socket, ...);
+extern int (*real_recv)(int sockfd, void *buf, size_t len, int flags);
 extern int (*real_chdir)(const char *path);
 extern int (*real_close)(int);
 extern int (*real_fcntl)(int, int, ...);

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -244,7 +244,7 @@ static void _socket_isr(int fd, void *arg)
     } else {
         /* discard frame */
         uint8_t tmp;
-        real_read(fd, &tmp, sizeof(tmp));
+        real_recv(fd, &tmp, sizeof(tmp), 0);
         _continue_reading(zepdev);
     }
 }
@@ -445,23 +445,25 @@ static int _confirm_transmit(ieee802154_dev_t *dev, ieee802154_tx_info_t *info)
 
 int _len(ieee802154_dev_t *dev)
 {
-    size_t size;
     socket_zep_t *zepdev = dev->priv;
 
-    int res = real_ioctl(zepdev->sock_fd, FIONREAD, &size);
+    zep_v2_data_hdr_t hdr;
+
+    int res = real_recv(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_TRUNC | MSG_PEEK);
     if (res < 0) {
         DEBUG("socket_zep::len: error reading FIONREAD: %s", strerror(errno));
         return 0;
     }
 
-    DEBUG("socket_zep::len %zu bytes on %d\n", size, zepdev->sock_fd);
-
-    if (size < sizeof(zep_v2_data_hdr_t)) {
+    if (res < (int)sizeof(zep_v2_data_hdr_t)) {
+        DEBUG("socket_zep::len discard short frame (%zu bytes)\n", res);
         return 0;
     }
 
+    DEBUG("socket_zep::len %u bytes on %d\n", hdr.length, zepdev->sock_fd);
+
     /* report size without ZEP header and checksum */
-    return size - (sizeof(zep_v2_data_hdr_t) + 2);
+    return hdr.length - 2;
 }
 
 static void _send_ack(socket_zep_t *zepdev, const void *frame)
@@ -495,18 +497,23 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t max_size,
 {
     int res;
     socket_zep_t *zepdev = dev->priv;
+    size_t frame_len = max_size + sizeof(zep_v2_data_hdr_t) + 2;
 
     DEBUG("socket_zep::read: reading up to %u bytes into %p\n", max_size, buf);
 
-    if (max_size + sizeof(zep_v2_data_hdr_t) > sizeof(zepdev->rcv_buf)) {
-        return 0;
+    if (frame_len > sizeof(zepdev->rcv_buf)) {
+        DEBUG("socket_zep::read: frame size (%zu) exceeds RX  buffer (%zu bytes)\n",
+              frame_len, sizeof(zepdev->rcv_buf));
+        res = -ENOBUFS;
+        goto out;
     }
 
-    res = real_read(zepdev->sock_fd, zepdev->rcv_buf, max_size + sizeof(zep_v2_data_hdr_t));
+    res = real_recv(zepdev->sock_fd, zepdev->rcv_buf, frame_len, MSG_TRUNC);
 
-    DEBUG("socket_zep::read: got %d bytes\n", res);
+    DEBUG("socket_zep::read: got %d/%zu bytes\n", res, frame_len);
 
-    if (res <= (int)sizeof(zep_v2_data_hdr_t)) {
+    if (res <= (int)sizeof(zep_v2_data_hdr_t) || res > (int)frame_len) {
+        DEBUG("socket_zep::read: %s\n", strerror(errno));
         res = 0;
         goto out;
     }

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -235,18 +235,10 @@ static void _send_zep_hello(socket_zep_t *dev)
 static void _socket_isr(int fd, void *arg)
 {
     ieee802154_dev_t *dev = arg;
-    socket_zep_t *zepdev = dev->priv;
 
     DEBUG("socket_zep::_socket_isr: bytes on %d\n", fd);
 
-    if (zepdev->rx) {
-        dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
-    } else {
-        /* discard frame */
-        uint8_t tmp;
-        real_recv(fd, &tmp, sizeof(tmp), 0);
-        _continue_reading(zepdev);
-    }
+    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
 }
 
 void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params)

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -51,6 +51,7 @@
 ssize_t (*real_read)(int fd, void *buf, size_t count);
 ssize_t (*real_write)(int fd, const void *buf, size_t count);
 size_t (*real_fread)(void *ptr, size_t size, size_t nmemb, FILE *stream);
+ssize_t (*real_recv)(int sockfd, void *buf, size_t len, int flags);
 void (*real_clearerr)(FILE *stream);
 __attribute__((noreturn)) void (*real_exit)(int status);
 void (*real_free)(void *ptr);
@@ -505,6 +506,7 @@ void _native_init_syscalls(void)
     *(void **)(&real_accept) = dlsym(RTLD_NEXT, "accept");
     *(void **)(&real_bind) = dlsym(RTLD_NEXT, "bind");
     *(void **)(&real_connect) = dlsym(RTLD_NEXT, "connect");
+    *(void **)(&real_recv) = dlsym(RTLD_NEXT, "recv");
     *(void **)(&real_printf) = dlsym(RTLD_NEXT, "printf");
     *(void **)(&real_gai_strerror) = dlsym(RTLD_NEXT, "gai_strerror");
     *(void **)(&real_getaddrinfo) = dlsym(RTLD_NEXT, "getaddrinfo");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The use of `ioctl(zepdev->sock_fd, FIONREAD, &size)` would report the number of total bytes available on the socket. This could mean the cumulative sum of bytes of all datagrams, not just a single one.

Instead, use `recv(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_TRUNC | MSG_PEEK)` to only read the ZEP header (without consuming the datagram) to get the real size of the ZEP message.

This prevents accidental concatenation of two ZEP packets into on, which with 6lo fragmentation, would cause the 2nd fragment to be lost as it is read together with the first fragment, but as part of the payload. 


### Testing procedure

Fragmented multicast datagrams should work now.

```
> ping -s 128 ff02::1
136 bytes from fe80::7c5e:5802:4449:e1b3%7: icmp_seq=0 ttl=64 rssi=0 dBm time=1.515 ms
136 bytes from fe80::7c5e:5802:4449:e1b3%7: icmp_seq=1 ttl=64 rssi=0 dBm time=1.644 ms
136 bytes from fe80::7c5e:5802:4449:e1b3%7: icmp_seq=2 ttl=64 rssi=0 dBm time=1.613 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 1.515/1.590/1.644 ms
```

### Issues/PRs references

fixes #19117
