### PR TITLE
Picolibc updates

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -132,6 +132,10 @@ SECTIONS
     } > rom
     __tls_size = __tbss_end - __tdata_start;
     __tbss_size = __tls_size - __tdata_size;
+    PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+    PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+    PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+    PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
     /* .ARM.exidx is sorted, so has to go in its own output section.  */
     PROVIDE_HIDDEN (__exidx_start = .);

--- a/cpu/lpc23xx/ldscripts/lpc23xx.ld
+++ b/cpu/lpc23xx/ldscripts/lpc23xx.ld
@@ -106,6 +106,9 @@ SECTIONS
     } > rom
     __tls_size = __tbss_end - __tdata_start;
     __tbss_size = __tls_size - __tdata_size;
+    PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+    PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+    PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
     /* .ARM.exidx is sorted, so has to go in its own output section.  */
     PROVIDE_HIDDEN (__exidx_start = .);

--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -159,6 +159,8 @@ SECTIONS
   } >flash : tls
   __tls_size = __tbss_end - __tdata_start;
   __tbss_size = __tls_size - __tdata_size;
+  PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+  PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
 
   .lalign         :
   {

--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -118,7 +118,8 @@ _exit(int n)
 {
     LOG_INFO("#! exit %i: powering off\n", n);
     pm_off();
-    while(1);
+    for (;;) {
+    }
 }
 
 /**
@@ -304,6 +305,13 @@ int open(const char *name, int flags, int mode)
 #endif
 }
 
+/*
+ * Picolibc newer than 1.8 uses standard posix types for read/write
+ * return values
+ */
+#if __PICOLIBC_MAJOR__ > 1 || __PICOLIBC_MINOR__ >= 8
+#define _READ_WRITE_RETURN_TYPE ssize_t
+#endif
 /**
  * @brief Read bytes from an open file
  *


### PR DESCRIPTION
### Contribution description

Minor updates to picolibc support for newer versions of picolibc, including 1.8.


### Testing procedure

Here's the current build result for a board I happen to have on my bench right now:

```
$ make -C examples/blinky BOARD=nucleo-f103rb FEATURES_REQUIRED=picolibc
...
/home/keithp/src/RIOT/sys/picolibc_syscalls_default/syscalls.c:319:1: error: unknown type name '_READ_WRITE_RETURN_TYPE'
  319 | _READ_WRITE_RETURN_TYPE read(int fd, void *dest, size_t count)
      | ^~~~~~~~~~~~~~~~~~~~~~~
/home/keithp/src/RIOT/sys/picolibc_syscalls_default/syscalls.c:351:1: error: unknown type name '_READ_WRITE_RETURN_TYPE'
  351 | _READ_WRITE_RETURN_TYPE write(int fd, const void *src, size_t count)
      | ^~~~~~~~~~~~~~~~~~~~~~~
...
```

### Description of changes

 1. Fix the read/write return values (Picolibc 1.8 uses POSIX standard types now)
 2. Add new symbols to linker scripts (Picolibc needs help dealing with TLS alignment)
 3. Align stack and thread local storage block during thread setup.
