### PR TITLE
README.md: Remove HiL Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Nightly CI status master][master-ci-badge]][master-ci-link]
-[![Nightly HiL CI overview][hil-ci-badge]][hil-ci-link]
 [![GitHub release][release-badge]][release-link]
 [![License][license-badge]][license-link]
 [![API docs][api-badge]][api-link]
@@ -165,5 +164,3 @@ https://www.riot-os.org
 [twitter-link]: https://twitter.com/RIOT_OS
 [wiki-badge]: https://img.shields.io/badge/docs-Wiki-informational.svg
 [wiki-link]: https://github.com/RIOT-OS/RIOT/wiki
-[hil-ci-link]: https://hil.riot-os.org/results/nightly/latest/overview
-[hil-ci-badge]: https://img.shields.io/badge/CI-HiL-blue


### PR DESCRIPTION
### Contribution description

Since the HAW-Hamburg hack and change to the RIOT community server the HiL is not operating.  We should remove it until it is brought back. likely with some improvements and with different links.


### Testing procedure

Before this PR: click on it  and be sad
After PR: Forget your sorrows

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
