### PR TITLE
CI: .murdock: use build checkout for ccache tmp

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -538,6 +538,11 @@ compile() {
     [ $# -ne 2 ] && error "$0: compile: invalid parameters (expected \$appdir \$board:\$toolchain)"
     [ ! -d "$appdir" ] && error "$0: compile: error: application directory \"$appdir\" doesn't exist"
 
+    # use our checkout as ccache temporary folder.
+    # On CI, this is a tmpfs, so using that instead of the `/cache/.ccache` volume
+    # reduces disk IO.
+    export CCACHE_TEMPDIR="$(pwd)/.ccache/tmp"
+
     # We compile a first time with Kconfig based dependency
     # resolution for regression purposes. $TEST_KCONFIG contains a
     # list of board-application tuples that are currently modeled to


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Using our nice graphana metrics, @bergzand pointed out some serious (~3MB/s) disk writes during CI runs. We figured out that .ccache is using the `/cache` volume for its temporary files, which is now on a real file system (since we've switched to redis for ccache).

This PR makes `CCACHE_TEMPDIR` point to the build checkout, which is on tmpfs.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
