### PR TITLE
gnrc_static: don't parse address as prefix

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
+++ b/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
@@ -60,10 +60,9 @@ static void _config_upstream(gnrc_netif_t *upstream)
     DEBUG("gnrc_ipv6_static_addr: interface %u selected as upstream\n", upstream->pid);
 
     /* configure static address */
-    int addr_len;
     if (static_addr != NULL &&
-        (addr_len = ipv6_prefix_from_str(&addr, static_addr)) > 0) {
-        gnrc_netif_ipv6_addr_add_internal(upstream, &addr, addr_len,
+        ipv6_addr_from_str(&addr, static_addr) != NULL) {
+        gnrc_netif_ipv6_addr_add_internal(upstream, &addr, 128,
                                           GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

To parse the static upstream address we should use `ipv6_addr_from_str()`, not `ipv6_prefix_from_str()` - otherwise the address will only be considered valid if it comes with a prefix length. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `make -C examples/gnrc_border_router PREFIX_CONF=static all term` 

#### master

Upstream interface has no pre-configured address 
```
Iface  5  HWaddr: 76:8F:E6:D7:42:6D 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::748f:e6ff:fed7:426d  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffd7:426d
          
Iface  6  HWaddr: 56:FE  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: AE:0F:4D:73:F7:54:56:FE 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::ac0f:4d73:f754:56fe  scope: link  VAL
          inet6 addr: 2001:db8::ac0f:4d73:f754:56fe  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff54:56fe
```

### this PR

upstream interface *has* pre-configured address 
```
Iface  5  HWaddr: 76:8F:E6:D7:42:6D 
          L2-PDU:1500  MTU:1280  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::748f:e6ff:fed7:426d  scope: link  VAL
 >>>      inet6 addr: 2001:db8:1::1  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffd7:426d
          inet6 group: ff02::1:ff00:1
          
Iface  6  HWaddr: 25:EF  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: AE:BB:DE:DD:00:85:A5:EF 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::acbb:dedd:85:a5ef  scope: link  VAL
          inet6 addr: 2001:db8::acbb:dedd:85:a5ef  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff85:a5ef

```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
