### PR TITLE
sys: partly refactor make dependency resolution

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -19,6 +19,9 @@ include $(RIOTBASE)/drivers/Makefile.dep
 # pull Makefile.dep of each driver modules if they exist
 -include $(sort $(USEMODULE:%=$(RIOTBASE)/drivers/%/Makefile.dep))
 
+# pull Makefile.dep of each sys modules if they exist
+-include $(sort $(USEMODULE:%=$(RIOTBASE)/sys/%/Makefile.dep))
+
 # pull dependencies from packages
 -include $(PKG_PATHS:%=%Makefile.dep)
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -680,42 +680,8 @@ ifneq (,$(filter usbus_msc,$(USEMODULE)))
   USEMODULE += mtd_write_page
 endif
 
-ifneq (,$(filter riotboot_flashwrite, $(USEMODULE)))
-  USEMODULE += riotboot_slot
-  FEATURES_REQUIRED += periph_flashpage
-endif
-
-ifneq (,$(filter riotboot_slot, $(USEMODULE)))
-  USEMODULE += riotboot_hdr
-endif
-
-ifneq (,$(filter riotboot_serial, $(USEMODULE)))
-  FEATURES_REQUIRED += periph_flashpage
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += riotboot_reset
-  USEMODULE += checksum
-endif
-
-ifneq (,$(filter riotboot_reset, $(USEMODULE)))
+ifneq (,$(filter riotboot_%, $(USEMODULE)))
   USEMODULE += riotboot
