### PR TITLE
shell_lock: don't set CONFIG_SHELL_SHUTDOWN_ON_EXIT

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -50,7 +50,7 @@ extern "C" {
  * Instead terminate RIOT, which is also the behavior a user would
  * expect from a CLI application.
  */
-#  if defined(CPU_NATIVE)
+#  if defined(CPU_NATIVE) && !IS_ACTIVE(MODULE_SHELL_LOCK)
 #    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 1
 #  else
 #    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 0

--- a/sys/include/shell_lock.h
+++ b/sys/include/shell_lock.h
@@ -68,6 +68,11 @@ void shell_lock_checkpoint(char *line_buf, int buf_size);
  */
 bool shell_lock_is_locked(void);
 
+/**
+ * @brief   Lock the shell
+ */
+void shell_lock_do_lock(void);
+
 #ifdef MODULE_SHELL_LOCK_AUTO_LOCKING
 /**
  * @brief   Restart the timeout interval before the shell is locked

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -501,6 +501,9 @@ void shell_run_once(const shell_command_t *shell_commands,
         switch (res) {
 
             case EOF:
+                if (IS_USED(MODULE_SHELL_LOCK)) {
+                    shell_lock_do_lock();
+                }
                 return;
 
             case -ENOBUFS:

--- a/sys/shell_lock/shell_lock.c
+++ b/sys/shell_lock/shell_lock.c
@@ -143,9 +143,14 @@ static void _login_barrier(char *line_buf, size_t buf_size)
 #ifdef MODULE_STDIO_TELNET
 void telnet_cb_disconneced(void)
 {
-    _shell_is_locked = true;
+    shell_lock_do_lock();
 }
 #endif
+
+void shell_lock_do_lock(void)
+{
+    _shell_is_locked = true;
+}
 
 #ifdef MODULE_SHELL_LOCK_AUTO_LOCKING
 static void _shell_auto_lock_ztimer_callback(void *arg)

--- a/tests/sys/shell_lock/Makefile
+++ b/tests/sys/shell_lock/Makefile
@@ -12,10 +12,6 @@ CFLAGS += -DCONFIG_SHELL_LOCK_PASSWORD=\"password\"
 CFLAGS += -DCONFIG_SHELL_LOCK_AUTO_LOCK_TIMEOUT_MS=7000
 endif
 
-# This config defaults to 1 on native, such that pm_off() would be called as soon as
-# shell_run_once is terminated in shell_run_forever. We do not want this behavior for this test.
-CFLAGS += -DCONFIG_SHELL_SHUTDOWN_ON_EXIT=0
-
 # test_utils_interactive_sync_shell assumes that the prompt is always '> ' which breaks
 # with the password prompt of the shell_lock module which is different from the shell's prompt
 DISABLE_MODULE += test_utils_interactive_sync_shell


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We *always* want `CONFIG_SHELL_SHUTDOWN_ON_EXIT` not to be set if `shell_lock` us used as `shell_lock` will exit the shell to lock it.


### Testing procedure

Run `tests/shell_lock` on `native` (or any other `native` app with `shell_lock` enabled)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
