### PR TITLE
nanocoap_sock: ensure response address is the same as request address

### DIFF
--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -268,6 +268,7 @@
 #ifndef NET_SOCK_UDP_H
 #define NET_SOCK_UDP_H
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -280,7 +281,10 @@
 # pragma clang diagnostic ignored "-Wtypedef-redefinition"
 #endif
 
+#include "net/af.h"
 #include "net/sock.h"
+#include "net/ipv4/addr.h"
+#include "net/ipv6/addr.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -783,6 +787,31 @@ static inline ssize_t sock_udp_sendv(sock_udp_t *sock,
                                      const sock_udp_ep_t *remote)
 {
     return sock_udp_sendv_aux(sock, snips, remote, NULL);
+}
+
+/**
+ * @brief   Checks if the IP address of an endpoint is multicast
+ *
+ * @param[in] ep end point to check
+ *
+ * @returns true if end point is multicast
+ */
+static inline bool sock_udp_ep_is_multicast(const sock_udp_ep_t *ep)
+{
+    switch (ep->family) {
+#ifdef SOCK_HAS_IPV6
+    case AF_INET6:
+        return ipv6_addr_is_multicast((const ipv6_addr_t *)&ep->addr.ipv6);
+#endif
+#ifdef SOCK_HAS_IPV4
+    case AF_INET:
+        return ipv4_addr_is_multicast((const ipv4_addr_t *)&ep->addr.ipv4);
+#endif
+    default:
+        assert(0);
+    }
+
+    return false;
 }
 
 #include "sock_types.h"

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -85,7 +85,6 @@ static void _cache_process(gcoap_request_memo_t *memo,
 static ssize_t _cache_build_response(nanocoap_cache_entry_t *ce, coap_pkt_t *pdu,
                                      uint8_t *buf, size_t len);
 static void _receive_from_cache_cb(void *arg);
-static bool _ep_is_multicast(const sock_udp_ep_t *remote_ep);
 
 static int _request_matcher_default(gcoap_listener_t *listener,
                                     const coap_resource_t **resource,
@@ -353,7 +352,7 @@ static void _on_sock_udp_evt(sock_udp_t *sock, sock_async_flags_t type, void *ar
             .flags = SOCK_AUX_SET_LOCAL,
             .local = aux_in.local,
         };
-        if (_ep_is_multicast(&aux_in.local)) {
+        if (sock_udp_ep_is_multicast(&aux_in.local)) {
             /* This eventually gets passed to sock_udp_send_aux, where NULL
              * simply does not set any flags */
             aux_out_ptr = NULL;
@@ -845,24 +844,6 @@ static int _find_resource(gcoap_socket_type_t tl_type,
     return ret;
 }
 
-static bool _ep_is_multicast(const sock_udp_ep_t *remote_ep)
-{
-    switch (remote_ep->family) {
-#ifdef SOCK_HAS_IPV6
-    case AF_INET6:
-        return ipv6_addr_is_multicast((const ipv6_addr_t *)&remote_ep->addr.ipv6);
-#endif
-#ifdef SOCK_HAS_IPV4
-    case AF_INET:
-        return ipv4_addr_is_multicast((const ipv4_addr_t *)&remote_ep->addr.ipv4);
-#endif
-    default:
-        assert(0);
-    }
-
-    return false;
-}
-
 /*
  * Finds the memo for an outstanding request within the _coap_state.open_reqs
  * array. Matches on remote endpoint and token.
@@ -900,7 +881,7 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
             if ((memcmp(coap_get_token(src_pdu), coap_get_token(memo_pdu), cmplen) == 0)
                     && (sock_udp_ep_equal(&memo->remote_ep, remote)
                       /* Multicast addresses are not considered in matching responses */
-                      || _ep_is_multicast(&memo->remote_ep)
+                      || sock_udp_ep_is_multicast(&memo->remote_ep)
                     )) {
                 *memo_ptr = memo;
                 break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a node has multiple addresses we must reply to a request with the same address on which the request was received.

Since nanoCoAP is not always used as a server and often with only a single address, keep it optional and only enable it when the `sock_aux_local` module is used.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CoAP server needs to have two public addresses for this issue to occur:

e.g. set `CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=3` in `examples/suit_update` and do

```
> ifconfig 5 add 2001:9e8:1416:8f00::1234
success: added 2001:9e8:1416:8f00::1234/64 to interface 5

> ifconfig
Iface  5  HWaddr: 7A:37:FC:7D:1A:AF 
          L2-PDU:1500  MTU:1492  HL:255  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::7837:fcff:fe7d:1aaf  scope: link  VAL
          inet6 addr: 2001:9e8:1416:8f00:7837:fcff:fe7d:1aaf  scope: global  VAL
          inet6 addr: 2001:9e8:1416:8f00::1234  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff7d:1aaf
          inet6 group: ff02::1:ff00:1234

```

CoAP requests to either public address should now be answered with the same public address to which the request was made:

```
> ncget coap://[2001:9e8:1416:8f00::1234]/.well-known/core -
</.well-known/core>,</riot/board>,</suit/>

> ncget coap://[2001:9e8:1416:8f00:7837:fcff:fe7d:1aaf]/.well-known/core -
</.well-known/core>,</riot/board>,</suit/>
```


### Issues/PRs references

same as #18026
