### PR TITLE
makefiles/utils/strings.mk: Fix version_is_greater_or_equal [backport 2023.01]

### DIFF
--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -7,8 +7,8 @@ lowercase = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst 
 uppercase = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(subst g,G,$(subst h,H,$(subst i,I,$(subst j,J,$(subst k,K,$(subst l,L,$(subst m,M,$(subst n,N,$(subst o,O,$(subst p,P,$(subst q,Q,$(subst r,R,$(subst s,S,$(subst t,T,$(subst u,U,$(subst v,V,$(subst w,W,$(subst x,X,$(subst y,Y,$(subst z,Z,$1))))))))))))))))))))))))))
 uppercase_and_underscore = $(call uppercase,$(subst -,_,$1))
 
-# Padds $2 number to $1 digits
-_pad_number = $(shell printf '%0$1d' $2)
+# Padds number $2 to $1 digits. If $2 is empty, zero will be printed instead.
+_pad_number = $(shell printf '%0$1d' $(if $2,$2,0))
 
 # Gets major, minor, patch from 'major.minor.patch', e.g.: 4.2.1 by index
 #   $1: index


### PR DESCRIPTION
# Backport of #19133

### Contribution description

The Makefile function `version_is_greater_or_equal` is used to check if a version of GNU Make is at least the required one. However, it has the built-in assumption the version numbers have to format x.y.z, but Alpine Linux currently ships GNU Make 4.4. This results in `$(call _pad_number,3,)` which runs `printf '$03d' ''` in the shell, which is not valid.

This fixes the issue by making `_pad_number` more robust by fall back to printing `0` with the given padding, if the number given to print is empty.

### Testing procedure

Append

```Makefile

$(info A=$(call version_is_greater_or_equal,4.2.0,4.2.0))
$(info B=$(call version_is_greater_or_equal,4.2,4.2.0))
$(info C=$(call version_is_greater_or_equal,4.1,4.2.0))
$(info D=$(call version_is_greater_or_equal,4.1.9,4.2.0))
$(info E=$(call version_is_greater_or_equal,5.1.9,4.2.0))
$(info F=$(call version_is_greater_or_equal,5.0.0,4.2.0))
$(info G=$(call version_is_greater_or_equal,4.2.1,4.2.0))
$(info H=$(call version_is_greater_or_equal,4.3.1,4.2.0))
```

e.g. to `makefiles/utils/strings.mk`, build something and observe the info output.

This yields

```
A=1
B=1
C=
D=
E=1
F=1
G=1
H=1
```

for me and does not complain about invalid `printf` invocations.

### Issues/PRs references

None