### PR TITLE
Best 6lo frag size

### DIFF
--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -58,11 +58,6 @@ extern "C" {
  * @brief   request ACK from receiver
  */
 #define NETDEV_IEEE802154_ACK_REQ           (IEEE802154_FCF_ACK_REQ)
-
-/**
- * @brief   set frame pending bit
- */
-#define NETDEV_IEEE802154_FRAME_PEND        (IEEE802154_FCF_FRAME_PEND)
 /**
  * @}
  */

--- a/drivers/netdev/ieee802154.c
+++ b/drivers/netdev/ieee802154.c
@@ -178,7 +178,8 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
             *((uint16_t *)value) = (_get_ieee802154_pdu(dev)
                                     - IEEE802154_MAX_HDR_LEN)
 #if IS_USED(MODULE_IEEE802154_SECURITY)
-                                    -IEEE802154_SEC_MAX_AUX_HDR_LEN
+                                    - IEEE802154_SEC_MAX_AUX_HDR_LEN
+                                    - IEEE802154_SEC_MAX_MAC_SIZE
 #endif /* IS_USED(MODULE_IEEE802154_SECURITY) */
                                     - IEEE802154_FCS_LEN;
             res = sizeof(uint16_t);

--- a/sys/include/net/gnrc/netif/ieee802154.h
+++ b/sys/include/net/gnrc/netif/ieee802154.h
@@ -19,6 +19,7 @@
 #define NET_GNRC_NETIF_IEEE802154_H
 
 #include "net/gnrc/netif.h"
+#include "net/gnrc/netif/hdr.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,6 +42,19 @@ extern "C" {
  */
 int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize,
                                  char priority, const char *name, netdev_t *dev);
