### PR TITLE
rust: Update riot-sys and riot-wrappers

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "riot-sys"
 version = "0.7.9"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8397c2ae343289daaa0b1bff584744af329210d9"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#81d791789e07a2e1019385ef2d1665348dea1df4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -579,8 +579,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#fef42fadc02f4f0cf2bb7d8e6b7b522b91bba058"
+version = "0.8.1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9c29faf55d4c14d2d7f55f8df5059c52af4e5317"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 [[package]]
 name = "riot-sys"
 version = "0.7.9"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8397c2ae343289daaa0b1bff584744af329210d9"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#81d791789e07a2e1019385ef2d1665348dea1df4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -460,8 +460,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#fef42fadc02f4f0cf2bb7d8e6b7b522b91bba058"
+version = "0.8.1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9c29faf55d4c14d2d7f55f8df5059c52af4e5317"
 dependencies = [
  "bare-metal",
  "cstr",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 [[package]]
 name = "riot-sys"
 version = "0.7.9"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8397c2ae343289daaa0b1bff584744af329210d9"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#81d791789e07a2e1019385ef2d1665348dea1df4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -460,8 +460,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#fef42fadc02f4f0cf2bb7d8e6b7b522b91bba058"
+version = "0.8.1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9c29faf55d4c14d2d7f55f8df5059c52af4e5317"
 dependencies = [
  "bare-metal",
  "cstr",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 [[package]]
 name = "riot-sys"
 version = "0.7.9"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8397c2ae343289daaa0b1bff584744af329210d9"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#81d791789e07a2e1019385ef2d1665348dea1df4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -460,8 +460,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#fef42fadc02f4f0cf2bb7d8e6b7b522b91bba058"
+version = "0.8.1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9c29faf55d4c14d2d7f55f8df5059c52af4e5317"
 dependencies = [
  "bare-metal",
  "cstr",


### PR DESCRIPTION
### Contribution description

rust: Update riot-sys and riot-wrappers

* riot-wrappers:
  * Fix infinite loop when using a Mutex
  * Make ValueInThread Copy/Clone
* riot-sys:
  * Export xxx_DEV (eg. I2C_DEV) C macros as functions
  * Add auto_init_utils.h

### Testing procedure

CI checks should suffice.

### Issues/PRs references

This pulls in fixes from

* https://github.com/RIOT-OS/rust-riot-sys/pull/18
* https://github.com/RIOT-OS/rust-riot-sys/pull/17 / https://github.com/RIOT-OS/rust-riot-wrappers/issues/37
* https://github.com/RIOT-OS/rust-riot-wrappers/pull/42 / https://github.com/RIOT-OS/rust-riot-wrappers/issues/41
