### PR TITLE
cpu/gd32v: add periph_dac support

### DIFF
--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -38,7 +38,7 @@ on-board components:
 | RTC         | 1 x 32-bit counter, 20-bit prescaler   |   yes     |
 | WDT         | 2 x 12-bit counter, 3-bit prescaler    |   yes     |
 | ADC         | 2 x 12-bit units, 16 channels @ 1 Msps |   yes     |
-| DAC         | 2 x 12-bit channel                     |   no      |
+| DAC         | 2 x 12-bit channel                     |   yes     |
 | UART        | 2                                      |   yes     |
 | USART       | 3                                      |   yes     |
 | SPI         | 3                                      |   yes     |

--- a/boards/sipeed-longan-nano/Kconfig
+++ b/boards/sipeed-longan-nano/Kconfig
@@ -15,6 +15,7 @@ config BOARD_SIPEED_LONGAN_NANO
     select BOARD_HAS_HXTAL
     select BOARD_HAS_LXTAL
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI

--- a/boards/sipeed-longan-nano/Makefile.features
+++ b/boards/sipeed-longan-nano/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = gd32vf103cbt6
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -32,7 +32,7 @@ on-board components:
 | RTC         | 1 x 32-bit counter, 20-bit prescaler   |   yes     |
 | WDT         | 2 x 12-bit counter, 3-bit prescaler    |   yes     |
 | ADC         | 2 x 12-bit units, 16 channels @ 1 Msps |   yes     |
-| DAC         | 2 x 12-bit channel                     |   no      |
+| DAC         | 2 x 12-bit channel                     |   yes     |
 | UART        | -                                      |   yes     |
 | USART       | 3                                      |   yes     |
 | SPI         | 3                                      |   yes     |

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -78,6 +78,20 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
+ * @name    DAC configuration
+ * @{
+ */
+static const dac_conf_t dac_config[] = {
+#if !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
+    { .pin = GPIO_PIN(PORT_A, 4), .chan = 0 },
+    { .pin = GPIO_PIN(PORT_A, 5), .chan = 1 },
+};
+#endif /* !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT */
+
+#define DAC_NUMOF           ARRAY_SIZE(dac_config)
+/** @} */
+
+/**
  * @name   PWM configuration
  * @{
  */

--- a/cpu/gd32v/include/periph_cpu.h
+++ b/cpu/gd32v/include/periph_cpu.h
@@ -198,6 +198,19 @@ typedef struct {
 } adc_conf_t;
 
 /**
+ * @brief   GD32V DAC has 2 channels
+ */
+#define DAC_CHANNEL_NUMOF (2)
+
+/**
+ * @brief   DAC line configuration data
+ */
+typedef struct {
+    gpio_t pin;             /**< pin connected to the line */
+    uint8_t chan;           /**< DAC device used for this line */
+} dac_conf_t;
+
+/**
  * @brief   GD32V timers have 4 capture-compare channels
  */
 #define TIMER_CHANNEL_NUMOF (4U)

--- a/cpu/gd32v/periph/dac.c
+++ b/cpu/gd32v/periph/dac.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_gd32v
+ * @ingroup     drivers_periph_dac
+ * @{
+ *
+ * @file
+ * @brief       Low-level DAC driver implementation for GD32VF103
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "assert.h"
+#include "cpu.h"
+#include "periph/dac.h"
+
+#define DAC_CTL_DENX_MASK  (DAC_CTL_DEN0_Msk | DAC_CTL_DEN1_Msk)
+
+int8_t dac_init(dac_t line)
+{
+    assert(line < DAC_NUMOF);
+
+    gpio_init_analog(dac_config[line].pin);
+
+    dac_poweron(line);
+    dac_set(line, 0);
+
+    return DAC_OK;
+}
+
+void dac_set(dac_t line, uint16_t value)
+{
+    assert(line < DAC_NUMOF);
+    assert(dac_config[line].chan < DAC_CHANNEL_NUMOF);
+
+    /* set the upper 12 bit of the left aligned DAC data holding register */
+    if (dac_config[line].chan) {
+        DAC->DAC1_L12DH = value & 0xfff0;
+    }
+    else {
+        DAC->DAC0_L12DH = value & 0xfff0;
+    }
+}
+
+void dac_poweron(dac_t line)
+{
+    assert(line < DAC_NUMOF);
+    assert(dac_config[line].chan < DAC_CHANNEL_NUMOF);
+
+    /* enable the DAC clock */
+    periph_clk_en(APB1, RCU_APB1EN_DACEN_Msk);
+
+    /* enable the DAC channel */
+    DAC->CTL |= (dac_config[line].chan) ? DAC_CTL_DEN1_Msk : DAC_CTL_DEN0_Msk;
+}
+
+void dac_poweroff(dac_t line)
+{
+    assert(line < DAC_NUMOF);
+    assert(dac_config[line].chan < DAC_CHANNEL_NUMOF);
+
+    /* disable the DAC channel */
+    DAC->CTL &= ~((dac_config[line].chan) ? DAC_CTL_DEN1_Msk : DAC_CTL_DEN0_Msk);
+
+    if ((DAC->CTL & DAC_CTL_DENX_MASK) == 0) {
+        /* disable the DAC clock only if both channels are disabled */
+        periph_clk_dis(APB1, RCU_APB1EN_DACEN_Msk);
+    }
+}

--- a/dist/tools/doccheck/generic_exclude_patterns
+++ b/dist/tools/doccheck/generic_exclude_patterns
@@ -13,6 +13,8 @@ warning: Member BTN[0-9]_PIN \(macro definition\) of
 warning: Member BTN[0-9]_PORT \(macro definition\) of
 warning: Member BTN[0-9]_PRESSED \(macro definition\) of
 warning: Member BTN[0-9]_RELEASED \(macro definition\) of
+warning: Member dac_config\[\] \(variable\) of
+warning: Member DAC_NUMOF \(macro definition\) of
 warning: Member EPD_BW_SPI_CMD_[A-Z0-9_]* \(macro definition\) of
 warning: Member EPD_BW_SPI_DISPLAY_UPDATE_OPTION_[A-Z0-9_]* \(macro definition\) of
 warning: Member EPD_BW_SPI_WAIT_[A-Z0-9_]* \(macro definition\) of


### PR DESCRIPTION
### Contribution description

This PR provides the `periph_dac` support for GD32VF103.

### Testing procedure

`tests/periph_dac` should work on `sipeed-longan-nano` port on PA4 and PA5.

### Issues/PRs references