### PR TITLE
tools/renode: add support for target reset

### DIFF
--- a/makefiles/tools/renode.inc.mk
+++ b/makefiles/tools/renode.inc.mk
@@ -27,6 +27,11 @@ endif
 RENODE_LOG_LEVEL ?= 2  # Warning level
 RENODE_CONFIG_FLAGS += -e "logLevel $(RENODE_LOG_LEVEL)"
 
+# Configure renode telnet port to allow sending command to the monitor while
+# the emulator is running (used to send reset command)
+RENODE_TELNET_PORT ?= 1234
+RENODE_CONFIG_FLAGS += -P $(RENODE_TELNET_PORT)
+
 # Renode GUI
 RENODE_SHOW_GUI ?= 0
 ifneq (1,$(RENODE_SHOW_GUI))
@@ -61,6 +66,9 @@ DEBUGSERVER_FLAGS ?= $(RENODE_DEBUG_FLAGS)
 
 DEBUGGER_FLAGS ?= $(BOARD) $(APPDIR) $(DEBUG_ELFFILE) $(GDB_REMOTE) $(EMULATOR_TMP_DIR) "-ex \"monitor start\""
 DEBUGGER ?= $(RIOTTOOLS)/emulator/debug.sh
+
+RESET ?= bash
+RESET_FLAGS ?= -c "{ sleep 0.2;echo machine RequestReset; } | telnet localhost $(RENODE_TELNET_PORT)" || true
 
 # No flasher available with renode emulator
 FLASHER ?=


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds support for the `reset` target when emulating a board with renode. This feature can be used when using renode 1.12 and above versions.

The default emulator listens on port 1234 but this can be overridden on command line using `RENODE_TELNET_PORT`. I don't think it's possible to use a Unix socket instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Tested this with emulated hifive1b and cc1538dk boards:

<details><summary>Start an emulated application in one terminal:</summary>

```
$ EMULATE=1 make BOARD=hifive1b -C examples/default flash term --no-print-directory 
Building application "default" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/cpu/riscv_common
"make" -C /work/riot/RIOT/cpu/riscv_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/rtc_utils
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/cmds
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  15552	   4120	   2340	  22012	   55fc	/work/riot/RIOT/examples/default/bin/hifive1b/default.elf
/work/riot/RIOT/dist/tools/emulator/term.sh renode hifive1b /work/riot/RIOT/examples/default /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_default_hifive1b.N6dXi/uart" -b "115200" ' /tmp/riot_default_hifive1b.N6dXi/uart /tmp/riot_default_hifive1b.N6dXi 
Using Renode pid file /tmp/riot_default_hifive1b.N6dXi/emulator_pid
renode -e "set image_file '/work/riot/RIOT/examples/default/bin/hifive1b/default.elf'" -e "include @/work/riot/RIOT/boards/hifive1b/dist/board.resc" --pid-file /tmp/riot_default_hifive1b.N6dXi/emulator_pid --hide-log -e "logLevel 2  " -P 1234 --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_default_hifive1b.N6dXi/uart\" true" -e "connector Connect sysbus.uart0 term" -e start
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2023-03-10 10:43:34,808 # Connect to serial port /tmp/riot_default_hifive1b.N6dXi/uart
Welcome to pyterm!
Type '/exit' to exit.
help
2023-03-10 10:43:37,068 # help
2023-03-10 10:43:37,068 # Command              Description
2023-03-10 10:43:37,068 # ---------------------------------------
2023-03-10 10:43:37,069 # pm                   interact with layered PM subsystem
2023-03-10 10:43:37,069 # ps                   Prints information about running threads.
2023-03-10 10:43:37,069 # reboot               Reboot the node
2023-03-10 10:43:37,069 # rtc                  control RTC peripheral interface
2023-03-10 10:43:37,070 # saul                 interact with sensors and actuators using SAUL
2023-03-10 10:43:37,070 # version              Prints current RIOT_VERSION
> 2023-03-10 10:43:50,844 # main(): This is RIOT! (Version: 2023.04-devel-636-g7ab8d6-pr/tools/renode_reset)
2023-03-10 10:43:50,844 # Welcome to RIOT!
2023-03-10 10:44:25,827 # main(): This is RIOT! (Version: 2023.04-devel-636-g7ab8d6-pr/tools/renode_reset)
2023-03-10 10:44:25,827 # Welcome to RIOT!


```

</details>

<details><summary>Reset the emulated board from another terminal::</summary>

```
$ EMULATE=1 make BOARD=hifive1b -C examples/hello-world reset --no-print-directory 
bash -c "{ sleep 0.2;echo machine RequestReset; } | telnet localhost 1234" || true
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
chine RequestReset
(SiFive-FE310) Connection closed by foreign host.
$ EMULATE=1 make BOARD=hifive1b -C examples/hello-world reset --no-print-directory 
bash -c "{ sleep 0.2;echo machine RequestReset; } | telnet localhost 1234" || true
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
chine RequestReset
(SiFive-FE310) Connection closed by foreign host.
```

</details>

One can see that the emulated RIOT application is rebooted twice.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
