### PR TITLE
tests/driver_dac_dds: fix output of sine and saw functions

### DIFF
--- a/tests/driver_dac_dds/main.c
+++ b/tests/driver_dac_dds/main.c
@@ -98,24 +98,17 @@ typedef void (*sample_gen_t)(uint8_t *dst, size_t len, uint16_t period);
 
 static void _fill_saw_samples_8(uint8_t *buf, size_t len, uint16_t period)
 {
-    uint8_t x = 0;
-    unsigned step = 0xFF / period;
-
     for (uint16_t i = 0; i < len; ++i) {
-        x += step;
-        buf[i] = x;
+        buf[i] = (i * 0xFFUL) / period;
     }
 }
 
 static void _fill_saw_samples_16(uint8_t *buf, size_t len, uint16_t period)
 {
-    uint16_t x = 0;
-    unsigned step = 0xFFFF / period;
-
     for (uint16_t i = 0; i < len; ++i) {
-        x += step;
-        buf[i]   = x;
-        buf[++i] = x >> 8;
+        uint16_t y = (i * 0xFFFFUL) / period;
+        buf[i]   = y;
+        buf[++i] = y >> 8;
     }
 }
 
@@ -126,8 +119,7 @@ static void _fill_sine_samples_8(uint8_t *buf, size_t len, uint16_t period)
 
     for (uint16_t i = 0; i < period; ++i) {
         x += step;
-        buf[i] = isin(x) >> 5;
-        buf[i] += INT8_MAX + 1;
+        buf[i] = (isin(x) + 4096) >> 6;
     }
 
     for (uint16_t i = period; i < len; i += period) {
@@ -145,8 +137,7 @@ static void _fill_sine_samples_16(uint8_t *buf, size_t len, uint16_t period)
     for (uint16_t i = 0; i < period; ++i) {
         x += step;
 
-        uint16_t y = isin(x);
-        y += INT16_MAX + 1;
+        uint16_t y = (isin(x) + 4096) << 2;
         buf[i]   = y;
         buf[++i] = y >> 8;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `sine` and `saw` commands have a bug that can lead to either distorted (sine) or no (saw) output.

 - the sine function would overflow to 0 when doing the signed -> unsigned conversion
 - the saw function would produce a step value of 0 if the frequency was too low 


### Testing procedure

#### sine in master



![bmp_26_000](https://user-images.githubusercontent.com/1301112/216967848-238ea982-b3f1-42af-8c42-9b53563d1417.png)

#### sine with this PR

![bmp_26_001](https://user-images.githubusercontent.com/1301112/216982862-25a1e1fe-911d-469b-9607-b10208a6e46f.png)

#### saw with this PR

![bmp_26_002](https://user-images.githubusercontent.com/1301112/216982926-c7e21189-2a58-4224-96c1-d9b3740d3e63.png)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
