### PR TITLE
cpu/esp32: fix compilation issues with GCC 12.2

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -207,6 +207,13 @@ CFLAGS += -D_CONST=const
 # TODO no relaxation yet
 ifneq (,$(filter riscv%,$(TARGET_ARCH)))
   CFLAGS += -mno-relax -march=rv32imc -mabi=ilp32 -DRISCV_NO_RELAX
+  GCC_NEW_RISCV_ISA ?= $(shell echo "typedef int dont_be_pedantic;" | \
+                               $(TARGET_ARCH)-gcc -march=rv32imac -mabi=ilp32 \
+                                                  -misa-spec=2.2 -E - > /dev/null 2>&1 && \
+                               echo 1 || echo 0)
+  ifeq (1,$(GCC_NEW_RISCV_ISA))
+    CFLAGS += -misa-spec=2.2
+  endif
 endif
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
@@ -242,6 +249,12 @@ else
 endif
 
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
+
+# all ESP32x SoCs have to load executable code into IRAM
+# warning 'LOAD segment with RWX permissions' has to be disabled therefore
+ifeq (1,$(GCC_NEW_RISCV_ISA))
+  LINKFLAGS += -Wl,--no-warn-rwx-segments
+endif
 
 # Libraries needed when using esp_wifi_any pseudomodule
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))

--- a/cpu/esp32/bootloader/Makefile
+++ b/cpu/esp32/bootloader/Makefile
@@ -164,6 +164,10 @@ INCLUDES = \
 # CONFIG_ESPTOOLPY_FLASHFREQ_* and CONFIG_FLASHMODE_*
 CFLAGS = -include '$(RIOTBUILD_CONFIG_HEADER_C)' \
 
+# TODO: required to be able to compile with GCC 12.1, remove them after upgrade to ESP-IDF 5.1
+CFLAGS += -Wno-error=format=
+CFLAGS += -Wno-format
+
 ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/riscv/include
   CFLAGS += -DCONFIG_IDF_TARGET_ARCH_RISCV

--- a/cpu/esp32/bootloader/Makefile
+++ b/cpu/esp32/bootloader/Makefile
@@ -171,6 +171,13 @@ ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   CFLAGS += -Wno-error=format=
   CFLAGS += -nostartfiles
   CFLAGS += -Wno-format
+  GCC_NEW_RISCV_ISA ?= $(shell echo "typedef int dont_be_pedantic;" | \
+                               $(TARGET_ARCH)-gcc -march=rv32imac -mabi=ilp32 \
+                                                  -misa-spec=2.2 -E - > /dev/null 2>&1 && \
+                               echo 1 || echo 0)
+  ifeq (1,$(GCC_NEW_RISCV_ISA))
+    CFLAGS += -misa-spec=2.2
+  endif
 endif
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))

--- a/cpu/esp32/esp-idf/esp_idf_cflags.mk
+++ b/cpu/esp32/esp-idf/esp_idf_cflags.mk
@@ -34,6 +34,14 @@ CFLAGS += -Wno-enum-compare
 # those are false positives.
 CFLAGS += -Wno-cast-align
 
+# TODO: required to be able to compile with GCC 12.1, remove them after upgrade to ESP-IDF 5.1
+CFLAGS += -Wno-attributes
+CFLAGS += -Wno-enum-conversion
+CFLAGS += -Wno-error=format=
+CFLAGS += -Wno-format
+CFLAGS += -Wno-use-after-free
+CFLAGS += -Wno-incompatible-pointer-types
+
 # additional CFLAGS required for RISC-V architecture
 ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/riscv/include

--- a/cpu/esp32/esp-idf/esp_idf_cflags.mk
+++ b/cpu/esp32/esp-idf/esp_idf_cflags.mk
@@ -42,4 +42,11 @@ ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   CFLAGS += -Wno-error=format=
   CFLAGS += -nostartfiles
   CFLAGS += -Wno-format
+  GCC_NEW_RISCV_ISA ?= $(shell echo "typedef int dont_be_pedantic;" | \
+                               $(TARGET_ARCH)-gcc -march=rv32imac -mabi=ilp32 \
+                                                  -misa-spec=2.2 -E - > /dev/null 2>&1 && \
+                               echo 1 || echo 0)
+  ifeq (1,$(GCC_NEW_RISCV_ISA))
+    CFLAGS += -misa-spec=2.2
+  endif
 endif

