### PR TITLE
dist/tools/esptools/export.sh: fixes IDF_TOOLS_PATH default setting

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -28,7 +28,7 @@ This document describes the RIOT implementation for supported variants
     3. [Limitations of the RIOT-port](#esp32_limitations)
 4. [Toolchain](#esp32_toolchain)
     1. [RIOT Docker Toolchain (riotdocker)](#esp32_riot_docker_toolchain)
-    2. [Manual Toolchain Installation](#esp32_local_toolchain_installation)
+    2. [Local Toolchain Installation](#esp32_local_toolchain_installation)
 5. [Flashing the Device](#esp32_flashing_the_device)
     1. [Toolchain Usage](#esp32_toolchain_usage)
     2. [Compile Options](#esp32_compile_options)

--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -5,6 +5,10 @@ ESP32_GCC_VERSION_DIR="8.4.0"
 
 ESP32_OPENOCD_VERSION="v0.11.0-esp32-20211220"
 
+if [ -z ${IDF_TOOLS_PATH} ]; then
+    IDF_TOOLS_PATH=${HOME}/.espressif
+fi
+
 TOOLS_PATH=${IDF_TOOLS_PATH}/tools
 
 export_arch()


### PR DESCRIPTION
### Contribution description

This PR re-adds the setting of the default value of the variable `IDF_TOOLS_PATH` which was accidentally removed with PR #18385.

The `IDF_TOOLS_PATH` variable is used by the ESP-IDF to define the path where the Espressif toolchain is installed. Reusing this variable to set the path of the toolchain in RIOT allows the use of an existing Espressif toolchain if it has already been installed with ESP-IDF. If the variable is not defined it is set to `${HOME}/.espressif` as described in [documentation](https://doc.riot-os.org/group__cpu__esp32.html#esp32_local_toolchain_installation):
```
if [ -z ${IDF_TOOLS_PATH} ]; then
    IDF_TOOLS_PATH=${HOME}/.espressif
fi
```
Unfortunatly were these 3 lines be removed in `dist/tools/esptools/export.sh` accidentially with #18385 so that it became necessary to set this variable manually. If the variable was not set, the `dist/tools/esptools/export.sh` script didn't work for the Espressif toolchain installed with the companion script `dist/tools/esptools/install.sh`.

### Testing procedure

```
dist/tools/esptools/install.sh esp32
. dist/tools/esptools/export.sh esp32
```
Without the PR, the export doesn't work, with the PR it works.

### Issues/PRs references

Fixes PR #18385 
