### PR TITLE
drivers/usbdev_synopsys_dwc2: fix and reenable DMA mode

### DIFF
--- a/boards/stm32f429i-disc1/Kconfig
+++ b/boards/stm32f429i-disc1/Kconfig
@@ -20,6 +20,7 @@ config BOARD_STM32F429I_DISC1
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_USBDEV_HS
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
@@ -37,5 +38,7 @@ config BOARD_STM32F429I_DISC1
     select HAVE_L3GXXXX_SPI
     select HAVE_I3G4250D
     select HAVE_L3GD20
+
+    select MODULE_PERIPH_USBDEV_HS if MODULE_PERIPH_USBDEV
 
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32f429i-disc1/Makefile.dep
+++ b/boards/stm32f429i-disc1/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter periph_usbdev,$(USEMODULE)))
+  USEMODULE += periph_usbdev_hs
+endif
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += l3gxxxx

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_usbdev_hs
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -131,20 +131,24 @@ typedef struct {
  * @brief Number of endpoints available with the OTG FS peripheral
  *        including the control endpoint
  */
-#ifdef STM32_USB_OTG_CID_1x
-#define STM32_USB_OTG_FS_NUM_EP (4)    /**< OTG FS with 4 endpoints */
+#if defined(USB_OTG_FS_MAX_IN_ENDPOINTS)
+#define STM32_USB_OTG_FS_NUM_EP     (USB_OTG_FS_MAX_IN_ENDPOINTS)
+#elif defined(STM32_USB_OTG_CID_1x)
+#define STM32_USB_OTG_FS_NUM_EP     (4)    /**< OTG FS with 4 endpoints */
 #elif defined(STM32_USB_OTG_CID_2x)
-#define STM32_USB_OTG_FS_NUM_EP (6)    /**< OTG FS with 6 endpoints */
+#define STM32_USB_OTG_FS_NUM_EP     (6)    /**< OTG FS with 6 endpoints */
 #endif
 
 /**
  * @brief Number of endpoints available with the OTG HS peripheral
  *        including the control endpoint
  */
-#ifdef STM32_USB_OTG_CID_1x
-#define STM32_USB_OTG_HS_NUM_EP (6)     /**< OTG HS with 6 endpoints */
+#if defined(USB_OTG_HS_MAX_IN_ENDPOINTS)
+#define STM32_USB_OTG_HS_NUM_EP     (USB_OTG_HS_MAX_IN_ENDPOINTS)
+#elif defined(STM32_USB_OTG_CID_1x)
+#define STM32_USB_OTG_HS_NUM_EP     (6)     /**< OTG HS with 6 endpoints */
 #elif defined(STM32_USB_OTG_CID_2x)
-#define STM32_USB_OTG_HS_NUM_EP (9)     /**< OTG HS with 9 endpoints */
+#define STM32_USB_OTG_HS_NUM_EP     (9)     /**< OTG HS with 9 endpoints */
 #endif
 
 /**

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -154,14 +154,17 @@ typedef struct {
 /**
  * @brief Number of IN/OUT endpoints including EP0 as used by USBUS
  *
- * @note Since only a single number of EPs can be defined for USBUS that is
- *       valid for all devices, the smallest number of EPs must be used for
- *       multiple USB devices.
+ * @note USBUS allows only one definition of the number of available EPs, which
+ *       is then used for all devices. To be able to use all EPs for devices
+ *       with more EPs, the largest possible number of available EPs for
+ *       several USB devices is defined here. The driver has to ensure that the
+ *       number of allocated EPs does not exceed the number of available EPs if
+ *       a device has less EPs.
  */
-#if defined(STM32_USB_OTG_FS_NUM_EP)
-#define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_FS_NUM_EP
-#elif defined(STM32_USB_OTG_HS_NUM_EP)
+#if defined(MODULE_PERIPH_USBDEV_HS) && defined(STM32_USB_OTG_HS_NUM_EP)
 #define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_HS_NUM_EP
+#elif defined(STM32_USB_OTG_FS_NUM_EP)
+#define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_FS_NUM_EP
 #else
 #define USBDEV_NUM_ENDPOINTS            8
 #endif

--- a/cpu/stm32/include/usbdev_stm32.h
+++ b/cpu/stm32/include/usbdev_stm32.h
@@ -111,19 +111,6 @@ extern "C" {
  */
 #define DWC2_USB_OTG_HS_TOTAL_FIFO_SIZE USB_OTG_HS_TOTAL_FIFO_SIZE
 
-/**
- * @brief Use the built-in DMA controller of the HS peripheral when possible
- */
-#ifndef STM32_USB_OTG_HS_USE_DMA
-#ifdef STM32_USB_OTG_CID_1x
-/* FIXME: It should be possible to use DMA with the 1.x version of the  *
- * peripheral, but somehow it doesn't work.                             */
-#define STM32_USB_OTG_HS_USE_DMA        (0)
-#else
-#define STM32_USB_OTG_HS_USE_DMA        (1)
-#endif
-#endif
-
 /* periph/usbdev.h is included after the definitions above by intention */
 #include "periph/usbdev.h"
 

--- a/drivers/periph_common/Kconfig.usbdev
+++ b/drivers/periph_common/Kconfig.usbdev
@@ -22,6 +22,16 @@ config MODULE_PERIPH_INIT_USBDEV
     bool "Auto initialize USBDEV peripheral"
     default y if MODULE_PERIPH_INIT
 
+config MODULE_PERIPH_USBDEV_HS
+    bool "Use USB HS peripheral"
+    depends on HAS_PERIPH_USBDEV_HS
+    default y if MODULE_PERIPH_INIT_USBDEV_HS_ULPI || MODULE_PERIPH_USBDEV_HS_UTMI
+
+config MODULE_PERIPH_INIT_USBDEV_HS
+    bool
+    depends on MODULE_PERIPH_USBDEV_HS
+    default y if MODULE_PERIPH_INIT
+
 config MODULE_PERIPH_USBDEV_HS_ULPI
     bool "Use USB HS peripheral with ULPI HS PHY"
     depends on HAS_PERIPH_USBDEV_HS_ULPI

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -12,7 +12,6 @@ USEMODULE += ps
 # Boards that don't have enough endpoints to use CDC ACM together with CDC ECM
 ifeq (,$(filter stdio_%,$(filter-out stdio_cdc_acm,$(USEMODULE))))
   BOARD_BLACKLIST += \
-    stm32f429i-disco \
     stm32f4discovery \
     weact-f401cc \
     weact-f401ce \


### PR DESCRIPTION
### Contribution description

This PR fixes the DMA mode for all STM32 USB OTG HS cores (including that for STM32F4xx CID 1.xxx) and reenables it. It fixes remaining problems in issue #19359.

This PR includes also includes some changes that are needed to use the DMA mode:
- EP number is used as defined in CMSIS (if defined) for STM32
- `periph_usbdev_hs` feature is added in Kconfig
- `periph_usbdev_hs` feature is added in board definition of `stm32f429i-disc1`
- largest number of available EPs is used for STM32 instead of the smallest number (to be able to use all EPs of HS peripheral)
- `stm32f429i-disco` is removed from blacklist in `tests/usbus_cdc_ecm` since it uses the HS peripheral

### Testing procedure

The following tests should work
```python
USEMODULE=stdio_cdc_acm BOARD=stm32f429i-disc1 make -j8 -C tests/usbus_cdc_ecm flash
```
<details>
<summary>Test results</summary>

```python
[526755.875691] usb 1-2.2: new full-speed USB device number 106 using xhci_hcd
[526755.977853] usb 1-2.2: config 1 interface 3 altsetting 1 endpoint 0x84 has invalid maxpacket 512, setting to 64
[526755.977856] usb 1-2.2: config 1 interface 3 altsetting 1 endpoint 0x2 has invalid maxpacket 512, setting to 64
[526755.978762] usb 1-2.2: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 1.00
[526755.978764] usb 1-2.2: New USB device strings: Mfr=3, Product=2, SerialNumber=4
[526755.978766] usb 1-2.2: Product: stm32f429i-disc1
[526755.978768] usb 1-2.2: Manufacturer: RIOT-os.org
[526755.978769] usb 1-2.2: SerialNumber: 7C156425A950A8EB
[526755.991190] cdc_acm 1-2.2:1.0: ttyACM1: USB ACM device
[526755.998131] cdc_ether 1-2.2:1.2 usb0: register 'cdc_ether' at usb-0000:00:14.0-2.2, CDC Ethernet Device, a6:f6:4a:85:1d:c9
[526756.044150] cdc_ether 1-2.2:1.2 enp0s20f0u2u2i2: renamed from usb0
```

</details>

```python
USEMODULE='stdio_cdc_acm periph_usbdev_hs_utmi' BOARD=stm32f723e-disco make -j8 -C tests/usbus_cdc_ecm flash
```
<details>
<summary>Test results</summary>

```python
[528733.480207] usb 1-4.3.4: reset high-speed USB device number 32 using xhci_hcd
[528733.707800] usb 1-4.4: new high-speed USB device number 111 using xhci_hcd
[528733.808257] usb 1-4.4: config 1 interface 0 altsetting 0 endpoint 0x81 has an invalid bInterval 255, changing to 11
[528733.808260] usb 1-4.4: config 1 interface 1 altsetting 0 bulk endpoint 0x1 has invalid maxpacket 64
[528733.808263] usb 1-4.4: config 1 interface 1 altsetting 0 bulk endpoint 0x82 has invalid maxpacket 64
[528733.808642] usb 1-4.4: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 1.00
[528733.808645] usb 1-4.4: New USB device strings: Mfr=3, Product=2, SerialNumber=4
[528733.808647] usb 1-4.4: Product: stm32f723e-disco
[528733.808649] usb 1-4.4: Manufacturer: RIOT-os.org
[528733.808651] usb 1-4.4: SerialNumber: A6BAC4E1B1E0806B
[528733.811988] cdc_acm 1-4.4:1.0: ttyACM1: USB ACM device
[528733.814456] cdc_ether 1-4.4:1.2 usb0: register 'cdc_ether' at usb-0000:00:14.0-4.4, CDC Ethernet Device, e6:75:97:3a:74:ba
[528733.854371] cdc_ether 1-4.4:1.2 enp0s20f0u4u4i2: renamed from usb0
```

</details>

```python
USEMODULE='stdio_cdc_acm periph_usbdev_hs_ulpi' BOARD=stm32f746g-disco make -j8 -C tests/usbus_cdc_ecm flash
```
<details>
<summary>Test results</summary>

```python
[529000.944482] usb 1-4.3.4: reset high-speed USB device number 32 using xhci_hcd
[529003.728260] usb 1-4.4: new high-speed USB device number 114 using xhci_hcd
[529003.833107] usb 1-4.4: config 1 interface 0 altsetting 0 endpoint 0x81 has an invalid bInterval 255, changing to 11
[529003.833111] usb 1-4.4: config 1 interface 1 altsetting 0 bulk endpoint 0x1 has invalid maxpacket 64
[529003.833113] usb 1-4.4: config 1 interface 1 altsetting 0 bulk endpoint 0x82 has invalid maxpacket 64
[529003.833743] usb 1-4.4: New USB device found, idVendor=1209, idProduct=7d00, bcdDevice= 1.00
[529003.833747] usb 1-4.4: New USB device strings: Mfr=3, Product=2, SerialNumber=4
[529003.833749] usb 1-4.4: Product: stm32f746g-disco
[529003.833751] usb 1-4.4: Manufacturer: RIOT-os.org
[529003.833753] usb 1-4.4: SerialNumber: 66FE8934D1A363E0
[529003.837143] cdc_acm 1-4.4:1.0: ttyACM1: USB ACM device
[529003.839755] cdc_ether 1-4.4:1.2 usb0: register 'cdc_ether' at usb-0000:00:14.0-4.4, CDC Ethernet Device, 6a:88:1f:1f:b1:f0
[529003.879025] cdc_ether 1-4.4:1.2 enp0s20f0u4u4i2: renamed from usb0```
```
</details>

### Issues/PRs references

Fixes #19359
