### PR TITLE
cpu/gd32v: add periph_pwm support

### DIFF
--- a/boards/common/gd32v/include/cfg_timer_default.h
+++ b/boards/common/gd32v/include/cfg_timer_default.h
@@ -38,12 +38,20 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
+        .dev      = TIMER0,
+        .max      = 0x0000ffff,
+        .rcu_mask = RCU_APB2EN_TIMER0EN_Msk,
+        .bus      = APB2,
+        .irqn     = TIMER0_Channel_IRQn
+    },
+    {
         .dev      = TIMER1,
         .max      = 0x0000ffff,
         .rcu_mask = RCU_APB1EN_TIMER1EN_Msk,
         .bus      = APB1,
         .irqn     = TIMER1_IRQn
     },
+#if !defined(MODULE_PERIPH_PM)
     {
         .dev      = TIMER2,
         .max      = 0x0000ffff,
@@ -70,12 +78,22 @@ static const timer_conf_t timer_config[] = {
         .irqn     = TIMER4_IRQn
     }
 #endif
+#endif /* !defined(MODULE_PERIPH_PWM) */
 };
 
-#define TIMER_0_IRQN        TIMER1_IRQn
-#define TIMER_1_IRQN        TIMER2_IRQn
-#define TIMER_2_IRQN        TIMER3_IRQn
-#define TIMER_3_IRQN        TIMER4_IRQn
+#define TIMER_0_IRQN        TIMER0_Channel_IRQn
+#define TIMER_1_IRQN        TIMER1_IRQn
+
+#if !defined(MODULE_PERIPH_PWM)
+#define TIMER_2_IRQN        TIMER2_IRQn
+#if defined(CPU_MODEL_GD32VF103C8T6) || defined(CPU_MODEL_GD32VF103CBT6) || \
+    defined(CPU_MODEL_GD32VF103R8T6) || defined(CPU_MODEL_GD32VF103RBT6) || \
+    defined(CPU_MODEL_GD32VF103T8U6) || defined(CPU_MODEL_GD32VF103TBU6) || \
+    defined(CPU_MODEL_GD32VF103V8T6) || defined(CPU_MODEL_GD32VF103VBT6)
+#define TIMER_3_IRQN        TIMER3_IRQn
+#define TIMER_4_IRQN        TIMER4_IRQn
+#endif
+#endif /* !defined(MODULE_PERIPH_PWM) */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/seeedstudio-gd32/Kconfig
+++ b/boards/seeedstudio-gd32/Kconfig
@@ -14,6 +14,7 @@ config BOARD_SEEEDSTUDIO_GD32
     select CPU_MODEL_GD32VF103VBT6
     select BOARD_HAS_HXTAL
     select BOARD_HAS_LXTAL
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAVE_SAUL_GPIO

--- a/boards/seeedstudio-gd32/Makefile.features
+++ b/boards/seeedstudio-gd32/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = gd32vf103vbt6
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -45,7 +45,7 @@ on-board components:
 | I2C         | 2 x Fast Mode 400 kHz                  |   no      |
 | I2S         | 2                                      |   no      |
 | CAN         | 2 x CAN 2.0B with up to 1 Mbps         |   no      |
