### PR TITLE
examples/gnrc_border_router: static: use router from advertisements by default

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -67,6 +67,11 @@ else ifeq (static,$(PREFIX_CONF))
 # Only set this if the default router does not send router advertisements
 # IPV6_DEFAULT_ROUTER ?= fe80::1
   USEMODULE += gnrc_ipv6_static_addr
+
+  # configure static DNS server
+  ifneq (,$(filter sock_dns,$(USEMODULE)))
+    USEMODULE += auto_init_sock_dns
+  endif
 endif
 
 # Comment this out to disable code in RIOT that does safety checking

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -64,7 +64,8 @@ else ifeq (auto_subnets,$(PREFIX_CONF))
   USEMODULE += gnrc_ipv6_auto_subnets_simple
 else ifeq (static,$(PREFIX_CONF))
   IPV6_ADDR ?= 2001:db8:1::1
-  IPV6_DEFAULT_ROUTER ?= fe80::1
+# Only set this if the default router does not send router advertisements
+# IPV6_DEFAULT_ROUTER ?= fe80::1
   USEMODULE += gnrc_ipv6_static_addr
 endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -155,7 +155,8 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
     uint32_t rdnss_ltime = _evtimer_lookup(&sock_dns_server,
                                            GNRC_IPV6_NIB_RDNSS_TIMEOUT);
 
-    if ((rdnss_ltime < UINT32_MAX) &&
+    /* with auto_init_sock_dns we always have a valid (static) DNS server */
+    if (((rdnss_ltime < UINT32_MAX) || IS_USED(MODULE_AUTO_INIT_SOCK_DNS)) &&
         (!ipv6_addr_is_link_local((ipv6_addr_t *)sock_dns_server.addr.ipv6))) {
         gnrc_pktsnip_t *rdnsso = gnrc_ndp_opt_rdnss_build(
                 rdnss_ltime * MS_PER_SEC,

--- a/sys/net/gnrc/network_layer/ipv6/static_addr/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/static_addr/Kconfig
@@ -30,6 +30,5 @@ config GNRC_IPV6_STATIC_ADDR_DOWNSTREAM
 
 config GNRC_IPV6_STATIC_DEFAULT_ROUTER
     string "Static IPv6 address of the default router"
-    default "2001:db8::1"
 
 endif # KCONFIG_USEMODULE_GNRC_IPV6_STATIC_ADDR


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A router that does not support DHCPv6 IA_PD will typically still support sending router advertisements.
Setting `IPV6_DEFAULT_ROUTER` by default prevents the node from getting the router config via RAs, leading to a broken configuration.

Setting `IPV6_DEFAULT_ROUTER` should only be needed in special cases where routes are not advertised.


### Testing procedure

`examples/gnrc_border_router` with `PREFIX_CONF=static IPV6_ADDR=2001:1438:400c:7720::7771/64 IPV6_PREFIX=2001:1438:400c:7771::/64`:

```
2023-01-27 18:05:21,780 - INFO # > nib route
2023-01-27 18:05:21,781 - INFO # 
2023-01-27 18:05:21,783 - INFO # 2001:1438:400c:7720::/64 dev #8
2023-01-27 18:05:21,786 - INFO # 2001:1438:400c:7771::/64 dev #7
2023-01-27 18:05:21,790 - INFO # default* via fe80::290:7fff:fed7:c528 dev #8

2023-01-27 18:05:37,000 - INFO # > ifconfig
2023-01-27 18:05:37,000 - INFO #
2023-01-27 18:05:37,054 - INFO # Iface  7  HWaddr: 2A:36  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2023-01-27 18:05:37,055 - INFO #           
2023-01-27 18:05:37,060 - INFO #           Long HWaddr: AE:EA:CB:8B:ED:4B:AA:36 
2023-01-27 18:05:37,066 - INFO #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2023-01-27 18:05:37,072 - INFO #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2023-01-27 18:05:37,075 - INFO #           RTR_ADV  6LO  IPHC  
2023-01-27 18:05:37,078 - INFO #           Source address length: 8
2023-01-27 18:05:37,081 - INFO #           Link type: wireless
2023-01-27 18:05:37,087 - INFO #           inet6 addr: fe80::acea:cb8b:ed4b:aa36  scope: link  VAL
2023-01-27 18:05:37,094 - INFO #           inet6 addr: 2001:1438:400c:7771:acea:cb8b:ed4b:aa36  scope: global  VAL
2023-01-27 18:05:37,097 - INFO #           inet6 group: ff02::2
2023-01-27 18:05:37,099 - INFO #           inet6 group: ff02::1
2023-01-27 18:05:37,103 - INFO #           inet6 group: ff02::1:ff4b:aa36
2023-01-27 18:05:37,104 - INFO #           
2023-01-27 18:05:37,107 - INFO # Iface  8  HWaddr: FC:C2:3D:23:22:DF 
2023-01-27 18:05:37,112 - INFO #           L2-PDU:1500  MTU:1280  HL:64  RTR  
2023-01-27 18:05:37,115 - INFO #           Source address length: 6
2023-01-27 18:05:37,117 - INFO #           Link type: wired
2023-01-27 18:05:37,123 - INFO #           inet6 addr: fe80::fec2:3dff:fe23:22df  scope: link  VAL
2023-01-27 18:05:37,129 - INFO #           inet6 addr: 2001:1438:400c:7720::7771  scope: global  VAL
2023-01-27 18:05:37,136 - INFO #           inet6 addr: 2001:1438:400c:7720:fec2:3dff:fe23:22df  scope: global  VAL
2023-01-27 18:05:37,139 - INFO #           inet6 group: ff02::2
2023-01-27 18:05:37,141 - INFO #           inet6 group: ff02::1
2023-01-27 18:05:37,145 - INFO #           inet6 group: ff02::1:ff23:22df
2023-01-27 18:05:37,149 - INFO #           inet6 group: ff02::1:ff00:7771
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
