### PR TITLE
cord: bump reference from draft to rfc

### DIFF
--- a/sys/include/net/cord/ep.h
+++ b/sys/include/net/cord/ep.h
@@ -15,7 +15,7 @@
  * allows RIOT nodes to register themselves with resource directories.
  * It implements the standard endpoint functionality as defined in
  * draft-ietf-core-resource-directory-27.
- * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-27
+ * @see https://datatracker.ietf.org/doc/html/rfc9176
  *
  * # Design Decisions
  * - all operations provided by this module are fully synchronous, meaning that


### PR DESCRIPTION
### Contribution description

The draft is an RFC, this bumps the "see also" in the docs to the rfc.

### Testing procedure

Check that the correct RFC is linked in the docs.

### Issues/PRs references

None
