### PR TITLE
sys/fmt: use `fflush(); stdio_write()` instead of `fwrite()`

### DIFF
--- a/sys/test_utils/print_stack_usage/print_stack_usage.c
+++ b/sys/test_utils/print_stack_usage/print_stack_usage.c
@@ -26,7 +26,11 @@
 #include <stdio.h>
 #endif
 
+#if MODULE_FMT
+# define MIN_SIZE   (THREAD_STACKSIZE_TINY)
+#else
 # define MIN_SIZE   (THREAD_STACKSIZE_TINY + THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
 
 void print_stack_usage_metric(const char *name, void *stack, unsigned max_size)
 {
@@ -37,7 +41,7 @@ void print_stack_usage_metric(const char *name, void *stack, unsigned max_size)
 #if MODULE_FMT
         print_str("{ \"threads\": [{ \"name\": \"");
         print_str(name);
-        print_str(", \"stack_size\": ");
+        print_str("\", \"stack_size\": ");
         print_u32_dec(max_size);
         print_str(", \"stack_used\": ");
         print_u32_dec(max_size - free);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, fmt's `print()` is using libc's `fwrite()` in order to mitigate both
libc and fmt output clashing wrt. libc stdio buffers. That causes `print()` to
use quite a bit more stack, we had to remove the lower stack case in
`print_stack_usage_metrics()`.

This PR changes `print()` to use `fflush()`; `stdio_write()` instead, bypassing
a lot of libc's FILE machinery.

A quick test on nrf52840dk shows that `print_stack_usage_metrics()` on an
otherwise empty thread uses 124b stack without the `fflush()`, 160b with the
`fflush()` (this PR's state). So another commit re-adds the `MIN_SIZE` fmt
case.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
