### PR TITLE
boards/microbit-v2: Recognize with MOST_RECENT_PORT

### DIFF
--- a/boards/microbit-v2/Makefile.include
+++ b/boards/microbit-v2/Makefile.include
@@ -2,6 +2,11 @@
 PROGRAMMER ?= openocd
 PROGRAMMERS_SUPPORTED += pyocd
 
+# The model text used has double quotes around the name. That's an odd enough
+# choice to warrant making them optional in the detection, in case later
+# programmer firmware revisions "fix" that.
+TTY_BOARD_FILTER := --model ".?BBC micro:bit CMSIS-DAP.?"
+
 # The board is not recognized automatically by pyocd, so the CPU target
 # option is passed explicitly
 PYOCD_FLASH_TARGET_TYPE ?= -t $(CPU)


### PR DESCRIPTION
### Contribution description

Since the introduction MOST_RECENT_PORT support, we've been gathering identifying criteria for particular boards to make it useful.

This adds such criteria to the microbit-v2. (They might also apply to the classical microbit board, but I have none to test; if it does, they're indistinguishable and that's something that can happen.)

### Testing procedure

* Connect something that has a USB UART, and then a microbit-v2, and then something yet different. (There might be simpler test setups).
* Run `make BOARD=microbit-v2 all term MOST_RECENT_PORT=1`
* Observe that /dev/ttyACM1 is selected.