### PR TITLE
pkg/esp8266_sdk: fix version string generation

### DIFF
--- a/pkg/esp8266_sdk/Makefile
+++ b/pkg/esp8266_sdk/Makefile
@@ -27,7 +27,8 @@ $(ESP8266_SDK_BUILD_DIR): $(PKG_PATCHED)
 
 # Set the SDK version from the SDK hash/tag. For example "v3.1-51-g913a06a9".
 $(ESP8266_SDK_BUILD_DIR)/esp8266_idf_version.h: | $(ESP8266_SDK_BUILD_DIR)
-	$(Q)echo "#define IDF_VER \"$(shell git -C $(PKG_SOURCE_DIR) describe --tags)\"" \
+	$(Q)echo -n "#define IDF_VER" \
+	  "\"$(shell git -C $(PKG_SOURCE_DIR) describe --tags $(PKG_VERSION))\"" \
 	  > $@
 
 $(ESP8266_SDK_BUILD_DIR)/lib%.a: \


### PR DESCRIPTION
### Contribution description

This PR (hopefully) fixes the problem of different binary hashes for the same application in subsequent compilations.

Patching a package creates a new HEAD of the package repository. Using `git describe --tag` to generate a version string used for the ESP8266 bootloader therefore generates a different version string for each new compilation, which in turn results in different hash values of the binaries for the same application in subsequent compilations in CI. To use the commit in `git describe --tag` for commit used by the package, the commit has to specified in the command.

### Testing procedure

Green CI

### Issues/PRs references