### PR TITLE
core/compiler_hints: add likely() / unlikely() hints

### DIFF
--- a/core/lib/include/assert.h
+++ b/core/lib/include/assert.h
@@ -22,6 +22,8 @@
 #ifndef ASSERT_H
 #define ASSERT_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,6 +44,9 @@ extern "C" {
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 #define DEBUG_ASSERT_VERBOSE
+#else
+/* we should not include custom headers in standard headers */
+#define _likely(x)      __builtin_expect((uintptr_t)(x), 1)
 #endif
 
 /**
@@ -106,10 +111,10 @@ __NORETURN void _assert_failure(const char *file, unsigned line);
  *
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/assert.html
  */
-#define assert(cond) ((cond) ? (void)0 :  _assert_failure(__FILE__, __LINE__))
+#define assert(cond) (_likely(cond) ? (void)0 :  _assert_failure(__FILE__, __LINE__))
 #else /* DEBUG_ASSERT_VERBOSE */
 __NORETURN void _assert_panic(void);
-#define assert(cond) ((cond) ? (void)0 : _assert_panic())
+#define assert(cond) (_likely(cond) ? (void)0 : _assert_panic())
 #endif /* DEBUG_ASSERT_VERBOSE */
 
 #if !defined __cplusplus

--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -21,6 +21,8 @@
 #ifndef COMPILER_HINTS_H
 #define COMPILER_HINTS_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -129,6 +131,24 @@ extern "C" {
 #else
 #define IS_CT_CONSTANT(expr) 0
 #endif
+
+/**
+ * @brief   Hint to the compiler that the condition @p x is likely taken
+ *
+ * @param[in] x     Condition that is likely taken
+ *
+ * @return result of @p x
+ */
+#define likely(x)       __builtin_expect((uintptr_t)(x), 1)
+
+/**
+ * @brief   Hint to the compiler that the condition @p x is likely not taken
+ *
+ * @param[in] x     Condition that is unlikely
+ *
+ * @return result of @p x
+ */
+#define unlikely(x)     __builtin_expect((uintptr_t)(x), 0)
 
 #ifdef __cplusplus
 }

--- a/sys/include/test_utils/expect.h
+++ b/sys/include/test_utils/expect.h
@@ -26,6 +26,7 @@
 #define TEST_UTILS_EXPECT_H
 
 #include <stdio.h>
+#include "compiler_hints.h"
 #include "panic.h"
 
 #ifdef __cplusplus
@@ -76,7 +77,7 @@ NORETURN static inline void _expect_failure(const char *file, unsigned line)
  * the condition failed in.
  *
  */
-#define expect(cond) ((cond) ? (void)0 :  _expect_failure(__FILE__, __LINE__))
+#define expect(cond) (likely(cond) ? (void)0 :  _expect_failure(__FILE__, __LINE__))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The compiler can optimize the code better if it knows whether a condition is likely taken / not taken.

This is usually something the developer should not bother with, but for things like `assert()` where the condition should *always* be true, we can tell the compiler to optimize that path.


### Testing procedure

No logic changes, CI will ensure that all our compilers know about the builtin. 


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/19155#issuecomment-1384094781
