### PR TITLE
drivers/mtd: use XFA for pointers to defined MTDs

### DIFF
--- a/boards/adafruit-grand-central-m4-express/board.c
+++ b/boards/adafruit-grand-central-m4-express/board.c
@@ -59,7 +59,7 @@ static mtd_spi_nor_t samd51_nor_dev = {
     .params = &_samd51_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+MTD_XFA_ADD(samd51_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 VFS_AUTO_MOUNT(littlefs2, VFS_MTD(samd51_nor_dev), VFS_DEFAULT_NVM(0), 0);

--- a/boards/adafruit-itsybitsy-m4/board.c
+++ b/boards/adafruit-itsybitsy-m4/board.c
@@ -54,7 +54,7 @@ static mtd_spi_nor_t samd51_nor_dev = {
     .params = &_samd51_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+MTD_XFA_ADD(samd51_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 VFS_AUTO_MOUNT(littlefs2, VFS_MTD(samd51_nor_dev), VFS_DEFAULT_NVM(0), 0);

--- a/boards/adafruit-pybadge/board.c
+++ b/boards/adafruit-pybadge/board.c
@@ -54,7 +54,7 @@ static mtd_spi_nor_t samd51_nor_dev = {
     .params = &_samd51_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+MTD_XFA_ADD(samd51_nor_dev, 0);
 #endif /* MODULE_MTD */
 
 void board_init(void)

--- a/boards/common/weact-f4x1cx/board.c
+++ b/boards/common/weact-f4x1cx/board.c
@@ -51,7 +51,7 @@ static mtd_spi_nor_t weact_nor_dev = {
     .params = &_weact_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&weact_nor_dev;
+MTD_XFA_ADD(weact_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 #include "vfs_default.h"

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -50,7 +50,7 @@ static mtd_spi_nor_t ikea_tradfri_nor_dev = {
     .params = &_ikea_tradfri_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&ikea_tradfri_nor_dev;
+MTD_XFA_ADD(ikea_tradfri_nor_dev, 0);
 #endif /* MODULE_MTD */
 
 void board_init(void)

--- a/boards/iotlab-m3/mtd.c
+++ b/boards/iotlab-m3/mtd.c
@@ -51,7 +51,7 @@ static mtd_spi_nor_t mtd_nor_dev = {
     .params = &_mtd_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd_nor_dev;
+MTD_XFA_ADD(mtd_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 #include "vfs_default.h"

--- a/boards/mcb2388/board_init.c
+++ b/boards/mcb2388/board_init.c
@@ -28,7 +28,7 @@
 #ifdef MODULE_MTD_MCI
 extern const mtd_desc_t mtd_mci_driver;
 static mtd_dev_t _mtd_mci = { .driver = &mtd_mci_driver };
-mtd_dev_t *mtd0 = &_mtd_mci;
+MTD_XFA_ADD(_mtd_mci, 0);
 #endif
 
 #ifdef MODULE_VFS_DEFAULT

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -31,7 +31,7 @@
 #ifdef MODULE_MTD_MCI
 extern const mtd_desc_t mtd_mci_driver;
 static mtd_dev_t _mtd_mci = { .driver = &mtd_mci_driver };
-mtd_dev_t *mtd0 = &_mtd_mci;
+MTD_XFA_ADD(_mtd_mci, 0);
 #endif
 
 #ifdef MODULE_VFS_DEFAULT

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -73,7 +73,7 @@ static mtd_spi_nor_t mulle_nor_dev = {
     .params = &mulle_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&mulle_nor_dev;
+MTD_XFA_ADD(mulle_nor_dev, 0);
 
 static devfs_t mulle_nor_devfs = {
     .path = "/mtd0",

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -32,7 +32,7 @@ mtd_native_dev_t mtd0_dev = {
     .fname = MTD_NATIVE_FILENAME,
 };
 
-mtd_dev_t *mtd0 = &mtd0_dev.base;
+MTD_XFA_ADD(mtd0_dev.base, 0);
 #endif
 
 #ifdef MODULE_VFS_DEFAULT

--- a/boards/nrf52840dk/mtd.c
+++ b/boards/nrf52840dk/mtd.c
@@ -52,7 +52,7 @@ static mtd_spi_nor_t nrf52840dk_nor_dev = {
     .params = &_nrf52840dk_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&nrf52840dk_nor_dev;
+MTD_XFA_ADD(nrf52840dk_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 #include "vfs_default.h"

--- a/boards/nrf5340dk-app/board.c
+++ b/boards/nrf5340dk-app/board.c
@@ -50,7 +50,7 @@ static mtd_spi_nor_t nrf5340_nor_dev = {
     },
     .params = &_nrf5340_nor_params,
 };
-mtd_dev_t *mtd0 = (mtd_dev_t *)&nrf5340_nor_dev;
+MTD_XFA_ADD(nrf5340_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 VFS_AUTO_MOUNT(littlefs2, VFS_MTD(nrf5340_nor_dev), VFS_DEFAULT_NVM(0), 0);

--- a/boards/nrf5340dk-app/include/board.h
+++ b/boards/nrf5340dk-app/include/board.h
@@ -102,7 +102,6 @@ extern "C" {
  */
 extern mtd_dev_t *mtd0;
 #define MTD_0       mtd0
-#define MTD_NUMOF   1
 
 #define BOARD_QSPI_PIN_CS       GPIO_PIN(0, 18)     /**< SPI Flash Chip Select */
 #define BOARD_QSPI_PIN_WP       GPIO_PIN(0, 15)     /**< SPI Flash Write Protect */

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -55,7 +55,7 @@ static mtd_spi_nor_t pinetime_nor_dev = {
     .params = &_pinetime_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&pinetime_nor_dev;
+MTD_XFA_ADD(pinetime_nor_dev, 0);
 #endif /* MODULE_MTD */
 
 void board_init(void)

--- a/boards/qn9080dk/board.c
+++ b/boards/qn9080dk/board.c
@@ -55,5 +55,5 @@ static mtd_spi_nor_t mtd_nor_dev = {
     .params = &_mtd_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd_nor_dev;
+MTD_XFA_ADD(mtd_nor_dev, 0);
 #endif /* MODULE_MTD */

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -51,7 +51,7 @@ static mtd_spi_nor_t same54_nor_dev = {
     },
     .params = &_same54_nor_params,
 };
-mtd_dev_t *mtd0 = (mtd_dev_t *)&same54_nor_dev;
+MTD_XFA_ADD(same54_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 VFS_AUTO_MOUNT(littlefs2, VFS_MTD(same54_nor_dev), VFS_DEFAULT_NVM(0), 0);
@@ -69,7 +69,8 @@ static mtd_at24cxxx_t at24mac_dev = {
     .at24cxxx_eeprom = &at24cxxx_dev,
     .params = at24cxxx_params,
 };
-mtd_dev_t *mtd1 = (mtd_dev_t *)&at24mac_dev;
+MTD_XFA_ADD(at24mac_dev, 1);
+
 #endif /* MODULE_MTD_AT24CXXX */
 
 #ifdef MODULE_SAM0_SDHC
@@ -84,7 +85,7 @@ static mtd_sam0_sdhc_t sdhc_dev = {
             .wp  = GPIO_PIN(PD, 21),
         },
     };
-mtd_dev_t *mtd2 = (mtd_dev_t *)&sdhc_dev;
+MTD_XFA_ADD(sdhc_dev, 2);
 
 #ifdef MODULE_VFS_DEFAULT
 /* default to FAT */

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -75,7 +75,6 @@ extern mtd_dev_t *mtd0, *mtd1, *mtd2;
 #define MTD_0       mtd0
 #define MTD_1       mtd1
 #define MTD_2       mtd2
-#define MTD_NUMOF   3
 
 #define CONFIG_SDMMC_GENERIC_MTD_OFFSET     2   /**< mtd2 is used for SD Card */
 /** @} */

--- a/boards/samr34-xpro/board.c
+++ b/boards/samr34-xpro/board.c
@@ -57,7 +57,7 @@ static mtd_spi_nor_t _nor_dev = {
     },
     .params = &_mtd_nor_params,
 };
-mtd_dev_t *mtd0 = (mtd_dev_t *)&_nor_dev;
+MTD_XFA_ADD(_nor_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 #include "vfs_default.h"

--- a/boards/serpente/board.c
+++ b/boards/serpente/board.c
@@ -53,5 +53,5 @@ static mtd_spi_nor_t serpente_nor_dev = {
     .params = &_serpente_nor_params,
 };
 
-mtd_dev_t *mtd0 = (mtd_dev_t *)&serpente_nor_dev;
+MTD_XFA_ADD(serpente_nor_dev, 0);
 #endif /* MODULE_MTD */

--- a/cpu/esp_common/periph/flash.c
+++ b/cpu/esp_common/periph/flash.c
@@ -57,11 +57,11 @@
 #define ESP_PART_ENTRY_SIZE         0x20
 #define ESP_PART_ENTRY_MAGIC        ESP_PARTITION_MAGIC
 
-/* the external pointer to the system MTD device */
-mtd_dev_t* mtd0 = 0;
-
 static mtd_dev_t  _flash_dev;
 static mtd_desc_t _flash_driver;
+
+/* the external pointer to the system MTD device */
+MTD_XFA_ADD(_flash_dev, 0);
 
 #ifdef MODULE_VFS_DEFAULT
 #include "vfs_default.h"
@@ -204,8 +204,6 @@ void spi_flash_drive_init(void)
 
     _flash_dev.driver = &_flash_driver;
     _flash_dev.sector_count = _flash_size / _flashchip->sector_size;
-
-    mtd0 = &_flash_dev;
 
     _flash_dev.pages_per_sector = _flashchip->sector_size / _flashchip->page_size;
     _flash_dev.page_size = _flashchip->page_size;

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -75,6 +75,8 @@
 
 #include <stdint.h>
 
+#include "xfa.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -115,6 +117,56 @@ typedef struct {
     void *work_area;           /**< sector-sized buffer (only present when @ref mtd_write_page is enabled) */
 #endif
 } mtd_dev_t;
+
+/**
+ * @brief   MTD device array as XFA
+ *
+ * The array contains the addresses of all MTD devices that are defined using
+ * the @ref MTD_XFA_ADD macro, for example:
+ * ```
+ * MTD_XFA_ADD(my_dev, 0);
+ * ```
+ * The MTD devices in this array can be used for automatic functions such as
+ * with the `mtd_default` module. The i-th device in this array can then be
+ * accessed with `mtd_dev_xfa[i]`. The number of MTDs defined in this array
+ * is `XFA_LEN(mtd_dev_xfa)`.
+ */
+#if !DOXYGEN
+XFA_USE_CONST(mtd_dev_t *, mtd_dev_xfa);
+#else
+mtd_dev_t * const mtd_dev_xfa[];
+#endif
+
+/**
+ * @brief   Define MTD device pointer variable `mtd<idx>`
+ *
+ * The macro defines the MTD device pointer variable `mtd<idx>`, sets it to
+ * the address of the MTD device specified by the @p dev parameter, and adds
+ * it to the XFA of MTD device pointers @ref mtd_dev_xfa. For example
+ * ```
+ * MTD_XFA_ADD(my_dev, 1);
+ * ```
+ * defines the variable `mtd1` pointing to the device `my_dev`.
+ *
+ * The parameter @p idx is used as priority of the MTD device pointer within
+ * the XFA. That means it determines the order of the MTD device pointers
+ * within @ref mtd_dev_xfa.
+ *
+ * @note Only if each MTD device is added with a unique priority and only if the
+ *       priorities start at 0 and are used in consecutive order, the parameter
+ *       @p idx corresponds to the position of the MTD device pointer within
+ *       the @ref mtd_dev_xfa XFA and `mtd_dev_xfa[i]` points to the i-th MTD
+ *       device.
+ *
+ * @param   dev     MTD device
+ * @param   idx     Priority of the MTD device pointer within the XFA
+ */
+#define MTD_XFA_ADD(dev, idx) XFA_CONST(mtd_dev_xfa, 0) mtd_dev_t *mtd ## idx = (mtd_dev_t *)&(dev)
+
+/**
+ * @brief   Number of MTDs defined in the MTD device array in XFA
+ */
+#define MTD_NUMOF   XFA_LEN(mtd_dev_t *, mtd_dev_xfa)
 
 /**
  * @brief   MTD driver can write any data to the storage without erasing it first.

--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -33,54 +33,28 @@ extern "C" {
 #include "mtd_emulated.h"
 #endif
 
-#if !defined(MTD_NUMOF) && !DOXYGEN
-
-#if defined(MTD_3)
-#define MTD_BOARD_NUMOF     4
-#elif defined(MTD_2)
-#define MTD_BOARD_NUMOF     3
-#elif defined(MTD_1)
-#define MTD_BOARD_NUMOF     2
-#elif defined(MTD_0)
-#define MTD_BOARD_NUMOF     1
-#else
-#define MTD_BOARD_NUMOF     0
-#endif
-
-#define MTD_SDCARD_NUMOF    IS_USED(MODULE_MTD_SDCARD_DEFAULT)
-#define MTD_EMULATED_NUMOF  IS_USED(MODULE_MTD_EMULATED)
-
-/**
- * @brief   Number of MTD devices
- */
-#define MTD_NUMOF           (MTD_BOARD_NUMOF + MTD_SDCARD_NUMOF + MTD_EMULATED_NUMOF)
-
-#else
-#define MTD_BOARD_NUMOF     MTD_NUMOF
-#endif /*  !defined(MTD_NUMOF) && !DOXYGEN */
-
 #if !DOXYGEN
 
 /**
- * @brief   Declare `mtd*` according to the number of MTD devices
+ * @brief   Declare `mtd*` according to the `MTD_*` symbols defined by the board
  */
-#if MTD_NUMOF > 0
-extern mtd_dev_t *mtd0;
+#ifdef MTD_0
+extern mtd_dev_t *MTD_0;
 #endif
-#if MTD_NUMOF > 1
-extern mtd_dev_t *mtd1;
+#ifdef MTD_1
+extern mtd_dev_t *MTD_1;
 #endif
-#if MTD_NUMOF > 2
-extern mtd_dev_t *mtd2;
+#ifdef MTD_2
+extern mtd_dev_t *MTD_2;
 #endif
-#if MTD_NUMOF > 3
-extern mtd_dev_t *mtd3;
+#ifdef MTD_3
+extern mtd_dev_t *MTD_3;
 #endif
-#if MTD_NUMOF > 4
-extern mtd_dev_t *mtd4;
+#ifdef MTD_4
+extern mtd_dev_t *MTD_4;
 #endif
-#if MTD_NUMOF > 5
-extern mtd_dev_t *mtd5;
+#ifdef MTD_5
+extern mtd_dev_t *MTD_5;
 #endif
 #endif /* !DOXYGEN */
 
@@ -102,27 +76,7 @@ extern mtd_emulated_t mtd_emulated_dev0;
  */
 static inline mtd_dev_t *mtd_default_get_dev(unsigned idx)
 {
-    switch (idx) {
-#if MTD_BOARD_NUMOF > 0
-    case 0: return MTD_0;
-#endif
-#if MTD_BOARD_NUMOF > 1
-    case 1: return MTD_1;
-#endif
-#if MTD_BOARD_NUMOF > 2
-    case 2: return MTD_2;
-#endif
-#if MTD_BOARD_NUMOF > 3
-    case 3: return MTD_3;
-#endif
-#if MTD_SDCARD_NUMOF > 0
-    case MTD_BOARD_NUMOF: return (mtd_dev_t *)&mtd_sdcard_dev0;
-#endif
-#if MTD_EMULATED_NUMOF > 0
-    case MTD_BOARD_NUMOF + MTD_SDCARD_NUMOF: return (mtd_dev_t *)&mtd_emulated_dev0;
-#endif
-    }
-    return NULL;
+    return ((MTD_NUMOF != 0) && (idx < MTD_NUMOF)) ? mtd_dev_xfa[idx] : NULL;
 }
 
 #ifdef __cplusplus

--- a/drivers/include/mtd_emulated.h
+++ b/drivers/include/mtd_emulated.h
@@ -38,7 +38,10 @@ extern "C" {
  * creates the emulated MTD device `mtd_emulated_dev0` with 16 sectors, 4 pages
  * per sector and a page size of 64 bytes. The write size is always 1 byte.
  *
- * @param   n   index of the emulated MTD (results into symbol `mtd_emulated_devn`)
+ * @note The emulated devices are added to the XFA of MTD device pointers
+ *       @ref mtd_dev_xfa with priority 99 to place them at the end of the XFA.
+ *
+ * @param   n   index of the emulated MTD (results into symbol `mtd_emulated_dev<n>`)
  * @param   sc  sectors of the emulated MTD
  * @param   pps pages per sector of the emulated MTD
  * @param   ps  page size in bytes
@@ -57,7 +60,9 @@ extern "C" {
         .size = sc * pps * ps,                          \
         .memory = _mtd_emulated_memory ## n,            \
         .init_done = false,                             \
-    }                                                   \
+    };                                                  \
+                                                        \
+    XFA_CONST(mtd_dev_xfa, 99) mtd_dev_t CONCAT(*mtd_emulated, n) = (mtd_dev_t *)&mtd_emulated_dev ## n
 
 #if MODULE_VFS_AUTO_MOUNT || DOXYGEN
 /**
@@ -70,7 +75,7 @@ extern "C" {
  * automatically mounts the emulated MTD `mtd_emulated_dev0` with FAT file
  * system under mount point `/mtde0` with unique index 2.
  *
- * @param   n   index of the emulated MTD (symbol `mtd_emulated_devn`, mount point `/mtde0`)
+ * @param   n   index of the emulated MTD (symbol `mtd_emulated_dev<n>`, mount point `/mtde0`)
  * @param   m   unique overall index of VFS mount point
  * @param   fs  filesystem type used
  */

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -28,6 +28,10 @@
 
 #include "bitarithm.h"
 #include "mtd.h"
+#include "xfa.h"
+
+/* Automatic MTD handling */
+XFA_INIT_CONST(mtd_dev_t *, mtd_dev_xfa);
 
 static bool out_of_bounds(mtd_dev_t *mtd, uint32_t page, uint32_t offset, uint32_t len)
 {

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -241,7 +241,7 @@ const mtd_desc_t mtd_sdcard_driver = {
         .params = &sdcard_spi_params[n]     \
     };                                      \
                                             \
-    mtd_dev_t CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdcard_dev ## n
+    XFA_CONST(mtd_dev_xfa, m) mtd_dev_t CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdcard_dev ## n
 
 #define MTD_SDCARD_DEV_FS(n, m, filesystem) \
     VFS_AUTO_MOUNT(filesystem, VFS_MTD(mtd_sdcard_dev ## n), VFS_DEFAULT_SD(n), m)

--- a/drivers/mtd_sdmmc/mtd_sdmmc.c
+++ b/drivers/mtd_sdmmc/mtd_sdmmc.c
@@ -235,7 +235,7 @@ const mtd_desc_t mtd_sdmmc_driver = {
         .sdmmc_idx = n,                     \
     };                                      \
                                             \
-    mtd_dev_t CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdmmc_dev ##n
+    XFA_CONST(mtd_dev_xfa, m) mtd_dev_t CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdmmc_dev ## n
 
 #if IS_USED(MODULE_MTD_SDCARD_DEFAULT)
 /* we use /sd1 as default mount point for coexistence with mtd_sdcard */

--- a/sys/include/usb/usbus/msc.h
+++ b/sys/include/usb/usbus/msc.h
@@ -51,17 +51,6 @@ extern "C" {
 #define USBUS_MSC_EP_OUT_REQUIRED_NUMOF  1
 
 /**
- * @brief USBUS MSC Number of exported MTD device through USB
- */
-#ifndef USBUS_MSC_EXPORTED_NUMOF
-#ifdef MTD_NUMOF
-#define USBUS_MSC_EXPORTED_NUMOF MTD_NUMOF
-#else
-#define USBUS_MSC_EXPORTED_NUMOF 0
-#endif
-#endif /* USBUS_MSC_EXPORTED_NUMOF */
-
-/**
  * @brief USBUS MSC internal state machine enum
  */
 typedef enum {
@@ -102,8 +91,7 @@ typedef struct usbus_msc_device {
     uint16_t block_nb;               /**< Number of block to transfer for READ and
                                           WRITE operations */
     uint16_t block_offset;           /**< Internal offset for endpoint size chunk transfer */
-    usbus_msc_lun_t lun_dev[USBUS_MSC_EXPORTED_NUMOF];    /**< Array holding exported logical
-                                                             unit descriptor */
+    usbus_msc_lun_t *lun_dev;        /**< Array holding exported logical unit descriptor */
 } usbus_msc_device_t;
 
 /**

--- a/tests/drivers/mtd_raw/main.c
+++ b/tests/drivers/mtd_raw/main.c
@@ -281,7 +281,7 @@ static int cmd_info(int argc, char **argv)
     if (argc < 2) {
         printf("mtd devices: %d\n", MTD_NUMOF);
 
-        for (int i = 0; i < MTD_NUMOF; ++i) {
+        for (unsigned i = 0; i < MTD_NUMOF; ++i) {
             printf(" -=[ MTD_%d ]=-\n", i);
             _print_info(mtd_default_get_dev(i));
         }
@@ -450,7 +450,7 @@ int main(void)
         puts("no MTD device present on the board.");
     }
 
-    for (int i = 0; i < MTD_NUMOF; ++i) {
+    for (unsigned i = 0; i < MTD_NUMOF; ++i) {
         printf("init MTD_%d… ", i);
 
         mtd_dev_t *dev = mtd_default_get_dev(i);


### PR DESCRIPTION
### Contribution description

This PR provides the support to hold pointers to defined MTDs within a XFA. The XFA allows
- to access MTDs of different types (`mtd_flashpage`, `mtd_sdcard`, `mtd_emulated`, ...) by an index
- to determine the number of MTDs defined in the system.

### Testing procedure

To be defined once PR #19443 is merged because emulated MTDs will allow to test this PR on arbitrary boards.

### Porting Guide

For external boards:
 - remove the `MTD_NUMOF` definition from `board.h`
 - add `MTD_XFA_ADD(<mtd_dev>, <idx>);` to the definition of `<mtd_dev>`.
 - `MTD_0`, `MTD_1`, … defines are no longer needed.

### Issues/PRs references

 Related to PR #19443