### PR TITLE
gnrc_netif: set lower bound for IEEE802154_STACKSIZE_DEFAULT

### DIFF
--- a/sys/net/gnrc/netif/init_devs/include/init_devs.h
+++ b/sys/net/gnrc/netif/init_devs/include/init_devs.h
@@ -22,6 +22,7 @@
 #include "thread.h"
 #include "msg.h"
 #include "net/gnrc/netif/conf.h"    /* <- GNRC_NETIF_MSG_QUEUE_SIZE */
+#include "macros/utils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +54,7 @@ extern "C" {
 /**
  * @brief   stack size of an ieee802154 device
  */
-#define IEEE802154_STACKSIZE_DEFAULT    (GNRC_NETIF_STACKSIZE_DEFAULT + \
+#define IEEE802154_STACKSIZE_DEFAULT    (MAX(520, GNRC_NETIF_STACKSIZE_DEFAULT) + \
                                          IEEE802154_SECURITY_EXTRA_STACKSIZE)
 #endif
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description


Since it was ported to the radio HAL, at86rf2xx requires more stack. This is a problem on AVR where the default stack is just 512 bytes:

```
2023-03-02 01:00:52,637 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current
2023-03-02 01:00:52,646 # 	  1 | idle                 | pending  Q |  15 |    192 (  130) (   62) |     0x263a |     0x269f
2023-03-02 01:00:52,655 # 	  2 | main                 | running  Q |   7 |   2560 ( 1732) (  828) |     0x26fa |     0x2cb1
2023-03-02 01:00:52,663 # 	  3 | 6lo                  | bl rx    _ |   3 |    512 (  276) (  236) |     0x5446 |     0x559b
2023-03-02 01:00:52,672 # 	  4 | ipv6                 | bl rx    _ |   4 |    512 (  372) (  140) |     0x318e |     0x32c4
2023-03-02 01:00:52,681 # 	  5 | udp                  | bl rx    _ |   5 |    256 (  214) (   42) |     0x5648 |     0x569d
2023-03-02 01:00:52,689 # 	  6 | at86rf2xx            | bl anyfl _ |   2 |    520 (  514) (    6) |     0x3582 |     0x371f
2023-03-02 01:00:52,697 # 	    | SUM                  |            |     |   4552 ( 3238) ( 1314)
```
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`avr-rss2` no longer crashes on init for `tests/nanocoap_cli`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
