### PR TITLE
examples/rust-gcoap: Modernize

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +80,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "build_const"
@@ -126,6 +144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
 name = "clang-sys"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,14 +186,14 @@ dependencies = [
 
 [[package]]
 name = "coap-handler"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16fbe39cc8c18a07e97f3fbf16e6771946f5cded9800db0ab2698c5a2409ddb2"
+checksum = "db834631a5a388596fdbded2b1b08144d504fdbb798455c6d0f335d7d4231a2b"
 dependencies = [
  "byteorder",
  "coap-message",
  "coap-numbers",
- "crc",
+ "crc 1.8.1",
  "serde",
  "serde_cbor",
  "windowed-infinity",
@@ -177,15 +201,33 @@ dependencies = [
 
 [[package]]
 name = "coap-handler-implementations"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620e584e19bd2432640d73fc29b5c8ac0904a903b863f7c3ad5cd989917c55e5"
+checksum = "a88fc2ff9ee38c4ff71d2ab2154afb842fa7c81e4e924753c74d89aed1b56bb6"
 dependencies = [
  "coap-handler",
  "coap-message",
  "coap-numbers",
- "crc",
- "minicbor",
+ "crc 1.8.1",
+ "minicbor 0.13.2",
+ "serde",
+ "serde_cbor",
+ "windowed-infinity",
+]
+
+[[package]]
+name = "coap-handler-implementations"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a840ddbd01dae0aa4bbc314f8040cee6ea4c8c9524e9017081a601146d5cf8"
+dependencies = [
+ "ciborium-io",
+ "coap-handler",
+ "coap-message",
+ "coap-numbers",
+ "crc 3.0.1",
+ "embedded-io",
+ "minicbor 0.19.0",
  "serde",
  "serde_cbor",
  "windowed-infinity",
@@ -199,23 +241,41 @@ checksum = "7cc888e15f6be910b58fda4f056f673f58fb9348ea45da014283a14e6d2b58ec"
 
 [[package]]
 name = "coap-message-demos"
-version = "0.2.0"
-source = "git+https://gitlab.com/chrysn/coap-message-demos/#6a55eef795b33765fe50d8aeb9cb8742ad80a63f"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c242421ca78b4fc3952883f4fc04768ccb9eff8a27061d1f57e3603297395b"
 dependencies = [
  "coap-handler",
- "coap-handler-implementations",
+ "coap-handler-implementations 0.4.0",
  "coap-message",
  "coap-numbers",
+ "coap-scroll-ring-server",
  "heapless",
+ "log",
+ "scroll-ring",
  "serde",
  "serde_cbor",
+ "static_cell",
 ]
 
 [[package]]
 name = "coap-numbers"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4135db61ac9b5fb4266fcd1294abd47c807e63b496882784543940dc3402e9"
+checksum = "3e06871acb2f7d2dae15701b4ee657f17f0d26266eeea37b62ceae3b38c21873"
+
+[[package]]
+name = "coap-scroll-ring-server"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499b57a813ef5a69f281fa946d25897fcfdab3073f688347b493c2c348b7a34c"
+dependencies = [
+ "coap-handler",
+ "coap-handler-implementations 0.4.0",
+ "coap-message",
+ "coap-numbers",
+ "scroll-ring",
+]
 
 [[package]]
 name = "crc"
@@ -227,10 +287,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cstr"
@@ -249,10 +343,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "either"
-version = "1.8.0"
+name = "digest"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "embedded-graphics"
@@ -274,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +394,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -319,7 +439,7 @@ version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
- "atomic-polyfill",
+ "atomic-polyfill 0.1.11",
  "hash32",
  "rustc_version",
  "serde",
@@ -427,6 +547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d319d47468f164e5138b1c629bdd82ea3da0784ed1d41a22f8e0bcef76c2ae52"
+
+[[package]]
 name = "minicbor-derive"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,9 +635,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -543,18 +669,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "ringbuf"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ca10b9c9e53ac855a2d6953bce34cef6edbac32c4b13047a4d59d67299420a"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "riot-coap-handler-demos"
 version = "0.1.0"
 source = "git+https://gitlab.com/etonomy/riot-module-examples/#75132650a5c8dfe16cd62eb3dcc91f8fd1630648"
 dependencies = [
  "coap-handler",
- "coap-handler-implementations",
+ "coap-handler-implementations 0.3.6",
  "coap-message",
  "coap-numbers",
  "embedded-graphics",
  "embedded-hal",
  "heapless",
- "minicbor",
+ "minicbor 0.13.2",
  "riot-sys",
  "riot-wrappers",
  "serde",
@@ -579,8 +714,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#fef42fadc02f4f0cf2bb7d8e6b7b522b91bba058"
+version = "0.8.1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9c29faf55d4c14d2d7f55f8df5059c52af4e5317"
 dependencies = [
  "bare-metal",
  "coap-handler",
@@ -604,8 +739,9 @@ dependencies = [
 name = "rust-gcoap"
 version = "0.1.0"
 dependencies = [
- "coap-handler-implementations",
+ "coap-handler-implementations 0.3.6",
  "coap-message-demos",
+ "log",
  "riot-coap-handler-demos",
  "riot-wrappers",
  "rust_riotmodules",
@@ -641,6 +777,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scroll-ring"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eda0dff67036ba3b032aa68eb47ceb9b53b6e848445f53d10bf93e033b17df2"
+dependencies = [
+ "ringbuf",
+ "try-lock",
+]
 
 [[package]]
 name = "semver"
@@ -689,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -712,9 +858,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
 dependencies = [
  "lock_api",
 ]
@@ -724,6 +870,15 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_cell"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c37c250d21f53fa7165e76e5401d7e6539c211a8d2cf449e3962956a5cc2ce"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+]
 
 [[package]]
 name = "strsim"
@@ -767,10 +922,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -822,10 +995,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windowed-infinity"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c89fb8bc3dc33aaffd4bf63652c4fa1f9d4d4eafd94800f774a6416df1f4fc"
+checksum = "c9487d1d565a9db59e1fd0b3c2d3f0c277bc375d348a6c46ff2b322917fbc035"
 dependencies = [
+ "ciborium-io",
+ "crc 3.0.1",
+ "digest",
+ "embedded-io",
+ "minicbor 0.19.0",
  "serde",
  "serde_cbor",
 ]

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -21,7 +21,8 @@ opt-level = "s"
 [dependencies]
 riot-wrappers = { version = "^0.8.1", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
 
-coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
+coap-message-demos = { version = "0.3", default-features = false, features = [ "with-log" ] }
+log = "0.4"
 coap-handler-implementations = "0.3"
 riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples/", features = [ "vfs" ] }
 

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -19,7 +19,7 @@ codegen-units = 1
 opt-level = "s"
 
 [dependencies]
-riot-wrappers = { version = "^0.8", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
+riot-wrappers = { version = "^0.8.1", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
 
 coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
 coap-handler-implementations = "0.3"

--- a/examples/rust-gcoap/src/lib.rs
+++ b/examples/rust-gcoap/src/lib.rs
@@ -21,7 +21,9 @@ fn main(tokens: riot_wrappers::thread::StartToken) -> ! {
 
     unsafe { do_vfs_init() };
 
-    let handler = coap_message_demos::full_application_tree(None)
+    let mainlog = coap_message_demos::log::Log::start_once();
+
+    let handler = coap_message_demos::full_application_tree(Some(mainlog))
         .below(&["ps"], riot_coap_handler_demos::ps::ps_tree())
         .below(&["vfs"], riot_coap_handler_demos::vfs::vfs("/const"))
         .with_wkc()
@@ -34,6 +36,8 @@ fn main(tokens: riot_wrappers::thread::StartToken) -> ! {
         greg.register(&mut listener);
 
         println!("CoAP server ready; waiting for interfaces to settle before reporting addresses...");
+        // This goes into the /log resource
+        log::info!("CoAP server is ready.");
 
         // Packing the clock for a single sleep doesn't save measurable runtime; this would be more
         // relevant if sleep were repeated.

--- a/examples/rust-gcoap/src/lib.rs
+++ b/examples/rust-gcoap/src/lib.rs
@@ -14,7 +14,7 @@ extern crate rust_riotmodules;
 
 riot_main!(main);
 
-fn main() {
+fn main(tokens: riot_wrappers::thread::StartToken) -> ! {
     extern "C" {
         fn do_vfs_init();
     }
@@ -35,7 +35,9 @@ fn main() {
 
         println!("CoAP server ready; waiting for interfaces to settle before reporting addresses...");
 
-        let sectimer = ztimer::Clock::sec();
+        // Packing the clock for a single sleep doesn't save measurable runtime; this would be more
+        // relevant if sleep were repeated.
+        let sectimer = tokens.in_thread().promote(ztimer::Clock::sec());
         sectimer.sleep_ticks(2);
 
         for netif in gnrc::Netif::all() {


### PR DESCRIPTION
### Contribution description

This pulls in two things that started working due to updates all around:

* Remove run-time checks around ZTimer
* Provide a `/log` resource exposing Rust's logging system (possible because its implementation doesn't need dynamic memory management any more)
* Dependencies are updated as a result of updated requirements

### Testing procedure

* Run examples/rust-gcoap
* GET /log
* POST something to /message/info
* GET /log again

### Roadmap

There's no hurry to get this in, it's mostly housekeeping. I'll turn this from draft to ready once I'm reasonably confident there's nothing immediate to add any more.