### PR TITLE
boards/esp32: enable RGB LED support

### DIFF
--- a/boards/esp32c3-devkit/doc.txt
+++ b/boards/esp32c3-devkit/doc.txt
@@ -62,8 +62,7 @@ see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
 ### Board Configuration {#esp32c3_devkit_board_configuration}
 
 ESP32-C3-DevKit boards have no special hardware on board with the exception
-of a single pin RGB-LED that uses a special bit-oriented protocol to
-control the RGB-LED by 24-bit RGB values which is not supported yet.
+of a single pin RGB-LED.
 
 All GPIOs are simply broken out for flexibility. Therefore, the board
 configuration is the most flexible one which provides:
@@ -108,6 +107,7 @@ ADC             | GPIO0, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5 | | see \ref esp32_ad
 PWM_DEV(0)      | GPIO3, GPIO4 | - | \ref esp32_pwm_channels "PWM Channels"
 I2C_DEV(0):SCL  | GPIO4 | | \ref esp32_i2c_interfaces "I2C Interfaces"
 I2C_DEV(0):SDA  | GPIO5 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+RGB-LED         | GPIO8 | supported by driver module `ws281x` | |
 SPI_DEV(0):CLK  | GPIO6 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0):MISO | GPIO2 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0):MOSI | GPIO7 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"

--- a/boards/esp32c3-devkit/include/board.h
+++ b/boards/esp32c3-devkit/include/board.h
@@ -73,11 +73,15 @@
  * @name    LED (on-board) configuration
  *
  * ESP32-C3-DevKit boards have a SK68XXMINI-HS smart RGB-LED connected to
- * GPIO8 on-board. This RGB-LEDs uses a special bit-oriented protocol to
- * control the RGB-LED by 24-bit RGB values. Therefore, it can't be used as
- * default LED definition for RIOT.
+ * GPIO8 on-board. The WS281x driver module `ws281x` can be used to control it.
  * @{
  */
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    (GPIO8)   /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)      /**< Number of LEDs chained */
+#endif
 /** @} */
 
 /* include common board definitions as last step */

--- a/boards/esp32s2-devkit/doc.txt
+++ b/boards/esp32s2-devkit/doc.txt
@@ -102,8 +102,7 @@ see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
 ### Board Configuration {#esp32s2_devkit_board_configuration}
 
 ESP32-S2-DevKit boards have no special hardware on board with the exception
-of a single pin RGB-LED that uses a special bit-oriented protocol to
-control the RGB-LED by 24-bit RGB values which is not supported yet.
+of a single pin RGB-LED.
 
 All GPIOs are simply broken out for flexibility. Therefore, the board
 configuration is the most flexible one which provides:
@@ -150,11 +149,12 @@ Function        | GPIOs  | Remarks | Configuration
 :---------------|:-------|:--------|:----------------------------------
 BUTTON0         | GPIO0  | | |
 ADC_LINE(n)     | GPIO1 ... GPIO10 | | \ref esp32_adc_channels "ADC Channels"
-DAC_LINE(n)     | GPIO17, GPIO18 | | \ref esp32_dac_channels "DAC Channels"
+DAC_LINE(n)     | GPIO17, GPIO18 | GPIO18 is connected to RGB-LED | \ref esp32_dac_channels "DAC Channels"
 I2C_DEV(0) SCL  | GPIO9  | | \ref esp32_i2c_interfaces "I2C Interfaces"
 I2C_DEV(0) SDA  | GPIO8  | | \ref esp32_i2c_interfaces "I2C Interfaces"
 PWM_DEV(0)      | GPIO11, GPIO12, GPIO13, GPIO14 | - | \ref esp32_pwm_channels "PWM Channels"
 PWM_DEV(1)      | GPIO15, GPIO16 | if module `esp_rtc_timer_32k` is not used | \ref esp32_pwm_channels "PWM Channels"
+RGB-LED         | GPIO18 | supported by driver module `ws281x` | |
 SPI_DEV(0) CLK  | GPIO12 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0) MISO | GPIO13 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0) MOSI | GPIO11 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"

