### PR TITLE
usbus/msc: add CONFIG_USBUS_MSC_AUTO_MTD option to create LUNs on init

### DIFF
--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup     drivers_mtd
+ * @{
+ * @brief       Default MTD device configuration
+ *
+ * Helpers for generic MTD use.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef MTD_DEFAULT_H
+#define MTD_DEFAULT_H
+
+#include "board.h"
+#include "mtd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Number of MTD devices
+ */
+#ifndef MTD_NUMOF
+#if defined(MTD_3)
+#define MTD_NUMOF 4
+#elif defined(MTD_2)
+#define MTD_NUMOF 3
+#elif defined(MTD_1)
+#define MTD_NUMOF 2
+#elif defined(MTD_0)
+#define MTD_NUMOF 1
+#else
+#define MTD_NUMOF 0
+#endif
+#endif
+
+/**
+ * @brief   Get the default MTD device by index
+ *
+ * @param[in] idx   Index of the MTD device
+ *
+ * @return  MTD_0 for @p idx 0 and so on
+ *          NULL if no MTD device exists for the given index
+ */
+static inline mtd_dev_t *mtd_default_get_dev(unsigned idx)
+{
+    switch (idx) {
+#ifdef MTD_0
+    case 0: return MTD_0;
+#endif
+#ifdef MTD_1
+    case 1: return MTD_1;
+#endif
+#ifdef MTD_2
+    case 2: return MTD_2;
+#endif
+#ifdef MTD_3
+    case 3: return MTD_3;
+#endif
+    }
+
+    return NULL;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_DEFAULT_H */
+/** @} */

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -78,3 +78,8 @@ void auto_init_usb(void)
     /* Finally initialize USBUS thread */
     usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus);
 }
+
+usbus_t *usbus_auto_init_get(void)
+{
+    return &usbus;
+}

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -39,6 +39,10 @@ usbus_cdcecm_device_t cdcecm;
 #include "usb/usbus/dfu.h"
 static usbus_dfu_device_t dfu;
 #endif
+#ifdef MODULE_USBUS_MSC
+#include "usb/usbus/msc.h"
+static usbus_msc_device_t msc;
+#endif
 
 static char _stack[USBUS_STACKSIZE];
 static usbus_t usbus;
@@ -64,6 +68,11 @@ void auto_init_usb(void)
 
 #ifdef MODULE_USBUS_DFU
     usbus_dfu_init(&usbus, &dfu, USB_DFU_PROTOCOL_RUNTIME_MODE);
+#endif
+
+#ifdef MODULE_USBUS_MSC
+    /* Initialize Mass Storage Class */
+    usbus_msc_init(&usbus, &msc);
 #endif
 
     /* Finally initialize USBUS thread */

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -74,6 +74,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief USBUS MSC auto MTD setting
+ *
+ * When set to 1, the USBUS MSC module will automatically create a LUN for
+ * each MTD device defined in `board.h`.
+ */
+#ifndef CONFIG_USBUS_MSC_AUTO_MTD
+#define CONFIG_USBUS_MSC_AUTO_MTD           1
+#endif
+
+/**
  * @brief USBUS endpoint 0 buffer size
  *
  * This configures the buffer size of the control endpoint. Unless you transfer

--- a/sys/include/usb/usbus/msc.h
+++ b/sys/include/usb/usbus/msc.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include "usb/usbus.h"
 #include "usb/usbus/msc/scsi.h"
-#include "mtd.h"
+#include "mtd_default.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/usb/usbus/msc/Kconfig
+++ b/sys/usb/usbus/msc/Kconfig
@@ -16,6 +16,13 @@ menuconfig MODULE_USBUS_MSC
 
 if MODULE_USBUS_MSC
 
+config USBUS_MSC_AUTO_MTD
+    bool "Automatically export all MTD devices via USB"
+    default true
+    help
+        This will automatically export all MTD devices that follow
+        the default naming scheme on startup.
+
 config USBUS_MSC_VENDOR_ID
     string "MSC Vendor ID"
     default "RIOT-OS"

--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -354,6 +354,13 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
 
     /* Prepare to receive first bytes from Host */
     usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
+
+    /* Auto-configure all MTD devices */
+    if (CONFIG_USBUS_MSC_AUTO_MTD) {
+        for (int i = 0; i < USBUS_MSC_EXPORTED_NUMOF; i++) {
+            usbus_msc_add_lun(usbus, mtd_default_get_dev(i));
+        }
+    }
 }
 
 static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -25,39 +25,11 @@
 #include <string.h>
 
 #include "od.h"
