### PR TITLE
cpu/gd32v: fix gpio_read in periph_gpio

### DIFF
--- a/cpu/gd32v/periph/gpio.c
+++ b/cpu/gd32v/periph/gpio.c
@@ -165,7 +165,7 @@ int gpio_read(gpio_t pin)
     GPIO_Type *port = _port(pin);
     unsigned pin_num = _pin_num(pin);
 
-    if (_pin_is_output(port, pin)) {
+    if (_pin_is_output(port, pin_num)) {
         /* pin is output */
         return (port->OCTL & (1 << pin_num));
     }


### PR DESCRIPTION
### Contribution description

This PR fixes a bug in `gpio_read` which made `gpio_read` completely unusable!

A small bug with big consequences. In `gpio_read` the combined port | pin_num parameter `pin` was used instead of the pin number `pin_num` for the call of `_pin_is_input`. This caused the problem that for example instead of accessing GPIOA->CTL0 with address 0x40010800, address 0x60018c00 was accessed. As a result, a pin was randomly detected as input or output and thus a result was arbitrarily returned. Approx. 50% of all inputs always returned LOW.

I found this error by coincidence when I tried to find out why the BOOT0 button on a Sipeed Longan Nano is not usable as a button in RIOT.

### Testing procedure

Flash `tests/periph_gpio`
```
BOARD=sipeed-longan-nano make -j8 -C tests/periph_gpio flash
```
and use commands
```
init_in 0 8
read 0 8
```
Without this PR, the pin is always LOW. With the PR, the pin should be HIGH when the BOOT button is pressed.

### Issues/PRs references