### PR TITLE
Makefile.features: output board on error

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -13,7 +13,7 @@ include $(BOARDDIR)/Makefile.features
 
 # Sanity check
 ifeq (,$(CPU))
-  $(error CPU must be defined by board / board_common Makefile.features)
+  $(error $(BOARD): CPU must be defined by board / board_common Makefile.features)
 endif
 
 include $(RIOTCPU)/$(CPU)/Makefile.features


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When running a command that affects multiple boards, it can be hard to find out what's the culprit, e.g. a leftover directory from a renamed board.


### Testing procedure

Generates errors like

```
/home/benpicco/dev/RIOT/Makefile.features:16: *** blackpill-128kib: CPU must be defined by board / board_common Makefile.features.  Stop.
```

instead of

```
/home/benpicco/dev/RIOT/Makefile.features:16: *** CPU must be defined by board / board_common Makefile.features.  Stop.
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
