### PR TITLE
core/xfa: disable asan on llvm

### DIFF
--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -69,6 +69,20 @@ extern "C" {
 #endif
 
 /**
+ * @def       NO_SANITIZE_ARRAY
+ * @brief     Tell the compiler that this array should be ignored during sanitizing.
+ * @details   In special cases, e.g. XFA, the address sanitizer might interfere
+ *            in a way that breaks the application. Use this macro to disable
+ *            address sanitizing for a given variable. Currently only utilised
+ *            by llvm.
+ */
+#if defined(__llvm__) || defined(__clang__)
+#define NO_SANITIZE_ARRAY __attribute__((no_sanitize("address")))
+#else
+#define NO_SANITIZE_ARRAY
+#endif
+
+/**
  * @def       UNREACHABLE()
  * @brief     Tell the compiler that this line of code cannot be reached.
  * @details   Most useful in junction with #NORETURN.

--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -26,6 +26,7 @@
 #define XFA_H
 
 #include <inttypes.h>
+#include "compiler_hints.h"
 
 /*
  * Unfortunately, current gcc trips over accessing XFA's because of their
@@ -42,16 +43,18 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  * @internal
  */
-#define _XFA(name, prio) __attribute__((used, section(".xfa." #name "." #prio)))
+#define _XFA(name, prio) \
+    NO_SANITIZE_ARRAY \
+    __attribute__((used, section(".xfa." #name "." #prio)))
 
 /**
  * @brief helper macro for other XFA_* macros
  *
  * @internal
  */
-#define _XFA_CONST(name, \
-                   prio) __attribute__((used, \
-                                        section(".roxfa." #name "." #prio)))
+#define _XFA_CONST(name, prio) \
+    NO_SANITIZE_ARRAY \
+    __attribute__((used, section(".roxfa." #name "." #prio)))
 
 /**
  * @brief Define a read-only cross-file array


### PR DESCRIPTION
### Contribution description
Hi! 🦎

When using llvm and address sanitation, the XFA trip the sanitizer.
This PR attempts to fix this by adding the `no_sanitize` attribute to the XFA macros. Sadly, this attribute is not known by gnu, a guard is hence needed. I'm open for alternatives as I dislike this solution but it is the best I could come up with.

### Testing procedure

Before this patch:

Go to `examples/gnrc_minimal` and run `TOOLCHAIN=llvm make all-asan` and then `make term`.
You should see an error similar to this:
```
==3374719==ERROR: AddressSanitizer: global-buffer-overflow on address 0x080774e0 at pc 0x0804af5e bp 0x0808eb88 sp 0x0808eb78
READ of size 4 at 0x080774e0 thread T0
    #0 0x804af5d in _auto_init_module /RIOT/sys/auto_init/auto_init.c:40
    #1 0x804af5d in auto_init /RIOT/sys/auto_init/auto_init.c:339
    #2 0x804b375 in main_trampoline /RIOT/core/lib/init.c:56
    #3 0xf76bc7b8 in makecontext (/lib32/libc.so.6+0x4a7b8)
...
``` 
After applying this PR, the example can be build and run with llvm or gcc, with or without asan.

