### PR TITLE
CI: .murdock: fix bors fast build

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -178,6 +178,15 @@ check_label() {
     return $?
 }
 
+is_bors_build() {
+    test "${CI_BUILD_BRANCH}" = "staging" || test "${CI_BUILD_BRANCH}" = "trying"
+}
+
+if test -z "${CI_BASE_COMMIT}" && is_bors_build ; then
+    previous_merge="$(git log --merges --max-count 1 --skip 1 --pretty=format:%H)"
+    export CI_BASE_COMMIT="${previous_merge}"
+fi
+
 # fullbuild logic
 # non-full-builds are those where can_fast_ci_run might reduce the build
 # automatically
@@ -193,12 +202,13 @@ if [ -z "${FULL_BUILD}" ]; then
     export FULL_BUILD
 fi
 
+
 # quickbuild logic
 # a "quickbuild" is only building a representative subset of all build
 # configurations.
 if [ -z "${QUICK_BUILD}" ]; then
     export QUICK_BUILD=0
-    if [ "${CI_BUILD_BRANCH}" = "staging" ] || [ "${CI_BUILD_BRANCH}" = "trying" ]; then
+    if is_bors_build ; then
         # always do full build for bors' branches
         true
     elif [ ${FULL_BUILD} -eq 1 ]; then

--- a/.murdock
+++ b/.murdock
@@ -178,10 +178,18 @@ check_label() {
     return $?
 }
 
+# this function returns 0 when this is build is building one of the two bors
+# branches ("staging" or "trying", 1 otherwise.
 is_bors_build() {
     test "${CI_BUILD_BRANCH}" = "staging" || test "${CI_BUILD_BRANCH}" = "trying"
 }
 
+# Set CI_BASE_COMMIT in case of a bors build.
+# This assumes that bors always adds a single merge commit (possibly itself
+# including multiple merges for PRs) on the base branch.
+# That git command outputs the hash of the second merge commit (the one before
+# the topmost merge), which should be the base branch HEAD.
+# (CI_BASE_COMMIT is used by `can_fast_ci_run.py` to only build changes.)
 if test -z "${CI_BASE_COMMIT}" && is_bors_build ; then
     previous_merge="$(git log --merges --max-count 1 --skip 1 --pretty=format:%H)"
     export CI_BASE_COMMIT="${previous_merge}"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, CI would not skip compilation for builds where `can_fast_ci_build.py`
can figure out that it should. That's because `cfcb.py` depends on `CI_BASE_COMMIT`
being set, which for a branch build like for bors' staging or trying, isn't.

This PR populates `CI_BASE_COMMIT` from the previous (second) merge commit, which
*should* always point to the base branch HEAD.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

[here](https://ci.riot-os.org/details/701e23634700496e9c3b568422d4b1a2/output) is the result of a bors try of this PR, but with a "remove me"  commit disabling full builds on ".murdock" changes.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
