### PR TITLE
tests/periph_spi clearly say when init succeeds

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -217,9 +217,11 @@ int cmd_init(int argc, char **argv)
     else {
         printf("Trying to initialize SPI_DEV(%i): mode: %i, clk: %i, cs_port: %i, cs_pin: %i\n",
                dev, mode, clk, port, pin);
-        puts("Note: Failed assertion (crash) means configuration not supported");
+        puts("(if below the program crashes with a failed assertion, then it means the"
+             " configuration is not supported)");
         spi_acquire(spiconf.dev, spiconf.cs, spiconf.mode, spiconf.clk);
         spi_release(spiconf.dev);
+        puts("Success.");
     }
 
     return 0;


### PR DESCRIPTION
When the `tests/periph_spi` program succeeds the output can be interpreted as an error happened.
This PR makes it clearer when it does succeed.

### Contribution description

In `tests/periph_spi`:

- Explicitely say that the init operation was successful
- Rephrase the note to avoid misinterpretations 


### Testing procedure

Run the `tests/periph_spi` program.
There is not much to test, just to verify the output, should be like this:

```
2023-01-19 10:42:33,768 # Trying to initialize SPI_DEV(1): mode: 0, clk: 0, cs_port: 0, cs_pin: 0
2023-01-19 10:42:33,777 # (if below the program crashes with a failed assertion, then it means the configuration is not supported)
2023-01-19 10:42:33,779 # Success.
```


### Issues/PRs references

Issue https://github.com/RIOT-OS/RIOT/issues/19025