### PR TITLE
doc/porting-boards.md: fix code snippets in Riot web page/doxygen

### DIFF
--- a/doc/doxygen/src/porting-boards.md
+++ b/doc/doxygen/src/porting-boards.md
@@ -221,7 +221,7 @@ The documentation must be under the proper doxygen group, you can compile the
 documentation by calling `make doc` and then open the generated html file on
 any browser.
 
-```c
+```
 /**
 @defgroup    boards_foo FooBoard
 @ingroup     boards


### PR DESCRIPTION
### Contribution description

PR #19206 fix issues with code snippets in the[ `porting-boards.md`](https://github.com/RIOT-OS/RIOT/blob/master/doc/doxygen/src/porting-boards.md) presented by GitHub.  However, in Riot web page comments in code snippets are not presented and in effect section `doc.txt` shows empty area - see [dox.txt section](https://doc.riot-os.org/porting-boards.html). 

This PR should fix this - it change for this code snippet C code to generic code.  

### Testing procedure

Generation of doxygen documentation by CI process and manual check if this change fix the problem.

### Issues/PRs references

PR #19206