### PR TITLE
Make: Add generate-Makefile.ci

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -235,7 +235,7 @@ GLOBAL_GOALS += buildtest \
                 info-boards-features-missing \
                 info-boards-supported \
                 info-buildsizes info-buildsizes-diff \
-                create-Makefile.ci \
+                generate-Makefile.ci \
                 #
 
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -149,8 +149,9 @@ info-boards-features-blacklisted:
 info-boards-features-conflicting:
 	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
 
-create-Makefile.ci:
+generate-Makefile.ci:
 	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh --no-docker
+
 
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only
 # needed for buildtests.inc.mk

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -150,7 +150,7 @@ info-boards-features-conflicting:
 	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
 
 generate-Makefile.ci:
-	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh --no-docker
+	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh
 
 
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -6,7 +6,7 @@
         check-toolchain-supported \
         info-programmers-supported \
         info-rust \
-        create-Makefile.ci \
+        generate-Makefile.ci \
         #
 
 info-objsize:


### PR DESCRIPTION
### Contribution description

This is the same as the create-Makefile.ci. The alias is added to stay in line with other generate-* Make targets. Now the documentation should also be valid again

### Testing procedure

The target should now match the documentation in the doxygen.

### Issues/PRs references

follow-up to #19239 