### PR TITLE
usbus/dfu: do not create alt interface if NUM_SLOTS=1

### DIFF
--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -152,7 +152,7 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     /* Add string descriptor to the interface */
     dfu->iface.descr = &dfu->slot0_str;
 
-#ifdef MODULE_RIOTBOOT_USB_DFU
+#if defined (MODULE_RIOTBOOT_USB_DFU) && NUM_SLOTS == 2
     /* Create needed string descriptor for the alternate settings */
     usbus_add_string_descriptor(usbus, &dfu->slot1_str, USB_DFU_MODE_SLOT1_NAME);
 


### PR DESCRIPTION
### Contribution description

In some cases, it is really useful to build `riotboot` with `NUM_SLOTS=1`.
When use in combination with `riotboot_dfu`, there is no need to export the second slot if `riotboot` is built with `NUM_SLOTS=1`.
Thus, prevent the alt interface declaration in dfu if `NUM_SLOTS=1` so that only slot0 can be used to flash.


### Testing procedure
Add `NUM_SLOTS=1` to `bootloaders/riotboot_dfu/Makefile`
Flash the riotboot DFU bootloader to any board supported by USBUS:
`make BOARD=xxx -C bootloaders/riotboot_dfu flash`
and run
`dfu-util -l`

With NUM_SLOTS=2 you will get:
```
dfu-util -l  
dfu-util 0.11

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2021 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Found DFU: [1209:7d02] ver=0100, devnum=11, cfg=1, intf=0, path="1-4", alt=1, name="RIOT-OS Slot 1", serial="AB88DCAE80893484"
Found DFU: [1209:7d02] ver=0100, devnum=11, cfg=1, intf=0, path="1-4", alt=0, name="RIOT-OS Slot 0", serial="AB88DCAE80893484"
```

with NUM_SLOTS=1 you will get:
```
dfu-util -l 
dfu-util 0.11

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2021 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Found DFU: [1209:7d02] ver=0100, devnum=14, cfg=1, intf=0, path="1-4", alt=0, name="RIOT-OS Slot 0", serial="AB88DCAE80893484"
```





### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
