### PR TITLE
pkg/tinydtls: Adjust defaults

### DIFF
--- a/pkg/tinydtls/Kconfig
+++ b/pkg/tinydtls/Kconfig
@@ -38,6 +38,7 @@ config DTLS_CONTEXT_MAX
 
 config DTLS_PEER_MAX
     int "Max number of peers"
+    default 2 if KCONFIG_USEMODULE_GCOAP_DTLS
     default 1
     help
         The maximum number of DTLS peers.

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -18,3 +18,18 @@ all:
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-format-nonliteral
 endif
+
+ifneq (,$(filter gcoap,$(USEMODULE)))
+    # Configuring the buffer large enough that a full Gcoap packet can be
+    # encrypted or decrypted.
+
+    # This is the default in gcoap.h, which we don't have access to, so it is copied over.
+    CONFIG_GCOAP_PDU_BUF_SIZE := $(or $(CONFIG_GCOAP_PDU_BUF_SIZE),128)
+
+    # If there were another way to set up DTLS_MAX_BUF, we'd need to set the
+    # maximum of these here.
+    #
+    # 29 bytes are the overhead measured with Wireshark on packets exchanged in
+    # default configuration; adding some to be safe against variable size fields.
+    CFLAGS += "-DDTLS_MAX_BUF=($(CONFIG_GCOAP_PDU_BUF_SIZE) + 36)"
+endif

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -33,3 +33,8 @@ ifneq (,$(filter gcoap,$(USEMODULE)))
     # default configuration; adding some to be safe against variable size fields.
     CFLAGS += "-DDTLS_MAX_BUF=($(CONFIG_GCOAP_PDU_BUF_SIZE) + 36)"
 endif
+
+# TinyDTLS emits several messages during connection establishment at the info
+# level; this is way more verbose than common in RIOT.
+TINYDTLS_LOG_LEVEL ?= LOG_WARNING
+CFLAGS += -DLOG_LEVEL=$(TINYDTLS_LOG_LEVEL)

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -63,6 +63,12 @@ endif
 PEER_MAX := $(or $(CONFIG_DTLS_PEER_MAX),$(patsubst -DCONFIG_DTLS_PEER_MAX=%,%,$(filter -DCONFIG_DTLS_PEER_MAX=%,$(CFLAGS))))
 ifneq (,$(PEER_MAX))
     CFLAGS += -DDTLS_PEER_MAX=$(PEER_MAX)
+else ifneq (,$(filter gcoap_dtls,$(USEMODULE)))
+    # The default value in sys/include/net/dtls.h for CONFIG_DTLS_PEER_MAX is 2
+    # when gcoap_dtls is active, otherwise 1. As the default in tinydtls is 1,
+    # we need to set it explicitly if the dtls.h default value deviates from
+    # the tinydtls default.
+    CFLAGS += -DDTLS_PEER_MAX=2
 endif
 
 HANDSHAKE_MAX := $(or $(CONFIG_DTLS_HANDSHAKE_MAX),$(patsubst -DCONFIG_DTLS_HANDSHAKE_MAX=%,%,$(filter -DCONFIG_DTLS_HANDSHAKE_MAX=%,$(CFLAGS))))

--- a/sys/include/net/dtls.h
+++ b/sys/include/net/dtls.h
@@ -36,6 +36,8 @@
 #ifndef NET_DTLS_H
 #define NET_DTLS_H
 
+#include "modules.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,7 +46,11 @@ extern "C" {
  * @brief The maximum number DTLS peers (i.e. sessions)
  */
 #ifndef CONFIG_DTLS_PEER_MAX
+#if IS_USED(MODULE_GCOAP_DTLS)
+#define CONFIG_DTLS_PEER_MAX       (2)
+#else
 #define CONFIG_DTLS_PEER_MAX       (1)
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

This adjusts two defaults in tinydtls:

* Default verbosity is set to warning. At the info level, this module produces way more output (several lines per new connection, and even per message) than is common in RIOT.
* If gcoap is used, the buffer size is adjusted to the gcoap buffer size plus overhead. Otherwise, CoAP-over-DTLS works fine until one happens to request larger resources.

### Testing procedure

* Run examples/gcoap_dtls
* Send a CoAP request from outside, eg. with `aiocoap-client 'coaps://[fe80::3c63:beff:fe85:ca96%tapbr0]/.well-known/core' --credentials testserver.json` (where testserver.json is `{"coaps://[fe80::3c63:beff:fe85:ca96%tapbr0]/*": {"dtls": {"psk": {"ascii": "secretPSK"}, "client-identity": {"ascii": "Client_identity"}}}}`).

Before, there are messages shown for every request; now there are none.

Modify `examples/gcoap/server.c` as follows:

```patch
diff --git a/examples/gcoap/server.c b/examples/gcoap/server.c
index bf2315cd01..28e1faac27 100644
--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -68,7 +68,7 @@ static const coap_resource_t _resources[] = {
 };
 
 static const char *_link_params[] = {
-    ";ct=0;rt=\"count\";obs",
+    ";ct=0;rt=\"count\";obs;looooooooooooooooooooooong-attribute=\"loooooooooooooooooooooooooooooong\"",
     NULL
 };
```

The request passes; without this patch, it is stuck in retransmissions until "Network error: Retransmissions exceeded".

### Issues/PRs references

This contributes to making #19289 usable with a minimum level of security. (That module fills up the gcoap buffer to the brim). While the module handles the verbosity as well as it can (occasionally admitting that it lost bytes of output), the previous verbosity produces an infinite stream of stdout data. (But the default should be quiet immaterial of that particular PR).