### PR TITLE
tests/gnrc_rpl: Disable CI test for native

### DIFF
--- a/tests/gnrc_rpl/Makefile
+++ b/tests/gnrc_rpl/Makefile
@@ -28,3 +28,6 @@ host-tools:
 TERMDEPS += host-tools
 
 include $(RIOTBASE)/Makefile.include
+
+# Test is flaky and regularly derails unrelated merge trains
+TEST_ON_CI_BLACKLIST += native


### PR DESCRIPTION
### Contribution description

This disables the `tests/grnc_rpl` test run for `native`. This test is too flaky to be included in the CI.

### Testing procedure

Not needed

### Issues/PRs references

None