### PR TITLE
tools/backport_pr: remove Unnecessary "else" after "raise" [backport 2023.01]

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -269,10 +269,10 @@ def main():
         # the worktree was deleted
         repo.delete_head(new_branch)
         raise exc
-    else:
-        # Delete worktree
-        print(f"Pruning temporary workdir at {worktree_dir}")
-        _delete_worktree(repo, worktree_dir)
+
+    # Delete worktree
+    print(f"Pruning temporary workdir at {worktree_dir}")
+    _delete_worktree(repo, worktree_dir)
 
     labels = _get_labels(pulldata)
     merger = pulldata["merged_by"]["login"]


### PR DESCRIPTION
# Backport of #19230

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This should make pylint happy again.


### Testing procedure

Static tests no longer fail with

    backport_pr.py:253:4: R1720: Unnecessary "else" after "raise", remove the "else" and de-indent the code inside it (no-else-raise)



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
