### PR TITLE
gnrc_dhcpv6_client_simple_pd: select upstream based on type/index

### DIFF
--- a/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
+++ b/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
@@ -37,6 +37,25 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Interface type of the upstream interface
+ *
+ * See @ref netdev_type_t for possible values
+ */
+#ifndef CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_TYPE
+#define CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_TYPE NETDEV_ANY
+#endif
+
+/**
+ * @brief   Interface index of the upstream interface
+ *
+ * If there are multiple interfaces of the same type, set this to select
+ * which one to use for the upstream.
+ */
+#ifndef CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_IDX
+#define CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_IDX (0)
+#endif
+
+/**
  * @brief   6LoWPAN compression context lifetime for configured prefixes in
  *          minutes
  *

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -48,6 +48,12 @@ static gnrc_netif_t *_find_upstream_netif(void)
     if (CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM) {
         return gnrc_netif_get_by_pid(CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM);
     }
+
+    if (CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_TYPE != NETDEV_ANY) {
+        return gnrc_netif_get_by_type(CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_TYPE,
+                                      CONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_IDX);
+    }
+
     while ((netif = gnrc_netif_iter(netif))) {
         if (!gnrc_netif_is_6lo(netif)) {
             LOG_WARNING("DHCPv6: Selecting interface %d as upstream\n",

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -99,9 +99,16 @@ static void _configure_dhcpv6_client(void)
 {
     gnrc_netif_t *netif = NULL;
     gnrc_netif_t *upstream = _find_upstream_netif();
+
+    if (upstream == NULL) {
+        LOG_ERROR("DHCPv6: No upstream interface found!\n");
+        return;
+    }
+
     if (IS_ACTIVE(MODULE_DHCPV6_CLIENT_IA_NA)) {
         upstream->ipv6.aac_mode |= GNRC_NETIF_AAC_DHCP;
     }
+
     while ((netif = gnrc_netif_iter(netif))) {
         if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_6LBR)
             && !gnrc_netif_is_6lo(netif)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This makes it more straightforward to select an upstream interface if there are multiple possible options.


### Testing procedure

Tested `examples/gnrc_border_router` with

    CFLAGS += -DCONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM_TYPE=NETDEV_ESP_WIFI

to set select the WiFi interface as the upstream.
The downstream was `tinyusb_netdev` in my case, so not a 6lo interface that could get auto-selected. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
