### PR TITLE
nanocoap: allow to define CoAP resources as XFA

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -18,6 +18,7 @@ USEMODULE += sock_udp
 USEMODULE += gnrc_icmpv6_echo
 
 USEMODULE += nanocoap_sock
+USEMODULE += nanocoap_server
 
 USEMODULE += xtimer
 

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -18,7 +18,7 @@ USEMODULE += sock_udp
 USEMODULE += gnrc_icmpv6_echo
 
 USEMODULE += nanocoap_sock
-USEMODULE += nanocoap_server
+USEMODULE += nanocoap_resources
 
 USEMODULE += xtimer
 
@@ -41,6 +41,23 @@ ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   $(info Using low-memory configuration for microcoap_server.)
   ## low-memory tuning values
   USEMODULE += prng_minstd
+endif
+
+# Enable fileserver for boards with plenty of memory
+HIGH_MEMORY_BOARDS := native same54-xpro mcb2388
+
+ifneq (,$(filter $(BOARD),$(HIGH_MEMORY_BOARDS)))
+  USEMODULE += gcoap_fileserver
+  USEMODULE += vfs_default
+
+  # we don't want to run GCoAP
+  CFLAGS += -DCONFIG_GCOAP_NO_AUTO_INIT=1
+  CFLAGS += -DCONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE=1
+
+  # always enable auto-format for native
+  ifeq ($(BOARD),native)
+    USEMODULE += vfs_auto_format
+  endif
 endif
 
 # Change this to 0 show compiler invocation lines by default:

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -181,3 +181,23 @@ NANOCOAP_RESOURCE(ver) {
 NANOCOAP_RESOURCE(sha256) {
     .path = "/sha256", .methods = COAP_POST, .handler = _sha256_handler
 };
+
+/* we can also include the fileserver module */
+#ifdef MODULE_GCOAP_FILESERVER
+#include "net/gcoap/fileserver.h"
+#include "vfs_default.h"
+
+NANOCOAP_RESOURCE(fileserver) {
+    .path = "/vfs",
+    .methods = COAP_GET
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
+      | COAP_PUT
+#endif
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
+      | COAP_DELETE
+#endif
+      | COAP_MATCH_SUBTREE,
+    .handler = gcoap_fileserver_handler,
+    .context = VFS_DEFAULT_DATA
+};
+#endif

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -166,14 +166,18 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_request_
     return pkt_pos - (uint8_t*)pkt->hdr;
 }
 
-/* must be sorted by path (ASCII order) */
-const coap_resource_t coap_resources[] = {
-    COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/echo/", COAP_GET | COAP_MATCH_SUBTREE, _echo_handler, NULL },
-    { "/riot/board", COAP_GET, _riot_board_handler, NULL },
-    { "/riot/value", COAP_GET | COAP_PUT | COAP_POST, _riot_value_handler, NULL },
-    { "/riot/ver", COAP_GET, _riot_block2_handler, NULL },
-    { "/sha256", COAP_POST, _sha256_handler, NULL },
+NANOCOAP_RESOURCE(echo) {
+    .path = "/echo/", .methods = COAP_GET | COAP_MATCH_SUBTREE, .handler = _echo_handler
 };
-
-const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);
+NANOCOAP_RESOURCE(board) {
+    .path = "/riot/board", .methods = COAP_GET, .handler = _riot_board_handler
+};
+NANOCOAP_RESOURCE(value) {
+    .path = "/riot/value", .methods = COAP_GET | COAP_PUT | COAP_POST, .handler = _riot_value_handler
+};
+NANOCOAP_RESOURCE(ver) {
+    .path = "/riot/ver", .methods = COAP_GET, .handler = _riot_block2_handler
+};
+NANOCOAP_RESOURCE(sha256) {
+    .path = "/sha256", .methods = COAP_POST, .handler = _sha256_handler
+};

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -739,6 +739,15 @@ ifneq (,$(filter nanocoap_dtls,$(USEMODULE)))
   USEPKG += tinydtls
 endif
 