--- a/cpu/esp32/esp-idf/esp_idf_support.c
+++ b/cpu/esp32/esp-idf/esp_idf_support.c
@@ -111,7 +111,7 @@ void IRAM_ATTR esp_log_writev(esp_log_level_t level,
      * We use the log level set for the given tag instead of using
      * the given log level.
      */
-    esp_log_level_t act_level = LOG_DEBUG;
+    esp_log_level_t act_level = (esp_log_level_t)LOG_DEBUG;
     size_t i;
     for (i = 0; i < ARRAY_SIZE(_log_levels); i++) {
         if (strcmp(tag, _log_levels[i].tag) == 0) {

--- a/cpu/esp32/esp-idf/nvs_flash/Makefile
+++ b/cpu/esp32/esp-idf/nvs_flash/Makefile
@@ -30,6 +30,10 @@ include ../esp_idf.mk
 # those are false positives.
 CFLAGS += -Wno-cast-align
 
+# TODO: required to be able to compile with GCC 12.1, remove them after upgrade to ESP-IDF 5.1
+CFLAGS += -Wno-error=format=
+CFLAGS += -Wno-format
+
 # additional CFLAGS required for RISC-V architecture
 ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   CFLAGS += -Wno-error=format=

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -212,16 +212,6 @@ typedef enum {
 #define GPIO_DRIVE_20   GPIO_DRIVE_STRONG       /**< 20 mA (default) */
 #define GPIO_DRIVE_30   GPIO_DRIVE_STRONGEST    /**< 30 mA */
 
-#define HAVE_GPIO_IRQ_TRIG_T
-typedef enum {
-    GPIO_TRIGGER_NONE = 0,
-    GPIO_TRIGGER_EDGE_RISING = 1,
-    GPIO_TRIGGER_EDGE_FALLING = 2,
-    GPIO_TRIGGER_EDGE_BOTH = 3,
-    GPIO_TRIGGER_LEVEL_LOW = 4,
-    GPIO_TRIGGER_LEVEL_HIGH = 5
-} gpio_irq_trig_t;
-
 /* END: GPIO LL overwrites */
 
 #endif /* ndef DOXYGEN */

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -131,16 +131,22 @@ int adc_init(adc_t line)
     }
 
     if (_adc_hw[rtcio].adc_ctrl == ADC_UNIT_1) {
+        /* ensure compatibility of given adc_channel_t with adc1_channel_t */
+        assert(_adc_hw[rtcio].adc_channel < (adc_channel_t)ADC1_CHANNEL_MAX);
         /* initialize the ADC1 unit if needed */
         _adc1_ctrl_init();
         /* set the attenuation and configure its associated GPIO pin mux */
-        adc1_config_channel_atten(_adc_hw[rtcio].adc_channel, ADC_ATTEN_DB_11);
+        adc1_config_channel_atten((adc1_channel_t)_adc_hw[rtcio].adc_channel,
+                                  ADC_ATTEN_DB_11);
     }
     else if (_adc_hw[rtcio].adc_ctrl == ADC_UNIT_2) {
+        /* ensure compatibility of given adc_channel_t with adc2_channel_t */
+        assert(_adc_hw[rtcio].adc_channel < (adc_channel_t)ADC2_CHANNEL_MAX);
         /* initialize the ADC2 unit if needed */
         _adc2_ctrl_init();
         /* set the attenuation and configure its associated GPIO pin mux */
-        adc2_config_channel_atten(_adc_hw[rtcio].adc_channel, ADC_ATTEN_DB_11);
+        adc2_config_channel_atten((adc2_channel_t)_adc_hw[rtcio].adc_channel,
+                                  ADC_ATTEN_DB_11);
     }
     else {
         return -1;
@@ -165,13 +171,17 @@ int32_t adc_sample(adc_t line, adc_res_t res)
 
     if (_adc_hw[rtcio].adc_ctrl == ADC_UNIT_1) {
         adc1_config_width(_adc_esp_res_map[res].res);
-        raw = adc1_get_raw(_adc_hw[rtcio].adc_channel);
+         /* ensure compatibility of given adc_channel_t with adc1_channel_t */
+        assert(_adc_hw[rtcio].adc_channel < (adc_channel_t)ADC1_CHANNEL_MAX);
+        raw = adc1_get_raw((adc1_channel_t)_adc_hw[rtcio].adc_channel);
         if (raw < 0) {
             return -1;
         }
     }
     else if (_adc_hw[rtcio].adc_ctrl == ADC_UNIT_2) {
-        if (adc2_get_raw(_adc_hw[rtcio].adc_channel,
+         /* ensure compatibility of given adc_channel_t with adc2_channel_t */
+        assert(_adc_hw[rtcio].adc_channel < (adc_channel_t)ADC2_CHANNEL_MAX);
+        if (adc2_get_raw((adc2_channel_t)_adc_hw[rtcio].adc_channel,
                          _adc_esp_res_map[res].res, &raw) < 0) {
             return -1;
         }
@@ -189,10 +199,14 @@ int adc_set_attenuation(adc_t line, adc_atten_t atten)
     assert(rtcio != RTCIO_NA);
 
     if (_adc_hw[rtcio].adc_ctrl == ADC_UNIT_1) {
-        return adc1_config_channel_atten(_adc_hw[rtcio].adc_channel, atten);
+         /* ensure compatibility of given adc_channel_t with adc1_channel_t */
+        assert(_adc_hw[rtcio].adc_channel < (adc_channel_t)ADC1_CHANNEL_MAX);
+        return adc1_config_channel_atten((adc1_channel_t)_adc_hw[rtcio].adc_channel, atten);
     }
     else if (_adc_hw[rtcio].adc_ctrl == ADC_UNIT_2) {
-        return adc2_config_channel_atten(_adc_hw[rtcio].adc_channel, atten);
+         /* ensure compatibility of given adc_channel_t with adc2_channel_t */
+        assert(_adc_hw[rtcio].adc_channel < (adc_channel_t)ADC2_CHANNEL_MAX);
+        return adc2_config_channel_atten((adc2_channel_t)_adc_hw[rtcio].adc_channel, atten);
     }
 
     return -1;

--- a/cpu/esp32/periph/flashpage.c
+++ b/cpu/esp32/periph/flashpage.c
@@ -76,8 +76,8 @@ void IRAM_ATTR esp_flashpage_init(void)
                                  p_addr, 64, p_numof, 0);
     Cache_Resume_ICache(autoload);
 
-    DEBUG("%s DCache MMU set paddr=%08x vaddr=%08x size=%d n=%u\n", __func__,
-           p_addr, (uint32_t)&_fp_mem_start, CONFIG_ESP_FLASHPAGE_CAPACITY,
+    DEBUG("%s DCache MMU set paddr=%08"PRIx32" vaddr=%08"PRIx32" size=%d n=%"PRIu32"\n",
+           __func__, p_addr, (uint32_t)&_fp_mem_start, CONFIG_ESP_FLASHPAGE_CAPACITY,
            p_numof);
 
     if (res != ESP_OK) {

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -229,8 +229,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
                       (mode == GPIO_OD_PU) ||
                       (mode == GPIO_IN_OD_PU)) ? GPIO_PULLUP_ENABLE
                                                : GPIO_PULLUP_DISABLE;
-    cfg.pull_down_en = (mode == GPIO_IN_PD) ? GPIO_PULLUP_ENABLE
-                                            : GPIO_PULLUP_DISABLE;
+    cfg.pull_down_en = (mode == GPIO_IN_PD) ? GPIO_PULLDOWN_ENABLE
+                                            : GPIO_PULLDOWN_DISABLE;
     cfg.intr_type = GPIO_INTR_DISABLE;
 
 #ifdef ESP_PM_WUP_PINS

--- a/cpu/esp32/periph/gpio_ll.c
+++ b/cpu/esp32/periph/gpio_ll.c
@@ -149,9 +149,25 @@ int gpio_ll_init(gpio_port_t port, uint8_t pin, const gpio_conf_t *conf)
     }
 
     /* if output pin, try to set drive strength */
+    gpio_drive_cap_t strength;
+    switch (conf->drive_strength) {
+    case GPIO_DRIVE_WEAKEST:
+        strength = GPIO_DRIVE_CAP_0;
+        break;
+    case GPIO_DRIVE_WEAK:
+        strength = GPIO_DRIVE_CAP_1;
+        break;
+    case GPIO_DRIVE_STRONG:
+        strength = GPIO_DRIVE_CAP_2;
+        break;
+    case GPIO_DRIVE_STRONGEST:
+        strength = GPIO_DRIVE_CAP_3;
+        break;
+    default:
+        strength = GPIO_DRIVE_CAP_DEFAULT;
+    }
     if ((cfg.pin_bit_mask & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) &&
-        (esp_idf_gpio_set_drive_capability(gpio,
-                                           conf->drive_strength) != ESP_OK)) {
+        (esp_idf_gpio_set_drive_capability(gpio, strength) != ESP_OK)) {
         return -ENOTSUP;
     }
 

--- a/cpu/esp32/periph/gpio_ll_irq.c
+++ b/cpu/esp32/periph/gpio_ll_irq.c
@@ -75,7 +75,27 @@ int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig,
     gpio_isr_service_installed = true;
 
     /* set the interrupt type for the pin */
-    if (esp_idf_gpio_set_intr_type(gpio, trig) != ESP_OK) {
+    gpio_int_type_t type;
+    switch (trig) {
+    case GPIO_TRIGGER_EDGE_FALLING:
+        type = GPIO_INTR_NEGEDGE;
+        break;
+    case GPIO_TRIGGER_EDGE_RISING:
+        type = GPIO_INTR_POSEDGE;
+        break;
+    case GPIO_TRIGGER_EDGE_BOTH:
+        type = GPIO_INTR_ANYEDGE;
+        break;
+    case GPIO_TRIGGER_LEVEL_HIGH:
+        type = GPIO_INTR_HIGH_LEVEL;
+        break;
+    case GPIO_TRIGGER_LEVEL_LOW:
+        type = GPIO_INTR_LOW_LEVEL;
+        break;
+    default:
+        type = GPIO_INTR_DISABLE;
+    }
+    if (esp_idf_gpio_set_intr_type(gpio, type) != ESP_OK) {
         return -1;
     }
 

--- a/cpu/esp32/periph/rtt.c
+++ b/cpu/esp32/periph/rtt.c
@@ -58,7 +58,7 @@ extern uint32_t rtc_clk_slow_freq_get_hz(void);
 /* forward declaration of functions */
 void rtt_restore_counter(bool sys_time);
 static void _rtt_update_hw_alarm(void);
-static void IRAM_ATTR _rtt_isr(void *arg);
+static void _rtt_isr(void *arg);
 
 /* forward declarations of driver functions */
 uint64_t _rtc_get_counter(void);

--- a/cpu/esp32/periph/rtt_hw_rtc.c
+++ b/cpu/esp32/periph/rtt_hw_rtc.c
@@ -135,13 +135,8 @@ static void _rtc_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     RTCCNTL.slp_timer0 = rtc_alarm & 0xffffffff;
     RTCCNTL.slp_timer1.slp_val_hi = rtc_alarm >> 32;
 
-#if __xtensa__
-    DEBUG("%s %08x%08x \n", __func__,
-          RTCCNTL.slp_timer1.slp_val_hi, RTCCNTL.slp_timer0);
-#else
     DEBUG("%s %08x%08x \n", __func__,
           (unsigned)RTCCNTL.slp_timer1.slp_val_hi, (unsigned)RTCCNTL.slp_timer0);
-#endif
 
     /* enable RTC timer alarm */
     RTCCNTL.slp_timer1.main_timer_alarm_en = 1;

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -240,8 +240,8 @@ static NORETURN void IRAM system_init (void)
 
     /* set log levels for SDK library outputs */
     extern void esp_log_level_set(const char* tag, esp_log_level_t level);
-    esp_log_level_set("wifi", LOG_DEBUG);
-    esp_log_level_set("gpio", LOG_DEBUG);
+    esp_log_level_set("wifi", (esp_log_level_t)LOG_DEBUG);
+    esp_log_level_set("gpio", (esp_log_level_t)LOG_DEBUG);
 
     /* init watchdogs */
     system_wdt_init();

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -382,8 +382,9 @@ void system_wdt_init(void)
     wdt_hal_write_protect_enable(&rwdt);
 
 #if defined(CPU_FAM_ESP32)
-    DEBUG("%s TIMERG0 wdtconfig0=%08x wdtconfig1=%08x wdtconfig2=%08x "
-          "wdtconfig3=%08x wdtconfig4=%08x regclk=%08x\n", __func__,
+    DEBUG("%s TIMERG0 wdtconfig0=%08"PRIx32" wdtconfig1=%08"PRIx32
+          " wdtconfig2=%08"PRIx32" wdtconfig3=%08"PRIx32
+          " wdtconfig4=%08"PRIx32" regclk=%08"PRIx32"\n", __func__,
           TIMERG0.wdt_config0.val, TIMERG0.wdt_config1.val,
           TIMERG0.wdt_config2, TIMERG0.wdt_config3,
           TIMERG0.wdt_config4, TIMERG0.clk.val);

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -79,7 +79,7 @@ static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, const uint8
 
     memcpy(peer.peer_addr, bssid, ESP_NOW_ETH_ALEN);
     peer.channel = channel;
-    peer.ifidx = ESP_IF_WIFI_AP;
+    peer.ifidx = WIFI_IF_AP;
 
     if (esp_now_params.key) {
         peer.encrypt = true;
@@ -391,13 +391,13 @@ esp_now_netdev_t *netdev_esp_now_setup(void)
     }
 
     /* set the Station and SoftAP configuration */
-    result = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config_sta);
+    result = esp_wifi_set_config(WIFI_IF_STA, &wifi_config_sta);
     if (result != ESP_OK) {
         LOG_TAG_ERROR("esp_now", "esp_wifi_set_config station failed with "
                       "return value %d\n", result);
         return NULL;
     }
-    result = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config_ap);
+    result = esp_wifi_set_config(WIFI_IF_AP, &wifi_config_ap);
     if (result != ESP_OK) {
         LOG_TAG_ERROR("esp_now",
                       "esp_wifi_set_config softap failed with return value %d\n",
@@ -416,7 +416,7 @@ esp_now_netdev_t *netdev_esp_now_setup(void)
 
 #if !ESP_NOW_UNICAST
     /* all ESP-NOW nodes get the shared mac address on their station interface */
-    esp_wifi_set_mac(ESP_IF_WIFI_STA, (uint8_t*)_esp_now_mac);
+    esp_wifi_set_mac(WIFI_IF_STA, (uint8_t*)_esp_now_mac);
 #endif
 
 #endif /* MODULE_ESP_WIFI */
@@ -471,7 +471,7 @@ int esp_now_set_channel(uint8_t channel)
     /* channel is controlled by `esp_now`, try to reconfigure SoftAP */
     uint8_t old_channel = wifi_config_ap.ap.channel;
     wifi_config_ap.ap.channel = channel;
-    esp_err_t result = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config_ap);
+    esp_err_t result = esp_wifi_set_config(WIFI_IF_AP, &wifi_config_ap);
     if (result != ESP_OK) {
         LOG_TAG_ERROR("esp_now",
                       "esp_wifi_set_config softap failed with return value %d\n",

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -501,13 +501,13 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
 #ifdef MODULE_ESP_WIFI_AP
         case SYSTEM_EVENT_AP_START:
             _esp_wifi_started = 1;
-            esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, _esp_wifi_rx_cb);
+            esp_wifi_internal_reg_rxcb(WIFI_IF_AP, _esp_wifi_rx_cb);
             ESP_WIFI_DEBUG("WiFi started");
             break;
 
         case SYSTEM_EVENT_AP_STOP:
             _esp_wifi_started = 0;
-            esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, NULL);
+            esp_wifi_internal_reg_rxcb(WIFI_IF_AP, NULL);
             ESP_WIFI_DEBUG("WiFi stopped");
             break;
 
@@ -560,7 +560,7 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
             esp_now_set_channel(_esp_wifi_channel);
 #endif
             /* register RX callback function */
-            esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, _esp_wifi_rx_cb);
+            esp_wifi_internal_reg_rxcb(WIFI_IF_STA, _esp_wifi_rx_cb);
 
             _esp_wifi_dev.connected = true;
             _esp_wifi_dev.event_conn++;
@@ -575,7 +575,7 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
                               reason, _esp_wifi_get_disc_reason(reason));
 
             /* unregister RX callback function */
-            esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, NULL);
+            esp_wifi_internal_reg_rxcb(WIFI_IF_STA, NULL);
 
             _esp_wifi_dev.connected = false;
             _esp_wifi_dev.event_disc++;
@@ -661,10 +661,10 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
     critical_exit();
 
 #ifdef MODULE_ESP_WIFI_AP
-    if (esp_wifi_internal_tx(ESP_IF_WIFI_AP, dev->tx_buf, dev->tx_len) == ESP_OK) {
+    if (esp_wifi_internal_tx(WIFI_IF_AP, dev->tx_buf, dev->tx_len) == ESP_OK) {
 #else /* MODULE_ESP_WIFI_AP */
     /* send the the packet to the peer(s) mac address */
-    if (esp_wifi_internal_tx(ESP_IF_WIFI_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
+    if (esp_wifi_internal_tx(WIFI_IF_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
 #endif
 #ifndef MCU_ESP8266
         /* for ESP8266 it is done in _esp_wifi_tx_cb */
@@ -758,9 +758,9 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
         case NETOPT_ADDRESS:
             assert(max_len >= ETHERNET_ADDR_LEN);
 #ifdef MODULE_ESP_WIFI_AP
-            esp_wifi_get_mac(ESP_MAC_WIFI_SOFTAP, (uint8_t *)val);
+            esp_wifi_get_mac(WIFI_IF_AP, (uint8_t *)val);
 #else /* MODULE_ESP_WIFI_AP */
-            esp_wifi_get_mac(ESP_MAC_WIFI_STA, (uint8_t *)val);
+            esp_wifi_get_mac(WIFI_IF_STA, (uint8_t *)val);
 #endif /* MODULE_ESP_WIFI_AP */
             return ETHERNET_ADDR_LEN;
         case NETOPT_LINK:
@@ -789,9 +789,9 @@ static int _esp_wifi_set(netdev_t *netdev, netopt_t opt, const void *val, size_t
         case NETOPT_ADDRESS:
             assert(max_len == ETHERNET_ADDR_LEN);
 #ifdef MODULE_ESP_WIFI_AP
-            esp_wifi_set_mac(ESP_MAC_WIFI_SOFTAP, (uint8_t *)val);
+            esp_wifi_set_mac(WIFI_IF_AP, (uint8_t *)val);
 #else /* MODULE_ESP_WIFI_AP */
-            esp_wifi_set_mac(ESP_MAC_WIFI_STA, (uint8_t *)val);
+            esp_wifi_set_mac(WIFI_IF_STA, (uint8_t *)val);
 #endif /* MODULE_ESP_WIFI_AP */
             return ETHERNET_ADDR_LEN;
         default:
@@ -972,13 +972,13 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
 #if defined(MCU_ESP8266) || defined(MODULE_ESP_WIFI_AP)
 #if IS_ACTIVE(ESP_WIFI_SSID_DYNAMIC)
     uint8_t mac[ETHERNET_ADDR_LEN];
-    esp_wifi_get_mac(ESP_MAC_WIFI_SOFTAP, mac);
+    esp_wifi_get_mac(WIFI_IF_AP, mac);
     sprintf((char*)wifi_config_ap.ap.ssid, "%s_%02x%02x%02x%02x%02x%02x",
             WIFI_SSID, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
     wifi_config_ap.ap.ssid_len = strlen((char*)wifi_config_ap.ap.ssid);
 #endif /* IS_ACTIVE(ESP_WIFI_SSID_DYNAMIC) */
     /* set the SoftAP configuration */
-    result = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config_ap);
+    result = esp_wifi_set_config(WIFI_IF_AP, &wifi_config_ap);
     if (result != ESP_OK) {
         ESP_WIFI_LOG_ERROR("esp_wifi_set_config softap failed with return value %d", result);
         return;
@@ -989,7 +989,7 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
 
 #ifndef MODULE_ESP_WIFI_AP
     /* set the Station configuration */
-    result = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config_sta);
+    result = esp_wifi_set_config(WIFI_IF_STA, &wifi_config_sta);
     if (result != ESP_OK) {
         ESP_WIFI_LOG_ERROR("esp_wifi_set_config station failed with return value %d", result);
         return;

--- a/cpu/esp_common/esp-xtensa/irq_arch.c
+++ b/cpu/esp_common/esp-xtensa/irq_arch.c
@@ -28,6 +28,7 @@
 #include "esp/common_macros.h"
 
 #include "esp/xtensa_ops.h"
+#include "xtensa/config/core-isa.h"
 #include "xtensa/xtensa_context.h"
 
 #define ENABLE_DEBUG 0
@@ -46,7 +47,7 @@ unsigned int IRAM irq_disable(void)
        interrupt level (bits 3..0) */
     state &= 0xf;
 
-    DEBUG("%s %02x(%02x)\n", __func__, XCHAL_EXCM_LEVEL, state);
+    DEBUG("%s %02x(%02x)\n", __func__, XCHAL_EXCM_LEVEL, (unsigned)state);
     return state;
 }
 
@@ -63,7 +64,7 @@ unsigned int IRAM irq_enable(void)
        interrupt level (bits 3..0) */
     state &= 0xf;
 
-    DEBUG("%s %02x(%02x)\n", __func__, 0, state);
+    DEBUG("%s %02x(%02x)\n", __func__, 0, (unsigned)state);
     return state;
 }
 
@@ -84,7 +85,7 @@ void IRAM irq_restore(unsigned int state)
                       "rsync                \n"
                      : "+a" (old) : "a" (state) : "memory");
 
-    DEBUG("%s %02x(%02x)\n", __func__, state, old & 0xf);
+    DEBUG("%s %02x(%02x)\n", __func__, (unsigned)state, (unsigned)old & 0xf);
 }
 
 /**

--- a/cpu/esp_common/esp-xtensa/thread_arch.c
+++ b/cpu/esp_common/esp-xtensa/thread_arch.c
@@ -275,7 +275,7 @@ void IRAM_ATTR thread_yield_higher(void)
 #if defined(ENABLE_DEBUG) && defined(DEVELHELP)
     thread_t *active_thread = thread_get_active();
     if (active_thread) {
-        DEBUG("%u old task %u %s %u\n", system_get_time(),
+        DEBUG("%"PRIu32" old task %u %s %u\n", system_get_time(),
                active_thread->pid, active_thread->name,
                active_thread->sp - active_thread-> stack_start);
     }
@@ -302,7 +302,7 @@ void IRAM_ATTR thread_yield_higher(void)
 #if defined(ENABLE_DEBUG) && defined(DEVELHELP)
     active_thread = thread_get_active();
     if (active_thread) {
-        DEBUG("%u new task %u %s %u\n", system_get_time(),
+        DEBUG("%"PRIu32" new task %u %s %u\n", system_get_time(),
                active_thread->pid, active_thread->name,
                active_thread->sp - active_thread-> stack_start);
     }

--- a/cpu/esp_common/freertos/ringbuf.c
+++ b/cpu/esp_common/freertos/ringbuf.c
@@ -38,6 +38,7 @@ RingbufHandle_t xRingbufferCreate(size_t xBufferSize, RingbufferType_t xBufferTy
         return NULL;
     }
     handle->item_size = 0;
+    handle->buf = NULL;
     ringbuffer_init((ringbuffer_t *)handle, handle->buf, xBufferSize);
 
     return handle;

--- a/pkg/esp32_sdk/patches/0028-hal-cast-esp-interrupt-type-to-riscv-interrupt-type.patch
+++ b/pkg/esp32_sdk/patches/0028-hal-cast-esp-interrupt-type-to-riscv-interrupt-type.patch
@@ -1,0 +1,25 @@
+From 19f7ed9aaab8be94571779fc8b738d3479e0aa23 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Tue, 4 Apr 2023 09:55:00 +0200
+Subject: [PATCH 28/29] hal: cast esp interrupt type to riscv interrupt type
+
+---
+ components/hal/esp32c3/include/hal/interrupt_controller_ll.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/hal/esp32c3/include/hal/interrupt_controller_ll.h b/components/hal/esp32c3/include/hal/interrupt_controller_ll.h
+index 70afe314cfe..3c3ef3b953e 100644
+--- a/components/hal/esp32c3/include/hal/interrupt_controller_ll.h
++++ b/components/hal/esp32c3/include/hal/interrupt_controller_ll.h
+@@ -124,7 +124,7 @@ static inline void intr_cntrl_ll_set_int_level(int intr, int level)
+  */
+ static inline void intr_cntrl_ll_set_int_type(int intr, int_type_t type)
+ {
+-    esprv_intc_int_set_type(BIT(intr), type);
++    esprv_intc_int_set_type(BIT(intr), (enum intr_type)type);
+ }
+ 
+ #ifdef __cplusplus
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0029-nfs_flash-include-stddef.h-for-size_t-deklaration.patch
+++ b/pkg/esp32_sdk/patches/0029-nfs_flash-include-stddef.h-for-size_t-deklaration.patch
@@ -1,0 +1,24 @@
+From 0e52f50f9c53eac78f5c70aed1f140b8ba3a3031 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Tue, 4 Apr 2023 09:55:45 +0200
+Subject: [PATCH 29/29] nfs_flash: include stddef.h for size_t deklaration
+
+---
+ components/nvs_flash/src/intrusive_list.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/nvs_flash/src/intrusive_list.h b/components/nvs_flash/src/intrusive_list.h
+index bb580502ec7..695020c415f 100644
+--- a/components/nvs_flash/src/intrusive_list.h
++++ b/components/nvs_flash/src/intrusive_list.h
+@@ -14,6 +14,7 @@
+ #ifndef intrusive_list_h
+ #define intrusive_list_h
+ 
++#include <stddef.h>
+ #include <cassert>
+ #include <unordered_map>
+ 
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0030-bt-controller-esp32s3-fix-return-types-in-functions.patch
+++ b/pkg/esp32_sdk/patches/0030-bt-controller-esp32s3-fix-return-types-in-functions.patch
@@ -1,0 +1,141 @@
+From e175ea4902cebfdd5b4edc470feff2dadbec408a Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Wed, 5 Apr 2023 01:17:12 +0200
+Subject: [PATCH 30/30] bt/controller/esp32s3: fix return types in functions
+
+Since the size of int and int32_t is the same, changing int to int32_t and vise versa to fix the compilation issue due to function declaration conflict isn't any risk.
+---
+ components/bt/controller/esp32s3/bt.c | 52 +++++++++++++--------------
+ 1 file changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/components/bt/controller/esp32s3/bt.c b/components/bt/controller/esp32s3/bt.c
+index 64e10ad4a70..ee68c6b834b 100644
+--- a/components/bt/controller/esp32s3/bt.c
++++ b/components/bt/controller/esp32s3/bt.c
+@@ -268,7 +268,7 @@ extern char _bt_tmp_bss_end;
+  */
+ static void interrupt_set_wrapper(int32_t cpu_no, int32_t intr_source, int32_t intr_num, int32_t intr_prio);
+ static void interrupt_clear_wrapper(int32_t intr_source, int32_t intr_num);
+-static void interrupt_handler_set_wrapper(int n, void *fn, void *arg);
++static void interrupt_handler_set_wrapper(int32_t n, void *fn, void *arg);
+ static void IRAM_ATTR interrupt_disable(void);
+ static void IRAM_ATTR interrupt_restore(void);
+ static void IRAM_ATTR task_yield_from_isr(void);
+@@ -486,28 +486,28 @@ static void semphr_delete_wrapper(void *semphr)
+     vSemaphoreDelete(semphr);
+ }
+ 
+-static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
++static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
+ {
+-    return (int)xSemaphoreTakeFromISR(semphr, hptw);
++    return xSemaphoreTakeFromISR(semphr, hptw);
+ }
+ 
+-static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
++static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
+ {
+-    return (int)xSemaphoreGiveFromISR(semphr, hptw);
++    return xSemaphoreGiveFromISR(semphr, hptw);
+ }
+ 
+-static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
++static int32_t semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
+ {
+     if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
+-        return (int)xSemaphoreTake(semphr, portMAX_DELAY);
++        return xSemaphoreTake(semphr, portMAX_DELAY);
+     } else {
+-        return (int)xSemaphoreTake(semphr, block_time_ms / portTICK_PERIOD_MS);
++        return xSemaphoreTake(semphr, block_time_ms / portTICK_PERIOD_MS);
+     }
+ }
+ 
+-static int semphr_give_wrapper(void *semphr)
++static int32_t semphr_give_wrapper(void *semphr)
+ {
+-    return (int)xSemaphoreGive(semphr);
++    return xSemaphoreGive(semphr);
+ }
+ 
+ static void *mutex_create_wrapper(void)
+@@ -520,14 +520,14 @@ static void mutex_delete_wrapper(void *mutex)
+     vSemaphoreDelete(mutex);
+ }
+ 
+-static int mutex_lock_wrapper(void *mutex)
++static int32_t mutex_lock_wrapper(void *mutex)
+ {
+-    return (int)xSemaphoreTake(mutex, portMAX_DELAY);
++    return xSemaphoreTake(mutex, portMAX_DELAY);
+ }
+ 
+-static int mutex_unlock_wrapper(void *mutex)
++static int32_t mutex_unlock_wrapper(void *mutex)
+ {
+-    return (int)xSemaphoreGive(mutex);
++    return xSemaphoreGive(mutex);
+ }
+ 
+ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
+@@ -540,37 +540,37 @@ static void queue_delete_wrapper(void *queue)
+     vQueueDelete(queue);
+ }
+ 
+-static int queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms)
++static int32_t queue_send_wrapper(void *queue, void *item, uint32_t block_time_ms)
+ {
+     if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
+-        return (int)xQueueSend(queue, item, portMAX_DELAY);
++        return xQueueSend(queue, item, portMAX_DELAY);
+     } else {
+-        return (int)xQueueSend(queue, item, block_time_ms / portTICK_PERIOD_MS);
++        return xQueueSend(queue, item, block_time_ms / portTICK_PERIOD_MS);
+     }
+ }
+ 
+-static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue, void *item, void *hptw)
+ {
+     return (int)xQueueSendFromISR(queue, item, hptw);
+ }
+ 
+-static int queue_recv_wrapper(void *queue, void *item, uint32_t block_time_ms)
++static int32_t queue_recv_wrapper(void *queue, void *item, uint32_t block_time_ms)
+ {
+     if (block_time_ms == OSI_FUNCS_TIME_BLOCKING) {
+-        return (int)xQueueReceive(queue, item, portMAX_DELAY);
++        return xQueueReceive(queue, item, portMAX_DELAY);
+     } else {
+-        return (int)xQueueReceive(queue, item, block_time_ms / portTICK_PERIOD_MS);
++        return xQueueReceive(queue, item, block_time_ms / portTICK_PERIOD_MS);
+     }
+ }
+ 
+-static int IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw)
++static int32_t IRAM_ATTR queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw)
+ {
+-    return (int)xQueueReceiveFromISR(queue, item, hptw);
++    return xQueueReceiveFromISR(queue, item, hptw);
+ }
+ 
+-static int task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id)
++static int32_t task_create_wrapper(void *task_func, const char *name, uint32_t stack_depth, void *param, uint32_t prio, void *task_handle, uint32_t core_id)
+ {
+-    return (uint32_t)xTaskCreatePinnedToCore(task_func, name, stack_depth, param, prio, task_handle, (core_id < portNUM_PROCESSORS ? core_id : tskNO_AFFINITY));
++    return xTaskCreatePinnedToCore(task_func, name, stack_depth, param, prio, task_handle, (core_id < portNUM_PROCESSORS ? core_id : tskNO_AFFINITY));
+ }
+ 
+ static void task_delete_wrapper(void *task_handle)
+@@ -592,7 +592,7 @@ static void *malloc_internal_wrapper(size_t size)
+     return p;
+ }
+ 
+-static int IRAM_ATTR read_mac_wrapper(uint8_t mac[6])
++static int32_t IRAM_ATTR read_mac_wrapper(uint8_t mac[6])
+ {
+     int ret = esp_read_mac(mac, ESP_MAC_BT);
+     ESP_LOGI(BT_LOG_TAG, "Bluetooth MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
+-- 
+2.34.1
+


### PR DESCRIPTION
### Contribution description

This PR provides the changes in `cpu/esp32` and `cpu/esp_common` to fix the compilation issues with GCC v12.2.  It is required as the first step in the preparation of the upgrade to ESP-IDF version 5.1.

**Please note**: Insead of fixing the ESP-IDF 4.4 code itself by a big bunch of patches to fix the compilation problems with GCC v12.2, it temporarily disables some warnings. The reason is that the ESP-IDF 5.1 requires GCC v12.2 and should be fixed for this compiler version by the vendor.

### Testing procedure

Green CI

The change were already tested with all ESP-specific modules like `esp_now`, `esp_wifi`, `esp_spi`  and `esp_ble` for all supported ESP platforms.

### Issues/PRs references

Prerequisite for https://github.com/RIOT-OS/riotdocker/pull/227
Fixes issue #19421