### PR TITLE
makefiles/boards/stm32: fix DFU_USB_ID handling

### DIFF
--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -18,17 +18,6 @@ OPENOCD_DEBUG_ADAPTER ?= stlink
 
 JLINK_DEVICE ?= $(CPU_MODEL)
 
-ifeq (dfu-util,$(PROGRAMMER))
-  # optionally, use dfu-util to flash via usb
-  # note: needs a bootloader flashed before, config below is compatible
-  # with blackmagic_dfu, see https://github.com/blacksphere/blackmagic/
-  # To stop bootloader from loading an existing firmware, pull down
-  # (ground) GPIO B1.
-  ifeq (,$(DFU_USB_ID))
-    $(error DFU_USB_ID is not set)
-  endif
-endif
-
 ifeq (stm32flash,$(PROGRAMMER))
   ROM_OFFSET ?= 0x0
   FLASHER = stm32flash


### PR DESCRIPTION
### Contribution description

This PR fixes the still existing problem that an application can't be flashed to a STM32 board if it uses `riotboot_dfu` with default  VID/PID (1209:7d02).

In PR #18964 item 1, the problem was already described that an application can't be flashed on a board that is using `riotboot_dfu`. Using for example
```python
FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=nucleo-f767zi \
PROGRAMMER=dfu-util all riotboot/flash-slot0
```
always leads to error
```python
/home/gs/src/RIOT-Xtensa-ESP.esp-idf-4.4/makefiles/boards/stm32.inc.mk:28: *** DFU_USB_ID is not set.  Stop.
/home/gs/src/RIOT-Xtensa-ESP.esp-idf-4.4/makefiles/boot/riotboot.mk:87: recipe for target 'riotboot/bootloader/binfile' failed
```
even if `DFU_USB_ID` variable is set as described in documentation.
```python
FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=nucleo-f767zi \
PROGRAMMER=dfu-util DFU_USB_ID=1209:7d02 all riotboot/flash-slot0
```
The reason is that the variable `DFU_USB_ID` isn't exported and the check https://github.com/RIOT-OS/RIOT/blob/8dc8bf35678493ecc8ef110e2f0359a67c03894c/makefiles/boards/stm32.inc.mk#L27-L29 sees an empty `DFU_USB_ID` variable here. It prevents to use `dfu-util` event though the following `dfu-util.mk` will generate a default value for this variable from the `USB_VID` and `USB_PID` variables if necessary.

Commit 6a76b94c6e0ae97bc743cc90d0811e691a35869e of PR #18964 tried to fix this problem but wasn't merged for any reason.

To fix this problem, the check is completely removed. If a board such as `weact-f4x1cx` uses a DFU boorloader and requires a certain VID/PID combination, board's makefile is responsible to set `DFU_USB_ID` variable.

### Testing procedure

It is not necessary to use a real boad, checking the compilation process is sufficient.

1. Using default VID/PID as described in documentation:
   ```python
   FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=nucleo-f767zi \
   PROGRAMMER=dfu-util all riotboot/flash-slot0
   ```
   can't be compiled without this PR but calls `dfu-util` correctly with this PR using the default VID/PID:
   ```python
   dfu-util --device 1209:7d02 --alt 0 --download examples/saul/bin/nucleo-f767zi/riotboot_files/slot0.1678440536.bin
   ```
2. Using a VID/PID as described in documentation:
   ```python
   FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=nucleo-f767zi \
   DFU_USB_ID=1209:affe PROGRAMMER=dfu-util all riotboot/flash-slot0
   ```
   can't be compiled without this PR but calls `dfu-util` correctly with this PR using the default VID/PID:
   ```python
   dfu-util --device 1209:affe --alt 0 --download examples/saul/bin/nucleo-f767zi/riotboot_files/slot0.1678440536.bin
   ```
3. Compiling a board with DFU bootloader
   ```python
   make -C examples/saul flash BOARD=weact-f411ce
   ```
   should still call dfu-util with correct VID/PID:
   ```python
   dfu-util --device 0483:df11 --alt 0 --download /home/gs/src/RIOT-Xtensa-ESP.esp-idf-4.4/examples/saul/bin/weact-f411ce/saul_example.bin  --dfuse-address 0x8000000:leave
   ```
### Issues/PRs references

