### PR TITLE
pkg/nanors: bump version

### DIFF
--- a/pkg/nanors/Makefile
+++ b/pkg/nanors/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanors
 PKG_URL=https://github.com/sleepybishop/nanors.git
-PKG_VERSION=389007b64a66f1c0c38c13bc510da1173cfe6097
+PKG_VERSION=395e5ada44dd8d5974eaf6bb6b17f23406e3ca72
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is just a tiny update that fixes an error that occurs when the number of parity blocks is greater than the number of data blocks. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/pkg_nanors` still works
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
