### PR TITLE
usbus/msc: fixes for synopsys dwc2 driver

### DIFF
--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -354,9 +354,6 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
 
     usbus_handler_set_flag(handler, USBUS_HANDLER_FLAG_RESET);
 
-    /* Prepare to receive first bytes from Host */
-    usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
-
     /* Auto-configure all MTD devices */
     if (CONFIG_USBUS_MSC_AUTO_MTD) {
         for (int i = 0; i < USBUS_MSC_EXPORTED_NUMOF; i++) {
@@ -384,6 +381,8 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
         }
         /* Return the number of MTD devices available on the board */
         usbus_control_slicer_put_bytes(usbus, &data, sizeof(data));
+        /* Prepare to receive first bytes from Host */
+        usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
         break;
     case USB_MSC_SETUP_REQ_BOMSR:
         DEBUG_PUTS("[msc]: TODO: implement reset setup request");

--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -384,7 +384,6 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
         }
         /* Return the number of MTD devices available on the board */
         usbus_control_slicer_put_bytes(usbus, &data, sizeof(data));
-        usbus_control_slicer_ready(usbus);
         break;
     case USB_MSC_SETUP_REQ_BOMSR:
         DEBUG_PUTS("[msc]: TODO: implement reset setup request");


### PR DESCRIPTION
### Contribution description

This PR provides two fixes for USBUS MSC driver.
9e88db7 removes a call to `usbdev_control_slicer_ready()` as this function is called by USBUS stack right after so remove this call to avoid duplication.
608d49c moves the call to `usbdev_ep_xmit()`, which prepares the bulk MSC OUT endpoint to receives data, from the `_init()` function to `USB_MSC_SETUP_REQ_GML` control request. The issue was that this endpoint was prepare to early and an USB reset might reset this setting. (This is the case for the `usbdev_synopsys_dwc2` driver) Thus the endpoint is not ready to receive data when the host send it. 

### Testing procedure
Test this PR with `tests/usbus_msc` on any board using the `usbdev_synopsys_dwc2` driver **with a FS PHY**
There is another issue with HS PHY that should be fix too.


### Issues/PRs references
None.
