### PR TITLE
Revert "sys/pm_layered: pm_(un)block add attribute optimize(3)"

### DIFF
--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -74,7 +74,6 @@ void pm_set_lowest(void)
     irq_restore(state);
 }
 
-__attribute__((optimize(3)))
 void pm_block(unsigned mode)
 {
     DEBUG("[pm_layered] pm_block(%d)\n", mode);
@@ -85,7 +84,6 @@ void pm_block(unsigned mode)
     irq_restore(state);
 }
 
-__attribute__((optimize(3)))
 void pm_unblock(unsigned mode)
 {
     DEBUG("[pm_layered] pm_unblock(%d)\n", mode);


### PR DESCRIPTION
Revert "sys/pm_layered: pm_(un)block add attribute optimize(3) -shortens hotpath"

This reverts commit 5447203921ab39962d7d378a631a6bc048e7f30b.

### Contribution description

Compiling `examples/gnrc_networking_mac` using `TOOLCHAIN=llvm` yields the following error:
```
RIOT/sys/pm_layered/pm.c:77:16: error: unknown attribute 'optimize' ignored [-Werror,-Wunknown-attributes]
__attribute__((optimize(3)))
```
As indicated, this is because the attribute `optimize` is GCC only and not present in LLVM.
Compare the manpages of [GCC](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html) and [LLVM](https://clang.llvm.org/docs/AttributeReference.html).


### Testing procedure

Since this should only affect performance and not behavior, no special testing is needed. I am not aware of any tests in RIOT which could verify that assumption.

### Issues/PRs references

Introduced in #18846

There is another instance of this attribute being used in[ shell_lock.c](https://github.com/RIOT-OS/RIOT/blob/6fb340d654ac8da07759cb9199c6aaa478589aa7/sys/shell_lock/shell_lock.c#L80). Since the usage is security related, I omit it from this PR.
