### PR TITLE
Add missing newline to output of telnet example

### DIFF
--- a/examples/telnet_server/main.c
+++ b/examples/telnet_server/main.c
@@ -79,7 +79,7 @@ int main(void)
 
     /* start shell */
     printf("All up, awaiting connection on port %u\n", CONFIG_TELNET_PORT);
-    printf("Local shell disabled");
+    puts("Local shell disabled");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 


### PR DESCRIPTION
### Contribution description

From the commit msg:

> The telnet example prints a line to the console, but it is not ended with a newline. When using pyterm, the last line is then never shown as it reads the console line by line and is waiting for the end of the line.
> 
> This patch swaps use of `printf` for `puts` for the last line printed. This means the missing newline character gets added. This is also done to be consistent with the rest of the file, where puts is used whenever possible instead of printf.


### Testing procedure

1. `cd examples/telnet`
2. `make all flash term`
3. observe the final line "Local shell disabled" is printed, but would not have without this patch


### Issues/PRs references

- none known
