### PR TITLE
Draft: Add alarms to qdec

### DIFF
--- a/sys/include/ztimer/periph_qdec.h
+++ b/sys/include/ztimer/periph_qdec.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_ztimer_periph_timer  ztimer periph/timer backend
+ * @ingroup     sys_ztimer
+ * @brief       ztimer periph/timer backend
+ *
+ * This ztimer module implements a ztimer virtual clock on top of periph/timer.
+ *
+ * This module has two tuning values:
+ * "adjust": will be subtracted from every timer set.
+ * "min": Every timer will be set to max("min", value).
+ * @{
+ *
+ * @file
+ * @brief       ztimer periph/timer backend API
+ */
+
+#ifndef ZTIMER_PERIPH_QDEC_H
+#define ZTIMER_PERIPH_QDEC_H
+
+#include "ztimer.h"
+#include "periph/qdec.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ztimer periph context structure
+ */
+typedef struct {
+    ztimer_clock_t super;   /**< super class            */
+    qdec_t dev;             /**< periph timer device    */
+} ztimer_periph_qdec_t;
+
+/**
+ * @brief   ztimer periph initialization
+ *
+ * Initializes the given periph timer and sets up the ztimer device.
+ *
+ * @param[in]   clock   ztimer periph device to initialize
+ * @param[in]   dev     periph timer to use
+ * @param[in]   freq    frequency to configure
+ * @param[in]   max_val maximum value this timer supports
+ */
+void ztimer_periph_qdec_init(ztimer_periph_qdec_t *clock, qdec_t dev,
+                              uint32_t max_val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZTIMER_PERIPH_QDEC_H */
+/** @} */

--- a/sys/ztimer/periph_qdec.c
+++ b/sys/ztimer/periph_qdec.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_ztimer_periph_timer
+ * @{
+ *
+ * @file
+ * @brief       ztimer periph/timer backend implementation
+ *
+ * @}
+ */
+
+#include "assert.h"
+#include "irq.h"
+#include "ztimer/periph_qdec.h"
+
+static bool _qdec_cb(void *arg)
+{
+    ztimer_handler(arg);
+    return false;
+}
+
+static void _set(ztimer_clock_t *clock, uint32_t val)
+{
+    ztimer_periph_qdec_t *ztimer_periph = (ztimer_periph_qdec_t *)clock;
+
+    const unsigned state = irq_disable(); //TODO: needed?
+    qdec_alarm_set(ztimer_periph->dev, 0, val, _qdec_cb, clock);
+    irq_restore(state);
+}
+
+static uint32_t _now(ztimer_clock_t *clock)
+{
+    ztimer_periph_qdec_t *ztimer_periph = (ztimer_periph_qdec_t *)clock;
+
+    return qdec_read(ztimer_periph->dev);
+}
+
+static void _cancel(ztimer_clock_t *clock)
+{
+    ztimer_periph_qdec_t *ztimer_periph = (ztimer_periph_qdec_t *)clock;
+
+    qdec_alarm_clear(ztimer_periph->dev, 0);
+}
+
+#if MODULE_ZTIMER_ONDEMAND_TIMER
+static void _start(ztimer_clock_t *clock)
+{
+    ztimer_periph_qdec_t *ztimer_periph = (ztimer_periph_qdec_t *)clock;
+
+    qdec_start(ztimer_periph->dev);
+}
+
+static void _stop(ztimer_clock_t *clock)
+{
+    ztimer_periph_qdec_t *ztimer_periph = (ztimer_periph_qdec_t *)clock;
+
+    qdec_stop(ztimer_periph->dev);
+}
+#endif /* MODULE_ZTIMER_ONDEMAND_TIMER */
+
+static const ztimer_ops_t _ops = {
+    .set = _set,
+    .now = _now,
+    .cancel = _cancel,
+#if MODULE_ZTIMER_ONDEMAND_TIMER //TODO: MODULE_ZTIMER_ONDEMAND_QDEC?
+    .start = _start,
+    .stop = _stop,
+#endif
+};
+
+void ztimer_periph_qdec_init(ztimer_periph_qdec_t *clock, qdec_t dev,
+                             uint32_t max_val)
+{
+    clock->dev = dev;
+    clock->super.ops = &_ops;
+    clock->super.max_value = max_val;
+    int ret = qdec_init(dev, QDEC_X4, NULL, NULL);
+
+    (void)ret;
+    assert(ret == 0);
+
+#if !MODULE_ZTIMER_ONDEMAND
+    /* extend lower clock only if the ondemand driver isn't selected
+     * otherwise, the clock extension will be called with the first
+     * ztimer_acquire() call */
+    ztimer_init_extend(&clock->super);
+#endif
+
+#if MODULE_ZTIMER_ONDEMAND_TIMER //TODO: MODULE_ZTIMER_ONDEMAND_QDEC?
+    /* turn off the timer peripheral after init
+     * the first ztimer_acquire() call starts the peripheral */
+    timer_stop(dev);
+#endif
+}


### PR DESCRIPTION
### Contribution description

This patch adds alarms (position based interrupts) to the qdec driver, and a ztimer_backend for qdec devices. It is not done yet, but I am requesting feedback before I finish.


### Testing procedure

TBA


### Issues/PRs references

- none known
