### PR TITLE
usbus: remove deprecated USBUS_HANDLER_FLAG_TR_FAIL flag

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -131,15 +131,6 @@ extern "C" {
 #define USBUS_HANDLER_FLAG_SOF      (0x0002)    /**< Report SOF events */
 #define USBUS_HANDLER_FLAG_SUSPEND  (0x0004)    /**< Report suspend events */
 #define USBUS_HANDLER_FLAG_RESUME   (0x0008)    /**< Report resume from suspend */
-
-/**
- * @brief Report transfer fail
- *
- * @deprecated This event is deprecated as only a limited number of low level
- *             devices report this and it doesn't offer value for upper layer
- *             code. This flag will be removed after the 2022.07 release
- */
-#define USBUS_HANDLER_FLAG_TR_FAIL  (0x0010)
 #define USBUS_HANDLER_FLAG_TR_STALL (0x0020)    /**< Report transfer stall complete */
 /** @} */
 

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -556,13 +556,6 @@ static void _event_ep_cb(usbdev_ep_t *ep, usbdev_event_t event)
                 case USBDEV_EVENT_TR_COMPLETE:
                     _usbus_transfer_complete(usbus, ep, handler);
                     break;
-                case USBDEV_EVENT_TR_FAIL:
-                    if (usbus_handler_isset_flag(handler,
-                                                 USBUS_HANDLER_FLAG_TR_FAIL)) {
-                        handler->driver->transfer_handler(usbus, handler, ep,
-                                                          USBUS_EVENT_TRANSFER_FAIL);
-                    }
-                    break;
                 case USBDEV_EVENT_TR_STALL:
                     if (usbus_handler_isset_flag(handler,
                                                  USBUS_HANDLER_FLAG_TR_STALL)) {


### PR DESCRIPTION
### Contribution description

This PR removes the deprecated `USBUS_HANDLER_FLAG_TR_FAIL` flag.

### Testing procedure

CI should be enough.

### Issues/PRs references

Was deprecated by #17046