### PR TITLE
drivers/periph_common/flashpage: fix silent error

### DIFF
--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -63,13 +63,12 @@ int flashpage_write_and_verify(unsigned page, const void *data)
 void flashpage_write_page(unsigned page, const void *data)
 {
     assert((unsigned) page < FLASHPAGE_NUMOF);
+    assert(data != NULL);
 
     flashpage_erase(page);
 
     /* write page */
-    if (data != NULL) {
-        flashpage_write(flashpage_addr(page), data, FLASHPAGE_SIZE);
-    }
+    flashpage_write(flashpage_addr(page), data, FLASHPAGE_SIZE);
 }
 #endif
 


### PR DESCRIPTION
### Contribution description

This patch removes a test that silently hides failed writes to NULL. Instead, assert is used to ensure that the address is not NULL.


### Testing procedure

I am not certain how to update the tests to catch asserts. If this is possible, I will add a test, if someone will point me to a good example to learn from.


### Issues/PRs references

- none
