### PR TITLE
pkg/nanopb: bump version to 0.4.7

### DIFF
--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=nanopb
 PKG_URL=https://github.com/nanopb/nanopb
-# 0.4.6
-PKG_VERSION=afc499f9a410fc9bbf6c9c48cdd8d8b199d49eb4
+# 0.4.7
+PKG_VERSION=b97aa657a706d3ba4a9a6ccca7043c9d6fe41cba
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Minor bugfix release


### Testing procedure

`tests/pkg_nanopb` still works


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
