### PR TITLE
gnrc_ipv6_static_addr: fix build with only static address

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
+++ b/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
@@ -113,25 +113,34 @@ static void _config_downstream(gnrc_netif_t *downstream)
 
 void auto_init_gnrc_ipv6_static_addr(void)
 {
-    gnrc_netif_t *netif = NULL;
     gnrc_netif_t *upstream = NULL;
     gnrc_netif_t *downstream = NULL;
 
-    if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM)) {
-        upstream = gnrc_netif_get_by_pid(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM);
-    }
+    if (gnrc_netif_highlander() || gnrc_netif_numof() == 1) {
+        upstream = gnrc_netif_iter(NULL);
 
-    if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM)) {
-        downstream = gnrc_netif_get_by_pid(CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM);
-    }
+        if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM)) {
+            assert(upstream->pid == CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM);
+        }
+    } else {
 
-    while ((netif = gnrc_netif_iter(netif))) {
-        bool is_wired = gnrc_netapi_get(netif->pid, NETOPT_IS_WIRED, 0, NULL, 0) == 1;
+        if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM)) {
+            upstream = gnrc_netif_get_by_pid(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM);
+        }
 
-        if (!upstream && is_wired) {
-            upstream = netif;
-        } else if (!downstream && !is_wired) {
-            downstream = netif;
+        if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM)) {
+            downstream = gnrc_netif_get_by_pid(CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM);
+        }
+
+        gnrc_netif_t *netif = NULL;
+        while ((netif = gnrc_netif_iter(netif))) {
+            bool is_wired = gnrc_netapi_get(netif->pid, NETOPT_IS_WIRED, 0, NULL, 0) == 1;
+
+            if (!upstream && is_wired) {
+                upstream = netif;
+            } else if (!downstream && !is_wired) {
+                downstream = netif;
+            }
         }
     }
 

--- a/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
+++ b/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
@@ -84,7 +84,7 @@ static void _config_downstream(gnrc_netif_t *downstream)
 
     DEBUG("gnrc_ipv6_static_addr: interface %u selected as downstream\n", downstream->pid);
 
-    if (CONFIG_GNRC_IPV6_STATIC_PREFIX == NULL) {
+    if (static_prefix == NULL) {
         return;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Using `gnrc_ipv6_static_addr` with only `CONFIG_GNRC_IPV6_STATIC_ADDR` set fails due to a copy & paste error.

Also remove the need to specify the interface if there is only one.

### Testing procedure

Running `examples/gnrc_networking` with 

```make
USEMODULE += gnrc_ipv6_static_addr
CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_ADDR=\"2001:db8::2\"
```

now has the expected result

```
Iface  7  HWaddr: 4F:C5  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: A6:8F:3A:12:5E:63:4F:C5 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::a48f:3a12:5e63:4fc5  scope: link  VAL
          inet6 addr: 2001:db8::2  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff63:4fc5
          inet6 group: ff02::1a
          inet6 group: ff02::1:ff00:2
``` 



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
