### PR TITLE
pkg/tinydtls: bump version

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/eclipse/tinydtls.git
-PKG_VERSION=297fced854b652591b78113f0ba8d57ad9f934d9
+PKG_VERSION=c58f484ac417afe036273d65506b63a0902c740c
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -39,12 +39,6 @@ ifeq (,$(CONFIG_KCONFIG_USEPKG_TINYDTLS))
   endif
 endif
 
-ifneq (,$(or $(CONFIG_DTLS_DEBUG),$(filter -DCONFIG_DTLS_DEBUG,$(CFLAGS))))
-  CFLAGS += -DTINYDTLS_LOG_LVL=6
-else
-  CFLAGS += -DTINYDTLS_LOG_LVL=0
-endif
-
 # For now contrib only contains sock_dtls adaption
 ifneq (,$(filter tinydtls_sock_dtls,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/tinydtls/contrib

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -887,7 +887,6 @@ void sock_dtls_close(sock_dtls_t *sock)
 void sock_dtls_init(void)
 {
     dtls_init();
-    dtls_set_log_level(TINYDTLS_LOG_LVL);
 }
 
 static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

tinyDTLS now uses RIOT's `log.h` facilities.
That means the log-level can no longer be changed at run-time, but the upside is that we save a lot of ROM as all the debug strings are now no longer included in the binary. (Unless RIOT log level is set to LOG_DEBUG).

### Testing procedure

This is the only change since the last update.


### Issues/PRs references

https://github.com/eclipse/tinydtls/pull/177
obsoletes #18907
