### PR TITLE
sys/usbus/msc: fix EP sizes for USB HS and buffer alignment in DMA-mode

### DIFF
--- a/sys/include/usb/usbus/msc.h
+++ b/sys/include/usb/usbus/msc.h
@@ -32,6 +32,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief USBUS MSC bulk data endpoint size.
+ */
+#if defined(MODULE_PERIPH_USBDEV_HS_UTMI) || defined(MODULE_PERIPH_USBDEV_HS_ULPI)
+#define USBUS_MSC_EP_DATA_SIZE  512
+#else
+#define USBUS_MSC_EP_DATA_SIZE  64
+#endif
+
+/**
  * @brief Number of IN EPs required for the MSC interface
  */
 #define USBUS_MSC_EP_IN_REQUIRED_NUMOF   1


### PR DESCRIPTION
### Contribution description

This PR fixes the EP data sizes for the bulk endpoints of USB HS peripherals and the buffer alignment required in DMA mode.

The fixes are required to get USBUS MSC working with USB HS peripherals.

### Testing procedure

The test requires PR #19459.

Connect a SPI SD Card interface with a STM32 board with USB HS port and HS PHY and use `tests/usbus_msc` to test, for example:
```
USEMODULE='sdcard_spi mtd_sdcard_default periph_usbdev_hs_ulpi' \
CFLAGS='-DSDCARD_SPI_PARAM_CLK=GPIO_PIN\(PORT_I,1\) -DSDCARD_SPI_PARAM_MISO=GPIO_PIN\(PORT_B,14\) -DSDCARD_SPI_PARAM_MOSI=GPIO_PIN\(PORT_B,15\) -DSDCARD_SPI_PARAM_CS=GPIO_PIN\(PORT_A,8\)' \
BOARD=stm32f746g-disco make -j8 -C tests/usbus_msc flash
```
SD card should work with this PR.

### Issues/PRs references
