### PR TITLE
Fix stm32 timer periodic

### DIFF
--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -22,7 +22,6 @@
 
 #include "cpu.h"
 #include "periph/timer.h"
-#include <sys/_intsup.h>
 
 /**
  * @brief   Interrupt context for each configured timer


### PR DESCRIPTION
### Contribution description

From the commit msg:

>     cpu/stm32/periph/timer: remove unneeded header
>     
>     I see no reason this header should be included. It does not exist in
>     RIOT's source tree. This patch removes the include.

and 

>     cpu/stm32/periph/timer: fix execution flow
>     
>     The implmentation of `timer_set_absolute()` has The following problems.
>     First, it attempts to restore the auto reload register (ARR) to it's
>     default if the ARR was previosly set by `timer_set_periodic()` by
>     comparing it to the channel's capture compare (CC) register _after_ it
>     has already set the CC register. Secondly, it clears spurious IRQs
>     _after_ the CC register has been set. If the value being set is equal to
>     the timer's current count (or the two become equal before the supurios
>     IRQ clearing happens), this could cause a legitimate IRQ to be cleared.
>     
>     The implmentation of `timer_set()` has the same error in handling the
>     ARR as described above.
>     
>     This patch reorders the operations of both functions to do:
>     
>     1. handle ARR
>     2. clear spurious IRQs
>     3. set channel's CC
>     4. enable IRQ
>     
>     Additionally, the calulation of `value` in `timer_set()` is moved
>     earlier in the function's exec path as a pedantic measure.


### Testing procedure

I tested by doing the following:

1. `make -C tests/periph_timer BOARD=nucleo-f767zi all flash term`
2. press s
3. press [ENTER]
4. observe test passes
5. `make -C tests/periph_timer_periodic BOARD=nucleo-f767zi all flash term`
6. press s
7. press [ENTER]
8. observe test passes
9. `make -C tests/periph_timer_short_relative_set BOARD=nucleo-f767zi all flash term`
10. press s
11. press [ENTER]
12. observe test passes


### Issues/PRs references

- none known
