### PR TITLE
sys/vfs: vfs.c missing includes

### DIFF
--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -23,6 +23,7 @@
 #include <fcntl.h> /* for O_ACCMODE, ..., fcntl */
 #include <unistd.h> /* for STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO */
 
+#include "container.h"
 #include "modules.h"
 #include "vfs.h"
 #include "mutex.h"

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -23,6 +23,7 @@
 #include <fcntl.h> /* for O_ACCMODE, ..., fcntl */
 #include <unistd.h> /* for STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO */
 
+#include "modules.h"
 #include "vfs.h"
 #include "mutex.h"
 #include "thread.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`vfs.c` uses `container_of()` and `IS_USED()`, but doesn't (directly) include the necessary includes.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

No changes with RIOT master. RIOT-rs stumbles over this.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
