### PR TITLE
sys/stdio: Wrap stdio.h to enforce printf()'s first arg is a str literal

### DIFF
--- a/core/lib/include/macros/utils.h
+++ b/core/lib/include/macros/utils.h
@@ -23,20 +23,102 @@
 extern "C" {
 #endif
 
+#ifdef DOXYGEN
 /**
- * @brief   Concatenate the tokens @p a and @p b
+ * @brief   Expands the arguments and concatenates them afterwards
+ *
+ * @details This is currently only implemented for up to 8 arguments.
+ *          Implementations for more arguments can be extended as the need
+ *          arises.
  */
-#define CONCAT(a, b) a ## b
+#define CONCAT(...)                 /* implementation details */
 
 /**
- * @brief   Concatenate the tokens @p a , @p b , and @p c
+ * @brief   Ensure that the preprocessor expands the token given as argument
+ *
+ * This is useful to e.g. when "calling" function-like macros as argument to
+ * a function-like macro
  */
-#define CONCAT3(a, b, c) a ## b ## c
+#define EXPAND(x)                   /* implementation details */
 
 /**
- * @brief   Concatenate the tokens @p a , @p b , @p c , and @p d
+ * @brief   Takes a number of tokens as argument and is replaced by
+ *          the decimal number of arguments
+ *
+ * @warning This only works for up to 64 tokens as argument
  */
-#define CONCAT4(a, b, c, d) a ## b ## c ## d
+#define COUNT_ARGS(...) /* implementation details */
+
+#else
+#define EXPAND(x) x
+
+#define _TAKE_65TH_TOKEN( _1,  _2,  _3,  _4,  _5,  _6,  _7,  _8,  _9, _10, \
+                          _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+                          _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
+                          _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+                          _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
+                          _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
+                          _61, _62, _63, _64, N, ...) N
+
+#define COUNT_ARGS(...) \
+        _TAKE_65TH_TOKEN(__VA_ARGS__,        64, 63, 62, 61, 60, \
+                         59, 58, 57, 56, 55, 54, 53, 52, 51, 50, \
+                         49, 48, 47, 46, 45, 44, 43, 42, 41, 40, \
+                         39, 38, 37, 36, 35, 34, 33, 32, 31, 30, \
+                         29, 28, 27, 26, 25, 24, 23, 22, 21, 20, \
+                         19, 18, 17, 16, 15, 14, 13, 12, 11, 10, \
+                          9,  8,  7,  6,  5,  4,  3,  2,  1)
+
+#define _CONCAT2_(a, b)         a ## b
+#define _CONCAT2(a, b)          _CONCAT2_(a, b)
+
+#define _OTHER_CONCAT2_(a, b)   a ## b
+#define _OTHER_CONCAT2(a, b)    _OTHER_CONCAT2_(a, b)
+
+#define _CONCAT3_(a, b, c)       a ## b ## c
+#define _CONCAT3(a, b, c)       _CONCAT3_(a, b, c)
+
+#define _CONCAT4_(a, b, c, d)   a ## b ## c ## d
+#define _CONCAT4(a, b, c, d)    _CONCAT4_(a, b, c, d)
+
+#define _CONCAT5_(a, b, c, d, e) \
+        a ## b ## c ## d ## e
+#define _CONCAT5(a, b, c, d, e) \
+        _CONCAT5_(a, b, c, d, e)
+
+#define _CONCAT6_(a, b, c, d, e, f) \
+        a ## b ## c ## d ## e ## f
+#define _CONCAT6(a, b, c, d, e, f) \
+        _CONCAT6_(a, b, c, d, e, f)
+
+#define _CONCAT7_(a, b, c, d, e, f, g) \
+        a ## b ## c ## d ## e ## f ## g
+#define _CONCAT7(a, b, c, d, e, f, g) \
+        _CONCAT7_(a, b, c, d, e, f, g)
+
+#define _CONCAT8_(a, b, c, d, e, f, g, h) \
+        a ## b ## c ## d ## e ## f ## g ## h
+#define _CONCAT8(a, b, c, d, e, f, g, h)    \
+        _CONCAT8_(a, b, c, d, e, f, g, h)
+
+/*
+ * This works as follows:
+ * CONCAT(foo, bar)
+ * --> EXPAND(_OTHER_CONCAT2(_CONCAT, COUNT_ARGS(foo, bar))(foo, bar))
+ * --> EXPAND(_OTHER_CONCAT2(_CONCAT, 2)(foo, bar))
+ * --> EXPAND(_CONCAT2(foo, bar))
+ * --> foobar
+ *
+ * It basically dispatches to a call of CONCAT<NUM>(__VA_ARGS__) where <NUM>
+ * is replaced with the number of arguments. We need to use _OTHER_CONCAT2
+ * instead of _CONCAT2 for the concatenation of _CONCAT and the number of
+ * args, as otherwise for 2 arguments _CONCAT2 would need to be expended twice,
+ * but the preprocessor will only expand the first instance of _CONCAT2
+ */
+#define CONCAT(...) \
+        EXPAND(_OTHER_CONCAT2(_CONCAT, COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__))
+
+#endif
 
 /* For compatibility with vendor headers, only provide MAX() and MIN() if not
  * provided. (The alternative approach of using #undef has the downside that

--- a/core/lib/include/macros/utils.h
+++ b/core/lib/include/macros/utils.h
@@ -25,6 +25,12 @@ extern "C" {
 
 #ifdef DOXYGEN
 /**
+ * @brief   Returns a string literal unmodified, but fails to compile for
+ *          non string literals
+ */
+#define ASSERT_IS_STR_LITERAL(x)    /* implementation details */
+
+/**
  * @brief   Expands the arguments and concatenates them afterwards
  *
  * @details This is currently only implemented for up to 8 arguments.
@@ -43,6 +49,15 @@ extern "C" {
 
 /**
  * @brief   Takes a number of tokens as argument and is replaced by
+ *          `SINGLEARG` if only one argument was passed or by `MULTIARG` if
+ *          more than one is passed
+ *
+ * @warning This only works for up to 64 tokens as argument
+ */
+#define SINGLEARG_OR_MULTIARG(...)  /* implementation details */
+
+/**
+ * @brief   Takes a number of tokens as argument and is replaced by
  *          the decimal number of arguments
  *
  * @warning This only works for up to 64 tokens as argument
@@ -52,6 +67,8 @@ extern "C" {
 #else
 #define EXPAND(x) x
 
+#define ASSERT_IS_STR_LITERAL(x)    EXPAND("" x)
+
 #define _TAKE_65TH_TOKEN( _1,  _2,  _3,  _4,  _5,  _6,  _7,  _8,  _9, _10, \
                           _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
                           _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
@@ -59,6 +76,25 @@ extern "C" {
                           _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
                           _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
                           _61, _62, _63, _64, N, ...) N
+
+#define SINGLEARG_OR_MULTIARG(...) \
+    _TAKE_65TH_TOKEN(__VA_ARGS__, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, MULTIARG, \
+            MULTIARG, MULTIARG, MULTIARG, SINGLEARG)
 
 #define COUNT_ARGS(...) \
         _TAKE_65TH_TOKEN(__VA_ARGS__,        64, 63, 62, 61, 60, \

--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -918,7 +918,7 @@ ATOMIC_STORE_IMPL(u64, uint64_t)
  * @param   type    Variable type, e.g. `uint8_t`
  */
 #define ATOMIC_FETCH_OP_IMPL(opname, op, name, type)                           \
