### PR TITLE
cpu/sam0_common: move adc_res_t to common code

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -719,12 +719,13 @@ static inline void sercom_clk_dis(void *sercom)
 
 #ifdef CPU_COMMON_SAMD5X
 static inline uint8_t _sercom_gclk_id_core(uint8_t sercom_id) {
-    if (sercom_id < 2)
+    if (sercom_id < 2) {
         return sercom_id + 7;
-    if (sercom_id < 4)
+    } else if (sercom_id < 4) {
         return sercom_id + 21;
-    else
+    } else {
         return sercom_id + 30;
+    }
 }
 #endif
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -807,6 +807,24 @@ typedef struct {
 #define ADC_REFSEL_AREFC_PIN    GPIO_PIN(PA, 6)
 #endif
 
+#ifndef DOXYGEN
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = 0xff,                       /**< not supported */
+#if defined(ADC_CTRLB_RESSEL)
+    ADC_RES_8BIT  = ADC_CTRLB_RESSEL_8BIT_Val,  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = ADC_CTRLB_RESSEL_10BIT_Val, /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = ADC_CTRLB_RESSEL_12BIT_Val, /**< ADC resolution: 12 bit */
+#elif defined(ADC_CTRLC_RESSEL)
+    ADC_RES_8BIT  = ADC_CTRLC_RESSEL_8BIT_Val,  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = ADC_CTRLC_RESSEL_10BIT_Val, /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = ADC_CTRLC_RESSEL_12BIT_Val, /**< ADC resolution: 12 bit */
+#endif
+    ADC_RES_14BIT = 0xfe,                       /**< not supported */
+    ADC_RES_16BIT = 0xfd                        /**< not supported */
+} adc_res_t;
+#endif /* DOXYGEN */
+
 /**
  * @name Ethernet peripheral parameters
  * @{

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -203,12 +203,10 @@ static int _adc_configure(Adc *dev, adc_res_t res)
     /* Set ADC resolution */
 #ifdef ADC_CTRLC_RESSEL
     /* Reset resolution bits in CTRLC */
-    dev->CTRLC.reg &= ~ADC_CTRLC_RESSEL_Msk;
-    dev->CTRLC.reg |= res;
+    dev->CTRLC.bit.RESSEL = res;
 #else
     /* Reset resolution bits in CTRLB */
-    dev->CTRLB.reg &= ~ADC_CTRLB_RESSEL_Msk;
-    dev->CTRLB.reg |= res;
+    dev->CTRLB.bit.RESSEL = res;
 #endif
 
     /* Set Voltage Reference */

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -99,18 +99,6 @@ static inline int _sercom_id(SercomUsart *sercom)
     return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
 }
 
-#ifndef DOXYGEN
-#define HAVE_ADC_RES_T
-typedef enum {
-    ADC_RES_6BIT  = 0xff,                       /**< not supported */
-    ADC_RES_8BIT  = ADC_CTRLB_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = ADC_CTRLB_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = ADC_CTRLB_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xfe,                       /**< not supported */
-    ADC_RES_16BIT = 0xfd                        /**< not supported */
-} adc_res_t;
-#endif /* ndef DOXYGEN */
-
 /**
  * @brief   Pins that can be used for ADC input
  */

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -83,18 +83,6 @@ enum {
  */
 #define SPI_HWCS(x)     (UINT_MAX - 1)
 
-#ifndef DOXYGEN
-#define HAVE_ADC_RES_T
-typedef enum {
-    ADC_RES_6BIT  = 0xff,                       /**< not supported */
-    ADC_RES_8BIT  = ADC_CTRLB_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = ADC_CTRLB_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = ADC_CTRLB_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xfe,                       /**< not supported */
-    ADC_RES_16BIT = 0xfd                        /**< not supported */
-} adc_res_t;
-#endif /* DOXYGEN */
-
 /**
  * @brief   Pins that can be used for ADC input
  */

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -43,18 +43,6 @@ enum {
 };
 /** @} */
 
-#ifndef DOXYGEN
-#define HAVE_ADC_RES_T
-typedef enum {
-    ADC_RES_6BIT  = 0xff,                       /**< not supported */
-    ADC_RES_8BIT  = ADC_CTRLC_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = ADC_CTRLC_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = ADC_CTRLC_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xfe,                       /**< not supported */
-    ADC_RES_16BIT = 0xfd                        /**< not supported */
-} adc_res_t;
-#endif /* ndef DOXYGEN */
-
 /**
  * @brief   Pins that can be used for ADC input
  */

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -74,18 +74,6 @@ enum {
 };
 /** @} */
 
-#ifndef DOXYGEN
-#define HAVE_ADC_RES_T
-typedef enum {
-    ADC_RES_6BIT  = 0xff,                       /**< not supported */
-    ADC_RES_8BIT  = ADC_CTRLC_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = ADC_CTRLC_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = ADC_CTRLC_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xfe,                       /**< not supported */
-    ADC_RES_16BIT = 0xfd                        /**< not supported */
-} adc_res_t;
-#endif /* ndef DOXYGEN */
-
 /**
  * @brief   Pins that can be used for ADC input
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`adc_res_t` is the same across all family members, so move it to common code.
This will help extending it as a follow-up.

Also move to `bit.RESSEL` access instead of masking the whole register to make the code more readable.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
