### PR TITLE
nanocoap_sock: store message ID in nanocoap_sock_t

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -132,6 +132,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include "random.h"
 #include "net/nanocoap.h"
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
@@ -186,6 +187,7 @@ typedef struct {
                                                  functions. */
     nanocoap_socket_type_t type;            /**< Socket type (UDP, DTLS) */
 #endif
+    uint16_t msg_id;                        /**< next CoAP message ID */
 } nanocoap_sock_t;
 
 /**
@@ -198,6 +200,19 @@ typedef struct {
     uint8_t method;                 /**< request method (GET, POST, PUT)    */
     uint8_t blksize;                /**< CoAP blocksize exponent            */
 } coap_block_request_t;
+
+/**
+ * @brief   Get next consecutive message ID for use when building a new
+ *          CoAP request.
+ *
+ * @param[in]   sock    CoAP socket on which the ID is used
+ *
+ * @return  A new message ID that can be used for a request or response.
+ */
+static inline uint16_t nanocoap_sock_next_msg_id(nanocoap_sock_t *sock)
+{
+    return sock->msg_id++;
+}
 
 /**
  * @brief   Start a nanocoap server instance
@@ -230,6 +245,7 @@ static inline int nanocoap_sock_connect(nanocoap_sock_t *sock,
 #if IS_USED(MODULE_NANOCOAP_DTLS)
     sock->type = COAP_SOCKET_TYPE_UDP;
 #endif
+    sock->msg_id = random_uint32();
 
     return sock_udp_create(&sock->udp, local, remote, 0);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Create a new message ID for each nanoCoAP socket.
This addresses the concerns raised when I attempted to create a common `coap_next_msg_id()`.

With the requirements brought up in the discussion, such a common function is not possible across GCoAP and nanoCoAP, so at least have such a function for all nanoCoAP users.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #18991