### PR TITLE
cpu/riscv_common: convert to uword_t usage

### DIFF
--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -30,6 +30,7 @@
 #include "sched.h"
 #include "plic.h"
 #include "clic.h"
+#include "architecture.h"
 
 #include "vendor/riscv_csr.h"
 
@@ -83,13 +84,13 @@ void riscv_irq_init(void)
  * @brief Global trap and interrupt handler
  */
 __attribute((used))
-static void handle_trap(uint32_t mcause)
+static void handle_trap(uword_t mcause)
 {
     /*  Tell RIOT to set sched_context_switch_request instead of
      *  calling thread_yield(). */
     riscv_in_isr = 1;
 
-    uint32_t trap = mcause & CPU_CSR_MCAUSE_CAUSE_MSK;
+    uword_t trap = mcause & CPU_CSR_MCAUSE_CAUSE_MSK;
 
     /* Check for INT or TRAP */
     if ((mcause & MCAUSE_INT) == MCAUSE_INT) {
@@ -129,7 +130,7 @@ static void handle_trap(uint32_t mcause)
             sched_context_switch_request = 1;
             /* Increment the return program counter past the ecall
              * instruction */
-            uint32_t return_pc = read_csr(mepc);
+            uword_t return_pc = read_csr(mepc);
             write_csr(mepc, return_pc + 4);
             break;
         }
@@ -137,8 +138,8 @@ static void handle_trap(uint32_t mcause)
 #ifdef DEVELHELP
             printf("Unhandled trap:\n");
             printf("  mcause: 0x%" PRIx32 "\n", trap);
-            printf("  mepc:   0x%lx\n", read_csr(mepc));
-            printf("  mtval:  0x%lx\n", read_csr(mtval));
+            printf("  mepc:   0x%" PRIx32 "\n", read_csr(mepc));
+            printf("  mtval:  0x%" PRIx32 "\n", read_csr(mtval));
 #endif
             /* Unknown trap */
             core_panic(PANIC_GENERAL_ERROR, "Unhandled trap");

--- a/cpu/riscv_common/periph/plic.c
+++ b/cpu/riscv_common/periph/plic.c
@@ -28,6 +28,7 @@
 #include "assert.h"
 #include "cpu.h"
 #include "plic.h"
+#include "architecture.h"
 
 /* Local macros to calculate register offsets */
 #ifndef _REG32
@@ -42,7 +43,7 @@ static plic_isr_cb_t _ext_isrs[PLIC_NUM_INTERRUPTS];
 
 static inline volatile uint32_t *_get_claim_complete_addr(void)
 {
-    uint32_t hart_id = read_csr(mhartid);
+    uword_t hart_id = read_csr(mhartid);
 
     /* Construct the claim address */
     return &PLIC_REG(PLIC_CLAIM_OFFSET +
@@ -51,7 +52,7 @@ static inline volatile uint32_t *_get_claim_complete_addr(void)
 
 static inline volatile uint32_t *_get_threshold_addr(void)
 {
-    uint32_t hart_id = read_csr(mhartid);
+    uword_t hart_id = read_csr(mhartid);
 
     /* Construct the claim address */
     return &PLIC_REG(PLIC_THRESHOLD_OFFSET +
@@ -60,7 +61,7 @@ static inline volatile uint32_t *_get_threshold_addr(void)
 
 static inline volatile uint32_t *_get_irq_reg(unsigned irq)
 {
-    uint32_t hart_id = read_csr(mhartid);
+    uword_t hart_id = read_csr(mhartid);
 
     return &PLIC_REG(PLIC_ENABLE_OFFSET +
                      (hart_id << PLIC_ENABLE_SHIFT_PER_TARGET)) +

--- a/cpu/riscv_common/thread_arch.c
+++ b/cpu/riscv_common/thread_arch.c
@@ -25,6 +25,7 @@
 #include "thread.h"
 #include "sched.h"
 #include "context_frame.h"
+#include "architecture.h"
 
 /**
  * @brief   Noticeable marker marking the beginning of a stack segment
@@ -101,11 +102,11 @@ char *thread_stack_init(thread_task_func_t task_func,
     memset(sf, 0, sizeof(*sf));
 
     /* set initial reg values */
-    sf->pc = (uint32_t)task_func;
-    sf->a0 = (uint32_t)arg;
+    sf->pc = (uword_t)task_func;
+    sf->a0 = (uword_t)arg;
 
     /* if the thread exits go to sched_task_exit() */
-    sf->ra = (uint32_t)sched_task_exit;
+    sf->ra = (uword_t)sched_task_exit;
 
     return (char *)stk_top;
 }


### PR DESCRIPTION
### Contribution description

This PR makes use of `uword_t` type in a few places in `cpu/riscv_common`.
This should not have any effect on produced binaries.

### Testing procedure

CI should be enough. 

### Issues/PRs references
Quickly adapt from #16994. It will help for 64 bits support one day ;)