+ifneq (,$(filter nanocoap_server_auto_init,$(USEMODULE)))
+  USEMODULE += nanocoap_server
+endif
+
+ifneq (,$(filter nanocoap_server,$(USEMODULE)))
+  USEMODULE += nanocoap_resources
+  USEMODULE += nanocoap_sock
+endif
+
 ifneq (,$(filter nanocoap_sock,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += sock_util

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -160,6 +160,10 @@ extern void gcoap_init(void);
 AUTO_INIT(gcoap_init,
           AUTO_INIT_PRIO_MOD_GCOAP);
 #endif
+#if IS_USED(MODULE_NANOCOAP_SERVER_AUTO_INIT)
+extern void auto_init_nanocoap_server(void);
+AUTO_INIT(auto_init_nanocoap_server, AUTO_INIT_PRIO_MOD_NANOCOAP);
+#endif
 #if IS_USED(MODULE_DEVFS)
 extern void auto_init_devfs(void);
 AUTO_INIT(auto_init_devfs,

--- a/sys/auto_init/include/auto_init_priorities.h
+++ b/sys/auto_init/include/auto_init_priorities.h
@@ -175,6 +175,12 @@ extern "C" {
 #endif
 #ifndef AUTO_INIT_PRIO_MOD_GCOAP
 /**
+ * @brief   nanoCoAP server priority
+ */
+#define AUTO_INIT_PRIO_MOD_NANOCOAP                     1235
+#endif
+#ifndef AUTO_INIT_PRIO_MOD_GCOAP
+/**
  * @brief   GCoAP priority
  */
 #define AUTO_INIT_PRIO_MOD_GCOAP                        1240

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -90,6 +90,7 @@
 #include "bitfield.h"
 #include "byteorder.h"
 #include "iolist.h"
+#include "macros/utils.h"
 #include "net/coap.h"
 #else
 #include "coap.h"
@@ -100,6 +101,10 @@
 #include "net/sock/udp.h"
 #else
 typedef void sock_udp_ep_t;
+#endif
+
+#if defined(MODULE_NANOCOAP_RESOURCES)
+#include "xfa.h"
 #endif
 
 #ifdef __cplusplus
@@ -402,15 +407,29 @@ typedef struct {
     uint8_t *opt;                   /**< Pointer to the placed option       */
 } coap_block_slicer_t;
 
+#if defined(MODULE_NANOCOAP_RESOURCES) || DOXYGEN
+/**
+ * @brief   CoAP XFA resource entry
+ *
+ * @param name  internal name of the resource entry, must be unique
+ */
+#define NANOCOAP_RESOURCE(name) \
+    XFA_CONST(coap_resources_xfa, 0) coap_resource_t CONCAT(coap_resource_, name) =
+#else
 /**
  * @brief   Global CoAP resource list
+ * @deprecated Use @ref NANOCOAP_RESOURCE instead.
+ *             The function will be removed after the 2024.01 release.
  */
 extern const coap_resource_t coap_resources[];
 
 /**
  * @brief   Number of entries in global CoAP resource list
+ * @deprecated Use @ref NANOCOAP_RESOURCE instead.
+ *             The function will be removed after the 2024.01 release.
  */
 extern const unsigned coap_resources_numof;
+#endif
 
 /**
  * @name    Functions -- Header Read/Write
@@ -2047,6 +2066,13 @@ extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
                                                     uint8_t *buf, size_t len,
                                                     coap_request_ctx_t *context);
 /**@}*/
+
+/**
+ * @brief   Respond to `/.well-known/core` to list all resources on the server
+ */
+#ifndef CONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE
+#define CONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE (1)
+#endif
 
 /**
  * @brief   Checks if a CoAP resource path matches a given URI

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -2071,7 +2071,7 @@ extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
  * @brief   Respond to `/.well-known/core` to list all resources on the server
  */
 #ifndef CONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE
-#define CONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE (1)
+#define CONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE !IS_USED(MODULE_GCOAP)
 #endif
 
 /**

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -160,6 +160,22 @@ extern "C" {
 #endif
 
 /**
+ * @brief   CoAP server work buf size
+ *          Used both for RX and TX, needs to hold payload block + header
+ */
+#ifndef CONFIG_NANOCOAP_SERVER_BUF_SIZE
+#define CONFIG_NANOCOAP_SERVER_BUF_SIZE         ((1 << (CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT + 3)) \
+                                                 + CONFIG_NANOCOAP_URI_MAX + 16)
+#endif
+
+/**
+ * @brief   CoAP server thread stack size
+ */
+#ifndef CONFIG_NANOCOAP_SERVER_STACK_SIZE
+#define CONFIG_NANOCOAP_SERVER_STACK_SIZE       THREAD_STACKSIZE_DEFAULT
+#endif
+
+/**
  * @brief   NanoCoAP socket types
  */
 typedef enum {
@@ -219,6 +235,18 @@ static inline uint16_t nanocoap_sock_next_msg_id(nanocoap_sock_t *sock)
  * @returns     -1 on error
  */
 int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
+
+/**
+ * @brief   Create and start the nanoCoAP server thread
+ *
+ * To automatically start the nanoCoAP server on startup, select the
+ * `nanocoap_server_auto_init` module.
+ *
+ * @param[in] local UDP endpoint to bind to
+ *
+ * @return pid of the server thread
+ */
+kernel_pid_t nanocoap_server_start(const sock_udp_ep_t *local);
 
 /**
  * @brief   Create a CoAP client socket

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -22,16 +22,22 @@
  *
  * ## Server Operation ##
  *
- * See the nanocoap_server example, which is built on the nanocoap_server()
- * function. A server must define an array of coap_resource_t resources for
- * which it responds. See the declarations of `coap_resources` and
- * `coap_resources_numof`. The array contents must be ordered by the resource
- * path, specifically the ASCII encoding of the path characters (digit and
- * capital precede lower case). Also see _Server path matching_ in the base
- * [nanocoap](group__net__nanocoap.html) documentation.
+ * See the nanocoap_server example, which is built on the `nanocoap_server()`
+ * function. A server must define CoAP resources for which it responds.
+ *
+ * Each @ref coap_resource_t is added to the XFA with NANOCOAP_RESOURCE(name)
+ * followed by the declaration of the CoAP resource, e.g.:
+ *
+ * ```C
+ * NANOCOAP_RESOURCE(board) {
+ *   .path = "/board", .methods = COAP_GET, .handler = _board_handler,
+ * };
+ * ```
  *
  * nanocoap itself provides the COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER entry for
  * `/.well-known/core`.
+ *
+ * To use the CoAP resource XFA, enable the `nanocoap_resources` module.
  *
  * ### Handler functions ###
  *

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1409,6 +1409,17 @@ kernel_pid_t gcoap_init(void)
         gcoap_forward_proxy_init();
     }
 
+#ifdef MODULE_NANOCOAP_RESOURCES
+    /* add CoAP resources from XFA */
+    XFA_USE_CONST(coap_resource_t, coap_resources_xfa);
+    static gcoap_listener_t _xfa_listener = {
+        .resources = coap_resources_xfa,
+    };
+    _xfa_listener.resources_len = XFA_LEN(coap_resource_t, coap_resources_xfa),
+
+    gcoap_register_listener(&_xfa_listener);
+#endif
+
     return _pid;
 }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -552,7 +552,8 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
     return len;
 }
 
-ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t token_len, unsigned code, uint16_t id)
+ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token,
+                       size_t token_len, unsigned code, uint16_t id)
 {
     assert(!(type & ~0x3));
     assert(!(token_len & ~0x1f));
@@ -658,7 +659,7 @@ static size_t _encode_uint(uint32_t *val)
 
     /* count number of used bytes */
     uint32_t tmp = *val;
-    while(tmp) {
+    while (tmp) {
         size++;
         tmp >>= 8;
     }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -41,6 +41,24 @@
 #define COAP_RST                (3)
 /** @} */
 
+#ifdef MODULE_NANOCOAP_RESOURCES
+/**
+ * @brief   CoAP resources XFA
+ */
+XFA_INIT_CONST(coap_resource_t, coap_resources_xfa);
+
+/**
+ * @brief   Add well-known .core handler
+ */
+#if CONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE
+NANOCOAP_RESOURCE(well_known_core) COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER;
+#endif
+
+/* re-define coap_resources for compatibility with non-XFA version */
+#define coap_resources ((const coap_resource_t *)coap_resources_xfa)
+#define coap_resources_numof XFA_LEN(coap_resource_t, coap_resources_xfa)
+#endif
+
 static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -817,3 +817,36 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
 
     return 0;
 }
+
+static kernel_pid_t _coap_server_pid;
+static void *_nanocoap_server_thread(void *local)
+{
+    static uint8_t buf[CONFIG_NANOCOAP_SERVER_BUF_SIZE];
+
+    nanocoap_server(local, buf, sizeof(buf));
+
+    return NULL;
+}
+
+kernel_pid_t nanocoap_server_start(const sock_udp_ep_t *local)
+{
+    static char stack[CONFIG_NANOCOAP_SERVER_STACK_SIZE];
+
+    if (_coap_server_pid) {
+        return _coap_server_pid;
+    }
+    _coap_server_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
+                                     THREAD_CREATE_STACKTEST, _nanocoap_server_thread,
+                                     (void *)local, "nanoCoAP server");
+    return _coap_server_pid;
+}
+
+void auto_init_nanocoap_server(void)
+{
+    sock_udp_ep_t local = {
+        .port = COAP_PORT,
+        .family = AF_INET6,
+    };
+
+    nanocoap_server_start(&local);
+}

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -14,6 +14,7 @@ USEMODULE += gnrc_ipv6_default
 # USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 USEMODULE += nanocoap_sock
