### PR TITLE
matrix_keypad: Move documentation to doxygen group

### DIFF
--- a/drivers/include/matrix_keypad.h
+++ b/drivers/include/matrix_keypad.h
@@ -11,12 +11,6 @@
  * @ingroup     drivers_sensors
  * @brief       Matrix keypad driver for row/column keypads
  *
- * @{
- *
- * @file
- *
- * @author      Koen Zandberg <koen@bergzand.net>
- *
  * This module implements a simple matrix keypad driver where keys are connected
  * between GPIO columns and rows. It works best with diodes in series with the
  * switches to prevent key ghosting, but it can be used without these diodes.
@@ -46,6 +40,13 @@
  * When a state change is detected on a switch, the @ref matrix_keypad_cb_t
  * callback is called with the row and column number together with the new state
  * of the switch (pressed or not pressed).
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the matrix keypad
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
  */
 
 #ifndef MATRIX_KEYPAD_H


### PR DESCRIPTION
### Contribution description

This moves the documentation for the matrix keypad module from the header file to the doxygen group. With this a reader doesn't have to click to the header file definitions from the doxygen group to read the documentation.

### Testing procedure

Take a brief look at the generated doxygen.


### Issues/PRs references

None
