### PR TITLE
sock_dtls: move common code into sock_dtls_establish_session()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -146,20 +146,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Timeout for CoAP over DTLS queries in milliseconds
- */
-#ifndef CONFIG_NANOCOAP_SOCK_DTLS_TIMEOUT_MS
-#define CONFIG_NANOCOAP_SOCK_DTLS_TIMEOUT_MS    (1000U)
-#endif
-
-/**
- * @brief   Number of CoAP over DTLS handshake retries
- */
-#ifndef CONFIG_NANOCOAP_SOCK_DTLS_RETRIES
-#define CONFIG_NANOCOAP_SOCK_DTLS_RETRIES       (2)
-#endif
-
-/**
  * @brief   Credman tag used for NanoCoAP
  *          Tag together with the credential type (PSK) needs to be unique
  */

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -31,6 +31,11 @@
 #include "net/sock/udp.h"
 #include "net/sock/tcp.h"
 
+#ifdef MODULE_SOCK_DTLS
+#include "net/credman.h"
+#include "net/sock/dtls.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -268,6 +273,29 @@ static inline bool sock_udp_ep_equal(const sock_udp_ep_t *a,
     return sock_tl_ep_equal(a, b);
 }
 
+#if defined(MODULE_SOCK_DTLS) || DOXYGEN
+/**
+ * @brief   Helper function to establish a DTLS connection
+ *
+ * @param[out]  sock_udp     Struct to store the underlying UDP socket
+ * @param[out]  sock_dtls    Struct for the actual DTLS socket
+ * @param[out]  session      Struct to store DTLS session information
+ * @param[in]   tag          Credential tag to use
+ * @param[in]   local        Local endpoint, must not be NULL
+ * @param[in]   remote       Server endpoint to connect to
+ * @param[in]   work_buf     Buffer used to negotiate connection
+ * @param[in]   work_buf_len Size of @p work buf. Should be at least
+ *                           160 bytes for AES_128_CCM_8 with PSK
+ *
+ * @return  0 on success
+ * @return negative error otherwise (see @ref sock_dtls_recv_aux)
+ */
+int sock_dtls_establish_session(sock_udp_t *sock_udp, sock_dtls_t *sock_dtls,
+                                sock_dtls_session_t *session, credman_tag_t tag,
+                                sock_udp_ep_t *local, const sock_udp_ep_t *remote,
+                                void *work_buf, size_t work_buf_len);
+#endif
+
 /**
  * @defgroup    net_sock_util_conf SOCK utility functions compile configurations
  * @ingroup     net_sock_conf
@@ -296,6 +324,20 @@ static inline bool sock_udp_ep_equal(const sock_udp_ep_t *a,
 #define CONFIG_SOCK_URLPATH_MAXLEN     (64U)
 #endif
 /** @} */
+
+/**
+ * @brief   Timeout in milliseconds for sock_dtls_establish_session()
+ */
+#ifndef CONFIG_SOCK_DTLS_TIMEOUT_MS
+#define CONFIG_SOCK_DTLS_TIMEOUT_MS    (1000U)
+#endif
+
+/**
+ * @brief   Number of DTLS handshake retries for sock_dtls_establish_session()
+ */
+#ifndef CONFIG_SOCK_DTLS_RETRIES
+#define CONFIG_SOCK_DTLS_RETRIES       (2)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently the logic to establish a DTLS session is open-coded in each protocol that uses DTLS (CoAPS, DoDTLS).

To avoid code duplication, move the common code to establish a connection into a `sock_dtls_connect()` helper function that can be shared by it's users.


### Testing procedure

 - [x] `tests/nanocoap_cli` still works as before, can connect to `examples/gcoap_dtls` server via CoAPS
 - [x] `tests/gnrc_sock_dodtls` ~~*still untested*~~
<details><summary>output of gnrc_sock_dodtls</summary>

```
> dodtls server [2001:db8::1]:853 5853 Client_identity secretPSK
DNS server: [2001:db8::1%5]:853

> dodtls request example.org inet6
example.org resolves to 2606:2800:220:1:248:1893:25c8:1946

> dodtls request example.org inet
example.org resolves to 93.184.216.34
```
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
