### PR TITLE
drivers/at86rf2xx: fix default page being ignored [backport 2023.01]

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -85,6 +85,11 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* set default channel, page and TX power */
     at86rf2xx_configure_phy(dev, AT86RF2XX_DEFAULT_CHANNEL, AT86RF2XX_DEFAULT_PAGE, AT86RF2XX_DEFAULT_TXPOWER);
 
+    /* Record the default channel page in the device descriptor */
+#if AT86RF2XX_HAVE_SUBGHZ
+    dev->page = AT86RF2XX_DEFAULT_PAGE;
+#endif
+
     /* set default options */
 
     if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {


### PR DESCRIPTION
# Backport of #19467

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR fixes the default page of the AT86rf2xx radios (subghz variants).
After restructuring the driver, it turns out the `dev->page` variable was never being set. Since we allocate drivers in the data segment, the page was always zero.
Although the `at86rf2xx_reset` function was setting the PHY configuration, changing any PHY parameter would simply set the page to zero (unless `NETOPT_CHANNEL_PAGE` is explicitly used).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure the subghz `at86rf2xx` variantes (e.g AT86RF212B) init with the default channel page (2).

EDIT: 
<details> <summary> Test results on IoT-LAB </summary>

```
1681378526.749873;samr30-1;> reboot
1681378526.750161;samr30-2;> reboot
1681378526.798788;samr30-1;main(): This is RIOT! (Version: 2023.07-devel-45-g26848-pr/at86rf2xx_fix_default_page)
1681378526.799055;samr30-2;main(): This is RIOT! (Version: 2023.07-devel-45-g26848-pr/at86rf2xx_fix_default_page)
1681378526.801973;samr30-2;RIOT network stack example application
1681378526.802162;samr30-1;RIOT network stack example application
1681378526.804745;samr30-2;All up, running the shell now
1681378526.804995;samr30-1;All up, running the shell now
ifconfig
1681378532.085210;samr30-1;> ifconfig
1681378532.085483;samr30-2;> ifconfig
1681378532.091924;samr30-1;Iface  6  HWaddr: 5F:39  Channel: 5  Page: 2  NID: 0x23  PHY: BPSK 
1681378532.092355;samr30-2;Iface  6  HWaddr: 18:7D  Channel: 5  Page: 2  NID: 0x23  PHY: BPSK 
1681378532.096573;samr30-1;          Long HWaddr: AE:7B:9E:8D:5E:E1:5F:39 
1681378532.096811;samr30-2;          Long HWaddr: BE:B1:A7:D2:75:3B:18:7D 
1681378532.103369;samr30-2;           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
1681378532.103509;samr30-1;           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
1681378532.111183;samr30-1;          AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
1681378532.111416;samr30-2;          AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
1681378532.113051;samr30-1;          6LO  IPHC  
1681378532.113207;samr30-2;          6LO  IPHC  
1681378532.116366;samr30-1;          Source address length: 8
1681378532.116443;samr30-2;          Source address length: 8
1681378532.118850;samr30-1;          Link type: wireless
1681378532.119366;samr30-2;          Link type: wireless
1681378532.125196;samr30-1;          inet6 addr: fe80::ac7b:9e8d:5ee1:5f39  scope: link  VAL
1681378532.125267;samr30-2;          inet6 addr: fe80::bcb1:a7d2:753b:187d  scope: link  VAL
1681378532.128232;samr30-1;          inet6 group: ff02::2
1681378532.128507;samr30-2;          inet6 group: ff02::2
1681378532.130584;samr30-1;          inet6 group: ff02::1
1681378532.131245;samr30-2;          inet6 group: ff02::1
1681378532.134557;samr30-1;          inet6 group: ff02::1:ffe1:5f39
1681378532.134720;samr30-2;          inet6 group: ff02::1:ff3b:187d
1681378532.137338;samr30-1;          inet6 group: ff02::1a
1681378532.137503;samr30-2;          inet6 group: ff02::1a
1681378532.138263;samr30-1;          
1681378532.138498;samr30-2;          
1681378532.141020;samr30-1;          Statistics for Layer 2
1681378532.141286;samr30-2;          Statistics for Layer 2
1681378532.144309;samr30-1;            RX packets 1  bytes 43
1681378532.144446;samr30-2;            RX packets 2  bytes 72
1681378532.149261;samr30-1;            TX packets 3 (Multicast: 3)  bytes 115
1681378532.149420;samr30-2;            TX packets 3 (Multicast: 3)  bytes 115
1681378532.151941;samr30-1;            TX succeeded 3 errors 0
1681378532.152034;samr30-2;            TX succeeded 3 errors 0
1681378532.155280;samr30-1;          Statistics for IPv6
1681378532.155353;samr30-2;          Statistics for IPv6
1681378532.157920;samr30-1;            RX packets 1  bytes 64
1681378532.158474;samr30-2;            RX packets 2  bytes 114
1681378532.162701;samr30-1;            TX packets 3 (Multicast: 3)  bytes 178
1681378532.162767;samr30-2;            TX packets 3 (Multicast: 3)  bytes 178
1681378532.165819;samr30-1;            TX succeeded 3 errors 0
1681378532.165853;samr30-1;
1681378532.165889;samr30-2;            TX succeeded 3 errors 0
1681378532.166282;samr30-2;
samr30-1;ping fe80::bcb1:a7d2:753b:187d
1681378565.235724;samr30-1;> ping fe80::bcb1:a7d2:753b:187d
1681378565.296682;samr30-1;12 bytes from fe80::bcb1:a7d2:753b:187d%6: icmp_seq=0 ttl=64 rssi=-51 dBm time=52.557 ms
1681378566.306161;samr30-1;12 bytes from fe80::bcb1:a7d2:753b:187d%6: icmp_seq=1 ttl=64 rssi=-51 dBm time=61.548 ms
1681378567.304283;samr30-1;12 bytes from fe80::bcb1:a7d2:753b:187d%6: icmp_seq=2 ttl=64 rssi=-51 dBm time=58.545 ms
1681378567.304509;samr30-1;
1681378567.308405;samr30-1;--- fe80::bcb1:a7d2:753b:187d PING statistics ---
1681378567.313934;samr30-1;3 packets transmitted, 3 packets received, 0% packet loss
1681378567.318138;samr30-1;round-trip min/avg/max = 52.557/57.550/61.548 ms
samr30-1;ifconfig 6 set page 0
1681378606.937134;samr30-1;> ifconfig 6 set page 0
1681378606.941168;samr30-1;success: set page on interface 6 to 0
samr30-1;ping fe80::bcb1:a7d2:753b:187d
1681378609.033083;samr30-1;> ping fe80::bcb1:a7d2:753b:187d
1681378612.035352;samr30-1;
1681378612.039847;samr30-1;--- fe80::bcb1:a7d2:753b:187d PING statistics ---
1681378612.044921;samr30-1;3 packets transmitted, 0 packets received, 100% packet loss
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Reported in https://forum.riot-os.org/t/at86rf2xx-default-page-being-ignored/3911/3
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
