### PR TITLE
sys/net/grnc/netreg: avoid creating an infinite loop

### DIFF
--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -152,6 +152,13 @@ int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
     }
 
     _gnrc_netreg_acquire_exclusive();
+
+    /* don't add the same entry twice */
+    gnrc_netreg_entry_t *e;
+    LL_FOREACH(netreg[type], e) {
+        assert(entry != e);
+    }
+
     LL_PREPEND(netreg[type], entry);
     _gnrc_netreg_release_exclusive();
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a socket is registered twice, it's `next` pointer will point to itself, creating an infinite loop in `_netreg_lookup()` when a packet is received.

Especially when this only happens sporadically (code path that would normally close the socket is not taken) it creates a very hard to debug issue where the system is just locked up.

Instead, fail early and loud.
This would be an infinite loop on RX before, now it's a crash right at the place where the error condition occurs.


### Testing procedure

Call `gnrc_sock_create()` on the same socket twice.
On `master` this will not fail, but as soon as you receive a packet on the socket, the system locks up in an infinite loop.

With this patch, the assertion will trigger on the 2nd call to `gnrc_sock_create()`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
