### PR TITLE
boards/seeedstudio-gd32: complete and improve board definition

### DIFF
--- a/boards/seeedstudio-gd32/Kconfig
+++ b/boards/seeedstudio-gd32/Kconfig
@@ -15,6 +15,7 @@ config BOARD_SEEEDSTUDIO_GD32
     select HAS_PERIPH_UART
     select BOARD_HAS_HXTAL
     select BOARD_HAS_LXTAL
+    select HAVE_SAUL_GPIO
 
 config BOARD_HAS_HXTAL
     bool

--- a/boards/seeedstudio-gd32/Makefile.dep
+++ b/boards/seeedstudio-gd32/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/seeedstudio-gd32/Makefile.include
+++ b/boards/seeedstudio-gd32/Makefile.include
@@ -1,2 +1,10 @@
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# configure the flasher
 PROGRAMMER ?= openocd
-OPENOCD_RESET_USE_CONNECT_ASSERT_SRST=1
+OPENOCD_DEBUG_ADAPTER ?= ftdi
+OPENOCD_FTDI_ADAPTER ?= openocd-usb
+OPENOCD_TRANSPORT = jtag
+OPENOCD_RESET_USE_CONNECT_ASSERT_SRST = 1

--- a/boards/seeedstudio-gd32/dist/openocd.cfg
+++ b/boards/seeedstudio-gd32/dist/openocd.cfg
@@ -1,12 +1,27 @@
-adapter driver ftdi
-adapter speed     10000
-ftdi_vid_pid 0x0403 0x6010
+adapter speed 10000
 adapter srst pulse_width 10
-reset_config srst_only srst_open_drain
-
-ftdi_layout_init 0x0020 0x001b
-ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
+reset_config srst_nogate srst_only srst_open_drain
 
 source [find target/gd32vf103.cfg]
 
-flash bank $_CHIPNAME.flash gd32vf103 0x08000000 0 0 0 $_TARGETNAME
+$_TARGETNAME configure -event reset-assert {
+
+    global _TARGETNAME
+
+    # Halt the core.
+    halt
+
+    # Unlock 0xe0042008 so that the next write triggers a reset
+    $_TARGETNAME mww 0xe004200c 0x4b5a6978
+
+    # We need to trigger the reset using abstract memory access, since
+    # progbuf access tries to read a status code out of a core register
+    # after the write happens, which fails when the core is in reset.
+    riscv set_mem_access abstract
+
+    # Go!
+    $_TARGETNAME mww 0xe0042008 0x1
+
+    # Put the memory access mode back to what it was.
+    riscv set_mem_access progbuf
+}

