### PR TITLE
nanocoap_sock: don't include token in empty ACK response

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -136,14 +136,13 @@ static int _sock_recv_buf(nanocoap_sock_t *sock, void **data, void **ctx, uint32
 static int _send_ack(nanocoap_sock_t *sock, coap_pkt_t *pkt)
 {
     coap_hdr_t ack;
-    unsigned tkl = coap_get_token_len(pkt);
 
     const iolist_t snip = {
         .iol_base = &ack,
         .iol_len  = sizeof(ack),
     };
 
-    coap_build_hdr(&ack, COAP_TYPE_ACK, coap_get_token(pkt), tkl,
+    coap_build_hdr(&ack, COAP_TYPE_ACK, NULL, 0,
                    COAP_CODE_EMPTY, ntohs(pkt->hdr->id));
 
     return _sock_sendv(sock, &snip);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

CoAP doesn't expect a Token in an empty ACK, but `coap_build_hdr()` will copy it over if we give it a token length.

This is bad as here we only provide space for the CoAP header `ack`. `coap_build_hdr()` will copy the token into `snip` where it causes all kinds of mayhem. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
