### PR TITLE
pkg/nimble/autoadv: fix flag comparisons

### DIFF
--- a/pkg/nimble/autoadv/nimble_autoadv.c
+++ b/pkg/nimble/autoadv/nimble_autoadv.c
@@ -192,11 +192,11 @@ void nimble_autoadv_start(ble_addr_t *addr)
     if (addr != NULL) {
         mode = BLE_GAP_CONN_MODE_DIR;
     }
-    else if (_cfg.flags && NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
+    else if (_cfg.flags & NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
         mode = BLE_GAP_CONN_MODE_UND;
     }
-    uint8_t disc = (_cfg.flags && NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
-                                                                 : BLE_GAP_CONN_MODE_UND;
+    uint8_t disc = (_cfg.flags & NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
+                                                                : BLE_GAP_CONN_MODE_UND;
     struct ble_gap_adv_params advp = {
         .conn_mode = mode,
         .disc_mode = disc,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fixes the following errors when building `examples/nimble_gatt` with `TOOLCHAIN=llvm`:

<details>

```
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:195:25: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
    else if (_cfg.flags && NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
                        ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:195:25: note: use '&' for a bitwise operation
    else if (_cfg.flags && NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
                        ^~
                        &
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:195:25: note: remove constant to silence this warning
    else if (_cfg.flags && NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
                       ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:195:28: error: converting the result of '<<' to a boolean always evaluates to true [-Werror,-Wtautological-constant-compare]
    else if (_cfg.flags && NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
                           ^
/home/kaspar/src/riot/pkg/nimble/autoadv/include/nimble_autoadv.h:81:48: note: expanded from macro 'NIMBLE_AUTOADV_FLAG_CONNECTABLE'
#define NIMBLE_AUTOADV_FLAG_CONNECTABLE     (1 << 2)        /**< if connectable advertisement */
                                               ^
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:198:32: error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand]
    uint8_t disc = (_cfg.flags && NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
                               ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:198:32: note: use '&' for a bitwise operation
    uint8_t disc = (_cfg.flags && NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
                               ^~
                               &
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:198:32: note: remove constant to silence this warning
    uint8_t disc = (_cfg.flags && NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
                              ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kaspar/src/riot/pkg/nimble/autoadv/nimble_autoadv.c:198:35: error: converting the result of '<<' to a boolean always evaluates to true [-Werror,-Wtautological-constant-compare]
    uint8_t disc = (_cfg.flags && NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
                                  ^
/home/kaspar/src/riot/pkg/nimble/autoadv/include/nimble_autoadv.h:82:48: note: expanded from macro 'NIMBLE_AUTOADV_FLAG_SCANNABLE'
#define NIMBLE_AUTOADV_FLAG_SCANNABLE       (1 << 3)        /**< if scannable advertisement */
                                               ^
4 errors generated.

```
</details>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Take a hard look at the code.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
