### PR TITLE
boards: common: stdio_cdc_acm: let tests wait a bit for serial port

### DIFF
--- a/boards/common/makefiles/stdio_cdc_acm.dep.mk
+++ b/boards/common/makefiles/stdio_cdc_acm.dep.mk
@@ -8,4 +8,9 @@ ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
     USEMODULE += stdio_cdc_acm
   endif
   FEATURES_REQUIRED += highlevel_stdio
+
+  # Enforce tests to wait a bit for the serial port after reset
+  TERM_DELAY ?= 2
+  TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
+  $(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
 endif

--- a/tests/congure_abe/tests/01-run.py
+++ b/tests/congure_abe/tests/01-run.py
@@ -8,12 +8,15 @@
 
 import logging
 import sys
+import time
 import unittest
 
 from riotctrl.ctrl import RIOTCtrl
 from riotctrl.shell.json import RapidJSONShellInteractionParser, rapidjson
 
 from riotctrl_shell.congure_test import CongureTest
+
+from testrunner.spawn import MAKE_TERM_CONNECT_DELAY
 
 
 class TestCongUREBase(unittest.TestCase):
@@ -25,6 +28,7 @@ class TestCongUREBase(unittest.TestCase):
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
         cls.ctrl.reset()
+        time.sleep(MAKE_TERM_CONNECT_DELAY)
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout

--- a/tests/congure_quic/tests/01-run.py
+++ b/tests/congure_quic/tests/01-run.py
@@ -8,12 +8,15 @@
 
 import logging
 import sys
+import time
 import unittest
 
 from riotctrl.ctrl import RIOTCtrl
 from riotctrl.shell.json import RapidJSONShellInteractionParser, rapidjson
 
 from riotctrl_shell.congure_test import CongureTest
+
+from testrunner.spawn import MAKE_TERM_CONNECT_DELAY
 
 
 class TestCongUREBase(unittest.TestCase):
@@ -25,6 +28,7 @@ class TestCongUREBase(unittest.TestCase):
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
         cls.ctrl.reset()
+        time.sleep(MAKE_TERM_CONNECT_DELAY)
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout

--- a/tests/congure_reno/tests/01-run.py
+++ b/tests/congure_reno/tests/01-run.py
@@ -8,12 +8,15 @@
 
 import logging
 import sys
+import time
 import unittest
 
 from riotctrl.ctrl import RIOTCtrl
 from riotctrl.shell.json import RapidJSONShellInteractionParser, rapidjson
 
 from riotctrl_shell.congure_test import CongureTest
+
+from testrunner.spawn import MAKE_TERM_CONNECT_DELAY
 
 
 class TestCongUREBase(unittest.TestCase):
@@ -25,6 +28,7 @@ class TestCongUREBase(unittest.TestCase):
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
         cls.ctrl.reset()
+        time.sleep(MAKE_TERM_CONNECT_DELAY)
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout

--- a/tests/congure_test/tests/01-run.py
+++ b/tests/congure_test/tests/01-run.py
@@ -9,6 +9,7 @@
 import logging
 import os
 import sys
+import time
 import unittest
 
 from riotctrl.ctrl import RIOTCtrl
@@ -16,6 +17,8 @@ from riotctrl.shell import ShellInteraction
 from riotctrl.shell.json import RapidJSONShellInteractionParser, rapidjson
 
 from riotctrl_shell.congure_test import CongureTest
+
+from testrunner.spawn import MAKE_TERM_CONNECT_DELAY
 
 
 class TestCongUREBase(unittest.TestCase):
@@ -25,6 +28,7 @@ class TestCongUREBase(unittest.TestCase):
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
         cls.ctrl.reset()
+        time.sleep(MAKE_TERM_CONNECT_DELAY)
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Some tests may fail spuriously with `stdio_cdc_acm`, since the `tty` might not exist yet. This configures a small delay after resetting for `testutils` and also piggybacks the honoring of that delay for the `riotctrl`-based tests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
CI should pass all tests. Maybe we should also run `tests-on-iotlab` for this PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
