### PR TITLE
tests/pkg_nanors: use static allocation

### DIFF
--- a/pkg/nanors/Makefile
+++ b/pkg/nanors/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanors
 PKG_URL=https://github.com/sleepybishop/nanors.git
-PKG_VERSION=395e5ada44dd8d5974eaf6bb6b17f23406e3ca72
+PKG_VERSION=e9e242e98e27037830490b2a752895ca68f75f8b
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/tests/pkg_nanors/main.c
+++ b/tests/pkg_nanors/main.c
@@ -36,10 +36,14 @@ int main(void)
     static uint8_t data[(DATA_SHARDS + RECOVERY_SHARDS) * SHARD_SIZE];
     /* copy of data for comparison */
     static uint8_t data_cmp[DATA_SHARDS * SHARD_SIZE];
+    /* nanors work buffer */
+    static uint8_t rs_buf[reed_solomon_bufsize(DATA_SHARDS, RECOVERY_SHARDS)];
+
     /* pointer to shards */
-    static uint8_t *shards[DATA_SHARDS + RECOVERY_SHARDS];
+    uint8_t *shards[DATA_SHARDS + RECOVERY_SHARDS];
     /* map of missing shards */
-    static uint8_t marks[DATA_SHARDS + RECOVERY_SHARDS];
+    uint8_t marks[DATA_SHARDS + RECOVERY_SHARDS];
+    memset(marks, 0, sizeof(marks));
 
     /* generate random data */
     random_bytes(data, sizeof(data_cmp));
@@ -51,8 +55,7 @@ int main(void)
     }
 
     puts("START");
-    reed_solomon_init();
-    rs_t *rs = reed_solomon_new(DATA_SHARDS, RECOVERY_SHARDS);
+    rs_t *rs = reed_solomon_new_static(rs_buf, sizeof(rs_buf), DATA_SHARDS, RECOVERY_SHARDS);
     if (!rs) {
         puts("failed to init codec");
         return -1;
@@ -79,7 +82,6 @@ int main(void)
     } else {
         puts("done.");
     }
-    reed_solomon_release(rs);
 
     if (memcmp(data, data_cmp, sizeof(data_cmp))) {
         puts("FAILED");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`reed_solomon_new()` uses `malloc()` internally, use `reed_solomon_new_static()` instead to use a static work buffer.


### Testing procedure

`tests/pkg_nanors` still works:

```
2023-03-14 19:43:21,130 # main(): This is RIOT! (Version: 2023.04-devel-648-g94ba33-pkg/nanors-static)
2023-03-14 19:43:21,132 # START
2023-03-14 19:43:21,135 # total: 30 shards (1920 bytes)
2023-03-14 19:43:21,150 # clear shard 25 (64 byte)
2023-03-14 19:43:21,152 # clear shard 17 (64 byte)
2023-03-14 19:43:21,154 # clear shard 18 (64 byte)
2023-03-14 19:43:21,156 # clear shard 18 (64 byte)
2023-03-14 19:43:21,159 # clear shard 28 (64 byte)
2023-03-14 19:43:21,161 # clear shard 12 (64 byte)
2023-03-14 19:43:21,163 # clear shard 11 (64 byte)
2023-03-14 19:43:21,165 # clear shard 0 (64 byte)
2023-03-14 19:43:21,168 # clear shard 12 (64 byte)
2023-03-14 19:43:21,170 # clear shard 24 (64 byte)
2023-03-14 19:43:21,171 # reconstruct…
2023-03-14 19:43:21,178 # done.
2023-03-14 19:43:21,179 # SUCCESS
2023-03-14 19:43:21,186 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 564 }]}
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
