### PR TITLE
gnrc_lorawan: add support for class C

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -34,6 +34,9 @@
 extern "C" {
 #endif
 
+#define SX126X_FLAG_SLEEP                   (0x01)  /**< Device is in sleep mode */
+#define SX126X_FLAG_RX_SINGLE               (0x02) /**< Device is in single rx mode */
+
 /**
  * * @note Forward declaration of the SX126x device descriptor
  */
@@ -109,7 +112,7 @@ struct sx126x {
     sx126x_mod_params_lora_t mod_params;    /**< Lora modulation parameters */
     uint32_t channel;                       /**< Current channel frequency (in Hz) */
     uint16_t rx_timeout;                    /**< Rx Timeout in terms of symbols */
-    bool radio_sleep;                       /**< Radio sleep status */
+    uint8_t flags;                          /**< Radio flags */
 };
 
 /**
@@ -300,6 +303,70 @@ bool sx126x_get_lora_iq_invert(const sx126x_t *dev);
  * @param[in] iq_invert                The LoRa IQ inverted mode
  */
 void sx126x_set_lora_iq_invert(sx126x_t *dev, bool iq_invert);
+
+/**
+ * @brief Sets an SX126x flag
+ *
+ * @param[in] dev  Device descriptor of the driver
+ * @param[in] flag Flag to set
+ */
+static inline void sx126x_set_flag(sx126x_t *dev, uint8_t flag)
+{
+    dev->flags |= flag;
+}
+
+/**
+ * @brief Clears an SX126x flag
+ *
+ * @param[in] dev  Device descriptor of the driver
+ * @param[in] flag Flag to clear
+ */
+static inline void sx126x_clear_flag(sx126x_t *dev, uint8_t flag)
+{
+    dev->flags &= ~flag;
+}
+
+/**
+ * @brief Checks if an SX126x flag is set
+ *
+ * @param[in] dev  Device descriptor of the driver
+ * @param[in] flag Flag to check
+ *
+ * @return true if flag is set
+ * @return false if flag is not set
+ */
+static inline bool sx126x_get_flag(sx126x_t *dev, uint8_t flag)
+{
+    return (dev->flags & flag);
+}
+
+/**
+ * @brief   Sets single RX reception
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ * @param[in] single                   whether the device should enable single RX.
+ */
+static inline void sx126x_set_rx_single(sx126x_t *dev, bool rx_single)
+{
+    if (rx_single) {
+        sx126x_set_flag(dev, SX126X_FLAG_RX_SINGLE);
+    }
+    else {
+        sx126x_clear_flag(dev, SX126X_FLAG_RX_SINGLE);
+    }
+}
+
+/**
+ * @brief   Checks if the device is in single RX reception
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ *
+ * @return whether the device has RX single enabled.
+ */
+static inline bool sx126x_get_rx_single(sx126x_t *dev)
+{
+    return sx126x_get_flag(dev, SX126X_FLAG_RX_SINGLE);
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -182,6 +182,8 @@ static void _isr(netdev_t *netdev)
     }
     else if (irq_mask & SX126X_IRQ_HEADER_ERROR) {
         DEBUG("[sx126x] netdev: SX126X_IRQ_HEADER_ERROR\n");
+        /* Report it to the upper layer as CRC error */
+        netdev->event_callback(netdev, NETDEV_EVENT_CRC_ERROR);
     }
     else if (irq_mask & SX126X_IRQ_CRC_ERROR) {
         DEBUG("[sx126x] netdev: SX126X_IRQ_CRC_ERROR\n");

--- a/examples/gnrc_lorawan/Makefile
+++ b/examples/gnrc_lorawan/Makefile
@@ -85,6 +85,9 @@ ifndef CONFIG_KCONFIG_USEMODULE_LORAWAN
 
   # Set region
   CFLAGS += -DCONFIG_LORAMAC_REGION_EU_868
+
+  # Uncomment to enable class C
+  # CFLAGS += -DCONFIG_GNRC_LORAWAN_CLASS_C
 endif
 
 # We can reduce the size of the packet buffer for LoRaWAN, since there's no IP

--- a/pkg/driver_sx126x/contrib/driver_sx126x_hal.c
+++ b/pkg/driver_sx126x/contrib/driver_sx126x_hal.c
@@ -46,7 +46,7 @@
 #if IS_USED(MODULE_SX126X_STM32WL)
 static uint8_t sx126x_radio_wait_until_ready(sx126x_t *dev)
 {
-    if (dev->radio_sleep == true) {
+    if (sx126x_get_flag(dev, SX126X_FLAG_SLEEP)) {
         DEBUG("[sx126x_radio] : Wakeup radio \n");
         sx126x_hal_wakeup(dev);
     }
@@ -72,10 +72,10 @@ sx126x_hal_status_t sx126x_hal_write(const void *context,
 
         /* Check if radio is set to sleep or `RxDutyCycle` mode */
         if (command[0] == 0x84 || command[0] == 0x94) {
-            dev->radio_sleep = true;
+            sx126x_set_flag(dev, SX126X_FLAG_SLEEP);
         }
         else {
-            dev->radio_sleep = false;
+            sx126x_clear_flag(dev, SX126X_FLAG_SLEEP);
         }
 
         /* Pull NSS low */
@@ -173,7 +173,7 @@ sx126x_hal_status_t sx126x_hal_reset(const void *context)
         /* Clear Pending Flag */
         PWR->SCR = PWR_SCR_CWRFBUSYF;
 
-        dev->radio_sleep = true;
+        sx126x_set_flag(dev, SX126X_FLAG_SLEEP);
 #endif
     }
     else {

--- a/sys/include/net/gnrc/netif/lorawan.h
+++ b/sys/include/net/gnrc/netif/lorawan.h
@@ -20,8 +20,6 @@
 
 #include "net/gnrc/lorawan.h"
 
-#include "ztimer.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,8 +61,7 @@ typedef struct {
     uint8_t deveui[LORAMAC_DEVEUI_LEN];             /**< Device EUI buffer */
     uint8_t joineui[LORAMAC_JOINEUI_LEN];           /**< Join EUI buffer */
     gnrc_lorawan_t mac;                             /**< gnrc lorawan mac descriptor */
-    ztimer_t timer;                                 /**< General purpose timer */
-    ztimer_t backoff_timer;                         /**< Backoff timer */
+    msg_t msg_sched;                                /**< Message used for scheduling uplinks */
     uint8_t flags;                                  /**< flags for the LoRaWAN interface */
     uint8_t demod_margin;                           /**< value of last demodulation margin */
     uint8_t num_gateways;                           /**< number of gateways of last link check */

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -536,6 +536,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default ACK Timeout
+ */
+#ifndef LORAMAC_DEFAULT_ACK_TIMEOUT
+#define LORAMAC_DEFAULT_ACK_TIMEOUT             (3U)
+#endif
+
+/**
  * @brief   Default second RX window delay (in ms)
  */
 #define LORAMAC_DEFAULT_RX2_DELAY               (1000U + CONFIG_LORAMAC_DEFAULT_RX1_DELAY)

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -34,6 +34,10 @@ ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
+	USEMODULE += event_timeout
+endif
+
+ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
   USEMODULE += ztimer_msec
   USEMODULE += random
   USEMODULE += hashes

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -27,6 +27,7 @@
 #include "net/lorawan/hdr.h"
 #include "net/loramac.h"
 #include "net/gnrc/lorawan/region.h"
+#include "random.h"
 #include "timex.h"
 
 #if IS_USED(MODULE_GNRC_LORAWAN_1_1)
@@ -40,6 +41,21 @@
 #define GNRC_LORAWAN_DL_RX2_DR_POS        (0)       /**< DL Settings DR Offset pos */
 #define GNRC_LORAWAN_DL_DR_OFFSET_MASK    (0x70)    /**< DL Settings RX2 DR mask */
 #define GNRC_LORAWAN_DL_DR_OFFSET_POS     (4)       /**< DL Settings RX2 DR pos */
+
+static gnrc_lorawan_fsm_status_t _state_idle(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+static gnrc_lorawan_fsm_status_t _state_wait_rx_window(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+static gnrc_lorawan_fsm_status_t _state_rx_window(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+static gnrc_lorawan_fsm_status_t _state_tx(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_link_down(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+static gnrc_lorawan_fsm_status_t _state_mac_state_wait_join_req(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+static gnrc_lorawan_fsm_status_t _state_mac_state_idle(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+//static gnrc_lorawan_fsm_status_t _state_mac_state_wait_ack_req(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+static gnrc_lorawan_fsm_status_t _state_mac_state_tx(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev);
+
+static void _ev_timer(event_t *ev);
+static void _ev_mac_timer(event_t *ev);
+static void _ev_toa(event_t *ev);
 
 static inline void gnrc_lorawan_mlme_reset(gnrc_lorawan_t *mac)
 {
@@ -104,20 +120,29 @@ static void _load_persistent_state(gnrc_lorawan_t *mac)
 #endif
 }
 
-void gnrc_lorawan_init(gnrc_lorawan_t *mac, uint8_t *joineui, const gnrc_lorawan_key_ctx_t *ctx)
+void gnrc_lorawan_init(gnrc_lorawan_t *mac, uint8_t *joineui, const gnrc_lorawan_key_ctx_t *ctx, event_queue_t *evq)
 {
     DEBUG("Lorawan init !\n");
     mac->joineui = joineui;
 
     memcpy(&mac->ctx, ctx, sizeof(gnrc_lorawan_key_ctx_t));
 
-    mac->busy = false;
+    mac->ev_timer.handler = _ev_timer;
+    mac->ev_mac.handler = _ev_mac_timer;
+    mac->ev_toa.handler = _ev_toa;
+
+    event_timeout_ztimer_init(&mac->evt, ZTIMER_MSEC, evq, &mac->ev_timer);
+    event_timeout_ztimer_init(&mac->evt_mac, ZTIMER_MSEC, evq, &mac->ev_mac);
+    event_timeout_ztimer_init(&mac->evt_toa, ZTIMER_MSEC, evq, &mac->ev_toa);
+
     gnrc_lorawan_mlme_backoff_init(mac);
     gnrc_lorawan_reset(mac);
 
     if (IS_USED(MODULE_GNRC_LORAWAN_1_1)) {
         _load_persistent_state(mac);
     }
+
+    event_timeout_set(&mac->evt_toa, GNRC_LORAWAN_BACKOFF_WINDOW_TICK);
 }
 
 void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
@@ -143,6 +168,14 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
     gnrc_lorawan_mcps_reset(mac);
     gnrc_lorawan_mlme_reset(mac);
     gnrc_lorawan_channels_init(mac);
+
+    /* By default the MAC is disconnected */
+    mac->phy_fsm = _state_idle;
+    mac->mac_fsm = _state_mac_state_link_down;
+
+    /* Trigger the entry state of each state machine */
+    _state_idle(mac, GNRC_LORAWAN_EV_ENTRY);
+    _state_mac_state_link_down(mac, GNRC_LORAWAN_EV_ENTRY);
 }
 
 void gnrc_lorawan_store_dev_nonce(uint8_t *dev_nonce)
@@ -164,10 +197,12 @@ void gnrc_lorawan_store_dev_nonce(uint8_t *dev_nonce)
 }
 
 static void _config_radio(gnrc_lorawan_t *mac, uint32_t channel_freq,
-                          uint8_t dr, int rx)
+                          uint8_t dr, int rx, bool rx_single)
 {
     netdev_t *dev = gnrc_lorawan_get_netdev(mac);
 
+    netopt_state_t state = NETOPT_STATE_STANDBY;
+    dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
     if (channel_freq != 0) {
         dev->driver->set(dev, NETOPT_CHANNEL_FREQUENCY, &channel_freq,
                          sizeof(channel_freq));
@@ -181,129 +216,319 @@ static void _config_radio(gnrc_lorawan_t *mac, uint32_t channel_freq,
 
     if (rx) {
         /* Switch to single listen mode */
-        const netopt_enable_t single = true;
+        const netopt_enable_t single = rx_single;
+        uint16_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
         dev->driver->set(dev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
-        const uint16_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
         dev->driver->set(dev, NETOPT_RX_SYMBOL_TIMEOUT, &timeout,
                          sizeof(timeout));
     }
 }
 
 static void _configure_rx_window(gnrc_lorawan_t *mac, uint32_t channel_freq,
-                                 uint8_t dr)
+                                 uint8_t dr, bool rx_single)
 {
-    _config_radio(mac, channel_freq, dr, true);
+    _config_radio(mac, channel_freq, dr, true, rx_single);
 }
 
-void gnrc_lorawan_open_rx_window(gnrc_lorawan_t *mac)
+void gnrc_lorawan_dispatch_event(gnrc_lorawan_t *mac, gnrc_lorawan_state_t *fsm, gnrc_lorawan_event_t event)
 {
-    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+    gnrc_lorawan_state_t last_state = *fsm;
+    int last_event = event;
+    int res;
 
-    /* Switch to RX state */
-    if (mac->state == LORAWAN_STATE_RX_1) {
-        gnrc_lorawan_set_timer(mac, US_PER_SEC);
-    }
-    netopt_state_t state = NETOPT_STATE_RX;
-
-    dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
-}
-
-void gnrc_lorawan_timeout_cb(gnrc_lorawan_t *mac)
-{
-    switch (mac->state) {
-    case LORAWAN_STATE_RX_1:
-    case LORAWAN_STATE_RX_2:
-        gnrc_lorawan_open_rx_window(mac);
-        break;
-    case LORAWAN_STATE_JOIN:
-        gnrc_lorawan_trigger_join(mac);
-        break;
-    case LORAWAN_STATE_IDLE:
-        gnrc_lorawan_event_retrans_timeout(mac);
-        break;
-    default:
-        assert(false);
-        break;
+    /* This line may update the state if there's a state transition */
+    while ((res = (*fsm)(mac, last_event)) == GNRC_LORAWAN_FSM_TRANSITION) {
+        res = last_state(mac, GNRC_LORAWAN_EV_EXIT);
+        assert(res != GNRC_LORAWAN_FSM_TRANSITION);
+        last_event = GNRC_LORAWAN_EV_ENTRY;
     }
 }
 
-void gnrc_lorawan_radio_tx_done_cb(gnrc_lorawan_t *mac)
+static void _ev_toa(event_t *ev)
 {
-    mac->state = LORAWAN_STATE_RX_1;
-
-    int rx_1;
-
-    /* if the MAC is not activated, then this is a Join Request */
-    rx_1 = mac->mlme.activation == MLME_ACTIVATION_NONE ?
-           CONFIG_LORAMAC_DEFAULT_JOIN_DELAY1 : mac->rx_delay;
-
-    gnrc_lorawan_set_timer(mac, rx_1 * US_PER_SEC);
-
-    uint8_t dr_offset = (mac->dl_settings & GNRC_LORAWAN_DL_DR_OFFSET_MASK) >>
-                        GNRC_LORAWAN_DL_DR_OFFSET_POS;
-
-    _configure_rx_window(mac, 0,
-                         gnrc_lorawan_rx1_get_dr_offset(mac->last_dr,
-                                                        dr_offset));
-
-    _sleep_radio(mac);
+    gnrc_lorawan_t *mac = container_of(ev, gnrc_lorawan_t, ev_toa);
+    gnrc_lorawan_mlme_backoff_expire_cb(mac);
+    event_timeout_set(&mac->evt_toa, GNRC_LORAWAN_BACKOFF_WINDOW_TICK);
 }
 
-void gnrc_lorawan_radio_rx_timeout_cb(gnrc_lorawan_t *mac)
+static void _ev_mac_timer(event_t *ev)
 {
-    (void)mac;
-    switch (mac->state) {
-    case LORAWAN_STATE_RX_1:
-        DEBUG("gnrc_lorawan: RX1 timeout.\n");
-        _configure_rx_window(mac, CONFIG_LORAMAC_DEFAULT_RX2_FREQ,
-                             mac->dl_settings &
-                             GNRC_LORAWAN_DL_RX2_DR_MASK);
-        mac->state = LORAWAN_STATE_RX_2;
-        break;
-    case LORAWAN_STATE_RX_2:
-        DEBUG("gnrc_lorawan: RX2 timeout.\n");
-        gnrc_lorawan_event_no_rx(mac);
-        mac->state = LORAWAN_STATE_IDLE;
-        break;
-    default:
-        assert(false);
-        break;
-    }
-    _sleep_radio(mac);
+    gnrc_lorawan_t *mac = container_of(ev, gnrc_lorawan_t, ev_mac);
+    gnrc_lorawan_dispatch_event(mac, &mac->mac_fsm, GNRC_LORAWAN_EV_TO);
+}
+
+static void _ev_timer(event_t *ev)
+{
+    gnrc_lorawan_t *mac = container_of(ev, gnrc_lorawan_t, ev_timer);
+    gnrc_lorawan_dispatch_event(mac, &mac->phy_fsm, GNRC_LORAWAN_EV_TO);
 }
 
 void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, iolist_t *psdu, uint8_t dr,
-                           uint32_t chan)
-{
-    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
-
-    mac->state = LORAWAN_STATE_TX;
-
-    DEBUG("gnrc_lorawan: Channel: %" PRIu32 "Hz \n", chan);
-
-    _config_radio(mac, chan, dr, false);
-
-    uint8_t cr;
-
-    dev->driver->get(dev, NETOPT_CODING_RATE, &cr, sizeof(cr));
-
-    mac->toa = lora_time_on_air(iolist_size(psdu), dr, cr);
-
-    if (dev->driver->send(dev, psdu) == -ENOTSUP) {
-        DEBUG("gnrc_lorawan: Cannot send: radio is still transmitting");
-    }
-
-}
-
-void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *psdu,
-                                   size_t size)
+                           uint32_t chan_idx)
 {
     assert(psdu);
-    _sleep_radio(mac);
-    mac->state = LORAWAN_STATE_IDLE;
-    gnrc_lorawan_remove_timer(mac);
+    mac->last_dr = dr;
+    mac->last_chan_idx = chan_idx;
+    mac->psdu = psdu;
+    gnrc_lorawan_dispatch_event(mac, &mac->phy_fsm, GNRC_LORAWAN_EV_REQUEST_TX);
+}
 
-    uint8_t mtype = (*psdu & MTYPE_MASK) >> 5;
+static gnrc_lorawan_fsm_status_t _state_transition(gnrc_lorawan_state_t *fsm, gnrc_lorawan_state_t next_state)
+{
+    *fsm = next_state;
+    return GNRC_LORAWAN_FSM_TRANSITION;
+}
+
+static void _transmit_pkt(gnrc_lorawan_t *mac)
+{
+    size_t mhdr_size = sizeof(lorawan_hdr_t) + 1 +
+                       lorawan_hdr_get_frame_opts_len((void *)mac->mcps.mhdr_mic);
+
+    iolist_t header =
+    { .iol_base = mac->mcps.mhdr_mic, .iol_len = mhdr_size,
+      .iol_next = mac->mcps.msdu };
+    iolist_t footer =
+    { .iol_base = mac->mcps.mhdr_mic + header.iol_len, .iol_len = MIC_SIZE,
+      .iol_next = NULL };
+    iolist_t *last_snip = mac->mcps.msdu;
+
+    while (last_snip->iol_next != NULL) {
+        last_snip = last_snip->iol_next;
+    }
+
+    uint16_t conf_fcnt = 0;
+
+    if (IS_USED(MODULE_GNRC_LORAWAN_1_1)) {
+        /**
+         * If the ACK bit of the uplink frame is set, meaning this frame is
+         * acknowledging a downlink “confirmed” frame, then ConfFCnt is the frame
+         * counter value modulo 2^16 of the “confirmed” downlink frame that is being
+         * acknowledged. In all other cases ConfFCnt = 0x0000
+         */
+        lorawan_hdr_t *lw_hdr = (lorawan_hdr_t *)header.iol_base;
+        if (lorawan_hdr_get_ack(lw_hdr)) {
+            conf_fcnt = gnrc_lorawan_get_last_fcnt_down(mac);
+        }
+    }
+
+    gnrc_lorawan_calculate_mic_uplink(&header, conf_fcnt, mac, footer.iol_base);
+
+    last_snip->iol_next = &footer;
+    gnrc_lorawan_send_pkt(mac, &header, mac->last_dr,
+                          gnrc_lorawan_pick_channel(mac));
+
+    /* cppcheck-suppress redundantAssignment
+     * (reason: cppcheck bug. The pointer is temporally modified to add a footer.
+     *          The `gnrc_lorawan_send_pkt` function uses this hack to append
+     *          the MIC independently of `gnrc_pktsnip_t` structures) */
+    last_snip->iol_next = NULL;
+}
+
+void gnrc_lorawan_event_retrans_timeout(gnrc_lorawan_t *mac)
+{
+    _transmit_pkt(mac);
+}
+
+/************************************* MAC FSM ********************************/
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_tx_join_req(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    switch (ev) {
+    case GNRC_LORAWAN_EV_ENTRY:
+        event_timeout_set(&mac->evt_mac, (random_uint32() & GNRC_LORAWAN_JOIN_DELAY_U32_MASK) / 1000);
+        return GNRC_LORAWAN_FSM_HANDLED;
+    case GNRC_LORAWAN_EV_TO:
+        gnrc_lorawan_trigger_join(mac);
+        return _state_transition(&mac->mac_fsm, _state_mac_state_wait_join_req);
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    default:
+        assert(false);
+    }
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_link_down(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    switch (ev) {
+    case GNRC_LORAWAN_EV_ENTRY:
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    case GNRC_LORAWAN_EV_LINK_UP:
+        if (mac->mlme.activation == MLME_ACTIVATION_ABP) {
+            return _state_transition(&mac->mac_fsm, _state_mac_state_idle);
+        }
+        else {
+            return _state_transition(&mac->mac_fsm, _state_mac_state_tx_join_req);
+        }
+    case GNRC_LORAWAN_EV_PHY_READY:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    default:
+        assert(false);
+        return GNRC_LORAWAN_FSM_IGNORED;
+    }
+}
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_wait_join_req(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    mlme_confirm_t mlme_confirm;
+    mlme_confirm.type = MLME_JOIN;
+    switch (ev) {
+    case GNRC_LORAWAN_EV_ENTRY:
+        return GNRC_LORAWAN_FSM_IGNORED;
+
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+
+    case GNRC_LORAWAN_EV_RX_ERROR:
+    case GNRC_LORAWAN_EV_PHY_READY:
+        mlme_confirm.status = -ETIMEDOUT;
+        gnrc_lorawan_mlme_confirm(mac, &mlme_confirm);
+        return _state_transition(&mac->mac_fsm, _state_mac_state_link_down);
+    case GNRC_LORAWAN_EV_RX_DONE:
+        mlme_confirm.status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
+        gnrc_lorawan_mlme_confirm(mac, &mlme_confirm);
+        return _state_transition(&mac->mac_fsm, _state_mac_state_idle);
+    default:
+        assert(false);
+        return GNRC_LORAWAN_FSM_IGNORED;
+    }
+}
+
+bool gnrc_lorawan_is_busy(gnrc_lorawan_t *mac)
+{
+    return ((mac->mac_fsm != _state_mac_state_idle
+             && mac->mac_fsm != _state_mac_state_link_down)
+            || mac->phy_fsm != _state_idle);
+}
+
+bool gnrc_lorawan_is_joined(gnrc_lorawan_t *mac)
+{
+    return (mac->mac_fsm != _state_mac_state_link_down
+            && mac->mac_fsm != _state_mac_state_wait_join_req
+            && mac->mac_fsm != _state_mac_state_tx_join_req);
+}
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_idle(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    (void) mac;
+    switch (ev) {
+    case GNRC_LORAWAN_EV_ENTRY:
+        mac->mcps.msdu = NULL;
+        mac->mcps.waiting_for_ack = false;
+        return GNRC_LORAWAN_FSM_HANDLED;
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    case GNRC_LORAWAN_EV_REQUEST_TX:
+        return _state_transition(&mac->mac_fsm, _state_mac_state_tx);
+    case GNRC_LORAWAN_EV_PHY_READY:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    default:
+        assert(false);
+    }
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_ifs(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    switch (ev) {
+    case GNRC_LORAWAN_EV_ENTRY:
+        event_timeout_set(&mac->evt_mac, 1000 + random_uint32_range(0, 2000));
+        return GNRC_LORAWAN_FSM_HANDLED;
+    case GNRC_LORAWAN_EV_TO:
+        return _state_transition(&mac->mac_fsm, _state_mac_state_tx);
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    default:
+        assert(false);
+    }
+
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_wait_ack_req(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+
+    switch (ev) {
+    case GNRC_LORAWAN_EV_ENTRY:
+        /* Set ACK Timeout... */
+        /* TODO: De-hardcode to ACK_Timeout */
+        event_timeout_set(&mac->evt_mac, LORAMAC_DEFAULT_ACK_TIMEOUT * MS_PER_SEC);
+        return GNRC_LORAWAN_FSM_HANDLED;
+    case GNRC_LORAWAN_EV_TO:
+        if (mac->mcps.waiting_for_ack && mac->mcps.nb_trials > 0) {
+            mac->mcps.nb_trials--;
+            return _state_transition(&mac->mac_fsm, _state_mac_state_ifs);
+        }
+        else {
+            /* Finish transmission */
+            mac->mcps.fcnt++;
+            mcps_confirm_t mcps_confirm;
+            mcps_confirm.type = MCPS_CONFIRMED;
+            mcps_confirm.status = mac->mcps.nb_trials > 0 ? GNRC_LORAWAN_REQ_STATUS_SUCCESS : -ETIMEDOUT;
+            mcps_confirm.msdu = mac->mcps.msdu;
+            gnrc_lorawan_mcps_confirm(mac, &mcps_confirm);
+            return _state_transition(&mac->mac_fsm, _state_mac_state_idle);
+        }
+    case GNRC_LORAWAN_EV_PHY_READY:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    default:
+        assert(false);
+    }
+
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static gnrc_lorawan_fsm_status_t _state_mac_state_tx(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    switch (ev) {
+    case GNRC_LORAWAN_EV_TO:
+    case GNRC_LORAWAN_EV_ENTRY:
+        /* Transmit packet on entry */
+        _transmit_pkt(mac);
+        break;
+    case GNRC_LORAWAN_EV_PHY_READY:
+        /* Check whether this is a confirmed transmission or not */
+        if (mac->mcps.waiting_for_ack) {
+            return _state_transition(&mac->mac_fsm, _state_mac_state_wait_ack_req);
+        }
+        else if (mac->mcps.nb_trials--) {
+            /* If we got here, this means the redundancy mode is activated */
+            /* Schedule another transmission */
+            event_timeout_set(&mac->evt_mac, 1000 + random_uint32_range(0, 2000));
+            return GNRC_LORAWAN_FSM_HANDLED;
+        }
+        else {
+            /* Finish transmission */
+            mac->mcps.fcnt++;
+            mcps_confirm_t mcps_confirm;
+            mcps_confirm.type = MCPS_UNCONFIRMED;
+            mcps_confirm.status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
+            mcps_confirm.msdu = mac->mcps.msdu;
+            gnrc_lorawan_mcps_confirm(mac, &mcps_confirm);
+            return _state_transition(&mac->mac_fsm, _state_mac_state_idle);
+            /* Otherwise, finish the MAC state immediately */
+        }
+
+    case GNRC_LORAWAN_EV_EXIT:
+        return GNRC_LORAWAN_FSM_IGNORED;
+    default:
+        assert(false);
+    }
+
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+/************************************* PHY FSM ********************************/
+
+static void _process_rx_done(gnrc_lorawan_t *mac)
+{
+    _sleep_radio(mac);
+    uint8_t *psdu = mac->psdu->iol_base;
+    uint8_t size = mac->psdu->iol_len;
+    uint8_t mtype = (*(psdu) & MTYPE_MASK) >> 5;
 
     switch (mtype) {
     case MTYPE_JOIN_ACCEPT:
@@ -316,4 +541,169 @@ void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *psdu,
     default:
         break;
     }
+}
+
+static gnrc_lorawan_fsm_status_t _state_rx_window(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+    netopt_state_t state;
+    switch(ev) {
+        case GNRC_LORAWAN_EV_ENTRY:
+            if (mac->rx_state == GNRC_LORAWAN_RXW_1) {
+                uint8_t dr_offset = (mac->dl_settings & GNRC_LORAWAN_DL_DR_OFFSET_MASK) >>
+                                    GNRC_LORAWAN_DL_DR_OFFSET_POS;
+
+                _configure_rx_window(mac, mac->channel[mac->last_chan_idx],
+                                     gnrc_lorawan_rx1_get_dr_offset(mac->last_dr, dr_offset),
+                                     true);
+            }
+            else {
+                _configure_rx_window(mac, CONFIG_LORAMAC_DEFAULT_RX2_FREQ,
+                                 mac->dl_settings &
+                                 GNRC_LORAWAN_DL_RX2_DR_MASK,
+                                 true);
+            }
+            /* Open RX Window */
+            state = NETOPT_STATE_RX;
+            dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
+            return GNRC_LORAWAN_FSM_HANDLED;
+        case GNRC_LORAWAN_EV_EXIT:
+            mac->rx_state = GNRC_LORAWAN_RXW_2;
+            return GNRC_LORAWAN_FSM_HANDLED;
+        case GNRC_LORAWAN_EV_RX_TO:
+            if (mac->rx_state == GNRC_LORAWAN_RXW_2) {
+                /* In class A the device will go to Idle at the end of RX2 */
+                return _state_transition(&mac->phy_fsm, _state_idle);
+            }
+            else if (mac->rx_state == GNRC_LORAWAN_RXW_1) {
+                /* Set timeout for RX2 */
+                uint16_t now = ztimer_now(ZTIMER_MSEC);
+                uint16_t delta = (uint16_t) (now - mac->rxw_ts);
+                assert(delta <= MS_PER_SEC);
+                event_timeout_set(&mac->evt, MS_PER_SEC - delta);
+                return _state_transition(&mac->phy_fsm, _state_wait_rx_window);
+            }
+            break;
+        case GNRC_LORAWAN_EV_TO:
+            /* This occurs when the packet is longer than the RX window duration.
+             * We set a maximum timeout in case the device does not trigger RX_DONE
+             */
+            if (mac->rx_state != GNRC_LORAWAN_RX_PENDING) {
+                mac->rx_state = GNRC_LORAWAN_RX_PENDING;
+                event_timeout_set(&mac->evt, 2000);
+            }
+            else {
+                /* If we get here again, go back to IDLE */
+                return _state_transition(&mac->phy_fsm, _state_idle);
+            }
+            break;
+        case GNRC_LORAWAN_EV_RX_ERROR:
+            return _state_transition(&mac->phy_fsm, _state_idle);
+        case GNRC_LORAWAN_EV_RX_DONE:
+            _process_rx_done(mac);
+            return _state_transition(&mac->phy_fsm, _state_idle);
+        default:
+            assert(false);
+            break;
+    }
+
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static gnrc_lorawan_fsm_status_t _state_wait_rx_window(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+    switch(ev) {
+        case GNRC_LORAWAN_EV_ENTRY:
+            if (mac->rx_state == GNRC_LORAWAN_RXW_1) {
+                /* Configure timeout */
+                /* if the MAC is not activated, then this is a Join Request */
+                int rx_1 = mac->mlme.activation == MLME_ACTIVATION_NONE ?
+                       CONFIG_LORAMAC_DEFAULT_JOIN_DELAY1 : mac->rx_delay;
+
+                event_timeout_set(&mac->evt, rx_1 * MS_PER_SEC);
+            }
+
+            _sleep_radio(mac);
+            return GNRC_LORAWAN_FSM_HANDLED;
+
+        case GNRC_LORAWAN_EV_RX_ERROR:
+            return GNRC_LORAWAN_FSM_IGNORED;
+        case GNRC_LORAWAN_EV_RX_DONE:
+            _process_rx_done(mac);
+            return GNRC_LORAWAN_FSM_HANDLED;
+            break;
+        case GNRC_LORAWAN_EV_EXIT:
+            return GNRC_LORAWAN_FSM_IGNORED;
+        case GNRC_LORAWAN_EV_TO:
+            /* Tag last 16-bit of timestamp */
+            mac->rxw_ts = (uint16_t) ztimer_now(ZTIMER_MSEC);
+            return _state_transition(&mac->phy_fsm, _state_rx_window);
+        default:
+            assert(false);
+            break;
+    }
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static gnrc_lorawan_fsm_status_t _state_tx(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+    switch(ev) {
+        case GNRC_LORAWAN_EV_ENTRY:
+            /* Send packet */
+            _config_radio(mac, mac->channel[mac->last_chan_idx], mac->last_dr, false, false);
+            uint8_t cr;
+
+            dev->driver->get(dev, NETOPT_CODING_RATE, &cr, sizeof(cr));
+            mac->toa = lora_time_on_air(iolist_size(mac->psdu), mac->last_dr, cr);
+            if (dev->driver->send(dev, mac->psdu) == -ENOTSUP) {
+                DEBUG("gnrc_lorawan: Cannot send: radio is still transmitting");
+            }
+            return GNRC_LORAWAN_FSM_HANDLED;
+        case GNRC_LORAWAN_EV_TX_DONE: {
+            /* Indicate upper layer */
+            return _state_transition(&mac->phy_fsm, _state_wait_rx_window);
+        }
+        case GNRC_LORAWAN_EV_EXIT:
+            mac->rx_state = GNRC_LORAWAN_RXW_1;
+            return GNRC_LORAWAN_FSM_HANDLED;
+        default:
+            assert(false);
+            break;
+    }
+    return GNRC_LORAWAN_FSM_IGNORED;
+}
+
+static void _set_idle(gnrc_lorawan_t *mac)
+{
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+    _sleep_radio(mac);
+}
+
+static gnrc_lorawan_fsm_status_t _state_idle(gnrc_lorawan_t *mac, gnrc_lorawan_event_t ev)
+{
+    switch(ev) {
+        case GNRC_LORAWAN_EV_ENTRY:
+            _set_idle(mac);
+            gnrc_lorawan_dispatch_event(mac, &mac->mac_fsm, GNRC_LORAWAN_EV_PHY_READY);
+            return GNRC_LORAWAN_FSM_HANDLED;
+        case GNRC_LORAWAN_EV_EXIT:
+            return GNRC_LORAWAN_FSM_IGNORED;
+        case GNRC_LORAWAN_EV_REQUEST_TX: {
+            return _state_transition(&mac->phy_fsm, _state_tx);
+        }
+        break;
+        case GNRC_LORAWAN_EV_RX_ERROR:
+            _set_idle(mac);
+            return GNRC_LORAWAN_FSM_HANDLED;
+        case GNRC_LORAWAN_EV_RX_DONE:
+            _process_rx_done(mac);
+            _set_idle(mac);
+            return GNRC_LORAWAN_FSM_HANDLED;
+        default:
+            assert(false);
+            break;
+    }
+    return GNRC_LORAWAN_FSM_IGNORED;
 }

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -29,28 +29,13 @@
 #include "net/loramac.h"
 #include "net/gnrc/lorawan/region.h"
 #include "net/gnrc/netreg.h"
+#include "random.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#define MSG_TYPE_MLME_BACKOFF_EXPIRE (0x3458)           /**< Backoff timer expiration message type */
-
-static uint8_t _appskey[LORAMAC_APPSKEY_LEN];
-static uint8_t _appkey[LORAMAC_APPKEY_LEN];
-static uint8_t _snwksintkey[LORAMAC_SNWKSINTKEY_LEN];
-static uint8_t _nwksenckey[LORAMAC_NWKSENCKEY_LEN];
-static uint8_t _nwkkey[LORAMAC_NWKKEY_LEN];
-static uint8_t _joineui[LORAMAC_JOINEUI_LEN];
-static uint8_t _fnwksintkey[LORAMAC_FNWKSINTKEY_LEN];
-static uint8_t _deveui[LORAMAC_DEVEUI_LEN];
-static uint8_t _devaddr[LORAMAC_DEVADDR_LEN];
-
-static msg_t timeout_msg = { .type = MSG_TYPE_TIMEOUT };
-static msg_t backoff_msg = { .type = MSG_TYPE_MLME_BACKOFF_EXPIRE };
-
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
-static void _msg_handler(gnrc_netif_t *netif, msg_t *msg);
 static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt);
 static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt);
 static int _init(gnrc_netif_t *netif);
@@ -61,14 +46,10 @@ static const gnrc_netif_ops_t lorawan_ops = {
     .recv = _recv,
     .get = _get,
     .set = _set,
-    .msg_handler = _msg_handler
 };
 
 void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm)
 {
-    gnrc_netif_lorawan_t *lw_netif =
-        container_of(mac, gnrc_netif_lorawan_t, mac);
-
     if (confirm->type == MLME_JOIN) {
         if (confirm->status == 0) {
             gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
@@ -84,25 +65,6 @@ void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm)
             DEBUG("gnrc_lorawan: join failed\n");
         }
     }
-    else if (confirm->type == MLME_LINK_CHECK) {
-        lw_netif->flags &= ~GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK;
-        lw_netif->demod_margin = confirm->link_req.margin;
-        lw_netif->num_gateways = confirm->link_req.num_gateways;
-    }
-}
-
-void gnrc_lorawan_set_timer(gnrc_lorawan_t *mac, uint32_t us)
-{
-    gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
-
-    ztimer_set_msg(ZTIMER_MSEC, &lw_netif->timer, us / 1000, &timeout_msg, thread_getpid());
-}
-
-void gnrc_lorawan_remove_timer(gnrc_lorawan_t *mac)
-{
-    gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
-
-    ztimer_remove(ZTIMER_MSEC, &lw_netif->timer);
 }
 
 static inline void _set_be_addr(gnrc_lorawan_t *mac, uint8_t *be_addr)
@@ -168,8 +130,24 @@ release:
 
 void gnrc_lorawan_mlme_indication(gnrc_lorawan_t *mac, mlme_indication_t *ind)
 {
-    (void)mac;
-    (void)ind;
+    gnrc_netif_lorawan_t *lw_netif =
+        container_of(mac, gnrc_netif_lorawan_t, mac);
+
+    if (ind->type == MLME_LINK_CHECK) {
+        lw_netif->demod_margin = ind->link_req.margin;
+        lw_netif->num_gateways = ind->link_req.num_gateways;
+    }
+    else if (ind->type == MLME_SCHEDULE_UPLINK) {
+        /* In the future this may schedule pending packets from the netif queue */
+        lw_netif->msg_sched.type = GNRC_NETAPI_MSG_TYPE_SND;
+        gnrc_pktsnip_t *pkt, *hdr;
+        uint8_t port = 1;
+        pkt = gnrc_pktbuf_add(NULL, NULL, 0, GNRC_NETTYPE_UNDEF);
+        hdr = gnrc_netif_hdr_build(NULL, 0, &port, sizeof(port));
+        pkt = gnrc_pkt_prepend(pkt, hdr);
+        lw_netif->msg_sched.content.ptr = pkt;
+        msg_send(&lw_netif->msg_sched, thread_getpid());
+    }
 }
 
 void gnrc_lorawan_mcps_confirm(gnrc_lorawan_t *mac, mcps_confirm_t *confirm)
@@ -278,6 +256,15 @@ netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac)
     return netif->dev;
 }
 
+static void _reverse_array(uint8_t *arr, size_t len)
+{
+    for (unsigned i = 0; i < len/2; i++) {
+        uint8_t p = arr[i];
+        arr[i] = arr[len - i - 1];
+        arr[len - i - 1] = p;
+    }
+}
+
 static int _init(gnrc_netif_t *netif)
 {
     DEBUG("netif init ! \n");
@@ -290,39 +277,38 @@ static int _init(gnrc_netif_t *netif)
     netif->dev->event_callback = _driver_cb;
     _reset(netif);
 
+    uint8_t buf[LORAMAC_APPSKEY_LEN];
+
     /* Convert default keys, address and EUIs to hex */
-    fmt_hex_bytes(_appskey, CONFIG_LORAMAC_APP_SKEY_DEFAULT);
+    fmt_hex_bytes(netif->lorawan.appskey, CONFIG_LORAMAC_APP_SKEY_DEFAULT);
     if (IS_USED(MODULE_GNRC_LORAWAN_1_1)) {
-        fmt_hex_bytes(_joineui, CONFIG_LORAMAC_JOIN_EUI_DEFAULT);
-        fmt_hex_bytes(_appkey, CONFIG_LORAMAC_APP_KEY_DEFAULT);
-        fmt_hex_bytes(_nwkkey, CONFIG_LORAMAC_NWK_KEY_DEFAULT);
-        fmt_hex_bytes(_fnwksintkey, CONFIG_LORAMAC_FNWKSINT_KEY_DEFAULT);
-        fmt_hex_bytes(_snwksintkey, CONFIG_LORAMAC_SNWKSINT_KEY_DEFAULT);
-        fmt_hex_bytes(_nwksenckey, CONFIG_LORAMAC_NWKSENC_KEY_DEFAULT);
+        fmt_hex_bytes(netif->lorawan.joineui, CONFIG_LORAMAC_JOIN_EUI_DEFAULT);
+        fmt_hex_bytes(netif->lorawan.nwkkey, CONFIG_LORAMAC_NWK_KEY_DEFAULT);
+        fmt_hex_bytes(netif->lorawan.fnwksintkey, CONFIG_LORAMAC_FNWKSINT_KEY_DEFAULT);
     }
     else {
-        fmt_hex_bytes(_joineui, CONFIG_LORAMAC_APP_EUI_DEFAULT);
-        fmt_hex_bytes(_nwkkey, CONFIG_LORAMAC_APP_KEY_DEFAULT);
-        fmt_hex_bytes(_fnwksintkey, CONFIG_LORAMAC_NWK_SKEY_DEFAULT);
+        fmt_hex_bytes(netif->lorawan.joineui, CONFIG_LORAMAC_APP_EUI_DEFAULT);
+        fmt_hex_bytes(netif->lorawan.nwkkey, CONFIG_LORAMAC_APP_KEY_DEFAULT);
+        fmt_hex_bytes(netif->lorawan.fnwksintkey, CONFIG_LORAMAC_NWK_SKEY_DEFAULT);
     }
 
-    fmt_hex_bytes(_deveui, CONFIG_LORAMAC_DEV_EUI_DEFAULT);
-    fmt_hex_bytes(_devaddr, CONFIG_LORAMAC_DEV_ADDR_DEFAULT);
+    fmt_hex_bytes(netif->lorawan.deveui, CONFIG_LORAMAC_DEV_EUI_DEFAULT);
 
     /* Initialize default keys, address and EUIs */
-    memcpy(netif->lorawan.appskey, _appskey, sizeof(_appskey));
-    _memcpy_reversed(netif->lorawan.deveui, _deveui, sizeof(_deveui));
-    _memcpy_reversed(netif->lorawan.joineui, _joineui, sizeof(_joineui));
-    memcpy(netif->lorawan.nwkkey, _nwkkey, sizeof(_nwkkey));
-    memcpy(netif->lorawan.fnwksintkey, _fnwksintkey, sizeof(_fnwksintkey));
+    _reverse_array(netif->lorawan.deveui, LORAMAC_DEVEUI_LEN);
+    _reverse_array(netif->lorawan.joineui, LORAMAC_JOINEUI_LEN);
 
     if (IS_USED(MODULE_GNRC_LORAWAN_1_1)) {
-        gnrc_netif_lorawan_set_appkey(&netif->lorawan, _appkey, sizeof(_appkey));
-        gnrc_netif_lorawan_set_snwksintkey(&netif->lorawan, _snwksintkey, sizeof(_snwksintkey));
-        gnrc_netif_lorawan_set_nwksenckey(&netif->lorawan, _nwksenckey, sizeof(_nwksenckey));
+        fmt_hex_bytes(buf, CONFIG_LORAMAC_APP_KEY_DEFAULT);
+        gnrc_netif_lorawan_set_appkey(&netif->lorawan, buf, LORAMAC_APPSKEY_LEN);
+        fmt_hex_bytes(buf, CONFIG_LORAMAC_SNWKSINT_KEY_DEFAULT);
+        gnrc_netif_lorawan_set_snwksintkey(&netif->lorawan, buf, LORAMAC_SNWKSINTKEY_LEN);
+        fmt_hex_bytes(buf, CONFIG_LORAMAC_NWKSENC_KEY_DEFAULT);
+        gnrc_netif_lorawan_set_nwksenckey(&netif->lorawan, buf, LORAMAC_NWKSENCKEY_LEN);
     }
 
-    _set_be_addr(&netif->lorawan.mac, _devaddr);
+    fmt_hex_bytes(buf, CONFIG_LORAMAC_DEV_ADDR_DEFAULT);
+    _set_be_addr(&netif->lorawan.mac, buf);
 
     const gnrc_lorawan_key_ctx_t ctx = {
         .appskey = netif->lorawan.appskey,
@@ -338,11 +324,7 @@ static int _init(gnrc_netif_t *netif)
 #endif
     };
 
-    gnrc_lorawan_init(&netif->lorawan.mac, netif->lorawan.joineui, &ctx);
-
-    ztimer_set_msg(ZTIMER_MSEC, &netif->lorawan.backoff_timer,
-                   GNRC_LORAWAN_BACKOFF_WINDOW_TICK / 1000,
-                   &backoff_msg, thread_getpid());
+    gnrc_lorawan_init(&netif->lorawan.mac, netif->lorawan.joineui, &ctx, &netif->evq[GNRC_NETIF_EVQ_INDEX_PRIO_LOW]);
 
     return res;
 }
@@ -363,9 +345,6 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
 {
-    mlme_request_t mlme_request;
-    mlme_confirm_t mlme_confirm;
-
     uint8_t port;
     int res = -EINVAL;
 
@@ -392,12 +371,6 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
         port = netif->lorawan.port;
     }
 
-    if (netif->lorawan.flags & GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK) {
-        mlme_request.type = MLME_LINK_CHECK;
-        gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
-                                  &mlme_confirm);
-    }
-
     mcps_request_t req =
     { .type = netif->lorawan.ack_req ? MCPS_CONFIRMED : MCPS_UNCONFIRMED,
       .data =
@@ -415,24 +388,6 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
 
 end:
     return res;
-}
-
-static void _msg_handler(gnrc_netif_t *netif, msg_t *msg)
-{
-    (void)netif;
-    (void)msg;
-    switch (msg->type) {
-    case MSG_TYPE_TIMEOUT:
-        gnrc_lorawan_timeout_cb(&netif->lorawan.mac);
-        break;
-    case MSG_TYPE_MLME_BACKOFF_EXPIRE:
-        gnrc_lorawan_mlme_backoff_expire_cb(&netif->lorawan.mac);
-        ztimer_set_msg(ZTIMER_MSEC, &netif->lorawan.backoff_timer,
-                       GNRC_LORAWAN_BACKOFF_WINDOW_TICK / 1000,
-                       &backoff_msg, thread_getpid());
-    default:
-        break;
-    }
 }
 
 static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
@@ -576,18 +531,19 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
         netopt_enable_t en = *((netopt_enable_t *)opt->data);
         if (en) {
             if (netif->lorawan.otaa) {
+                gnrc_netif_lorawan_t *lw_netif = &netif->lorawan;
                 mlme_request.type = MLME_JOIN;
-                mlme_request.join.deveui = netif->lorawan.deveui;
-                mlme_request.join.joineui = netif->lorawan.joineui;
-                mlme_request.join.nwkkey = netif->lorawan.nwkkey;
+                mlme_request.join.deveui = lw_netif->deveui;
+                mlme_request.join.joineui = lw_netif->joineui;
+                mlme_request.join.nwkkey = lw_netif->nwkkey;
 
                 if (IS_USED(MODULE_GNRC_LORAWAN_1_1)) {
                     gnrc_lorawan_mlme_join_set_appkey(&mlme_request.join, gnrc_netif_lorawan_get_appkey(
-                                                          &netif->lorawan));
+                                                          lw_netif));
                 }
 
-                mlme_request.join.dr = netif->lorawan.datarate;
-                gnrc_lorawan_mlme_request(&netif->lorawan.mac,
+                mlme_request.join.dr = lw_netif->datarate;
+                gnrc_lorawan_mlme_request(&lw_netif->mac,
                                           &mlme_request, &mlme_confirm);
             }
             else {
@@ -617,7 +573,12 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
         _set_be_addr(&netif->lorawan.mac, opt->data);
         break;
     case NETOPT_LINK_CHECK:
+        assert(opt->data_len == sizeof(netopt_enable_t));
         netif->lorawan.flags |= GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK;
+        mlme_request.type = MLME_SET;
+        mlme_request.mib.link_check = *((bool*) opt->data);
+        gnrc_lorawan_mlme_request(&netif->lorawan.mac,
+                                  &mlme_request, &mlme_confirm);
         break;
     case NETOPT_LORAWAN_RX2_DR:
         assert(opt->data_len == sizeof(uint8_t));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds support for Class C in GNRC LoRaWAN.
To activate, enable the `CONFIG_GNRC_LORAWAN_CLASS_C` CFLAG.

With Class C LoRaWAN nodes keep the receiver on all the time and therefore show the lowest downlink latency.
Class C is also supported by common LoRaWAN network servers (e.g TTN, Chirpstack).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Enable Class C support in the LoRaWAN Network Server (e.g TTN)
- Run `examples/gnrc_lorawan` with `CFLAGS=-DCONFIG_GNRC_LORAWAN_CLASS_C`. Join the network and transmit and uplink.
- Schedule a downlink to the LoRaWAN node. The node should indicate packet reception.
Also, make sure that LoRaWAN class A still works as expected.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #19342 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
