### PR TITLE
boards/rpi-pico-w: fix too large board image

### DIFF
--- a/boards/rpi-pico-w/doc.txt
+++ b/boards/rpi-pico-w/doc.txt
@@ -12,9 +12,10 @@ chip.
 
 ## Hardware
 
-Raspberry Pi Pico W (third from left) and Pico WH (forth from right).
+![Raspberry Pi Pico W](https://www.raspberrypi.com/app/uploads/2022/06/Copy-of-PICO-W-HERO-800x533.jpg)
 
-![Raspberry Pi Pico family](https://www.raspberrypi.com/documentation/microcontrollers/images/four_picos.jpg)
+Raspberry Pi Pico W is provided in two versions - without and with headers,
+the second one is called Pico WH. Detailed photos can be found at [Raspberry Pi Pico family](https://www.raspberrypi.com/documentation/microcontrollers/images/four_picos.jpg).
 
 ### MCU
 


### PR DESCRIPTION
### Contribution description

PR #19071 adds Raspberry Pico W board to RIOT. Unfortunately, current Doxygen version used for generation boards documentation available in RIOT webpage, do not scale images. In effect current [documentation](https://doc.riot-os.org/group__boards__rpi__pico__w.html) presents to users very, very huge board image. This PR change this image to smaller one, like in other boards. 
  
### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__rpi__pico__w.htm
```
and compare with current [documentation](https://doc.riot-os.org/group__boards__rpi__pico__w.html).

### Issues/PRs references

PR #19071
