### PR TITLE
makefiles/tools/serial.inc.mk: Handle new miniterm versions [backport 2023.01]

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -48,7 +48,13 @@ else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
 else ifeq ($(RIOT_TERMINAL),miniterm)
-  TERMPROG  ?= miniterm.py
+  # Check if miniterm.py is available in the path, if not use just miniterm
+  # since new versions will only have miniterm and not miniterm.py
+  ifeq (,$(shell command -v miniterm.py 2>/dev/null))
+    TERMPROG ?= miniterm
+  else
+    TERMPROG ?= miniterm.py
+  endif
   # The RIOT shell will still transmit back a CRLF, but at least with --eol LF
   # we avoid sending two lines on every "enter".
   TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)" $(MINITERMFLAGS)


### PR DESCRIPTION
# Backport of #19444



### Contribution description

While testing examples/micropython I notice that the default of miniterm.py is actually miniterm. To simplify user setups, this checks for miniterm.py first then falls back to miniterm.

### Testing procedure

Take any board with any newish version of Ubuntu and run
```
make -C flash test examples/micropython
```

If you have `miniterm.py` in `PATH` or if it is `miniterm` both should work.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
