### PR TITLE
examples/gnrc_border_router: add BLE as downlink option

### DIFF
--- a/examples/gnrc_border_router/Makefile.board.dep
+++ b/examples/gnrc_border_router/Makefile.board.dep
@@ -7,10 +7,15 @@ ifeq (,$(filter native,$(BOARD)))
   else ifeq (wifi,$(UPLINK))
     ifneq (,$(filter esp32 esp8266,$(CPU)))
       USEMODULE += esp_wifi
-      USEMODULE += esp_now
+      ifneq (ble, $(DOWNLINK))
+        USEMODULE += esp_now
+      endif
     else
       $(error Only esp32 and esp8266 are currently supported)
     endif
+  endif
+  ifeq (ble, $(DOWNLINK))
+    USEMODULE += nimble_rpble
   endif
 else
   USEMODULE += netdev_tap


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Turns out we can also use BLE as a downlink for the gnrc_border_router.
This allows to create a border router with any ESP32 board as an alternative to ESP NOW.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Create a WiFi <-> BLE border router

    make -C examples/gnrc_border_router BOARD=esp32-wroom-32 UPLINK=wifi DOWNLINK=ble all flash term



```
2023-02-26 23:08:40,261 # Iface  10  HWaddr: 3C:71:BF:9E:13:FD 
2023-02-26 23:08:40,265 #           L2-PDU:1280  MTU:1280  HL:64  RTR  
2023-02-26 23:08:40,267 #           RTR_ADV  6LO  IPHC  
2023-02-26 23:08:40,270 #           Source address length: 6
2023-02-26 23:08:40,273 #           Link type: wireless
2023-02-26 23:08:40,279 #           inet6 addr: fe80::3c71:bfff:fe9e:13fd  scope: link  VAL
2023-02-26 23:08:40,286 #           inet6 addr: 2001:9e8:1412:1efa:3c71:bfff:fe9e:13fd  scope: global  VAL
2023-02-26 23:08:40,288 #           inet6 group: ff02::2
2023-02-26 23:08:40,291 #           inet6 group: ff02::1
2023-02-26 23:08:40,295 #           inet6 group: ff02::1:ff9e:13fd
2023-02-26 23:08:40,297 #           inet6 group: ff02::1a
2023-02-26 23:08:40,298 #           
2023-02-26 23:08:40,304 # Iface  12  HWaddr: 3C:71:BF:9E:13:FC  Channel: 6  Link: up 
2023-02-26 23:08:40,308 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2023-02-26 23:08:40,311 #           Source address length: 6
2023-02-26 23:08:40,313 #           Link type: wireless
2023-02-26 23:08:40,319 #           inet6 addr: fe80::3e71:bfff:fe9e:13fc  scope: link  VAL
2023-02-26 23:08:40,326 #           inet6 addr: 2001:9e8:1412:1e00:3e71:bfff:fe9e:13fc  scope: global  VAL
2023-02-26 23:08:40,329 #           inet6 group: ff02::2
2023-02-26 23:08:40,331 #           inet6 group: ff02::1
2023-02-26 23:08:40,335 #           inet6 group: ff02::1:ff9e:13fc
2023-02-26 23:08:40,336 #           

2023-02-26 23:08:42,220 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2023-02-26 23:08:42,228 # 	  1 | sys_evt              | bl mutex _ |   4 |   2616 ( 1184) ( 1432) | 0x3ffb74e8 | 0x3ffb7cc0 
2023-02-26 23:08:42,237 # 	  2 | esp_timer            | sleeping _ |   2 |   3640 (  468) ( 3172) | 0x3ffba6ac | 0x3ffbb310 
2023-02-26 23:08:42,246 # 	  3 | idle                 | pending  Q |  31 |   2048 (  448) ( 1600) | 0x3ffc02d0 | 0x3ffc0910 
2023-02-26 23:08:42,254 # 	  4 | main                 | running  Q |  15 |   3584 ( 1632) ( 1952) | 0x3ffc0ad0 | 0x3ffc13b0 
2023-02-26 23:08:42,263 # 	  5 | 6lo                  | bl rx    _ |  11 |   2048 (  760) ( 1288) | 0x3ffc8618 | 0x3ffc8be0 
2023-02-26 23:08:42,271 # 	  6 | ipv6                 | bl rx    _ |  12 |   2048 (  780) ( 1268) | 0x3ffc4e4c | 0x3ffc5400 
2023-02-26 23:08:42,280 # 	  7 | udp                  | bl rx    _ |  13 |   1024 (  668) (  356) | 0x3ffc8e1c | 0x3ffc8fe0 
2023-02-26 23:08:42,289 # 	  8 | btController         | bl mutex _ |   1 |   3640 ( 1724) ( 1916) | 0x3ffd3b34 | 0x3ffd4730 
2023-02-26 23:08:42,297 # 	  9 | nimble_host          | bl anyfl _ |   1 |   2048 ( 1596) (  452) | 0x3ffcd23c | 0x3ffcd810 
2023-02-26 23:08:42,306 # 	 10 | nimble_netif         | bl anyfl _ |  10 |   2048 (  684) ( 1364) | 0x3ffca0fc | 0x3ffca710 
2023-02-26 23:08:42,314 # 	 11 | wifi                 | bl mutex _ |   1 |   6200 ( 1808) ( 4392) | 0x3ffd5188 | 0x3ffd6780 
2023-02-26 23:08:42,323 # 	 12 | netif-esp-wifi       | bl anyfl _ |  10 |   2048 (  860) ( 1188) | 0x3ffc2aac | 0x3ffc30c0 
2023-02-26 23:08:42,331 # 	 13 | dhcpv6-client        | bl anyfl _ |  13 |   2048 ( 1736) (  312) | 0x3ffc4648 | 0x3ffc4c30 
2023-02-26 23:08:42,340 # 	 14 | RPL                  | bl rx    _ |  13 |   2048 (  724) ( 1324) | 0x3ffc7a34 | 0x3ffc8040 
2023-02-26 23:08:42,346 # 	    | SUM                  |            |     |  37088 (15072) (22016)
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
