### PR TITLE
sys/shell: don't include suit command by default

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -26,6 +26,7 @@ USEMODULE += gnrc_icmpv6_echo
 # include this for printing IP addresses
 USEMODULE += shell
 USEMODULE += shell_cmds_default
+USEMODULE += shell_cmd_suit
 
 # Set this to 1 to enable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -129,9 +129,6 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter sht1x,$(USEMODULE)))
     USEMODULE += shell_cmd_sht1x
   endif
-  ifneq (,$(filter suit_transport_worker,$(USEMODULE)))
-    USEMODULE += shell_cmd_suit
-  endif
   ifneq (,$(filter vfs,$(USEMODULE)))
     USEMODULE += shell_cmd_vfs
   endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `suit` command is pretty expensive as it calls `suit_worker_trigger()` which starts the SUIT worker thread.
If this function is not called otherwise, this will pull in the (quite substantial) suit worker thread stack.


### Testing procedure

If your application calls `suit_handle_url()` directly (doesn't make use of the worker thread) this saves `3 * THREAD_STACKSIZE_LARGE` Bytes of RAM.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
