### PR TITLE
boards/stm32f4discovery: default to stdio via CDC ACM

### DIFF
--- a/boards/stm32f4discovery/Kconfig
+++ b/boards/stm32f4discovery/Kconfig
@@ -28,11 +28,20 @@ config BOARD_STM32F4DISCOVERY
     # Various other features (if any)
     select HAS_ARDUINO
     select HAS_TINYUSB_DEVICE
+    select HAS_HIGHLEVEL_STDIO
 
     # Clock configuration
     select BOARD_HAS_HSE
 
     select HAVE_SAUL_GPIO
+
+    select MODULE_USBUS if TEST_KCONFIG && !PACKAGE_TINYUSB
+    select MODULE_USBUS_CDC_ACM if TEST_KCONFIG && !PACKAGE_TINYUSB
+
+choice STDIO_IMPLEMENTATION
+    default MODULE_STDIO_CDC_ACM if MODULE_USBUS
+    default MODULE_STDIO_TINYUSB_CDC_ACM if PACKAGE_TINYUSB
+endchoice
 
 source "$(RIOTBOARD)/common/stm32/Kconfig"
 

--- a/boards/stm32f4discovery/Makefile.dep
+++ b/boards/stm32f4discovery/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -17,6 +17,8 @@ FEATURES_PROVIDED += periph_usbdev
 FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += tinyusb_device
 
+FEATURES_PROVIDED += highlevel_stdio
+
 # TODO: re-think concept for conflicts based on actual used peripherals...
 FEATURES_CONFLICT += periph_spi:periph_dac
 FEATURES_CONFLICT_MSG += "On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0."

--- a/boards/stm32f4discovery/doc.txt
+++ b/boards/stm32f4discovery/doc.txt
@@ -58,7 +58,11 @@ arbitrary and can be altered by editing the
 LEDs LD7 and LD8 are used by the USB connector for over-current (LD8) and
 data (LD7) indication.
 
+### USB Device Interface
 
+The board has a micro USB port that can be used for USB device mode.
+As the ST-Link on the board does not provide a USB-UART interface, the STDIO is
+mapped to the micro USB port by default (via CDC ACM).
 
 ### Accelerometer
 

--- a/tests/xtimer_now32_overflow/Makefile
+++ b/tests/xtimer_now32_overflow/Makefile
@@ -14,6 +14,7 @@ BOARD_BLACKLIST += \
                    pinetime \
                    ruuvitag \
                    stm32f429i-disco \
+                   stm32f4discovery \
                    thingy52 \
                    waspmote-pro  \
                    weact-f401cc \

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -15,6 +15,7 @@ BOARD_BLACKLIST += \
                    pinetime \
                    ruuvitag \
                    stm32f429i-disco \
+                   stm32f4discovery \
                    thingy52 \
                    waspmote-pro  \
                    weact-f401cc \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Looks like `stm32f4discovery` also has one of the old on-board ST-Links that don't implement a USB-UART interface (like on `stm32f429i-disco`).
Since wiring up a USB-UART interface manually is annoying and the board provides a micro-USB port, default to `stdio_cdc_acm` so the user only needs an extra USB cable to access the shell.

### Testing procedure

Connect a micro-USB cable to he port of the `stm32f4discovery`.
It should be recognized as a CDC ACM interface and `make term` should automatically connect to it.

*I don't have this board.*

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/19248#issuecomment-1419723939
