### PR TITLE
shell/cmds: GNRC: replace puts() with printf()

### DIFF
--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -12,7 +12,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
-    microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \

--- a/sys/net/network_layer/sixlowpan/sixlowpan_print.c
+++ b/sys/net/network_layer/sixlowpan/sixlowpan_print.c
@@ -21,7 +21,7 @@
 void sixlowpan_print(uint8_t *data, size_t size)
 {
     if (data[0] == SIXLOWPAN_UNCOMP) {
-        puts("Uncompressed IPv6 packet");
+        printf("Uncompressed IPv6 packet\n");
 
         /* might just be the dispatch (or fragmented) so better check */
         if (size > sizeof(ipv6_hdr_t)) {
@@ -32,13 +32,13 @@ void sixlowpan_print(uint8_t *data, size_t size)
         }
     }
     else if (sixlowpan_nalp(data[0])) {
-        puts("Not a LoWPAN (NALP) frame");
+        printf("Not a LoWPAN (NALP) frame\n");
         od_hex_dump(data, size, OD_WIDTH_DEFAULT);
     }
     else if ((data[0] & SIXLOWPAN_FRAG_DISP_MASK) == SIXLOWPAN_FRAG_1_DISP) {
         sixlowpan_frag_t *hdr = (sixlowpan_frag_t *)data;
 
-        puts("Fragmentation Header (first)");
+        printf("Fragmentation Header (first)\n");
         printf("datagram size: %u\n",
                (byteorder_ntohs(hdr->disp_size) & SIXLOWPAN_FRAG_SIZE_MASK));
         printf("tag: 0x%04x\n", byteorder_ntohs(hdr->tag));
@@ -50,7 +50,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
     else if ((data[0] & SIXLOWPAN_FRAG_DISP_MASK) == SIXLOWPAN_FRAG_N_DISP) {
         sixlowpan_frag_n_t *hdr = (sixlowpan_frag_n_t *)data;
 
-        puts("Fragmentation Header (subsequent)");
+        printf("Fragmentation Header (subsequent)\n");
         printf("datagram size: %u\n",
                (byteorder_ntohs(hdr->disp_size) & SIXLOWPAN_FRAG_SIZE_MASK));
         printf("tag: 0x%04x\n", byteorder_ntohs(hdr->tag));
@@ -62,51 +62,51 @@ void sixlowpan_print(uint8_t *data, size_t size)
     }
     else if ((data[0] & SIXLOWPAN_IPHC1_DISP_MASK) == SIXLOWPAN_IPHC1_DISP) {
         uint8_t offset = SIXLOWPAN_IPHC_HDR_LEN;
-        puts("IPHC dispatch");
+        printf("IPHC dispatch\n");
 
         switch (data[0] & SIXLOWPAN_IPHC1_TF) {
             case 0x00:
-                puts("TF: ECN + DSCP + Flow Label (4 bytes)");
+                printf("TF: ECN + DSCP + Flow Label (4 bytes)\n");
                 break;
 
             case 0x08:
-                puts("TF: ECN + Flow Label (3 bytes)");
+                printf("TF: ECN + Flow Label (3 bytes)\n");
                 break;
 
             case 0x10:
-                puts("TF: ECN + DSCP (1 bytes)");
+                printf("TF: ECN + DSCP (1 bytes)\n");
                 break;
 
             case 0x18:
-                puts("TF: traffic class and flow label elided");
+                printf("TF: traffic class and flow label elided\n");
                 break;
         }
 
         switch (data[0] & SIXLOWPAN_IPHC1_NH) {
             case 0x00:
-                puts("NH: inline");
+                printf("NH: inline\n");
                 break;
 
             case 0x04:
-                puts("NH: LOWPAN_NHC");
+                printf("NH: LOWPAN_NHC\n");
                 break;
         }
 
         switch (data[0] & SIXLOWPAN_IPHC1_HL) {
             case 0x00:
-                puts("HLIM: inline");
+                printf("HLIM: inline\n");
                 break;
 
             case 0x01:
-                puts("HLIM: 1");
+                printf("HLIM: 1\n");
                 break;
 
             case 0x02:
-                puts("HLIM: 64");
+                printf("HLIM: 64\n");
                 break;
 
             case 0x03:
-                puts("HLIM: 255");
+                printf("HLIM: 255\n");
                 break;
         }
 
@@ -115,19 +115,19 @@ void sixlowpan_print(uint8_t *data, size_t size)
 
             switch (data[1] & SIXLOWPAN_IPHC2_SAM) {
                 case 0x00:
-                    puts("unspecified address (::)");
+                    printf("unspecified address (::)\n");
                     break;
 
                 case 0x10:
-                    puts("64 bits inline");
+                    printf("64 bits inline\n");
                     break;
 
                 case 0x20:
-                    puts("16 bits inline");
+                    printf("16 bits inline\n");
                     break;
 
                 case 0x30:
-                    puts("elided (use L2 address)");
+                    printf("elided (use L2 address)\n");
                     break;
             }
         }
@@ -136,57 +136,57 @@ void sixlowpan_print(uint8_t *data, size_t size)
 
             switch (data[1] & SIXLOWPAN_IPHC2_SAM) {
                 case 0x00:
-                    puts("128 bits inline");
+                    printf("128 bits inline\n");
                     break;
 
                 case 0x10:
-                    puts("64 bits inline");
+                    printf("64 bits inline\n");
                     break;
 
                 case 0x20:
-                    puts("16 bits inline");
+                    printf("16 bits inline\n");
                     break;
 
                 case 0x30:
-                    puts("elided (use L2 address)");
+                    printf("elided (use L2 address)\n");
                     break;
             }
         }
 
         if (data[1] & SIXLOWPAN_IPHC2_M) {
             if (data[1] & SIXLOWPAN_IPHC2_DAC) {
-                puts("Stateful destination multicast address compression:");
+                printf("Stateful destination multicast address compression:\n");
 
                 switch (data[1] & SIXLOWPAN_IPHC2_DAM) {
                     case 0x00:
-                        puts("    48 bits carried inline (Unicast-Prefix-based)");
+                        printf("    48 bits carried inline (Unicast-Prefix-based)\n");
                         break;
 
                     case 0x01:
                     case 0x02:
                     case 0x03:
-                        puts("    reserved");
+                        printf("    reserved\n");
                         break;
                 }
             }
             else {
-                puts("Stateless destination multicast address compression:");
+                printf("Stateless destination multicast address compression:\n");
 
                 switch (data[1] & SIXLOWPAN_IPHC2_DAM) {
                     case 0x00:
-                        puts("    128 bits carried inline");
+                        printf("    128 bits carried inline\n");
                         break;
 
                     case 0x01:
-                        puts("    48 bits carried inline");
+                        printf("    48 bits carried inline\n");
                         break;
 
                     case 0x02:
-                        puts("    32 bits carried inline");
+                        printf("    32 bits carried inline\n");
                         break;
 
                     case 0x03:
-                        puts("    8 bits carried inline");
+                        printf("    8 bits carried inline\n");
                         break;
                 }
             }
@@ -197,19 +197,19 @@ void sixlowpan_print(uint8_t *data, size_t size)
 
                 switch (data[1] & SIXLOWPAN_IPHC2_DAM) {
                     case 0x00:
-                        puts("reserved");
+                        printf("reserved\n");
                         break;
 
                     case 0x01:
-                        puts("64 bits inline");
+                        printf("64 bits inline\n");
                         break;
 
                     case 0x02:
-                        puts("16 bits inline");
+                        printf("16 bits inline\n");
                         break;
 
                     case 0x03:
-                        puts("elided (use L2 address)");
+                        printf("elided (use L2 address)\n");
                         break;
                 }
             }
@@ -218,19 +218,19 @@ void sixlowpan_print(uint8_t *data, size_t size)
 
                 switch (data[1] & SIXLOWPAN_IPHC2_DAM) {
                     case 0x00:
-                        puts("128 bits inline");
+                        printf("128 bits inline\n");
                         break;
 
                     case 0x01:
-                        puts("64 bits inline");
+                        printf("64 bits inline\n");
                         break;
 
                     case 0x02:
-                        puts("16 bits inline");
+                        printf("16 bits inline\n");
                         break;
 
                     case 0x03:
-                        puts("elided (use L2 address)");
+                        printf("elided (use L2 address)\n");
                         break;
                 }
             }

