### PR TITLE
examples/gcoap: Fix shell parameter validation

### DIFF
--- a/examples/gcoap/client.c
+++ b/examples/gcoap/client.c
@@ -294,6 +294,11 @@ int gcoap_cli_cmd(int argc, char **argv)
             uri_len = strlen(argv[apos+1]);
         }
 
+        if (uri && ((uri_len <= 0) || (uri[0] != '/'))) {
+            puts("ERROR: URI-Path must start with a \"/\"");
+            return _print_usage(argv);
+        }
+
         if (_proxied) {
             sock_udp_ep_t tmp_remote;
             if (sock_udp_name2ep(&tmp_remote, argv[apos]) != 0) {
@@ -329,7 +334,7 @@ int gcoap_cli_cmd(int argc, char **argv)
 
             gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos, NULL);
         }
-        else{
+        else {
             gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos, uri);
         }
         coap_hdr_set_type(pdu.hdr, msg_type);


### PR DESCRIPTION
### Contribution description

Executing the shell command with an URI-Path that doesn't start with a slash results in an assertion error while composing the client side message. This is suboptimal user experience, so add an explicit check for a valid URI-Path and a dedicated error message.

### Testing procedure

#### In `master`

```
 $ make BOARD=microbit-v2 -C examples/gcoap flash term
[...]
2023-01-15 22:23:32,512 #  coap get [::1] /.well-known/core
2023-01-15 22:23:32,516 # gcoap_cli: sending msg ID 52272, 23 bytes
2023-01-15 22:23:32,520 # gcoap: response Success, code 2.05, 46 bytes
2023-01-15 22:23:32,524 # </cli/stats>;ct=0;rt="count";obs,</riot/board>
> coap get [::1] foo
2023-01-15 22:23:34,763 # coap get [::1] foo
2023-01-15 22:23:34,763 # 2329
2023-01-15 22:23:34,765 # *** RIOT kernel panic:
2023-01-15 22:23:34,767 # FAILED ASSERTION.
2023-01-15 22:23:34,767 # 
2023-01-15 22:23:34,775 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2023-01-15 22:23:34,784 # 	 - | isr_stack            | -        - |   - |    512 (  200) (  312) | 0x20000000 | 0x200001c8
2023-01-15 22:23:34,793 # 	 1 | main                 | running  Q |   7 |   1536 ( 1072) (  464) | 0x200006c0 | 0x2000095c 
2023-01-15 22:23:34,802 # 	 2 | 6lo                  | bl rx    _ |   3 |   1024 (  328) (  696) | 0x200036c0 | 0x200039c4 
2023-01-15 22:23:34,810 # 	 3 | ipv6                 | bl rx    _ |   4 |   1024 (  460) (  564) | 0x20001294 | 0x20001574 
2023-01-15 22:23:34,819 # 	 4 | udp                  | bl rx    _ |   5 |    512 (  300) (  212) | 0x20003e98 | 0x20003f9c 
2023-01-15 22:23:34,828 # 	 5 | coap                 | bl anyfl _ |   6 |   1112 (  704) (  408) | 0x20000e38 | 0x200011c4 
2023-01-15 22:23:34,837 # 	 6 | nrf802154            | bl anyfl _ |   2 |    896 (  288) (  608) | 0x20001a90 | 0x20001d54 
2023-01-15 22:23:34,843 # 	   | SUM                  |            |     |   6616 ( 3352) ( 3264)
2023-01-15 22:23:34,843 # 
2023-01-15 22:23:34,844 # *** halted.
2023-01-15 22:23:34,844 # 
```

#### This PR

```
 $ make BOARD=microbit-v2 -C examples/gcoap flash term
[...]
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/gcoap'
/home/maribu/Repos/software/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
2023-01-15 22:22:27,842 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
coap get [::1] /.well-known/core
2023-01-15 22:22:40,042 #  coap get [::1] /.well-known/core
2023-01-15 22:22:40,046 # gcoap_cli: sending msg ID 25182, 23 bytes
2023-01-15 22:22:40,050 # gcoap: response Success, code 2.05, 46 bytes
2023-01-15 22:22:40,054 # </cli/stats>;ct=0;rt="count";obs,</riot/board>
> coap get [::1] foo
2023-01-15 22:22:43,858 # coap get [::1] foo
2023-01-15 22:22:43,862 # ERROR: URI-Path must start with a "/"
2023-01-15 22:22:43,866 # usage: coap <get|post|put|ping|proxy|info>
```

### Issues/PRs references

None