### PR TITLE
sam0_sdhc: MTD: try to re-init the SDHC on failed command

### DIFF
--- a/cpu/sam0_common/sam0_sdhc/sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/sdhc.c
@@ -319,7 +319,7 @@ int sdhc_init(sdhc_state_t *state)
 
 bool sdhc_send_cmd(sdhc_state_t *state, uint32_t cmd, uint32_t arg)
 {
-    uint32_t timeout = 0xFFFFFFFF;
+    uint32_t timeout = 0xFFFF;
     uint32_t command;
     uint32_t eis;
 

--- a/cpu/sam0_common/sam0_sdhc/sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/sdhc.c
@@ -208,6 +208,9 @@ int sdhc_init(sdhc_state_t *state)
     bool f8;
     uint32_t response;
 
+    /* set power control bits to 0 to power off the SD card */
+    SDHC_DEV->PCR.reg = 0;
+
     /* set the initial clock slow, single bit and normal speed */
     state->type = CARD_TYPE_SD;
     state->version = CARD_VER_UNKNOWN;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We found that the SD Host Controller would sometimes get in a state where it can't recover from a failed command.

A re-init of the controller usually helps in that case.

While not the most elegant fix, it works to increase the reliability of the driver.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
