### PR TITLE
drivers/mtd: Kconfig use selects

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -7,52 +7,52 @@
 
 config HAVE_MTD_AT24CXXX
     bool
-    imply MODULE_MTD_AT24CXXX if MODULE_MTD
+    select MODULE_MTD_AT24CXXX if MODULE_MTD
     help
         Indicates that a at24cxxx EEPROM MTD is present
 
 config HAVE_MTD_AT25XXX
     bool
-    imply MODULE_MTD_AT25XXX if MODULE_MTD
+    select MODULE_MTD_AT25XXX if MODULE_MTD
     help
         Indicates that a at25xxx SPI-EEPROM MTD is present
 
 config HAVE_MTD_NATIVE
     bool
-    imply MODULE_MTD_NATIVE if MODULE_MTD
+    select MODULE_MTD_NATIVE if MODULE_MTD
     help
         Indicates that a native MTD is present.
 
 config HAVE_MTD_SDCARD_DEFAULT
     bool
-    imply MODULE_MTD_SDCARD if MODULE_MTD
-    imply MODULE_MTD_SDCARD_DEFAULT if MODULE_MTD
-    imply MODULE_SDCARD_SPI if MODULE_MTD
+    select MODULE_MTD_SDCARD if MODULE_MTD
+    select MODULE_MTD_SDCARD_DEFAULT if MODULE_MTD
+    select MODULE_SDCARD_SPI if MODULE_MTD
     select HAS_SDCARD_SPI
     help
         Indicates that a sdcard MTD is present with generic configuration
 
 config HAVE_MTD_SDCARD
     bool
-    imply MODULE_MTD_SDCARD if MODULE_MTD
+    select MODULE_MTD_SDCARD if MODULE_MTD
     help
         Indicates that a sdcard MTD is present
 
 config HAVE_MTD_SPI_NOR
     bool
-    imply MODULE_MTD_SPI_NOR if MODULE_MTD
+    select MODULE_MTD_SPI_NOR if MODULE_MTD
     help
         Indicates that a spi-nor MTD is present
 
 config HAVE_SAM0_SDHC
     bool
-    imply MODULE_SAM0_SDHC if MODULE_MTD
+    select MODULE_SAM0_SDHC if MODULE_MTD
     help
         Indicates that a SAM0 SD Host Controller MTD is present
 
 config HAVE_MTD_SPI_MCI
     bool
-    imply MODULE_MTD_MCI if MODULE_MTD
+    select MODULE_MTD_MCI if MODULE_MTD
     help
         Indicates that a Multimedia Card Interface (MCI) MTD is present
 

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -5,57 +5,6 @@
 # directory for more details.
 #
 
-config HAVE_MTD_AT24CXXX
-    bool
-    select MODULE_MTD_AT24CXXX if MODULE_MTD
-    help
-        Indicates that a at24cxxx EEPROM MTD is present
-
-config HAVE_MTD_AT25XXX
-    bool
-    select MODULE_MTD_AT25XXX if MODULE_MTD
-    help
-        Indicates that a at25xxx SPI-EEPROM MTD is present
-
-config HAVE_MTD_NATIVE
-    bool
-    select MODULE_MTD_NATIVE if MODULE_MTD
-    help
-        Indicates that a native MTD is present.
-
-config HAVE_MTD_SDCARD_DEFAULT
-    bool
-    select MODULE_MTD_SDCARD if MODULE_MTD
-    select MODULE_MTD_SDCARD_DEFAULT if MODULE_MTD
-    select MODULE_SDCARD_SPI if MODULE_MTD
-    select HAS_SDCARD_SPI
-    help
-        Indicates that a sdcard MTD is present with generic configuration
-
-config HAVE_MTD_SDCARD
-    bool
-    select MODULE_MTD_SDCARD if MODULE_MTD
-    help
-        Indicates that a sdcard MTD is present
-
-config HAVE_MTD_SPI_NOR
-    bool
-    select MODULE_MTD_SPI_NOR if MODULE_MTD
-    help
-        Indicates that a spi-nor MTD is present
-
-config HAVE_SAM0_SDHC
-    bool
-    select MODULE_SAM0_SDHC if MODULE_MTD
-    help
-        Indicates that a SAM0 SD Host Controller MTD is present
-
-config HAVE_MTD_SPI_MCI
-    bool
-    select MODULE_MTD_MCI if MODULE_MTD
-    help
-        Indicates that a Multimedia Card Interface (MCI) MTD is present
-
 menuconfig MODULE_MTD
     bool "Memory Technology Device interface (MTD)"
     depends on TEST_KCONFIG
@@ -115,3 +64,54 @@ config MODULE_MTD_WRITE_PAGE
     bool "MTD write page API"
 
 endif
+
+config HAVE_MTD_AT24CXXX
+    bool
+    select MODULE_MTD_AT24CXXX if MODULE_MTD
+    help
+        Indicates that a at24cxxx EEPROM MTD is present
+
+config HAVE_MTD_AT25XXX
+    bool
+    select MODULE_MTD_AT25XXX if MODULE_MTD
+    help
+        Indicates that a at25xxx SPI-EEPROM MTD is present
+
+config HAVE_MTD_NATIVE
+    bool
+    select MODULE_MTD_NATIVE if MODULE_MTD
+    help
+        Indicates that a native MTD is present.
+
+config HAVE_MTD_SDCARD_DEFAULT
+    bool
+    select MODULE_MTD_SDCARD if MODULE_MTD
+    select MODULE_MTD_SDCARD_DEFAULT if MODULE_MTD
+    select MODULE_SDCARD_SPI if MODULE_MTD
+    select HAS_SDCARD_SPI
+    help
+        Indicates that a sdcard MTD is present with generic configuration
+
+config HAVE_MTD_SDCARD
+    bool
+    select MODULE_MTD_SDCARD if MODULE_MTD
+    help
+        Indicates that a sdcard MTD is present
+
+config HAVE_MTD_SPI_NOR
+    bool
+    select MODULE_MTD_SPI_NOR if MODULE_MTD
+    help
+        Indicates that a spi-nor MTD is present
+
+config HAVE_SAM0_SDHC
+    bool
+    select MODULE_SAM0_SDHC if MODULE_MTD
+    help
+        Indicates that a SAM0 SD Host Controller MTD is present
+
+config HAVE_MTD_SPI_MCI
+    bool
+    select MODULE_MTD_MCI if MODULE_MTD
+    help
+        Indicates that a Multimedia Card Interface (MCI) MTD is present


### PR DESCRIPTION
### Contribution description

Imply has the chance to silently fail, when using a HAVE_* symbol there is an assumption that only boards select them and those boards contain the correct requirements.

See the `SAUL_DEFAULT` pattern.

### Testing procedure

Green murdock

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
