### PR TITLE
sys /cpp11-compat: remove pseudo anonymous namespaces

### DIFF
--- a/sys/cpp11-compat/include/riot/chrono.hpp
+++ b/sys/cpp11-compat/include/riot/chrono.hpp
@@ -34,10 +34,6 @@
 
 namespace riot {
 
-namespace {
-constexpr uint32_t microsecs_in_sec = 1000000;
-} // namespace anaonymous
-
 /**
  * @brief A time point for timed wait, as clocks from the standard are not
  *        available on RIOT.
@@ -94,9 +90,9 @@ class time_point {
  private:
   timex_t m_handle;
   void inline adjust_overhead() {
-    auto secs = m_handle.microseconds / microsecs_in_sec;
+    auto secs = m_handle.microseconds / US_PER_SEC;
     m_handle.seconds += secs;
-    m_handle.microseconds -= (secs * microsecs_in_sec);
+    m_handle.microseconds -= (secs * US_PER_SEC);
   }
 };
 

--- a/sys/cpp11-compat/thread.cpp
+++ b/sys/cpp11-compat/thread.cpp
@@ -44,7 +44,7 @@ void thread::join() {
       m_data->joining_thread = thread_getpid();
       thread_sleep();
     }
-    m_handle = thread_uninitialized;
+    m_handle = KERNEL_PID_UNDEF;
   } else {
     throw system_error(make_error_code(errc::invalid_argument),
                        "Can not join an unjoinable thread.");
@@ -54,7 +54,7 @@ void thread::join() {
 
 void thread::detach() {
   if (joinable()) {
-    m_handle = thread_uninitialized;
+    m_handle = KERNEL_PID_UNDEF;
   } else {
     throw system_error(make_error_code(errc::invalid_argument),
                        "Can not detach an unjoinable thread.");


### PR DESCRIPTION
### Contribution description

remove pseudo anonymous namespaces in favor of defines that are used thoughout the rest of riot 

### Testing procedure

cpp test do not fail 

### Issues/PRs references

