### PR TITLE
examples/suit_update: improve default module selection

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -13,12 +13,9 @@ RIOTBASE ?= $(CURDIR)/../..
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 
-# uncomment this to compile in support for a possibly available radio
-#USEMODULE += netdev_default
-
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_ipv6_default
 USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
@@ -87,6 +84,8 @@ ifeq (1,$(USE_ETHOS))
   IFACE ?= riot0
   TERMPROG = $(RIOTTOOLS)/ethos/ethos
   TERMFLAGS = $(IFACE) $(PORT)
+else
+  USEMODULE += netdev_default
 endif
 
 # Ensure both slot bin files are always generated and linked to avoid compiling

--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -40,6 +40,7 @@
 #endif
 
 #ifdef MODULE_PERIPH_GPIO
+#include "board.h"
 #include "periph/gpio.h"
 #endif
 

--- a/sys/suit/handlers_global.c
+++ b/sys/suit/handlers_global.c
@@ -44,7 +44,7 @@ static int _version_handler(suit_manifest_t *manifest, int key,
     if (nanocbor_get_int32(it, &version) >= 0) {
         if (version == SUIT_VERSION) {
             manifest->validated |= SUIT_VALIDATED_VERSION;
-            LOG_INFO("suit: validated manifest version\n)");
+            LOG_INFO("suit: validated manifest version\n");
             return SUIT_OK;
         }
     }
@@ -71,11 +71,11 @@ static int _seq_no_handler(suit_manifest_t *manifest, int key,
              seq_nr, stored_seq_no);
 
     if (seq_nr <= stored_seq_no) {
-        LOG_ERROR("seq_nr <= running image\n)");
+        LOG_ERROR("seq_nr <= running image\n");
         return SUIT_ERR_SEQUENCE_NUMBER;
     }
 
-    LOG_INFO("suit: validated sequence number\n)");
+    LOG_INFO("suit: validated sequence number\n");
     manifest->seq_number = seq_nr;
     manifest->validated |= SUIT_VALIDATED_SEQ_NR;
     return SUIT_OK;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - when we set `USE_ETHOS=0` the default netdev should be selected instead of no netdev
 - include `board.h` so the button auto-detection works.
 - this example does not need the routing module
 - drop the `)` from output such as `)Manifest seq_no`


### Testing procedure

Updating the board via a press of the button does now work again:

```
2023-03-10 02:25:50,790 # Button pressed! Triggering suit update! 
2023-03-10 02:25:50,792 # suit_worker: started.
2023-03-10 02:25:50,799 # suit_worker: downloading "coap://[2001:db8:1::1]/fw/samr21-xpro/riot.suit.latest.bin"
2023-03-10 02:25:50,912 # suit_worker: got manifest with size 445
2023-03-10 02:25:50,915 # suit: verifying manifest signature
2023-03-10 02:25:55,616 # suit: validated manifest version
2023-03-10 02:25:55,620 # Manifest seq_no: 10, highest available: 1
2023-03-10 02:25:55,622 # suit: validated sequence number
2023-03-10 02:25:55,625 # Formatted component name: 
2023-03-10 02:25:55,630 # Comparing manifest offset 1000 with other slot offset
2023-03-10 02:25:55,635 # Comparing manifest offset 20800 with other slot offset
2023-03-10 02:25:55,637 # validating vendor ID
2023-03-10 02:25:55,646 # Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
2023-03-10 02:25:55,648 # validating vendor ID: OK
2023-03-10 02:25:55,650 # validating class id
2023-03-10 02:25:55,659 # Comparing 8818989e-a257-5994-ac9a-554b77898083 to 8818989e-a257-5994-ac9a-554b77898083 from manifest
2023-03-10 02:25:55,661 # validating class id: OK
2023-03-10 02:25:55,666 # Comparing manifest offset 1000 with other slot offset
2023-03-10 02:25:55,671 # Comparing manifest offset 20800 with other slot offset
2023-03-10 02:25:55,673 # SUIT policy check OK.
2023-03-10 02:25:55,676 # Formatted component name: 
2023-03-10 02:25:55,681 # riotboot_flashwrite: initializing update to target slot 1
2023-03-10 02:25:55,698 # Fetching firmware |████████████             |  47%
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
