### PR TITLE
core/assert: mark failed condition unreachable with NDEBUG

### DIFF
--- a/core/lib/include/assert.h
+++ b/core/lib/include/assert.h
@@ -14,6 +14,14 @@
  * @file
  * @brief       POSIX.1-2008 compliant version of the assert macro
  *
+ *              This version of `assert()` slightly deviates from the one
+ *              described in the standard in that it turns into a compiler
+ *              hint when `NDEBUG` is set.
+ *              This allows the compiler to assume that the asserted condition
+ *              is always true (as it would do in the `!NDEBUG` case where the
+ *              `assert()` function is marked as `noreturn`) and optimize the
+ *              code accordingly.
+ *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
@@ -67,7 +75,7 @@ extern "C" {
 #endif /*__NORETURN*/
 
 #ifdef NDEBUG
-#define assert(ignore)((void)0)
+#define assert(cond) ((cond) ? (void)0 : __builtin_unreachable())
 #elif defined(DEBUG_ASSERT_VERBOSE)
 /**
  * @brief   Function to handle failed assertion
@@ -114,7 +122,7 @@ __NORETURN void _assert_failure(const char *file, unsigned line);
  *
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/assert.html
  */
-#define assert(cond) (_likely(cond) ? (void)0 :  _assert_failure(__FILE__, __LINE__))
+#define assert(cond) (_likely(cond) ? (void)0 : _assert_failure(__FILE__, __LINE__))
 #else /* DEBUG_ASSERT_VERBOSE */
 __NORETURN void _assert_panic(void);
 #define assert(cond) (_likely(cond) ? (void)0 : _assert_panic())

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -177,20 +177,20 @@ static inline void _gpio_reg_out_xor(gpio_t pin)
 #error "Platform implementation is missing"
 #endif
 
-#ifndef NDEBUG
-int _gpio_init_mode_check(gpio_t pin, gpio_mode_t mode)
+static int _gpio_init_mode_check(gpio_t pin, gpio_mode_t mode)
 {
     assert(pin < GPIO_PIN_NUMOF);
 
     /* check if the pin can be used as GPIO or if it is used for something else */
     if (_gpio_pin_usage[pin] != _GPIO) {
+#ifndef NDEBUG
         LOG_TAG_ERROR("gpio", "GPIO%d is already used as %s signal\n", pin,
                       _gpio_pin_usage_str[_gpio_pin_usage[pin]]);
+#endif
         return -1;
     }
     return 0;
 }
-#endif
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -455,7 +455,6 @@ static usbdev_ep_t *_get_ep(dwc2_usb_otg_fshs_t *usbdev, unsigned num,
     return dir == USB_EP_DIR_IN ? &usbdev->in[num] : &usbdev->out[num].ep;
 }
 
-#if defined(DEVELHELP) && !defined(NDEBUG)
 static size_t _total_fifo_size(const dwc2_usb_otg_fshs_config_t *conf)
 {
     if (conf->type == DWC2_USB_OTG_FS) {
@@ -474,7 +473,6 @@ static size_t _total_fifo_size(const dwc2_usb_otg_fshs_config_t *conf)
     }
 
 }
-#endif /* defined(DEVELHELP) && !defined(NDEBUG) */
 
 static void _configure_tx_fifo(dwc2_usb_otg_fshs_t *usbdev, size_t num,
                                size_t len)

--- a/sys/ecc/golay2412.c
+++ b/sys/ecc/golay2412.c
@@ -80,7 +80,6 @@ static inline void liquid_print_bitstring(uint32_t _x,
     }
 }
 
-#ifndef NDEBUG
 static uint32_t block_get_enc_msg_len(uint32_t _dec_msg_len,
                                       uint32_t _m,
                                       uint32_t _k)
@@ -111,7 +110,6 @@ static uint32_t block_get_enc_msg_len(uint32_t _dec_msg_len,
 
     return num_bytes_out;
 }
