### PR TITLE
drivers/sx126x: make MODULE_SX126X_RF_SWITCH hidden in kconfig

### DIFF
--- a/boards/nucleo-wl55jc/Kconfig
+++ b/boards/nucleo-wl55jc/Kconfig
@@ -24,10 +24,13 @@ config BOARD_NUCLEO_WL55JC
 
     # Put other features for this board (in alphabetical order)
     select HAS_ARDUINO
-    select HAS_RIOTBOOT
     select HAS_PERIPH_GPIO_IRQ
+    select HAS_RIOTBOOT
     select HAVE_SX126X_STM32WL
-    select HAVE_SX126X_RF_SWITCH
+
+    # This board must use the MODULE_SX126X_RF_SWITCH module if the on-board
+    # lora module is being used.
+    imply MODULE_SX126X_RF_SWITCH if MODULE_SX126X_STM32WL
 
     select MODULE_PERIPH_LPUART if MODULE_STDIO_UART && HAS_PERIPH_LPUART
 

--- a/drivers/sx126x/Kconfig
+++ b/drivers/sx126x/Kconfig
@@ -48,9 +48,7 @@ config MODULE_SX126X_STM32WL
 endchoice
 
 config MODULE_SX126X_RF_SWITCH
-    bool "Enable RF switch support"
-    default y if HAVE_SX126X_RF_SWITCH
-    depends on MODULE_SX126X
+    bool
     depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_GPIO
 
@@ -90,8 +88,3 @@ config HAVE_SX126X
     bool
     help
       Indicates that an sx126x transceiver is present.
-
-config HAVE_SX126X_RF_SWITCH
-    bool
-    help
-      Indicates that an sx126x rf switch pin is wired.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It turns out this is really a board specific setting and should always and only be used when the onboard module is being used...


### Testing procedure

Green murdock with nightlies enabled...


### Issues/PRs references

Follow-up of #19191