### PR TITLE
socket_zep: properly implement the radio HAL

### DIFF
--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -41,6 +41,9 @@
  * (https://pubs.opengroup.org/onlinepubs/9699919799.2016edition/basedefs/time.h.html) */
 #define TV_USEC_PER_SEC         (1000000L)
 
+/* IEEE 802.15.4 ACK delay */
+#define ACK_DELAY_US            (IEEE802154_SYMBOL_TIME_US * IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS)
+
 /* dummy packet to register with ZEP dispatcher */
 #define SOCKET_ZEP_V2_TYPE_HELLO   (255)
 
@@ -89,6 +92,8 @@ static void _continue_reading(socket_zep_t *dev)
     FD_SET(dev->sock_fd, &rfds);
 
     _native_in_syscall++; /* no switching here */
+
+    dev->state = ZEPDEV_STATE_RX_ON;
 
     if (real_select(dev->sock_fd + 1, &rfds, NULL, NULL, &t) == 1) {
         int sig = SIGIO;
@@ -232,13 +237,117 @@ static void _send_zep_hello(socket_zep_t *dev)
     }
 }
 
+static void _send_ack(void *arg)
+{
+    ieee802154_dev_t *dev = arg;
+    socket_zep_t *zepdev = dev->priv;
+    const uint8_t *rxbuf = &zepdev->rcv_buf[sizeof(zep_v2_data_hdr_t)];
+    uint8_t ack[3];
+    zep_v2_data_hdr_t hdr;
+
+    assert(zepdev->state == ZEPDEV_STATE_RX_RECV);
+    assert((rxbuf[0] & IEEE802154_FCF_ACK_REQ) != 0);
+
+    DEBUG("socket_zep::send_ack: seq_no: %u\n", rxbuf[2]);
+
+    _zep_hdr_fill(zepdev, &hdr.hdr, sizeof(ack) + 2);
+
+    ack[0] = IEEE802154_FCF_TYPE_ACK; /* FCF */
+    ack[1] = 0; /* FCF */
+    ack[2] = rxbuf[2];  /* SeqNum */
+
+    /* calculate checksum */
+    uint16_t chksum = crc16_ccitt_false_update(0, ack, 3);
+
+    real_send(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_MORE);
+    real_send(zepdev->sock_fd, ack, sizeof(ack), MSG_MORE);
+    real_send(zepdev->sock_fd, &chksum, sizeof(chksum), 0);
+
+    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
+}
+
+static void _send_frame(void *arg)
+{
+    ieee802154_dev_t *dev = arg;
+    socket_zep_t *zepdev = dev->priv;
+
+    assert(zepdev->state == ZEPDEV_STATE_TX);
+
+    int res = real_write(zepdev->sock_fd, zepdev->snd_buf, zepdev->snd_len);
+    DEBUG("socket_zep::send_frame: wrote %d bytes\n", res);
+
+    zepdev->state = ZEPDEV_STATE_IDLE;
+    dev->cb(dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
+}
+
 static void _socket_isr(int fd, void *arg)
 {
     ieee802154_dev_t *dev = arg;
+    socket_zep_t *zepdev = dev->priv;
+    int res;
 
-    DEBUG("socket_zep::_socket_isr: bytes on %d\n", fd);
+    if (zepdev->state != ZEPDEV_STATE_RX_ON) {
+        res = real_recv(zepdev->sock_fd, &res, sizeof(res), MSG_TRUNC);
+        DEBUG("socket_zep::_socket_isr: discard frame (%d bytes, state %u)\n", res, zepdev->state);
+        return;
+    }
 
-    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
+    zepdev->rcv_len = 0;
+    zepdev->state = ZEPDEV_STATE_RX_RECV;
+
+    res = real_recv(zepdev->sock_fd, zepdev->rcv_buf, sizeof(zepdev->rcv_buf), 0);
+    DEBUG("socket_zep::_socket_isr: %d bytes on %d\n", res, fd);
+
+    if (res < (int)sizeof(zep_v2_data_hdr_t)) {
+        DEBUG("socket_zep::_socket_isr: frame is shorter than the header, %d < %zu\n",
+              res, sizeof(zep_v2_data_hdr_t));
+        goto out;
+    }
+
+    zep_hdr_t *tmp = (zep_hdr_t *)zepdev->rcv_buf;
+
+    if ((tmp->preamble[0] != 'E') || (tmp->preamble[1] != 'X')) {
+        DEBUG("socket_zep::read: invalid ZEP header\n");
+        goto out;
+    }
+
+    if (tmp->version != 2) {
+        DEBUG("socket_zep::read: unsupported ZEP version %u\n", tmp->version);
+        goto out;
+    }
+
+    if (((zep_v2_ack_hdr_t *)tmp)->type != ZEP_V2_TYPE_DATA) {
+        DEBUG("socket_zep::read: unknown type %u\n", ((zep_v2_ack_hdr_t *)tmp)->type);
+        goto out;
+    }
+
+    /* we received a valid ZEP frame */
+    zep_v2_data_hdr_t *zep = (zep_v2_data_hdr_t *)tmp;
+
+    if (zep->chan != zepdev->chan) {
+        DEBUG("socket_zep::read: wrong channel %d but expected %d\n", zep->chan, zepdev->chan);
+        goto out;
+    }
+
+    if (_dst_not_me(zepdev, zep + 1)) {
+        DEBUG("socket_zep::read: dst not me\n");
+        goto out;
+    }
+
+    zepdev->rcv_len = res;
+    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_START);
+
+    /* send ACK after 192 µs */
+    if ((((uint8_t *)(zep + 1))[0] & IEEE802154_FCF_ACK_REQ) != 0) {
+        zepdev->ack_timer.callback = _send_ack;
+        ztimer_set(ZTIMER_USEC, &zepdev->ack_timer, ACK_DELAY_US);
+    } else {
+        dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
+    }
+
+    return;
+out:
+    _continue_reading(zepdev);
 }
 
 void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params)
