### PR TITLE
usbus/msc: fixes for synopsys dwc2 [backport 2023.04]

### DIFF
--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -354,9 +354,6 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
 
     usbus_handler_set_flag(handler, USBUS_HANDLER_FLAG_RESET);
 
-    /* Prepare to receive first bytes from Host */
-    usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
-
     /* Auto-configure all MTD devices */
     if (CONFIG_USBUS_MSC_AUTO_MTD) {
         for (int i = 0; i < USBUS_MSC_EXPORTED_NUMOF; i++) {
@@ -384,6 +381,8 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
         }
         /* Return the number of MTD devices available on the board */
         usbus_control_slicer_put_bytes(usbus, &data, sizeof(data));
+        /* Prepare to receive first bytes from Host */
+        usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
         break;
     case USB_MSC_SETUP_REQ_BOMSR:
         DEBUG_PUTS("[msc]: TODO: implement reset setup request");

--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -384,7 +384,6 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
         }
         /* Return the number of MTD devices available on the board */
         usbus_control_slicer_put_bytes(usbus, &data, sizeof(data));
-        usbus_control_slicer_ready(usbus);
         break;
     case USB_MSC_SETUP_REQ_BOMSR:
         DEBUG_PUTS("[msc]: TODO: implement reset setup request");


### PR DESCRIPTION
### Contribution description
This is a backport PR containing two fixes for USBUS MSC driver so it can works with `usbdev_synopsys_dwc2` driver
See #19455 for more context.


### Testing procedure
Same as #19455 

### Issues/PRs references
See #19455 
