### PR TITLE
boards/esp*: complete SD Card MTD config

### DIFF
--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -129,6 +129,15 @@ extern "C" {
 /** Pointer to the default MTD drive structure */
 extern mtd_dev_t *mtd0;
 
+/**
+ * @brief   MTD offset for SD Card interfaces
+ *
+ * MTD_1 is used for SD Card.
+ */
+#ifndef CONFIG_SDCARD_GENERIC_MTD_OFFSET
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1
+#endif
+
 /** @} */
 #endif /* MODULE_MTD || DOXYGEN */
 

--- a/boards/common/esp32c3/include/board_common.h
+++ b/boards/common/esp32c3/include/board_common.h
@@ -110,6 +110,15 @@ extern "C" {
 /** Pointer to the default MTD drive structure */
 extern mtd_dev_t *mtd0;
 
+/**
+ * @brief   MTD offset for SD Card interfaces
+ *
+ * MTD_1 is used for SD Card.
+ */
+#ifndef CONFIG_SDCARD_GENERIC_MTD_OFFSET
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1
+#endif
+
 /** @} */
 #endif /* MODULE_MTD || DOXYGEN */
 

--- a/boards/common/esp32s2/include/board_common.h
+++ b/boards/common/esp32s2/include/board_common.h
@@ -110,6 +110,15 @@ extern "C" {
 /** Pointer to the default MTD drive structure */
 extern mtd_dev_t *mtd0;
 
+/**
+ * @brief   MTD offset for SD Card interfaces
+ *
+ * MTD_1 is used for SD Card.
+ */
+#ifndef CONFIG_SDCARD_GENERIC_MTD_OFFSET
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1
+#endif
+
 /** @} */
 #endif /* MODULE_MTD || DOXYGEN */
 

--- a/boards/common/esp32s3/include/board_common.h
+++ b/boards/common/esp32s3/include/board_common.h
@@ -110,6 +110,15 @@ extern "C" {
 /** Pointer to the default MTD drive structure */
 extern mtd_dev_t *mtd0;
 
+/**
+ * @brief   MTD offset for SD Card interfaces
+ *
+ * MTD_1 is used for SD Card.
+ */
+#ifndef CONFIG_SDCARD_GENERIC_MTD_OFFSET
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1
+#endif
+
 /** @} */
 #endif /* MODULE_MTD || DOXYGEN */
 

--- a/boards/common/esp8266/include/board_common.h
+++ b/boards/common/esp8266/include/board_common.h
@@ -95,6 +95,15 @@ extern "C" {
 /** Pointer to the default MTD device structure */
 extern mtd_dev_t *mtd0;
 
+/**
+ * @brief   MTD offset for SD Card interfaces
+ *
+ * MTD_1 is used for SD Card.
+ */
+#ifndef CONFIG_SDCARD_GENERIC_MTD_OFFSET
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1
+#endif
+
 /** @} */
 #endif /* defined(MODULE_MTD) || defined(DOXYGEN) */
 

--- a/boards/esp32-wemos-lolin-d32-pro/Kconfig
+++ b/boards/esp32-wemos-lolin-d32-pro/Kconfig
@@ -18,5 +18,9 @@ config BOARD_ESP32_WEMOS_LOLIN_D32_PRO
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI
+    select HAS_SDCARD_SPI
+
+    select HAVE_MTD_SDCARD_DEFAULT
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
@@ -1,1 +1,11 @@
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_sdcard_default
+endif
+
+# default to using fatfs on SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.features
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.features
@@ -9,5 +9,6 @@ FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += sdcard_spi
 
 FEATURES_PROVIDED += arduino

--- a/boards/esp32-wrover-kit/Kconfig
+++ b/boards/esp32-wrover-kit/Kconfig
@@ -22,5 +22,7 @@ config BOARD_ESP32_WROVER_KIT
     select HAS_SDCARD_SPI
 
     select HAVE_ILI9341
+    select HAVE_MTD_SDCARD_DEFAULT
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -5,4 +5,14 @@ endif
 # Sets up configuration for openocd
 USEMODULE += esp_jtag
 
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_sdcard_default
+endif
+
+# default to using fatfs on SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep


### PR DESCRIPTION
### Contribution description

This PR provides the remaining changes necessary to use the generic MTD SD Card configuration as described in PR #19216. 

This includes defining the MTD offset for SD cards, since the default `MTD_0` device always uses the internal flash device, and the completion of the configuration for the ESP32 boards with a SD card interface.

### Testing procedure

`tests/vfs_default` should work now with SD Cards:
```
main(): This is RIOT! (Version: 2023.04-devel-323-gfcc07)
mount points:
	/nvm0
	/sd0

data dir: /sd0
> vfs df 
Mountpoint              Total         Used    Available     Use%
/nvm0                3052 KiB        8 KiB     3044 KiB       0%
/sd0                 7580 MiB 3632148992 B   21089792 B      99%
```

### Issues/PRs references
