### PR TITLE
pkg/semtech-loramac: fix makefile highlighting in documentation

### DIFF
--- a/pkg/semtech-loramac/doc.txt
+++ b/pkg/semtech-loramac/doc.txt
@@ -16,21 +16,21 @@
  * This package only works with Semtech SX1272 and SX1276 radio devices. Thus,
  * in order to use it properly, the application `Makefile` must import the
  * corresponding device driver:
- * ```
+ * ```mk
  *     USEMODULE += sx1272  # for a SX1272 radio device
  *     USEMODULE += sx1276  # for a SX1276 radio device
  * ```
  *
  * In order to use this package in an application, add the following in
  * the application `Makefile`:
- * ```
+ * ```mk
  *     USEPKG += semtech-loramac
  * ```
  *
  * Since the LoRa radio depends on regional parameters regarding the access
  * to the physical support, the region where the device is used needs to be
  * set at compile time. Example for EU868:
- * ```
+ * ```mk
  *     LORA_REGION = EU868
  * ```
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes the highlighting of Makefile snippets in the semtech-loramac package documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

In the current documentation the words `for` in comments are interpreted while they shouldn't. Comment text is also not hightighted.

![image](https://user-images.githubusercontent.com/1375137/229426633-cd965784-cef5-43c3-a971-e4c8e63826ae.png)

With this PR:

![image](https://user-images.githubusercontent.com/1375137/229426796-746f7fdc-8325-45d8-8f22-c160c261b7c2.png)


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
