### PR TITLE
drivers/at24cxxx: implement _mtd_at24cxxx_read_page

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -57,6 +57,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Maximum bytes per frame for I2C operations
+ */
+#define PERIPH_I2C_MAX_BYTES_PER_FRAME 256
+
+/**
  * @brief   Override GPIO type
  * @{
  */

--- a/drivers/at24cxxx/mtd/mtd.c
+++ b/drivers/at24cxxx/mtd/mtd.c
@@ -45,16 +45,11 @@ static int _mtd_at24cxxx_init(mtd_dev_t *mtd)
     return 0;
 }
 
-static int _mtd_at24cxxx_read(mtd_dev_t *mtd, void *dest, uint32_t addr,
-                              uint32_t size)
+static int _mtd_at24cxxx_read_page(mtd_dev_t *mtd, void *dest, uint32_t page,
+                                   uint32_t offset, uint32_t size)
 {
-    return at24cxxx_read(DEV(mtd), addr, dest, size) == AT24CXXX_OK ? 0 : -EIO;
-}
-
-static int _mtd_at24cxxx_write(mtd_dev_t *mtd, const void *src, uint32_t addr,
-                               uint32_t size)
-{
-    return at24cxxx_write(DEV(mtd), addr, src, size) == AT24CXXX_OK ? 0 : -EIO;
+    int rc = at24cxxx_read(DEV(mtd), page * mtd->page_size + offset, dest, size);
+    return rc == AT24CXXX_OK ? (int)size : rc;
 }
 
 static int mtd_at24cxxx_write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
@@ -77,8 +72,7 @@ static int _mtd_at24cxxx_power(mtd_dev_t *mtd, enum mtd_power_state power)
 
 const mtd_desc_t mtd_at24cxxx_driver = {
     .init = _mtd_at24cxxx_init,
-    .read = _mtd_at24cxxx_read,
-    .write = _mtd_at24cxxx_write,
+    .read_page = _mtd_at24cxxx_read_page,
     .write_page = mtd_at24cxxx_write_page,
     .erase = _mtd_at24cxxx_erase,
     .power = _mtd_at24cxxx_power,

--- a/drivers/include/at24cxxx.h
+++ b/drivers/include/at24cxxx.h
@@ -96,8 +96,7 @@ int at24cxxx_read_byte(const at24cxxx_t *dev, uint32_t pos, void *dest);
  * @return          -ERANGE if @p pos + @p len is out of bounds
  * @return          @see i2c_read_regs
  */
-int at24cxxx_read(const at24cxxx_t *dev, uint32_t pos, void *data,
-                  size_t len);
+int at24cxxx_read(const at24cxxx_t *dev, uint32_t pos, void *data, size_t len);
 
 /**
  * @brief   Write a byte at a given position @p pos


### PR DESCRIPTION
### Contribution description

The function `read_page` was missing which lead to (from a user perspective) undefined behavior on the MTD layer.

### Testing procedure

Any application using MTD in conjunction with a board with an at24cxxx.
