### PR TITLE
toolchain/gnu.inc.mk: don't check version if CC is not installed [backport 2023.01]

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -23,7 +23,7 @@ endif
 _OBJDUMP         := $(or $(shell command -v $(PREFIX)objdump || command -v gobjdump),objdump)
 OBJDUMP   ?= $(_OBJDUMP)
 
-GCC_VERSION := $(shell $(CC) -dumpversion | cut -d . -f 1)
+GCC_VERSION := $(shell command -v $(CC) > /dev/null && $(CC) -dumpversion | cut -d . -f 1)
 
 # -fmacro-prefix-map requires GCC 8
 ifneq (8, $(firstword $(shell echo 8 $(GCC_VERSION) | tr ' ' '\n' | sort -n)))


### PR DESCRIPTION
# Backport of #19137



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
With b30efeeb65 a warning was introduced when using `make term` without the proper toolchain installed (e.g. when using BUILD_IN_DOCKER, but `term` outside of the docker). This removes this warning.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `make term` for a board where you do not have the toolchain installed. Output such as

```
/bin/sh: line 1: xtensa-esp32-elf-gcc: command not found
```

should disappear with this PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes a minor issue introduced in https://github.com/RIOT-OS/RIOT/pull/18935.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