--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -155,17 +155,17 @@ static void _usage(char *cmdname)
 {
     printf("%s [-c <count>] [-h] [-i <ms interval>] [-s <packetsize>]\n",
            cmdname);
-    puts("     [-t hoplimit] [-W <ms timeout>] <host>[%<interface>]");
-    puts("     count: number of pings (default: 3)");
-    puts("     ms interval: wait interval milliseconds between sending "
-              "(default: 1000)");
-    puts("     packetsize: number of bytes in echo payload; must be >= 4 to "
-              "measure round trip time (default: 4)");
-    puts("     hoplimit: Set the IP time to life/hoplimit "
-              "(default: interface config)");
-    puts("     ms timeout: Time to wait for a response in milliseconds "
+    printf("     [-t hoplimit] [-W <ms timeout>] <host>[%%<interface>]\n");
+    printf("     count: number of pings (default: 3)\n");
+    printf("     ms interval: wait interval milliseconds between sending "
+              "(default: 1000)\"");
+    printf("     packetsize: number of bytes in echo payload; must be >= 4 to "
+              "measure round trip time (default: 4)\n");
+    printf("     hoplimit: Set the IP time to life/hoplimit "
+              "(default: interface config)\n");
+    printf("     ms timeout: Time to wait for a response in milliseconds "
               "(default: 1000). The option affects only timeout in absence "
-              "of any responses, otherwise wait for two RTTs");
+              "of any responses, otherwise wait for two RTTs\n");
 }
 
 static int _configure(int argc, char **argv, _ping_data_t *data)
