### PR TITLE
tests/driver_ws281x: don't overwrite board definition

### DIFF
--- a/tests/driver_ws281x/Makefile
+++ b/tests/driver_ws281x/Makefile
@@ -2,8 +2,8 @@ BOARD ?= atmega328p
 include ../Makefile.tests_common
 
 # Update this to your needs
-PIN ?= GPIO_PIN(0, 0)
-N ?= 8
+# PIN ?= GPIO_PIN(0, 0)
+# N ?= 8
 
 USEMODULE += ws281x
 USEMODULE += xtimer
@@ -14,5 +14,9 @@ BOARD_BLACKLIST := waspmote-pro
 
 include $(RIOTBASE)/Makefile.include
 
-CFLAGS += '-DWS281X_PARAM_PIN=$(PIN)'
-CFLAGS += '-DWS281X_PARAM_NUMOF=$(N)'
+ifneq (, $(PIN))
+  CFLAGS += '-DWS281X_PARAM_PIN=$(PIN)'
+endif
+ifneq (, $(N))
+  CFLAGS += '-DWS281X_PARAM_NUMOF=$(N)'
+endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a board has fixed defines for `WS281X_PARAM_PIN` and `WS281X_PARAM_NUMOF` the test will overwrite them.
This leads to the LEDs *not* working in with the test, which is very confusing.


### Testing procedure

Run the test on any board that has `WS281X_PARAM_PIN` set  in `board.h`.
The test should now work properly on those without tweaking the Makefile.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