+
+/**
+ * @brief   Convert GNRC netif header to an IEEE 802.15.4 header
+ *
+ * @param[out]  mhr     Destination IEEE 802.15.4 header
+ * @param[in]   netif   IEEE 802.15.4 network interface
+ * @param[in]   hdr     GNRC netif header
+ *
+ * @return  IEEE 802.15.4 header on success
+ * @return  negative number on error
+ */
+int gnrc_netif_hdr_to_ieee802154(uint8_t *mhr, const gnrc_netif_t *netif,
+                                 const gnrc_netif_hdr_t *hdr);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/sixlowpan/frag/fb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/fb.h
@@ -57,7 +57,7 @@ typedef struct {
     uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
                              *   payload datagram */
     /**
-     * @brief  Per packet computed fragment size;
+     * @brief  Per packet computed fragment size
      */
     uint16_t best_frag_size;
 #if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR)

--- a/sys/include/net/gnrc/sixlowpan/frag/fb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/fb.h
@@ -56,6 +56,10 @@ typedef struct {
     uint16_t tag;           /**< Tag used for the fragment */
     uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
                              *   payload datagram */
+    /**
+     * @brief  Per packet computed fragment size;
+     */
+    uint16_t best_frag_size;
 #if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR)
     /**
      * @brief   Extension for selective fragment recovery.

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -167,6 +167,11 @@ extern "C" {
 #define IEEE802154_CCA_DURATION_IN_SYMBOLS      (8)
 
 /**
+ * @brief   Unassociated PAN ID
+ */
+#define IEEE802154_PANID_UNASSOCIATED           (0xffff)
+
+/**
  * @brief   802.15.4 PHY modes
  */
 typedef enum {
@@ -198,6 +203,20 @@ enum {
 #define IEEE802154_ADDR_BCAST               { 0xff, 0xff }
 
 /**
+ * @brief   Static initializer for an unassigned short address
+ *
+ * If the short source address has this value, the extended source address must be preferred
+ */
+#define IEEE802154_ADDR_UNASSIGNED          { 0xff, 0xfe }
+
+/**
+ * @brief   Static initializer for the short address if unassociated to a PAN coordinator
+ *
+ * If the short source address has this value, the device is not associated to a PAN coordinator
+ */
+#define IEEE802154_ADDR_UNASSOCIATED        { 0xff, 0xff }
+
+/**
  * @brief   Length in byte of @ref IEEE802154_ADDR_BCAST
  */
 #define IEEE802154_ADDR_BCAST_LEN           (IEEE802154_SHORT_ADDRESS_LEN)
@@ -206,6 +225,16 @@ enum {
  * @brief   Broadcast address
  */
 extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
+
+/**
+ * @brief   Unassigned short address
+ */
+extern const uint8_t ieee802154_addr_unassigned[IEEE802154_SHORT_ADDRESS_LEN];
+
+/**
+ * @brief   Unassociated short address
+ */
+extern const uint8_t ieee802154_addr_unassociated[IEEE802154_SHORT_ADDRESS_LEN];
 /** @} */
 
 /**

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -386,7 +386,7 @@ void ieee802154_sec_init(ieee802154_sec_context_t *ctx);
  * @brief   Encrypt IEEE 802.15.4 frame according to @p ctx
  *
  * @param[in]       ctx                     IEEE 802.15.4 security context
- * @param[in]       header                  Pointer to frame header
+ * @param[in, out]  header                  Pointer to frame header
  * @param[in, out]  header_size             in: Header size; out: Size of header and auxiliary header
  * @param[in,out]   payload                 in: Plain payload; out: Encrypted payload
  * @param[in]       payload_size            Size of payload
@@ -400,7 +400,7 @@ void ieee802154_sec_init(ieee802154_sec_context_t *ctx);
  * @return          negative integer on error
  */
 int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
-                                 const uint8_t *header, uint8_t *header_size,
+                                 uint8_t *header, uint8_t *header_size,
                                  uint8_t *payload, uint16_t payload_size,
                                  uint8_t *mic, uint8_t *mic_size,
                                  const uint8_t *src_address);

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -431,6 +431,18 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
                                  const uint8_t *src_address);
 
 /**
+ * @brief   Get auxiliary security headeer size extimation
+ *
+ * @param[in]       ctx                     IEEE 802.15.4 security context
+ * @param[in]       header                  Pointer to IEEE 802.15.4 header
+ * @param[in]       header_size             Header size
+ *
+ * @return          Auxiliary security headeer size
+ */
+size_t ieee802154_sec_get_aux_hdr_len(ieee802154_sec_context_t *ctx,
+                                      const uint8_t *header, size_t header_size);
+
+/**
  * @brief Default descriptor that will fallback to default implementations
  */
 extern const ieee802154_radio_cipher_ops_t ieee802154_radio_cipher_ops;

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -176,6 +176,10 @@ typedef enum {
      */
     NETOPT_TX_POWER,
     /**
+     * @brief   (uint16_t) Given a packet, maximum L2 Service Data Unit
+     */
+    NETOPT_MAX_SDU_SIZE,
+    /**
      * @brief   (uint16_t) maximum protocol data unit
      */
     NETOPT_MAX_PDU_SIZE,

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -42,6 +42,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_IPV6_SND_RTR_ADV]      = "NETOPT_IPV6_SND_RTR_ADV",
     [NETOPT_TX_POWER]              = "NETOPT_TX_POWER",
     [NETOPT_PDU_SIZE]              = "NETOPT_PDU_SIZE",
+    [NETOPT_MAX_SDU_SIZE]          = "NETOPT_MAX_SDU_SIZE",
     [NETOPT_MAX_PDU_SIZE]          = "NETOPT_MAX_PDU_SIZE",
     [NETOPT_PRELOADING]            = "NETOPT_PRELOADING",
     [NETOPT_PROMISCUOUSMODE]       = "NETOPT_PROMISCUOUSMODE",

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -44,6 +44,76 @@ int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize
                              &ieee802154_ops);
 }
 
+int gnrc_netif_hdr_to_ieee802154(uint8_t *mhr, const gnrc_netif_t *netif, const gnrc_netif_hdr_t *hdr)
+{
+    const uint8_t *src = NULL, *dst = NULL;
+    size_t src_len = 0, dst_len = 0;
+    le_uint16_t src_pan, dst_pan;
+    uint8_t *fcf = mhr;
+    fcf[0] = fcf[1] = 0;
+    netdev_ieee802154_t *dev = container_of(netif->dev, netdev_ieee802154_t, netdev);
+    if ((dev->flags & NETDEV_IEEE802154_SECURITY_EN)) {
+        fcf[0] |= IEEE802154_FCF_SECURITY_EN;
+    }
+    if (hdr->flags & GNRC_NETIF_HDR_FLAGS_MORE_DATA) {
+        fcf[0] |= IEEE802154_FCF_FRAME_PEND;
+    }
+    if (dev->flags & NETDEV_IEEE802154_ACK_REQ) {
+        fcf[0] |= IEEE802154_FCF_ACK_REQ;
+    }
+    fcf[0] |= IEEE802154_FCF_TYPE_DATA;
+    fcf[1] |= IEEE802154_FCF_VERS_V1;
+    if (dev->pan == IEEE802154_PANID_UNASSOCIATED) {
+        return -ENOTCONN;
+    }
+    /* As long as netif header has no field for destination network,
+       source and destination PAN are assumed to be equal */
+    src_pan = dst_pan = byteorder_htols(dev->pan);
+    if ((src_len = hdr->src_l2addr_len)) {
+        src = gnrc_netif_hdr_get_src_addr(hdr);
+    }
+    else {
+        /* if not PAN coordinator */
+        /* As long as only implicit keys and no peering are supported,
+           the sender needs to include long source address because the recipient
+           will need it to decrypt the frame. */
+        if ((fcf[0] & IEEE802154_FCF_SECURITY_EN) ||
+            (dev->flags & NETDEV_IEEE802154_SRC_MODE_LONG) ||
+            !memcmp(dev->short_addr, ieee802154_addr_unassigned, sizeof(dev->short_addr)) ||
+            !memcmp(dev->short_addr, ieee802154_addr_unassociated, sizeof(dev->short_addr))) {
+            src = dev->long_addr;
+            src_len = sizeof(dev->long_addr);
+        }
+        else {
+            src = dev->short_addr;
+            src_len = sizeof(dev->short_addr);
+        }
+    }
+    if ((dst_len = hdr->dst_l2addr_len)) {
+        dst = gnrc_netif_hdr_get_dst_addr(hdr);
+    }
+    else if (hdr->flags & (GNRC_NETIF_HDR_FLAGS_BROADCAST |
+                           GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+        dst = ieee802154_addr_bcast;
+        dst_len = 2;
+        fcf[0] &= ~IEEE802154_FCF_ACK_REQ;
+    }
+    else {
+        /* dst is PAN coordinator */
+        return -ENOTSUP;
+    }
+    int res;
+    /* set addressing modes and PAN compression */
+    if ((res = ieee802154_set_frame_hdr(mhr,
+                                        src, src_len,
+                                        dst, dst_len,
+                                        src_pan, dst_pan,
+                                        mhr[0], 0)) < 0) {
+        return -EINVAL;
+    }
+    return res;
+}
+
 static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
 {
     gnrc_netif_hdr_t *hdr;
@@ -188,7 +258,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
                 netdev_ieee802154_t *netdev_ieee802154 = container_of(dev,
                                                                       netdev_ieee802154_t,
                                                                       netdev);
-                if (mhr[0] & NETDEV_IEEE802154_SECURITY_EN) {
+                if (mhr[0] & IEEE802154_FCF_SECURITY_EN) {
                     if (ieee802154_sec_decrypt_frame(&netdev_ieee802154->sec_ctx,
                                                      nread,
                                                      mhr, (uint8_t *)&mhr_len,
@@ -253,19 +323,13 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     netdev_t *dev = netif->dev;
     netdev_ieee802154_t *state = container_of(dev, netdev_ieee802154_t, netdev);
     gnrc_netif_hdr_t *netif_hdr;
-    const uint8_t *src, *dst = NULL;
     int res = 0;
-    size_t src_len, dst_len;
     uint8_t mhr_len;
 #if IS_USED(MODULE_IEEE802154_SECURITY)
     uint8_t mhr[IEEE802154_MAX_HDR_LEN + IEEE802154_SEC_MAX_AUX_HDR_LEN];
 #else
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
 #endif
-    uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
-    le_uint16_t dev_pan = byteorder_htols(state->pan);
-
-    flags |= IEEE802154_FCF_TYPE_DATA;
     if (pkt == NULL) {
         DEBUG("_send_ieee802154: pkt was NULL\n");
         return -EINVAL;
@@ -275,44 +339,12 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         return -EBADMSG;
     }
     netif_hdr = pkt->data;
-    if (netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_MORE_DATA) {
-        /* Set frame pending field */
-        flags |= IEEE802154_FCF_FRAME_PEND;
-    }
-    /* prepare destination address */
-    if (netif_hdr->flags & /* If any of these flags is set assume broadcast */
-        (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-        dst = ieee802154_addr_bcast;
-        dst_len = IEEE802154_ADDR_BCAST_LEN;
-    }
-    else {
-        dst = gnrc_netif_hdr_get_dst_addr(netif_hdr);
-        dst_len = netif_hdr->dst_l2addr_len;
-    }
-    if (flags & NETDEV_IEEE802154_SECURITY_EN) {
-        /* need to include long source address because the recipient
-           will need it to decrypt the frame */
-        src_len = IEEE802154_LONG_ADDRESS_LEN;
-        src = state->long_addr;
-    }
-    else {
-        src_len = netif_hdr->src_l2addr_len;
-        if (src_len > 0) {
-            src = gnrc_netif_hdr_get_src_addr(netif_hdr);
-        }
-        else {
-            src_len = netif->l2addr_len;
-            src = netif->l2addr;
-        }
-    }
-    /* fill MAC header, seq should be set by device */
-    if ((res = ieee802154_set_frame_hdr(mhr, src, src_len,
-                                        dst, dst_len, dev_pan,
-                                        dev_pan, flags, state->seq++)) == 0) {
+    if ((res = gnrc_netif_hdr_to_ieee802154(mhr, netif, netif_hdr)) < 0) {
         DEBUG("_send_ieee802154: Error preperaring frame\n");
         gnrc_pktbuf_release(pkt);
         return -EINVAL;
     }
+    mhr[2] = state->seq++;
     mhr_len = res;
 
     /* prepare iolist for netdev / mac layer */
@@ -352,7 +384,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         uint8_t mic[IEEE802154_SEC_MAX_MAC_SIZE];
         uint8_t mic_size = 0;
 
-        if (flags & NETDEV_IEEE802154_SECURITY_EN) {
+        if (mhr[0] & IEEE802154_FCF_SECURITY_EN) {
             res = ieee802154_sec_encrypt_frame(&state->sec_ctx,
                                                mhr, &mhr_len,
                                                pkt->next->data, pkt->next->size,

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -55,7 +55,7 @@ static inline uint8_t _max_frag_size(gnrc_netif_t *iface,
     }
 #endif /* MODULE_GNRC_SIXLOWPAN_FRAG_HINT */
     (void)fbuf;
-    return iface->sixlo.max_frag_size;
+    return fbuf->best_frag_size ? fbuf->best_frag_size : iface->sixlo.max_frag_size;
 }
 
 static inline int _payload_diff(gnrc_sixlowpan_frag_fb_t *fbuf,
@@ -186,7 +186,7 @@ static uint16_t _send_nth_fragment(gnrc_netif_t *iface,
     uint16_t local_offset = 0, offset_count = 0, offset = fbuf->offset;
     /* since dispatches aren't supposed to go into subsequent fragments, we need not account
      * for payload difference as for the first fragment */
-    uint16_t max_frag_size = _floor8(iface->sixlo.max_frag_size -
+    uint16_t max_frag_size = _floor8(_max_frag_size(iface, fbuf) -
                                      sizeof(sixlowpan_frag_n_t));
 
     DEBUG("6lo frag: determined max_frag_size = %" PRIu16 "\n", max_frag_size);

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -110,17 +110,26 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
     assert(pkt != NULL);
     assert(netif != NULL);
     size_t datagram_size = gnrc_pkt_len(pkt->next);
-    DEBUG("6lo: iface->sixlo.max_frag_size = %u for interface %i\n",
-          netif->sixlo.max_frag_size, netif->pid);
-    if ((netif->sixlo.max_frag_size == 0) ||
-        (datagram_size <= netif->sixlo.max_frag_size)) {
+    /* worst case fragment size if NETOPT_MAX_SDU_SIZE is not supported */
+    uint16_t best_frag_size = netif->sixlo.max_frag_size;
+    union {
+        iolist_t in;
+        uint16_t out;
+    } value;
+    value.in.iol_base = pkt->data;
+    value.in.iol_len = pkt->size;
+    if (gnrc_netapi_get(netif->pid, NETOPT_MAX_SDU_SIZE, 0, &value.in, sizeof(value)) > 0) {
+        best_frag_size = value.out;
+        assert(netif->sixlo.max_frag_size <= best_frag_size);
+    }
+    DEBUG("6lo: packet size = %u, fragment size = %u for interface %i\n",
+          datagram_size, best_frag_size, netif->pid);
+    if ((netif->sixlo.max_frag_size == 0) || (datagram_size <= best_frag_size)) {
         DEBUG("6lo: Dispatch for sending\n");
         gnrc_sixlowpan_dispatch_send(pkt, NULL, page);
     }
 #if defined(MODULE_GNRC_SIXLOWPAN_FRAG) || defined(MODULE_GNRC_SIXLOWPAN_FRAG_SFR)
     else if (orig_datagram_size <= SIXLOWPAN_FRAG_MAX_LEN) {
-        DEBUG("6lo: Send fragmented (%u > %u)\n",
-              (unsigned int)datagram_size, netif->sixlo.max_frag_size);
         gnrc_sixlowpan_frag_fb_t *fbuf;
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_SFR
         bool sfr = gnrc_sixlowpan_frag_sfr_netif(netif);
@@ -140,10 +149,10 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
         fbuf->tag = gnrc_sixlowpan_frag_fb_next_tag();
         /* Sending the first fragment has an offset==0 */
         fbuf->offset = 0;
+        fbuf->best_frag_size = best_frag_size;
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_HINT
         fbuf->hint.fragsz = 0;
 #endif
-
         if (!sfr) {
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
             gnrc_sixlowpan_frag_send(pkt, fbuf, page);
@@ -160,8 +169,7 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
 #endif /* defined(MODULE_GNRC_SIXLOWPAN_FRAG) || defined(MODULE_GNRC_SIXLOWPAN_FRAG_SFR) */
     else {
         (void)orig_datagram_size;
-        DEBUG("6lo: packet too big (%u > %u)\n",
-              (unsigned int)datagram_size, netif->sixlo.max_frag_size);
+        DEBUG("6lo: packet too big (%zu > %u)\n", datagram_size, best_frag_size);
         gnrc_pktbuf_release_error(pkt, EMSGSIZE);
     }
 }
@@ -327,6 +335,7 @@ static void _send(gnrc_pktsnip_t *pkt)
                 fbuf->datagram_size = datagram_size;
                 fbuf->tag = gnrc_sixlowpan_frag_fb_next_tag();
                 fbuf->offset = 0;
+                fbuf->best_frag_size = 0;
                 /* fbuf->hint only exists with the `gnrc_sixlowpan_frag_hint`
                  * module, so despite already specifying that this `if` block
                  * only works with `IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_HINT)`

--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -20,6 +20,8 @@
 #include "net/ieee802154.h"
 
 const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN] = IEEE802154_ADDR_BCAST;
+const uint8_t ieee802154_addr_unassigned[IEEE802154_SHORT_ADDRESS_LEN] = IEEE802154_ADDR_UNASSIGNED;
+const uint8_t ieee802154_addr_unassociated[IEEE802154_SHORT_ADDRESS_LEN] = IEEE802154_ADDR_UNASSOCIATED;
 
 size_t ieee802154_set_frame_hdr(uint8_t *buf, const uint8_t *src, size_t src_len,
                                 const uint8_t *dst, size_t dst_len,

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -408,7 +408,7 @@ void ieee802154_sec_init(ieee802154_sec_context_t *ctx)
 }
 
 int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
-                                 const uint8_t *header, uint8_t *header_size,
+                                 uint8_t *header, uint8_t *header_size,
                                  uint8_t *payload, uint16_t payload_size,
                                  uint8_t *mic, uint8_t *mic_size,
                                  const uint8_t *src_address)
@@ -419,6 +419,7 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
 
     if (ctx->security_level == IEEE802154_SEC_SCF_SECLEVEL_NONE) {
         *mic_size = 0;
+        header[0] &= ~IEEE802154_FCF_SECURITY_EN;
         return IEEE802154_SEC_OK;
     }
     if (ctx->frame_counter == 0xFFFFFFFF) {

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -542,3 +542,15 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     *header_size += aux_size;
     return IEEE802154_SEC_OK;
 }
+
+size_t ieee802154_sec_get_aux_hdr_len(ieee802154_sec_context_t *ctx,
+                                      const uint8_t *header, size_t header_size)
+{
+    /* The aux. header size depends on the security mode which depends on the peer.
+       Currently, only implicit keys are used. */
+    if (!header_size || !(header[0] & IEEE802154_FCF_SECURITY_EN)) {
+        return 0;
+    }
+    return _get_aux_hdr_size(ctx->security_level, ctx->key_id_mode) +
+           _mac_size(ctx->security_level);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Finds the most efficient fragment size for 6LoWPAN fragmentation over IEEE 802.15.4 per packet instead of worst case estimation per interface. Layer 2 protocols also using 6LoWPAN are not affected unless they implement the new `NETOPT_MAX_SDU_SIZE`. Note that a 6LoWPAN interface uses the long source address on start up: `gnrc_netif_init_6ln()`.

### Testing procedure

Also Works with `USEMODULE+=ieee802154_security` and multicast.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

```
sudo modprobe mac802154_hwsim
sudo dist/tools/zep_dispatch/bin/zep_dispatch -w wpan0 ::1 17754
```

A: `make -C examples/gnrc_networking all term`
```
ping -s 200 fe80::a433:1806:fcc1:692b
208 bytes from fe80::a433:1806:fcc1:692b%7: icmp_seq=0 ttl=64 rssi=0 dBm time=5.536 ms
208 bytes from fe80::a433:1806:fcc1:692b%7: icmp_seq=1 ttl=64 rssi=0 dBm time=5.504 ms
208 bytes from fe80::a433:1806:fcc1:692b%7: icmp_seq=2 ttl=64 rssi=0 dBm time=3.300 ms

--- fe80::a433:1806:fcc1:692b PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 3.300/4.780/5.536 ms
```
B: `make -C examples/gnrc_networking all term`
```
Iface  7  HWaddr: 69:2B  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: A6:33:18:06:FC:C1:69:2B 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::a433:1806:fcc1:692b  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc1:692b
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 4  bytes 158
            TX packets 4 (Multicast: 4)  bytes 0
            TX succeeded 4 errors 0
          Statistics for IPv6
            RX packets 4  bytes 242
            TX packets 4 (Multicast: 4)  bytes 242
            TX succeeded 4 errors 0
```
![Screenshot_20230123_111254](https://user-images.githubusercontent.com/15147337/214016762-ab98eade-6b1a-490c-b170-b22f7bbe6dec.png)

Note 6LoWPAN fragments of about 124 bytes. It is not using the full 127 bytes because fragment offsets in subsequent fragments have to be a multiple of 8.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Alternative for #19150 
Fixes #19132 