### PR TITLE
cpu/stm32/periph/i2c: export PERIPH_I2C_MAX_BYTES_PER_FRAME

### DIFF
--- a/cpu/stm32/include/periph/cpu_i2c.h
+++ b/cpu/stm32/include/periph/cpu_i2c.h
@@ -161,6 +161,19 @@ static const i2c_timing_param_t timing_params[] = {
             CPU_FAM_STM32G0 || CPU_FAM_STM32G4 || CPU_FAM_STM32U5 ||
             CPU_FAM_STM32WB || CPU_FAM_STM32WL */
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
+    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32G0) || \
+    defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32WL)
+/**
+ * @brief   The I2C implementation supports only a limited frame size.
+ *          See i2c_1.c
+ */
+#define PERIPH_I2C_MAX_BYTES_PER_FRAME  (256U)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -51,7 +51,6 @@
 #include "debug.h"
 
 #define TICK_TIMEOUT    (0xFFFF)
-#define MAX_BYTES_PER_FRAME (256)
 
 #define I2C_IRQ_PRIO    (1)
 #define I2C_FLAG_READ   (I2C_READ << I2C_CR2_RD_WRN_Pos)
@@ -217,7 +216,7 @@ int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
 int i2c_read_bytes(i2c_t dev, uint16_t address, void *data,
                    size_t length, uint8_t flags)
 {
-    assert(dev < I2C_NUMOF && length < MAX_BYTES_PER_FRAME);
+    assert(dev < I2C_NUMOF && length < PERIPH_I2C_MAX_BYTES_PER_FRAME);
 
     I2C_TypeDef *i2c = i2c_config[dev].dev;
     assert(i2c != NULL);
@@ -275,7 +274,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t address, const void *data,
 static int _write(I2C_TypeDef *i2c, uint16_t addr, const void *data,
                     size_t length, uint8_t flags, uint32_t cr2_flags)
 {
-    assert(i2c != NULL && length < MAX_BYTES_PER_FRAME);
+    assert(i2c != NULL && length < PERIPH_I2C_MAX_BYTES_PER_FRAME);
 
     /* If reload was NOT set, must either stop or start */
     if ((i2c->ISR & I2C_ISR_TC) && (flags & I2C_NOSTART)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This exports the previously internally defined `MAX_BYTES_PER_FRAME` in `cpu/stm32/periph/i2c_1.c`.
If such a limit exists, a driver must know about it.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

CI

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

The problem came up in #19270.
