### PR TITLE
sys/shell: fix missing generic lora settings in ifconfig

### DIFF
--- a/drivers/sx126x/Kconfig
+++ b/drivers/sx126x/Kconfig
@@ -14,6 +14,7 @@ menuconfig MODULE_SX126X
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
     select MODULE_IOLIST
+    select MODULE_LORA
     select MODULE_NETDEV_LEGACY_API
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ

--- a/drivers/sx126x/Makefile.dep
+++ b/drivers/sx126x/Makefile.dep
@@ -2,3 +2,5 @@ USEMODULE += iolist
 USEMODULE += netdev_legacy_api
 USEPKG += driver_sx126x
 FEATURES_REQUIRED += periph_gpio_irq
+
+USEMODULE += lora

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -215,10 +215,12 @@ static void _set_usage(char *cmd_name)
          "       * \"pan\" - alias for \"nid\"\n"
          "       * \"pan_id\" - alias for \"nid\"\n"
          "       * \"phy_busy\" - set busy mode on-off\n"
-#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
+#if IS_USED(MODULE_LORA)
          "       * \"bw\" - alias for channel bandwidth\n"
          "       * \"sf\" - alias for spreading factor\n"
          "       * \"cr\" - alias for coding rate\n"
+#endif
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
          "       * \"appkey\" - sets Application key\n"
          "       * \"appskey\" - sets Application session key\n"
 #if IS_USED(MODULE_GNRC_LORAWAN_1_1)
@@ -391,7 +393,7 @@ static void _print_netopt(netopt_t opt)
         printf("encryption key");
         break;
 
-#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
+#if IS_USED(MODULE_LORA)
     case NETOPT_BANDWIDTH:
         printf("bandwidth");
         break;
@@ -504,7 +506,7 @@ static const char *_netopt_state_str[] = {
     [NETOPT_STATE_STANDBY] = "STANDBY"
 };
 
