### PR TITLE
drivers/at86rf2xx: set netdev channel on init

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -65,6 +65,9 @@ const netdev_driver_t at86rf2xx_driver = {
     .set = _set,
 };
 
+/* Default AT86RF2XX channel */
+static const uint16_t at86rf2xx_chan_default = AT86RF2XX_DEFAULT_CHANNEL;
+
 #if IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
     IS_USED(MODULE_IEEE802154_SECURITY)
 /**
@@ -171,6 +174,10 @@ static int _init(netdev_t *netdev)
     netdev_ieee802154_reset(&dev->netdev);
     at86rf2xx_set_addr_long(dev, (eui64_t *)dev->netdev.long_addr);
     at86rf2xx_set_addr_short(dev, (network_uint16_t *)dev->netdev.short_addr);
+
+    /* `netdev_ieee802154_reset` does not set the default channel. */
+    netdev_ieee802154_set(&dev->netdev, NETOPT_CHANNEL, &at86rf2xx_chan_default, sizeof(at86rf2xx_chan_default));
+
     if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
         static const netopt_enable_t ack_req =
             IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR sets the correct value of `netdev_ieee802154->chan` during the at86rf2xx initialization.
This regression was introduced in https://github.com/RIOT-OS/RIOT/pull/18988, because it removes all `memcpy` instances from internal driver setters/getters. Since `netdev_ieee802154_reset`  does not set the value of `dev->chan`, nobody was setting the channel value.

This definitely needs a backport, but IMO it doesn't justify re-running release tests for AT86RF2XX related devices, since existing MAC layers store the channel in the MAC Information Base and don't rely on NETOPT_CHANNEL.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`ifconfig` should display the correct channel number:
```
2023-01-30 18:37:05,997 # Iface  6  HWaddr: 7B:4E  Channel: 26  NID: 0x23  PHY: O-QPSK 
2023-01-30 18:37:05,999 #           
2023-01-30 18:37:06,000 #           Long HWaddr: AA:84:99:37:4F:86:7B:4E 
2023-01-30 18:37:06,004 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
```

Without this PR, it displays `0`:
```
2023-01-30 17:26:59,276 # Iface  6  HWaddr: 7B:4E  Channel: 0  NID: 0x23  PHY: O-QPSK 
2023-01-30 17:26:59,277 #           
2023-01-30 17:26:59,280 #           Long HWaddr: AA:84:99:37:4F:86:7B:4E 
2023-01-30 17:26:59,285 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered during Release Tests.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
