### PR TITLE
boards/seeedstudio-gd32: fix HXTAL clock in Kconfig [backport 2023.01]

### DIFF
--- a/boards/seeedstudio-gd32/Kconfig
+++ b/boards/seeedstudio-gd32/Kconfig
@@ -28,4 +28,4 @@ config BOARD_HAS_LXTAL
 
 config CLOCK_HXTAL
     int
-    default 80000000
+    default 8000000


### PR DESCRIPTION
# Backport of #19129

### Contribution description

This PR fixes the wrong default value of `CLOCK_HXTAL` in Kconfig introduced with PR #19109. It was accidentally set to the default value of 80 MHz instead of 8 MHz.

### Testing procedure

```
python3 dist/tools/compile_test/compile_like_murdock.py -a tests/shell -b seeedstudio-gd32 -j8
```
Without the PR the command gives:
```
tests/shell                    seeedstudio-gd32               FAIL: Kconfig hash mismatch
```
WIth the PR the compile test should pass:
```
tests/shell                    seeedstudio-gd32               PASS
```

### Issues/PRs references
