### PR TITLE
subsystems: Assign chrysn to Rust

### DIFF
--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -73,6 +73,8 @@ affect more than one module.
 
 ## RUST support
 
+  - Christian Amsüss (@chrysn)
+
 ## C++ support
 
 ## Crypto


### PR DESCRIPTION
This sets me as the (so far, sole) subsystem assignee for Rust.