### PR TITLE
pkg/tinydtls: drop libc_gettimeofday dependency

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/eclipse/tinydtls.git
-PKG_VERSION=c58f484ac417afe036273d65506b63a0902c740c
+PKG_VERSION=5e14e4930b0f329f35809c623976df1e08ca4593
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -6,9 +6,6 @@ PKG_LICENSE=EPL-1.0,EDL-1.0
 include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-implicit-fallthrough
-# following is require due to known issue with newlib 2.4.x, see bug report:
-# http://lists-archives.com/cygwin/97008-gettimeofday-not-defined.html
-CFLAGS += -D_XOPEN_SOURCE=600
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(PKG_SOURCE_DIR)/Makefile.riot

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -14,11 +14,3 @@ ifneq (,$(filter sock_dtls,$(USEMODULE)))
   USEMODULE += tinydtls_sock_dtls
   USEMODULE += ztimer_usec
 endif
-
-ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
-  USEMODULE += libc_gettimeofday
-endif
-
-ifneq (,$(filter native,$(CPU)))
-  USEMODULE += libc_gettimeofday
-endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`gettimeofday()` (via `time()`) is only used to print timestamps in the debug output. 
We don't need this, use our own debug functions without the expensive timestamp.

With this, we can drop the requirement to include `libc_gettimeofday`.

### Testing procedure

#### before

Code should still compile

``` 
   text	   data	    bss	    dec	    hex	filename
 123068	    384	  24920	 148372	  24394	/home/benpicco/dev/RIOT/examples/dtls-sock/bin/openmote-b/dtls_sock.elf
```

#### with this patch

```
   text	   data	    bss	    dec	    hex	filename
 107756	    272	  24776	 132804	  206c4	/home/benpicco/dev/RIOT/examples/dtls-sock/bin/openmote-b/dtls_sock.elf
```

### Issues/PRs references

upstream PR https://github.com/eclipse/tinydtls/pull/187