-#include "mtd.h"
+#include "mtd_default.h"
 #include "shell.h"
 #include "board.h"
 #include "macros/units.h"
 #include "test_utils/expect.h"
-
-#ifndef MTD_NUMOF
-#ifdef MTD_0
-#define MTD_NUMOF 1
-#else
-#define MTD_NUMOF 0
-#endif
-#endif
-
-static mtd_dev_t *_get_mtd_dev(unsigned idx)
-{
-    switch (idx) {
-#ifdef MTD_0
-    case 0: return MTD_0;
-#endif
-#ifdef MTD_1
-    case 1: return MTD_1;
-#endif
-#ifdef MTD_2
-    case 2: return MTD_2;
-#endif
-#ifdef MTD_3
-    case 3: return MTD_3;
-#endif
-    }
-
-    return NULL;
-}
 
 static mtd_dev_t *_get_dev(int argc, char **argv)
 {
@@ -73,7 +45,7 @@ static mtd_dev_t *_get_dev(int argc, char **argv)
         return NULL;
     }
 
-    return _get_mtd_dev(idx);
+    return mtd_default_get_dev(idx);
 }
 
 static uint64_t _get_size(mtd_dev_t *dev)
@@ -311,7 +283,7 @@ static int cmd_info(int argc, char **argv)
 
         for (int i = 0; i < MTD_NUMOF; ++i) {
             printf(" -=[ MTD_%d ]=-\n", i);
-            _print_info(_get_mtd_dev(i));
+            _print_info(mtd_default_get_dev(i));
         }
         return 0;
     }
@@ -481,7 +453,7 @@ int main(void)
     for (int i = 0; i < MTD_NUMOF; ++i) {
         printf("init MTD_%d… ", i);
 
-        mtd_dev_t *dev = _get_mtd_dev(i);
+        mtd_dev_t *dev = mtd_default_get_dev(i);
         int res = mtd_init(dev);
         if (res) {
             printf("error: %d\n", res);

--- a/tests/usbus_msc/Makefile
+++ b/tests/usbus_msc/Makefile
@@ -18,8 +18,6 @@ USEMODULE += ps
 USEMODULE += shell
 USEMODULE += usbus_msc
 USEMODULE += ztimer_msec
-# Purposely disable auto_attach for this application
-CFLAGS += -DCONFIG_USBUS_AUTO_ATTACH=0
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I had some trouble combining `tests/usbus_msc` with `stdio_cdc_acm`.
Turns out the test was creating it's own usbus and was therefore not compatible with other modules that make use of usbus.

Fix this by adding USB MSC to `auto_init_usbus` and add a config option `CONFIG_USBUS_MSC_AUTO_MTD` to export all MTD devices on startup.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/usbus_msc` now provides all MTD devices via USB without manual configutaiton.

More importantly, it now also works on boards that use `stdio_cdc_acm` like `adafruit-itsybitsy-m4`:

```
[ 5252.107261] usb 1-1.4: new full-speed USB device number 40 using ehci-pci
[ 5252.217906] usb 1-1.4: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 1.00
[ 5252.217917] usb 1-1.4: New USB device strings: Mfr=3, Product=2, SerialNumber=4
[ 5252.217920] usb 1-1.4: Product: adafruit-itsybitsy-m4
[ 5252.217923] usb 1-1.4: Manufacturer: RIOT-os.org
[ 5252.217925] usb 1-1.4: SerialNumber: 6B1818B4AF9DA5EE
[ 5252.220677] cdc_acm 1-1.4:1.0: ttyACM0: USB ACM device
[ 5252.221092] usb-storage 1-1.4:1.2: USB Mass Storage device detected
[ 5252.221457] scsi host8: usb-storage 1-1.4:1.2
[ 5253.240488] scsi 8:0:0:0: Direct-Access     RIOT-OS  RIOT_MSC_DISK     1.0 PQ: 0 ANSI: 1
[ 5253.240895] sd 8:0:0:0: Attached scsi generic sg3 type 0
[ 5253.241621] sd 8:0:0:0: [sdc] 512 4096-byte logical blocks: (2.10 MB/2.00 MiB)
[ 5253.242220] sd 8:0:0:0: [sdc] Write Protect is off
[ 5253.242223] sd 8:0:0:0: [sdc] Mode Sense: 03 00 00 00
[ 5253.242855] sd 8:0:0:0: [sdc] No Caching mode page found
[ 5253.242858] sd 8:0:0:0: [sdc] Assuming drive cache: write through
[ 5253.266933] sd 8:0:0:0: [sdc] Attached SCSI removable disk
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
