### PR TITLE
ci/print_versions: print all ESP32 toolchains

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -129,7 +129,10 @@ for p in \
          riscv-none-elf \
          riscv64-unknown-elf \
          riscv-none-embed \
+         riscv32-esp-elf \
          xtensa-esp32-elf \
+         xtensa-esp32s2-elf \
+         xtensa-esp32s3-elf \
          xtensa-esp8266-elf \
          ; do
     printf "%25s: %s\n" "$p-gcc" "$(get_cmd_version ${p}-gcc)"
@@ -145,7 +148,10 @@ for p in \
          riscv-none-elf \
          riscv64-unknown-elf \
          riscv-none-embed \
+         riscv32-esp-elf \
          xtensa-esp32-elf \
+         xtensa-esp32s2-elf \
+         xtensa-esp32s3-elf \
          xtensa-esp8266-elf \
          ; do
     printf "%25s: %s\n" "$p-newlib" "$(newlib_version ${p}-gcc)"

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -24,7 +24,7 @@ get_define() {
     local cc="$1"
     local line=
     if command -v "$cc" 2>&1 >/dev/null; then
-        line=$(echo "$3" | "$cc" -x c -include "$2" -E -o - - 2>&1 | sed -e '/^[   ]*#/d' -e '/^[  ]*$/d')
+        line=$(echo "$3" | "$cc" -x c -include "$2" -E -o - - 2>/dev/null | sed -e '/^[   ]*#/d' -e '/^[  ]*$/d')
     fi
     if [ -z "$line" ]; then
         line=missing


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Include the versions of the different ESP32 family toolchains in the output of `make print-versions`.


### Testing procedure

Run `make print-versions`

```
Operating System Environment
----------------------------
         Operating System: "Ubuntu" "22.10 (Kinetic Kudu)"
                   Kernel: Linux 6.1.7-060107-generic x86_64 x86_64
             System shell: /usr/bin/dash (probably dash)
             make's shell: /usr/bin/dash (probably dash)

Installed compiler toolchains
-----------------------------
               native gcc: gcc (Ubuntu 12.2.0-3ubuntu1) 12.2.0
        arm-none-eabi-gcc: arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621 (release)
                  avr-gcc: avr-gcc (GCC) 5.4.0
           msp430-elf-gcc: msp430-elf-gcc (Mitto Systems Limited - msp430-gcc 9.2.0.50) 9.2.0
       riscv-none-elf-gcc: missing
  riscv64-unknown-elf-gcc: riscv64-unknown-elf-gcc () 10.2.0
     riscv-none-embed-gcc: missing
      riscv32-esp-elf-gcc: riscv32-esp-elf-gcc (crosstool-NG esp-2021r2-patch3) 8.4.0
     xtensa-esp32-elf-gcc: xtensa-esp32-elf-gcc (crosstool-NG esp-2021r2-patch3) 8.4.0
   xtensa-esp32s2-elf-gcc: xtensa-esp32s2-elf-gcc (crosstool-NG esp-2021r2-patch3) 8.4.0
   xtensa-esp32s3-elf-gcc: xtensa-esp32s3-elf-gcc (crosstool-NG esp-2021r2-patch3) 8.4.0
   xtensa-esp8266-elf-gcc: xtensa-esp8266-elf-gcc (crosstool-NG crosstool-ng-1.22.0-80-g6c4433a5) 5.2.0
                    clang: Ubuntu clang version 15.0.6

Installed compiler libs
-----------------------
     arm-none-eabi-newlib: "3.3.0"
        msp430-elf-newlib: "2.4.0"
    riscv-none-elf-newlib: missing
riscv64-unknown-elf-newlib: missing
  riscv-none-embed-newlib: missing
   riscv32-esp-elf-newlib: "3.3.0"
  xtensa-esp32-elf-newlib: "3.3.0"
xtensa-esp32s2-elf-newlib: "3.3.0"
xtensa-esp32s3-elf-newlib: "3.3.0"
xtensa-esp8266-elf-newlib: "2.2.0"
                 avr-libc: "2.0.0" ("20150208")

Installed development tools
---------------------------
                   ccache: missing
                    cmake: cmake version 3.24.2
                 cppcheck: missing
                  doxygen: 1.9.1
                      git: git version 2.37.2
                     make: GNU Make 4.3
                  openocd: Open On-Chip Debugger 0.11.0
                   python: Python 2.7.18
                  python2: Python 2.7.18
                  python3: Python 3.10.7
                   flake8: error: /usr/bin/python3: No module named flake8
               coccinelle: missing
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