@@ -277,7 +277,7 @@ static void _pinger(_ping_data_t *data)
     case 0:
         break;
     case ENOMEM:
-        puts("error: packet buffer full");
+        printf("error: packet buffer full\n");
         break;
     default:
         printf("error: %d\n", res);

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -159,7 +159,7 @@ static int _netif_stats(netif_t *iface, unsigned module, bool reset)
                             sizeof(stats));
 
     if (res < 0) {
-        puts("           Protocol or device doesn't provide statistics.");
+        printf("           Protocol or device doesn't provide statistics.\n");
     }
     else if (reset) {
         res = netif_set_opt(iface, NETOPT_STATS, module, NULL, 0);
@@ -194,7 +194,7 @@ static void _link_usage(char *cmd_name)
 static void _set_usage(char *cmd_name)
 {
     printf("usage: %s <if_id> set <key> <value>\n", cmd_name);
-    puts("      Sets an hardware specific specific value\n"
+    printf("      Sets an hardware specific specific value\n"
          "      <key> may be one of the following\n"
          "       * \"addr\" - sets (short) address\n"
          "       * \"addr_long\" - sets long address\n"
@@ -287,7 +287,7 @@ static void _del_usage(char *cmd_name)
 static void _stats_usage(char *cmd_name)
 {
     printf("usage: %s <if_id> stats [l2|ipv6] [reset]\n", cmd_name);
-    puts("       reset can be only used if the module is specified.");
+    printf("       reset can be only used if the module is specified.\n");
 }
 #endif
 
@@ -921,9 +921,9 @@ static void _netif_list(netif_t *iface)
     res = netif_get_opt(iface, NETOPT_L2FILTER, 0, &filter, sizeof(filter));
     if (res > 0) {
 #ifdef MODULE_L2FILTER_WHITELIST
-        puts("\n           White-listed link layer addresses:");
+        printf("\n           White-listed link layer addresses:\n");
 #else
-        puts("\n           Black-listed link layer addresses:");
+        printf("\n           Black-listed link layer addresses:\n");
 #endif
         int count = 0;
         for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
@@ -935,7 +935,7 @@ static void _netif_list(netif_t *iface)
             }
         }
         if (count == 0) {
-            puts("            --- none ---");
+            printf("            --- none ---\n");
         }
     }
 #endif
@@ -958,15 +958,15 @@ static int _netif_set_u32(netif_t *iface, netopt_t opt, uint32_t context,
 
     if (fmt_is_number(u32_str)) {
         if ((res = strtoul(u32_str, NULL, 10)) == ULONG_MAX) {
-            puts("error: unable to parse value.\n"
-                 "Must be a 32-bit unsigned integer (dec or hex)\n");
+            printf("error: unable to parse value.\n"
+                   "Must be a 32-bit unsigned integer (dec or hex)\n");
             return 1;
         }
     }
     else {
         if ((res = strtoul(u32_str, NULL, 32)) == ULONG_MAX) {
-            puts("error: unable to parse value.\n"
-                 "Must be a 32-bit unsigned integer (dec or hex)\n");
+            printf("error: unable to parse value.\n"
+                   "Must be a 32-bit unsigned integer (dec or hex)\n");
             return 1;
         }
 
@@ -1014,7 +1014,7 @@ static int _netif_set_bandwidth(netif_t *iface, char *value)
         bw = LORA_BW_500_KHZ;
     }
     else {
-        puts("usage: ifconfig <if_id> set bw [125|250|500]");
+        printf("usage: ifconfig <if_id> set bw [125|250|500]\n");
         return 1;
     }
     if (netif_set_opt(iface, NETOPT_BANDWIDTH, 0,
@@ -1046,7 +1046,7 @@ static int _netif_set_coding_rate(netif_t *iface, char *value)
         cr = LORA_CR_4_8;
     }
     else {
-        puts("usage: ifconfig <if_id> set cr [4/5|4/6|4/7|4/8]");
+        printf("usage: ifconfig <if_id> set cr [4/5|4/6|4/7|4/8]\n");
         return 1;
     }
     if (netif_set_opt(iface, NETOPT_CODING_RATE, 0,
@@ -1083,7 +1083,7 @@ static int _netif_set_fsk_fec(netif_t *iface, char *value)
         return 0;
     }
 
-    puts("usage: ifconfig <if_id> set fec [none|NRNSC|RSC]");
+    printf("usage: ifconfig <if_id> set fec [none|NRNSC|RSC]\n");
     return 1;
 }
 
@@ -1155,15 +1155,15 @@ static int _netif_set_u16(netif_t *iface, netopt_t opt, uint16_t context,
 
     if (fmt_is_number(u16_str)) {
         if ((res = strtoul(u16_str, NULL, 10)) == ULONG_MAX) {
-            puts("error: unable to parse value.\n"
-                 "Must be a 16-bit unsigned integer (dec or hex)\n");
+            printf("error: unable to parse value.\n"
+                   "Must be a 16-bit unsigned integer (dec or hex)\n");
             return 1;
         }
     }
     else {
         if ((res = strtoul(u16_str, NULL, 16)) == ULONG_MAX) {
-            puts("error: unable to parse value.\n"
-                 "Must be a 16-bit unsigned integer (dec or hex)\n");
+            printf("error: unable to parse value.\n"
+                   "Must be a 16-bit unsigned integer (dec or hex)\n");
             return 1;
         }
 
@@ -1171,8 +1171,8 @@ static int _netif_set_u16(netif_t *iface, netopt_t opt, uint16_t context,
     }
 
     if (res > 0xffff) {
-        puts("error: unable to parse value.\n"
-             "Must be a 16-bit unsigned integer (dec or hex)\n");
+        printf("error: unable to parse value.\n"
+               "Must be a 16-bit unsigned integer (dec or hex)\n");
         return 1;
     }
 
@@ -1245,7 +1245,7 @@ static int _netif_set_u8(netif_t *iface, netopt_t opt, uint16_t context,
 static int _netif_set_flag(netif_t *iface, netopt_t opt, netopt_enable_t set)
 {
     if (netif_set_opt(iface, opt, 0, &set, sizeof(netopt_enable_t)) < 0) {
-        puts("error: unable to set option");
+        printf("error: unable to set option\n");
         return 1;
     }
     printf("success: %sset option\n", (set) ? "" : "un");
@@ -1277,7 +1277,7 @@ static int _netif_set_lw_key(netif_t *iface, netopt_t opt, char *key_str)
         expected_len = LORAMAC_DEVEUI_LEN;
     }
     if (!key_len || key_len != expected_len) {
-        puts("error: unable to parse key.\n");
+        printf("error: unable to parse key.\n");
         return 1;
     }
 
@@ -1297,9 +1297,9 @@ static int _netif_set_addr(netif_t *iface, netopt_t opt, char *addr_str)
     size_t addr_len = gnrc_netif_addr_from_str(addr_str, addr);
 
     if (addr_len == 0) {
-        puts("error: unable to parse address.\n"
-             "Must be of format [0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*\n"
-             "(hex pairs delimited by colons)");
+        printf("error: unable to parse address.\n"
+               "Must be of format [0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*\n"
+               "(hex pairs delimited by colons)\n");
         return 1;
     }
 
@@ -1351,7 +1351,7 @@ static int _netif_set_state(netif_t *iface, char *state_str)
         state = NETOPT_STATE_STANDBY;
     }
     else {
-        puts("usage: ifconfig <if_id> set state [off|sleep|idle|rx|tx|reset|standby]");
+        printf("usage: ifconfig <if_id> set state [off|sleep|idle|rx|tx|reset|standby]\n");
         return 1;
     }
     if (netif_set_opt(iface, NETOPT_STATE, 0,
@@ -1416,7 +1416,7 @@ static int _netif_set_encrypt_key(netif_t *iface, netopt_t opt, char *key_str)
         int i2 = _hex_to_int(key_str[i + 1]);
 
         if (i1 == -1 || i2 == -1) {
-            puts("error: unable to parse key");
+            printf("error: unable to parse key\n");
             return 1;
         }
 
@@ -1424,7 +1424,7 @@ static int _netif_set_encrypt_key(netif_t *iface, netopt_t opt, char *key_str)
     }
 
     if (netif_set_opt(iface, opt, 0, key, key_len) < 0) {
-        puts("error: unable to set encryption key");
+        printf("error: unable to set encryption key\n");
         return 1;
     }
 
@@ -1446,23 +1446,23 @@ static int _netif_addrm_l2filter(netif_t *iface, char *val, bool add)
     size_t addr_len = gnrc_netif_addr_from_str(val, addr);
 
     if ((addr_len == 0) || (addr_len > CONFIG_L2FILTER_ADDR_MAXLEN)) {
-        puts("error: given address is invalid");
+        printf("error: given address is invalid\n");
         return 1;
     }
 
     if (add) {
         if (netif_set_opt(iface, NETOPT_L2FILTER, 0, addr, addr_len) < 0) {
-            puts("unable to add link layer address to filter");
+            printf("unable to add link layer address to filter\n");
             return 1;
         }
-        puts("successfully added address to filter");
+        printf("successfully added address to filter\n");
     }
     else {
         if (netif_set_opt(iface, NETOPT_L2FILTER_RM, 0, addr, addr_len) < 0) {
-            puts("unable to remove link layer address from filter");
+            printf("unable to remove link layer address from filter\n");
             return 1;
         }
-        puts("successfully removed address to filter");
+        printf("successfully removed address to filter\n");
     }
     return 0;
 }
@@ -1709,7 +1709,7 @@ static int _netif_add(char *cmd_name, netif_t *iface, int argc, char **argv)
     prefix_len = _get_prefix_len(addr_str);
 
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
-        puts("error: unable to parse IPv6 address.");
+        printf("error: unable to parse IPv6 address.\n");
         return 1;
     }
 
@@ -1742,7 +1742,7 @@ static int _netif_add(char *cmd_name, netif_t *iface, int argc, char **argv)
     (void)iface;
     (void)argc;
     (void)argv;
-    puts("error: unable to add IPv6 address.");
+    printf("error: unable to add IPv6 address.\n");
 
     return 1;
 #endif
@@ -1754,7 +1754,7 @@ static int _netif_del(netif_t *iface, char *addr_str)
     ipv6_addr_t addr;
 
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
-        puts("error: unable to parse IPv6 address.");
+        printf("error: unable to parse IPv6 address.\n");
         return 1;
     }
 
@@ -1781,7 +1781,7 @@ static int _netif_del(netif_t *iface, char *addr_str)
 #else
     (void)iface;
     (void)addr_str;
-    puts("error: unable to delete IPv6 address.");
+    printf("error: unable to delete IPv6 address.\n");
     return 1;
 #endif
 }
@@ -1804,7 +1804,7 @@ static int _gnrc_netif_send(int argc, char **argv)
 
     iface = netif_get_by_name(argv[1]);
     if (!iface) {
-        puts("error: invalid interface given");
+        printf("error: invalid interface given\n");
         return 1;
     }
 
@@ -1816,7 +1816,7 @@ static int _gnrc_netif_send(int argc, char **argv)
             flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
         }
         else {
-            puts("error: invalid address given");
+            printf("error: invalid address given\n");
             return 1;
         }
     }
@@ -1824,12 +1824,12 @@ static int _gnrc_netif_send(int argc, char **argv)
     /* put packet together */
     pkt = gnrc_pktbuf_add(NULL, argv[3], strlen(argv[3]), GNRC_NETTYPE_UNDEF);
     if (pkt == NULL) {
-        puts("error: packet buffer full");
+        printf("error: packet buffer full\n");
         return 1;
     }
     hdr = gnrc_netif_hdr_build(NULL, 0, addr, addr_len);
     if (hdr == NULL) {
-        puts("error: packet buffer full");
+        printf("error: packet buffer full\n");
         gnrc_pktbuf_release(pkt);
         return 1;
     }
@@ -1838,7 +1838,7 @@ static int _gnrc_netif_send(int argc, char **argv)
     nethdr->flags = flags;
     /* and send it */
     if (gnrc_netif_send(container_of(iface, gnrc_netif_t, netif), pkt) < 1) {
-        puts("error: unable to send");
+        printf("error: unable to send\n");
         gnrc_pktbuf_release(pkt);
         return 1;
     }
@@ -1881,7 +1881,7 @@ int _gnrc_netif_config(int argc, char **argv)
                 return 0;
             }
             else {
-                puts("error: invalid interface given");
+                printf("error: invalid interface given\n");
                 return 1;
             }
         }