--- a/boards/esp32s2-devkit/include/board.h
+++ b/boards/esp32s2-devkit/include/board.h
@@ -75,11 +75,19 @@
  * @name    LED (on-board) configuration
  *
  * ESP32-S2-DevKit boards have a SK68XXMINI-HS smart RGB-LED connected to
- * GPIO18 on-board. This RGB-LEDs uses a special bit-oriented protocol to
- * control the RGB-LED by 24-bit RGB values. Therefore, it can't be used as
- * default LED definition for RIOT.
+ * GPIO18 on-board. The WS281x driver module `ws281x` can be used to control it.
+ *
+ * @note GPIO18 is also be defined as DAC channel. The RGB-LED can be
+ * used as long as GPIO18 is not initialized as DAC channel with the
+ * function `dac_init`.
  * @{
  */
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    (GPIO18)  /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)      /**< Number of LEDs chained */
+#endif
 /** @} */
 
 /* include common board definitions as last step */

--- a/boards/esp32s2-devkit/include/periph_conf.h
+++ b/boards/esp32s2-devkit/include/periph_conf.h
@@ -69,7 +69,7 @@ extern "C" {
  *
  * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
  * channels with the `dac_init` function, they can be used for other
- * purposes.
+ * purposes. GPIO18 is also used for the RGB-LED.
  */
 #ifndef DAC_GPIOS
 #define DAC_GPIOS   { GPIO17, GPIO18 }

--- a/boards/esp32s3-devkit/doc.txt
+++ b/boards/esp32s3-devkit/doc.txt
@@ -108,8 +108,7 @@ see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
 ### Board Configuration {#esp32s3_devkit_board_configuration}
 
 ESP32-S3-DevKit boards have no special hardware on board with the exception
-of a single pin RGB-LED that uses a special bit-oriented protocol to
-control the RGB-LED by 24-bit RGB values which is not supported yet.
+of a single pin RGB-LED.
 
 All GPIOs are simply broken out for flexibility. Therefore, the board
 configuration is the most flexible one which provides:
@@ -158,6 +157,7 @@ PWM_DEV(0)      | GPIO14, GPIO17, GPIO18, GPIO21 | - | \ref esp32_pwm_channels "
 PWM_DEV(1)      | GPIO15, GPIO16 | if module `esp_rtc_timer_32k` is not used | \ref esp32_pwm_channels "PWM Channels"
 I2C_DEV(0) SCL  | GPIO9  | | \ref esp32_i2c_interfaces "I2C Interfaces"
 I2C_DEV(0) SDA  | GPIO8  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+RGB-LED         | GPIO48 | supported by driver module `ws281x` | |
 SPI_DEV(0) CLK  | GPIO12 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0) MISO | GPIO13 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0) MOSI | GPIO11 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"

--- a/boards/esp32s3-devkit/include/board.h
+++ b/boards/esp32s3-devkit/include/board.h
@@ -75,11 +75,15 @@
  * @name    LED (on-board) configuration
  *
  * ESP32-S3-DevKit boards have a SK68XXMINI-HS smart RGB-LED connected to
- * GPIO48 on-board. This RGB-LEDs uses a special bit-oriented protocol to
- * control the RGB-LED by 24-bit RGB values. Therefore, it can't be used as
- * default LED definition for RIOT.
+ * GPIO48 on-board. The WS281x driver module `ws281x` can be used to control it.
  * @{
  */
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    (GPIO48)  /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)      /**< Number of LEDs chained */
+#endif
 /** @} */
 
 /* include common board definitions as last step */


### PR DESCRIPTION
### Contribution description

A couple of ESP32x boards have a SK68XXMINI-HS RGB LED on board.
- `esp32c3-devkit`
- `esp32s2-devkit`
- `esp32s3-devkit`

 This RGB LED can be used with the driver module `ws2812x`. This PR adds the `WS2812X_PARAMS*` parameter definitions to the board definition and updates the documentation.

### Testing procedure

Use any of these boards to flash `tests/driver_ws2812x`, for example:
```
BOARD=esp32c3-devkit make -j8 -C tests/driver_ws281x/ flash
```
The RGB LED should work as expected.

### Issues/PRs references
