### PR TITLE
cpu/stm32/periph/timer: fix clobered IRQ flag

### DIFF
--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -267,7 +267,12 @@ static inline void irq_handler(tim_t tim)
 {
     uint32_t top = dev(tim)->ARR;
     uint32_t status = dev(tim)->SR & dev(tim)->DIER;
-    dev(tim)->SR = 0;
+
+    /* clear interrupts which we are about to service */
+    /* Note, the flags in the SR register can be cleared by software, but
+     * setting them has no effect on the register. Only the hardware can set
+     * them. */
+    dev(tim)->SR = ~status;
 
     for (unsigned int i = 0; status; i++) {
         uint32_t msk = TIM_SR_CC1IF << i;


### PR DESCRIPTION
### Contribution description

From the git commit:

> The STM32 periph_timer driver reads the timer's status flags, then clears them all. It is possible that a timer interrupt could occur between reading the flag and clearing it. This would lead to a lost interrupt.
> 
> The timer's status flags can be cleared by software, but can only be set by the hardware. This patch takes advantage of this by only clearing the flags it knows are set. The rest of the flags are set, which doesn't actually change their state.

I had trouble finding anything in ST's datasheet saying that software could not set the timer's status flags, but testing showed that this is how it works in practice. Further, [ST's own HAL ](https://github.com/STMicroelectronics/STM32CubeF4/blob/master/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_tim.h#L1258)confirms this. If the hardware didn't work this way, it would be impossible to atomically read-modify-write the flags.

### Testing procedure

I tested by doing the following:

1. `make -C tests/periph_timer BOARD=nucleo-f767zi all flash term`
2. press s
3. press [ENTER]
4. observe test passes
5. `make -C tests/periph_timer_periodic BOARD=nucleo-f767zi all flash term`
6. press s
7. press [ENTER]
8. observe test passes
9. `make -C tests/periph_timer_short_relative_set BOARD=nucleo-f767zi all flash term`
10. press s
11. press [ENTER]
12. observe test passes


### Issues/PRs references

- none known