### PR TITLE
cpu/esp32: fix and improve UART initialization [backport 2023.01]

### DIFF
--- a/cpu/esp32/bootloader/sdkconfig.h
+++ b/cpu/esp32/bootloader/sdkconfig.h
@@ -91,7 +91,7 @@ extern "C" {
  * If custom TX and RX are defined, use custom UART configuration for 2nd stage
  * bootloader.
  */
-#if defined(CONFIG_CONSOLE_UART_RX) && defined(CONFIG_CONSOLE_UART_RX)
+#if defined(CONFIG_CONSOLE_UART_TX) && defined(CONFIG_CONSOLE_UART_RX)
 #define CONFIG_ESP_CONSOLE_UART_CUSTOM      1
 #define CONFIG_ESP_CONSOLE_UART_TX_GPIO     CONFIG_CONSOLE_UART_TX
 #define CONFIG_ESP_CONSOLE_UART_RX_GPIO     CONFIG_CONSOLE_UART_RX

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -150,6 +150,10 @@ static NORETURN void IRAM system_startup_cpu0(void)
     /* initialize system call tables of ESP32x rom and newlib */
     syscalls_init();
 
+    /* systemwide UART initialization */
+    extern void uart_system_init (void);
+    uart_system_init();
+
     /* initialize stdio */
     esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
     stdio_init();
@@ -233,10 +237,6 @@ static NORETURN void IRAM system_init (void)
 
     /* install exception handlers */
     init_exceptions();
-
-    /* systemwide UART initialization */
-    extern void uart_system_init (void);
-    uart_system_init();
 
     /* set log levels for SDK library outputs */
     extern void esp_log_level_set(const char* tag, esp_log_level_t level);

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -147,6 +147,9 @@ static NORETURN void IRAM system_startup_cpu0(void)
     puf_sram_init((uint8_t *)&_sheap, SEED_RAM_LEN);
 #endif
 
+    /* initialize system call tables of ESP32x rom and newlib */
+    syscalls_init();
+
     /* initialize stdio */
     esp_rom_uart_tx_wait_idle(CONFIG_ESP_CONSOLE_UART_NUM);
     stdio_init();
@@ -227,9 +230,6 @@ static NORETURN void IRAM system_init (void)
 
     /* initialize the ISR stack for usage measurements */
     thread_isr_stack_init();
-
-    /* initialize system call tables of ESP32x rom and newlib */
-    syscalls_init();
 
     /* install exception handlers */
     init_exceptions();

--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -60,6 +60,7 @@
 #else /* defined(MCU_ESP8266) */
 
 #include "esp_rom_gpio.h"
+#include "esp_rom_uart.h"
 #include "hal/interrupt_controller_types.h"
 #include "hal/interrupt_controller_ll.h"
 #include "soc/gpio_reg.h"
@@ -68,6 +69,7 @@
 #include "soc/periph_defs.h"
 #include "soc/rtc.h"
 #include "soc/soc_caps.h"
+#include "soc/uart_pins.h"
 #include "soc/uart_reg.h"
 #include "soc/uart_struct.h"
 
@@ -166,7 +168,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     assert(uart < UART_NUMOF);
 
 #ifndef MCU_ESP8266
-    /* reset the pins when they were already used as UART pins */
+    assert(uart_config[uart].txd != GPIO_UNDEF);
+    assert(uart_config[uart].rxd != GPIO_UNDEF);
+
+    /* reset the pin usage when they were already used as UART pins */
     if (gpio_get_pin_usage(uart_config[uart].txd) == _UART) {
         gpio_set_pin_usage(uart_config[uart].txd, _GPIO);
     }
@@ -186,6 +191,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     gpio_set_pin_usage(uart_config[uart].txd, _UART);
     gpio_set_pin_usage(uart_config[uart].rxd, _UART);
 
+    esp_rom_uart_tx_wait_idle(uart);
     esp_rom_gpio_connect_out_signal(uart_config[uart].txd,
                                     _uarts[uart].signal_txd, false, false);
     esp_rom_gpio_connect_in_signal(uart_config[uart].rxd,
@@ -247,6 +253,18 @@ void uart_system_init(void)
         /* reset all UART interrupt status registers */
         _uarts[uart].regs->int_clr.val = ~0;
     }
+#ifndef MCU_ESP8266
+    /* reset the pin usage of the default UART0 pins to GPIO to allow
+     * reinitialization and usage for other purposes */
+    gpio_set_pin_usage(U0TXD_GPIO_NUM, _GPIO);
+    gpio_set_pin_usage(U0RXD_GPIO_NUM, _GPIO);
+#if defined(CONFIG_CONSOLE_UART_TX) && defined(CONFIG_CONSOLE_UART_TX)
+    /* reset the pin usage of the UART pins used by the bootloader to
+     * _GPIO to be able to use them later for other purposes */
+    gpio_set_pin_usage(CONFIG_CONSOLE_UART_TX, _GPIO);
+    gpio_set_pin_usage(CONFIG_CONSOLE_UART_RX, _GPIO);
+#endif
+#endif
 }
 
 void uart_print_config(void)

