### PR TITLE
boards: support for the LILYGO TTGO T8 ESP32-S2 board

### DIFF
--- a/boards/esp32s2-lilygo-ttgo-t8/Kconfig
+++ b/boards/esp32s2-lilygo-ttgo-t8/Kconfig
@@ -1,0 +1,61 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32s2-lilygo-ttgo-t8" if BOARD_ESP32S2_LILYGO_TTGO_T8
+
+config BOARD_ESP32S2_LILYGO_TTGO_T8
+    bool
+    default y
+    select BOARD_COMMON_ESP32S2
+    select CPU_MODEL_ESP32S2
+    select HAS_ARDUINO
+    select HAS_ESP_RTC_TIMER_32K if ESP32S2_LILYGO_TTGO_T8_32K_XTAL
+    select HAS_ESP_SPI_RAM
+    select HAS_HIGHLEVEL_STDIO if ESP32S2_LILYGO_TTGO_T8_USB
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_USBDEV
+    select HAS_SDCARD_SPI
+    select HAS_TINYUSB_DEVICE
+    select HAVE_MTD_SDCARD_DEFAULT
+    select HAVE_ST7735
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
+    select MODULE_USBUS_CDC_ACM if MODULE_USBUS
+
+menu "LILYGO TTGO T8 ESP32-S2 Board configurations"
+    depends on BOARD_ESP32S2_LILYGO_TTGO_T8
+
+    config ESP32S2_LILYGO_TTGO_T8_USB
+        bool "USB interface is used instead of USB-to-UART bridge"
+        help
+            The USB D-/D+ signals are connected via DIP switches either to the
+            USB-to-UART bridge (default) or to GPIO19/GPIO20 of the ESP32-S2.
+            To use the USB interface of the ESP32-S2, the USB D-/D+ signals
+            must be connected to GPIO19 and GPIO20 and this option has to be
+            enabled.
+
+    config ESP32S2_LILYGO_TTGO_T8_32K_XTAL
+        bool "32.768 kHz crystal is used"
+        default y
+        help
+            GPIO15 and GPIO16 of the ESP32-S2 are connected via DIP switches
+            either with the on-board 32.768 kHz crystal (default) or the
+            according pins at the extension headers. If the pins at the
+            extension headers are used instead, disable this option.
+
+endmenu
+
+choice STDIO_IMPLEMENTATION
+    default MODULE_STDIO_CDC_ACM if MODULE_USBUS
+    default MODULE_STDIO_TINYUSB_CDC_ACM if MODULE_TINYUSB_DEVICE
+endchoice
+
+source "$(RIOTBOARD)/common/esp32s2/Kconfig"

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32s2
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile.dep
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile.dep
@@ -1,0 +1,19 @@
+ifneq (,$(filter esp32s2-lilygo-ttgo-t8-usb,$(USEMODULE)))
+  include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_sdcard_default
+endif
+
+# default to using fatfs on SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif
+
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += st7735
+endif
+
+include $(RIOTBOARD)/common/esp32s2/Makefile.dep

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile.features
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile.features
@@ -1,0 +1,24 @@
+# the board uses a ESP32-S2 with external 4MB QSPI Flash and external 8MB QSPI PSRAM
+CPU_MODEL = esp32s2
+FEATURES_PROVIDED += esp_spi_ram
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s2/Makefile.features
+
+# peripherals provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_usbdev
+
+# other features provided by the board
+FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += esp_rtc_timer_32k
+FEATURES_PROVIDED += sdcard_spi
+FEATURES_PROVIDED += tinyusb_device
+
+ifneq (,$(filter esp32s2-lilygo-ttgo-t8-usb,$(USEMODULE)))
+  FEATURES_PROVIDED += highlevel_stdio
+endif

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile.include
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile.include
@@ -1,0 +1,7 @@
+PSEUDOMODULES += esp32s2-lilygo-ttgo-t8-usb
+
+ifneq (,$(filter esp32s2-lilygo-ttgo-t8-usb,$(USEMODULE)))
+  PORT_LINUX ?= /dev/ttyACM0
+endif
+
+include $(RIOTBOARD)/common/esp32s2/Makefile.include

--- a/boards/esp32s2-lilygo-ttgo-t8/board.c
+++ b/boards/esp32s2-lilygo-ttgo-t8/board.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s2_lilygo_ttgo_t8
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the LILYGO TTGO T8 ESP32-S2 board
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    if (IS_USED(MODULE_ST7735)) {
+        gpio_init(BACKLIGHT_PIN, GPIO_OUT);
+    }
+}

