### PR TITLE
native/syscalls: rename real_clock_gettime to clock_gettime

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -148,8 +148,6 @@ extern mode_t (*real_umask)(mode_t cmask);
 extern ssize_t (*real_writev)(int fildes, const struct iovec *iov, int iovcnt);
 extern ssize_t (*real_send)(int sockfd, const void *buf, size_t len, int flags);
 
-extern int (*real_clock_gettime)(clockid_t clk_id, struct timespec *tp);
-
 /**
  * data structures
  */

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -204,7 +204,7 @@ unsigned int timer_read(tim_t dev)
 
     _native_syscall_enter();
 
-    if (real_clock_gettime(CLOCK_MONOTONIC, &t) == -1) {
+    if (clock_gettime(CLOCK_MONOTONIC, &t) == -1) {
         err(EXIT_FAILURE, "timer_read: clock_gettime");
     }
 

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -106,11 +106,6 @@ mode_t (*real_umask)(mode_t cmask);
 ssize_t (*real_writev)(int fildes, const struct iovec *iov, int iovcnt);
 ssize_t (*real_send)(int sockfd, const void *buf, size_t len, int flags);
 
-#ifdef __MACH__
-#else
-int (*real_clock_gettime)(clockid_t clk_id, struct timespec *tp);
-#endif
-
 void _native_syscall_enter(void)
 {
     _native_in_syscall++;
@@ -553,8 +548,4 @@ void _native_init_syscalls(void)
     *(void **)(&real_ftell) = dlsym(RTLD_NEXT, "ftell");
     *(void **)(&real_fputc) = dlsym(RTLD_NEXT, "fputc");
     *(void **)(&real_fgetc) = dlsym(RTLD_NEXT, "fgetc");
-#ifdef __MACH__
-#else
-    *(void **)(&real_clock_gettime) = dlsym(RTLD_NEXT, "clock_gettime");
-#endif
 }


### PR DESCRIPTION
### Contribution description

When compiling RIOT for native using a recent LLVM and enabling ASAN, one might encounter "Duplicated symbol".

This is due to a name clash with `real_clock_gettime()` in compiler-rt from [LLVM](https://github.com/llvm/llvm-project/commit/f50246da651ee11fec68b2a29c3b21325cdc12b1), I renamed RIOTs `real_clock_gettime` and just default to the posix function `clock_gettime`. The wrapper existed, most likely, for consistency only.

(The best solution would probably to convince the LLVM folks to declare their symbol as `static` and refactor a bit)

### Testing procedure

Passing CI should be enough.
