### PR TITLE
pkg/wolfssl: Fix memory leaks in wolfSSL sock_tls

### DIFF
--- a/pkg/wolfssl/sock_tls/sock_tls.c
+++ b/pkg/wolfssl/sock_tls/sock_tls.c
@@ -65,7 +65,7 @@ static int tls_session_create(sock_tls_t *sk)
 
 static void tls_session_destroy(sock_tls_t *sk)
 {
-    if (!sk || sk->ssl)
+    if (!sk || !sk->ssl)
         return;
     wolfSSL_free(sk->ssl);
 }


### PR DESCRIPTION
When sk->ssl is NULL it doesn't need to be free()d, otherwise it may be free()d