@@ -247,6 +356,7 @@ void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params)
     assert((params->remote_addr != NULL) && (params->remote_port != NULL));
 
     dev->params = params;
+
     native_async_read_setup();
 }
 
@@ -409,17 +519,17 @@ static int _request_transmit(ieee802154_dev_t *dev)
 {
     socket_zep_t *zepdev = dev->priv;
 
-    DEBUG("socket_zep::request_transmit(%u bytes)\n", zepdev->snd_len);
+    zepdev->state = ZEPDEV_STATE_TX;
+
+    /* 8 bit are mapped to 2 symbols */
+    unsigned time_tx = 2 * zepdev->snd_len * IEEE802154_SYMBOL_TIME_US;
+    DEBUG("socket_zep::request_transmit(%u bytes, %u µs)\n", zepdev->snd_len, time_tx);
 
     dev->cb(dev, IEEE802154_RADIO_INDICATION_TX_START);
 
-    int res = real_write(zepdev->sock_fd, zepdev->snd_buf, zepdev->snd_len);
-
-    dev->cb(dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
-
-    if (res < 0) {
-        return res;
-    }
+    /* delay transmission to simulate airtime */
+    zepdev->ack_timer.callback = _send_frame;
+    ztimer_set(ZTIMER_USEC, &zepdev->ack_timer, time_tx);
 
     return 0;
 }
@@ -439,128 +549,47 @@ int _len(ieee802154_dev_t *dev)
 {
     socket_zep_t *zepdev = dev->priv;
 
-    zep_v2_data_hdr_t hdr;
+    zep_v2_data_hdr_t *hdr = (zep_v2_data_hdr_t *)zepdev->rcv_buf;
 
-    int res = real_recv(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_TRUNC | MSG_PEEK);
-    if (res < 0) {
-        DEBUG("socket_zep::len: error reading FIONREAD: %s", strerror(errno));
-        return 0;
-    }
-
-    if (res < (int)sizeof(zep_v2_data_hdr_t)) {
-        DEBUG("socket_zep::len discard short frame (%u bytes)\n", res);
-        return 0;
-    }
-
-    DEBUG("socket_zep::len %u bytes on %d\n", hdr.length, zepdev->sock_fd);
+    DEBUG("socket_zep::len: %u\n", hdr->length - IEEE802154_FCS_LEN);
 
     /* report size without ZEP header and checksum */
-    return hdr.length - 2;
-}
-
-static void _send_ack(socket_zep_t *zepdev, const void *frame)
-{
-    const uint8_t *rxbuf = frame;
-    uint8_t ack[3];
-    zep_v2_data_hdr_t hdr;
-
-    if ((rxbuf[0] & IEEE802154_FCF_ACK_REQ) == 0) {
-        return;
-    }
-
-    DEBUG("socket_zep::send_ack: seq_no: %u\n", rxbuf[2]);
-
-    _zep_hdr_fill(zepdev, &hdr.hdr, sizeof(ack) + 2);
-
-    ack[0] = IEEE802154_FCF_TYPE_ACK; /* FCF */
-    ack[1] = 0; /* FCF */
-    ack[2] = rxbuf[2];  /* SeqNum */
-
-    /* calculate checksum */
-    uint16_t chksum = crc16_ccitt_false_update(0, ack, 3);
-
-    real_send(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_MORE);
-    real_send(zepdev->sock_fd, ack, sizeof(ack), MSG_MORE);
-    real_send(zepdev->sock_fd, &chksum, sizeof(chksum), 0);
+    return hdr->length - IEEE802154_FCS_LEN;
 }
 
 static int _read(ieee802154_dev_t *dev, void *buf, size_t max_size,
                  ieee802154_rx_info_t *info)
 {
-    int res;
     socket_zep_t *zepdev = dev->priv;
-    size_t frame_len = max_size + sizeof(zep_v2_data_hdr_t) + 2;
+    int res = 0;
 
     DEBUG("socket_zep::read: reading up to %zu bytes into %p\n", max_size, buf);
 
-    if (frame_len > sizeof(zepdev->rcv_buf)) {
-        DEBUG("socket_zep::read: frame size (%zu) exceeds RX  buffer (%zu bytes)\n",
-              frame_len, sizeof(zepdev->rcv_buf));
-        res = -ENOBUFS;
+    if (buf == NULL || zepdev->rcv_len == 0) {
         goto out;
     }
 
-    res = real_recv(zepdev->sock_fd, zepdev->rcv_buf, frame_len, MSG_TRUNC);
+    DEBUG("socket_zep::read: %zu/%zu bytes into %p\n",
+           max_size, zepdev->rcv_len - sizeof(zep_v2_data_hdr_t) - IEEE802154_FCS_LEN, buf);
 
-    DEBUG("socket_zep::read: got %d/%zu bytes\n", res, frame_len);
-
-    if (res <= (int)sizeof(zep_v2_data_hdr_t) || res > (int)frame_len) {
-        DEBUG("socket_zep::read: %s\n", strerror(errno));
-        res = 0;
-        goto out;
-    }
-
-    zep_hdr_t *tmp = (zep_hdr_t *)zepdev->rcv_buf;
-
-    if ((tmp->preamble[0] != 'E') || (tmp->preamble[1] != 'X')) {
-        DEBUG("socket_zep::read: invalid ZEP header\n");
+    if (max_size != zepdev->rcv_len - sizeof(zep_v2_data_hdr_t) - IEEE802154_FCS_LEN) {
+        DEBUG("socket_zep::read: size mismatch!\n");
         res = -EINVAL;
         goto out;
     }
 
-    if (tmp->version != 2) {
-        DEBUG("socket_zep::read: unsupported ZEP version %u\n", tmp->version);
-        res = -EINVAL;
-        goto out;
+    zep_v2_data_hdr_t *zep = (zep_v2_data_hdr_t *)zepdev->rcv_buf;
+
+    if (info) {
+        info->lqi = zep->lqi_val;
+        info->rssi = -IEEE802154_RADIO_RSSI_OFFSET;
     }
 
-    switch (((zep_v2_ack_hdr_t *)tmp)->type) {
-    case ZEP_V2_TYPE_DATA: {
-        zep_v2_data_hdr_t *zep = (zep_v2_data_hdr_t *)tmp;
-
-        if (zep->chan != zepdev->chan) {
-            DEBUG("socket_zep::read: wrong channel\n");
-            res = -EINVAL;
-            break;
-        }
-
-        if (info) {
-            info->lqi = zep->lqi_val;
-            info->rssi = -IEEE802154_RADIO_RSSI_OFFSET;
-        }
-
-        if (_dst_not_me(zepdev, zep + 1)) {
-            DEBUG("socket_zep::read: dst not me\n");
-            res = -EINVAL;
-            break;
-        }
-
-        _send_ack(zepdev, zep + 1);
-
-        memcpy(buf, zep + 1, max_size);
-        res = max_size;
-
-        break;
-    }
-    default:
-        DEBUG("socket_zep::read: unknown type %u\n", ((zep_v2_ack_hdr_t *)tmp)->type);
-        res = -EINVAL;
-        break;
-    }
-
+    /* return payload size without frame checksum */
+    res = zep->length - IEEE802154_FCS_LEN;
+    /* skip the ZEP header, just copy payload without FCS */
+    memcpy(buf, zep + 1, res);
 out:
-    _continue_reading(zepdev);
-
     return res;
 }
 
@@ -572,14 +601,41 @@ static int _request_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
 
     switch (op) {
     case IEEE802154_HAL_OP_TRANSMIT:
+        if (zepdev->state != ZEPDEV_STATE_IDLE) {
+            return -EBUSY;
+        }
         res = _request_transmit(dev);
         break;
     case IEEE802154_HAL_OP_SET_RX:
-        zepdev->rx = true;
-        res = 0;
+        switch (zepdev->state) {
+        case ZEPDEV_STATE_IDLE:
+            DEBUG("socket_zep::request_op: switch to state RX_ON\n");
+            _continue_reading(zepdev);
+            return 0;
+        case ZEPDEV_STATE_TX:
+            DEBUG("socket_zep::request_op: request RX in state TX\n");
+            return -EBUSY;
+        case ZEPDEV_STATE_RX_RECV:
+            DEBUG("socket_zep::request_op: already have RX frame\n");
+            return -EBUSY;
+        case ZEPDEV_STATE_RX_ON:
+            DEBUG("socket_zep::request_op: already in state RX_ON\n");
+            return 0;
+        }
+
         break;
     case IEEE802154_HAL_OP_SET_IDLE:
-        zepdev->rx = false;
+        assert(ctx);
+        bool force = *((bool*) ctx);
+
+        DEBUG("socket_zep::request_op: switch to IDLE from %u\n", zepdev->state);
+        if (force || zepdev->state != ZEPDEV_STATE_TX) {
+            ztimer_remove(ZTIMER_USEC, &zepdev->ack_timer);
+            zepdev->state = ZEPDEV_STATE_IDLE;
+        } else {
+            return -EBUSY;
+        }
+
         res = 0;
         break;
     case IEEE802154_HAL_OP_CCA:
@@ -590,15 +646,22 @@ static int _request_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
     return res;
 }
 
-
 static int _confirm_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
 {
+    socket_zep_t *zepdev = dev->priv;
     int res = -EAGAIN;
+
     switch (op) {
     case IEEE802154_HAL_OP_TRANSMIT:
         res = _confirm_transmit(dev, ctx);
         break;
     case IEEE802154_HAL_OP_SET_RX:
+        /* we are still in RX state while ACK is being sent */
+        if (zepdev->state != ZEPDEV_STATE_RX_ON &&
+            zepdev->state != ZEPDEV_STATE_RX_RECV) {
+            break;
+        }
+        /* fall-through */
     case IEEE802154_HAL_OP_SET_IDLE:
         res = 0;
         break;
@@ -616,6 +679,7 @@ static const ieee802154_radio_ops_t socket_zep_rf_ops = {
           | IEEE802154_CAP_AUTO_CSMA
           | IEEE802154_CAP_IRQ_TX_DONE
           | IEEE802154_CAP_IRQ_TX_START
+          | IEEE802154_CAP_IRQ_RX_START
           | IEEE802154_CAP_PHY_OQPSK,
 
     .write = _write,
@@ -639,6 +703,8 @@ void socket_zep_hal_setup(socket_zep_t *dev, ieee802154_dev_t *hal)
 {
     hal->driver = &socket_zep_rf_ops;
     hal->priv = dev;
+
+    dev->ack_timer.arg = hal;
 }
 
 /** @} */

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -158,6 +158,17 @@ extern "C" {
 #define IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS   (12)
 
 /**
+ * O-QPSK Symbol time for 2.4 GHz:
+ *
+ * IEEE Std 802.15.4-2006
+ * 6.5.2.3: Each data symbol shall be mapped into a 32-chip PN sequence
+ * 6.5.2.4: Chip rate is nominally 2.0 Mchip/s on the 2.4 GHz O-QPSK band
+ *
+ * -> 32 Chip/symbol / 2MChip/s = 16 µs/symbol
+ */
+#define IEEE802154_SYMBOL_TIME_US               (16)
+
+/**
  * IEEE Std 802.15.4-2020
  * Table 11-1—PHY constants: For all other PHYs¹, the duration of
  * 8 symbol periods.

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/tests/01-run.py
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/tests/01-run.py
@@ -130,7 +130,7 @@ def test_fragmentation(factory, zep_dispatch):
         # 2 intermediate hops, 64 - 2
         assert_result(result, 34, 1, 64 - 2)
 
-        result = parser.parse(D.ping6(root_addr, count=100, interval=30, packet_size=500))
+        result = parser.parse(D.ping6(root_addr, count=100, interval=200, packet_size=500))
         # assert packetloss is under 90%
         # assert at least one response
         # 2 intermediate hops, 64 - 2


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The radio HAL implementation of `socket_zep` was a bit off.

 - `IEEE802154_RADIO_INDICATION_RX_DONE` must only be sent *after* the ACK was sent (if the frame contained an ACK request)
 - there is now a 192µs delay between receiving a frame and sending the ACK. During this period received frames are discarded.
 - read the frame into the RX buffer directly in `_socket_isr()` instead of fumbling around with `MSG_PEEK | MSG_TRUNC`
 - delay sending frames for how long it would take to send the frame on 2.4 GHz O-QPSK


### Testing procedure

Build and run `examples/gnrc_networking` with `USE_ZEP=1`

Start the ZEP dispatcher with 80% transmission success probability:

```
 echo "A B 0.8" | dist/tools/zep_dispatch/bin/zep_dispatch -t - :: 17754
```

`socket_zep` should now behave more like a real radio.

```
ping ff02::1
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=0 ttl=64 rssi=0 dBm time=5.077 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=1 ttl=64 rssi=0 dBm time=5.945 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=2 ttl=64 rssi=0 dBm time=8.654 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
```

<details><summary>100 unicast pings, 20% packet loss</summary>

```
> ping -c 100 -i 100 fe80::6cfa:3703:993e:cc20%7
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=0 ttl=64 rssi=0 dBm time=5.585 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=1 ttl=64 rssi=0 dBm time=5.370 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=2 ttl=64 rssi=0 dBm time=6.639 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=3 ttl=64 rssi=0 dBm time=6.121 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=4 ttl=64 rssi=0 dBm time=6.612 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=5 ttl=64 rssi=0 dBm time=6.856 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=7 ttl=64 rssi=0 dBm time=6.583 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=7 ttl=64 rssi=0 dBm time=10.067 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=8 ttl=64 rssi=0 dBm time=9.286 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=9 ttl=64 rssi=0 dBm time=6.087 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=10 ttl=64 rssi=0 dBm time=13.455 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=11 ttl=64 rssi=0 dBm time=9.326 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=12 ttl=64 rssi=0 dBm time=9.284 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=13 ttl=64 rssi=0 dBm time=5.972 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=14 ttl=64 rssi=0 dBm time=6.115 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=15 ttl=64 rssi=0 dBm time=15.131 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=16 ttl=64 rssi=0 dBm time=20.441 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=17 ttl=64 rssi=0 dBm time=10.167 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=18 ttl=64 rssi=0 dBm time=6.039 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=19 ttl=64 rssi=0 dBm time=9.714 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=19 ttl=64 rssi=0 dBm time=13.240 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=20 ttl=64 rssi=0 dBm time=19.218 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=20 ttl=64 rssi=0 dBm time=22.486 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=21 ttl=64 rssi=0 dBm time=9.448 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=22 ttl=64 rssi=0 dBm time=9.527 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=23 ttl=64 rssi=0 dBm time=6.076 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=23 ttl=64 rssi=0 dBm time=12.798 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=24 ttl=64 rssi=0 dBm time=19.263 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=25 ttl=64 rssi=0 dBm time=6.230 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=26 ttl=64 rssi=0 dBm time=9.456 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=26 ttl=64 rssi=0 dBm time=12.786 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=27 ttl=64 rssi=0 dBm time=12.824 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=27 ttl=64 rssi=0 dBm time=19.412 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=28 ttl=64 rssi=0 dBm time=6.147 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=29 ttl=64 rssi=0 dBm time=19.262 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=30 ttl=64 rssi=0 dBm time=6.326 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=31 ttl=64 rssi=0 dBm time=5.346 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=32 ttl=64 rssi=0 dBm time=9.361 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=34 ttl=64 rssi=0 dBm time=6.155 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=35 ttl=64 rssi=0 dBm time=5.942 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=36 ttl=64 rssi=0 dBm time=9.308 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=37 ttl=64 rssi=0 dBm time=6.122 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=37 ttl=64 rssi=0 dBm time=9.361 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=38 ttl=64 rssi=0 dBm time=6.030 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=39 ttl=64 rssi=0 dBm time=6.155 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=40 ttl=64 rssi=0 dBm time=6.076 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=43 ttl=64 rssi=0 dBm time=13.682 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=45 ttl=64 rssi=0 dBm time=20.032 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=46 ttl=64 rssi=0 dBm time=13.616 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=46 ttl=64 rssi=0 dBm time=17.042 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=47 ttl=64 rssi=0 dBm time=5.539 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=48 ttl=64 rssi=0 dBm time=15.759 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=48 ttl=64 rssi=0 dBm time=19.073 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=49 ttl=64 rssi=0 dBm time=9.807 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=50 ttl=64 rssi=0 dBm time=19.230 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=52 ttl=64 rssi=0 dBm time=13.739 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=52 ttl=64 rssi=0 dBm time=17.176 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=53 ttl=64 rssi=0 dBm time=6.068 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=53 ttl=64 rssi=0 dBm time=9.322 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=54 ttl=64 rssi=0 dBm time=6.076 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=55 ttl=64 rssi=0 dBm time=19.726 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=56 ttl=64 rssi=0 dBm time=6.899 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=56 ttl=64 rssi=0 dBm time=10.417 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=56 ttl=64 rssi=0 dBm time=13.790 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=57 ttl=64 rssi=0 dBm time=6.144 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=58 ttl=64 rssi=0 dBm time=6.191 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=58 ttl=64 rssi=0 dBm time=9.458 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=59 ttl=64 rssi=0 dBm time=6.244 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=60 ttl=64 rssi=0 dBm time=6.076 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=60 ttl=64 rssi=0 dBm time=12.601 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=61 ttl=64 rssi=0 dBm time=6.160 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=62 ttl=64 rssi=0 dBm time=19.331 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=63 ttl=64 rssi=0 dBm time=5.420 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=63 ttl=64 rssi=0 dBm time=8.570 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=63 ttl=64 rssi=0 dBm time=11.742 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=63 ttl=64 rssi=0 dBm time=14.920 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=63 ttl=64 rssi=0 dBm time=18.136 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=64 ttl=64 rssi=0 dBm time=6.000 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=65 ttl=64 rssi=0 dBm time=20.389 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=66 ttl=64 rssi=0 dBm time=19.670 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=66 ttl=64 rssi=0 dBm time=22.898 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=67 ttl=64 rssi=0 dBm time=6.588 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=68 ttl=64 rssi=0 dBm time=6.052 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=69 ttl=64 rssi=0 dBm time=9.345 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=69 ttl=64 rssi=0 dBm time=12.698 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=70 ttl=64 rssi=0 dBm time=6.084 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=71 ttl=64 rssi=0 dBm time=6.082 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=72 ttl=64 rssi=0 dBm time=12.555 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=72 ttl=64 rssi=0 dBm time=15.816 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=72 ttl=64 rssi=0 dBm time=19.333 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=73 ttl=64 rssi=0 dBm time=19.359 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=74 ttl=64 rssi=0 dBm time=20.546 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=75 ttl=64 rssi=0 dBm time=13.303 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=76 ttl=64 rssi=0 dBm time=6.016 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=77 ttl=64 rssi=0 dBm time=6.071 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=78 ttl=64 rssi=0 dBm time=9.291 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=79 ttl=64 rssi=0 dBm time=5.422 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=79 ttl=64 rssi=0 dBm time=8.578 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=79 ttl=64 rssi=0 dBm time=11.740 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=80 ttl=64 rssi=0 dBm time=22.561 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=81 ttl=64 rssi=0 dBm time=20.455 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=82 ttl=64 rssi=0 dBm time=6.828 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=83 ttl=64 rssi=0 dBm time=19.352 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=84 ttl=64 rssi=0 dBm time=6.288 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=85 ttl=64 rssi=0 dBm time=9.451 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=85 ttl=64 rssi=0 dBm time=12.814 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=86 ttl=64 rssi=0 dBm time=6.058 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=87 ttl=64 rssi=0 dBm time=12.668 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=88 ttl=64 rssi=0 dBm time=9.258 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=89 ttl=64 rssi=0 dBm time=9.388 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=89 ttl=64 rssi=0 dBm time=12.668 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=90 ttl=64 rssi=0 dBm time=9.408 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=91 ttl=64 rssi=0 dBm time=6.038 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=92 ttl=64 rssi=0 dBm time=12.652 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=93 ttl=64 rssi=0 dBm time=9.349 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=94 ttl=64 rssi=0 dBm time=6.429 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=95 ttl=64 rssi=0 dBm time=8.569 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=96 ttl=64 rssi=0 dBm time=9.193 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=97 ttl=64 rssi=0 dBm time=6.661 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=98 ttl=64 rssi=0 dBm time=19.391 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=99 ttl=64 rssi=0 dBm time=10.250 ms

--- fe80::6cfa:3703:993e:cc20%7 PING statistics ---
100 packets transmitted, 94 packets received, 27 duplicates, 6% packet loss
round-trip min/avg/max = 5.346/10.964/22.898 ms
```

-> retransmissions reduce loss, introduce duplicates
</details>

<details><summary>100 multicast pings, 20% packet loss</summary>

```
> ping -c 100 -i 100 ff02::1
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=1 ttl=64 rssi=0 dBm time=4.958 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=2 ttl=64 rssi=0 dBm time=9.558 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=3 ttl=64 rssi=0 dBm time=5.651 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=4 ttl=64 rssi=0 dBm time=5.706 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=6 ttl=64 rssi=0 dBm time=5.533 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=7 ttl=64 rssi=0 dBm time=12.273 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=8 ttl=64 rssi=0 dBm time=5.635 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=9 ttl=64 rssi=0 dBm time=12.254 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=10 ttl=64 rssi=0 dBm time=5.619 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=11 ttl=64 rssi=0 dBm time=9.029 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=12 ttl=64 rssi=0 dBm time=5.622 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=14 ttl=64 rssi=0 dBm time=6.254 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=14 ttl=64 rssi=0 dBm time=16.462 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=14 ttl=64 rssi=0 dBm time=19.641 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=17 ttl=64 rssi=0 dBm time=4.939 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=18 ttl=64 rssi=0 dBm time=5.710 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=19 ttl=64 rssi=0 dBm time=6.458 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=19 ttl=64 rssi=0 dBm time=9.576 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=20 ttl=64 rssi=0 dBm time=5.593 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=20 ttl=64 rssi=0 dBm time=8.861 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=21 ttl=64 rssi=0 dBm time=5.683 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=22 ttl=64 rssi=0 dBm time=5.597 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=23 ttl=64 rssi=0 dBm time=5.795 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=24 ttl=64 rssi=0 dBm time=5.724 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=24 ttl=64 rssi=0 dBm time=12.240 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=25 ttl=64 rssi=0 dBm time=9.012 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=25 ttl=64 rssi=0 dBm time=12.436 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=26 ttl=64 rssi=0 dBm time=5.643 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=27 ttl=64 rssi=0 dBm time=5.788 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=29 ttl=64 rssi=0 dBm time=5.650 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=30 ttl=64 rssi=0 dBm time=12.228 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=31 ttl=64 rssi=0 dBm time=5.627 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=32 ttl=64 rssi=0 dBm time=5.732 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=33 ttl=64 rssi=0 dBm time=5.154 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=35 ttl=64 rssi=0 dBm time=5.727 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=36 ttl=64 rssi=0 dBm time=5.674 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=37 ttl=64 rssi=0 dBm time=5.669 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=39 ttl=64 rssi=0 dBm time=5.642 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=39 ttl=64 rssi=0 dBm time=12.616 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=40 ttl=64 rssi=0 dBm time=5.678 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=41 ttl=64 rssi=0 dBm time=5.729 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=42 ttl=64 rssi=0 dBm time=5.671 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=43 ttl=64 rssi=0 dBm time=5.722 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=44 ttl=64 rssi=0 dBm time=5.780 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=45 ttl=64 rssi=0 dBm time=9.293 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=46 ttl=64 rssi=0 dBm time=5.749 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=48 ttl=64 rssi=0 dBm time=5.724 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=49 ttl=64 rssi=0 dBm time=5.080 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=50 ttl=64 rssi=0 dBm time=8.947 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=51 ttl=64 rssi=0 dBm time=5.899 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=52 ttl=64 rssi=0 dBm time=5.650 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=53 ttl=64 rssi=0 dBm time=5.919 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=54 ttl=64 rssi=0 dBm time=5.708 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=55 ttl=64 rssi=0 dBm time=5.592 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=57 ttl=64 rssi=0 dBm time=5.842 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=57 ttl=64 rssi=0 dBm time=9.396 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=58 ttl=64 rssi=0 dBm time=6.015 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=59 ttl=64 rssi=0 dBm time=5.598 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=59 ttl=64 rssi=0 dBm time=8.868 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=60 ttl=64 rssi=0 dBm time=5.796 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=62 ttl=64 rssi=0 dBm time=6.114 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=62 ttl=64 rssi=0 dBm time=9.609 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=63 ttl=64 rssi=0 dBm time=6.143 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=65 ttl=64 rssi=0 dBm time=5.056 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=66 ttl=64 rssi=0 dBm time=5.612 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=69 ttl=64 rssi=0 dBm time=6.365 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=70 ttl=64 rssi=0 dBm time=5.809 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=71 ttl=64 rssi=0 dBm time=5.734 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=73 ttl=64 rssi=0 dBm time=6.083 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=74 ttl=64 rssi=0 dBm time=8.948 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=75 ttl=64 rssi=0 dBm time=5.619 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=75 ttl=64 rssi=0 dBm time=8.895 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=77 ttl=64 rssi=0 dBm time=6.047 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=78 ttl=64 rssi=0 dBm time=5.504 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=79 ttl=64 rssi=0 dBm time=5.616 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=80 ttl=64 rssi=0 dBm time=5.619 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=83 ttl=64 rssi=0 dBm time=5.970 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=84 ttl=64 rssi=0 dBm time=12.235 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=85 ttl=64 rssi=0 dBm time=5.616 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=87 ttl=64 rssi=0 dBm time=6.134 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=89 ttl=64 rssi=0 dBm time=6.055 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=90 ttl=64 rssi=0 dBm time=5.820 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=91 ttl=64 rssi=0 dBm time=5.792 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=92 ttl=64 rssi=0 dBm time=5.688 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=93 ttl=64 rssi=0 dBm time=6.124 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=93 ttl=64 rssi=0 dBm time=13.129 ms (DUP!)
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=94 ttl=64 rssi=0 dBm time=5.459 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=95 ttl=64 rssi=0 dBm time=5.476 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=97 ttl=64 rssi=0 dBm time=5.001 ms
12 bytes from fe80::6cfa:3703:993e:cc20%7: icmp_seq=99 ttl=64 rssi=0 dBm time=6.111 ms

--- ff02::1 PING statistics ---
100 packets transmitted, 78 packets received, 12 duplicates, 22% packet loss
round-trip min/avg/max = 4.939/7.044/19.641 ms
```
-> broadcast frames are not re-transmitted, giving us expected 20% loss, unicast replies are 

</details>

 - `tests/gnrc_rpl` still works
 - `tests/gcoap_fileserver` still works

### Issues/PRs references

follow-up to #16932
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
