### PR TITLE
boards/common: add common timer config for GD32VF103 boards

### DIFF
--- a/boards/common/gd32v/include/board_common.h
+++ b/boards/common/gd32v/include/board_common.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *               2023 Gunar Schorcht <gunar@schorcht.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_gd32v
+ * @{
+ *
+ * @file
+ * @brief       Common board definitions for GD32VF103 boards
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_COMMON_H */
+/** @} */

--- a/boards/seeedstudio-gd32/include/board.h
+++ b/boards/seeedstudio-gd32/include/board.h
@@ -21,6 +21,8 @@
 #ifndef BOARD_H
 #define BOARD_H
 
+#include "board_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/boards/sipeed-longan-nano/include/board.h
+++ b/boards/sipeed-longan-nano/include/board.h
@@ -20,6 +20,8 @@
 #ifndef BOARD_H
 #define BOARD_H
 
+#include "board_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Turns out this is still needed.


### Testing procedure

Flash `examples/blinky` with this patch:

```patch
diff --git a/examples/blinky/Makefile b/examples/blinky/Makefile
index 2d58be2d6b..c25a66db48 100644
--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -16,6 +16,7 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 # Use a peripheral timer for the delay, if available
+USEMODULE += ztimer_msec
 FEATURES_OPTIONAL += periph_timer
 
 include $(RIOTBASE)/Makefile.include
diff --git a/examples/blinky/main.c b/examples/blinky/main.c
index ac90ccbc15..23486e1c58 100644
--- a/examples/blinky/main.c
+++ b/examples/blinky/main.c
@@ -29,7 +29,7 @@
 static void delay(void)
 {
     if (IS_USED(MODULE_ZTIMER)) {
-        ztimer_sleep(ZTIMER_USEC, 1 * US_PER_SEC);
+        ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
     }
     else {
         /*
```

<details><summary>on master this will get you very erratic LED behavior</summary>

https://user-images.githubusercontent.com/1301112/215072779-fcb2507d-63ff-4a34-b51d-3d699272fcfe.mp4

</details>

<details><summary>With this patch 1s intervals are achieved</summary>

https://user-images.githubusercontent.com/1301112/215074712-798fc613-5c7f-415e-a42b-0c2e7800a3be.MOV

</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
