### PR TITLE
makefiles/features_modules: ignore periph_wdt_auto_start

### DIFF
--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -40,6 +40,7 @@ PERIPH_IGNORE_MODULES := \
   periph_uart_collision \
   periph_uart_rxstart_irq \
   periph_wdog \
+  periph_wdt_auto_start \
   #
 PERIPH_MODULES := $(filter-out $(PERIPH_IGNORE_MODULES),\
                                $(filter periph_%,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`periph_wdt_auto_start` is not a feature but a pseudo-module that indicates that the Watchdog should be initialized in early boot.


### Testing procedure

Add

    USEMODULE += auto_init_wdt_thread

to your application.


### Issues/PRs references

fixes build error introduced with #19234
