### PR TITLE
pkg/tinydtls: don't require ztimer64

### DIFF
--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -5,7 +5,7 @@ USEMODULE += hashes
 USEMODULE += random
 USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
-USEMODULE += ztimer64_msec
+USEMODULE += ztimer_msec
 
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The [RIOT integration](https://github.com/eclipse/tinydtls/blob/main/dtls_time.c#L44) makes no use of ztimer64, so drop it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Code still compiles, ztimer64 is not used.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
