### PR TITLE
cpu/esp32: fixes for boot issues and crashes on ESP32

### DIFF
--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -147,6 +147,14 @@ static NORETURN void IRAM system_startup_cpu0(void)
     puf_sram_init((uint8_t *)&_sheap, SEED_RAM_LEN);
 #endif
 
+#if IS_USED(MODULE_ESP_IDF_HEAP)
+    /* init heap */
+    heap_caps_init();
+    if (IS_ACTIVE(ENABLE_DEBUG)) {
+        ets_printf("Heap free: %u byte\n", get_free_heap_size());
+    }
+#endif
+
     /* initialize system call tables of ESP32x rom and newlib */
     syscalls_init();
 
@@ -205,14 +213,6 @@ static NORETURN void IRAM system_startup_cpu0(void)
     }
 
     LOG_STARTUP("PRO cpu is up (single core mode, only PRO cpu is used)\n");
-
-#if IS_USED(MODULE_ESP_IDF_HEAP)
-    /* init heap */
-    heap_caps_init();
-    if (IS_ACTIVE(ENABLE_DEBUG)) {
-        ets_printf("Heap free: %u byte\n", get_free_heap_size());
-    }
-#endif
 
     /* init esp_timer implementation */
     esp_timer_early_init();

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -116,6 +116,9 @@ void vTaskDelete(TaskHandle_t xTaskToDelete)
     DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToDelete);
 
     uint32_t pid = (uint32_t)xTaskToDelete;
+    if (pid == 0) {
+        pid = thread_getpid();
+    }
     assert(pid_is_valid(pid));
 
     /* remove the task from scheduling */


### PR DESCRIPTION
### Contribution description

In syscalls_init() there is a call to malloc(), which will return NULL if the heap is not initialized before, causing the entire board to fail booting if MODULE_ESP_IDF_HEAP is used.

API of [vTaskDelete()](https://www.freertos.org/a00126.html) says, that if NULL is passed to vTaskDelete the calling task should be deleted.

This PR needs a backport to 2023.01.

### Testing procedure

Just compiling on the ESP32S2 and running it with WiFi caused it to not start anymore, no output, nothing. When Null is written to that null-pointer it hangs.

The second commit fixed an issue/assertion fail that happens when the WiFi connection drops/disconnects.

### Issues/PRs references

Issue was introduced with PR #19146 