### PR TITLE
release-tests: fix PASSED chat message

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -179,7 +179,7 @@ jobs:
       id: generate_results
       run: |
         if [ "${{ steps.tests.conclusion }}" == "success" ]; then
-          nice_str=echo "&#x2705; **PASSED**"
+          nice_str="&#x2705; **PASSED**"
         elif [ "${{ steps.tests.conclusion }}" == "failure" ]; then
           nice_str="&#x274C; **FAILED**"
         fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
When I was testing the new chat posting feature for the release-tests, the tests were not passing... of course [an error snuck in in that case](https://github.com/RIOT-OS/RIOT/actions/runs/3916585600/jobs/6697801134#step:16:14). This fixes this error.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I can start another release tests if desired.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #19102.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
