### PR TITLE
sys/shell: Fix missing dependency

### DIFF
--- a/examples/asymcute_mqttsn/Makefile
+++ b/examples/asymcute_mqttsn/Makefile
@@ -16,7 +16,6 @@ USEMODULE += gnrc_ipv6_default
 # Include MQTT-SN
 USEMODULE += asymcute
 # Add also the shell, some shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 # For testing we also include the ping command and some stats

--- a/examples/benchmark_udp/Makefile
+++ b/examples/benchmark_udp/Makefile
@@ -22,7 +22,6 @@ else
 endif
 
 # Add also the shell, some shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += netstats_l2

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -26,7 +26,6 @@ CFLAGS += -DNEEDS_PACKET_CRAFTING
 QUIET ?= 1
 
 USEMODULE += ps
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/gnrc_networking_mac/Makefile
+++ b/examples/gnrc_networking_mac/Makefile
@@ -30,7 +30,6 @@ USEMODULE += gnrc_pktdump
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 # Add also the shell, some shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += netstats_l2

--- a/examples/gnrc_networking_subnets/Makefile
+++ b/examples/gnrc_networking_subnets/Makefile
@@ -19,7 +19,6 @@ USEMODULE += gnrc_pktdump
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 # Add also the shell, some shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += netstats_l2

--- a/examples/ndn-ping/Makefile
+++ b/examples/ndn-ping/Makefile
@@ -11,7 +11,6 @@ RIOTBASE ?= $(CURDIR)/../../
 USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += random
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 USEPKG += ndn-riot

--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -33,7 +33,6 @@ ifneq (,$(DEFAULT_MQTT_PWD))
   CFLAGS += -DDEFAULT_MQTT_PWD=\"$(DEFAULT_MQTT_PWD)\"
 endif
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += netdev_default

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -18,7 +18,6 @@ USEMODULE += posix_sockets
 USEMODULE += posix_sleep
 USEMODULE += posix_inet
 # Add also the shell, some shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/examples/saul/Makefile
+++ b/examples/saul/Makefile
@@ -10,7 +10,6 @@ RIOTBASE ?= $(CURDIR)/../..
 # we want to use SAUL:
 USEMODULE += saul_default
 # include the shell:
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 # additional modules for debugging:
 USEMODULE += ps

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -334,8 +334,22 @@ ifneq (,$(filter random_cmd,$(USEMODULE)))
   USEMODULE += shell_cmd_random
 endif
 
-ifneq (,$(filter shell%,$(USEMODULE)))
-  USEMODULE += stdin
+ifneq (,$(filter shell_commands,$(USEMODULE)))
+  # shell_commands has been renamed to shell_cmds_default, but let's keep this
+  # for backward compatibility
+  USEMODULE += shell_cmds_default
+endif
+
+ifneq (,$(filter shell_cmd%,$(USEMODULE)))
+  # each and every command is a submodule of shell_cmds
+  USEMODULE += shell_cmds
+endif
+
+ifneq (,$(filter shell_cmds,$(USEMODULE)))
+  USEMODULE += shell
+endif
+
+ifneq (,$(filter shell,$(USEMODULE)))
   include $(RIOTBASE)/sys/shell/Makefile.dep
 endif
 

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -3,6 +3,10 @@ ifneq (,$(filter shell_cmd_%,$(USEMODULE)))
   USEMODULE += shell_cmds
 endif
 
+ifneq (,$(filter shell_cmds,$(USEMODULE)))
+  USEMODULE += shell
+endif
+
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   # shell_commands has been renamed to shell_cmds_default, but let's keep this
   # for backward compatibility

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -1,17 +1,4 @@
-ifneq (,$(filter shell_cmd_%,$(USEMODULE)))
-  # each and every command is a submodule of shell_cmds
-  USEMODULE += shell_cmds
-endif
-
-ifneq (,$(filter shell_cmds,$(USEMODULE)))
-  USEMODULE += shell
-endif
-
-ifneq (,$(filter shell_commands,$(USEMODULE)))
-  # shell_commands has been renamed to shell_cmds_default, but let's keep this
-  # for backward compatibility
-  USEMODULE += shell_cmds_default
-endif
+USEMODULE += stdin
 
 ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   USEMODULE += shell_cmd_sys

--- a/tests/can_trx/Makefile
+++ b/tests/can_trx/Makefile
@@ -1,7 +1,6 @@
 export APPLICATION = can_trx
 include ../Makefile.tests_common
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/congure_reno/Makefile
+++ b/tests/congure_reno/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 USEMODULE += congure_reno
 USEMODULE += congure_test
 USEMODULE += fmt
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 INCLUDES += -I$(CURDIR)