--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -1,0 +1,113 @@
+/**
+@defgroup   boards_seeedstudio-gd32 SeeedStudio GD32 RISC-V board
+@ingroup    boards
+@brief      Support for the SeeedStudio GD32 RISC-V board
+@author     Koen Zandberg <koen@bergzand.net>
+@author     Gunar Schorcht <gunar@schorcht.net>
+
+## Overview
+
+The [Seedstudio GD32 RISC-V Dev Board]
+(https://wiki.seeedstudio.com/SeeedStudio-GD32-RISC-V-Dev-Board/) is a
+development board for the GigaDevice GD32VF103VBT6 MCU with the following
+on-board components:
+
+- GD32VF103VBT6 RISC-V MCU @108MHz
+- 8MB on-board Flash W25Q64
+- 256 byte EEPROM
+- LCD Interface: 16-bit 8080 interface and SPI touch screen control interface
+- USB Type C
+- TF card slot
+- 2 user buttons
+- 3 user LEDs
+
+@image html "https://files.seeedstudio.com/wiki/GD32VF103/img/GD32VF-103VBT6-pin.jpg" "Seeedstudio GD32 RISC-V Dev Board" width=600
+
+## Hardware:
+
+| MCU         | GD32VF103VBT6                          | Supported |
+|:----------- |:-------------------------------------- | --------- |
+| Family      | RISC-V with ECLIC                      |           |
+| Vendor      | GigaDevice                             |           |
+| RAM         | 32 kByte                               |           |
+| Flash       | 128 KByte                              |           |
+| Frequency   | 108 MHz                                |           |
+| Power Modes | 3 (Sleep, Deep Sleep, Standby)         |   no      |
+| GPIOs       | 80                                     |   yes     |
+| Timers      | 5 x 16-bit timer                       |   yes     |
+| RTC         | 1 x 32-bit counter, 20-bit prescaler   |   no      |
+| WDT         | 2 x 12-bit counter, 3-bit prescaler    |   yes     |
+| ADC         | 2 x 12-bit units, 16 channels, 1 Msps  |   no      |
+| DAC         | 2 x 12-bit channel                     |   no      |
+| UART        | 2                                      |   yes     |
+| USART       | 3                                      |   yes     |
+| SPI         | 3                                      |   no      |
+| I2C         | 2 x Fast Mode 400 kHz                  |   no      |
+| I2S         | 2                                      |   no      |
+| CAN         | 2 x CAN 2.0B with up to 1 Mbps         |   no      |
+| PWM         | 6 Channels                             |   no      |
+| USB         | 1 x USB FS OTG                         |   no      |
+| Vcc         | 3.0V - 3.6V                            |           |
+| Datasheet   | [Datasheet](https://gd32mcu.com/data/documents/datasheet/GD32VF103_Datasheet_Rev1.6.pdf) | |
+| Reference Manual | [Reference Manual](https://gd32mcu.com/download/down/document_id/222/path_type/1) | |
+| Board Manual | [Board Manual](https://wiki.seeedstudio.com/SeeedStudio-GD32-RISC-V-Dev-Board/) | |
+| Board Schematic | [Board Schematic](https://github.com/SeeedDocument/GD32VF103/raw/master/res/GD32VF103VBT6-dev-board.pdf) | |
+
+## Pin Layout / Configuration
+
+The general pin layout is shown below.
+
+@image html "https://raw.githubusercontent.com/SeeedDocument/GD32VF103/master/img/GD32VF-103VBT6-c.jpg" "Seeedstudio GD32 RISC-V Dev Board Pinout" width=600
+
+The following table shows the connection of the on-board components with the
+MCU pins and their configuration in RIOT.
+
+| MCU Pin | MCU Peripheral | RIOT Peripheral     | Board Function        |
+|:--------|:---------------|:--------------------|:----------------------|
+| PA0     |                |                     | BTN0                  |
+| PA9     | USART0 TX      | UART_DEV(0) TX      | UART TX               |
+| PA10    | USART0 RX      | UART_DEV(0) RX      | UART RX               |
+| PB0     |                |                     | LED1                  |
+| PB1     |                |                     | LED2                  |
+| PB5     |                |                     | LED0                  |
+| PC13    |                |                     | BTN1                  |
+
+## Flash the board
+
+The board is flashed via a JTAG interface with OpenOCD (at least [release version 0.12.0]
+(https://github.com/openocd-org/openocd/tree/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c)).
+By default, an FTDI adapter according to the configuration defined in
+[`interface/openocd-usb.cfg`]
+(https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
+is assumed.
+```
+BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+```
+To use an FTDI adapter with a different configuration, the configuration can be
+defined using the variable `OPENOCD_FTDI_ADAPTER`, for example:
+```
+OPENOCD_FTDI_ADAPTER=tigar BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+```
+If another adapter is used, it can be specified using variable
+`OPENOCD_DEBUG_ADAPTER`, for example for a Segger J-Link adapter:
+```
+OPENOCD_DEBUG_ADAPTER=jlink BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+```
+
+## Accessing STDIO via UART
+
+The `stdio` is directly accessible through the first UART interface. If an
+external USB-to-UART interface is used, this interface is mapped to
+`/dev/ttyUSB<n>` on a Linux host, where `<n>` is the index of the UART
+interface, which is 0 by default.
+
+Use the `term` target to connect to the board using `/dev/ttyUSB0`:
+```
+BOARD=seeedstudio-gd32 make -C examples/hello-world term
+```
+If the UART interface index of board's USB to UART bridge is not 0, use
+the following command to connect:
+```
+BOARD=seeedstudio-gd32 make -C examples/hello-world term PORT=/dev/ttyUSB<n>
+```
+ */