--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -179,11 +179,14 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         gpio_set_pin_usage(uart_config[uart].rxd, _GPIO);
     }
 
-    /* try to initialize the pins as GPIOs first */
-    if ((uart_config[uart].txd != GPIO_UNDEF &&
-         gpio_init(uart_config[uart].txd, GPIO_OUT)) ||
-        (uart_config[uart].rxd != GPIO_UNDEF &&
-         gpio_init(uart_config[uart].rxd, GPIO_IN_PU))) {
+    /* Try to initialize the pins where the TX line is set and temporarily
+     * configured as a pull-up open-drain output before configuring it as
+     * a push-pull output to avoid a several msec long LOW pulse resulting
+     * in some garbage */
+    gpio_set(uart_config[uart].txd);
+    if (gpio_init(uart_config[uart].txd, GPIO_OD_PU) ||
+        gpio_init(uart_config[uart].txd, GPIO_OUT) ||
+        gpio_init(uart_config[uart].rxd, GPIO_IN_PU)) {
         return -1;
     }
 


### PR DESCRIPTION
# Backport of PR #19146

### Contribution description

This PR fixes issue #19138 that was introduced with PR #19100. It contains the following changes to fix the problems and to improve the UART initialization:

- If `LOG_LEVEL` is greater or equal 4, such as in `tests/log_printfnoformat`, the ESP-IDF config function called for the GPIO pins of the UART will output the configuration with `printf` before the `_GLOBAL_REENT` structure is initialized. This causes a crash during system startup. Therefore the initialization by `syscalls_init` must be called by `earlier in the startup procedure.
- Since PR #19100 it is possible to define:
   - other pins for `UART_DEV(0)` than the default pins
   - different `UART_DEV(0)` pins for the bootloader and RIOT
   
   To allow correct reinitialization of the UART pins used by the bootloader as well as their usage for other purposes, the pin usage for the default UART0 pins and the UART pinsused by the bootloader are reset to `_GPIO`. This is done in `uart_system_init` which has to be called earlier in the startup procedure.
- To avoid garbage on reconfiguring the UART console pins, e.g. in initialization of the `arduino` module, pins that are already configured as UART pins must not be initialized.
- To avoid a several msec long LOW pulse resulting in some garbage during the UART initialization, the TX line is set to HIGH and temporarily configured as a pull-up open-drain output before configuring it as a push-pull output.

The PR requires a backport to 2023.1

### Testing procedure

The following tests should work with this PR:
- [ ] `tests/log_color`
- [ ] `tests/log_printfnoformat`
- [ ] `tests/sys_arduino`

### Issues/PRs references

Fixes #19138 