--- a/sys/shell/cmds/gnrc_rpl.c
+++ b/sys/shell/cmds/gnrc_rpl.c
@@ -36,7 +36,7 @@ int _gnrc_rpl_init(char *arg)
 {
     kernel_pid_t iface_pid = atoi(arg);
     if (gnrc_netif_get_by_pid(iface_pid) == NULL) {
-        puts("unknown interface specified");
+        printf("unknown interface specified\n");
         return 1;
     }
 
@@ -51,7 +51,7 @@ int _gnrc_rpl_dodag_root(char *arg1, char *arg2)
     ipv6_addr_t dodag_id;
 
     if (ipv6_addr_from_str(&dodag_id, arg2) == NULL) {
-        puts("error: <dodag_id> must be a valid IPv6 address");
+        printf("error: <dodag_id> must be a valid IPv6 address\n");
         return 1;
     }
 
@@ -75,12 +75,12 @@ int _gnrc_rpl_find(char *arg1, char *arg2)
     ipv6_addr_t target;
 
     if (ipv6_addr_from_str(&dodag_id, arg1) == NULL) {
-        puts("<dodag_id> must be a valid IPv6 address");
+        printf("<dodag_id> must be a valid IPv6 address\n");
         return 1;
     }
 
     if (ipv6_addr_from_str(&target, arg2) == NULL) {
-        puts("<target> must be a valid IPv6 address");
+        printf("<target> must be a valid IPv6 address\n");
         return 1;
     }
 
@@ -122,7 +122,7 @@ int _gnrc_rpl_trickle_reset(char *arg1)
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
     if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {
-        puts("error: could not find the <instance_id>");
+        printf("error: could not find the <instance_id>\n");
         return 1;
     }
 
@@ -141,7 +141,7 @@ int _gnrc_rpl_trickle_stop(char *arg1)
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
     if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {
-        puts("error: could not find the <instance_id>");
+        printf("error: could not find the <instance_id>\n");
         return 1;
     }
     trickle_stop(&(inst->dodag.trickle));
@@ -159,7 +159,7 @@ int _gnrc_rpl_trickle_start(char *arg1)
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
     if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {
-        puts("error: could not find the <instance_id>");
+        printf("error: could not find the <instance_id>\n");
         return 1;
     }
 
@@ -190,7 +190,7 @@ int _gnrc_rpl_send_dis_w_sol_opt(char* VID, char* version, char* instance, char*
     {
         gnrc_rpl_internal_opt_t* opt[] = {(gnrc_rpl_internal_opt_t*)&sol};
         gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes, opt, 1);
-        puts("success: send a DIS with SOL option\n");
+        printf("success: send a DIS with SOL option\n\n");
     }
     return 0;
 }
