### PR TITLE
Fix `compile_like_murdock.py` when board is empty

### DIFF
--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -36,3 +36,5 @@ jobs:
       run: cd dist/pythonlibs/riotctrl_shell && tox
     - name: Test kconfig script
       run: cd dist/tools/kconfiglib/tests && ./test.sh
+    - name: Test compile_like_murdock script
+      run: cd dist/tools/compile_test/tests && ./test.sh

--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -269,7 +269,7 @@ def main():
         if args.cpu:
             target_boards = _supported_boards_from_cpu(args.cpu, full_env,
                                                        test_dir)
-        elif args.boards[0] == "all":
+        elif args.boards and args.boards[0] == "all":
             target_boards = _supported_boards(boards, full_env, test_dir, True)
         else:
             target_boards = _supported_boards(boards, full_env, test_dir,

--- a/dist/tools/compile_test/tests/test.sh
+++ b/dist/tools/compile_test/tests/test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Run a simple tests to check various inputs to compile_like_murdock.py in an
+# attempt to prevent regressions as features get added.
+# This can be invoked manually and also via github actions.
+
+
+readonly COMPILE_TEST_DIR="$(readlink -f "$(dirname "$0")/..")"
+
+
+# sets the global accumulative RESULT variable to keep record of errors during
+# tests.
+function accumulate_errors {
+    if (( $1 != 0 )); then
+        RESULT=$1
+    fi
+}
+
+# Run a test passed in $1. It will print the corresponding name and result and
+# update the global state of the tests.
+function run_test {
+    echo -n "Running test: \"$*\" "
+    if OUT=$($1 2>&1); then
+        echo -e "\033[0;32m✓\033[0m"
+    else
+        accumulate_errors $?
+        echo -e "\033[0;31mx\033[0m"
+        1>&2 echo "$OUT"
+    fi
+}
+
+# Call compile_like_murdock.py with default arguments.
+function call_with_defaults {
+    ${COMPILE_TEST_DIR}/compile_like_murdock.py --dry-run
+}
+
+# Call compile_like_murdock.py with specific board and app arguments.
+function call_with_specific_board_app {
+    ${COMPILE_TEST_DIR}/compile_like_murdock.py \
+    --boards native \
+    --apps tests/shell \
+    --dry-run
+}
+
+RESULT=0
+run_test call_with_defaults
+run_test call_with_specific_board_app
+
+exit $(( RESULT ))


### PR DESCRIPTION
### Contribution description

Turns out we didn't test the simplest case, board being empty.

I added some automatic testing to check that and we can build when needed...


### Testing procedure

Green `tools-test` action

### Issues/PRs references
