### PR TITLE
boards/nucleo-f429zi: Provide 2nd timer

### DIFF
--- a/boards/common/stm32/include/cfg_timer_tim5_and_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim5_and_tim2.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Common configuration for STM32 Timer peripheral based on TIM5
+ *              and TIM2
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CFG_TIMER_TIM5_AND_TIM2_H
+#define CFG_TIMER_TIM5_AND_TIM2_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    /* intentionally not sorted alphabetically: E.g. on STM32L1 TIM5 is
+     * 32 bit while TIM2 is only 16 bit. ztimer defaults to the first timer
+     * defined and does profit from using a 32 bit timer */
+    {
+        .dev      = TIM5,
+        .max      = 0xffffffff,
+#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L5) || \
+    defined(CPU_FAM_STM32U5)
+        .rcc_mask = RCC_APB1ENR1_TIM5EN,
+#else
+        .rcc_mask = RCC_APB1ENR_TIM5EN,
+#endif
+        .bus      = APB1,
+        .irqn     = TIM5_IRQn
+    },
+    {
+        .dev      = TIM2,
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+        .max      = 0x0000ffff,
+#else
+        .max      = 0xffffffff,
+#endif
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32G4)
+        .rcc_mask = RCC_APB1ENR1_TIM2EN,
+#elif CPU_FAM_STM32MP1
+        .rcc_mask = RCC_MC_APB1ENSETR_TIM2EN,
+#else
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+#endif
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    },
+};
+
+#define TIMER_0_ISR         isr_tim5    /**< IRQ of timer at idx 0 */
+#define TIMER_1_ISR         isr_tim2    /**< IRQ of timer at idx 1 */
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_TIMER_TIM5_AND_TIM2_H */
+/** @} */

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -32,7 +32,7 @@
 #include "periph_cpu.h"
 #include "clk_conf.h"
 #include "cfg_i2c1_pb8_pb9.h"
-#include "cfg_timer_tim5.h"
+#include "cfg_timer_tim5_and_tim2.h"
 #include "cfg_usb_otg_fs.h"
 #include "mii.h"
 


### PR DESCRIPTION
### Contribution description

- Add a common timer config with two (instead of only one) timer using TIM2 + TIM5
    - Mostly copy-pasting the cfg_timer_tim2.h and cfg_timer_tim5.h together
- Make use of that for the `nucleo-f429zi`

### Testing procedure

E.g. `tests/periph_timer`, but also grepping for TIM2 and TIM5 in `boards/nucleo-f429zi/include/periph_conf.h` to detect any conflict e.g. between PWM and timer config.

### Issues/PRs references

None