### PR TITLE
sys/bitfield: don't touch unrelated bits in bf_{set, clear}_all()

### DIFF
--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -90,7 +90,18 @@ void bf_set_all(uint8_t field[], size_t size)
 
     memset(field, 0xff, bytes);
     if (bits) {
-        field[bytes] = ~((1U << (8 - bits)) - 1);
+        field[bytes] |= ~((1U << (8 - bits)) - 1);
+    }
+}
+
+void bf_clear_all(uint8_t field[], size_t size)
+{
+    unsigned bytes = size >> 3;
+    unsigned bits = size & 0x7;
+
+    memset(field, 0, bytes);
+    if (bits) {
+        field[bytes] &= ((1U << (8 - bits)) - 1);
     }
 }
 

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -365,10 +365,7 @@ static inline void bf_set_all_atomic(uint8_t field[], size_t size)
  * @param[in]     field The bitfield
  * @param[in]     size  The number of bits in the bitfield
  */
-static inline void bf_clear_all(uint8_t field[], size_t size)
-{
-    memset(field, 0, (size + 7) / 8);
-}
+void bf_clear_all(uint8_t field[], size_t size);
 
 /**
  * @brief  Atomically clear all bits in the bitfield to 0

--- a/tests/unittests/tests-bitfield/tests-bitfield.c
+++ b/tests/unittests/tests-bitfield/tests-bitfield.c
@@ -299,6 +299,16 @@ static void test_bf_set_all(void)
     TEST_ASSERT_EQUAL_INT(0, field[4]);
 }
 
+static void test_bf_clear_all(void)
+{
+    uint8_t field[5];
+
+    memset(field, 0xFF, sizeof(field));
+    bf_clear_all(field, 5);
+    TEST_ASSERT_EQUAL_INT(0x7, field[0]);
+    TEST_ASSERT_EQUAL_INT(0xFF, field[1]);
+}
+
 static void test_bf_popcnt(void)
 {
     uint8_t field[5];
@@ -334,6 +344,7 @@ Test *tests_bitfield_tests(void) {
         new_TestFixture(test_bf_find_first_set),
         new_TestFixture(test_bf_find_first_unset),
         new_TestFixture(test_bf_set_all),
+        new_TestFixture(test_bf_clear_all),
         new_TestFixture(test_bf_popcnt),
     };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When I added those functions I thought there was no use-case for *not* touching the remaining bits of the last byte of the bitfield (e.g. in a bitfield of size 5 a `bf_clear_all()` would set all 8 bits of the bitfield-byte to 0).

But it turns out there *is* a use case for only clearing/setting part of a bitfield, so make the `bf_{set, clear}_all()` functions actually honor the proper size they are called with.


### Testing procedure

A new test case has been added to the unit test to check if no unrelated bits are touched.
This test case will fail on `master`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
