### PR TITLE
tests/periph_flashpage_unittest: enable periph_flashpage

### DIFF
--- a/tests/periph_flashpage_unittest/Makefile
+++ b/tests/periph_flashpage_unittest/Makefile
@@ -1,6 +1,9 @@
 include ../Makefile.tests_common
 
+FEATURES_REQUIRED += periph_flashpage
+
 USEMODULE += embunit
+USEMODULE += periph_flashpage
 
 # avoid running Kconfig by default
 SHOULD_RUN_KCONFIG ?=

--- a/tests/periph_flashpage_unittest/app.config.test
+++ b/tests/periph_flashpage_unittest/app.config.test
@@ -1,3 +1,4 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_EMBUNIT=y
+CONFIG_MODULE_PERIPH_FLASHPAGE=y


### PR DESCRIPTION
### Contribution description

This PR enables the `periph_flashpage` module for  the unittest in `tests/periph_flashpage_unittest` so that it requires feature `periph_flashpage` and expects only correct calculation of flashpage indices if it is used.

Testing the correct calculation of flashpage indices without assuming the `periph_flashpage` feature and enabling the `periph_flashpage` module makes no sense. On ESP32x SoCs for example, the space in the flash is only reserved and `FLASHPAGE_NUMOF` is greater than 0 if `periph_flashpage` is used.

The PR fixes the unittest problem for ESP32x SoCs.

### Testing procedure

Green CI with label `CI: run test`.

### Issues/PRs references
