### PR TITLE
test_utils/print_stack_usage: use thread.h API

### DIFF
--- a/sys/test_utils/print_stack_usage/print_stack_usage.c
+++ b/sys/test_utils/print_stack_usage/print_stack_usage.c
@@ -54,12 +54,13 @@ void print_stack_usage_metric(const char *name, void *stack, unsigned max_size)
 void test_utils_print_stack_usage(void)
 {
     for (kernel_pid_t i = KERNEL_PID_FIRST; i <= KERNEL_PID_LAST; i++) {
-        thread_t *p = (thread_t *)sched_threads[i];
+        thread_t *p = thread_get(i);
 
         if (p == NULL) {
             continue;
         }
-        print_stack_usage_metric(p->name, p->stack_start, p->stack_size);
+        print_stack_usage_metric(thread_get_name(p), thread_get_stackstart(
+                                     p), thread_get_stacksize(p));
     }
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There's now an API for getting a thread's name, stack size and stack start value. So, use it.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should suffice. Here's some native output *with* this PR:

<details>

```
riot/tests/fmt_print on  print_stack_usage_use_api                                                                                                
❯ /home/kaspar/src/riot/tests/fmt_print/bin/native/tests_fmt_print.elf                                                                             
RIOT native interrupts/signals initialized.                                                                                                        
RIOT native board initialized.                                                                                                                     
RIOT native hardware initialization complete.                                                                                                      
                                                                                                                                                   
Help: Press s to start test, r to print it is ready                                                                                                
s                                                                                                                                                  
START                                                                                                                                              
main(): This is RIOT! (Version: 2023.04-devel-227-gfcf63c-print_stack_usage_use_api)
If you can read this:                                                    
4294967295 
-2147483648                                                                                                                                        
FA                                                                       
-2147483648                                                              
12345678                                                                                                                                           
123456789ABCDEF0                                                         
18446744073709551615
-9223372036854775808               
1.23450         
30313233343536373839                                                     
Test successful.           
{ "threads": [{ "name": "idle, "stack_size": 8192, "stack_used": 436}]}
{ "threads": [{ "name": "main, "stack_size": 12288, "stack_used": 2608}]} 

```

</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Without this, RIOT-rs doesn't compile, as the direct member access isn't available there.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
