### PR TITLE
Fix SX126X-STM32WL module in Kconfig

### DIFF
--- a/boards/nucleo-wl55jc/Kconfig
+++ b/boards/nucleo-wl55jc/Kconfig
@@ -25,6 +25,9 @@ config BOARD_NUCLEO_WL55JC
     # Put other features for this board (in alphabetical order)
     select HAS_ARDUINO
     select HAS_RIOTBOOT
+    select HAS_PERIPH_GPIO_IRQ
+    select HAVE_SX126X_STM32WL
+    select HAVE_SX126X_RF_SWITCH
 
     select MODULE_PERIPH_LPUART if MODULE_STDIO_UART && HAS_PERIPH_LPUART
 

--- a/drivers/sx126x/Kconfig
+++ b/drivers/sx126x/Kconfig
@@ -16,12 +16,14 @@ menuconfig MODULE_SX126X
     select MODULE_IOLIST
     select MODULE_NETDEV_LEGACY_API
     select MODULE_PERIPH_GPIO
+    select MODULE_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_SPI
     select PACKAGE_DRIVER_SX126X
 
+if MODULE_SX126X
+
 choice
     bool "Radio variant"
-    depends on MODULE_SX126X
     default MODULE_SX1261 if HAVE_SX1261
     default MODULE_SX1262 if HAVE_SX1262
     default MODULE_SX1268 if HAVE_SX1268
@@ -30,24 +32,29 @@ choice
 
 config MODULE_SX1261
     bool "SX1261"
-    select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_SX1262
     bool "SX1262"
-    select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_SX1268
     bool "SX1268"
-    select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_LLCC68
     bool "LLCC68"
-    select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_SX126X_STM32WL
     bool "SX126X-STM32WL"
 
 endchoice
+
+config MODULE_SX126X_RF_SWITCH
+    bool "Enable RF switch support"
+    default y if HAVE_SX126X_RF_SWITCH
+    depends on MODULE_SX126X
+    depends on HAS_PERIPH_GPIO
+    select MODULE_PERIPH_GPIO
+
+endif # MODULE_SX126X
 
 config HAVE_SX1261
     bool
@@ -83,3 +90,8 @@ config HAVE_SX126X
     bool
     help
       Indicates that an sx126x transceiver is present.
+
+config HAVE_SX126X_RF_SWITCH
+    bool
+    help
+      Indicates that an sx126x rf switch pin is wired.


### PR DESCRIPTION
### Contribution description

Master is broken due to kconfig mismatch for the `nucleo-wl55jc`.  The radio was just not declared.

This fixes the board and cleans up some of the SX126X kconfig.


### Testing procedure

Murdock should pass

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