--- a/boards/seeedstudio-gd32/include/board.h
+++ b/boards/seeedstudio-gd32/include/board.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *               2023 Gunar Schorcht <gunar@schorcht.net>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,15 +8,14 @@
  */
 
 /**
- * @defgroup    boards_seeedstudio-gd32 SeeedStudio GD32 RISC-V board
- * @ingroup     boards
- * @brief       Support for the SeeedStudio GD32 RISC-V board
+ * @ingroup     boards_seeedstudio-gd32
  * @{
  *
  * @file
  * @brief       Board specific definitions for the SeeedStudio GD32 RISC-V board
  *
  * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
 #ifndef BOARD_H
@@ -26,6 +26,46 @@ extern "C" {
 #endif
 
 #include "macros/units.h"
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_A, 0)
+#define BTN0_MODE           GPIO_IN
+#define BTN0_INT_FLANK      GPIO_RISING
+
+#define BTN1_PIN            GPIO_PIN(PORT_C, 13)
+#define BTN1_MODE           GPIO_IN
+#define BTN1_INT_FLANK      GPIO_RISING
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B, 5)
+#define LED0_MASK           (1 << 5)
+#define LED0_ON             (GPIOB->BC = LED0_MASK)
+#define LED0_OFF            (GPIOB->BOP = LED0_MASK)
+#define LED0_TOGGLE         (GPIOB->OCTL ^= LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PORT_B, 0)
+#define LED1_MASK           (1 << 0)
+#define LED1_ON             (GPIOB->BC = LED1_MASK)
+#define LED1_OFF            (GPIOB->BOP = LED1_MASK)
+#define LED1_TOGGLE         (GPIOB->OCTL ^= LED1_MASK)
+
+#define LED2_PIN            GPIO_PIN(PORT_B, 1)
+#define LED2_MASK           (1 << 1)
+#define LED2_ON             (GPIOB->BC = LED2_MASK)
+#define LED2_OFF            (GPIOB->BOP = LED2_MASK)
+#define LED2_TOGGLE         (GPIOB->OCTL ^= LED2_MASK)
+
+#define LED_RED_PIN         LED0_PIN    /**< LED0 is red */
+#define LED_GREEN_PIN       LED1_PIN    /**< LED1 is green */
+#define LED_BLUE_PIN        LED2_PIN    /**< LED2 is blue */
+/** @} */
 
 /**
  * @name    Xtimer configuration

--- a/boards/seeedstudio-gd32/include/gpio_params.h
+++ b/boards/seeedstudio-gd32/include/gpio_params.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-gd32
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED/Button SAUL configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED RED",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED GREEN",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED BLUE",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "KEY1",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+    },
+    {
+        .name  = "KEY2",
+        .pin   = BTN1_PIN,
+        .mode  = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR completes and improves the board definition for the Seeedstudio GD32 RISC-V Dev board. It
- adds the user LED and Button definitions to `board.h` (bef42091091cfd8d79130f2109b22b2379959057)
- adds the SAUL support for user LED and Button definitions (7a5b2f1fb43f5e28eec4f65c8e7367510be6eb80)
- changes the OpenOCD configuration (32c0c4b1b5b9705ffcd2bb02a1d868ad35ca3bbc)
   - to be usable with Upstream OpenOCD release version 0.12.0
   - to allow different FTDI configuration and other adapters
- adds a documentation with flashing guide, feature list, support status, pinout, schematic reference (9dcc83b8ceb8a9ce526f0a03053a242e866ebf4a)

These changes is the first PR for a number of follow-up PR I will provide in next days to extend the GD32VF103 support. I have already working
- `periph_adc` support,
- `periph_spi` support,
- `tinyusb_device` support,

and almost finished
- `periph_i2c` support (implemented and working with some errors),
- `pm_layered` support (implemented but not working correctly yet), and
- `periph_usbdev` support (implemented by extending `usbdev_synopsys_dwc2 driver but bot working yet).

I will try to implement
- `periph_gpio_irq` support,
- `periph_rtc` support, and
- `periph_rtt` support.

Since I'm using the Sispeed Longan Nano board for testing, I will add the board definition for this board. I will then move some board definitions to a common folder.

### Testing procedure

Green CI.
Documentation should be generated correctly.
Flashing the `seeedstudio-gd32` should still work.
`tests/leds` should work.

### Issues/PRs references