### PR TITLE
cpu/stm32/periph_gpio_ll: Fix misleading comments

### DIFF
--- a/cpu/stm32/periph/gpio_ll.c
+++ b/cpu/stm32/periph/gpio_ll.c
@@ -16,7 +16,7 @@
  * @{
  *
  * @file
- * @brief       GPIO Low-level API implementation for the STM32 GPIO peripheral (except F1)
+ * @brief       GPIO Low-level API implementation for the STM32 GPIO peripheral
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
@@ -69,7 +69,6 @@
 #  define GPIO_BUS      APB2
 #  define GPIOAEN       RCC_APB2ENR_IOPAEN
 #endif
-
 
 static void _init_clock(gpio_port_t port)
 {

--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -16,7 +16,7 @@
  * @{
  *
  * @file
- * @brief       IRQ implementation of the GPIO Low-Level API for STM32 (except F1)
+ * @brief       IRQ implementation of the GPIO Low-Level API for STM32
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>


### PR DESCRIPTION
### Contribution description

The comments still claim STM32F1 support is missing, but this was recently added.

Also, drop an empty line to fix `too many consecutive empty lines` nitpick of the CI.

### Testing procedure

This since only changes comments, this won't effect the binaries. Technically, those comments would be Doxygen compatible comments. But as only Doxygen comments in headers are parsed, these are in practice regular plain comments.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/19407 added basic GPIO LL support for STM32F1, https://github.com/RIOT-OS/RIOT/pull/19412 added the IRQ support on top of that.