--- a/tests/congure_test/Makefile
+++ b/tests/congure_test/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 USEMODULE += congure_mock
 USEMODULE += congure_test
 USEMODULE += fmt
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 INCLUDES += -I$(CURDIR)

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -2,7 +2,6 @@ BOARD ?= nucleo-f767zi
 
 include ../Makefile.tests_common
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/cpu_cortexm_address_check/Makefile
+++ b/tests/cpu_cortexm_address_check/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED += cpu_check_address
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_at30tse75x/Makefile
+++ b/tests/driver_at30tse75x/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += at30tse75x
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ata8520e/Makefile
+++ b/tests/driver_ata8520e/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += ata8520e
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bq2429x/Makefile
+++ b/tests/driver_bq2429x/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += bq2429x
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_cc110x/Makefile
+++ b/tests/driver_cc110x/Makefile
@@ -5,7 +5,6 @@ DEVICE ?= cc1100 # The MSB-A2 uses the CC1100. New boards use CC1101
 
 # This test will rely on a human interacting with the shell, so we better add
 # the shell and some commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 # Add the device driver
 USEMODULE += $(DEVICE)

--- a/tests/driver_dfplayer/Makefile
+++ b/tests/driver_dfplayer/Makefile
@@ -2,7 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += dfplayer
 USEMODULE += event_thread
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lis2dh12/Makefile
+++ b/tests/driver_lis2dh12/Makefile
@@ -6,7 +6,6 @@ DRIVER ?= lis2dh12_spi
 USEMODULE += fmt
 USEMODULE += ztimer
 USEMODULE += ztimer_msec
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += $(DRIVER)
 

--- a/tests/driver_motor_driver/Makefile
+++ b/tests/driver_motor_driver/Makefile
@@ -3,7 +3,6 @@ BOARD ?= native
 include ../Makefile.tests_common
 
 USEMODULE += motor_driver
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += xtimer
 

--- a/tests/driver_netdev_common/Makefile.netdev.mk
+++ b/tests/driver_netdev_common/Makefile.netdev.mk
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 # Modules to include:
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -1,6 +1,5 @@
 include ../Makefile.tests_common
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += ztimer_usec

--- a/tests/driver_nrf24l01p_ng/Makefile
+++ b/tests/driver_nrf24l01p_ng/Makefile
@@ -2,7 +2,6 @@ DEBUG ?= 0
 
 include ../Makefile.tests_common
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += gnrc

--- a/tests/driver_nrfmin/Makefile
+++ b/tests/driver_nrfmin/Makefile
@@ -8,7 +8,6 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_icmpv6_echo
 # also add the shell with some basic shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 # microbit qemu failing currently

--- a/tests/driver_rn2xx3/Makefile
+++ b/tests/driver_rn2xx3/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 DRIVER ?= rn2483
 
 USEMODULE += $(DRIVER)
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_servo/Makefile
+++ b/tests/driver_servo/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += servo
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += saul_default
 

--- a/tests/driver_sht1x/Makefile
+++ b/tests/driver_sht1x/Makefile
@@ -4,7 +4,6 @@ DRIVER ?= sht11
 BOARD ?= msba2
 
 USEMODULE += $(DRIVER)
-USEMODULE += shell
 USEMODULE += saul_default
 USEMODULE += shell_cmds_default
 USEMODULE += ps

--- a/tests/driver_sx126x/Makefile
+++ b/tests/driver_sx126x/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 LORA_DRIVER ?= sx1261
 USEMODULE += $(LORA_DRIVER)
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -3,7 +3,6 @@ BOARD ?= b-l072z-lrwan1
 include ../Makefile.tests_common
 
 USEMODULE += od
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/driver_sx1280/Makefile
+++ b/tests/driver_sx1280/Makefile
@@ -5,7 +5,6 @@ include ../Makefile.tests_common
 # required modules
 USEMODULE += sx1280
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 USEMODULE += iolist

--- a/tests/memarray/Makefile
+++ b/tests/memarray/Makefile
@@ -1,8 +1,6 @@
 include ../Makefile.tests_common
 USEMODULE += memarray
 
-# Used for invoking _ps_handler
-USEMODULE += shell_cmds_default
 USEMODULE += ps
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/nimble_statconn_gnrc/Makefile
+++ b/tests/nimble_statconn_gnrc/Makefile
@@ -2,7 +2,6 @@ BOARD ?= nrf52dk
 include ../Makefile.tests_common
 
 # include shell support
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/nimble_statconn_gnrc_ext/Makefile
+++ b/tests/nimble_statconn_gnrc_ext/Makefile
@@ -2,7 +2,6 @@ BOARD ?= nrf52dk
 include ../Makefile.tests_common
 
 # include shell support
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/periph_eeprom/Makefile
+++ b/tests/periph_eeprom/Makefile
@@ -2,7 +2,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_eeprom
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default  # provides reboot command
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -7,7 +7,6 @@ FEATURES_OPTIONAL += periph_gpio_irq
 FEATURES_OPTIONAL += periph_gpio_fast_read
 FEATURES_OPTIONAL += periph_gpio_tamper_wake
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += benchmark
 

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_i2c
 FEATURES_OPTIONAL = periph_i2c_reconfigure
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += shell_cmd_i2c_scan
 USEMODULE += xtimer

