### PR TITLE
sam0/usbdev: partial revert of #17086

### DIFF
--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -584,14 +584,12 @@ static inline void _enable_ep_stall_in(UsbDeviceEndpoint *ep_reg)
 
 static inline void _disable_ep_stall_out(UsbDeviceEndpoint *ep_reg)
 {
-    ep_reg->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ0 |
-                              USB_DEVICE_EPSTATUSCLR_DTGLOUT;
+    ep_reg->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ0;
 }
 
 static inline void _disable_ep_stall_in(UsbDeviceEndpoint *ep_reg)
 {
-    ep_reg->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ1 |
-                              USB_DEVICE_EPSTATUSCLR_DTGLIN;
+    ep_reg->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_STALLRQ1;
 }
 
 static void _usbdev_ep0_stall(usbdev_t *usbdev)


### PR DESCRIPTION
### Contribution description
Reverting theses changes from #17086 because it breaks SAM0 `usbdev` in master.
The idea was to following the USB spec but for not obvious reason yet, it doesn't work as intended.
So revert these changes so `usbdev` works again on master.
We will try to figured out what's wrong later.


### Testing procedure
Test any `usbus` related test application w/ a SAM0-based board.


### Issues/PRs references
See discussion in #17086 
