### PR TITLE
Makefile.dep: pull in FEATURES_REQUIRED for periph

### DIFF
--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -97,3 +97,10 @@ USEMODULE += $(filter vdd_lc_filter_%,$(FEATURES_USED))
 
 # select arduino_pwm pseudomodule if the corresponding feature is used
 USEMODULE += $(filter arduino_pwm, $(FEATURES_USED))
+
+# always register a peripheral driver as a required feature when the corresponding
+# module is requested
+PERIPH_IGNORE_MODULES += periph_usbdev_clk periph_gpio_mock periph_gpio_linux
+ifneq (,$(filter periph_%,$(DEFAULT_MODULE)))
+  FEATURES_REQUIRED += $(filter-out $(PERIPH_IGNORE_MODULES),$(filter periph_%,$(USEMODULE)))
+endif


### PR DESCRIPTION
### Contribution description

Whenever the module of a peripheral driver, i.e., periph_* should be used, the corresponding entry in the FEATURES_REQUIRED should be added. Conflicts between these modules are only checked when this entry is present.

### Testing procedure

Use, for example, the `default` example on a board with `periph_rtt` and `periph_rtc` available (e.g., the iotlab-m3). 
Change the Makefile from `FEATURES_OPTIONAL += periph_rtc` to `USEMODULE += periph_rtc`. Build and flash the application and call the `rtc gettime` shell command a couple of times.

#### On current master:
You should see incorrect timestamps because the `periph_rtc` conflicts with `periph_rtt` (which is pulled in by the `ztimer_periph_rtt` module).

#### With this PR:
You should see a warning like
```
The following features may conflict: periph_rtc periph_rtt
Rationale: On the STM32F1, the RTC and RTT map to the same hardware peripheral. Only one standard C library can be used. Only one GPIO IRQ implementation can be used. Package tinyUSB is not yet compatible with periph_usbdev.

EXPECT undesired behaviour!
```