### PR TITLE
boards/gd32v: improve board definitions

### DIFF
--- a/boards/common/gd32v/include/cfg_i2c_default.h
+++ b/boards/common/gd32v/include/cfg_i2c_default.h
@@ -31,6 +31,26 @@ extern "C" {
  * @note    This board may require external pullup resistors for i2c operation.
  * @{
  */
+
+/**
+ * @brief   Enable the second I2C device `I2C_DEV(1)` by default
+ *
+ */
+#ifndef I2C_DEV_1_USED
+#define I2C_DEV_1_USED
+#endif
+
+/**
+ * @brief   Default I2C device configuration
+ *
+ * The default I2C device configuration allows to define up to two I2C devices
+ * `I2C_DEV(0)` and `I2C_DEV(1)`. `I2C_DEV(0)` is always defined if the I2C
+ * peripheral is enabled by the module `periph_spi`. The second I2C device
+ * `I2C_DEV(1)` is only defined if `I2C_DEV_1_USED` is defined by the board.
+ * This allows to use the default configuration with one or two I2C devices
+ * depending on whether other peripherals are enabled that would collide with
+ * the I2C devices.
+ */
 static const i2c_conf_t i2c_config[] = {
     {
         .dev            = I2C0,

--- a/boards/common/gd32v/include/cfg_spi_default.h
+++ b/boards/common/gd32v/include/cfg_spi_default.h
@@ -31,23 +31,63 @@ extern "C" {
  * @name   SPI configuration
  * @{
  */
+
+/**
+ * @brief   Enable the second SPI device `SPI_DEV(1)` by default
+ *
+ */
+#ifndef SPI_DEV_1_USED
+#define SPI_DEV_1_USED
+#endif
+
+/**
+ * @brief   Defines PB12 as the default CS signal for `SPI_DEV(0)`
+ *
+ * Overriding this default allows the use of another pin as CS signal if
+ * the default CS signal is connected to an unused hardware.
+ */
+#ifndef SPI_DEV_0_CS
+#define SPI_DEV_0_CS    GPIO_PIN(PORT_B, 12)
+#endif
+
+/**
+ * @brief   Defines PA4 as the default CS signal for `SPI_DEV(1)`
+ *
+ * Overriding this default allows the use of another pin as CS signal if
+ * the default CS signal is connected to an unused hardware.
+ */
+#ifndef SPI_DEV_1_CS
+#define SPI_DEV_1_CS    GPIO_PIN(PORT_A, 4)
+#endif
+
+/**
+ * @brief   Default SPI device configuration
+ *
+ * The default SPI device configuration allows to define up to two SPI devices
+ * `SPI_DEV(0)` and `SPI_DEV(1)`. `SPI_DEV(0)` is always defined if the SPI
+ * peripheral is enabled by the module `periph_spi`. The second SPI device
+ * `SPI_DEV(1)` is only defined if `SPI_DEV_1_USED` is defined by the board.
+ * This allows to use the default configuration with one or two SPI devices
+ * depending on whether other peripherals are enabled that would collide with
+ * the SPI devices.
+ */
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,
         .mosi_pin = GPIO_PIN(PORT_B, 15),
         .miso_pin = GPIO_PIN(PORT_B, 14),
         .sclk_pin = GPIO_PIN(PORT_B, 13),
-        .cs_pin   = GPIO_PIN(PORT_B, 12),
+        .cs_pin   = SPI_DEV_0_CS,
         .rcumask  = RCU_APB1EN_SPI1EN_Msk,
         .apbbus   = APB1,
     },
-#ifndef MODULE_PERIPH_ADC
+#ifdef SPI_DEV_1_USED
     {
         .dev      = SPI0,
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .cs_pin   = SPI_DEV_1_CS,
         .rcumask  = RCU_APB2EN_SPI0EN_Msk,
         .apbbus   = APB2,
     },

--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -32,7 +32,7 @@ on-board components:
 | RAM         | 32 kByte                               |           |
 | Flash       | 128 KByte                              |           |
 | Frequency   | 108 MHz                                |           |
-| Power Modes | 3 (Sleep, Deep Sleep, Standby)         |   no      |
+| Power Modes | 3 (Sleep, Deep Sleep, Standby)         |   yes     |
 | GPIOs       | 80                                     |   yes     |
 | Timers      | 5 x 16-bit timer                       |   yes     |
 | RTC         | 1 x 32-bit counter, 20-bit prescaler   |   yes     |
@@ -59,43 +59,91 @@ The general pin layout is shown below.
 
 @image html "https://raw.githubusercontent.com/SeeedDocument/GD32VF103/master/img/GD32VF-103VBT6-c.jpg" "Seeedstudio GD32 RISC-V Dev Board Pinout" width=600
 
-The following table shows the connection of the on-board components with the
-MCU pins and their configuration in RIOT.
+The following tables show the connection of the on-board components with the
+MCU pins and their configuration in RIOT sorted by RIOT peripherals and
+by pins.
 
-| MCU Pin | MCU Peripheral | RIOT Peripheral  | Board Function | Remark                       |
-|:--------|:---------------|:-----------------|:---------------|:-----------------------------|
-| PA0     | BOOT0          | BTN0             | KEY1           |                              |
-| PA1     | ADC01_IN1      | ADC_LINE(0)      |                |                              |
-| PA2     | ADC01_IN2      | ADC_LINE(1)      |                |                              |
-| PA3     | ADC01_IN3      | ADC_LINE(2)      |                |                              |
-| PA9     | USART0 TX      | UART_DEV(0) TX   | UART TX        |                              |
-| PA10    | USART0 RX      | UART_DEV(0) RX   | UART RX        |                              |
-| PA4     | SPI1 CS        | SPI_DEV(1) CS    |                |                              |
-| PA5     | SPI1 SCLK      | SPI_DEV(1) SCLK  |                |                              |
-| PA6     | SPI1 MISO      | SPI_DEV(1) MISO  |                |                              |
-| PA7     | SPI1 MOSI      | SPI_DEV(1) MOSI  |                |                              |
-| PB0     |                | PWM_DEV(0) CH0   | LED1 green     |                              |
-| PB1     |                | PWM_DEV(0) CH1   | LED2 blue      |                              |
-| PB5     |                |                  | LED0 red       |                              |
-| PB6     | I2C0 SCL       | I2C_DEV(0) SCL   |                |                              |
-| PB7     | I2C0 SDA       | I2C_DEV(0) SDA   |                |                              |
-| PB8     |                | PWM_DEV(1) CH0   |                | N/A if CAN is used           |
-| PB9     |                | PWM_DEV(1) CH1   |                | N/A if CAN is used           |
-| PB10    | I2C1 SCL       | I2C_DEV(1) SCL   |                |                              |
-| PB11    | I2C1 SDA       | I2C_DEV(1) SDA   |                |                              |
-| PB12    | SPI0 CS        | SPI_DEV(0) CS    |                |                              |
-| PB13    | SPI0 SCLK      | SPI_DEV(0) SCLK  |                |                              |
-| PB14    | SPI0 MISO      | SPI_DEV(0) MISO  |                |                              |
-| PB15    | SPI0 MOSI      | SPI_DEV(0) MOSI  |                |                              |
-| PC0     | ADC01_IN10     | ADC_LINE(3)      |                |                              |
-| PC1     | ADC01_IN11     | ADC_LINE(4)      |                |                              |
-| PC2     | ADC01_IN12     | ADC_LINE(5)      |                |                              |
-| PC3     | ADC01_IN13     | ADC_LINE(6)      |                |                              |
-| PC4     | ADC01_IN14     | ADC_LINE(7)      |                |                              |
-| PC5     | ADC01_IN15     | ADC_LINE(8)      |                |                              |
-| PC13    |                | BTN1             | KEY2           |                              |
-| -       | ADC01_IN16     | ADC_LINE(9)      |                | internal Temperature channel |
-| -       | ADC01_IN17     | ADC_LINE(10)     |                | internal VFEF channel        |
+| RIOT Peripheral  | MCU Pin | MCU Peripheral | Board Function | Remark                       |
+|:-----------------|:--------|:---------------|:---------------|:-----------------------------|
+| ADC_LINE(0)      | PA1     | ADC01_IN1      |                |                              |
+| ADC_LINE(1)      | PA2     | ADC01_IN2      |                |                              |
+| ADC_LINE(2)      | PA3     | ADC01_IN3      |                |                              |
+| ADC_LINE(3)      | PC0     | ADC01_IN10     |                |                              |
+| ADC_LINE(4)      | PC1     | ADC01_IN11     |                |                              |
+| ADC_LINE(5)      | PC2     | ADC01_IN12     |                |                              |
+| ADC_LINE(6)      | PC3     | ADC01_IN13     |                |                              |
+| ADC_LINE(7)      | PC4     | ADC01_IN14     |                |                              |
+| ADC_LINE(8)      | PC5     | ADC01_IN15     |                |                              |
+| ADC_LINE(9)      | -       | ADC01_IN16     |                | internal Temperature channel |
+| ADC_LINE(10)     | -       | ADC01_IN17     |                | internal VFEF channel        |
+| BTN0             | PA0     | BOOT0          | KEY1           |                              |
+| BTN1             | PC13    |                | KEY2           |                              |
+| I2C_DEV(0) SCL   | PB6     | I2C0 SCL       |                |                              |
+| I2C_DEV(0) SDA   | PB7     | I2C0 SDA       |                |                              |
+| I2C_DEV(1) SCL   | PB10    | I2C1 SCL       |                |                              |
+| I2C_DEV(1) SDA   | PB11    | I2C1 SDA       |                |                              |
+| LED0             | PB5     |                | LED red        |                              |
+| LED1             | PB0     |                | LED green      |                              |
+| LED2             | PB1     |                | LED blue       |                              |
+| PWM_DEV(0) CH0   | PB0     |                | LED1 green     |                              |
+| PWM_DEV(0) CH1   | PB1     |                | LED2 blue      |                              |
+| PWM_DEV(1) CH0   | PB8     |                |                | N/A if CAN is used           |
+| PWM_DEV(1) CH1   | PB9     |                |                | N/A if CAN is used           |
+| SPI_DEV(0) CS    | PB12    | SPI0 CS        |                |                              |
+| SPI_DEV(0) SCLK  | PB13    | SPI0 SCLK      |                |                              |
+| SPI_DEV(0) MISO  | PB14    | SPI0 MISO      |                |                              |
+| SPI_DEV(0) MOSI  | PB15    | SPI0 MOSI      |                |                              |
+| SPI_DEV(1) CS    | PA4     | SPI1 CS        |                |                              |
+| SPI_DEV(1) SCLK  | PA5     | SPI1 SCLK      |                |                              |
+| SPI_DEV(1) MISO  | PA6     | SPI1 MISO      |                |                              |
+| SPI_DEV(1) MOSI  | PA7     | SPI1 MOSI      |                |                              |
+| UART_DEV(0) TX   | PA9     | USART0 TX      | UART TX        |                              |
+| UART_DEV(0) RX   | PA10    | USART0 RX      | UART RX        |                              |
+
+| Pin  | Board Function | RIOT Function 1 | RIOT Function 2 | RIOT Function 3 |
+|:-----|:---------------|:----------------|:----------------|:----------------|
+| PA0  | KEY1           |                 |                 | BTN0            |
+| PA1  |                |                 | ADC_LINE(0)     |                 |
+| PA2  |                |                 | ADC_LINE(1)     |                 |
+| PA3  |                |                 | ADC_LINE(2)     |                 |
+| PA4  | FLASH CS       | SPI_DEV(1) CS   |                 |                 |
+| PA5  | FLASH SCK      | SPI_DEV(1) SCLK |                 |                 |
+| PA6  | FLASH MISO     | SPI_DEV(1) MISO |                 |                 |
+| PA7  | FLASH MOSI     | SPI_DEV(1) MOSI |                 |                 |
+| PA8  |                |                 |                 |                 |
+| PA9  |                | UART_DEV(0) TX  |                 |                 |
+| PA10 |                | UART_DEV(0) RX  |                 |                 |
+| PA11 | USB D-         |                 |                 |                 |
+| PA12 | USB D+         |                 |                 |                 |
+| PA13 | JTAG TMS       |                 |                 |                 |
+| PA14 | JTAG TCK       |                 |                 |                 |
+| PA15 | JTAG TDI       |                 |                 |                 |
+| PB0  | LED green      | PWM_DEV(0) CH0  |                 | LED1            |
+| PB1  | LED blue       | PWM_DEV(0) CH1  |                 | LED2            |
+| PB3  | JTAG TDO       |                 |                 |                 |
+| PB4  | JTAG NRST      |                 |                 |                 |
+| PB5  | LED red        |                 |                 | LED3            |
+| PB6  |                | I2C_DEV(0) SCL  |                 |                 |
+| PB7  |                | I2C_DEV(0) SDA  |                 |                 |
+| PB8  |                | PWM_DEV(1) CH0  |                 |                 |
+| PB9  |                | PWM_DEV(1) CH1  |                 |                 |
+| PB10 |                | I2C_DEV(1) SCL  |                 |                 |
+| PB11 |                | I2C_DEV(1) SDA  |                 |                 |
+| PB12 | SD CS          | SPI_DEV(0) CS   |                 |                 |
+| PB13 | SD SCK         | SPI_DEV(0) SCLK |                 |                 |
+| PB14 | SD MISO        | SPI_DEV(0) MISO |                 |                 |
+| PB15 | SD MOSI        | SPI_DEV(0) MOSI |                 |                 |
+| PC0  |                |                 | ADC_LINE(3)     |                 |
+| PC1  |                |                 | ADC_LINE(4)     |                 |
+| PC2  |                |                 | ADC_LINE(5)     |                 |
+| PC3  |                |                 | ADC_LINE(6)     |                 |
+| PC4  |                |                 | ADC_LINE(7)     |                 |
+| PC5  |                |                 | ADC_LINE(8)     |                 |
+| PC13 | KEY2           |                 |                 | BTN1            |
+| -    | Temperature    |                 | ADC_LINE(9)     |                 |
+| -    | VREF           |                 | ADC_LINE(10)    |                 |
+
+All other pins are either not broken out or have no special usage.
 
 ## Flashing the Device
 

--- a/boards/seeedstudio-gd32/include/periph_conf.h
+++ b/boards/seeedstudio-gd32/include/periph_conf.h
@@ -35,6 +35,8 @@
 #define CONFIG_CLOCK_HXTAL      MHZ(8)      /**< HXTAL frequency */
 #endif
 
+#define SPI_DEV_1_USED              /**< Enable SPI_DEV(1) for the connected flash */
+
 #include "periph_cpu.h"
 #include "periph_common_conf.h"
 

--- a/boards/sipeed-longan-nano/Kconfig
+++ b/boards/sipeed-longan-nano/Kconfig
@@ -25,9 +25,13 @@ config BOARD_SIPEED_LONGAN_NANO
     select HAVE_MTD_SDCARD_DEFAULT
     select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
 
-config SIPEED_LONGAN_NANO_WITH_TFT
-    bool "Board with TFT display"
-    help
-        Indicates that a Sipeed Longan Nano board with TFT display is used.
+menu "Sipeed Longan Nano Board Configuration"
+
+    config SIPEED_LONGAN_NANO_WITH_TFT
+        bool "Board with TFT display"
+        help
+            Indicates that a Sipeed Longan Nano board with TFT display is used.
+
+endmenu
 
 source "$(RIOTBOARD)/common/gd32v/Kconfig"

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -26,7 +26,7 @@ on-board components:
 | RAM         | 32 kByte                               |           |
 | Flash       | 128 KByte                              |           |
 | Frequency   | 108 MHz                                |           |
-| Power Modes | 3 (Sleep, Deep Sleep, Standby)         |   no      |
+| Power Modes | 3 (Sleep, Deep Sleep, Standby)         |   yes     |
 | GPIOs       | 37                                     |   yes     |
 | Timers      | 5 x 16-bit timer                       |   yes     |
 | RTC         | 1 x 32-bit counter, 20-bit prescaler   |   yes     |
@@ -53,40 +53,89 @@ The general pin layout is shown below.
 
 @image html "https://longan.sipeed.com/assets/longan_nano_pinout_v1.1.0_w5676_h4000_large.png" "Sipeed Longan Nano Pinout" width=800
 
-The following table shows the connection of the on-board components with the
-MCU pins and their configuration in RIOT.
+The following tables show the connection of the on-board components with the
+MCU pins and their configuration in RIOT sorted by RIOT peripherals and
+by pins.
 
-| MCU Pin | MCU Peripheral | RIOT Peripheral  | Board Function | Remark                       |
-|:--------|:---------------|:-----------------|:---------------|:-----------------------------|
-| PA0     | BOOT0          | BTN0             | BOOT           |                              |
-| PA1     |                | PWM_DEV(0) CH0   | LED1 green     |                              |
-| PA2     |                | PWM_DEV(0) CH1   | LED2 blue      |                              |
-| PA3     | ADC01_IN3      | ADC_LINE(1)      |                |                              |
-| PA4     | ADC01_IN4      | ADC_LINE(6)      |                | N/A if SPI is used           |
-| PA5     | ADC01_IN5      | ADC_LINE(7)      |                | N/A if SPI or TFT is used    |
-| PA6     | ADC01_IN6      | ADC_LINE(8)      |                | N/A if SPI is used           |
-| PA7     | ADC01_IN7      | ADC_LINE(9)      |                | N/A if SPI or TFT is used    |
-| PA4     | SPI1 CS        | SPI_DEV(1) CS    |                | N/A if ADC_LINE(6) is used   |
-| PA5     | SPI1 SCLK      | SPI_DEV(1) SCLK  |                | N/A if ADC_LINE(7) is used   |
-| PA6     | SPI1 MISO      | SPI_DEV(1) MISO  |                | N/A if ADC_LINE(8) is used   |
-| PA7     | SPI1 MOSI      | SPI_DEV(1) MOSI  |                | N/A if ADC_LINE(9) is used   |
-| PA9     | USART0 TX      | UART_DEV(0) TX   | UART TX        |                              |
-| PA10    | USART0 RX      | UART_DEV(0) RX   | UART RX        |                              |
-| PB0     | ADC01_IN8      | ADC_LINE(4)      |                | N/A if TFT is used           |
-| PB1     | ADC01_IN8      | ADC_LINE(5)      |                | N/A if TFT is used           |
-| PB6     | I2C0 SCL       | I2C_DEV(0) SCL   |                |                              |
-| PB7     | I2C0 SDA       | I2C_DEV(0) SDA   |                |                              |
-| PB8     |                | PWM_DEV(1) CH0   |                | N/A if CAN is used           |
-| PB9     |                | PWM_DEV(1) CH1   |                | N/A if CAN is used           |
-| PB10    | I2C1 SCL       | I2C_DEV(1) SCL   |                |                              |
-| PB11    | I2C1 SDA       | I2C_DEV(1) SDA   |                |                              |
-| PB12    | SPI0 CS        | SPI_DEV(0) CS    |                |                              |
-| PB13    | SPI0 SCLK      | SPI_DEV(0) SCLK  |                |                              |
-| PB14    | SPI0 MISO      | SPI_DEV(0) MISO  |                |                              |
-| PB15    | SPI0 MOSI      | SPI_DEV(0) MOSI  |                |                              |
-| PC13    |                |                  | LED0 red       |                              |
-| -       | ADC01_IN16     | ADC_LINE(2)      |                | internal Temperature channel |
-| -       | ADC01_IN17     | ADC_LINE(3)      |                | internal VFEF channel        |
+| RIOT Peripheral  | MCU Pin | MCU Peripheral | Board Function | Remark                         |
+|:-----------------|:--------|:---------------|:---------------|:-------------------------------|
+| ADC_LINE(0)      | PA0     | ADC01_IN0      |                |                                |
+| ADC_LINE(1)      | PA3     | ADC01_IN3      |                |                                |
+| ADC_LINE(2)      | -       | ADC01_IN16     |                | internal Temperature channel   |
+| ADC_LINE(3)      | -       | ADC01_IN17     |                | internal VFEF channel          |
+| ADC_LINE(4)      | PB0     | ADC01_IN8      | TFT RS         | N/A if TFT is used             |
+| ADC_LINE(5)      | PB1     | ADC01_IN9      | TFT RST        | N/A if TFT is used             |
+| ADC_LINE(6)      | PA6     | ADC01_IN6      |                | N/A if TFT is used             |
+| ADC_LINE(7)      | PA7     | ADC01_IN7      |                | N/A if TFT is used             |
+| ADC_LINE(8)      | PA8     | ADC01_IN4      |                | N/A if TFT is used             |
+| ADC_LINE(9)      | PA9     | ADC01_IN5      |                | N/A if TFT is used             |
+| BTN0             | PA0     | BOOT0          | BOOT           |                                |
+| DAC_LINE(0)      | PA4     | DAC0           |                | N/A if TFT is used             |
+| DAC_LINE(1)      | PA5     | DAC1           |                | N/A if TFT is used             |
+| GPIO_PIN(1, 2)   | PB2     |                | TFT CS         |                                |
+| I2C_DEV(0) SCL   | PB6     | I2C0 SCL       |                |                                |
+| I2C_DEV(0) SDA   | PB7     | I2C0 SDA       |                |                                |
+| I2C_DEV(1) SCL   | PB10    | I2C1 SCL       |                |                                |
+| I2C_DEV(1) SDA   | PB11    | I2C1 SDA       |                |                                |
+| LED0             | PC13    |                | LED red        |                                |
+| LED1             | PA1     |                | LED green      |                                |
+| LED2             | PA2     |                | LED blue       |                                |
+| PWM_DEV(0) CH0   | PA1     |                | LED green      |                                |
+| PWM_DEV(0) CH1   | PA2     |                | LED blue       |                                |
+| PWM_DEV(1) CH0   | PB8     |                |                | N/A if CAN is used             |
+| PWM_DEV(1) CH1   | PB9     |                |                | N/A if CAN is used             |
+| SPI_DEV(0) CS    | PB12    | SPI1 CS        | SD CS          |                                |
+| SPI_DEV(0) SCLK  | PB13    | SPI1 SCLK      | SD SCK         |                                |
+| SPI_DEV(0) MISO  | PB14    | SPI1 MISO      | SD MISO        |                                |
+| SPI_DEV(0) MOSI  | PB15    | SPI1 MOSI      | SD MOSI        |                                |
+| SPI_DEV(1) CS    | PA4     | SPI0 CS        |                |                                |
+| SPI_DEV(1) SCLK  | PA5     | SPI0 SCLK      | TFT SCL        |                                |
+| SPI_DEV(1) MISO  | PA6     | SPI0 MISO      |                |                                |
+| SPI_DEV(1) MOSI  | PA7     | SPI0 MOSI      | TFT SDA        |                                |
+| UART_DEV(0) TX   | PA9     | USART0 TX      | UART TX        |                                |
+| UART_DEV(0) RX   | PA10    | USART0 RX      | UART RX        |                                |
+
+| Pin  | Board Function | RIOT Function 1 | RIOT Function 2 | RIOT Function 3 |
+|:-----|:---------------|:----------------|:----------------|:----------------|
+| PA0  |                |                 | ADC_LINE(0)     |                 |
+| PA1  | LED green      | PWM_DEV(0) CH0  |                 | LED0            |
+| PA2  | LED blue       | PWM_DEV(0) CH1  |                 | LED1            |
+| PA3  |                |                 | ADC_LINE(1)     |                 |
+| PA4  |                | SPI_DEV(1) CS   | ADC_LINE(8)*    | DAC_LINE(0)*    |
+| PA5  | TFT SCL        | SPI_DEV(1) SCLK | ADC_LINE(9)*    | DAC_LINE(1)*    |
+| PA6  |                | SPI_DEV(1) MISO | ADC_LINE(6)*    |                 |
+| PA7  | TFT SDA        | SPI_DEV(1) MOSI | ADC_LINE(7)*    |                 |
+| PA8  |                |                 |                 |                 |
+| PA9  |                | UART_DEV(0) TX  |                 |                 |
+| PA10 |                | UART_DEV(0) RX  |                 |                 |
+| PA11 | USB D-         |                 |                 |                 |
+| PA12 | USB D+         |                 |                 |                 |
+| PA13 | JTAG TMS       |                 |                 |                 |
+| PA14 | JTAG TCK       |                 |                 |                 |
+| PA15 | JTAG TDI       |                 |                 |                 |
+| PB0  | TFT RS         |                 | ADC_LINE(4)     |                 |
+| PB1  | TFT RST        |                 | ADC_LINE(5)     |                 |
+| PB2  | TFT CS         |                 |                 |                 |
+| PB3  | JTAG TDO       |                 |                 |                 |
+| PB4  | JTAG NRST      |                 |                 |                 |
+| PB5  |                |                 |                 |                 |
+| PB6  |                | I2C_DEV(0) SCL  |                 |                 |
+| PB7  |                | I2C_DEV(0) SDA  |                 |                 |
+| PB8  |                | PWM_DEV(1) CH0  |                 |                 |
+| PB9  |                | PWM_DEV(1) CH1  |                 |                 |
+| PB10 |                | I2C_DEV(1) SCL  |                 |                 |
+| PB11 |                | I2C_DEV(1) SDA  |                 |                 |
+| PB12 | SD CS          | SPI_DEV(0) CS   |                 |                 |
+| PB13 | SD SCK         | SPI_DEV(0) SCLK |                 |                 |
+| PB14 | SD MISO        | SPI_DEV(0) MISO |                 |                 |
+| PB15 | SD MOSI        | SPI_DEV(0) MOSI |                 |                 |
+| PC13 | LED red        |                 |                 | LED3            |
+| PC14 | OSC32IN        |                 |                 |                 |
+| PC15 | OSC32OUT       |                 |                 |                 |
+| -    | Temperature    |                 | ADC_LINE(2)     |                 |
+| -    | VREF           |                 | ADC_LINE(3)     |                 |
+
+(*) The availability of these peripherals depend on the use of other peripherals.
 
 @note Since the availability of `ADC_LINE(4)` to `ADC_LINE(9)` depends on other
 peripheral configurations, their index may vary.

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -33,6 +33,10 @@
 #define CONFIG_CLOCK_HXTAL      MHZ(8)      /**< HXTAL frequency */
 #endif
 
+#if CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
+#define SPI_DEV_1_USED              /**< Enable SPI_DEV(1) if TFT is connected */
+#endif
+
 #include "periph_cpu.h"
 #include "periph_common_conf.h"
 
@@ -56,22 +60,18 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },
     /* ADC VREF channel */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 17 },
-#if !defined(CONFIG_SIPEED_LONGAN_NANO_WITH_TFT)
+#if !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
     /* This conflicts with TFT pins if connected. */
     { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 8 },
     { .pin = GPIO_PIN(PORT_B, 1), .dev = 0, .chan = 9 },
-#endif
-#if !defined(MODULE_PERIPH_SPI)
-    /* This conflicts with the SPI0 controller which is used for TFT if connected */
-    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
-#if !defined(CONFIG_SIPEED_LONGAN_NANO_WITH_TFT)
-    { .pin = GPIO_PIN(PORT_A, 5), .dev = 0, .chan = 5 },
-#endif /* !defined(CONFIG_SIPEED_LONGAN_NANO_WITH_TFT) */
+    /* This conflicts with the SPI0 controller which is used is TFT is connected */
     { .pin = GPIO_PIN(PORT_A, 6), .dev = 0, .chan = 6 },
-#if !defined(CONFIG_SIPEED_LONGAN_NANO_WITH_TFT)
     { .pin = GPIO_PIN(PORT_A, 7), .dev = 0, .chan = 7 },
-#endif /* !defined(CONFIG_SIPEED_LONGAN_NANO_WITH_TFT) */
-#endif
+#if !defined(MODULE_PERIPH_DAC)
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
+    { .pin = GPIO_PIN(PORT_A, 5), .dev = 0, .chan = 5 },
+#endif /* !defined(MODULE_PERIPH_DAC) */
+#endif /* !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT */
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)

--- a/cpu/gd32v/periph/spi.c
+++ b/cpu/gd32v/periph/spi.c
@@ -120,6 +120,15 @@ void spi_init(spi_t bus)
 
 void spi_init_pins(spi_t bus)
 {
+    if (spi_config[bus].sclk_pin == GPIO_PIN(PORT_B, 3) &&
+        spi_config[bus].miso_pin == GPIO_PIN(PORT_B, 4) &&
+        spi_config[bus].mosi_pin == GPIO_PIN(PORT_B, 5)) {
+        /* The remapping periph clock must first be enabled */
+        RCU->APB2EN |= RCU_APB2EN_AFEN_Msk;
+        /* Then the remap can occur */
+        AFIO->PCF0 |= AFIO_PCF0_SPI0_REMAP_Msk;
+    }
+
     if (gpio_is_valid(spi_config[bus].sclk_pin)) {
         gpio_init_af(spi_config[bus].sclk_pin, GPIO_AF_OUT_PP);
     }


### PR DESCRIPTION
### Contribution description

This PR provides some small improvements of the existing board definitions for GD32VF103 boards for more flexibel default configurations and documentation of the board peripherals:

- Allow the remapping of SPI0 pins in SPI configuration (ae984b0bea59ba0803cd5418d1169f38a5fe3796)
- More flexible I2C configuration (0c337583b4a0542c109794b903433f6fde2b8a10)
  The default I2C device configuration allows to define up to two I2C devices `I2C_DEV(0)` and `I2C_DEV(1)`. `I2C_DEV(0)` is always defined if the I2C peripheral is enabled by the module `periph_spi`. The second I2C device `I2C_DEV(1)` is only defined if `I2C_DEV_1_USED` is defined by the board. This allows to use the default configuration with one or two I2C devices depending on whether other peripherals are enabled that would collide with the I2C devices.
- More flexible SPI configuration (edbf59e37e8172d2fc1f389d0ad165972a37311b)
  The default SPI device configuration allows to define up to two SPI devices `SPI_DEV(0)` and `SPI_DEV(1)`. `SPI_DEV(0)` is always defined if the SPI peripheral is enabled by the module `periph_spi`. The second SPI device `SPI_DEV(1)` is only defined if `SPI_DEV_1_USED` is defined by the board. This allows to use the default configuration with one or two SPI devices depending on whether other peripherals are enabled that would collide with the SPI devices.
Furthermore, the CS signal in the SPI configuration is given by a define that can be overriden with another pin if
the default CS signal is connected to an unused hardware.
- Improve ADC config for Sipeed-Longan-Nano (c9c587ee0032327e92e457242dd3d023d1650279)
  The ADC configuration was too complex. It was hard to follow when certain ADC lines are available. Furthermore, the order of ADC lines did depend on the use of other peripherals. Now, either the TFT display is not connected and all ADC lines are available or the TFT display is connected and the second SPI device is used so that only the first 4 ADC lines are available.
- Improve Kconfig for Sipeed-Longan-Nano (025f4fdf004538ff6a6325cbdc177bb69f46676d)
  Board-specific configuration not shown any longer directly in the top level menu but within a submenu.
- Improve peripherals documentation (7f0d560dd86f921074d7567c2a93ee6558cae812, e24abe495a8c3c04f807706f80519272bf326620)
 Available peripherals for the board are now documented in two tables ordered by RIOT peripheral names and by pins.

Although the different changes are small and mostly related to the documentation, I could split the PR if necessary.

### Testing

Green CI

### Issues/PRs references

