### PR TITLE
cpu/native: implement periph_rtc_ms

### DIFF
--- a/boards/native/Kconfig
+++ b/boards/native/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NATIVE
 
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTC_MS
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_GPIO

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -2,6 +2,7 @@ CPU = native
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtc_ms
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio

--- a/cpu/native/periph/rtc.c
+++ b/cpu/native/periph/rtc.c
@@ -37,6 +37,13 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+/**
+ * @brief   Time source of the native RTC
+ */
+#ifndef NATIVE_RTC_SOURCE
+#define NATIVE_RTC_SOURCE CLOCK_REALTIME
+#endif
+
 static int _native_rtc_initialized = 0;
 static int _native_rtc_powered = 0;
 
@@ -141,9 +148,14 @@ int rtc_set_time(struct tm *ttime)
         warnx("rtc_set_time: out of time_t range");
         return -1;
     }
+
+    struct timespec tv;
+
     _native_syscall_enter();
-    _native_rtc_offset = tnew - time(NULL);
+    clock_gettime(NATIVE_RTC_SOURCE, &tv);
     _native_syscall_leave();
+
+    _native_rtc_offset = tnew - tv.tv_sec;
 
     if (_native_rtc_alarm_callback) {
         rtc_set_alarm(&_native_rtc_alarm, _native_rtc_alarm_callback,
@@ -153,9 +165,9 @@ int rtc_set_time(struct tm *ttime)
     return 0;
 }
 
-int rtc_get_time(struct tm *ttime)
+int rtc_get_time_ms(struct tm *ttime, uint16_t *ms)
 {
-    time_t t;
+    struct timespec tv;
 
     if (!_native_rtc_initialized) {
         warnx("rtc_get_time: not initialized");
@@ -167,9 +179,14 @@ int rtc_get_time(struct tm *ttime)
     }
 
     _native_syscall_enter();
-    t = time(NULL) + _native_rtc_offset;
+    clock_gettime(NATIVE_RTC_SOURCE, &tv);
+    tv.tv_sec += _native_rtc_offset;
 
-    if (localtime_r(&t, ttime) == NULL) {
+    if (ms) {
+        *ms = tv.tv_nsec / NS_PER_MS;
+    }
+
+    if (localtime_r(&tv.tv_sec, ttime) == NULL) {
         err(EXIT_FAILURE, "rtc_get_time: localtime_r");
     }
     _native_syscall_leave();
@@ -178,6 +195,11 @@ int rtc_get_time(struct tm *ttime)
     _remove_struct_tm_extra(ttime);
 
     return 0;
+}
+
+int rtc_get_time(struct tm *ttime)
+{
+    return rtc_get_time_ms(ttime, NULL);
 }
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`periph_rtc` on `native` can have ms accuracy, so implement the `periph_rtc_ms` interface.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/periph_rtc` now shows sub-second precision:

```
RIOT RTC low-level driver test
This test will display 'Alarm!' every 2 seconds for 4 times
Native RTC initialized.
  Setting clock to   2020-02-28 23:59:57
Clock value is now   2020-02-28 23:59:57.393
  Setting alarm to   2020-02-28 23:59:59
   Alarm is set to   2020-02-28 23:59:59
  Alarm cleared at   2020-02-28 23:59:57.393
       No alarm at   2020-02-28 23:59:59.393
  Setting alarm to   2020-02-28 23:59:61

Alarm!
Alarm!
Alarm!
Alarm!
{ "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 1100 }]}
{ "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2732 }]}
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
