### PR TITLE
sys/crypto: make AES_KEY struct private & rename it

### DIFF
--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -32,8 +32,6 @@
  * @}
  */
 
-#include <stdio.h>
-#include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -62,6 +60,16 @@
 #  define AES_KEY_SIZE(ctx) ctx->key_size
 #endif
 
+/**
+ * @brief AES key
+ * @see cipher_context_t
+ */
+typedef struct {
+    /** @cond INTERNAL */
+    uint32_t rd_key[4 * (AES_MAXNR + 1)];
+    int rounds;
+    /** @endcond */
+} aes_key_t;
 /**
  * Interface to the aes cipher
  */
@@ -860,7 +868,7 @@ int aes_init(cipher_context_t *context, const uint8_t *key, uint8_t keySize)
  * Expand the cipher key into the encryption key schedule.
  */
 static int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
-                               AES_KEY *key)
+                               aes_key_t *key)
 {
     u32 *rk;
     int i = 0;
@@ -979,7 +987,7 @@ static int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
  * Expand the cipher key into the decryption key schedule.
  */
 static int aes_set_decrypt_key(const unsigned char *userKey, const int bits,
-                               AES_KEY *key)
+                               aes_key_t *key)
 {
     u32 *rk;
     int i, j;
@@ -1062,8 +1070,8 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plainBlock,
 {
     /* setup AES_KEY */
     int res;
-    AES_KEY aeskey;
-    const AES_KEY *key = &aeskey;
+    aes_key_t aeskey;
+    const aes_key_t *key = &aeskey;
 
     res = aes_set_encrypt_key((unsigned char *)context->context,
                               AES_KEY_SIZE(context) * 8, &aeskey);
@@ -1331,8 +1339,8 @@ int aes_decrypt(const cipher_context_t *context, const uint8_t *cipherBlock,
 {
     /* setup AES_KEY */
     int res;
-    AES_KEY aeskey;
-    const AES_KEY *key = &aeskey;
+    aes_key_t aeskey;
+    const aes_key_t *key = &aeskey;
 
     res = aes_set_decrypt_key((unsigned char *)context->context,
                               AES_KEY_SIZE(context) * 8, &aeskey);

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -30,10 +30,6 @@
 #ifndef CRYPTO_AES_H
 #define CRYPTO_AES_H
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include "crypto/ciphers.h"
 
@@ -63,17 +59,6 @@ typedef uint8_t u8;
 #define AES_KEY_SIZE_192    24
 #define AES_KEY_SIZE_256    32
 /** @} */
-
-/**
- * @brief AES key
- * @see cipher_context_t
- */
-typedef struct aes_key_st {
-    /** @cond INTERNAL */
-    uint32_t rd_key[4 * (AES_MAXNR + 1)];
-    int rounds;
-    /** @endcond */
-} AES_KEY;
 
 /**
  * @brief the cipher_context_t-struct adapted for AES

--- a/tests/sys_crypto/tests-crypto-aes.c
+++ b/tests/sys_crypto/tests-crypto-aes.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include <string.h>
 #include <limits.h>
 
 #include "embUnit.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This struct is only used internally and it's naming does not follow the RIOT coding convention.


### Testing procedure

Code should still compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/18148#issuecomment-1437337900
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
