### PR TITLE
sys/stdio: mark stdio_tinyusb_cdc_acm as buffered

### DIFF
--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -82,7 +82,7 @@ endif
 
 # enable stdout buffering for modules that benefit from sending out buffers in larger chunks
 ifneq (,$(filter picolibc,$(USEMODULE)))
-  ifneq (,$(filter stdio_cdc_acm stdio_ethos slipdev_stdio stdio_semihosting,$(USEMODULE)))
+  ifneq (,$(filter stdio_cdc_acm stdio_ethos slipdev_stdio stdio_semihosting stdio_tinyusb_cdc_acm,$(USEMODULE)))
     USEMODULE += picolibc_stdout_buffered
   endif
 endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`stdio_tinyusb_cdc_acm` benefits from stdio buffering (not transferring individual bytes) just like `stdio_cdc_acm`.


### Testing procedure

Run any application that uses `stdio_tinyusb_cdc_acm` with

    FEATURES_REQUIRED += picolibc

with newlib, stdio buffering is the default.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
