### PR TITLE
drivers/usbdev_synopsys_dwc2: add ESP32x power management

### DIFF
--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -596,6 +596,8 @@ static void _sleep_periph(const dwc2_usb_otg_fshs_config_t *conf)
     /* switch USB core clock source either to LFXO or LFRCO */
     CMU_ClockSelectSet(cmuClock_USB, CLOCK_LFA);
     pm_unblock(EFM32_PM_MODE_EM2);
+#elif defined(MCU_ESP32)
+    pm_unblock(ESP_PM_LIGHT_SLEEP);
 #endif
 }
 
@@ -613,6 +615,8 @@ static void _wake_periph(const dwc2_usb_otg_fshs_config_t *conf)
 #else
 #error "EFM32 family not yet supported"
 #endif
+#elif defined(MCU_ESP32)
+    pm_block(ESP_PM_LIGHT_SLEEP);
 #endif
     *_pcgcctl_reg(conf) &= ~USB_OTG_PCGCCTL_STOPCLK;
     _flush_rx_fifo(conf);
@@ -691,6 +695,9 @@ static void _usbdev_init(usbdev_t *dev)
     _enable_gpio(conf);
 
 #elif defined(MCU_ESP32)
+
+    pm_block(ESP_PM_DEEP_SLEEP);
+    pm_block(ESP_PM_LIGHT_SLEEP);
 
     usb_phy_handle_t phy_hdl;               /* only needed temporarily */
 


### PR DESCRIPTION
### Contribution description

This PR adds power management handling for ESP32x SoCs.

### Testing procedure

Use and ESP32-S2 or ESP32-S3 board and flash `tests/periph_pm` using the `stdio_cdc_acm`
```
USEMODULE=stdio_cdc_acm BOARD=esp32s3-devkit make -j8 -C tests/periph_pm flash
```
Connect the terminal to the board and execute command:
```
set_rtc 1 1
```
The console should continue to work after the 1-s light sleep.

### Issues/PRs references
