### PR TITLE
doc: add quicklink to boards in navbar

### DIFF
--- a/doc/doxygen/RIOTDoxygenLayout.xml
+++ b/doc/doxygen/RIOTDoxygenLayout.xml
@@ -4,6 +4,7 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
+    <tab type="user" url="@ref boards" title="Supported Boards"/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>


### PR DESCRIPTION
### Contribution description

Finding a list of supported boards and how to use them is an essential information. Currently this list is somewhat hidden under "Modules" which is not very intuitive. Hence, I propose to (at least) put a link in the side menu to this overview page.

### Testing procedure

1. Call `make doc`
2. Check the sidebar `${RIOT_BASE}/doc/doxygen/html/index.html` for an entry "Supported Boards"