### PR TITLE
tests/gnrc_rpl: speed up test

### DIFF
--- a/tests/gnrc_rpl/Makefile
+++ b/tests/gnrc_rpl/Makefile
@@ -4,10 +4,13 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += auto_init_gnrc_rpl
 USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
+USEMODULE += gnrc_netif_bus
 USEMODULE += gnrc_rpl
 
 USEMODULE += shell
 USEMODULE += shell_cmds_default
+
+DISABLE_MODULE += test_utils_print_stack_usage
 
 ifeq (native, $(BOARD))
   USEMODULE += socket_zep

--- a/tests/gnrc_rpl/main.c
+++ b/tests/gnrc_rpl/main.c
@@ -18,15 +18,35 @@
  * @}
  */
 
+#include <stdio.h>
 #include "shell.h"
 #include "msg.h"
+#include "thread.h"
+#include "net/gnrc/netif.h"
 
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+static char _uplink_mon_stack[THREAD_STACKSIZE_DEFAULT];
+
+static void * _uplink_mon(void *arg)
+{
+    (void)arg;
+
+    if (gnrc_netif_ipv6_wait_for_global_address(NULL, 10 * MS_PER_SEC)) {
+        puts("uplink ready");
+    } else {
+        puts("uplink timeout");
+    }
+
+    return NULL;
+}
 
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+    thread_create(_uplink_mon_stack, sizeof(_uplink_mon_stack), THREAD_PRIORITY_MAIN - 1,
+                  THREAD_CREATE_STACKTEST, _uplink_mon, NULL, "uplink monitor");
 
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/gnrc_rpl/tests/01-run.py
+++ b/tests/gnrc_rpl/tests/01-run.py
@@ -90,13 +90,14 @@ def test_linear_topology(factory, zep_dispatch):
     D = nodes[3]
 
     # add prefix to root node
-    A.cmd("nib prefix add 5 2001:db8::/32")
-    A.cmd("ifconfig 5 add 2001:db8::1/32")
+    A.cmd("nib prefix add 5 2001:db8::/64")
+    A.cmd("ifconfig 5 add 2001:db8::1/64")
     A.cmd("rpl root 0 2001:db8::1")
     root_addr = global_addr(A.ifconfig_list())[1]
 
     # wait for the creation of the DODAG
-    time.sleep(10)
+    D.riotctrl.term.expect("uplink ready")
+    time.sleep(5)
 
     # ping root node from last node
     parser = GNRCICMPv6EchoParser()
@@ -137,13 +138,14 @@ def test_alternative_route(factory, zep_dispatch):
     D = nodes[3]
 
     # add prefix to root node
-    A.cmd("nib prefix add 5 2001:db8::/32")
-    A.cmd("ifconfig 5 add 2001:db8::1/32")
+    A.cmd("nib prefix add 5 2001:db8::/64")
+    A.cmd("ifconfig 5 add 2001:db8::1/64")
     A.cmd("rpl root 0 2001:db8::1")
     root_addr = global_addr(A.ifconfig_list())[1]
 
     # wait for the creation of the DODAG
-    time.sleep(10)
+    D.riotctrl.term.expect("uplink ready")
+    time.sleep(5)
 
     # ping root node from last node
     parser = GNRCICMPv6EchoParser()


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Add a printout when the global prefix has been received that we can await.
Strangely we still have to wait 5s after that for ping to work.


### Testing procedure

    make -C tests/gnrc_rpl all test

should still work.

<details><summary>Without 5s sleep, routing is broken</summary>

```
 -=[ A ]=-
ifconfig
Iface  5  HWaddr: 5E:76  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: E6:B2:35:37:6F:CC:DE:76 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::e4b2:3537:6fcc:de76  scope: link  VAL
          inet6 addr: 2001:db8::1  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffcc:de76
          inet6 group: ff02::1a
          inet6 group: ff02::1:ff00:1
          

rpl
instance table:	[X]	
parent table:	[ ]	[ ]	[ ]	

instance [0 | Iface: 5 | mop: 2 | ocp: 0 | mhri: 256 | mri 0]
	dodag [2001:db8::1 | R: 256 | OP: Router | PIO: on | TR(I=[8,20], k=10, c=1)]

nib route
2001:db8::/32 dev #5

 -=[ B ]=-
ifconfig
Iface  5  HWaddr: 6E:86  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: 7E:D6:55:9B:BF:1C:6E:86 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::7cd6:559b:bf1c:6e86  scope: link  VAL
          inet6 addr: 2001:db8::7cd6:559b:bf1c:6e86  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff1c:6e86
          inet6 group: ff02::1a
          

rpl
instance table:	[X]	
parent table:	[X]	[ ]	[ ]	

instance [0 | Iface: 5 | mop: 2 | ocp: 0 | mhri: 256 | mri 0]
	dodag [2001:db8::1 | R: 512 | OP: Router | PIO: on | TR(I=[8,20], k=10, c=2)]
		parent [addr: fe80::e4b2:3537:6fcc:de76 | rank: 256]

nib route
2001:db8::/64 dev #5
default* via fe80::e4b2:3537:6fcc:de76 dev #5

 -=[ C ]=-
ifconfig
Iface  5  HWaddr: 5E:F6  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: E6:62:B5:07:EF:4C:5E:F6 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::e462:b507:ef4c:5ef6  scope: link  VAL
          inet6 addr: 2001:db8::e462:b507:ef4c:5ef6  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:5ef6
          inet6 group: ff02::1a
          

rpl
instance table:	[X]	
parent table:	[X]	[ ]	[ ]	

instance [0 | Iface: 5 | mop: 2 | ocp: 0 | mhri: 256 | mri 0]
	dodag [2001:db8::1 | R: 768 | OP: Router | PIO: on | TR(I=[8,20], k=10, c=2)]
		parent [addr: fe80::7cd6:559b:bf1c:6e86 | rank: 512]

nib route
2001:db8::/64 dev #5
default* via fe80::7cd6:559b:bf1c:6e86 dev #5

 -=[ D ]=-
ifconfig
Iface  5  HWaddr: 73:C1  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: 7E:56:B4:97:DA:1F:F3:C1 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::7c56:b497:da1f:f3c1  scope: link  VAL
          inet6 addr: 2001:db8::7c56:b497:da1f:f3c1  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff1f:f3c1
          inet6 group: ff02::1a
          

rpl
instance table:	[X]	
parent table:	[X]	[ ]	[ ]	

instance [0 | Iface: 5 | mop: 2 | ocp: 0 | mhri: 256 | mri 0]
	dodag [2001:db8::1 | R: 1024 | OP: Router | PIO: on | TR(I=[8,20], k=10, c=0)]
		parent [addr: fe80::e462:b507:ef4c:5ef6 | rank: 768]

nib route
2001:db8::/64 dev #5
default* via fe80::e462:b507:ef4c:5ef6 dev #5

ping 2001:db8::1

--- 2001:db8::1 PING statistics ---
3 packets transmitted, 0 packets received, 100% packet loss
```
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
