### PR TITLE
SECURITY: Describe that declassification is an option

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,6 +20,14 @@ bottom of this file.
 
 [security-gpg]: https://riot-os.org/assets/keys/security.asc
 
+### Classification of a vulnerability
+
+Unless the reporter explicitly requests not to do so,
+the RIOT security maintainers may declassify an issue
+if the issue is not deemed critical --
+for example when it requires an unlikely combination of circumstances and/or configuration options,
+or when it can only be exploited by a user who gains no additional privileges.
+
 ## Notification of a Vulnerability
 
 After a fix is provided the security issue will be privately disclosed to the


### PR DESCRIPTION
### Contribution description

Our security policy does not contain provisions for the case when what is reported is not what we consider an actual security issue. As it is described now, everything reported through security@ would go through the full treatment, including a point release.

I'm not sure it belongs into the text itself (as it's more about how security reporters interact with the project than internals), but declassification should IMO be backed at least by 3 maintainers, and no strong NACK.

### Issues/PRs references

#19141 followed that procedure after some chat on it on the maintainers channel. (In the discussion, I proposed declassification, with 2.5 people supporting it and one "I was about to, but can we be sure nobody is using it?" voice).