-#endif
 
 /* multiply input vector with parity check matrix, H */
 static uint32_t golay2412_matrix_mul(uint32_t _v,

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -618,7 +618,9 @@ static inline int gnrc_netif_ipv6_iid_to_addr(const gnrc_netif_t *netif,
                                               const eui64_t *iid, uint8_t *addr)
 {
     assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
-    return l2util_ipv6_iid_to_addr(netif->device_type, iid, addr);
+    int res = l2util_ipv6_iid_to_addr(netif->device_type, iid, addr);
+    assert(res != -ENOTSUP);
+    return res;
 }
 
 /**
@@ -685,7 +687,9 @@ static inline int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
                                                     const ndp_opt_t *opt)
 {
     assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
-    return l2util_ndp_addr_len_from_l2ao(netif->device_type, opt);
+    int res = l2util_ndp_addr_len_from_l2ao(netif->device_type, opt);
+    assert(res != -ENOTSUP);
+    return res;
 }
 
 /**

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -90,9 +90,12 @@ int gnrc_netif_eui64_from_addr(const gnrc_netif_t *netif,
                 }
 #endif  /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) */
                 /* Intentionally falls through */
-            default:
-                return l2util_eui64_from_addr(netif->device_type, addr,
-                                              addr_len, eui64);
+            default: {
+                int res = l2util_eui64_from_addr(netif->device_type, addr,
+                                                 addr_len, eui64);
+                assert(res != -ENOTSUP);
+                return res;
+            }
         }
     }
 #endif /* GNRC_NETIF_L2ADDR_MAXLEN > 0 */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -203,7 +203,6 @@ static gnrc_sixlowpan_frag_rb_t *_rbuf_get_by_tag(const gnrc_netif_hdr_t *netif_
     return NULL;
 }
 
-#ifndef NDEBUG
 static bool _valid_offset(gnrc_pktsnip_t *pkt, size_t offset)
 {
     return (
@@ -219,7 +218,6 @@ static bool _valid_offset(gnrc_pktsnip_t *pkt, size_t offset)
         (sixlowpan_sfr_rfrag_get_offset(pkt->data) != 0)
     );
 }
-#endif
 
 static uint8_t *_6lo_frag_payload(gnrc_pktsnip_t *pkt)
 {

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -136,7 +136,6 @@ int l2util_eui64_from_addr(int dev_type, const uint8_t *addr, size_t addr_len,
             LOG_ERROR("l2util: can't convert hardware address to EUI-64 "
                       "for device type %d\n", dev_type);
 #endif  /* DEVELHELP */
-            assert(false);
             break;
     }
     return -ENOTSUP;
@@ -247,7 +246,6 @@ int l2util_ipv6_iid_to_addr(int dev_type, const eui64_t *iid, uint8_t *addr)
             LOG_ERROR("l2util: can't convert IID to hardware address for "
                       "device type %d\n", dev_type);
 #endif  /* DEVELHELP */
-            assert(false);
             break;
     }
     return -ENOTSUP;
@@ -308,7 +306,6 @@ int l2util_ndp_addr_len_from_l2ao(int dev_type,
             LOG_ERROR("l2util: can't get address length from NDP link-layer "
                       "address option for device type %d\n", dev_type);
 #endif
-            assert(false);
             break;
     }
     return -ENOTSUP;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The compiler is pretty smart about optimizing code when it knows that a condition can not happen.
When `DEVELHELP` is enabled it knows that the condition inside the `assert()` must be always true and can optimize the code accordingly, as otherwise a `__NORETURN _assert_failure()` function is called.

With `DEVELHELP` disabled the compiler no longer has this information because the `assert(cond)` is replaced by a `(void)cond` by the preprocessor.

Replace it by a `if (!cond) { __builtin_unreachable(); }` instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Code size decrease shows the compiler can optimize the code with `DEVELHELP=0`:

#### master

```
   text	   data	    bss	    dec	    hex	filename
  96116	    228	  18300	 114644	  1bfd4	examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

#### this PR

```
   text	   data	    bss	    dec	    hex	filename
  95880	    228	  18300	 114408	  1bee8	examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

see also https://godbolt.org/z/KaajqWv5Y
and https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1774r4.pdf

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
