### PR TITLE
pkg/tinyusb: bump to 0.15

### DIFF
--- a/pkg/tinyusb/Makefile
+++ b/pkg/tinyusb/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=tinyusb
 PKG_URL=https://github.com/hathach/tinyusb
-# TinyUSB 0.14.0
-PKG_VERSION=9e91b02ec7fb3502747b5c413a4824654fa7fc7e
+# TinyUSB 0.15.0
+PKG_VERSION=86c416d4c0fb38432460b3e11b08b9de76941bf5
 
 PKG_LICENSE=MIT
 

--- a/pkg/tinyusb/patches/0002-src-portable-synopsys-define-SystemCoreClock-variabl.patch
+++ b/pkg/tinyusb/patches/0002-src-portable-synopsys-define-SystemCoreClock-variabl.patch
@@ -5,31 +5,30 @@ Subject: [PATCH 2/2] src/portable/synopsys: define SystemCoreClock variable
 
 DWC2 for STM32 uses the `SystemCoreClock` variable from CMSIS which is usually declared/defined in `system_stm32fxxx.{h,c}`and set when function SystemCoreClockUpdate is called. Since RIOT explicitely excludes these files, the variable is neither declared nor defined nor set correctly. Therefore, it is defined in `dwc2_stm32` and set to RIOT's `CLOCK_CORECLOCK` define.
 ---
- src/portable/synopsys/dwc2/dwc2_stm32.h | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ src/portable/synopsys/dwc2/dwc2_stm32.h | 3 +++
+ 1 file changed, 3 insertions(+)
 
 diff --git a/src/portable/synopsys/dwc2/dwc2_stm32.h b/src/portable/synopsys/dwc2/dwc2_stm32.h
-index 1187e0d6e..0c307322d 100644
+index cb455bd9..9564f879 100644
 --- a/src/portable/synopsys/dwc2/dwc2_stm32.h
 +++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
-@@ -82,6 +82,8 @@
-   #error "Unsupported MCUs"
+@@ -99,6 +99,8 @@
+   #define DWC2_EP_MAX   EP_MAX_FS
  #endif
  
 +#include "clk_conf.h"
 +
- // OTG HS always has higher number of endpoints than FS
- #ifdef USB_OTG_HS_PERIPH_BASE
-   #define DWC2_EP_MAX   EP_MAX_HS
-@@ -107,7 +109,7 @@ static const dwc2_controller_t _dwc2_controller[] =
- //--------------------------------------------------------------------+
+ // On STM32 for consistency we associate
+ // - Port0 to OTG_FS, and Port1 to OTG_HS
+ static const dwc2_controller_t _dwc2_controller[] =
+@@ -118,6 +120,7 @@ static const dwc2_controller_t _dwc2_controller[] =
  
- // SystemCoreClock is alrady included by family header
--// extern uint32_t SystemCoreClock;
+ // SystemCoreClock is already included by family header
+ // extern uint32_t SystemCoreClock;
 +static uint32_t SystemCoreClock = CLOCK_CORECLOCK;
  
  TU_ATTR_ALWAYS_INLINE
  static inline void dwc2_dcd_int_enable(uint8_t rhport)
 -- 
-2.17.1
+2.37.2
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Bump to the latest [upstream release](https://github.com/hathach/tinyusb/releases/tag/0.15.0). 


### Testing procedure

 - [x] `tests/pkg_tinyusb_cdc_acm_stdio`
 - [x] `tests/pkg_tinyusb_cdc_msc`
 - [x] `tests/pkg_tinyusb_netdev`

on `weact-f411ce` and `esp32s2-wemos-mini`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
