### PR TITLE
dist/tools/insufficient_memory: Minor improvements

### DIFF
--- a/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
@@ -61,7 +61,12 @@ for app in ${APPLICATIONS}; do
         if grep -e overflowed -e "not within region" "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
             make -f "$(dirname "$0")"/Makefile.for_sh DIR="${RIOTBASE}/${application}" BOARD="${BOARD}" Makefile.ci > /dev/null
-        elif grep -e "not whitelisted" -e "unsatisfied feature requirements" "$TMPFILE" > /dev/null; then
+        elif grep -e "not whitelisted" \
+                  -e "unsatisfied feature requirements" \
+                  -e "Some feature requirements are blacklisted:" \
+                  -e "not supported.  Stop." \
+                  -e "let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1" \
+                  "$TMPFILE" > /dev/null; then
             printf "${CWARN}%s${CRESET}\n" "not supported"
         else
             printf "${CERROR}%s${CRESET}\n" "build failed"

--- a/dist/tools/insufficient_memory/create_makefile.ci.sh
+++ b/dist/tools/insufficient_memory/create_makefile.ci.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Copyright (C) 2021 Benjamin Valentin <benjamin.valentin@ml-pa.com>
 #
@@ -7,10 +7,12 @@
 # directory for more details.
 #
 
-MAKE_ARGS="-j4"
+if nproc > /dev/null 2>&1; then
+    MAKE_ARGS="-j$(nproc)"
+fi
 APP_DIR=$(pwd)
 
-if tput colors &> /dev/null && [ "$(tput colors)" -ge 8 ]; then
+if tput colors > /dev/null 2>&1 && [ "$(tput colors)" -ge 8 ]; then
     COK="\e[1;32m"
     CBIG="\e[1;34m"
     CNORMAL="\e[1m"
@@ -28,12 +30,12 @@ else
     CRESET=
 fi
 
-if [ "$1" == "--no-docker" ]; then
-    LOCAL_MAKE_ARGS=${MAKE_ARGS}
+if [ "$1" = "--no-docker" ]; then
+    LOCAL_MAKE_ARGS="${MAKE_ARGS}"
     shift 1
 else
     # Use a standardized build within Docker and with minimal output
-    export DOCKER_MAKE_ARGS=${MAKE_ARGS}
+    export DOCKER_MAKE_ARGS="${MAKE_ARGS}"
     export BUILD_IN_DOCKER=1
 fi
 
@@ -43,21 +45,30 @@ BOARDS=
 
 rm "${APP_DIR}/Makefile.ci" 2>/dev/null
 touch "${APP_DIR}/Makefile.ci"
+TMPFILE="$(mktemp)"
 
-for BOARD in $(make  --no-print-directory info-boards-supported -C "${APP_DIR}"); do
+for BOARD in $(EXTERNAL_BOARD_DIRS="" make  --no-print-directory info-boards-supported -C "${APP_DIR}"); do
     printf "${CNORMAL}%-40s${CRESET}" "${BOARD}"
-    output=$(make BOARD="${BOARD}" ${LOCAL_MAKE_ARGS} clean all -C "${APP_DIR}" 2>&1)
-    if [ "$?" != 0 ]; then
-        if echo "${output}" | grep -e overflowed -e "not within region" > /dev/null; then
+    # disabling warning about globbing and word splitting for LOCAL_MAKE_ARGS,
+    # as this is exactly what we want here
+    # shellcheck disable=SC2086
+    if ! make BOARD="${BOARD}" ${LOCAL_MAKE_ARGS} clean all -C "${APP_DIR}" > "$TMPFILE" 2>&1; then
+        if grep -e overflowed -e "not within region" "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
             BOARDS="${BOARDS} ${BOARD}"
-        elif echo "${output}" | grep -e "not whitelisted" -e "unsatisfied feature requirements" > /dev/null; then
+        elif grep -e "not whitelisted" \
+                  -e "unsatisfied feature requirements" \
+                  -e "Some feature requirements are blacklisted:" \
+                  -e "not supported.  Stop." \
+                  -e "let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1" \
+                  "$TMPFILE" > /dev/null; then
             printf "${CWARN}%s${CRESET}\n" "not supported"
         else
             printf "${CERROR}%s${CRESET}\n" "build failed"
+            cat "$TMPFILE"
         fi
     else
-        if echo "${output}" | grep -e "skipping link step" > /dev/null; then
+        if grep -e "skipping link step" "$TMPFILE" > /dev/null; then
             printf "${CSKIP}%s${CRESET}\n" "skipped"
         else
             printf "${COK}%s${CRESET}\n" "OK"


### PR DESCRIPTION
### Contribution description

`create_makefile.sh`:
- address all shellcheck warnings
- make script POSIX shell compatible
- use nproc to set the number of parallel jobs to increase throughput
- print error messages when building fails
- run `make info-boards-supported` with `EXTERNAL_BOARD_DIRS=""` to avoid adding out-of-tree boards to `Makefile.ci`.
- classify output as "not supported" also when used features are blacklisted, not only when required features are missing

`add_insufficient_memory_board.sh`:
- classify output as "not supported" also when used features are blacklisted, not only when required features are missing

### Testing procedure

Run the script; it should still work.

### Issues/PRs references

None