+USEMODULE += nanocoap_resources
 
 # boards where basic nanocoap functionality fits, but no VFS
 LOW_MEMORY_BOARDS := \

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -72,10 +72,6 @@ static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_re
             COAP_FORMAT_TEXT, (uint8_t*)rsp, p);
 }
 
-/* must be sorted by path (ASCII order) */
-const coap_resource_t coap_resources[] = {
-    COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/value", COAP_GET | COAP_PUT | COAP_POST, _value_handler, NULL },
+NANOCOAP_RESOURCE(value) {
+    .path = "/value", .methods = COAP_GET | COAP_PUT | COAP_POST, .handler = _value_handler,
 };
-
-const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Having to define all CoAP resources in one continuous array is a bit of a hassle.
We have XFA now which is a perfect fit for this kind of thing.

The only caveat is that `coap_handle_req()` lives in `nanocoap.c` which is shared by all CoAP users.
By the nature of XFAs, we can't have them garbage collected by the linker as the linker is what brings them into existence.
So I added a new `nanocoap_resources` pseudo-module that needs to be selected to enable the XFA. This has the advantage that we can use the absence of this module to fall-back to the previous implementation, so existing users are not forced to change their code.

### Testing procedure

`examples/nanocoap_server` still works:

```
$ aiocoap-client coap://[fe80::7837:fcff:fe7d:1aaf%tapbr0]/.well-known/core
application/link-format content was re-formatted
</sha256>,
</riot/ver>,
</riot/value>,
</riot/board>,
</echo/>,
</.well-known/core>
```

unmodified `tests/pkg_edhoc_c` also still works

```
$ aiocoap-client coap://[fe80::7837:fcff:fe7d:1aaf%tapbr0]/.well-known/core
application/link-format content was re-formatted
</.well-known/core>,
</.well-known/edhoc>
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