--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.tests_common
 FEATURES_OPTIONAL += periph_rtc
 FEATURES_OPTIONAL += periph_gpio_irq
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 # avoid running Kconfig by default

--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -12,7 +12,6 @@ endif
 
 USEMODULE += ztimer_usec
 USEMODULE += ztimer_sec
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += schedstatistics
 

--- a/tests/pkg_edhoc_c/Makefile
+++ b/tests/pkg_edhoc_c/Makefile
@@ -28,7 +28,6 @@ USEMODULE += gnrc_icmpv6_echo
 USEMODULE += nanocoap_sock
 
 # include this for printing IP addresses
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += xtimer

--- a/tests/pkg_openwsn/Makefile
+++ b/tests/pkg_openwsn/Makefile
@@ -79,7 +79,6 @@ endif
 ## Test application Modules
 USEMODULE += ps
 USEMODULE += od_string
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 # ztimer is used instead of xtimer because it's a dependency of some

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -20,7 +20,6 @@ ifeq (,$(filter $(BOARD),$(BOARD_WITHOUT_LORAMAC_RX)))
 endif
 
 USEMODULE += auto_init_loramac
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += fmt
 

--- a/tests/pkg_tinydtls_sock_async/Makefile
+++ b/tests/pkg_tinydtls_sock_async/Makefile
@@ -22,7 +22,6 @@ USEPKG += tinydtls
 USEMODULE += prng_sha1prng
 
 # Add also the shell, some shell commands
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 # Bitfield to log open sessions

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -6,7 +6,6 @@ FEATURES_REQUIRED += riotboot
 
 # Include modules to test the bootloader
 USEMODULE += riotboot_slot
-USEMODULE += shell
 # Add shell_cmds_default to use the shell version of `test_utils_interactive_sync`
 USEMODULE += shell_cmds_default
 

--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -15,7 +15,6 @@ USEMODULE += gnrc_icmpv6_echo
 USEMODULE += nanocoap_sock
 
 # include this for printing IP addresses
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 # include riotboot modules

--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -10,7 +10,6 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN=\($(MAIN_THREAD_SIZE)\)
 USEMODULE += fmt
 USEMODULE += random
 USEMODULE += shell_cmd_random
-USEMODULE += shell
 USEMODULE += xtimer
 
 FEATURES_OPTIONAL += periph_hwrng

--- a/tests/sched_change_priority/Makefile
+++ b/tests/sched_change_priority/Makefile
@@ -2,7 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += nice
 USEMODULE += ps
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 # Use a terminal that does not introduce extra characters into the stream.

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -2,7 +2,6 @@ DEVELHELP=0
 include ../Makefile.tests_common
 
 USEMODULE += app_metadata
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/shell_ble/Makefile
+++ b/tests/shell_ble/Makefile
@@ -3,7 +3,6 @@ BOARD ?= nrf52dk
 include ../Makefile.tests_common
 
 USEMODULE += app_metadata
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -4,7 +4,6 @@ USEMODULE += sntp
 USEMODULE += gnrc_ipv6_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += netdev_default
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sock_udp_aux/Makefile
+++ b/tests/sock_udp_aux/Makefile
@@ -13,7 +13,6 @@ USEMODULE += sock_udp
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_l2
 USEMODULE += ps
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 USEMODULE += sock_aux_local

--- a/tests/stm32_bootloader/Makefile
+++ b/tests/stm32_bootloader/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = bootloader_stm32
 
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += usb_board_reset
 

--- a/tests/sys_stdio_semihosting/Makefile
+++ b/tests/sys_stdio_semihosting/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += stdio_semihosting
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/usbus_board_reset/Makefile
+++ b/tests/usbus_board_reset/Makefile
@@ -4,7 +4,6 @@ FEATURES_REQUIRED += periph_usbdev
 
 USEMODULE += app_metadata
 USEMODULE += ps
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += usb_board_reset
 USEMODULE += usbus_cdc_acm

--- a/tests/usbus_cdc_acm_stdio/Makefile
+++ b/tests/usbus_cdc_acm_stdio/Makefile
@@ -2,7 +2,6 @@ BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 USEMODULE += stdio_cdc_acm
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -5,7 +5,6 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += usbus_cdc_ecm
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 

--- a/tests/vfs_default/Makefile
+++ b/tests/vfs_default/Makefile
@@ -4,7 +4,6 @@ USEMODULE += vfs_default
 USEMODULE += vfs_auto_format
 
 USEMODULE += ps
-USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The shell commands depend on the shell module being use. This was already the case in KConfig, but was overlooked in the shell's `Makefile.dep`.

In addition, this uncovered that `tests/memarray` had a bogus dependency on shell commands without every using the shell.

### Testing procedure

Ideally binaries should not differ (except for debug section).

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/19483