-| PWM         | 6 Channels                             |   no      |
+| PWM         | 6 Channels                             |   yes     |
 | USB         | 1 x USB FS OTG                         |   no      |
 | Vcc         | 3.0V - 3.6V                            |           |
 | Datasheet   | [Datasheet](https://gd32mcu.com/data/documents/datasheet/GD32VF103_Datasheet_Rev1.6.pdf) | |
@@ -62,15 +62,17 @@ The general pin layout is shown below.
 The following table shows the connection of the on-board components with the
 MCU pins and their configuration in RIOT.
 
-| MCU Pin | MCU Peripheral | RIOT Peripheral     | Board Function        |
-|:--------|:---------------|:--------------------|:----------------------|
-| PA0     |                |                     | BTN0                  |
-| PA9     | USART0 TX      | UART_DEV(0) TX      | UART TX               |
-| PA10    | USART0 RX      | UART_DEV(0) RX      | UART RX               |
-| PB0     |                |                     | LED1                  |
-| PB1     |                |                     | LED2                  |
-| PB5     |                |                     | LED0                  |
-| PC13    |                |                     | BTN1                  |
+| MCU Pin | MCU Peripheral | RIOT Peripheral  | Board Function | Remark                       |
+|:--------|:---------------|:-----------------|:---------------|:-----------------------------|
+| PA0     |                |                  | BTN0           |                              |
+| PA9     | USART0 TX      | UART_DEV(0) TX   | UART TX        |                              |
+| PA10    | USART0 RX      | UART_DEV(0) RX   | UART RX        |                              |
+| PB0     |                | PWM_DEV(0) CH0   | LED1 green     |                              |
+| PB1     |                | PWM_DEV(0) CH1   | LED2 blue      |                              |
+| PB5     |                |                  | LED0 red       |                              |
+| PB8     |                | PWM_DEV(1) CH0   |                | N/A if CAN is used           |
+| PB9     |                | PWM_DEV(2) CH1   |                | N/A if CAN is used           |
+| PC13    |                |                  | BTN1           |                              |
 
 ## Flash the board
 

--- a/boards/seeedstudio-gd32/include/periph_conf.h
+++ b/boards/seeedstudio-gd32/include/periph_conf.h
@@ -43,6 +43,44 @@
 extern "C" {
 #endif
 
+/**
+ * @name   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIMER2,
+        .rcu_mask = RCU_APB1EN_TIMER2EN_Msk,
+        .chan     = {
+                        { .pin = GPIO_PIN(PORT_B, 0), .cc_chan = 2 },
+                        { .pin = GPIO_PIN(PORT_B, 1), .cc_chan = 3 },
+                        /* unused channels have to be defined by GPIO_UNDEF */
+                        { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                        { .pin = GPIO_UNDEF, .cc_chan = 1 },
+                    },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB1,
+    },
+#if !defined(MODULE_PERIPH_CAN)
+    {
+        .dev      = TIMER3,
+        .rcu_mask = RCU_APB1EN_TIMER3EN_Msk,
+        .chan     = {
+                        { .pin = GPIO_PIN(PORT_B, 8), .cc_chan = 2 },
+                        { .pin = GPIO_PIN(PORT_B, 9), .cc_chan = 3 },
+                        /* unused channels have to be defined by GPIO_UNDEF */
+                        { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                        { .pin = GPIO_UNDEF, .cc_chan = 1 },
+                    },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB1,
+    },
+#endif
+};
+
+#define PWM_NUMOF ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/sipeed-longan-nano/Kconfig
+++ b/boards/sipeed-longan-nano/Kconfig
@@ -14,6 +14,7 @@ config BOARD_SIPEED_LONGAN_NANO
     select CPU_MODEL_GD32VF103CBT6
     select BOARD_HAS_HXTAL
     select BOARD_HAS_LXTAL
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAVE_SAUL_GPIO

--- a/boards/sipeed-longan-nano/Makefile.features
+++ b/boards/sipeed-longan-nano/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = gd32vf103cbt6
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -39,7 +39,7 @@ on-board components:
 | I2C         | 2 x Fast Mode 400 kHz                  |   no      |
 | I2S         | 2                                      |   no      |
 | CAN         | 2 x CAN 2.0B with up to 1 Mbps         |   no      |
-| PWM         | 6 Channels                             |   no      |
+| PWM         | 6 Channels                             |   yes     |
 | USB         | 1 x USB FS OTG                         |   no      |
 | Vcc         | 3.0V - 3.6V                            |           |
 | Datasheet   | [Datasheet](https://gd32mcu.com/data/documents/datasheet/GD32VF103_Datasheet_Rev1.6.pdf) | |
@@ -56,13 +56,15 @@ The general pin layout is shown below.
 The following table shows the connection of the on-board components with the
 MCU pins and their configuration in RIOT.
 
-| MCU Pin | MCU Peripheral | RIOT Peripheral     | Board Function        |
-|:--------|:---------------|:--------------------|:----------------------|
-| PA9     | USART0 TX      | UART_DEV(0) TX      | UART TX               |
-| PA10    | USART0 RX      | UART_DEV(0) RX      | UART RX               |
-| PB0     |                |                     | LED1                  |
-| PB1     |                |                     | LED2                  |
-| PB5     |                |                     | LED0                  |
+| MCU Pin | MCU Peripheral | RIOT Peripheral  | Board Function | Remark                       |
+|:--------|:---------------|:-----------------|:---------------|:-----------------------------|
+| PA1     |                | PWM_DEV(0) CH0   | LED1 green     |                              |
+| PA2     |                | PWM_DEV(0) CH1   | LED2 blue      |                              |
+| PA9     | USART0 TX      | UART_DEV(0) TX   | UART TX        |                              |
+| PA10    | USART0 RX      | UART_DEV(0) RX   | UART RX        |                              |
+| PB8     |                | PWM_DEV(1) CH0   |                | N/A if CAN is used           |
+| PB9     |                | PWM_DEV(2) CH1   |                | N/A if CAN is used           |
+| PC13    |                |                  | LED0 red       |                              |
 
 ## Flashing the Device
 

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -43,6 +43,44 @@
 extern "C" {
 #endif
 
+/**
+ * @name   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIMER4,
+        .rcu_mask = RCU_APB1EN_TIMER4EN_Msk,
+        .chan     = {
+                        { .pin = GPIO_PIN(PORT_A, 1), .cc_chan = 1 },
+                        { .pin = GPIO_PIN(PORT_A, 2), .cc_chan = 2 },
+                        /* unused channels have to be defined by GPIO_UNDEF */
+                        { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                        { .pin = GPIO_UNDEF, .cc_chan = 3 },
+                    },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB1,
+    },
+#if !defined(MODULE_PERIPH_CAN)
+    {
+        .dev      = TIMER3,
+        .rcu_mask = RCU_APB1EN_TIMER3EN_Msk,
+        .chan     = {
+                        { .pin = GPIO_PIN(PORT_B, 8), .cc_chan = 2 },
+                        { .pin = GPIO_PIN(PORT_B, 9), .cc_chan = 3 },
+                        /* unused channels have to be defined by GPIO_UNDEF */
+                        { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                        { .pin = GPIO_UNDEF, .cc_chan = 1 },
+                    },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB1,
+    },
+#endif
+};
+
+#define PWM_NUMOF ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/gd32v/include/periph_cpu.h
+++ b/cpu/gd32v/include/periph_cpu.h
@@ -260,6 +260,29 @@ typedef struct {
 } i2c_conf_t;
 
 /**
+ * @brief   PWM channel
+ */
+typedef struct {
+    gpio_t pin;             /**< GPIO pin mapped to this channel */
+    uint8_t cc_chan;        /**< capture compare channel used */
+} pwm_chan_t;
+
+/**
+ * @brief   PWM configuration
+ */
+typedef struct {
+    TIMER_Type *dev;                        /**< Timer used */
+    uint32_t rcu_mask;                      /**< bit in clock enable register */
+    uint32_t remap;                         /**< AFIO remap mask to route periph
+                                                 to other pins (or zero, if not
+                                                 needed) */
+    pwm_chan_t chan[TIMER_CHANNEL_NUMOF];   /**< channel mapping set to
+                                                 {GPIO_UNDEF, 0} if not used */
+    gpio_af_t af;                           /**< alternate function used */
+    uint8_t bus;                            /**< APB bus */
+} pwm_conf_t;
+
+/**
  * @name    WDT upper and lower bound times in ms
  * @{
  */

--- a/cpu/gd32v/include/periph_cpu.h
+++ b/cpu/gd32v/include/periph_cpu.h
@@ -166,6 +166,16 @@ typedef enum {
 } gpio_af_t;
 
 /**
+ * @brief   GD32V timers have 4 capture-compare channels
+ */
+#define TIMER_CHANNEL_NUMOF (4U)
+
+/**
+ * @brief   Macro for accessing the capture/compare register of a timer channel
+ */
+#define TIMER_CHANNEL(tim, chan) *(&dev(tim)->CH0CV + (chan * 2))
+
+/**
  * @brief   Timer configuration
  */
 typedef struct {

--- a/cpu/gd32v/periph/pwm.c
+++ b/cpu/gd32v/periph/pwm.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2014-2016 Freie Universität Berlin
+ *               2015 Engineering-Spirit
+ *               2016 OTA keys S.A.
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_gd32v
+ * @ingroup     drivers_periph_pwm
+ * @{
+ *
+ * @file
+ * @brief       Low-level PWM driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ * @author      Nick v. IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ * @author      Aurelien Gonce <aurelien.gonce@altran.fr>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "assert.h"
+#include "periph/pwm.h"
+#include "periph/gpio.h"
+#include "periph_conf.h"
+#include <stdio.h>
+
+#define TIM_CHCTL0_CH0COMCT_0   (0x1U << TIMER0_CHCTL0_Output_CH0COMCTL_Pos)
+#define TIM_CHCTL0_CH0COMCT_1   (0x2U << TIMER0_CHCTL0_Output_CH0COMCTL_Pos)
+#define TIM_CHCTL0_CH0COMCT_2   (0x4U << TIMER0_CHCTL0_Output_CH0COMCTL_Pos)
+
+#define TIM_CHCTL0_CH1COMCT_0   (0x1U << TIMER0_CHCTL0_Output_CH1COMCTL_Pos)
+#define TIM_CHCTL0_CH1COMCT_1   (0x2U << TIMER0_CHCTL0_Output_CH1COMCTL_Pos)
+#define TIM_CHCTL0_CH1COMCT_2   (0x4U << TIMER0_CHCTL0_Output_CH1COMCTL_Pos)
+
+#define CHCTL0_MODE0    (TIM_CHCTL0_CH0COMCT_1 | TIM_CHCTL0_CH0COMCT_2 | \
+                         TIM_CHCTL0_CH1COMCT_1 | TIM_CHCTL0_CH1COMCT_2)
+
+#define CHCTL0_MODE1    (TIM_CHCTL0_CH0COMCT_0 | TIM_CHCTL0_CH0COMCT_1 | \
+                         TIM_CHCTL0_CH0COMCT_2 | TIM_CHCTL0_CH1COMCT_0 | \
+                         TIM_CHCTL0_CH1COMCT_1 | TIM_CHCTL0_CH1COMCT_2)
+
+static inline TIMER_Type *dev(pwm_t pwm)
+{
+    return pwm_config[pwm].dev;
+}
+
+uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
+{
+    uint32_t timer_clk = periph_apb_clk(pwm_config[pwm].bus) * 2;
+
+    /* in PWM_CENTER mode the counter counts up and down at each period
+     * so the resolution had to be divided by 2 */
+    res *= (mode == PWM_CENTER) ? 2 : 1;
+
+    /* verify parameters */
+    assert((pwm < PWM_NUMOF) && ((freq * res) <= timer_clk));
+
+    /* power on the used timer */
+    periph_clk_en(pwm_config[pwm].bus, pwm_config[pwm].rcu_mask);
+    /* reset configuration and CC channels */
+    dev(pwm)->CTL0 = 0;
+    dev(pwm)->CTL1 = 0;
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
+        TIMER_CHANNEL(pwm, i) = (mode == PWM_RIGHT) ? res : 0;
+    }
+
+    /* remap the timer to the configured pins (F1 only) */
+    AFIO->PCF0 |= pwm_config[pwm].remap;
+
+    /* configure the used pins */
+    unsigned i = 0;
+    while ((i < TIMER_CHANNEL_NUMOF) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+        gpio_init(pwm_config[pwm].chan[i].pin, GPIO_OUT);
+        gpio_init_af(pwm_config[pwm].chan[i].pin, pwm_config[pwm].af);
+        i++;
+    }
+
+    /* configure the PWM frequency and resolution by setting the auto-reload
+     * and prescaler registers */
+    dev(pwm)->PSC = (timer_clk / (res * freq)) - 1;
+    dev(pwm)->CAR = (mode == PWM_CENTER) ? (res / 2) : res - 1;
+
+    /* set PWM mode */
+    switch (mode) {
+        case PWM_LEFT:
+            dev(pwm)->CHCTL0_Output = CHCTL0_MODE0;
+            dev(pwm)->CHCTL1_Output = CHCTL0_MODE0;
+            break;
+        case PWM_RIGHT:
+            dev(pwm)->CHCTL0_Output = CHCTL0_MODE1;
+            dev(pwm)->CHCTL1_Output = CHCTL0_MODE1;
+            /* duty cycle should be reversed */
+            break;
+        case PWM_CENTER:
+            dev(pwm)->CHCTL0_Output = CHCTL0_MODE0;
+            dev(pwm)->CHCTL1_Output = CHCTL0_MODE0;
+            /* center-aligned mode 3 */
+            dev(pwm)->CTL0 |= TIMER0_CTL0_CAM_Msk;
+            break;
+    }
+
+    /* enable PWM outputs and start PWM generation */
+#ifdef TIM_BDTR_MOE
+    dev(pwm)->BDTR = TIM_BDTR_MOE;
+#endif
+    dev(pwm)->CHCTL2 = (TIMER0_CHCTL2_CH0EN_Msk | TIMER0_CHCTL2_CH1EN_Msk |
+                        TIMER0_CHCTL2_CH2EN_Msk | TIMER0_CHCTL2_CH3EN_Msk);
+    dev(pwm)->CTL0 |= TIMER0_CTL0_CEN_Msk;
+
+    /* return the actual used PWM frequency */
+    return (timer_clk / (res * (dev(pwm)->PSC + 1)));
+}
+
+uint8_t pwm_channels(pwm_t pwm)
+{
+    assert(pwm < PWM_NUMOF);
+
+    unsigned i = 0;
+    while ((i < TIMER_CHANNEL_NUMOF) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+        i++;
+    }
+    return (uint8_t)i;
+}
+
+void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
+{
+    assert((pwm < PWM_NUMOF) &&
+           (channel < TIMER_CHANNEL_NUMOF) &&
+           (pwm_config[pwm].chan[channel].pin != GPIO_UNDEF));
+
+    /* norm value to maximum possible value */
+    if (value > dev(pwm)->CAR + 1) {
+        value = (uint16_t)dev(pwm)->CAR + 1;
+    }
+
+    if (dev(pwm)->CHCTL0_Output == CHCTL0_MODE1) {
+        /* reverse the value */
+        value = (uint16_t)dev(pwm)->CAR + 1 - value;
+    }
+
+    /* set new value */
+    TIMER_CHANNEL(pwm, pwm_config[pwm].chan[channel].cc_chan) = value;
+}
+
+void pwm_poweron(pwm_t pwm)
+{
+    assert(pwm < PWM_NUMOF);
+    periph_clk_en(pwm_config[pwm].bus, pwm_config[pwm].rcu_mask);
+    dev(pwm)->CTL0 |= TIMER0_CTL0_CEN_Msk;
+}
+
+void pwm_poweroff(pwm_t pwm)
+{
+    assert(pwm < PWM_NUMOF);
+    dev(pwm)->CTL0 &= ~TIMER0_CTL0_CEN_Msk;
+    periph_clk_dis(pwm_config[pwm].bus, pwm_config[pwm].rcu_mask);
+}

--- a/cpu/gd32v/periph/timer.c
+++ b/cpu/gd32v/periph/timer.c
@@ -25,12 +25,6 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-/**
- * @brief   Define a macro for accessing a timer channel
- */
-#define TIM_CHAN(tim, chan) *(&dev(tim)->CH0CV + chan)
-#define TIMER_CHANNEL_NUMOF     (4)
-
 static void _timer_isr(unsigned irq);
 
 /**
@@ -143,10 +137,10 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
     set_oneshot(tim, channel);
 
-    TIM_CHAN(tim, channel) = (value & timer_config[tim].max);
+    TIMER_CHANNEL(tim, channel) = (value & timer_config[tim].max);
 
 #ifdef MODULE_PERIPH_TIMER_PERIODIC
-    if (dev(tim)->CAR == TIM_CHAN(tim, channel)) {
+    if (dev(tim)->CAR == TIMER_CHANNEL(tim, channel)) {
         dev(tim)->CAR = timer_config[tim].max;
     }
 #endif
@@ -207,7 +201,7 @@ int timer_clear(tim_t tim, int channel)
     dev(tim)->DMAINTEN &= ~(TIMER0_DMAINTEN_CH0IE_Msk << channel);
 
 #ifdef MODULE_PERIPH_TIMER_PERIODIC
-    if (dev(tim)->CAR == TIM_CHAN(tim, channel)) {
+    if (dev(tim)->CAR == TIMER_CHANNEL(tim, channel)) {
         dev(tim)->CAR = timer_config[tim].max;
     }
 #endif
@@ -247,7 +241,7 @@ static void _irq_handler(tim_t tim)
         status &= ~msk;
 
         /* interrupt flag gets set for all channels > ARR */
-        if (TIM_CHAN(tim, i) > top) {
+        if (TIMER_CHANNEL(tim, i) > top) {
             continue;
         }
 

--- a/cpu/gd32v/periph/timer.c
+++ b/cpu/gd32v/periph/timer.c
@@ -151,6 +151,8 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     }
 #endif
 
+    /* clear a possibly pending interrupt and enable the interrupt */
+    dev(tim)->INTF &= ~(TIMER0_DMAINTEN_CH0IE_Msk << channel);
     dev(tim)->DMAINTEN |= (TIMER0_DMAINTEN_CH0IE_Msk << channel);
 
     return 0;
@@ -182,7 +184,10 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value,
         irq_restore(state);
     }
 
