### PR TITLE
core/lib/debug: Add DEBUG_VERBOSE()

### DIFF
--- a/core/lib/include/debug.h
+++ b/core/lib/include/debug.h
@@ -71,6 +71,10 @@ extern "C" {
 #define ENABLE_DEBUG 0
 #endif
 
+#if !defined(ENABLE_DEBUG_VERBOSE) || defined(DOXYGEN)
+#define ENABLE_DEBUG_VERBOSE 0
+#endif
+
 /**
  * @def DEBUG_FUNC
  *
@@ -97,12 +101,27 @@ extern "C" {
 #define DEBUG(...) do { if (ENABLE_DEBUG) { DEBUG_PRINT(__VA_ARGS__); } } while (0)
 
 /**
+ * @def DEBUG_VERBOSE
+ *
+ * @brief Print debug information to stdout if and only if `ENABLE_DEBUG_VERBOSE` is `1`
+ */
+#define DEBUG_VERBOSE(...) do { if (ENABLE_DEBUG_VERBOSE) { DEBUG_PRINT(__VA_ARGS__); } } while (0)
+
+/**
  * @def DEBUG_PUTS
  *
  * @brief Print debug information to stdout using puts(), so no stack size
  *        restrictions do apply.
  */
 #define DEBUG_PUTS(str) do { if (ENABLE_DEBUG) { puts(str); } } while (0)
+
+/**
+ * @def DEBUG_PUTS_VERBOSE
+ *
+ * @brief Print debug information to stdout using puts(), so no stack size
+ *        restrictions do apply.
+ */
+#define DEBUG_PUTS_VERBOSE(str) do { if (ENABLE_DEBUG_VERBOSE) { puts(str); } } while (0)
 /** @} */
 
 /**

--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -590,17 +590,13 @@ static int stm32_eth_send(netdev_t *netdev, const struct iolist *iolist)
     /* start TX */
     ETH->DMATPDR = 0;
     /* await completion */
-    if (IS_ACTIVE(ENABLE_DEBUG_VERBOSE)) {
-        DEBUG("[stm32_eth] Started to send %u B via DMA\n", bytes_to_send);
-    }
+    DEBUG_VERBOSE("[stm32_eth] Started to send %u B via DMA\n", bytes_to_send);
     mutex_lock(&stm32_eth_tx_completed);
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
         gpio_ll_clear(GPIO_PORT(STM32_ETH_TRACING_TX_PORT_NUM),
                       (1U << STM32_ETH_TRACING_TX_PIN_NUM));
     }
-    if (IS_ACTIVE(ENABLE_DEBUG_VERBOSE)) {
-        DEBUG("[stm32_eth] TX completed\n");
-    }
+    DEBUG_VERBOSE("[stm32_eth] TX completed\n");
 
     /* Error check */
     int error = 0;


### PR DESCRIPTION
### Contribution description

Add a variant of the `DEBUG(...)` macro that gets enabled separately with `ENABLE_DEBUG_VERBOSE`, just like `ENABLE_DEBUG` enables the `DEBUG(...)` macro.

This feature was previously already in use in `cpu/stm32/periph_eth`, which now has been refactored to make u se of the new `DEBUG_VERBOSE()` macro.

The SPI SD card driver also has been updated to make heavy use of `DEBUG_VERBOSE()`, so that with `ENABLE_DEBUG` but without `ENABLE_DEBUG_VERBOSE` only output is generated when indication of issues is present. If in-depth information is needed, setting `ENABLE_DEBUG_VERBOSE` will re-enable all the debug output again.

### Testing procedure

Set `ENABLE_DEBUG` in SD card driver to `1` and observe some debug output. Then, also set `ENABLE_DEBUG_VERBOSE` to `1` and see *lots* of debug output.

### Issues/PRs references

None