### PR TITLE
test/periph_rtc: reset struct tm time between tests

### DIFF
--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -125,14 +125,8 @@ static inline void _get_rtc_mem(void) {}
 
 int main(void)
 {
-    struct tm time = {
-        .tm_year = 2020 - TM_YEAR_OFFSET,   /* years are counted from 1900 */
-        .tm_mon  =  1,                      /* 0 = January, 11 = December */
-        .tm_mday = 28,
-        .tm_hour = 23,
-        .tm_min  = 59,
-        .tm_sec  = 57
-    };
+    struct tm time = (struct tm){0};
+    uint16_t ms;
 
     mutex_t rtc_mtx = MUTEX_INIT_LOCKED;
 
@@ -145,13 +139,33 @@ int main(void)
     _set_rtc_mem();
     _get_rtc_mem();
 
+    /* read RTC to retrieve initial */
+    if (IS_USED(MODULE_PERIPH_RTC_MS)) {
+        rtc_get_time_ms(&time, &ms);
+        print_time_ms("Clock value is now ", &time, ms);
+    } else {
+        rtc_get_time(&time);
+        print_time("Clock value is now ", &time);
+    }
+
+    time = (struct tm){
+        .tm_year = 2020 - TM_YEAR_OFFSET,   /* years are counted from 1900 */
+        .tm_mon  =  1,                      /* 0 = January, 11 = December */
+        .tm_mday = 28,
+        .tm_hour = 23,
+        .tm_min  = 59,
+        .tm_sec  = 57
+    };
+
     /* set RTC */
     print_time("  Setting clock to ", &time);
     rtc_set_time(&time);
 
+    time = (struct tm){0};
+    ms = 0;
+
     /* read RTC to confirm value */
     if (IS_USED(MODULE_PERIPH_RTC_MS)) {
-        uint16_t ms;
         rtc_get_time_ms(&time, &ms);
         print_time_ms("Clock value is now ", &time, ms);
     } else {
@@ -164,14 +178,19 @@ int main(void)
     print_time("  Setting alarm to ", &time);
     rtc_set_alarm(&time, cb, &rtc_mtx);
 
+    time = (struct tm){0};
+    ms = 0;
+
     /* verify alarm */
     rtc_get_alarm(&time);
     print_time("   Alarm is set to ", &time);
 
+    time = (struct tm){0};
+    ms = 0;
+
     /* clear alarm */
     rtc_clear_alarm();
     if (IS_USED(MODULE_PERIPH_RTC_MS)) {
-        uint16_t ms;
         rtc_get_time_ms(&time, &ms);
         print_time_ms("  Alarm cleared at ", &time, ms);
     } else {
@@ -189,14 +208,19 @@ int main(void)
         message = "       No alarm at ";
     }
 
+    time = (struct tm){0};
+    ms = 0;
+
     if (IS_USED(MODULE_PERIPH_RTC_MS)) {
-        uint16_t ms;
         rtc_get_time_ms(&time, &ms);
         print_time_ms(message, &time, ms);
     } else {
         rtc_get_time(&time);
         print_time(message, &time);
     }
+
+    time = (struct tm){0};
+    ms = 0;
 
     /* set alarm */
     rtc_get_time(&time);

--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -19,11 +19,14 @@ def testfunc(child):
     child.expect(r'This test will display \'Alarm\!\' every 2 seconds '
                  r'for (\d{1}) times')
     alarm_count = int(child.match.group(1))
+    child.expect(r'Clock value is now   ({})'.format(DATE_PATTERN))
+    clock_reboot = child.match.group(1)
     child.expect(r'  Setting clock to   ({})'.format(DATE_PATTERN))
     clock_set = child.match.group(1)
     child.expect(r'Clock value is now   ({})'.format(DATE_PATTERN))
     clock_value = child.match.group(1)
     assert clock_set == clock_value
+    assert clock_reboot != clock_value
 
     child.expect(r'  Setting alarm to   ({})'.format(DATE_PATTERN))
     alarm_set = child.match.group(1)


### PR DESCRIPTION
### Contribution description

while reviewing #19340 i found test/periph_rtc to be insufficient to prove rtc_set_time is working. this changes that and avoids accidental reuse of struct tm time and ms  values by resetting time and ms;

### Testing procedure

run the test

### Issues/PRs references

#19340