### PR TITLE
add missing includes for arduino_*.h for stm32f746g-disco board

### DIFF
--- a/boards/stm32f746g-disco/include/arduino_board.h
+++ b/boards/stm32f746g-disco/include/arduino_board.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2019 Inria
+ *                2023 Université Grenoble Alpes
+ *
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f746g-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ * @author      Didier Donsez <didier.donsez@univ-grenoble-alpes.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/stm32f746g-disco/include/arduino_pinmap.h
+++ b/boards/stm32f746g-disco/include/arduino_pinmap.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C)  2023 Université Grenoble Alpes
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f746g-disco
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Didier Donsez <didier.donsez@univ-grenoble-alpes.fr>
+ *
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_C, 7)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_C, 6)
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_G, 6)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_G, 7)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_I, 0)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_H, 6)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_I, 3)
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_I, 2)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_A, 15)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_A, 8)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_B, 15)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_B, 14)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_I, 1)
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_B, 9)
+#define ARDUINO_PIN_15          GPIO_PIN(PORT_B, 8)
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PORT_A, 0)
+#define ARDUINO_PIN_A1          GPIO_PIN(PORT_F, 10)
+#define ARDUINO_PIN_A2          GPIO_PIN(PORT_F, 9)
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_F, 8)
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_F, 7)
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_F, 6)
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

add missing includes for `arduino_*.h` for `stm32f746g-disco` board

The files has been copy-paste from `boards/p-nucleo-wb55/include`

`uncrustify` has been ran
```bash
uncrustify -c $RIOTBASE/uncrustify-riot.cfg --no-backup arduino_*
Parsing: arduino_board.h as language C-Header
parse_cleanup(456): pc->orig_line is 72, orig_col is 1, text() is '}', type is BRACE_CLOSE
Parsing: arduino_pinmap.h as language C-Header
parse_cleanup(456): pc->orig_line is 75, orig_col is 1, text() is '}', type is BRACE_CLOSE
```

The output of `uncrustify` is the same for `boards/p-nucleo-wb55/include`




<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The include files has been tested with a SX1302 transceiver plugged into D8,D9,D10,D11,D12

https://github.com/thingsat/riot_modules/tree/main/tests/driver_sx1302

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
