### PR TITLE
cord: include gcoap_req_send returning 0 in error

### DIFF
--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -151,8 +151,10 @@ static int _update_remove(unsigned code, gcoap_resp_handler_t handle)
     ssize_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
 
     /* send request */
-    gcoap_req_send(buf, pkt_len, &_rd_remote, handle, NULL);
-
+    ssize_t send_len = gcoap_req_send(buf, pkt_len, &_rd_remote, handle, NULL);
+    if (send_len <= 0) {
+        return CORD_EP_ERR;
+    }
     /* synchronize response */
     return _sync();
 }
@@ -224,7 +226,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
     coap_opt_add_uri_query(&pkt, "rt", "core.rd");
     size_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
     res = gcoap_req_send(buf, pkt_len, remote, _on_discover, NULL);
-    if (res < 0) {
+    if (res <= 0) {
         return CORD_EP_ERR;
     }
     return _sync();
@@ -295,7 +297,7 @@ int cord_ep_register(const sock_udp_ep_t *remote, const char *regif)
 
     /* send out the request */
     res = gcoap_req_send(buf, pkt_len, remote, _on_register, NULL);
-    if (res < 0) {
+    if (res <= 0) {
         retval = CORD_EP_ERR;
         goto end;
     }


### PR DESCRIPTION
### Contribution description

gcoap_req_send returns 0 if it was unable to send the CoAP request. CoRD did not include that case in the return code checks. This changes CoRD to include it and drop the registration if CoAP could not send the request. The old behaviour made the CoRD thread lock up.

### Testing procedure

- Check with the gcoap API docs.
- I can reliable trigger the issue with a RIOT application including both the `cord_ep_standalone` module and some measurement reported both sending requests to the same application. If at some point the application is shut down, gcoap has all its memo's occupied with the measurement reporting and can't add the CoRD update request. Thus the CoRD update request fails with a zero code and the thread (previously) would lock up.

### Issues/PRs references

None