-  USEMODULE += usb_board_reset
-endif
-
-ifneq (,$(filter riotboot_hdr, $(USEMODULE)))
-  USEMODULE += checksum
-  USEMODULE += riotboot
-endif
-
-ifneq (,$(filter riotboot_usb_dfu, $(USEMODULE)))
-  USEMODULE += usbus_dfu
-  USEMODULE += riotboot_flashwrite
-  USEMODULE += ztimer_sec
-  FEATURES_REQUIRED += no_idle_thread
-  FEATURES_REQUIRED += periph_pm
-endif
-
-ifneq (,$(filter riotboot_tinyusb_dfu, $(USEMODULE)))
-  USEPKG += tinyusb
 endif
 
 ifneq (,$(filter irq_handler,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -349,10 +349,6 @@ ifneq (,$(filter shell_cmds,$(USEMODULE)))
   USEMODULE += shell
 endif
 
-ifneq (,$(filter shell,$(USEMODULE)))
-  include $(RIOTBASE)/sys/shell/Makefile.dep
-endif
-
 # Include all stdio_% dependencies after all USEMODULE += stdio_%
 include $(RIOTBASE)/makefiles/stdio.inc.mk
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -757,8 +757,4 @@ ifneq (,$(filter auto_init%,$(USEMODULE)))
   USEMODULE += preprocessor_successor
 endif
 
-ifneq (,$(filter uri_parser,$(USEMODULE)))
-  USEMODULE += fmt
-endif
-
 include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -403,9 +403,6 @@ endif
 
 ifneq (,$(filter entropy_source_%,$(USEMODULE)))
   USEMODULE += entropy_source
-  ifneq (,$(filter entropy_source_adc_noise,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_adc
-  endif
 endif
 
 ifneq (,$(filter puf_sram,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -346,10 +346,6 @@ ifneq (,$(filter telnet,$(USEMODULE)))
   USEMODULE += sock_tcp
 endif
 
-ifneq (,$(filter luid,$(USEMODULE)))
-  FEATURES_OPTIONAL += periph_cpuid
-endif
-
 ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE += universal_address
   USEMODULE += xtimer
@@ -684,10 +680,6 @@ ifneq (,$(filter gcoap_dns,$(USEMODULE)))
   USEMODULE += ipv6_addr
   USEMODULE += uri_parser
   USEMODULE += sock_util
-endif
-
-ifneq (,$(filter luid,$(USEMODULE)))
-  FEATURES_OPTIONAL += periph_cpuid
 endif
 
 ifneq (,$(filter nanocoap_dtls,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -65,10 +65,6 @@ ifneq (,$(filter debug_irq_disable,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
-ifneq (,$(filter eepreg,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_eeprom
-endif
-
 ifneq (,$(filter fmt_table,$(USEMODULE)))
   USEMODULE += fmt
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -590,10 +590,6 @@ ifneq (,$(filter nanocoap_%,$(USEMODULE)))
   USEMODULE += nanocoap
 endif
 
-ifneq (,$(filter benchmark,$(USEMODULE)))
-  USEMODULE += ztimer_usec
-endif
-
 ifneq (,$(filter skald_%,$(USEMODULE)))
   USEMODULE += skald
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -360,12 +360,6 @@ ifneq (,$(filter log_%,$(USEMODULE)))
   USEMODULE += log
 endif
 
-ifneq (,$(filter log_color,$(USEMODULE)))
-  # log_color fails to compile with -Wformat-nonliteral but this is required
-  # for the wrapped stdio that pushes the format string into progmem
-  FEATURES_BLACKLIST += arch_avr8
-endif
-
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   USEMODULE += cpp_new_delete
   USEMODULE += ztimer64_usec

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -439,18 +439,6 @@ endif
 
 ifneq (,$(filter vfs_default,$(USEMODULE)))
   USEMODULE += vfs
-  DEFAULT_MODULE += vfs_auto_mount
-endif
-
-ifneq (,$(filter vfs_util,$(USEMODULE)))
-  USEMODULE += vfs
-endif
-
-ifneq (,$(filter vfs,$(USEMODULE)))
-  USEMODULE += posix_headers
-  ifeq (native, $(BOARD))
-    USEMODULE += native_vfs
-  endif
 endif
 
 ifneq (,$(filter sock_async_event,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -745,33 +745,7 @@ ifneq (,$(filter dbgpin,$(USEMODULE)))
   FEATURES_REQUIRED += dbgpin
 endif
 
-ifneq (,$(filter fido2_ctap_%,$(USEMODULE)))
-  USEMODULE += fido2_ctap_transport
-  USEMODULE += fido2_ctap
-  ifneq (,$(filter fido2_ctap_transport_hid,$(USEMODULE)))
-      USEMODULE += ztimer64_msec
-      USEMODULE += usbus_hid
-      DISABLE_MODULE += auto_init_usbus
-  endif
-endif
-
-ifneq (,$(filter fido2_ctap,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_flashpage
-  FEATURES_REQUIRED += periph_flashpage_in_address_space
-  FEATURES_REQUIRED += periph_gpio_irq
-
-  USEPKG += tiny-asn1
-  USEPKG += tinycbor
-  USEPKG += micro-ecc
-
-  USEMODULE += mtd_flashpage
-  USEMODULE += mtd_write_page
-  USEMODULE += ztimer_msec
-  USEMODULE += event
-  USEMODULE += event_timeout_ztimer
-  USEMODULE += cipher_modes
-  USEMODULE += crypto_aes_256
-  USEMODULE += hashes
+ifneq (,$(filter fido2_ctap%,$(USEMODULE)))
   USEMODULE += fido2
 endif
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -394,25 +394,11 @@ ifneq (,$(filter evtimer_mbox,$(USEMODULE)))
   USEMODULE += core_mbox
 endif
 
-ifneq (,$(filter can,$(USEMODULE)))
-  USEMODULE += can_raw
-  ifneq (,$(filter can_mbox,$(USEMODULE)))
-    USEMODULE += core_mbox
-  endif
-  USEMODULE += memarray
-endif
-
-ifneq (,$(filter can_isotp,$(USEMODULE)))
-  USEMODULE += ztimer
-  USEMODULE += ztimer_usec
-  USEMODULE += gnrc_pktbuf
+ifneq (,$(filter can_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter conn_can,$(USEMODULE)))
   USEMODULE += can
-  USEMODULE += can_mbox
-  USEMODULE += ztimer
-  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter entropy_source_%,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -385,8 +385,8 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_reg
 endif
 
-ifneq (,$(filter senml%,$(USEMODULE)))
-  include $(RIOTBASE)/sys/senml/Makefile.dep
+ifneq (,$(filter senml_%,$(USEMODULE)))
+  USEMODULE += senml
 endif
 
 ifneq (,$(filter phydat,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -715,10 +715,6 @@ ifneq (,$(filter ztimer64%,$(USEMODULE)))
   include $(RIOTBASE)/sys/ztimer64/Makefile.dep
 endif
 
-ifneq (,$(filter evtimer,$(USEMODULE)))
-  USEMODULE += ztimer_msec
-endif
-
 # handle xtimer's deps. Needs to be done *after* ztimer
 ifneq (,$(filter xtimer,$(USEMODULE)))
   include $(RIOTBASE)/sys/xtimer/Makefile.dep

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -96,11 +96,6 @@ ifneq (,$(filter ieee802154_security,$(USEMODULE)))
   USEMODULE += cipher_modes
 endif
 
-ifneq (,$(filter trace,$(USEMODULE)))
-  USEMODULE += ztimer
-  USEMODULE += ztimer_usec
-endif
-
 ifneq (,$(filter shell_lock,$(USEMODULE)))
   USEMODULE += ztimer_msec
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -185,11 +185,6 @@ ifneq (,$(filter netdev_tap,$(USEMODULE)))
   USEMODULE += iolist
 endif
 
-ifneq (,$(filter trickle,$(USEMODULE)))
-  USEMODULE += random
-  USEMODULE += ztimer_msec
-endif
-
 ifneq (,$(filter eui_provider,$(USEMODULE)))
   USEMODULE += luid
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -697,47 +697,6 @@ ifneq (,$(filter credman_load, $(USEMODULE)))
   USEPKG += tiny-asn1
 endif
 
-ifneq (,$(filter suit,$(USEMODULE)))
-  USEPKG += nanocbor
-  USEPKG += libcose
-  USEMODULE += uuid
-
-  ifeq (,$(filter libcose_crypt_%,$(USEMODULE)))
-    USEMODULE += libcose_crypt_c25519
-  endif
-endif
-
-ifneq (,$(filter suit_transport_%, $(USEMODULE)))
-  USEMODULE += suit_transport
-  USEMODULE += suit_transport_worker
-endif
-
-ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
-  USEMODULE += nanocoap_sock
-  USEMODULE += ztimer_msec
-  USEMODULE += sock_util
-endif
-
-ifneq (,$(filter suit_transport_vfs, $(USEMODULE)))
-  USEMODULE += vfs_util
-endif
-
-ifneq (,$(filter suit_storage_%, $(USEMODULE)))
-  USEMODULE += suit_storage
-endif
-
-ifneq (,$(filter suit_storage_flashwrite, $(USEMODULE)))
-  FEATURES_REQUIRED += riotboot
-  USEMODULE += riotboot_slot
-  USEMODULE += riotboot_flashwrite
-  USEMODULE += riotboot_flashwrite_verify_sha256
-endif
-
-ifneq (,$(filter suit_storage_vfs,$(USEMODULE)))
-  USEMODULE += vfs
-  USEMODULE += mtd
-endif
-
 ifneq (,$(filter suit_%,$(USEMODULE)))
   USEMODULE += suit
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -614,46 +614,11 @@ ifneq (,$(filter cord_lc,$(USEMODULE)))
   USEMODULE += clif
 endif
 
-ifneq (,$(filter usbus,$(USEMODULE)))
-  DEFAULT_MODULE += auto_init_usbus
-  USEMODULE += core_thread_flags
-  USEMODULE += event
-  USEMODULE += luid
-  USEMODULE += fmt
-  ifeq (,$(filter usbdev_mock,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_usbdev
-  endif
-endif
-
-ifneq (,$(filter usbus_cdc_acm,$(USEMODULE)))
-  USEMODULE += tsrb
+ifneq (,$(filter usbus%,$(USEMODULE)))
   USEMODULE += usbus
-endif
-
-ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
-  USEMODULE += iolist
-  USEMODULE += fmt
-  USEMODULE += usbus
-  USEMODULE += usbus_urb
-  USEMODULE += netdev_eth
-  USEMODULE += luid
-endif
-
-ifneq (,$(filter usbus_hid,$(USEMODULE)))
-  USEMODULE += isrpipe_read_timeout
-  USEMODULE += usbus
-endif
-
-ifneq (,$(filter usbus_dfu,$(USEMODULE)))
-  FEATURES_REQUIRED += riotboot
-  USEMODULE += usbus
-  USEMODULE += riotboot_slot
-endif
-
-ifneq (,$(filter usbus_msc,$(USEMODULE)))
-  USEMODULE += usbus
-  USEMODULE += mtd
-  USEMODULE += mtd_write_page
+  # usbus is not directly in a subdirectory of sys, so we have to include the
+  # Makefile.dep manually
+  include $(RIOTBASE)/sys/usb/usbus/Makefile.dep
 endif
 
 ifneq (,$(filter riotboot_%, $(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -670,10 +670,6 @@ ifneq (,$(filter usbus_dfu,$(USEMODULE)))
   USEMODULE += riotboot_slot
 endif
 
-ifneq (,$(filter ut_process,$(USEMODULE)))
-  USEMODULE += fmt
-endif
-
 ifneq (,$(filter usbus_msc,$(USEMODULE)))
   USEMODULE += usbus
   USEMODULE += mtd

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -378,10 +378,6 @@ ifneq (,$(filter pthread,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter saul_reg,$(USEMODULE)))
-  USEMODULE += saul
-endif
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_saul
   DEFAULT_MODULE += saul_init_devs

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -100,10 +100,6 @@ ifneq (,$(filter shell_lock,$(USEMODULE)))
   USEMODULE += ztimer_msec
 endif
 
-ifneq (,$(filter ssp,$(USEMODULE)))
-  FEATURES_REQUIRED += ssp
-endif
-
 ifneq (,$(filter base64url,$(USEMODULE)))
   USEMODULE += base64
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -405,40 +405,6 @@ ifneq (,$(filter entropy_source_%,$(USEMODULE)))
   USEMODULE += entropy_source
 endif
 
-ifneq (,$(filter random,$(USEMODULE)))
-  DEFAULT_MODULE += auto_init_random
-  USEMODULE += prng
-
-  ifneq (,$(filter prng_fortuna,$(USEMODULE)))
-    USEMODULE += fortuna
-    USEMODULE += hashes
-    USEMODULE += crypto
-    ifneq (,$(filter fortuna_reseed,$(USEMODULE)))
-        USEMODULE += atomic_utils
-        USEMODULE += xtimer
-    endif
-  endif
-
-  ifneq (,$(filter prng_tinymt32,$(USEMODULE)))
-    USEMODULE += tinymt32
-  endif
-
-  ifneq (,$(filter prng_sha%prng,$(USEMODULE)))
-    USEMODULE += prng_shaxprng
-    USEMODULE += hashes
-  endif
-
-  ifneq (,$(filter prng_hwrng,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_hwrng
-  endif
-
-  ifeq (,$(filter puf_sram,$(USEMODULE)))
-    FEATURES_OPTIONAL += periph_hwrng
-  endif
-
-  USEMODULE += luid
-endif
-
 ifneq (,$(filter hashes,$(USEMODULE)))
   USEMODULE += crypto
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1,24 +1,3 @@
-ifneq (,$(filter arduino,$(USEMODULE)))
-  FEATURES_OPTIONAL += periph_adc
-  FEATURES_OPTIONAL += periph_i2c
-  FEATURES_OPTIONAL += periph_spi
-  FEATURES_REQUIRED += arduino
-  FEATURES_REQUIRED += cpp
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += arduino_sketches
-  USEMODULE += fmt
-  USEMODULE += ztimer_usec
-  USEMODULE += ztimer_msec
-  ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
-    USEMODULE += arduino_serial_stdio
-  endif
-endif
-
-ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))
-  FEATURES_REQUIRED += periph_pwm
-endif
-
 # cannot be moved to GNRC's Makefile.dep, as module name neither starts or ends with gnrc
 ifneq (,$(filter auto_init_gnrc_netif,$(USEMODULE)))
   USEMODULE += gnrc_netif_init_devs

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -29,10 +29,6 @@ ifneq (,$(filter auto_init_sock_dns,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter coding,$(USEMODULE)))
-  USEMODULE += bitfield
-endif
-
 ifneq (,$(filter congure_%,$(USEMODULE)))
   USEMODULE += congure
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -389,10 +389,6 @@ ifneq (,$(filter senml_%,$(USEMODULE)))
   USEMODULE += senml
 endif
 
-ifneq (,$(filter pm_layered,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_pm
-endif
-
 ifneq (,$(filter evtimer_mbox,$(USEMODULE)))
   USEMODULE += evtimer
   USEMODULE += core_mbox

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -680,12 +680,6 @@ ifneq (,$(filter usbus_msc,$(USEMODULE)))
   USEMODULE += mtd_write_page
 endif
 
-ifneq (,$(filter uuid,$(USEMODULE)))
-  USEMODULE += hashes
-  USEMODULE += random
-  USEMODULE += fmt
-endif
-
 ifneq (,$(filter riotboot_flashwrite, $(USEMODULE)))
   USEMODULE += riotboot_slot
   FEATURES_REQUIRED += periph_flashpage

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -405,12 +405,6 @@ ifneq (,$(filter entropy_source_%,$(USEMODULE)))
   USEMODULE += entropy_source
 endif
 
-ifneq (,$(filter puf_sram,$(USEMODULE)))
-  USEMODULE += hashes
-  USEMODULE += random
-  FEATURES_REQUIRED += puf_sram
-endif
-
 ifneq (,$(filter random,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_random
   USEMODULE += prng

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -378,11 +378,6 @@ ifneq (,$(filter pthread,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter schedstatistics,$(USEMODULE)))
-  USEMODULE += ztimer_usec
-  USEMODULE += sched_cb
-endif
-
 ifneq (,$(filter sched_round_robin,$(USEMODULE)))
 # this depends on either ztimer_usec or ztimer_msec if neither is used
 # prior to this msec is preferred

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -335,14 +335,6 @@ ifneq (,$(filter posix_inet,$(USEMODULE)))
   USEMODULE += posix_headers
 endif
 
-ifneq (,$(filter sema_inv,$(USEMODULE)))
-  USEMODULE += atomic_utils
-endif
-
-ifneq (,$(filter sema,$(USEMODULE)))
-  USEMODULE += ztimer
-endif
-
 ifneq (,$(filter sema_deprecated,$(USEMODULE)))
   USEMODULE += sema
   USEMODULE += ztimer64

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -309,10 +309,6 @@ endif
 # Include all stdio_% dependencies after all USEMODULE += stdio_%
 include $(RIOTBASE)/makefiles/stdio.inc.mk
 
-ifneq (,$(filter isrpipe,$(USEMODULE)))
-  USEMODULE += tsrb
-endif
-
 ifneq (,$(filter isrpipe_read_timeout,$(USEMODULE)))
   USEMODULE += isrpipe
   USEMODULE += ztimer_usec

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -378,15 +378,6 @@ ifneq (,$(filter pthread,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter sched_round_robin,$(USEMODULE)))
-# this depends on either ztimer_usec or ztimer_msec if neither is used
-# prior to this msec is preferred
-  ifeq (,$(filter ztimer_usec,$(USEMODULE))$(filter ztimer_msec,$(USEMODULE)))
-    USEMODULE += ztimer_msec
-  endif
-  USEMODULE += sched_runq_callback
-endif
-
 ifneq (,$(filter saul_reg,$(USEMODULE)))
   USEMODULE += saul
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -486,23 +486,6 @@ ifneq (,$(filter event_%,$(USEMODULE)))
   USEMODULE += event
 endif
 
-ifneq (,$(filter event_thread_%,$(USEMODULE)))
-  USEMODULE += event_thread
-endif
-
-ifneq (,$(filter event_timeout_ztimer,$(USEMODULE)))
-  USEMODULE += ztimer
-endif
-
-ifneq (,$(filter event_timeout,$(USEMODULE)))
-  USEMODULE += event_timeout_ztimer
-  USEMODULE += ztimer_usec
-endif
-
-ifneq (,$(filter event,$(USEMODULE)))
-  USEMODULE += core_thread_flags
-endif
-
 ifneq (,$(filter l2filter_%,$(USEMODULE)))
   USEMODULE += l2filter
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -213,12 +213,12 @@ ifneq (,$(filter l2util,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
-ifneq (,$(filter od,$(USEMODULE)))
-  USEMODULE += fmt
-endif
-
 ifneq (,$(filter od_string,$(USEMODULE)))
   USEMODULE += od
+endif
+
+ifneq (,$(filter od,$(USEMODULE)))
+  USEMODULE += fmt
 endif
 
 ifneq (,$(filter netutils,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -389,10 +389,6 @@ ifneq (,$(filter senml_%,$(USEMODULE)))
   USEMODULE += senml
 endif
 
-ifneq (,$(filter phydat,$(USEMODULE)))
-  USEMODULE += fmt
-endif
-
 ifneq (,$(filter pm_layered,$(USEMODULE)))
   FEATURES_REQUIRED += periph_pm
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -33,26 +33,6 @@ ifneq (,$(filter congure_%,$(USEMODULE)))
   USEMODULE += congure
 endif
 
-ifneq (,$(filter congure_abe,$(USEMODULE)))
-  USEMODULE += congure_reno_methods
-endif
-
-ifneq (,$(filter congure_quic,$(USEMODULE)))
-  USEMODULE += ztimer_msec
-endif
-
-ifneq (,$(filter congure_test,$(USEMODULE)))
-  USEMODULE += fmt
-endif
-
-ifneq (,$(filter congure_reno,$(USEMODULE)))
-  USEMODULE += congure_reno_methods
-endif
-
-ifneq (,$(filter congure_reno_methods,$(USEMODULE)))
-  USEMODULE += seq
-endif
-
 ifneq (,$(filter crc16_fast,$(USEMODULE)))
   USEMODULE += checksum
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -360,18 +360,6 @@ ifneq (,$(filter log_%,$(USEMODULE)))
   USEMODULE += log
 endif
 
-ifneq (,$(filter cpp11-compat,$(USEMODULE)))
-  USEMODULE += cpp_new_delete
-  USEMODULE += ztimer64_usec
-  USEMODULE += timex
-  FEATURES_REQUIRED += cpp
-  FEATURES_REQUIRED += libstdcpp
-  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-    # requires 64bit for syscalls
-    USEMODULE += ztimer64_xtimer_compat
-  endif
-endif
-
 ifneq (,$(filter netstats_%, $(USEMODULE)))
   USEMODULE += netstats
 endif

--- a/sys/arduino/Makefile.dep
+++ b/sys/arduino/Makefile.dep
@@ -1,0 +1,19 @@
+FEATURES_OPTIONAL += periph_adc
+FEATURES_OPTIONAL += periph_i2c
+FEATURES_OPTIONAL += periph_spi
+FEATURES_REQUIRED += arduino
+FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_uart
+USEMODULE += arduino_sketches
+USEMODULE += fmt
+USEMODULE += ztimer_usec
+USEMODULE += ztimer_msec
+
+ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  USEMODULE += arduino_serial_stdio
+endif
+
+ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))
+  FEATURES_REQUIRED += periph_pwm
+endif

--- a/sys/benchmark/Makefile.dep
+++ b/sys/benchmark/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += ztimer_usec

--- a/sys/can/Makefile.dep
+++ b/sys/can/Makefile.dep
@@ -1,0 +1,19 @@
+USEMODULE += can_raw
+
+ifneq (,$(filter can_isotp,$(USEMODULE)))
+  USEMODULE += ztimer
+  USEMODULE += ztimer_usec
+  USEMODULE += gnrc_pktbuf
+endif
+
+ifneq (,$(filter conn_can,$(USEMODULE)))
+  USEMODULE += can_mbox
+  USEMODULE += ztimer
+  USEMODULE += ztimer_usec
+endif
+
+ifneq (,$(filter can_mbox,$(USEMODULE)))
+  USEMODULE += core_mbox
+endif
+
+USEMODULE += memarray

--- a/sys/coding/Makefile.dep
+++ b/sys/coding/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += bitfield

--- a/sys/congure/Makefile.dep
+++ b/sys/congure/Makefile.dep
@@ -1,0 +1,19 @@
+ifneq (,$(filter congure_abe,$(USEMODULE)))
+  USEMODULE += congure_reno_methods
+endif
+
+ifneq (,$(filter congure_quic,$(USEMODULE)))
+  USEMODULE += ztimer_msec
+endif
+
+ifneq (,$(filter congure_test,$(USEMODULE)))
+  USEMODULE += fmt
+endif
+
+ifneq (,$(filter congure_reno,$(USEMODULE)))
+  USEMODULE += congure_reno_methods
+endif
+
+ifneq (,$(filter congure_reno_methods,$(USEMODULE)))
+  USEMODULE += seq
+endif

--- a/sys/cpp11-compat/Makefile.dep
+++ b/sys/cpp11-compat/Makefile.dep
@@ -1,0 +1,9 @@
+USEMODULE += cpp_new_delete
+USEMODULE += ztimer64_usec
+USEMODULE += timex
+FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += libstdcpp
+ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  # requires 64bit for syscalls
+  USEMODULE += ztimer64_xtimer_compat
+endif

--- a/sys/eepreg/Makefile.dep
+++ b/sys/eepreg/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_eeprom

--- a/sys/entropy_source/Makefile.dep
+++ b/sys/entropy_source/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter entropy_source_adc_noise,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_adc
+endif

--- a/sys/event/Makefile.dep
+++ b/sys/event/Makefile.dep
@@ -1,0 +1,14 @@
+USEMODULE += core_thread_flags
+
+ifneq (,$(filter event_thread_%,$(USEMODULE)))
+  USEMODULE += event_thread
+endif
+
+ifneq (,$(filter event_timeout_ztimer,$(USEMODULE)))
+  USEMODULE += ztimer
+endif
+
+ifneq (,$(filter event_timeout,$(USEMODULE)))
+  USEMODULE += event_timeout_ztimer
+  USEMODULE += ztimer_usec
+endif

--- a/sys/evtimer/Makefile.dep
+++ b/sys/evtimer/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter evtimer,$(USEMODULE)))
+  USEMODULE += ztimer_msec
+endif

--- a/sys/fido2/Makefile.dep
+++ b/sys/fido2/Makefile.dep
@@ -1,0 +1,29 @@
+ifneq (,$(filter fido2_ctap_%,$(USEMODULE)))
+  USEMODULE += fido2_ctap_transport
+  USEMODULE += fido2_ctap
+  ifneq (,$(filter fido2_ctap_transport_hid,$(USEMODULE)))
+      USEMODULE += ztimer64_msec
+      USEMODULE += usbus_hid
+      DISABLE_MODULE += auto_init_usbus
+  endif
+endif
+
+ifneq (,$(filter fido2_ctap,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_flashpage
+  FEATURES_REQUIRED += periph_flashpage_in_address_space
+  FEATURES_REQUIRED += periph_gpio_irq
+
+  USEPKG += tiny-asn1
+  USEPKG += tinycbor
+  USEPKG += micro-ecc
+
+  USEMODULE += mtd_flashpage
+  USEMODULE += mtd_write_page
+  USEMODULE += ztimer_msec
+  USEMODULE += event
+  USEMODULE += event_timeout_ztimer
+  USEMODULE += cipher_modes
+  USEMODULE += crypto_aes_256
+  USEMODULE += hashes
+  USEMODULE += fido2
+endif

--- a/sys/isrpipe/Makefile.dep
+++ b/sys/isrpipe/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += tsrb

--- a/sys/log_color/Makefile.dep
+++ b/sys/log_color/Makefile.dep
@@ -1,0 +1,3 @@
+# log_color fails to compile with -Wformat-nonliteral but this is required
+# for the wrapped stdio that pushes the format string into progmem
+FEATURES_BLACKLIST += arch_avr8

--- a/sys/luid/Makefile.dep
+++ b/sys/luid/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_OPTIONAL += periph_cpuid

--- a/sys/od/Makefile.dep
+++ b/sys/od/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += fmt

--- a/sys/phydat/Makefile.dep
+++ b/sys/phydat/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += fmt

--- a/sys/pm_layered/Makefile.dep
+++ b/sys/pm_layered/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_pm

--- a/sys/puf_sram/Makefile.dep
+++ b/sys/puf_sram/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += hashes
+USEMODULE += random
+FEATURES_REQUIRED += puf_sram

--- a/sys/random/Makefile.dep
+++ b/sys/random/Makefile.dep
@@ -1,0 +1,31 @@
+DEFAULT_MODULE += auto_init_random
+USEMODULE += prng
+
+ifneq (,$(filter prng_fortuna,$(USEMODULE)))
+  USEMODULE += fortuna
+  USEMODULE += hashes
+  USEMODULE += crypto
+  ifneq (,$(filter fortuna_reseed,$(USEMODULE)))
+      USEMODULE += atomic_utils
+      USEMODULE += xtimer
+  endif
+endif
+
+ifneq (,$(filter prng_tinymt32,$(USEMODULE)))
+  USEMODULE += tinymt32
+endif
+
+ifneq (,$(filter prng_sha%prng,$(USEMODULE)))
+  USEMODULE += prng_shaxprng
+  USEMODULE += hashes
+endif
+
+ifneq (,$(filter prng_hwrng,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_hwrng
+endif
+
+ifeq (,$(filter puf_sram,$(USEMODULE)))
+  FEATURES_OPTIONAL += periph_hwrng
+endif
+
+USEMODULE += luid

--- a/sys/riotboot/Makefile.dep
+++ b/sys/riotboot/Makefile.dep
@@ -1,0 +1,35 @@
+ifneq (,$(filter riotboot_flashwrite, $(USEMODULE)))
+  USEMODULE += riotboot_slot
+  FEATURES_REQUIRED += periph_flashpage
+endif
+
+ifneq (,$(filter riotboot_slot, $(USEMODULE)))
+  USEMODULE += riotboot_hdr
+endif
+
+ifneq (,$(filter riotboot_serial, $(USEMODULE)))
+  FEATURES_REQUIRED += periph_flashpage
+  FEATURES_REQUIRED += periph_uart
+  USEMODULE += riotboot_reset
+  USEMODULE += checksum
+endif
+
+ifneq (,$(filter riotboot_reset, $(USEMODULE)))
+  USEMODULE += usb_board_reset
+endif
+
+ifneq (,$(filter riotboot_hdr, $(USEMODULE)))
+  USEMODULE += checksum
+endif
+
+ifneq (,$(filter riotboot_usb_dfu, $(USEMODULE)))
+  USEMODULE += usbus_dfu
+  USEMODULE += riotboot_flashwrite
+  USEMODULE += ztimer_sec
+  FEATURES_REQUIRED += no_idle_thread
+  FEATURES_REQUIRED += periph_pm
+endif
+
+ifneq (,$(filter riotboot_tinyusb_dfu, $(USEMODULE)))
+  USEPKG += tinyusb
+endif

--- a/sys/saul_reg/Makefile.dep
+++ b/sys/saul_reg/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += saul

--- a/sys/sched_round_robin/Makefile.dep
+++ b/sys/sched_round_robin/Makefile.dep
@@ -1,0 +1,7 @@
+# this depends on either ztimer_usec or ztimer_msec if neither is used
+# prior to this msec is preferred
+ifeq (,$(filter ztimer_usec,$(USEMODULE))$(filter ztimer_msec,$(USEMODULE)))
+  USEMODULE += ztimer_msec
+endif
+
+USEMODULE += sched_runq_callback

--- a/sys/schedstatistics/Makefile.dep
+++ b/sys/schedstatistics/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += ztimer_usec
+USEMODULE += sched_cb

--- a/sys/sema/Makefile.dep
+++ b/sys/sema/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += ztimer

--- a/sys/sema_inv/Makefile.dep
+++ b/sys/sema_inv/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += atomic_utils

--- a/sys/senml/Makefile.dep
+++ b/sys/senml/Makefile.dep
@@ -1,5 +1,4 @@
 ifneq (,$(filter senml_saul,$(USEMODULE)))
-  USEMODULE += senml
   USEMODULE += senml_cbor
   USEMODULE += senml_phydat
   USEMODULE += saul_reg
@@ -7,10 +6,8 @@ endif
 
 ifneq (,$(filter senml_cbor,$(USEMODULE)))
   USEPKG += nanocbor
-  USEMODULE += senml
 endif
 
 ifneq (,$(filter senml_phydat,$(USEMODULE)))
-  USEMODULE += senml
   USEMODULE += phydat
 endif

--- a/sys/ssp/Makefile.dep
+++ b/sys/ssp/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += ssp

--- a/sys/suit/Makefile.dep
+++ b/sys/suit/Makefile.dep
@@ -1,0 +1,38 @@
+USEPKG += nanocbor
+USEPKG += libcose
+USEMODULE += uuid
+
+ifeq (,$(filter libcose_crypt_%,$(USEMODULE)))
+  USEMODULE += libcose_crypt_c25519
+endif
+
+ifneq (,$(filter suit_transport_%, $(USEMODULE)))
+  USEMODULE += suit_transport
+  USEMODULE += suit_transport_worker
+endif
+
+ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
+  USEMODULE += nanocoap_sock
+  USEMODULE += ztimer_msec
+  USEMODULE += sock_util
+endif
+
+ifneq (,$(filter suit_transport_vfs, $(USEMODULE)))
+  USEMODULE += vfs_util
+endif
+
+ifneq (,$(filter suit_storage_%, $(USEMODULE)))
+  USEMODULE += suit_storage
+endif
+
+ifneq (,$(filter suit_storage_flashwrite, $(USEMODULE)))
+  FEATURES_REQUIRED += riotboot
+  USEMODULE += riotboot_slot
+  USEMODULE += riotboot_flashwrite
+  USEMODULE += riotboot_flashwrite_verify_sha256
+endif
+
+ifneq (,$(filter suit_storage_vfs,$(USEMODULE)))
+  USEMODULE += vfs
+  USEMODULE += mtd
+endif

--- a/sys/trace/Makefile.dep
+++ b/sys/trace/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += ztimer
+USEMODULE += ztimer_usec

--- a/sys/trickle/Makefile.dep
+++ b/sys/trickle/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += random
+USEMODULE += ztimer_msec

--- a/sys/uri_parser/Makefile.dep
+++ b/sys/uri_parser/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += fmt

--- a/sys/usb/usbus/Makefile.dep
+++ b/sys/usb/usbus/Makefile.dep
@@ -1,0 +1,35 @@
+DEFAULT_MODULE += auto_init_usbus
+USEMODULE += core_thread_flags
+USEMODULE += event
+USEMODULE += luid
+USEMODULE += fmt
+
+ifeq (,$(filter usbdev_mock,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_usbdev
+endif
+
+ifneq (,$(filter usbus_cdc_acm,$(USEMODULE)))
+  USEMODULE += tsrb
+endif
+
+ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
+  USEMODULE += iolist
+  USEMODULE += fmt
+  USEMODULE += usbus_urb
+  USEMODULE += netdev_eth
+  USEMODULE += luid
+endif
+
+ifneq (,$(filter usbus_hid,$(USEMODULE)))
+  USEMODULE += isrpipe_read_timeout
+endif
+
+ifneq (,$(filter usbus_dfu,$(USEMODULE)))
+  FEATURES_REQUIRED += riotboot
+  USEMODULE += riotboot_slot
+endif
+
+ifneq (,$(filter usbus_msc,$(USEMODULE)))
+  USEMODULE += mtd
+  USEMODULE += mtd_write_page
+endif

--- a/sys/ut_process/Makefile.dep
+++ b/sys/ut_process/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += fmt

--- a/sys/uuid/Makefile.dep
+++ b/sys/uuid/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += hashes
+USEMODULE += random
+USEMODULE += fmt

--- a/sys/vfs/Makefile.dep
+++ b/sys/vfs/Makefile.dep
@@ -1,0 +1,9 @@
+USEMODULE += posix_headers
+
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  DEFAULT_MODULE += vfs_auto_mount
+endif
+
+ifeq (native, $(BOARD))
+  USEMODULE += native_vfs
+endif

--- a/sys/vfs_util/Makefile.dep
+++ b/sys/vfs_util/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += vfs


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

After the discussion in #19485, I had another look at the dependency resolution in sys (I had time to spend). This (draft) PR is applying a similar approach proposed in https://github.com/RIOT-OS/RIOT/pull/19485#issuecomment-1517395822 to other modules (except those in shell, net, usb, ztimer* and xtimer).

It seems the order of resolution might make a difference in the result. This is why I'm opening this PR as a draft PR, to see what the CI has to say.

~While doing that, I noticed were not ported to Kconfig yet. This PR also adds some commits for that and could be split out in another PR if requested.~ merged in #19622 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Same modules included (there's a tool for that but I don't remember which one)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
