### PR TITLE
driver/usbdev_synopsys_dwc2: use correct number of EPs

### DIFF
--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -451,7 +451,7 @@ static void _set_address(dwc2_usb_otg_fshs_t *usbdev, uint8_t address)
 static usbdev_ep_t *_get_ep(dwc2_usb_otg_fshs_t *usbdev, unsigned num,
                             usb_ep_dir_t dir)
 {
-    if (num >= DWC2_USB_OTG_FS_NUM_EP) {
+    if (num >= _max_endpoints(usbdev->config)) {
         return NULL;
     }
     return dir == USB_EP_DIR_IN ? &usbdev->in[num] : &usbdev->out[num].ep;
@@ -532,7 +532,7 @@ static usbdev_ep_t *_usbdev_new_ep(usbdev_t *dev, usb_ep_type_t type,
     }
     else {
         /* Find the first unassigned ep with matching direction */
-        for (unsigned idx = 1; idx < DWC2_USB_OTG_FS_NUM_EP && !ep; idx++) {
+        for (unsigned idx = 1; idx < _max_endpoints(usbdev->config) && !ep; idx++) {
             usbdev_ep_t *candidate_ep = _get_ep(usbdev, idx, dir);
             if (candidate_ep->type == USB_EP_TYPE_NONE) {
                 ep = candidate_ep;


### PR DESCRIPTION
### Contribution description

This PR fixes the problem that the driver uses the wrong number of EPs when using the USB OTG HS core.

The constant `DWC2_USB_OTG_FS_NUM_EP` was used in several places independent on whether the USB OTG FS core or the USB OTG HS core is used even though there is a function `_max_endpoints` which takes into account the configuration used. For most MCUs this was not a problem, because they have only a USB OTG FS core anyway. But for MCUs like the STM32, which have both a USB OTG FS core and a USB OTG HS core, it matters.

### Testing procedure

Use either
```
USEMODULE='stdio_cdc_acm' BOARD=stm32f429i-disc1 make -j8 -C tests/usbus_cdc_ecm flash
```
or
```
BOARD=stm32f429i-disco make -j8 -C tests/usbus_cdc_ecm flash
```
Without this PR it just stucks due to an `assert` here: https://github.com/RIOT-OS/RIOT/blob/19da279ba5a5b022c9f0dfbadf49ac684bae6028/sys/usb/usbus/cdc/ecm/cdc_ecm.c#L217-L221 The reason is that the USB OTG FS core has only 4 EPs but the application requires 5 IN EPS.

With the PR it works as expected.

### Issues/PRs references
