### PR TITLE
mtd: drop .write() function

### DIFF
--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -197,25 +197,6 @@ struct mtd_desc {
                      uint32_t size);
 
     /**
-     * @brief   Write to the Memory Technology Device (MTD)
-     *
-     * @p addr + @p size must be inside a page boundary. @p addr can be anywhere
-     * but the buffer cannot overlap two pages.
-     *
-     * @param[in] dev       Pointer to the selected driver
-     * @param[in] buff      Pointer to the data to be written
-     * @param[in] addr      Starting address
-     * @param[in] size      Number of bytes
-     *
-     * @return 0 on success
-     * @return < 0 value on error
-     */
-    int (*write)(mtd_dev_t *dev,
-                 const void *buff,
-                 uint32_t addr,
-                 uint32_t size);
-
-    /**
      * @brief   Write to the Memory Technology Device (MTD) using
      *          pagewise addressing.
      *

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -139,10 +139,6 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
         return -ENODEV;
     }
 
-    if (mtd->driver->write) {
-        return mtd->driver->write(mtd, src, addr, count);
-    }
-
     /* page size is always a power of two */
     const uint32_t page_shift = bitarithm_msb(mtd->page_size);
     const uint32_t page_mask = mtd->page_size - 1;
@@ -252,15 +248,6 @@ int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t 
 {
     if (!mtd || !mtd->driver) {
         return -ENODEV;
-    }
-
-    if (mtd->driver->write_page == NULL) {
-        /* TODO: remove when all backends implement write_page */
-        if (mtd->driver->write) {
-            return mtd->driver->write(mtd, src, mtd->page_size * page + offset, count);
-        } else {
-            return -ENOTSUP;
-        }
     }
 
     /* Implementation assumes page size is <= INT_MAX and a power of two. */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

All MTD drivers do now implement the `.write_page()` function instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Code should compile because the function is now unused by all MTD drivers.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

depends on #15380 & #19258
