### PR TITLE
nanocoap_link_format: fix off-by-one error

### DIFF
--- a/sys/net/application_layer/nanocoap/link_format.c
+++ b/sys/net/application_layer/nanocoap/link_format.c
@@ -85,7 +85,7 @@ int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
     char buffer[CONFIG_NANOCOAP_QS_MAX];
     struct dir_list_ctx ctx = {
         .buf = buffer,
-        .end = buffer + sizeof(buffer),
+        .end = buffer + sizeof(buffer) - 1,
         .cur = buffer,
         .cb = cb,
         .ctx = arg,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We set the byte at the `end` postition [to 0](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/application_layer/nanocoap/link_format.c#L61), but `buffer[sizeof(buffer)]` is actually outside of `buffer`, we have to use `sizeof(buffer) - 1`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Thanks to @Teufelchen1 for spotting this!
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Resource listing still works

```
> ncget coap://coap.me/
/test
/validate
/hello
/blåbærsyltetøy
/sink
/separate
/large
/secret
/broken
/weird33
/weird44
/weird55
/weird333
/weird3333
/weird33333
/123412341234123412341234
/location-query
/create1
/large-update
/large-create
/query
/seg1
/path
/location1
/multi-format
/3
/4
/5
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
