### PR TITLE
usbus: allow to forward EP0 transfer events to other handlers

### DIFF
--- a/bootloaders/riotboot_dfu/Makefile
+++ b/bootloaders/riotboot_dfu/Makefile
@@ -4,10 +4,6 @@ APPLICATION = riotboot_dfu
 # Add RIOTBOOT USB DFU integration
 USEMODULE += riotboot_usb_dfu
 
-# Use xtimer for scheduled reboot
-USEMODULE += ztimer
-USEMODULE += ztimer_init
-
 # USB device vendor and product ID
 # pid.codes test VID/PID, not globally unique
 

--- a/bootloaders/riotboot_dfu/main.c
+++ b/bootloaders/riotboot_dfu/main.c
@@ -26,9 +26,8 @@
 #include "panic.h"
 #include "riotboot/slot.h"
 #include "riotboot/usb_dfu.h"
-#include "ztimer.h"
-
 #include "riotboot/bootloader_selection.h"
+#include "ztimer.h"
 
 #ifdef BTN_BOOTLOADER_PIN
 #include "periph/gpio.h"
@@ -74,9 +73,9 @@ void kernel_init(void)
         }
     }
 
-    /* Init ztimer before starting DFU mode */
-    ztimer_init();
-
+    if (IS_USED(MODULE_ZTIMER)) {
+        ztimer_init();
+    }
     /* Flash the unused slot if magic word is set */
     riotboot_usb_dfu_init(0);
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -893,7 +893,6 @@ endif
 ifneq (,$(filter riotboot_usb_dfu, $(USEMODULE)))
   USEMODULE += usbus_dfu
   USEMODULE += riotboot_flashwrite
