### PR TITLE
gnrc_sixlowpan: use actual l2 header size to decide whether to fragment or not

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -25,6 +25,8 @@
 #ifndef NET_NETOPT_H
 #define NET_NETOPT_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -867,6 +869,42 @@ typedef enum {
                                  *   not listening to packets. */
     /* add other states if needed */
 } netopt_state_t;
+
+/**
+ * @brief   Prepare context value for NETOPT_PDU_SIZE
+ *
+ * @param[in] src_len   length of the l2 src address
+ * @param[in] dst_len   length of the l2 dst address
+ * @param[in] flags     l2 flags
+ *
+ * @return context for NETOPT_PDU_SIZE - needs to be passed in value pointer
+ */
+static inline uint16_t netopt_pdu_size_ctx_pack(uint8_t src_len, uint8_t dst_len, uint8_t flags)
+{
+    uint16_t out = 0;
+
+    out |= src_len & 0xF;
+    out |= (dst_len & 0xF) << 4;
+    out |= flags << 8;
+
+    return out;
+}
+
+/**
+ * @brief   Parse context value of NETOPT_PDU_SIZE
+ *
+ * @param[in]  ctx      context that was passwd via the value pointer
+ * @param[out] src_len  length of the l2 src address
+ * @param[out] dst_len  length of the l2 dst address
+ * @param[out] flags    l2 flags
+ */
+static inline void netopt_pdu_size_ctx_unpack(uint16_t ctx, uint8_t *src_len,
+                                              uint8_t *dst_len, uint8_t *flags)
+{
+    *src_len = ctx & 0xF;
+    *dst_len = (ctx & 0xF0) >> 4;
+    *flags = ctx >> 8;
+}
 
 /**
  * @brief   Option parameter to be used with @ref NETOPT_RF_TESTMODE


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently GNRC uses the static `NETOPT_MAX_PDU_SIZE` to decide whether to fragment or not.
This can lead to premature fragmentation (e.g. for broadcast packets).

As a solution, ask netdev what the l2 header size would be for a given source/destination/flags combination via `NETOPT_PDU_SIZE`¹

If the option is not implemented, `.max_frag_size` will remain at it's original value (`NETOPT_MAX_PDU_SIZE`).

Since netdev does not allow to pass information via context, it is passed via the value pointer. This looks a bit weird on the gnrc level where `gnrc_netdev` has a context that is then stripped when forwarding the request to the low-level netdev driver.

[1] I realized after implementing this that the name is already taken by LoRa to get information about the *RX* frame. So we need a different name, but I found `NETOPT_PDU_SIZE` to be most logical for this. So either we find a better name for the use in LoRa or here, but I just wanted to put it out already.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #19132