--- a/boards/esp32s2-lilygo-ttgo-t8/doc.txt
+++ b/boards/esp32s2-lilygo-ttgo-t8/doc.txt
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32s2_lilygo_ttgo_t8 LILYGO TTGO T8 ESP32-S2 Board
+ * @ingroup     boards_esp32s2
+ * @brief       Support for LILYGO TTGO T8 ESP32-S2 Board
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32s2_lilygo_ttgo_t8 LILYGO TTGO T8 ESP32-S2
+
+## Table of Contents {#esp32s2_lilygo_ttgo_t8_toc}
+
+1. [Overview](#esp32s2_lilygo_ttgo_t8_overview)
+2. [Hardware](#esp32s2_lilygo_ttgo_t8_hardware)
+    1. [MCU](#esp32s2_lilygo_ttgo_t8_mcu)
+    2. [Board Configuration](#esp32s2_lilygo_ttgo_t8_board_configuration)
+    3. [Board Pinout](#esp32s2_lilygo_ttgo_t8_pinout)
+3. [Flashing the Device](#esp32s2_lilygo_ttgo_t8_flashing)
+
+## Overview {#esp32s2_lilygo_ttgo_t8_overview}
+
+The Espressif LILYGO TTGO T8 ESP32-S2 is a ESP32-S2 board with an OLED Display
+(not yet supported) and a TF Card slot.
+
+\image html https://ae01.alicdn.com/kf/H8062f551fe7b4233809294d4a5b1d45d1.jpg "LILYGO TTGO T8 ESP32-S2" width=600px
+
+The board has following main features:
+
+Feature              | Support
+:--------------------|:-------
+ESP32-S2 SoC         | yes
+4 MB Flash           | yes
+8 MB QSPI RAM        | yes
+SD Card slot         | yes
+32.768KHz Crystal    | yes
+OLED display ST77789 | no
+
+[Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
+
+## Hardware {#esp32s2_lilygo_ttgo_t8_hardware}
+
+This section describes
+
+- the [MCU](#esp32s2_lilygo_ttgo_t8_mcu),
+- the default [board configuration](#esp32s2_lilygo_ttgo_t8_board_configuration),
+- [optional hardware configurations](#esp32s2_lilygo_ttgo_t8_optional_hardware),
+- the [board pinout](#esp32s2_lilygo_ttgo_t8_pinout).
+
+[Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
+
+### MCU {#esp32s2_lilygo_ttgo_t8_mcu}
+
+Most features of the board are provided by the ESP32-S2 SoC. For detailed
+information about the ESP32-S2 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
+
+### Board Configuration {#esp32s2_lilygo_ttgo_t8_board_configuration}
+
+The LILYGO TTGO T8 ESP32-S2 board uses the `SPI_DEV(0)` (FSPI) for the
+OLED Display. The GPIOs of `SPI_DEV(0)` are therefore not broken out.
+SPI_DEV(1) is used for the SD Card slot. These GPIOs are broken out and
+can also be used by other devices.
+
+The LILYGO TTGO T8 ESP32-S2 has a USB-to-UART bridge on board. The USB D-/D+
+signals of the USB-C connector are connected via DIP switches either to this
+USB-to-UART bridge (default) or to GPIO19/GPIO20 of the ESP32-S2. To use the
+USB-OTG interface of the ESP32-S2, the USB D-/D+ signals must be connected to
+GPIO19 and GPIO20, see section \ref esp32s2_lilygo_ttgo_t8_pinout "Pinout".
+If the USB-to-UART bridge is used, module `stdio_cdc_acm` or module
+`stdio_tinyusb_cdc_acm` can be enabled to use the USB interface also for the
+console.
+
+The LILYGO TTGO T8 ESP32-S2 has a 32.768 kHz crystal on the board, which is
+connected to GPIO15 and GPIO16 via DIP switches (default). The crystal can
+be switched off via the DIP switches so that GPIO15 and GPIO16 become available
+at the headers, see section \ref esp32s2_lilygo_ttgo_t8_pinout "Pinout".
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks | Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO0  | | |
+ADC_LINE(n)     | GPIO1 ... GPIO9 | | \ref esp32_adc_channels "ADC Channels"
+DAC_LINE(n)     | GPIO17, GPIO18 | | \ref esp32_dac_channels "DAC Channels"
+GPIO38          | GPIO38 | OLED RESET (not broken out) | |
+I2C_DEV(0) SCL  | GPIO7 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0) SDA  | GPIO8 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+PWM_DEV(0)      | GPIO39, GPIO40, GPIO41, GPIO42 | - | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1)      | GPIO15, GPIO16 | if module `esp_rtc_timer_32k` is not used | \ref esp32_pwm_channels "PWM Channels"
+SPI_DEV(0) CLK  | GPIO36 | OLED CLK (not broken out) | |
+SPI_DEV(0) MISO | GPIO37 | OLED MISO (not broken out) | |
+SPI_DEV(0) MOSI | GPIO35 | OLED MOSI (not broken out) | |
+SPI_DEV(0) CS0  | GPIO34 | OLED CS0 (not broken out) | |
+SPI_DEV(1) CLK  | GPIO12 | SD Card CLK | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) MISO | GPIO37 | SD Card MISO | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) MOSI | GPIO35 | SD Card MOSI | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) CS0  | GPIO34 | SD Card CS | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0) TxD | GPIO43 | Console | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0) RxD | GPIO44 | Console | \ref esp32_uart_interfaces "UART interfaces"
+USB D-          | GPIO19 | if USB-to-UART bridge is not used | |
+USB D+          | GPIO20 | if USB-to-UART bridge is not used | |
+</center>
+\n
+
+For detailed information about the peripheral configurations of ESP32-S2
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
+
+### Board Pinout {#esp32s2_lilygo_ttgo_t8_pinout}
+
+The following figure shows the pinout as configured by the board
+definition.
+
+@image html https://ae01.alicdn.com/kf/H4a77f8684c144384a165d7a89476c602q.jpg "LILYGO TTGO T8 ESP32-S2 Pinout" width=900px
+
+The corresponding board schematics can be found [here]
+(https://github.com/Xinyuan-LilyGO/LilyGo-T-Display-S2/raw/master/schematic/ESP32_S2-Display.pdf)
+
+[Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
+
+## Flashing the Device {#esp32s2_lilygo_ttgo_t8_flashing}
+
+Flashing RIOT is quite easy. The board has an USB-C connector which is either
+connected to the USB-to-UART bridge (default) with a built-in reset/boot/flash
+logic or to the USB signals of the ESP32-S2 SoC. The flash method depends on
+the configuration of the DIP switches,
+see section \ref esp32s2_lilygo_ttgo_t8_pinout "Pinout".
+
+### USB-C connector is connected to the USB-to-UART bridge (default)
+
+Just connect the board to your host computer and type using the programming
+port:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s2-liligo-ttgo-t8 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For detailed information about ESP32-S2 as well as configuring and compiling
+RIOT for ESP32-S2 boards, see \ref esp32_riot.
+
+### USB-C connector is connected to the USB signals of the ESP32-S2 SoC
+
+In this configuration the integrated USB-to-JTAG bridge can be used to flash
+the board. The USB-to-JTAG bridge is automatically activated in the download
+mode of the bootloader, provided that the eFuses `JTAG_SEL_ENABLE` and
+`DIS_USB_JTAG` are not burned (see also section
+\ref esp32_jtag_interface_esp32s2 "JTAG Interface" strapping pin GPIO3).
+
+For this purpose, connect the board to your host computer and enter the
+following command using the programming port:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+USEMODULE=esp32s2-lilygo-ttgo-t8-usb BOARD=esp32s2-liligo-ttgo-t8 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If RIOT is already on the device, it should automatically reset the device
+and enter the bootloader download mode. If
+
+- RIOT is not already on the device or
+- automatic reset does not work or
+- the device is stuck in some other mode,
+
+the download mode has to be forced before by pressing the Reset (RST) button
+while holding the BOOT (BOT) button.
+
+[Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
+ */

--- a/boards/esp32s2-lilygo-ttgo-t8/include/arduino_board.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/arduino_board.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s2_lilygo_ttgo_t8
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is not available
+ */
+#define ARDUINO_LED         (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/esp32s2-lilygo-ttgo-t8/include/arduino_pinmap.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/arduino_pinmap.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s2_lilygo_ttgo_t8
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO44      /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO43      /**< Arduino Uno pin 1 (TxD) */
+#define ARDUINO_PIN_2   GPIO21      /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO39      /**< Arduino Uno pin 3 (PWM) */
+#define ARDUINO_PIN_4   GPIO21      /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO40      /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO41      /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO17      /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO18      /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO42      /**< Arduino Uno pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO38      /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO35      /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO37      /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO36      /**< Arduino Uno pin 13 (SCK)  */
+
+#define ARDUINO_PIN_A0  GPIO1       /**< Arduino Uno pin A0 */
+#define ARDUINO_PIN_A1  GPIO2       /**< Arduino Uno pin A1 */
+#define ARDUINO_PIN_A2  GPIO4       /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO5       /**< Arduino Uno pin A3 */
+
+#define ARDUINO_PIN_A4  GPIO7       /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO8       /**< Arduino Uno pin A5 (SCL) */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/esp32s2-lilygo-ttgo-t8/include/board.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/board.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s2_lilygo_ttgo_t8
+ * @brief       Board definitions for the LILYGO TTGO T8 ESP32-S2 board
+ * @{
+ *
+ * The board definitions in this file are valid for the LILYGO TTGO T8 ESP32-S2
+ * board.
+ *
+ * @note
+ * Most definitions can be overridden by an
+ * \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * LILYGO TTGO T8 ESP32-S2 boards have a BOOT button connected to GPIO0, which
+ * can be used as button during normal operation. Since the GPIO9 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name SD-Card interface configuration
+ *
+ * SD-Card interface uses SPI_DEV(1) on this board.
+ * @{
+ */
+#if (MODULE_SDCARD_SPI) || DOXYGEN
+#define SDCARD_SPI_PARAM_SPI        SPI_DEV(1)
+#define SDCARD_SPI_PARAM_CS         SPI1_CS0
+#define SDCARD_SPI_PARAM_CLK        SPI1_SCK
+#define SDCARD_SPI_PARAM_MOSI       SPI1_MOSI
+#define SDCARD_SPI_PARAM_MISO       SPI1_MISO
+#define SDCARD_SPI_PARAM_POWER      GPIO_UNDEF
+#endif
+/** @} */
+
+/**
+ * @name OLED display configuration
+ *
+ * OLED display uses SPI_DEV(0) on this board.
+ * @{
+ */
+#if defined(MODULE_ST7735)
+#define ST7735_PARAM_SPI            SPI_DEV(1)      /**< SPI device */
+#define ST7735_PARAM_SPI_CLK        SPI_CLK_5MHZ    /**< SPI clock frequency */
+#define ST7735_PARAM_SPI_MODE       SPI_MODE_0      /**< SPI mode */
+#define ST7735_PARAM_CS             GPIO34          /**< Chip Select pin */
+#define ST7735_PARAM_DCX            GPIO37          /**< DCX pin */
+#define ST7735_PARAM_RST            GPIO38          /**< Reset pin */
+#define ST7735_PARAM_RGB            1               /**< RGB mode enable */
+#define ST7735_PARAM_INVERTED       0               /**< Inverted mode enable */
+#define ST7735_PARAM_NUM_LINES      135U            /**< Number of lines */
+#define ST7735_PARAM_RGB_CHANNELS   240U            /**< Number of columns */
+#endif
+/** @} */
+
+/**
+ * @name    Backlight control
+ * @{
+ */
+#define BACKLIGHT_PIN   GPIO33                      /**< Backlight pin */
+#define BACKLIGHT_ON    gpio_set(BACKLIGHT_PIN)     /**< Turn backlight on */
+#define BACKLIGHT_OFF   gpio_clear(BACKLIGHT_PIN)   /**< Turn backlight off */
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32s2-lilygo-ttgo-t8/include/gpio_params.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32s2_lilygo_ttgo_t8
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32s2-lilygo-ttgo-t8/include/periph_conf.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/periph_conf.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s2_lilygo_ttgo_t8
+ * @brief       Peripheral configurations for the LILYGO TTGO T8 ESP32-S2 board
+ * @{
+ *
+ * The peripheral configurations in this file can be used for the
+ * LILYGO TTGO T8 ESP32-S2 board.
+ *
+ * For detailed information about the peripheral configuration for ESP32-S2
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an
+ * \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * All ADC pins of ADC1 that are broken out are declared as ADC channels except
+ * GPIO3 which is a strapping pin. GPIO7 and GPIO8 are also used by `I2C_DEV(0)`
+ * if enabled. GPIO9 is not broken out and used to measure V_BAT.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO1, GPIO2, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO9 }
+#endif
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
+ * channels with the `dac_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { GPIO17, GPIO18 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * Only one I2C interface I2C_DEV(0) is defined.
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO7           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO8           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * Two PWM devices are configured. These devices
+ * contain all GPIOs that are not defined as I2C, SPI or UART for this board.
+ * Generally, all outputs pins could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO39, GPIO40, GPIO41, GPIO42 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ *
+ * These PWM channels cannot be used if an external 32 kHz crystal is
+ * connected to the board at GPIO15 and GPIO16 (configured by the DIP switches).
+ */
+#ifndef MODULE_ESP_RTC_TIMER_32K
+#ifndef PWM1_GPIOS
+#define PWM1_GPIOS  { GPIO15, GPIO16 }
+#endif
+#endif
+
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * SPI_DEV(0) is used for the Display. The GPIOs are not broken out.<br>
+ * SPI_DEV(1) is used for the SD Card slot. The GPIOs are broken out and can
+ * also be used by other devices.
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   FSPI    /**< FSPI (SPI Controller 2) is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO36  /**< FSPICLK used as signal `OLED_CLK` */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO37  /**< FSPIQ used as Display signal `OLED_MISO` */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO35  /**< FSPID used as Display signal `OLED_MOSI` */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO34  /**< FSPICS0 used as Display signal `OLED_CS` */
+#endif
+
+#ifndef SPI1_CTRL
+#define SPI1_CTRL   HSPI    /**< HSPI (SPI Controller 3) is used as SPI_DEV(1) */
+#endif
+#ifndef SPI1_SCK
+#define SPI1_SCK    GPIO12  /**< SPI SCK */
+#endif
+#ifndef SPI1_MISO
+#define SPI1_MISO   GPIO13  /**< SPI MISO */
+#endif
+#ifndef SPI1_MOSI
+#define SPI1_MOSI   GPIO11  /**< SPI MOSI */
+#endif
+#ifndef SPI1_CS0
+#define SPI1_CS0    GPIO10  /**< SPI CS0 used for Display */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S2 provides 2 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -858,7 +858,7 @@ as DAC channels with the #dac_init function, they can be used for other
 purposes.
 
 DACs are currently only supported for the \ref esp32_dac_channels_esp32
-"ESP32 SoC" variant.
+"ESP32 SoC" and the \ref esp32_dac_channels_esp32s2 "ESP32-S2 SoC" variant.
 
 [Back to table of contents](#esp32_toc)
 

--- a/cpu/esp32/doc_esp32s2.txt
+++ b/cpu/esp32/doc_esp32s2.txt
@@ -91,8 +91,8 @@ GPIO13 | In/Out | X   | X    | X       | -                | -
 GPIO14 | In/Out | X   | X    | X       | -                | -
 GPIO15 | In/Out | X   | X    | X       | XTAL_32K_P       | External 32k crystal
 GPIO16 | In/Out | X   | X    | X       | XTAL_32K_N       | External 32k crystal
-GPIO17 | In/Out | X   | X    | X       | -                | -
-GPIO18 | In/Out | X   | X    | X       | -                | -
+GPIO17 | In/Out | X   | X    | X       | DAC1             | -
+GPIO18 | In/Out | X   | X    | X       | DAC2             | -
 GPIO19 | In/Out | X   | X    | X       | USB D-           | USB 2.0 OTG / USB-JTAG bridge
 GPIO20 | In/Out | X   | X    | X       | USB D+           | USB 2.0 OTG / USB-JTAG bridge
 GPIO21 | In/Out | -   | X    | X       | -                | -
@@ -173,6 +173,10 @@ total:
 - Vref can be read with function #adc_line_vref_to_gpio at any ADC2 channel,
   that is at GPIO11 ... GPIO20.
 - GPIO3 is a strapping pin und shouldn't be used as ADC channel
+
+## DAC Channels {#esp32_dac_channels_esp32s2}
+
+ESP32 SoC supports 2 DAC lines at GPIO17 and GPIO18.
 
 ## I2C Interfaces {#esp32_i2c_interfaces_esp32s2}
 

--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -59,7 +59,7 @@ static uint32_t fill_memory(struct node *head)
 
     total = 0;
     while (head && (head->ptr = malloc(CHUNK_SIZE)) && total < MAX_MEM) {
-        printf("Allocated %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
+        printf("Allocated %"PRIu32" Bytes at %p, total %"PRIu32"\n",
                (uint32_t)CHUNK_SIZE, head->ptr, total += CHUNK_SIZE);
         memset(head->ptr, '@', CHUNK_SIZE);
         head = head->next = malloc(sizeof(struct node));
@@ -88,7 +88,7 @@ static void free_memory(struct node *head)
                 total -= CHUNK_SIZE;
                 freed++;
             }
-            printf("Free %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
+            printf("Free %"PRIu32" Bytes at %p, total %"PRIu32"\n",
                    (uint32_t)CHUNK_SIZE, head->ptr, total);
             free(head->ptr);
         }


### PR DESCRIPTION
### Contribution description

This PR provides the support for the LILYGO TTGO T8 ESP32-S2 board which has a OLED display (not yet supported) and a SD-Card slot on board.

The board is equipped with a USB-C connector that connects either to a USB-to-UART bridge or to the USB-OTG/JTAG interface of the ESP32-S2 via some DIP switches.

The PR includes a very small fix of printf format string in `tests/malloc`. I can split it off.

### Testing procedure

t.b.d.

### Issues/PRs references
