### PR TITLE
boards/weact-f4x1cx: enable tinyUSB

### DIFF
--- a/boards/common/weact-f4x1cx/Kconfig
+++ b/boards/common/weact-f4x1cx/Kconfig
@@ -16,6 +16,7 @@ config BOARD_COMMON_WEACT_F4X1CX
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_TINYUSB_DEVICE
     select HAS_HIGHLEVEL_STDIO
 
     # Clock configuration

--- a/boards/common/weact-f4x1cx/Makefile.features
+++ b/boards/common/weact-f4x1cx/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += tinyusb_device
 
 # Various other features (if any)
 FEATURES_PROVIDED += highlevel_stdio


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The MCU already has tinyUSB support, we only need to mark it as available in the board, together with `periph_usbdev`. (Ideally this should just be a single USB port feature on which both `periph_usbdev` and `tinyusb_device` depend).


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
