### PR TITLE
thread: Terminating threads go to zombie state instead of stopped

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -319,10 +319,7 @@ NORETURN void sched_task_exit(void)
     sched_threads[thread_getpid()] = NULL;
     sched_num_threads--;
 
-    sched_set_status(thread_get_active(), STATUS_STOPPED);
-
-    sched_active_thread = NULL;
-    cpu_switch_context_exit();
+    thread_zombify();
 }
 
 #ifdef MODULE_SCHED_CB


### PR DESCRIPTION
### Contribution description

Let's categorize threads in general:

1. Looping threads. They just don't quit. (Or maybe they quit in an error situation).
2. Setup threads. Once they quit, they're not started again.
3. Threads that perform a task, and when they're done, they close, and expect to be created again.

Category 3 is currently hard to do -- I know of one example (the SUIT worker), and that [got it subtly wrong](https://github.com/RIOT-OS/RIOT/issues/19195).

I think that it'll be easier to get category 3 right if threads are not completely stopped after termination (something that makes their PID free for reuse, which means that once you hold a PID you'll never know if the thread maybe just terminated and anything you do with that PID now goes to a different process). Instead, this PR makes the thread into a zombie when it dies.

After this PR, it's up to the creator of the process to stop the zombie thread, if its resources are to be reused. Cleanup doesn't need to be done by the same task that created it -- could be anyone. Threads of category 1 and 2 can easily just stay zombies without clean-up: There was enough space in the PID range to accommodate them when they were live, so there's still space after. Category 3 tasks already needed to do some cleanup, now they have better tools for it.

#### Possible extensions (in this PR or a follow-up)

* [ ] Documentation (really needs to go here)
* [ ] Fixing the SUIT case
* [ ] Storing the thread's return value somewhere in the zombie state (`thread_zombify_with_value`? Maybe unioned with the SP?)
* [ ] Adding a way to wait for a thread when it's not clear yet that the thread has terminated. (It's generally hard to do that from a higher priority thread: Imagine you used a message or mutex to signal that the dying process is done, right before returning. Then the waiting thread would still be awoken right before the dying thread had a chance to go to zombie mode. One implementation solution would be for the waiting call to lift the awaited process's priority to the caller and yield; still, this can be abused and badly block the system).

  I think that having this is not critical for a MVP version of this PR -- after all, creating the thread anew will "just" fail, and the caller is invited to try again.

### Testing procedure

TBD. Right now, this only contains the change itself to see what the fall-out will be.

### Issues/PRs references

This is one way to close https://github.com/RIOT-OS/RIOT/issues/19195.

There was previous discussion of this topic in https://github.com/RIOT-OS/RIOT/issues/17542 -- back when I thought the underlying problem could be resolved more easily.

This is similar to how POSIX systems handle terminated threads. On those systems, there's a clear parent process that's responsible for clean-up -- here we don't have that, but we don't need it: Any process can do the clean-up, as long as it's only one process. (Similar to how we unlock mutexes).