### PR TITLE
boards/common/gd32v: improve openocd config

### DIFF
--- a/boards/common/gd32v/dist/openocd.cfg
+++ b/boards/common/gd32v/dist/openocd.cfg
@@ -19,9 +19,12 @@ $_TARGETNAME configure -event reset-assert {
     # after the write happens, which fails when the core is in reset.
     riscv set_mem_access abstract
 
-    # Go!
+    # Reset the Hart
     $_TARGETNAME mww 0xe0042008 0x1
 
     # Put the memory access mode back to what it was.
     riscv set_mem_access progbuf
+
+    # Continue execution
+    resume
 }


### PR DESCRIPTION
### Contribution description

This PR improves the OpenOCD config for GD32V.

To restart GD32V after flashing, a special magic procedure has to be used. For short:
```python
    halt
    gd32vf103.cpu mww 0xe004200c 0x4b5a6978      # unlock 0xe0042008, the next write triggers a reset
    riscv set_mem_access abstract                # set abstract memory access
    gd32vf103.cpu mww 0xe0042008 0x1             # write to 0xe0042008 to triggers a reset
    riscv set_mem_access progbuf                 # set memory access mode back
    resume
```

The final `resume` was missing so that a timeout with an error message happened after flashing, for example:
```python
wrote 14692 bytes from file tests/shell/bin/sipeed-longan-nano/tests_shell.elf in 1.845550s (7.774 KiB/s)

verified 14692 bytes in 0.071006s (202.063 KiB/s)

Info : JTAG tap: gd32vf103.cpu tap/device found: 0x1000563d (mfg: 0x31e (Andes Technology Corporation), part: 0x0005, ver: 0x1)
Info : JTAG tap: auto0.tap tap/device found: 0x790007a3 (mfg: 0x3d1 (GigaDevice Semiconductor (Beijing) Inc), part: 0x9000, ver: 0x7)
Error: Timed out after 2s waiting for busy to go low (abstractcs=0x2001004). Increase the timeout with riscv set_command_timeout_sec.
Warn : Failed to write memory via abstract access.
Error: Target gd32vf103.cpu: Failed to write memory (addr=0xe0042008)
Error:   progbuf=disabled, sysbus=disabled, abstract=failed
Error executing event reset-assert on target gd32vf103.cpu:
embedded:startup.tcl:1187: Error: 
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 1187
shutdown command invoked
Done flashing
```
With the final `resume`, still an error message happens that hart 0 is unavialable, but the timeout with all these errors do not occur and OpenOCD exits immediatly:
```python
wrote 14732 bytes from file /home/gs/src/RIOT-Xtensa-ESP.esp-idf-4.4/tests/shell/bin/sipeed-longan-nano/tests_shell.elf in 1.516376s (9.488 KiB/s)

verified 14732 bytes in 0.045381s (317.021 KiB/s)

Info : JTAG tap: gd32vf103.cpu tap/device found: 0x1000563d (mfg: 0x31e (Andes Technology Corporation), part: 0x0005, ver: 0x1)
Info : JTAG tap: auto0.tap tap/device found: 0x790007a3 (mfg: 0x3d1 (GigaDevice Semiconductor (Beijing) Inc), part: 0x9000, ver: 0x7)
Error: Hart 0 is unavailable.
Info : Hart 0 unexpectedly reset!
shutdown command invoked
Done flashing
```
### Testing procedure

Flash any GD32V board with and without this PR and observe the output.

### Issues/PRs references
