### PR TITLE
tools/compile_like_murdock: Add features

### DIFF
--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -140,10 +140,12 @@ def _all_apps(cwd):
     return out.decode("utf-8", errors="replace").split()
 
 
-def _supported_boards(boards, env, cwd):
+def _supported_boards(boards, env, cwd, all_boards=False):
     cmd = ['make', 'info-boards-supported', '--no-print-directory']
     out = subprocess.check_output(cmd, env=env, cwd=cwd, stderr=subprocess.DEVNULL)
     supported_boards = out.decode("utf-8", errors="replace").split()
+    if all_boards:
+        return supported_boards
     return [brd for brd in supported_boards if brd in boards]
 
 
@@ -181,7 +183,8 @@ def main():
                         help=("Optional boards list, will test all supported "
                               "boards on the list. Will override the cpu "
                               "filter.  If empty, a subset of boards will be "
-                              "selected for you..."))
+                              "selected for you. If 'all' then it will test "
+                              "all supported boards."))
     parser.add_argument("-c", "--cpu", type=str,
                         help=("Optional filter for all supported boards "
                               "belonging to the cpu family, for example, "
@@ -217,8 +220,10 @@ def main():
         if args.cpu:
             target_boards = _supported_boards_from_cpu(args.cpu, full_env,
                                                        test_dir)
+        elif args.boards[0] == "all":
+            target_boards = _supported_boards(boards, full_env, test_dir, True)
         else:
-            target_boards = _supported_boards(boards, full_env, test_dir)
+            target_boards = _supported_boards(boards, full_env, test_dir, False)
         for board in target_boards:
             if args.dry_run:
                 print(f"{app: <30} {board: <30}")

--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -136,13 +136,13 @@ def _end(sec, job):
 
 def _all_apps(cwd):
     cmd = ['make', 'info-applications', '--no-print-directory']
-    out = subprocess.check_output(cmd, cwd=cwd)
+    out = subprocess.check_output(cmd, cwd=cwd, stderr=subprocess.DEVNULL)
     return out.decode("utf-8", errors="replace").split()
 
 
 def _supported_boards(boards, env, cwd):
     cmd = ['make', 'info-boards-supported', '--no-print-directory']
-    out = subprocess.check_output(cmd, env=env, cwd=cwd)
+    out = subprocess.check_output(cmd, env=env, cwd=cwd, stderr=subprocess.DEVNULL)
     supported_boards = out.decode("utf-8", errors="replace").split()
     return [brd for brd in supported_boards if brd in boards]
 
@@ -150,7 +150,7 @@ def _supported_boards(boards, env, cwd):
 def _supported_boards_from_cpu(cpu, env, cwd):
     cmd = (f'FEATURES_REQUIRED=cpu_{cpu} make info-boards-supported '
            '--no-print-directory')
-    out = subprocess.check_output(cmd, shell=True, env=env, cwd=cwd)
+    out = subprocess.check_output(cmd, shell=True, env=env, cwd=cwd, stderr=subprocess.DEVNULL)
     return out.decode("utf-8", errors="replace").split()
 
 


### PR DESCRIPTION
### Contribution description

This adds a few nice-to-have features:
- The `-b all` allows all supported boards to build
- The `-v, -vv, -vvv` allows different levels of verbosity, the most useful might be `-v` which filters only the kconfig diffs
- All warning or STDERR based output from `info-*` are hidden
- The `-m` that only runs a diff of modules and packages, skipping any compilation

### Testing procedure

In induce a mismatch and check the output with `-v`, `-vv` options, clean it up and see the full output with `-vvv`:
```
./dist/tools/compile_test/compile_like_murdock.py -a APP -d -b BOARD -v
```

Check all supported boards are listed with
```
./dist/tools/compile_test/compile_like_murdock.py -a examples/hello-world/ -d -b all
```


### Issues/PRs references

