### PR TITLE
tests/rmutex: clean up test and reduce stack size

### DIFF
--- a/tests/rmutex/Makefile.ci
+++ b/tests/rmutex/Makefile.ci
@@ -5,19 +5,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
-    bluepill-stm32f030c8 \
-    i-nucleo-lrwan1 \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
-    nucleo-l053r8 \
     samd10-xmini \
-    slstk3400a \
     stk3200 \
     stm32f030f4-demo \
-    stm32f0discovery \
-    stm32g0316-disco \
-    stm32l0538-disco \
     #

--- a/tests/rmutex/README.md
+++ b/tests/rmutex/README.md
@@ -5,7 +5,8 @@ When successful, you should see 5 different threads printing their
 PID, priority and recursion depth. The thread with the lowest priority
 should be able to lock (and unlock) the mutex first, followed by the
 other threads in the order of their priority (highest next). If two
-threads have the same priority the lower thread id should acquire the
+threads have the same priority the thread who comes first in the run queue
+(in this test this is the one with the lower thread id) should acquire the
 lock. The output should look like the following:
 
 ```


### PR DESCRIPTION
### Contribution description

As the title says. This results in a few more boards being able to run the test.

Also, the wording in the README.md is improved to not be interpreted as generally threads with lower thread ID being preferred over threads with higher when locking a mutex.

### Testing procedure

```
make -C tests/rmutex BOARD=foo flash test
```

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/19140