-#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
+#if IS_USED(MODULE_LORA)
 static const char *_netopt_bandwidth_str[] = {
     [LORA_BW_125_KHZ] = "125",
     [LORA_BW_250_KHZ] = "250",
@@ -676,7 +678,7 @@ static void _netif_list(netif_t *iface)
     if (res >= 0) {
         printf(" RSSI: %d ", i16);
     }
-#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
+#if IS_USED(MODULE_LORA)
     res = netif_get_opt(iface, NETOPT_BANDWIDTH, 0, &u8, sizeof(u8));
     if (res >= 0) {
         printf(" BW: %skHz ", _netopt_bandwidth_str[u8]);
@@ -999,7 +1001,7 @@ static int _netif_set_u32(netif_t *iface, netopt_t opt, uint32_t context,
     return 0;
 }
 
-#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
+#if IS_USED(MODULE_LORA)
 static int _netif_set_bandwidth(netif_t *iface, char *value)
 {
     uint8_t bw;
@@ -1504,7 +1506,7 @@ static int _netif_set(char *cmd_name, netif_t *iface, char *key, char *value)
     else if ((strcmp("frequency", key) == 0) || (strcmp("freq", key) == 0)) {
         return _netif_set_u32(iface, NETOPT_CHANNEL_FREQUENCY, 0, value);
     }
-#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
+#if IS_USED(MODULE_LORA)
     else if ((strcmp("bandwidth", key) == 0) || (strcmp("bw", key) == 0)) {
         return _netif_set_bandwidth(iface, value);
     }
@@ -1514,6 +1516,8 @@ static int _netif_set(char *cmd_name, netif_t *iface, char *key, char *value)
     else if ((strcmp("coding_rate", key) == 0) || (strcmp("cr", key) == 0)) {
         return _netif_set_coding_rate(iface, value);
     }
+#endif
+#if IS_USED(MODULE_SHELL_CMD_GNRC_NETIF_LORAWAN)
 #if IS_USED(MODULE_GNRC_LORAWAN_1_1)
     else if (strcmp("joineui", key) == 0) {
         return _netif_set_lw_key(iface, NETOPT_LORAWAN_JOINEUI, value);

--- a/tests/Makefile.boards.netif
+++ b/tests/Makefile.boards.netif
@@ -17,6 +17,7 @@ BOARD_PROVIDES_NETIF := \
     iotlab-a8-m3 \
     iotlab-m3 \
     lobaro-lorabox \
+    lora-e5-dev \
     lsn50 \
     microbit \
     microbit-v2 \

--- a/tests/Makefile.boards.netif
+++ b/tests/Makefile.boards.netif
@@ -35,6 +35,7 @@ BOARD_PROVIDES_NETIF := \
     nucleo-f429zi \
     nucleo-f439zi \
     nucleo-f767zi \
+    nucleo-wl55jc \
     openlabs-kw41z-mini \
     openlabs-kw41z-mini-256kib \
     openmote-b \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR is fixing the missing bandwitdh, SF and CR LoRa parameter in the ifconfig command. In the `gnrc_netif.c`, they are only available when using `gnrc_lorawan` while they are more generally specific to LoRa (and there's a module for that).
So this PR basically just fixes the module used to enable them.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run the `examples/default` on a LoRa board, for example b-l072z-lrwan1 (there are a few available on iot-lab).

On master, the BW, SF and CR are missing:

<details>

```
$ IOTLAB_NODE=auto make BOARD=b-l072z-lrwan1 -C examples/default/ flash term
make: Entering directory '/work/riot/RIOT/examples/default'
Building application "default" for "b-l072z-lrwan1" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/b-l072z-lrwan1
"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/netdev
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/drivers/sx127x
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/pktdump
"make" -C /work/riot/RIOT/sys/net/link_layer/eui_provider
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/od
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/rtc_utils
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/cmds
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  49308	    132	   6004	  55444	   d894	/work/riot/RIOT/examples/default/bin/b-l072z-lrwan1/default.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,st-lrwan1,13 --flash /work/riot/RIOT/examples/default/bin/b-l072z-lrwan1/default.bin
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:st-lrwan1-13.saclay.iot-lab.info:20000' 
help
help
Command              Description
---------------------------------------
ifconfig             Configure network interfaces
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
reboot               Reboot the node
rtc                  control RTC peripheral interface
saul                 interact with sensors and actuators using SAUL
txtsnd               Sends a custom string as is over the link layer
version              Prints current RIOT_VERSION
> ifconfig
ifconfig
Iface  3  Frequency: 868299987Hz  RSSI: -157 
           TX-Power: 14dBm  State: SLEEP 
          L2-PDU:255  
          
> 
```

</details>

With this PR:

<details>

```
$ IOTLAB_NODE=auto make BOARD=b-l072z-lrwan1 -C examples/default/ flash term
make: Entering directory '/work/riot/RIOT/examples/default'
Building application "default" for "b-l072z-lrwan1" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/b-l072z-lrwan1
"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/netdev
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/drivers/sx127x
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/pktdump
"make" -C /work/riot/RIOT/sys/net/link_layer/eui_provider
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/od
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/rtc_utils
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/cmds
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  50368	    132	   6004	  56504	   dcb8	/work/riot/RIOT/examples/default/bin/b-l072z-lrwan1/default.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,st-lrwan1,13 --flash /work/riot/RIOT/examples/default/bin/b-l072z-lrwan1/default.bin
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:st-lrwan1-13.saclay.iot-lab.info:20000' 
help
help
Command              Description
---------------------------------------
ifconfig             Configure network interfaces
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
reboot               Reboot the node
rtc                  control RTC peripheral interface
saul                 interact with sensors and actuators using SAUL
txtsnd               Sends a custom string as is over the link layer
version              Prints current RIOT_VERSION
> ifconfig
ifconfig
Iface  3  Frequency: 868299987Hz  RSSI: -157  BW: 125kHz  SF: 7  CR: 4/5 
           TX-Power: 14dBm  State: SLEEP 
          L2-PDU:255  
          
```

</details>

</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~I'm too lazy to track which PR introduced this regression (because it was working before)~ I found it: #18649

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
