### PR TITLE
makefiles/arch/msp430.inc.mk: Fix compilation issues with GCC 12

### DIFF
--- a/cpu/msp430_common/ldscripts/riot-msp430f1611.ld
+++ b/cpu/msp430_common/ldscripts/riot-msp430f1611.ld
@@ -1,0 +1,3 @@
+INCLUDE msp430f1611.ld
+INCLUDE msp430_common.ld
+INCLUDE xfa.ld

--- a/cpu/msp430_common/ldscripts/riot-msp430f1612.ld
+++ b/cpu/msp430_common/ldscripts/riot-msp430f1612.ld
@@ -1,0 +1,3 @@
+INCLUDE msp430f1612.ld
+INCLUDE msp430_common.ld
+INCLUDE xfa.ld

--- a/cpu/msp430_common/ldscripts/riot-msp430f1617.ld
+++ b/cpu/msp430_common/ldscripts/riot-msp430f1617.ld
@@ -1,0 +1,3 @@
+INCLUDE msp430f1617.ld
+INCLUDE msp430_common.ld
+INCLUDE xfa.ld

--- a/cpu/msp430_common/ldscripts/riot-msp430f2617.ld
+++ b/cpu/msp430_common/ldscripts/riot-msp430f2617.ld
@@ -1,0 +1,3 @@
+INCLUDE msp430f2617.ld
+INCLUDE msp430_common.ld
+INCLUDE xfa.ld

--- a/makefiles/arch/avr8.inc.mk
+++ b/makefiles/arch/avr8.inc.mk
@@ -41,10 +41,3 @@ endif
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
 OPTIONAL_CFLAGS_BLACKLIST += -gz
-
-ifeq ($(TOOLCHAIN),gnu)
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-  ifneq ($(findstring 12.,$(shell $(TARGET_ARCH)-gcc --version 2>/dev/null)),)
-    CFLAGS += --param=min-pagesize=0
-  endif
-endif

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -13,11 +13,21 @@ CFLAGS_OPT  ?= -Os
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 
+BINUTILS_VERSION := $(shell $(PREFIX)ld --version | grep -Eo '[0-9]\.[0-9]+')
+NEEDS_NEW_LINKER_SCRIPT := $(call version_is_greater_or_equal,$(BINUTILS_VERSION),2.40)
+
 LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
-LINKFLAGS += -Wl,--gc-sections -Wl,-L$(MSP430_SUPPORT_FILES)/include
-LINKFLAGS += -T $(MSP430_SUPPORT_FILES)/include/$(CPU_MODEL).ld
-LINKFLAGS += -T $(RIOTCPU)/msp430_common/ldscripts/msp430_common.ld
-LINKFLAGS += $(RIOTCPU)/msp430_common/ldscripts/xfa.ld
+LINKFLAGS += -Wl,--gc-sections
+LINKFLAGS += -Wl,-L$(MSP430_SUPPORT_FILES)/include
+LINKFLAGS += -Wl,-L$(RIOTCPU)/msp430_common/ldscripts
+
+ifeq (1,$(NEEDS_NEW_LINKER_SCRIPT))
+  LINKFLAGS += -T riot-$(CPU_MODEL).ld
+else
+  LINKFLAGS += -T $(MSP430_SUPPORT_FILES)/include/$(CPU_MODEL).ld
+  LINKFLAGS += -T $(RIOTCPU)/msp430_common/ldscripts/msp430_common.ld
+  LINKFLAGS += $(RIOTCPU)/msp430_common/ldscripts/xfa.ld
+endif
 
 OPTIONAL_CFLAGS_BLACKLIST += -fdiagnostics-color
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -32,3 +32,10 @@ endif
 
 # We use GDB for debugging
 include $(RIOTMAKE)/tools/gdb.inc.mk
+
+# Data address spaces starts at zero for all supported architectures. This fixes
+# compilation at least on MSP430 and AVR.
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+ifeq ($(GCC_VERSION),12)
+  CFLAGS += --param=min-pagesize=0
+endif


### PR DESCRIPTION
### Contribution description

This fixes the following compilation issues:

    /home/maribu/Repos/software/RIOT/cpu/msp430fxyz/periph/gpio.c: In function 'gpio_periph_mode':
    /home/maribu/Repos/software/RIOT/cpu/msp430fxyz/periph/gpio.c:95:15: error: array subscript 0 is outside array bounds of 'msp_port_isr_t[0]' [-Werror=array-bounds]
       95 |         sel = &(isrport->SEL);
          |               ^~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors

by adding `CFLAGS += --param-min-pagesize=0` for GCC 12 (same issue as already fixed for AVR).

and:

    /usr/lib/gcc/msp430-elf/12.2.0/../../../../msp430-elf/bin/ld: warning: /home/maribu/Repos/software/RIOT/cpu/msp430_common/ldscripts/xfa.ld contains output sections; did you forget -T?

by adding the missing `-T`.

### Testing procedure

The following should still work:

- `make BOARD=msb-430 -C examples/hello-world`
- `make BOARD=msb-430 -C tests/xfa flash test`

### Issues/PRs references

None