### PR TITLE
pkg/tinydtls: allow build for AVR

### DIFF
--- a/cpu/avr8_common/avr_libc_extra/posix_unistd.c
+++ b/cpu/avr8_common/avr_libc_extra/posix_unistd.c
@@ -177,4 +177,9 @@ ssize_t write(int fd, const void *src, size_t count)
 #endif
 }
 
+void perror(const char *s)
+{
+    printf("%s: %s\n", s, strerror(errno));
+}
+
 /** @} */

--- a/examples/dtls-echo/Makefile.ci
+++ b/examples/dtls-echo/Makefile.ci
@@ -1,22 +1,30 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
-    b-l072z-lrwan1 \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atxmega-a3bu-xplained \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
     bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
     calliope-mini \
-    cc2650-launchpad \
-    cc2650stk \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     im880b \
-    lsn50 \
-    maple-mini \
+    mega-xplained \
     microbit \
-    nrf51dk \
+    microduino-corerf \
+    msb-430 \
+    msb-430h \
     nrf51dongle \
     nrf6310 \
     nucleo-f030r8 \
@@ -24,20 +32,16 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f070rb \
     nucleo-f072rb \
-    nucleo-f103rb \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
-    nucleo-l073rz \
-    opencm904 \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
     slstk3400a \
-    spark-core \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
@@ -45,5 +49,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    telosb \
+    waspmote-pro \
     yunjia-nrf51822 \
+    z1 \
+    zigduino \
     #

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -3,21 +3,15 @@ BOARD_INSUFFICIENT_MEMORY := \
     b-l072z-lrwan1 \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
+    bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
-    bluepill-stm32f030c8 \
     calliope-mini \
-    cc1350-launchpad \
-    cc2650-launchpad \
-    cc2650stk \
-    e104-bt5010a-tb \
-    e104-bt5011a-tb \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     lsn50 \
-    maple-mini \
     microbit \
     nrf51dongle \
     nrf6310 \
@@ -26,28 +20,22 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f070rb \
     nucleo-f072rb \
-    nucleo-f103rb \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
-    nucleo-l073rz \
-    olimexino-stm32 \
-    opencm904 \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
     slstk3400a \
-    spark-core \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
-    stm32mindev \
     stm32mp157c-dk2 \
     yunjia-nrf51822 \
     #

--- a/examples/gcoap_dtls/Makefile.ci
+++ b/examples/gcoap_dtls/Makefile.ci
@@ -1,5 +1,16 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atxmega-a1-xplained \
+    atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
@@ -7,12 +18,17 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
     calliope-mini \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     lsn50 \
+    mega-xplained \
     microbit \
+    microduino-corerf \
+    msb-430 \
+    msb-430h \
     nrf51dongle \
     nrf6310 \
     nucleo-f030r8 \
@@ -29,8 +45,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
-    seeedstudio-gd32 \
-    sipeed-longan-nano \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
@@ -39,5 +53,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    telosb \
+    waspmote-pro \
     yunjia-nrf51822 \
+    z1 \
+    zigduino \
     #

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -5,7 +5,10 @@ PKG_LICENSE=EPL-1.0,EDL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-CFLAGS += -Wno-implicit-fallthrough
+# tinyDTLS custom logging functions pass non-literals to printf(), so disable them
+ifneq (,$(filter arch_avr8,$(FEATURES_USED)))
+  CFLAGS += -DNDEBUG
+endif
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(PKG_SOURCE_DIR)/Makefile.riot

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -7,9 +7,6 @@ USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
 USEMODULE += ztimer64_msec
 
-# TinyDTLS only has support for 32-bit architectures ATM
-FEATURES_REQUIRED += arch_32bit
-
 ifneq (,$(filter sock_dtls,$(USEMODULE)))
   USEMODULE += tinydtls_sock_dtls
   USEMODULE += ztimer_usec

