### PR TITLE
gnrc_netif/lorawan: fix setting nwkskey via NETOPT

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -559,7 +559,7 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
     case NETOPT_LORAWAN_SNWKSINTKEY:
     case NETOPT_LORAWAN_NWKSENCKEY:
         assert(opt->data_len == LORAMAC_FNWKSINTKEY_LEN);
-        _memcpy_reversed(netif->lorawan.fnwksintkey, opt->data,
+        memcpy(netif->lorawan.fnwksintkey, opt->data,
                          LORAMAC_FNWKSINTKEY_LEN);
         break;
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes setting the `nwkskey` via `ifconfig`. As it is now, the NETOPT implementation reverses the array, which is not what we want for keys.
Therefore, this simply replaces the `_memcpy_reverse` call with regular `memcpy`.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and flash `examples/gnrc_lorawan` and set all ABP parameters using `ifconfig`:
```
ifconfig 3 set addr AAAAAAAA
ifconfig 3 set nwkskey BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
ifconfig 3 set appskey CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
ifconfig 3 -otaa
ifconfig 3 up
```

Transmit payload using `txtsnd` and make sure it is received by the network server:
```
txtsnd 3 01 RIOT
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
