### PR TITLE
debug: add DEBUG_BREAKPOINT() macro, set breakpoint on failed assertion

### DIFF
--- a/core/lib/assert.c
+++ b/core/lib/assert.c
@@ -18,6 +18,7 @@
 #include "assert.h"
 #include "architecture.h"
 #include "cpu.h"
+#include "debug.h"
 #include "panic.h"
 #if IS_USED(MODULE_BACKTRACE)
 #include "backtrace.h"
@@ -30,6 +31,7 @@ __NORETURN void _assert_failure(const char *file, unsigned line)
     printf("failed assertion. Backtrace:\n");
     backtrace_print();
 #endif
+    DEBUG_BREAKPOINT(1);
     core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
 }
 
@@ -39,6 +41,7 @@ __NORETURN void _assert_panic(void)
 #if IS_USED(MODULE_BACKTRACE)
     backtrace_print();
 #endif
+    DEBUG_BREAKPOINT(1);
     core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
 }
 

--- a/core/lib/include/debug.h
+++ b/core/lib/include/debug.h
@@ -60,6 +60,27 @@ extern "C" {
 #endif
 
 /**
+ * @def DEBUG_BREAKPOINT
+ *
+ * @brief Set a debug breakpoint
+ *
+ * When `DEVELHELP` is enabled, this traps the CPU and allows to debug the
+ * program with e.g. `gdb`.
+ * Without `DEVELHELP` this turns into a no-op.
+ *
+ * @warning     If no Debugger is attached, the CPU might get stuck here
+ *              and consume a lot of power until reset.
+ *
+ * @param val   Breakpoint context for debugger, usually ignored.
+ */
+#ifdef DEVELHELP
+#include "architecture.h"
+#define DEBUG_BREAKPOINT(val)   ARCHITECTURE_BREAKPOINT(val)
+#else
+#define DEBUG_BREAKPOINT(val)   (void)0
+#endif
+
+/**
  * @name Debugging defines
  * @{
  */

--- a/cpu/cortexm_common/include/architecture_arch.h
+++ b/cpu/cortexm_common/include/architecture_arch.h
@@ -26,7 +26,8 @@ extern "C" {
 
 /* Doc is provided centrally in architecture.h, hide this from Doxygen */
 #ifndef DOXYGEN
-#define ARCHITECTURE_WORD_BITS      (32U)
+#define ARCHITECTURE_WORD_BITS          (32U)
+#define ARCHITECTURE_BREAKPOINT(value)  __BKPT(value)
 #endif /* DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/native/include/architecture_arch.h
+++ b/cpu/native/include/architecture_arch.h
@@ -24,9 +24,17 @@
 extern "C" {
 #endif
 
+/**
+ * @brief raise SIGTRAP
+ *
+ *        We must not include signal.h directly into RIOT application namespace.
+ */
+void native_breakpoint(void);
+
 /* Doc is provided centrally in architecture.h, hide this from Doxygen */
 #ifndef DOXYGEN
 #define ARCHITECTURE_WORD_BITS      (32U)
+#define ARCHITECTURE_BREAKPOINT(v)  native_breakpoint()
 #endif /* DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -99,6 +99,11 @@ int thread_isr_stack_usage(void)
     return -1;
 }
 
+void native_breakpoint(void)
+{
+    raise(SIGTRAP);
+}
+
 static inline void *align_stack(uintptr_t start, int *stacksize)
 {
     const size_t alignment = sizeof(uintptr_t);

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -33,6 +33,19 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   Set a breakpoint
+ * @warning         If no Debugger is attached, the CPU might get stuck here
+ *                  and consume a lot of power until reset.
+ * @param[in] value Context value for debugger, usually ignored.
+ */
+#ifndef ARCHITECTURE_BREAKPOINT
+/* If no breakpoint instruction is defined, busy wait for debugger
+ * to attach and break to ease backtrace
+ */
+#define ARCHITECTURE_BREAKPOINT(value)  do {} while (1)
+#endif
+
 /* Provide doxygen doc centrally, instead of in every architecture_arch.h */
 #ifdef DOXYGEN
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 This provides an architecture independent macro to set breakpoints. So far it has only been implemented for Cortex-M and native, but it degrades to a no-op if not defined, so the situation is the same as before.

To make use of this, I added a breakpoints to the `assert()` function in the case of failure. 
This makes debugging failed asserts much easier. 

### Testing procedure
I simply added a `assert(0)` to `main()` in `examples/hello-world` and ran `make debug`:

#### master

```
main(): This is RIOT! (Version: 2023.04-devel-583-gb13ed2-DEBUG_BREAKPOINT)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
examples/hello-world/main.c:32 => *** RIOT kernel panic:
FAILED ASSERTION.

*** halted.


native: exiting
[Inferior 1 (process 17242) exited normally]
``` 

#### this PR


```
main(): This is RIOT! (Version: 2023.04-devel-583-gb13ed2-DEBUG_BREAKPOINT)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
examples/hello-world/main.c:32 => 
Program received signal SIGTRAP, Trace/breakpoint trap.
0xf7fc6549 in __kernel_vsyscall ()
(gdb) bt
#0  0xf7fc6549 in __kernel_vsyscall ()
#1  0xf7c89147 in __pthread_kill_implementation (threadid=threadid@entry=4160492864, 
    signo=signo@entry=5, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:43
#2  0xf7c891cf in __pthread_kill_internal (signo=5, threadid=4160492864) at ./nptl/pthread_kill.c:78
#3  0xf7c35b15 in __GI_raise (sig=5) at ../sysdeps/posix/raise.c:26
#4  0x08049740 in _assert_failure (file=0x804d018 "examples/hello-world/main.c", line=32)
    at /home/benpicco/dev/RIOT-BHT/core/lib/assert.c:34
#5  0x08049662 in main () at /home/benpicco/dev/RIOT-BHT/examples/hello-world/main.c:32
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
