### PR TITLE
cpu/gd32v: move board dependent RTT configs to board config

### DIFF
--- a/boards/common/gd32v/include/periph_common_conf.h
+++ b/boards/common/gd32v/include/periph_common_conf.h
@@ -34,6 +34,23 @@ extern "C" {
 #define CLOCK_APB1              CLOCK_AHB/2     /**< Half AHB clock */
 #define CLOCK_APB2              CLOCK_AHB       /**< Equal to the AHB clock */
 
+/**
+ * @name    RTT/RTC configuration
+ * @{
+ */
+#if CONFIG_BOARD_HAS_LXTAL
+#define RTT_CLOCK_FREQUENCY (32768U)        /**< Low frequency XTAL is used as clock source */
+#else
+#define RTT_CLOCK_FREQUENCY (40000U)        /**< IRC40K is used as clock source */
+#endif
+
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)   /* maximum RTT frequency in Hz */
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)     /* RTT frequency in Hz */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/gd32v/include/periph_cpu.h
+++ b/cpu/gd32v/include/periph_cpu.h
@@ -306,27 +306,16 @@ typedef struct {
 
 /**
  * @name    RTT/RTC configuration
- *
  * @{
  */
 #define RTT_DEV             RTC             /**< RTC is used as RTT device */
 
 #define RTT_IRQ             RTC_ALARM_IRQn  /**< RTC_ALARM_IRQn is used as IRQ number */
 #define RTT_IRQ_PRIORITY    (2)             /**< RTT interrupt priority */
+#define RTT_MAX_VALUE       (0xffffffff)    /**< maximum RTT value */
 
-#if CONFIG_BOARD_HAS_LXTAL
-#define RTT_CLOCK_FREQUENCY (32768U)        /**< Low frequency XTAL is used as clock source */
-#else
-#define RTT_CLOCK_FREQUENCY (40000U)        /**< IRC40K is used as clock source */
-#endif
-
-#define RTT_MIN_FREQUENCY   (1U)                    /* in Hz */
-#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)   /* in Hz */
-#define RTT_MAX_VALUE       (0xffffffff)
-
-#ifndef RTT_FREQUENCY
-#define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)     /* in Hz */
-#endif
+#define RTT_MIN_FREQUENCY   (1U)            /**< minimum RTT frequency in Hz */
+/** @} */
 
 /**
  * @brief   Enable the given peripheral clock
@@ -364,8 +353,6 @@ void gpio_init_af(gpio_t pin, gpio_af_t af);
 void gd32vf103_clock_init(void);
 void gd32v_enable_irc8(void);
 void gd32v_disable_irc8(void);
-
-/** @} */
 
 #ifdef __cplusplus
 }

--- a/dist/tools/doccheck/generic_exclude_patterns
+++ b/dist/tools/doccheck/generic_exclude_patterns
@@ -40,6 +40,8 @@ warning: Member PULSE_COUNTER_GPIO_FLANK \(macro definition\) of
 warning: Member PULSE_COUNTER_SAUL_INFO \(macro definition\) of
 warning: Member pwm_config\[\] \(variable\) of
 warning: Member PWM_NUMOF \(macro definition\) of
+warning: Member RTT_FREQUENCY \(macro definition\) of
+warning: Member RTT_MAX_FREQUENCY \(macro definition\) of
 warning: Member SHT1X_PARAMS \(macro definition\) of
 warning: Member SHT1X_PARAM_[A-Z0-9_]* \(macro definition\) of
 warning: Member SHT1X_SAULINFO \(macro definition\) of


### PR DESCRIPTION
### Contribution description

This PR fixes the problem that the RTT frequency is defined to be 40.0 kHz instead of 32.768 kHz if `TEST_KCONFIG=1` is not defined.

The problem was caused by the order in which the headers were included. In `cpu/gd32v/include/periph_cpu.h` the RTT frequency was defined to be 32.768 kHz or 40.0 kHz, depending on the `CONFIG_BOARD_HAS_LXTAL` configuration of the board. If `TEST_KCONFIG=1` is used, it is defined in `autoconfig.h` and is always known, but without `TEST_KCONFIG=1` it is defined in the `periph_conf.h` of the board. If `periph_cpu.h` is included but not `periph_conf.h`, `CONFIG_BOARD_HAS_LXTAL` is not defined without `TEST_KCONFIG=1` and the RTT frequency is defined to be 40.0 kHz.

The solution is to move board dependent RTT configurations to `periph_common.conf`.

### Testing procedure

```
BOARD=sipeed-longan-nano make -C tests/periph_rtt flash
```
should still work.

### Issues/PRs references