### PR TITLE
boards/adafruit-itsybitsy-m4: configure littleFS on external flash

### DIFF
--- a/boards/adafruit-itsybitsy-m4/Makefile.dep
+++ b/boards/adafruit-itsybitsy-m4/Makefile.dep
@@ -7,5 +7,11 @@ ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_spi_nor
 endif
 
+# default to using littlefs2 on the external flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif
+
 # setup the samd21 arduino bootloader related dependencies
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.dep

--- a/boards/adafruit-itsybitsy-m4/board.c
+++ b/boards/adafruit-itsybitsy-m4/board.c
@@ -21,6 +21,9 @@
 #include "periph/gpio.h"
 #include "mtd_spi_nor.h"
 #include "timex.h"
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+#endif
 
 #ifdef MODULE_MTD
 /* GD25x16 */
@@ -52,4 +55,8 @@ static mtd_spi_nor_t samd51_nor_dev = {
 };
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+
+#ifdef MODULE_VFS_DEFAULT
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(samd51_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
 #endif /* MODULE_MTD */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The board comes with 2 MiB QSPI flash, we might as well configure a filesystem on it.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/vfs_default` works as expected. 

```
2023-03-07 01:28:39,730 # > vfs df
2023-03-07 01:28:39,732 # Mountpoint              Total         Used    Available     Use%
2023-03-07 01:28:39,737 # /nvm0                   2 MiB        8 KiB     2040 KiB       0%

2023-03-07 01:28:46,010 # > ls /nvm0
2023-03-07 01:28:46,012 # ./
2023-03-07 01:28:46,012 # ../
2023-03-07 01:28:46,014 # total 0 files
```



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
