### PR TITLE
efm32/dac: Shift instead of masking

### DIFF
--- a/cpu/efm32/periph/dac.c
+++ b/cpu/efm32/periph/dac.c
@@ -66,7 +66,7 @@ void dac_set(dac_t line, uint16_t value)
 
     DAC_ChannelOutputSet(dac_config[dev].dev,
                          dac_channel_config[line].index,
-                         value & 0xfff);
+                         value >> 4);
 }
 
 void dac_poweron(dac_t line)


### PR DESCRIPTION
The documented behavior is:

> The value is always given as 16-bit value and is internally scaled to the actual resolution that the DAC unit provides (e.g. 12-bit). So to get the maximum output voltage, this function has to be called with value set to 65535 (UINT16_MAX).

The previous behavior was masking, now it's shifting.

### Testing procedure

* Run tests/periph_dac interactively and look at the voltage with an oscilloscope.

  Before, the period was 100ms/16, now it's 100ms as advertised.

*Note: I couldn't do that yet, the above is just what I expect.*

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/19317