### PR TITLE
boards: fix USB configuration for stm32f429i-disco

### DIFF
--- a/boards/common/stm32/include/cfg_usb_otg_hs_phy_fs.h
+++ b/boards/common/stm32/include/cfg_usb_otg_hs_phy_fs.h
@@ -36,7 +36,7 @@ extern "C" {
 #define DWC2_USB_OTG_HS_ENABLED
 
 /**
- * @brief Common USB OTG FS configuration
+ * @brief Common USB OTG HS configuration with on-chip FS PHY
  */
 static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
     {

--- a/boards/stm32f429i-disc1/Kconfig
+++ b/boards/stm32f429i-disc1/Kconfig
@@ -20,7 +20,6 @@ config BOARD_STM32F429I_DISC1
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_PERIPH_USBDEV_HS
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
@@ -38,7 +37,5 @@ config BOARD_STM32F429I_DISC1
     select HAVE_L3GXXXX_SPI
     select HAVE_I3G4250D
     select HAVE_L3GD20
-
-    select MODULE_PERIPH_USBDEV_HS if MODULE_PERIPH_USBDEV
 
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32f429i-disc1/Makefile.dep
+++ b/boards/stm32f429i-disc1/Makefile.dep
@@ -1,7 +1,3 @@
-ifneq (,$(filter periph_usbdev,$(USEMODULE)))
-  USEMODULE += periph_usbdev_hs
-endif
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += l3gxxxx

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -8,7 +8,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-FEATURES_PROVIDED += periph_usbdev_hs
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -12,6 +12,7 @@ USEMODULE += ps
 # Boards that don't have enough endpoints to use CDC ACM together with CDC ECM
 ifeq (,$(filter stdio_%,$(filter-out stdio_cdc_acm,$(USEMODULE))))
   BOARD_BLACKLIST += \
+    stm32f429i-disco \
     stm32f4discovery \
     weact-f401cc \
     weact-f401ce \


### PR DESCRIPTION
### Contribution description

This PR fixes the problem that CDC ECM is not working for `stm32f429i-disco`.

With PR #19358, the EP data size for CDC ECM bulk endpoints was increased to 512 byte to fix the problem that CDC ECM was not working for boards with USB High-Speed peripherals. Module `periph_usbdev_hs` was introduced to indicate whether a high-speed peripheral is used.

However, the `stm32f429i-disco` board uses a mixture of USB OTG HS peripheral together with the on-hip FS PHY. Using the USB OTG HS peripheral together with a FS-PHY and increasing the EP data size for the CDC ECM bulk endpoint to 512 bytes doesn't work. Therefore, module `periph_usbdev_hs` is not used for now to workaround the problem. Thus, the maximum number of EPs used is that of the USB OTG FS peripheral, which is only 4. This is not sufficient for this test application since the board uses `stdio_cdc_acm`. The board is therefore blacklisted.

### Testing procedure

Use a `stm32f429i-disc1` or a `stm32f429i-disco` board and flash the test app:
```
USEMODULE=stdio_uart BOARD=stm32f429i-disco make -j8 -C tests/usbus_cdc_ecm flash
```
With this PR it should be possible to ping the board.

### Issues/PRs references