### PR TITLE
native/stdio: Explicitly provide getchar

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -308,6 +308,10 @@ int fgetc(FILE *fp)
     return getc(fp);
 }
 
+int getchar(void) {
+    return getc(stdin);
+}
+
 int getc(FILE *fp)
 {
     char c;


### PR DESCRIPTION
### Contribution description

This ensures that even when libc does not implement getchar through getc, any custom stdio is still in the loop when getchar is used.

Frankly, I don't know when this broke -- I'm pretty sure custom stdio worked just a few days ago -- but either way, without this patch RIOT on native currently bypasses a configured stdio for me.

### Testing procedure

* `make -C examples/saul all debug`
* `break stdio_read`
* `run`

Without this patch, observe how the shell runs w/o ever breaking. After, lots of breakpoint hits.

This is the way it behaves for me (Debian sid, libc6:i386 2.36-8). If it works for you before this patch, we might start bisecting the differences between the systems, but we may also accept that libcs may imlpement getchar in different ways, and not all of them pass by the getc which we're patching.

### Issues/PRs references

This is needed for testing #19289.

The implementation stems from the `fgetc(3)` man page, which states that "getchar() is equivalent to getc(stdin)".