-    TIM_CHAN(tim, channel) = value;
+    TIMER_CHANNEL(tim, channel) = value;
+
+    /* clear a possibly pending interrupt before the interrupt is enabled */
+    dev(tim)->INTF &= ~(TIMER0_DMAINTEN_CH0IE_Msk << channel);
     dev(tim)->DMAINTEN |= (TIMER0_DMAINTEN_CH0IE_Msk << channel);
 
     if (flags & TIM_FLAG_RESET_ON_MATCH) {

--- a/cpu/gd32v/periph/timer.c
+++ b/cpu/gd32v/periph/timer.c
@@ -111,7 +111,12 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev(tim)->CAR = timer_config[tim].max;
 
     /* set prescaler */
-    dev(tim)->PSC = (((periph_apb_clk(timer_config[tim].bus) * 2) / freq) - 1);
+    if (dev(tim) == TIMER0) {
+        dev(tim)->PSC = ((periph_apb_clk(timer_config[tim].bus) / freq) - 1);
+    }
+    else {
+        dev(tim)->PSC = (((periph_apb_clk(timer_config[tim].bus) * 2) / freq) - 1);
+    }
     DEBUG("[timer]: %" PRIu32 "/%lu =  %" PRIu16 "\n",
           periph_apb_clk(timer_config[tim].bus), freq, dev(tim)->PSC);
 
@@ -275,6 +280,11 @@ static void _timer_isr(unsigned irq)
 #ifdef TIMER_3_IRQN
     case TIMER_3_IRQN:
         _irq_handler(TIMER_DEV(3));
+        break;
+#endif
+#ifdef TIMER_4_IRQN
+    case TIMER_4_IRQN:
+        _irq_handler(TIMER_DEV(4));
         break;
 #endif
     default:

--- a/dist/tools/doccheck/generic_exclude_patterns
+++ b/dist/tools/doccheck/generic_exclude_patterns
@@ -38,6 +38,8 @@ warning: Member PIR_SAUL_INFO \(macro definition\) of
 warning: Member PULSE_COUNTER_GPIO \(macro definition\) of
 warning: Member PULSE_COUNTER_GPIO_FLANK \(macro definition\) of
 warning: Member PULSE_COUNTER_SAUL_INFO \(macro definition\) of
+warning: Member pwm_config\[\] \(variable\) of
+warning: Member PWM_NUMOF \(macro definition\) of
 warning: Member SHT1X_PARAMS \(macro definition\) of
 warning: Member SHT1X_PARAM_[A-Z0-9_]* \(macro definition\) of
 warning: Member SHT1X_SAULINFO \(macro definition\) of


### PR DESCRIPTION
### Contribution description

This PR provides the `periph_pwm` support for GD32VF103.

It includes a bug fix (2c6e527339f2cdbb4b0cccdc79d4abb6b0b60c12) of `periph_timer` which clears pending interrupts on setting the timer before the interrupt is enabled. This avoids that a pending interrupt is triggered immediately when the timer is set. The bug caused `tests/periph_timer` and `tests/periph_timer_periodic` to crash. (I could split-off this bug fix if necessary).

Furthermore, the default timer configuration has been extended and reordered. `TIMER0` can be used now as timer device (0dfbdebaf74050ca6b9cc764be73a635c915a884). The default timer configuration has been changed (377b5b321c0da8f0ed71a25719e8ec4a08ce972a) so that `TIMER0` and `TIMER1` are always timer devices. `TIMER2` can only be used as timer device if it is not used for PWM devices. `TIMER3` and `TIMER4` are only available as timer devices if they are supported by the CPU model and not used for PWM devices.

### Testing procedure

- `tests/periph_timer` and `tests/periph_timer_periodic` should work now. Without the PR, these tests lead to kernel panic.
- `tests/periph_pwm` should work on any GD32VF103 board. Command `osci` should also let LED1 and LED2 oscillate.

### Issues/PRs references