### PR TITLE
bootloaders: fix bootloader button logic

### DIFF
--- a/bootloaders/riotboot_dfu/main.c
+++ b/bootloaders/riotboot_dfu/main.c
@@ -36,9 +36,19 @@
 
 static bool _bootloader_alternative_mode(void)
 {
-#ifdef BTN_BOOTLOADER_PIN
+#if defined (BTN_BOOTLOADER_PIN) && defined (BTN_BOOTLOADER_MODE)
+    bool state;
+
     gpio_init(BTN_BOOTLOADER_PIN, BTN_BOOTLOADER_MODE);
-    return (bool)gpio_read(BTN_BOOTLOADER_PIN) != BTN_BOOTLOADER_INVERTED;
+    state = gpio_read(BTN_BOOTLOADER_PIN);
+    /* If button configures w/ internal or external pullup, then it is an
+       active-low, thus reverts the logic */
+    if (BTN_BOOTLOADER_EXT_PULLUP || BTN_BOOTLOADER_MODE == GPIO_IN_PU ||
+        BTN_BOOTLOADER_MODE == GPIO_OD_PU ) {
+       return !state;
+    } else {
+        return state;
+    }
 #else
     return false;
 #endif

--- a/bootloaders/riotboot_tinyusb_dfu/main.c
+++ b/bootloaders/riotboot_tinyusb_dfu/main.c
@@ -36,9 +36,19 @@
 
 static bool _bootloader_alternative_mode(void)
 {
-#ifdef BTN_BOOTLOADER_PIN
+#if defined (BTN_BOOTLOADER_PIN) && defined (BTN_BOOTLOADER_MODE)
+    bool state;
+
     gpio_init(BTN_BOOTLOADER_PIN, BTN_BOOTLOADER_MODE);
-    return (bool)gpio_read(BTN_BOOTLOADER_PIN) != BTN_BOOTLOADER_INVERTED;
+    state = gpio_read(BTN_BOOTLOADER_PIN);
+    /* If button configures w/ internal or external pullup, then it is an
+       active-low, thus reverts the logic */
+    if (BTN_BOOTLOADER_EXT_PULLUP || BTN_BOOTLOADER_MODE == GPIO_IN_PU ||
+        BTN_BOOTLOADER_MODE == GPIO_OD_PU ) {
+       return !state;
+    } else {
+        return state;
+    }
 #else
     return false;
 #endif

--- a/sys/include/riotboot/bootloader_selection.h
+++ b/sys/include/riotboot/bootloader_selection.h
@@ -58,19 +58,12 @@ extern "C" {
 
 /** @brief Interpretation of @ref BTN_BOOTLOADER_PIN.
  *
- * Set to true for active-low buttons (go to DFU if the pin is low), otherwise
- * to false (go to DFU if the pin is high).
- *
- * The default value for all boards is inverted (active-low), except if
- * BTN0_MODE is defined as GPIO_IN_PD. In this case the value is not
- * inverted (high-active).
+ * This value should be set to true if the button has an *external* pull-up and
+ * thus, works as an active-low button.
+ * If the button has an internal pull-up, the default value should remains false
  */
-#ifndef BTN_BOOTLOADER_INVERTED
-#if (BTN0_MODE == GPIO_IN_PD)
-#define BTN_BOOTLOADER_INVERTED false
-#else
-#define BTN_BOOTLOADER_INVERTED true
-#endif
+#ifndef BTN_BOOTLOADER_EXT_PULLUP
+#define BTN_BOOTLOADER_EXT_PULLUP false
 #endif
 
 /** @brief LED pin for bootloader indication

--- a/sys/riotboot/serial.c
+++ b/sys/riotboot/serial.c
@@ -57,8 +57,11 @@ static inline void uart_write_byte(uart_t uart, uint8_t data)
 
 static inline bool _boot_pin(void)
 {
-#ifdef BTN_BOOTLOADER_PIN
-    if (BTN_BOOTLOADER_INVERTED) {
+#if defined (BTN_BOOTLOADER_PIN) && defined(BTN_BOOTLOADER_MODE)
+    /* Reverts the logic if the button has an internal or external pullup and
+       thus, is an active-low button */
+    if (BTN_BOOTLOADER_EXT_PULLUP || BTN_BOOTLOADER_MODE == GPIO_IN_PU ||
+        BTN_BOOTLOADER_MODE == GPIO_OD_PU ) {
         return !gpio_read(BTN_BOOTLOADER_PIN);
     }
     else {


### PR DESCRIPTION
### Contribution description

In lastest master, the `BTN_BOOTLOADER_INVERTED` logic doesn't work as expected.
This PR fixes the underlying logic by replacing the `BTN_BOOTLOADER_INVERTED` macro definition by a runtime function.
In fact the current code:
```
#ifndef BTN_BOOTLOADER_INVERTED
#if (BTN0_MODE == GPIO_IN_PD)
#define BTN_BOOTLOADER_INVERTED false
#else
#define BTN_BOOTLOADER_INVERTED true
#endif
#endif
```
cannot work because both `BTN0_MODE` and `GPIO_IN_PD` are not known by the precompiler as they are enum values defined at cpu level.
Thus, replaces it by a runtime function in our bootloader applications.
I've also add `GPIO_OD_PU` along side `GPIO_IN_PU` and add a new define (which can be override at board level or app level) in case an external pullup is used.

### Testing procedure
Flash the riotboot_dfu bootloader:
`make BOARD=saml21-xpro -C bootloaders/riotboot_dfu flash`
Then, flash any test app:
`PROGRAMMER=dfu-util USEMODULE=usbus_dfu make BOARD=saml21-xpro -C tests/shell riotboot/flash-slot0`

With master, the application will not start.
With this PR, the application will start after flashing.

### Issues/PRs references
Fixes #19364 
