### PR TITLE
ztimer/ztimer64: uncrustify code

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -430,7 +430,7 @@ bool ztimer_acquire(ztimer_clock_t *clock);
 #else
 static inline bool ztimer_acquire(ztimer_clock_t *clock)
 {
-    (void) clock;
+    (void)clock;
     return false;
 }
 #endif
@@ -450,7 +450,7 @@ bool ztimer_release(ztimer_clock_t *clock);
 #else
 static inline bool ztimer_release(ztimer_clock_t *clock)
 {
-    (void) clock;
+    (void)clock;
     return false;
 }
 #endif

--- a/sys/include/ztimer/periodic.h
+++ b/sys/include/ztimer/periodic.h
@@ -89,12 +89,12 @@ typedef bool (*ztimer_periodic_callback_t)(void *);
  * @brief   ztimer periodic structure
  */
 typedef struct {
-    ztimer_t timer;             /**< timer object used for this timer   */
-    ztimer_clock_t *clock;      /**< clock for this timer               */
-    uint32_t interval;          /**< interval of this timer             */
-    ztimer_now_t last;          /**< last trigger time                  */
-    ztimer_periodic_callback_t callback;   /**< called on each trigger             */
-    void *arg;                  /**< argument for callback              */
+    ztimer_t timer;                         /**< timer object used for this timer   */
+    ztimer_clock_t *clock;                  /**< clock for this timer               */
+    uint32_t interval;                      /**< interval of this timer             */
+    ztimer_now_t last;                      /**< last trigger time                  */
+    ztimer_periodic_callback_t callback;    /**< called on each trigger             */
+    void *arg;                              /**< argument for callback              */
 } ztimer_periodic_t;
 
 /**

--- a/sys/ztimer/convert.c
+++ b/sys/ztimer/convert.c
@@ -56,7 +56,7 @@ void ztimer_convert_init(ztimer_convert_t *ztimer_convert,
     ztimer_convert_t tmp = {
         .lower = lower,
         .lower_entry = {
-            .callback = (void (*)(void *))ztimer_handler,
+            .callback = (void (*)(void *)) ztimer_handler,
             .arg = ztimer_convert,
         },
         .super.max_value = max_value,

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -101,7 +101,7 @@ void ztimer_convert_frac_init(ztimer_convert_frac_t *self,
         .super.super = { .ops = &ztimer_convert_frac_ops, },
         .super.lower = lower,
         .super.lower_entry =
-        { .callback = (void (*)(void *))ztimer_handler, .arg = &self->super, },
+        { .callback = (void (*)(void *)) ztimer_handler, .arg = &self->super, },
     };
 
     ztimer_convert_frac_compute_scale(self, freq_self, freq_lower);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Noticed this while looking at https://github.com/RIOT-OS/RIOT/pull/19392.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Uncrustify should now pass without warning on the files changed here.

In fact, I just ran

```sh
uncrustify -c uncrustify-riot.cfg --replace sys/ztimer64/*.c sys/ztimer/*.c sys/include/ztimer*.h sys/include/ztimer*/*.h
```

to generate this PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/19392
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