-  USEMODULE += ztimer_sec
   FEATURES_REQUIRED += no_idle_thread
   FEATURES_REQUIRED += periph_pm
 endif

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -141,6 +141,7 @@ extern "C" {
  */
 #define USBUS_HANDLER_FLAG_TR_FAIL  (0x0010)
 #define USBUS_HANDLER_FLAG_TR_STALL (0x0020)    /**< Report transfer stall complete */
+#define USBUS_HANDLER_FLAG_TR_EP0_FWD   (0x0100)    /**< Forward transfer complete */
 /** @} */
 
 /**

--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -25,9 +25,6 @@
 #include "usb/usbus/dfu.h"
 #include "riotboot/magic.h"
 #include "riotboot/usb_dfu.h"
-#ifdef MODULE_RIOTBOOT_USB_DFU
-#include "ztimer.h"
-#endif
 #include "periph/pm.h"
 
 #include "riotboot/slot.h"
@@ -45,12 +42,6 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
 static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
                               usbdev_ep_t *ep, usbus_event_transfer_t event);
 static void _init(usbus_t *usbus, usbus_handler_t *handler);
-
-#ifdef MODULE_RIOTBOOT_USB_DFU
-static void _reboot(void *arg);
-static ztimer_t scheduled_reboot = { .callback=_reboot };
-#define REBOOT_DELAY 2
-#endif
 
 #define DEFAULT_XFER_SIZE 64
 
@@ -87,14 +78,6 @@ static const usbus_descr_gen_funcs_t _dfu_descriptor = {
     },
     .len_type = USBUS_DESCR_LEN_FIXED,
 };
-
-#ifdef MODULE_RIOTBOOT_USB_DFU
-static void _reboot(void *arg)
-{
-    (void)arg;
-    pm_reboot();
-}
-#endif
 
 void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, unsigned mode)
 {
@@ -233,7 +216,6 @@ static int _dfu_class_control_req(usbus_t *usbus, usbus_dfu_device_t *dfu, usb_s
                 /* Scheduled reboot, so we can answer back dfu-util before rebooting */
                 dfu->dfu_state = USB_DFU_STATE_DFU_DL_IDLE;
 #ifdef MODULE_RIOTBOOT_USB_DFU
-                ztimer_set(ZTIMER_SEC, &scheduled_reboot, 1);
                 /* Set specific flag to forward TRANSFER_COMPLETE event to this interface */
                 usbus_handler_set_flag(&dfu->handler_ctrl, USBUS_HANDLER_FLAG_TR_EP0_FWD);
 #endif

--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -496,6 +496,13 @@ static void _handler_ep0_transfer(usbus_t *usbus, usbus_handler_t *handler,
     switch (event) {
         case USBUS_EVENT_TRANSFER_COMPLETE:
             _handle_tr_complete(usbus, ep0_handler, ep);
+            /* Forward to every handler, EP0 transfer event, except the first
+             * handler as this is the current handler used for this event */
+            for (usbus_handler_t *hdl = handler->next; hdl; hdl = hdl->next) {
+                if(usbus_handler_isset_flag(hdl, USBUS_HANDLER_FLAG_TR_EP0_FWD)) {
+                    hdl->driver->transfer_handler(usbus, hdl, ep, USBUS_EVENT_TRANSFER_COMPLETE);
+                }
+            }
             break;
         default:
             break;


### PR DESCRIPTION
### Contribution description

This PR introduces a new `usbus` handler flag to allows to forward transfer complete event from EP0 only (control endpoints) to other handlers.
The idea is to let other interfaces know the state of the transfer on these EPs. Each interface should set this flag (at any moment) so it will receive these events.

For a more real use case on DFU:
Currently, DFU uses `ztimer` for a unique purpose, schedule the reboot. At the end of the firmware transfer, `dfu-util` will request the 'DFU state' of the device. Device must answer it, then reboot to start the newly flashed application. Thus, we cannot simply reboot as soon as we fill the buffer and ready the transfer with `usbdev_ep_xmit()`. We need to wait the end of the transfer and that the host ACK it. This is why `ztimer` was used. To wait a bit, to let the transfer completes properly, then reboot. Rebooting without this small delay, leads to an error in `dfu-util` message log (but the device is correctly flashed). 
`dfu-util: unable to read DFU status after completion (LIBUSB_ERROR_PIPE)`

Nevertheless, using `ztimer` for this purpose is more a workaround than a proper solution. That's why, a new flag is introduced by this PR. Each handler can set this bit at any point in time (we don't necessarily need it all the time). When the EP0 transfer event handling is done by `usbus`, it will loop through all available handlers (except the first one which is already being call, to avoid a deathloop) and forward the event to interfaces that need it.

`ztimer` is now optional for `riotboot_dfu`. It will only init `ztimer` if the dependency is pull by another module (e.g `periph_usbdev` on STM32).


If `ztimer` dependency was only pull by DFU, this PR allows to reduce the bootloader size:

```
saml21-xpro master arm-none-eabi-gcc (Arm GNU Toolchain 12.2.MPACBTI-Bet1)
   text    data     bss     dec     hex filename
  11464      20    2936   14420    3854 /home/dylan/work/RIOT/bootloaders/riotboot_dfu/bin/saml21-xpro/riotboot_dfu.elf
make : on quitte le répertoire « /home/dylan/work/RIOT/bootloaders/riotboot_dfu »
```

saml21-xpro w/ PR same toolchain
```
   text    data     bss     dec     hex filename
   9776       0    2816   12592    3130 /home/dylan/work/RIOT/bootloaders/riotboot_dfu/bin/saml21-xpro/riotboot_dfu.elf
make : on quitte le répertoire « /home/dylan/work/RIOT/bootloaders/riotboot_dfu »
```


### Testing procedure

Flash `riotboot_dfu` on any board that support `periph_usbdev` and `riotboot`
`make -j8 BOARD=xxxx -C bootloaders/riotboot_dfu flash`

Reboot into bootloader by resetting your board while pushing on BTN0.

Then flash any test app on your board through DFU:
`PROGRAMMER=dfu-util USEMODULE=usbus_dfu make -j8 BOARD=xxxx -C tests/shell riotboot/flash-slot1`

Board should reboot automatically and start the newly flashed test application.
No error message are reported by `dfu-util`

### Issues/PRs references
None.
