### PR TITLE
gcoap: Finish the gcoap_get_resource_list_tl -> gcoap_get_resource_list renaming

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -1100,8 +1100,7 @@ uint8_t gcoap_op_state(void);
  *                      (i.e. usage of modules no `gcoap_dtls`, ...) this will
  *                      be ignored and @ref GCOAP_SOCKET_TYPE_UDP assumed.
  *
- * @todo    add support for `JSON CoRE Link Format`
- * @todo    add support for 'CBOR CoRE Link Format`
+ * @todo    add support for CoRAL once it is done
  *
  * @return  the number of bytes written to @p buf
  * @return  -1 on error

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -1087,9 +1087,6 @@ uint8_t gcoap_op_state(void);
  * @brief   Get the resource list, currently only `CoRE Link Format`
  *          (COAP_FORMAT_LINK) supported
  *
- * @deprecated Will be an alias for @ref gcoap_get_resource_list after the
- *             2022.01 release. Will be removed after the 2022.04 release.
- *
  * If @p buf := NULL, nothing will be written but the size of the resulting
  * resource list is computed and returned.
  *
@@ -1109,31 +1106,8 @@ uint8_t gcoap_op_state(void);
  * @return  the number of bytes written to @p buf
  * @return  -1 on error
  */
-int gcoap_get_resource_list_tl(void *buf, size_t maxlen, uint8_t cf,
+int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf,
                                gcoap_socket_type_t tl_type);
-
-/**
- * @brief   Get the resource list for all transports,
- *          currently only `CoRE Link Format` (COAP_FORMAT_LINK) supported
- *
- * If @p buf := NULL, nothing will be written but the size of the resulting
- * resource list is computed and returned.
- *
- * @param[out] buf      output buffer to write resource list into, my be NULL
- * @param[in]  maxlen   length of @p buf, ignored if @p buf is NULL
- * @param[in]  cf       content format to use for the resource list, currently
- *                      only COAP_FORMAT_LINK supported
- *
- * @todo    add support for `JSON CoRE Link Format`
- * @todo    add support for 'CBOR CoRE Link Format`
- *
- * @return  the number of bytes written to @p buf
- * @return  -1 on error
- */
-static inline int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
-{
-    return gcoap_get_resource_list_tl(buf, maxlen, cf, GCOAP_SOCKET_TYPE_UNDEF);
-}
 
 /**
  * @brief   Writes a resource in CoRE Link Format to a provided buffer.

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -286,7 +286,7 @@ int cord_ep_register(const sock_udp_ep_t *remote, const char *regif)
 
     /* add the resource description as payload */
     res = gcoap_get_resource_list(pkt.payload, pkt.payload_len,
-                                  COAP_FORMAT_LINK);
+                                  COAP_FORMAT_LINK, GCOAP_SOCKET_TYPE_UNDEF);
     if (res < 0) {
         retval = CORD_EP_ERR;
         goto end;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -946,7 +946,7 @@ static ssize_t _well_known_core_handler(coap_pkt_t* pdu, uint8_t *buf, size_t le
     coap_opt_add_format(pdu, COAP_FORMAT_LINK);
     ssize_t plen = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
 
-    plen += gcoap_get_resource_list_tl(pdu->payload, (size_t)pdu->payload_len,
+    plen += gcoap_get_resource_list(pdu->payload, (size_t)pdu->payload_len,
                                        COAP_FORMAT_LINK,
                                        (gcoap_socket_type_t)coap_request_ctx_get_tl_type(ctx));
     return plen;
@@ -1706,7 +1706,7 @@ uint8_t gcoap_op_state(void)
     return count;
 }
 
-int gcoap_get_resource_list_tl(void *buf, size_t maxlen, uint8_t cf,
+int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf,
                                gcoap_socket_type_t tl_type)
 {
     assert(cf == COAP_FORMAT_LINK);

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -378,15 +378,15 @@ static void test_gcoap__server_get_resource_list(void)
     gcoap_register_listener(&listener);
     gcoap_register_listener(&listener_second);
 
-    size = gcoap_get_resource_list(NULL, 0, COAP_FORMAT_LINK);
+    size = gcoap_get_resource_list(NULL, 0, COAP_FORMAT_LINK, GCOAP_SOCKET_TYPE_UNDEF);
     TEST_ASSERT_EQUAL_INT(strlen(resource_list_str), size);
 
     res[0] = 'A';
-    size = gcoap_get_resource_list(res, 0, COAP_FORMAT_LINK);
+    size = gcoap_get_resource_list(res, 0, COAP_FORMAT_LINK, GCOAP_SOCKET_TYPE_UNDEF);
     TEST_ASSERT_EQUAL_INT(0, size);
     TEST_ASSERT_EQUAL_INT((int)'A', (int)res[0]);
 
-    size = gcoap_get_resource_list(res, 127, COAP_FORMAT_LINK);
+    size = gcoap_get_resource_list(res, 127, COAP_FORMAT_LINK, GCOAP_SOCKET_TYPE_UNDEF);
     res[size] = '\0';
     TEST_ASSERT_EQUAL_INT(strlen(resource_list_str), size);
     TEST_ASSERT_EQUAL_STRING(resource_list_str, (char *)res);


### PR DESCRIPTION
### Contribution description

In #16688, an argument was added to the `gcoap_get_resource_list` function by creating a new function `gcoap_get_resource_list_tl` with a deprecation and roll-over plan.

This plan has not been acted on so far.

This PR shortens the original plan by just adding the argument to `gcoap_get_resource_list` and removing `gcoap_get_resource_list_tl` in a single go. The rationale for this deviation is that while it's a public API, its only two practical consumers are the (built-in) well-known/core implementation, and the (built-in) CoRE Resource Directory (cord) endpoint. Moreover, a further change to this API (switching over to `coap_block_slicer_t`) is expected to happen within this release cycle, which would take something like 4 total releases to get through otherwise, which is unrealistic for an API that there are no known external users of.

A second commit clean up ToDo items (in the changed function's documentation) that referred to a IETF draft that has long been abandoned by the CoRE WG.

### Testing procedure

Plain inspection and CI passing should suffice.

### AOB

There is a second analogous pair left over from #16688, `gcoap_req_send` / `gcoap_req_send_tl`. As that *is* expected to be used widely, I prefer not to mix these two concerns, and get the present one through without unnecessary hold-up.