-    static inline type CONCAT4(atomic_fetch_, opname, _, name)                 \
+    static inline type CONCAT(atomic_fetch_, opname, _, name)                 \
             (volatile type *dest, type val)                                    \
     {                                                                          \
         unsigned state = irq_disable();                                        \

--- a/sys/include/stdio.h
+++ b/sys/include/stdio.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_stdio_wrapper   stdio wrapper to extend the C libs stdio
+ * @ingroup     sys
+ *
+ * This module a wrapper for the stdio.h header intended to extend the behavior
+ * of the standard C libs stdio.h
+ *
+ * @{
+ *
+ * @file
+ * @brief       stdio wrapper to extend the C libs stdio
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef STDIO_H
+#define STDIO_H
+#include_next "stdio.h"
+
+/* External tools such as uhcpd also use `-I $(RIOTBASE)/sys/include but are
+ * compiled for the host instead and fail to locate macros/utils.h. So just
+ * don't wrap stdio.h when not building a RIOT app. */
+#ifdef RIOT_BOARD
+
+#include "macros/utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef DOXYGEN
+/**
+ * @brief   A wrapper for the `printf()` function that passes arguments through
+ *          unmodified, but fails to compile if the first argument is not a
+ *          string literal.
+ *
+ * See e.g. `man 3 printf` or https://linux.die.net/man/3/printf for
+ * documentation the printf function. This applies fully here, as it passes
+ * through the arguments unmodified.
+ *
+ * The motivation for enforcing the first argument to be a string literal is
+ * three-fold:
+ *
+ * 1. It prevents security issues due format strings controlled by adversaries.
+ * 2. It makes sure that modern C compilers that do understand format
+ *    specifiers have knowledge of the format string and can verify that the
+ *    other arguments match what is given via format string specifiers
+ * 3. It allows to force the format string to flash even for Harvard
+ *    architectures transparently
+ */
+#define printf(...) /* implementation details */
+#else
+#define _PRINTF_SINGLEARG(x) printf(ASSERT_IS_STR_LITERAL(x))
+#define _PRINTF_MULTIARG(x, ...) printf(ASSERT_IS_STR_LITERAL(x), __VA_ARGS__)
+
+
+#define printf(...) \
+        EXPAND(CONCAT(_PRINTF_, SINGLEARG_OR_MULTIARG(__VA_ARGS__))(__VA_ARGS__))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIOT_BOARD */
+
+#endif /* STDIO_H */
+/** @} */

--- a/tests/bench_sys_atomic_utils/main.c
+++ b/tests/bench_sys_atomic_utils/main.c
@@ -126,7 +126,7 @@ BENCH_ATOMIC_LOAD(u32, uint32_t, atomic_uint_least32_t)
 BENCH_ATOMIC_LOAD(u64, uint64_t, atomic_uint_least64_t)
 
 #define BENCH_ATOMIC_FETCH_OP(opname, op, name, type, c11type) \
-    static void CONCAT4(bench_atomic_fetch_, opname, _, name)(uint32_t *result_us) \
+    static void CONCAT(bench_atomic_fetch_, opname, _, name)(uint32_t *result_us) \
     {                                                                          \
         uint32_t start, stop;                                                  \
                                                                                \
@@ -145,7 +145,7 @@ BENCH_ATOMIC_LOAD(u64, uint64_t, atomic_uint_least64_t)
             type val = 0;                                                      \
             start = xtimer_now_usec();                                         \
             for (uint32_t i = 0; i < LOOPS; i++) {                             \
-                CONCAT4(atomic_fetch_, opname, _, name)(&val, 1);              \
+                CONCAT(atomic_fetch_, opname, _, name)(&val, 1);              \
             }                                                                  \
             stop = xtimer_now_usec();                                          \
             result_us[IMPL_ATOMIC_UTIL] = stop - start;                        \
@@ -183,7 +183,7 @@ BENCH_ATOMIC_FETCH_OP(and, &, u32, uint32_t, atomic_uint_least32_t)
 BENCH_ATOMIC_FETCH_OP(and, &, u64, uint64_t, atomic_uint_least64_t)
 
 #define BENCH_ATOMIC_SET_CLEAR_BIT(name, type, c11type, opname, set_or_clear) \
-    static void CONCAT4(bench_atomic_, opname, _bit_, name)(uint32_t *result_us) \
+    static void CONCAT(bench_atomic_, opname, _bit_, name)(uint32_t *result_us) \
     {                                                                          \
         uint32_t start, stop;                                                  \
         static const uint8_t _bit = 5;                                         \
@@ -207,11 +207,11 @@ BENCH_ATOMIC_FETCH_OP(and, &, u64, uint64_t, atomic_uint_least64_t)
                                                                                \
         {                                                                      \
             static type val = 0;                                               \
-            CONCAT3(atomic_bit_, name, _t) bit =                               \
+            CONCAT(atomic_bit_, name, _t) bit =                               \
                 CONCAT(atomic_bit_, name)(&val, _bit);                         \
             start = xtimer_now_usec();                                         \
             for (uint32_t i = 0; i < LOOPS; i++) {                             \
-                CONCAT4(atomic_, opname, _bit_, name)(bit);                    \
+                CONCAT(atomic_, opname, _bit_, name)(bit);                    \
             }                                                                  \
             stop = xtimer_now_usec();                                          \
             result_us[IMPL_ATOMIC_UTIL] = stop - start;                        \
@@ -242,7 +242,7 @@ BENCH_ATOMIC_SET_CLEAR_BIT(u32, uint32_t, atomic_uint_least32_t, clear, 0)
 BENCH_ATOMIC_SET_CLEAR_BIT(u64, uint64_t, atomic_uint_least64_t, clear, 0)
 
 #define BENCH_SEMI_ATOMIC_FETCH_OP(opname, op, name, type, c11type) \
-    static void CONCAT4(bench_semi_atomic_fetch_, opname, _, name)(uint32_t *result_us) \
+    static void CONCAT(bench_semi_atomic_fetch_, opname, _, name)(uint32_t *result_us) \
     {                                                                          \
         uint32_t start, stop;                                                  \
                                                                                \
@@ -261,7 +261,7 @@ BENCH_ATOMIC_SET_CLEAR_BIT(u64, uint64_t, atomic_uint_least64_t, clear, 0)
             type val = 0;                                                      \
             start = xtimer_now_usec();                                         \
             for (uint32_t i = 0; i < LOOPS; i++) {                             \
-                CONCAT4(semi_atomic_fetch_, opname, _, name)(&val, 1);         \
+                CONCAT(semi_atomic_fetch_, opname, _, name)(&val, 1);         \
             }                                                                  \
             stop = xtimer_now_usec();                                          \
             result_us[IMPL_ATOMIC_UTIL] = stop - start;                        \

--- a/tests/unittests/tests-core/tests-core-macros.c
+++ b/tests/unittests/tests-core/tests-core-macros.c
@@ -12,6 +12,7 @@
 #include "embUnit.h"
 #include "tests-core.h"
 #include "macros/math.h"
+#include "macros/utils.h"
 
 static void test_math_signof(void)
 {
@@ -78,6 +79,20 @@ static void test_math_div_round_inf(void)
     TEST_ASSERT_EQUAL_INT(1536, MATH_ALIGN(1514, 64));
 }
 
+/* Use macro HEX_15 here to ensure that CONCAT indeed expands its arguments
+ * prior to the concatenation */
+#define HEX_15  F
+static void test_concat(void)
+{
+    TEST_ASSERT(0xF                == CONCAT(0x, HEX_15));
+    TEST_ASSERT(0xFE               == CONCAT(0x, HEX_15, E));
+    TEST_ASSERT(0xFED              == CONCAT(0x, HEX_15, E, D));
+    TEST_ASSERT(0xFEDC             == CONCAT(0x, HEX_15, E, D, C));
+    TEST_ASSERT(0xFEDCB            == CONCAT(0x, HEX_15, E, D, C, B));
+    TEST_ASSERT(0xFEDCBA           == CONCAT(0x, HEX_15, E, D, C, B, A));
+    TEST_ASSERT(0xFEDCBA9          == CONCAT(0x, HEX_15, E, D, C, B, A, 9));
+}
+
 Test *tests_core_macros_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -85,6 +100,7 @@ Test *tests_core_macros_tests(void)
         new_TestFixture(test_math_div_round),
         new_TestFixture(test_math_div_round_up),
         new_TestFixture(test_math_div_round_inf),
+        new_TestFixture(test_concat),
    };
 
     EMB_UNIT_TESTCALLER(core_macros_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

This PR adds a `stdio.h` that will get included instead of the C lib's `stdio.h`, which however will include the C lib's `stdio.h` via `#include_next`. The intent is that this can transparently extend/modify the behavior of the C lib's `stdio.h`.

This is directly done by modifying `printf()` to only accept string literals as first argument. The motivation for this is three-fold:

1. It prevents security issues due format strings controlled by adversaries.
2. It makes sure that modern C compilers that do understand format specifiers have knowledge of the format string and can verify that the other arguments match what is given via format string specifiers
3. It allows to force the format string to flash even for Harvard architectures transparently

In PR https://github.com/RIOT-OS/RIOT/pull/18148, this will be extended to send the string literal into flash on Harvard Arches (such as used by the still immensely popular Arduino UNO and Arduino Nano).

Note: https://github.com/RIOT-OS/RIOT/pull/18148 is not yet using this. It does make sense to wait for this, so that this approach is actually proven to work. Otherwise just adding `-Wformat-nonliteral` to `CFLAGS` may be a tiny bit more readable than the dark magic used here.

### Testing procedure

No changes in generated binaries and everything (hopefully!) still compiles. Adding something like

```C
    const char *test = "Foobar!\n";
    printf(test);
```

to e.g. `examples/hello-world/main.c` should result in compilation failures.

### Issues/PRs references

Useful for https://github.com/RIOT-OS/RIOT/pull/18148