### PR TITLE
cpu/efm32: pwm_init errors are zeros

### DIFF
--- a/cpu/efm32/periph/pwm.c
+++ b/cpu/efm32/periph/pwm.c
@@ -33,7 +33,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     /* check if device is valid */
     if (dev >= PWM_NUMOF) {
-        return -1;
+        return 0;
     }
 
     /* enable clocks */
@@ -46,7 +46,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
                                                            freq_timer);
 
     if (prescaler > timerPrescale1024) {
-        return -2;
+        return 0;
     }
 
     /* reset and initialize peripheral */

--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -42,7 +42,7 @@
 #define OSC_STEPS       (256U)
 #define PWR_SLEEP       (1U)
 
-static uint32_t initiated;
+static uint32_t initialized;
 
 static unsigned _get_dev(const char *dev_str)
 {
@@ -94,11 +94,11 @@ static int _init(int argc, char** argv)
                                  (uint16_t)atoi(argv[4]));
     if (pwm_freq != 0) {
         printf("The pwm frequency is set to %" PRIu32 "\n", pwm_freq);
-        initiated |= (1 << dev);
+        initialized |= (1 << dev);
         return 0;
     }
 
-    puts("Error: device is not initiated");
+    puts("Error: device is not initialized");
     return 1;
 }
 
@@ -117,8 +117,8 @@ static int _set(int argc, char**argv)
         return 1;
     }
 
-    if ((initiated & (1 << dev)) == 0) {
-        puts("Error: pwm is not initiated.\n");
+    if ((initialized & (1 << dev)) == 0) {
+        puts("Error: pwm is not initialized.\n");
         puts("Execute init function first.\n");
         return 1;
     }
@@ -245,7 +245,7 @@ static const shell_command_t shell_commands[] = {
 int main(void)
 {
     puts("PWM peripheral driver test\n");
-    initiated = 0;
+    initialized = 0;
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);


### PR DESCRIPTION
### Contribution description

pwm_init is documented to return 0 on errors, and has an unsigned return value.

EFM32's initialization function returned negative values, which through implicit casting become 0xffffffff or 0xfffffffe, which are successful by the documentation.

This makes all the EFM32 error paths return 0 as they should.

Also, it fixes a variable name and the corresponding error message that used to talk of "initiation" (which would be the start of a process) rather than "initialization" (which is a process that is completed before something else can happen).

### Testing procedure

* on stk3700, tests/periph_pwm, run `init 0 0 10 1000` / `set 0 0 500`
* The init used to respond with "The pwm frequency is set to 4294967294", and the set does nothing.
* The init now responds with "Error: device is not <del>initiated</del><ins>initialized</ins>". The set still does nothing, but then one doesn't expect it to any more.

(But really, looking at the patch and the docs should suffice).

### Issues/PRs references

By-catch from testing the Rust wrappers provided by @remmirad at https://github.com/RIOT-OS/rust-riot-wrappers/pull/38