--- a/pkg/tinydtls/patches/0001-dtls_debug-mock-dsrv_log-when-NDEBUG.patch
+++ b/pkg/tinydtls/patches/0001-dtls_debug-mock-dsrv_log-when-NDEBUG.patch
@@ -1,0 +1,93 @@
+From 3eade60499185b40c0593774af52dbe42042a939 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Mon, 27 Feb 2023 16:37:14 +0100
+Subject: [PATCH] dtls_debug: mock dsrv_log() when NDEBUG is set
+
+Setting NDEBUG already replaces dtls_dsrv_hexdump_log(), dtls_dsrv_log_addr()
+etc with dummy implementations.
+
+This extends this to also replace dsrv_log() and dtls_{get,set}_log_level()
+with a no-op implementation.
+---
+ dtls_debug.c | 26 +++++++++++++++++++-------
+ 1 file changed, 19 insertions(+), 7 deletions(-)
+
+diff --git a/dtls_debug.c b/dtls_debug.c
+index 70c88ff..e7a9902 100644
+--- a/dtls_debug.c
++++ b/dtls_debug.c
+@@ -51,8 +51,6 @@ typedef int in_port_t;
+ LOG_MODULE_REGISTER(TINYDTLS, CONFIG_TINYDTLS_LOG_LEVEL);
+ #endif /* WITH_ZEPHYR */
+ 
+-static int maxlog = DTLS_LOG_WARN;      /* default maximum log level */
+-
+ const char *dtls_package_name(void) {
+   return PACKAGE_NAME;
+ }
+@@ -61,6 +59,9 @@ const char *dtls_package_version(void) {
+   return PACKAGE_VERSION;
+ }
+ 
++#ifndef NDEBUG
++static int maxlog = DTLS_LOG_WARN;      /* default maximum log level */
++
+ log_t
+ dtls_get_log_level(void) {
+   return maxlog;
+@@ -101,8 +102,6 @@ print_timestamp(char *s, size_t len, clock_time_t t) {
+ 
+ #endif /* HAVE_TIME_H */
+ 
+-#ifndef NDEBUG
+-
+ /**
+  * A length-safe strlen() fake.
+  *
+@@ -240,8 +239,6 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
+ #endif /* ! HAVE_INET_NTOP */
+ }
+ 
+-#endif /* NDEBUG */
+-
+ #if !defined(WITH_CONTIKI) && !defined(_MSC_VER)
+ 
+ static void
+@@ -332,7 +329,6 @@ dsrv_log(log_t level, char *format, ...) {
+ }
+ #endif /* WITH_CONTIKI */
+ 
+-#ifndef NDEBUG
+ /** dumps packets in usual hexdump format */
+ void hexdump(const unsigned char *packet, int length) {
+   int n = 0;
+@@ -497,6 +493,16 @@ dtls_dsrv_hexdump_log(log_t level, const char *name, const unsigned char *buf, s
+ 
+ #else /* NDEBUG */
+ 
++log_t
++dtls_get_log_level(void) {
++  return 0;
++}
++
++void
++dtls_set_log_level(log_t level) {
++  (void)level;
++}
++
+ void
+ hexdump(const unsigned char *packet, int length) {
+   (void)packet;
+@@ -518,6 +524,12 @@ dtls_dsrv_hexdump_log(log_t level, const char *name, const unsigned char *buf, s
+   (void)extend;
+ }
+ 
++void
++dsrv_log(log_t level, const char *format, ...) {
++  (void)level;
++  (void)format;
++}
++
+ void
+ dtls_dsrv_log_addr(log_t level, const char *name, const session_t *addr) {
+   (void)level;

--- a/tests/gcoap_dns/Makefile.ci
+++ b/tests/gcoap_dns/Makefile.ci
@@ -1,12 +1,28 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atxmega-a1-xplained \
+    atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     blackpill-stm32f103c8 \
     bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
     calliope-mini \
+    derfmega128 \
     i-nucleo-lrwan1 \
     im880b \
+    mega-xplained \
     microbit \
+    microduino-corerf \
+    msb-430 \
+    msb-430h \
     nrf51dongle \
     nrf6310 \
     nucleo-f030r8 \
@@ -21,8 +37,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
-    seeedstudio-gd32 \
-    sipeed-longan-nano \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
@@ -31,5 +45,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    telosb \
+    waspmote-pro \
     yunjia-nrf51822 \
+    z1 \
+    zigduino \
     #

--- a/tests/gnrc_sock_dodtls/Makefile
+++ b/tests/gnrc_sock_dodtls/Makefile
@@ -4,9 +4,6 @@ RIOTBASE ?= $(CURDIR)/../..
 
 export TAP ?= tap0
 
-# TinyDTLS only has support for 32-bit architectures ATM
-FEATURES_REQUIRED += arch_32bit
-
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += ipv4_addr
 USEMODULE += ipv6_addr

--- a/tests/gnrc_sock_dodtls/Makefile.ci
+++ b/tests/gnrc_sock_dodtls/Makefile.ci
@@ -1,11 +1,23 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atxmega-a3bu-xplained \
     blackpill-stm32f103c8 \
-    bluepill-stm32f103c8 \
     bluepill-stm32f030c8 \
+    bluepill-stm32f103c8 \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     im880b \
+    mega-xplained \
+    microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \
@@ -26,12 +38,12 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
-    stm32l0538-disco \
     stm32f7508-dk \
     stm32g0316-disco \
+    stm32l0538-disco \
     stm32mp157c-dk2 \
     telosb \
-    thingy52 \
+    waspmote-pro \
     z1 \
     zigduino \
     #

--- a/tests/nanocoap_cli/Makefile.ci
+++ b/tests/nanocoap_cli/Makefile.ci
@@ -1,7 +1,17 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atxmega-a1-xplained \
+    atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
-    m1284p \
+    mega-xplained \
+    microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \
@@ -14,7 +24,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l053r8 \
     samd10-xmini \
     seeedstudio-gd32 \
-    sipeed-longan-nano \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
@@ -22,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \
+    waspmote-pro \
     z1 \
     zigduino \
     #

--- a/tests/pkg_tinydtls_sock_async/Makefile
+++ b/tests/pkg_tinydtls_sock_async/Makefile
@@ -1,8 +1,5 @@
 include ../Makefile.tests_common
 
-# TinyDTLS only has support for 32-bit architectures ATM
-FEATURES_REQUIRED += arch_32bit
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += netdev_default

--- a/tests/pkg_tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg_tinydtls_sock_async/Makefile.ci
@@ -1,15 +1,25 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
+    bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
-    bluepill-stm32f030c8 \
     calliope-mini \
     cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
+    derfmega128 \
     e104-bt5010a-tb \
     e104-bt5011a-tb \
     hifive1 \
@@ -18,7 +28,11 @@ BOARD_INSUFFICIENT_MEMORY := \
     im880b \
     lsn50 \
     maple-mini \
+    mega-xplained \
     microbit \
+    microduino-corerf \
+    msb-430 \
+    msb-430h \
     nrf51dongle \
     nrf6310 \
     nucleo-f030r8 \
@@ -47,7 +61,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
-    stm32mindev \
     stm32mp157c-dk2 \
+    telosb \
+    waspmote-pro \
     yunjia-nrf51822 \
+    z1 \
+    zigduino \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

tinyDTLS builds and works just fine on AVR, we only have to disable the custom logging functions as those will try to call `printf()` with non-literal strings. (We don't even call them, but they get built anyway)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I used `tests/nanocoap_cli` for testing. As `THREAD_STACKSIZE_DEFAULT` is lower on AVR we have to bump the main stack size here:

```patch
--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -43,7 +43,7 @@ ifeq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   USEMODULE += shell_cmds_default
 
   # DTLS and VFS operations require more stack on the main thread
-  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(5*THREAD_STACKSIZE_DEFAULT\)
 
   # always enable auto-format for native
   ifeq ($(BOARD),native)
```

I ran a border router on `samr21-xpro` with 

```
sudo dist/tools/tapsetup/tapsetup -u eno1
make BOARD=samr21-xpro REUSE_TAP=1 flash term
```

and `examples/gcoap_dtls` on `native` on the `tap1` port. I then connected from the `avr-rss2` to the `native` instance via the `samr21-xpro` border router:

```
> ncget coaps://[2001:9e8:1400:e100:58b0:8ff:fe67:ad82]/.well-known/core -
2023-03-04 23:06:02,562 # </cli/stats>;ct=0;rt="count";obs,</riot/board>

> ncget coaps://[2001:9e8:1400:e100:58b0:8ff:fe67:ad82]/riot/board -
2023-03-04 23:06:14,386 # netq_node_new: malloc
2023-03-04 23:06:14,390 # cannot add alert, retransmit buffer full
2023-03-04 23:06:14,434 # unexpected ChangeCipherSpec during handshake
2023-03-04 23:06:14,447 # No security context for epoch: 1 (handshake)
2023-03-04 23:06:14,487 # No security context for epoch: 1 (alert)
2023-03-04 23:06:15,981 # No security context for epoch: 1 (handshake)
2023-03-04 23:06:16,411 # netq_node_new: malloc
2023-03-04 23:06:16,416 # cannot add alert, retransmit buffer full
2023-03-04 23:06:16,713 # No security context for epoch: 1 (alert)
2023-03-04 23:06:19,993 # native
```


### Issues/PRs references

upstream PR to no build custom logging functions: https://github.com/eclipse/tinydtls/pull/189
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