@@ -199,7 +199,7 @@ int _gnrc_rpl_send_dis(void)
 {
     gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes, NULL, 0);
 
-    puts("success: send a DIS\n");
+    printf("success: send a DIS\n\n");
     return 0;
 }
 
@@ -242,7 +242,7 @@ static void _print_stats_block(netstats_rpl_block_t *block, const char *name)
 
 int _stats(void)
 {
-    puts(  "Statistics        (ucast) RX / TX                  RX / TX (mcast)");
+   printf(  "Statistics        (ucast) RX / TX                  RX / TX (mcast)\n");
     _print_stats_block(&gnrc_rpl_netstats.dio, "DIO");
     _print_stats_block(&gnrc_rpl_netstats.dis, "DIS");
     _print_stats_block(&gnrc_rpl_netstats.dao, "DAO");
@@ -450,25 +450,25 @@ static int _gnrc_rpl(int argc, char **argv)
 #endif
 
 #ifdef MODULE_GNRC_RPL_P2P
-    puts("* find <dodag_id> <target>\t\t\t- initiate a P2P-RPL route discovery");
+    printf("* find <dodag_id> <target>\t\t\t- initiate a P2P-RPL route discovery\n");
 #endif
-    puts("* help\t\t\t\t\t- show usage");
-    puts("* init <if_id>\t\t\t\t- initialize RPL on the given interface");
-    puts("* leaf <instance_id>\t\t\t- operate as leaf in the instance");
-    puts("* trickle reset <instance_id>\t\t- reset the trickle timer");
-    puts("* trickle start <instance_id>\t\t- start the trickle timer");
-    puts("* trickle stop <instance_id>\t\t- stop the trickle timer");
-    puts("* rm <instance_id>\t\t\t- delete the given instance and related dodag");
-    puts("* root <inst_id> <dodag_id>\t\t- add a dodag to a new or existing instance");
-    puts("* router <instance_id>\t\t\t- operate as router in the instance");
-    puts("* send dis\t\t\t\t- send a multicast DIS");
-    puts("* send dis <VID_flags> <version> <instance_id> <dodag_id> - send a multicast DIS with SOL option");
+    printf("* help\t\t\t\t\t- show usage\n");
+    printf("* init <if_id>\t\t\t\t- initialize RPL on the given interface\n");
+    printf("* leaf <instance_id>\t\t\t- operate as leaf in the instance\n");
+    printf("* trickle reset <instance_id>\t\t- reset the trickle timer\n");
+    printf("* trickle start <instance_id>\t\t- start the trickle timer\n");
+    printf("* trickle stop <instance_id>\t\t- stop the trickle timer\n");
+    printf("* rm <instance_id>\t\t\t- delete the given instance and related dodag\n");
+    printf("* root <inst_id> <dodag_id>\t\t- add a dodag to a new or existing instance\n");
+    printf("* router <instance_id>\t\t\t- operate as router in the instance\n");
+    printf("* send dis\t\t\t\t- send a multicast DIS\n");
+    printf("* send dis <VID_flags> <version> <instance_id> <dodag_id> - send a multicast DIS with SOL option\n");
 
     if (!IS_ACTIVE(CONFIG_GNRC_RPL_WITHOUT_PIO)) {
-        puts("* set pio <on/off> <instance_id>\t- (de-)activate PIO transmissions in DIOs");
+        printf("* set pio <on/off> <instance_id>\t- (de-)activate PIO transmissions in DIOs\n");
     }
 
-    puts("* show\t\t\t\t\t- show instance and dodag tables");
+    printf("* show\t\t\t\t\t- show instance and dodag tables\n");
     return 0;
 }
 

