### PR TITLE
cpu/stm32/periph/timer: don't stop counter

### DIFF
--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -177,9 +177,7 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
     if (value > timeout) {
         /* time till timeout is larger than requested --> timer already expired
          * ==> let's make sure we have an IRQ pending :) */
-        dev(tim)->CR1 &= ~(TIM_CR1_CEN);
-        TIM_CHAN(tim, channel) = dev(tim)->CNT;
-        dev(tim)->CR1 |= TIM_CR1_CEN;
+        dev(tim)->EGR |= (TIM_EGR_CC1G << channel);
     }
 
     irq_restore(irqstate);


### PR DESCRIPTION
### Contribution description

From the git comment msg:

If a timer's channel was set with a really small realtive duration from now, such that it would be missed (underflowed), the driver would stop the timer, potentially causing missed ticks. It was stopped to ensure that the channel's output-compare register could be set to the current counter value, before re-enabling the timer's counter. This is a condition that will ensure that the underflow won't happen again and the interrupt will fire, at the cost of losing some ticks for very high speed clocks.

This patch replaces the logic that stopped the timer. Instead it uses a register provided by the timer hardware to trigger timer interrupts via software.


### Testing procedure

1. do
    ``` bash
    $ cd tests/periph_timer_short_relative_set
    $ make BOARD=nucleo-f303ze flash term
    ```
1. follow prompts to run test
1. observe all tests pass
1. apply patch below to break test
1. rerun test
1. observe test fails, so new method is doing its job


##### patch to intentionally break test

```` diff
diff --git a/cpu/stm32/periph/timer.c b/cpu/stm32/periph/timer.c
index 64a6f3a656..7078c46ab4 100644
--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -177,7 +177,7 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
     if (value > timeout) {
         /* time till timeout is larger than requested --> timer already expired
          * ==> let's make sure we have an IRQ pending :) */
-        dev(tim)->EGR |= (TIM_EGR_CC1G << channel);
+        //dev(tim)->EGR |= (TIM_EGR_CC1G << channel);
     }
````


### Issues/PRs references

- none known
