### PR TITLE
sys/ztimer: ztimer_mock: guard ztimer_ondemand static functions [backport 2023.01]

### DIFF
--- a/sys/ztimer/mock.c
+++ b/sys/ztimer/mock.c
@@ -119,6 +119,7 @@ static void ztimer_mock_op_cancel(ztimer_clock_t *clock)
     self->armed = 0;
 }
 
+#if MODULE_ZTIMER_ONDEMAND
 static void ztimer_mock_op_start(ztimer_clock_t *clock)
 {
     ztimer_mock_t *self = (ztimer_mock_t *)clock;
@@ -138,6 +139,7 @@ static void ztimer_mock_op_stop(ztimer_clock_t *clock)
     DEBUG("zmock_stop: %3u\n", self->calls.stop);
     self->running = 0;
 }
+#endif
 
 static const ztimer_ops_t ztimer_mock_ops = {
     .set = ztimer_mock_op_set,


### PR DESCRIPTION
# Backport of #19118

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
 
Some ztimer_mock static functions need to be guarded.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This issue is not triggered by CI. To test manually, try

`make -C tests/unittests tests-ztimer64`, it should fail on master, succeed with this PR.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes https://gist.github.com/riot-ci/ab2129a707fa5eb413a4a161d90ce3ac/aae0dceadb40acacc99d78ce9f0045c860bbe470#file-task_01-03-tests-ztimer64_result-md.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