--- a/sys/shell/cmds/gnrc_sixlowpan_ctx.c
+++ b/sys/shell/cmds/gnrc_sixlowpan_ctx.c
@@ -45,14 +45,14 @@ void _del_cb(void *ptr)
 static void _usage(char *cmd_str)
 {
     printf("usage: %s [{add <0-15> <prefix>/<prefix_len> <ltime in min>|del <ctx>}]\n", cmd_str);
-    puts("       `del` will only invalidate the context for compression. It can be");
-    puts("       reassigned after 5 min.");
+    printf("       `del` will only invalidate the context for compression. It can be\n");
+    printf("       reassigned after 5 min.\n");
 }
 
 static int _gnrc_6ctx_list(void)
 {
-    puts("cid|prefix                                     |C|ltime");
-    puts("-----------------------------------------------------------");
+    printf("cid|prefix                                     |C|ltime\n");
+    printf("-----------------------------------------------------------\n");
     for (uint8_t cid = 0; cid < GNRC_SIXLOWPAN_CTX_SIZE; cid++) {
         gnrc_sixlowpan_ctx_t *ctx = gnrc_sixlowpan_ctx_lookup_id(cid);
         if (ctx != NULL) {
@@ -78,7 +78,7 @@ static int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *
         return 1;
     }
     if (!IS_USED(MODULE_GNRC_IPV6_NIB_6LBR)) {
-        puts("WARNING: context dissemination by non-6LBR not supported");
+        printf("WARNING: context dissemination by non-6LBR not supported\n");
     }
     addr_str = strtok_r(prefix_str, "/", &save_ptr);
     if (addr_str == NULL) {
@@ -92,18 +92,18 @@ static int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *
     }
     prefix_len = atoi(prefix_len_str);
     if ((prefix_len - 1U) > 128U) {
-        puts("ERROR: prefix_len < 1 || prefix_len > 128");
+        printf("ERROR: prefix_len < 1 || prefix_len > 128\n");
         return 1;
     }
     ipv6_addr_from_str(&prefix, addr_str);
     if (ipv6_addr_is_unspecified(&prefix)) {
-        puts("ERROR: prefix may not be ::");
+        printf("ERROR: prefix may not be ::\n");
         return 1;
     }
     ltime = atoi(ltime_str);
     if (gnrc_sixlowpan_ctx_update((uint8_t)ctx, &prefix, (uint8_t)prefix_len, ltime,
                                   true) == NULL) {
-        puts("ERROR: can not add context");
+        printf("ERROR: can not add context\n");
         return 1;
     }
     return 0;
@@ -118,7 +118,7 @@ static int _gnrc_6ctx_del(char *cmd_str, char *ctx_str)
         return 1;
     }
     if (!IS_USED(MODULE_GNRC_IPV6_NIB_6LBR)) {
-        puts("WARNING: context dissemination by non-6LBR not supported");
+        printf("WARNING: context dissemination by non-6LBR not supported\n");
     }
     if (del_timer[cid].callback == NULL) {
         ctx = gnrc_sixlowpan_ctx_lookup_id(cid);

--- a/sys/shell/cmds/gnrc_udp.c
+++ b/sys/shell/cmds/gnrc_udp.c
@@ -52,13 +52,13 @@ static void _send(const char *addr_str, const char *port_str,
 
     /* parse destination address */
     if (netutils_get_ipv6(&addr, &netif, addr_str) < 0) {
-        puts("Error: unable to parse destination address");
+        printf("Error: unable to parse destination address\n");
         return;
     }
     /* parse port */
     port = atoi(port_str);
     if (port == 0) {
-        puts("Error: unable to parse destination port");
+        printf("Error: unable to parse destination port\n");
         return;
     }
 
@@ -68,7 +68,7 @@ static void _send(const char *addr_str, const char *port_str,
         /* allocate payload */
         payload = gnrc_pktbuf_add(NULL, data, strlen(data), GNRC_NETTYPE_UNDEF);
         if (payload == NULL) {
-            puts("Error: unable to copy data to packet buffer");
+            printf("Error: unable to copy data to packet buffer\n");
             return;
         }
         /* store size for output */
@@ -76,14 +76,14 @@ static void _send(const char *addr_str, const char *port_str,
         /* allocate UDP header, set source port := destination port */
         udp = gnrc_udp_hdr_build(payload, port, port);
         if (udp == NULL) {
-            puts("Error: unable to allocate UDP header");
+            printf("Error: unable to allocate UDP header\n");
             gnrc_pktbuf_release(payload);
             return;
         }
         /* allocate IPv6 header */
         ip = gnrc_ipv6_hdr_build(udp, NULL, &addr);
         if (ip == NULL) {
-            puts("Error: unable to allocate IPv6 header");
+            printf("Error: unable to allocate IPv6 header\n");
             gnrc_pktbuf_release(udp);
             return;
         }
@@ -98,7 +98,7 @@ static void _send(const char *addr_str, const char *port_str,
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP,
                                        GNRC_NETREG_DEMUX_CTX_ALL, ip)) {
-            puts("Error: unable to locate UDP thread");
+            printf("Error: unable to locate UDP thread\n");
             gnrc_pktbuf_release(ip);
             return;
         }
@@ -132,7 +132,7 @@ static void _start_server(const char *port_str)
     /* parse port */
     port = atoi(port_str);
     if (port == 0) {
-        puts("Error: invalid port specified");
+        printf("Error: invalid port specified\n");
         return;
     }
     /* start server (which means registering pktdump for the chosen port) */
@@ -152,7 +152,7 @@ static void _stop_server(void)
     /* stop server */
     gnrc_netreg_unregister(GNRC_NETTYPE_UDP, &server);
     server.target.pid = KERNEL_PID_UNDEF;
-    puts("Success: stopped UDP server");
+    printf("Success: stopped UDP server\n");
 }
 
 static int _gnrc_udp_cmd(int argc, char **argv)
@@ -196,11 +196,11 @@ static int _gnrc_udp_cmd(int argc, char **argv)
             _stop_server();
         }
         else {
-            puts("error: invalid command");
+            printf("error: invalid command\n");
         }
     }
     else {
-        puts("error: invalid command");
+        printf("error: invalid command\n");
     }
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Strings output with `printf()` will automatically be placed in the `.text` section on AVR now.
This is not true for strings output with `puts()`.

Replace `puts()` with `puts()` by running 

    sed -Ei 's/puts\(\"(.*)\"\)/printf\(\"\1\\n\"\)/g'

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Observe the reduced `.data` RAM usage on AVR:

#### master

```
   text	   data	    bss	    dec	    hex	filename
 123950	   6710	  13123	 143783	  231a7	/home/benpicco/dev/RIOT/examples/gnrc_networking/bin/avr-rss2/gnrc_networking.elf

```

#### this PR

```
   text	   data	    bss	    dec	    hex	filename
 129840	   2042	  13123	 145005	  2366d	/home/benpicco/dev/RIOT/examples/gnrc_networking/bin/avr-rss2/gnrc_networking.elf

```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
