### PR TITLE
Make: default to docker with create-Makefile.ci

### DIFF
--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -150,7 +150,7 @@ info-boards-features-conflicting:
 	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
 
 create-Makefile.ci:
-	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh --no-docker
+	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh
 
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only
 # needed for buildtests.inc.mk


### PR DESCRIPTION
### Contribution description

This way the output should match with the CI.

### Testing procedure

Run the target for an example or test and check that it uses docker.

### Issues/PRs references

None