### PR TITLE
sys/vfs: Drop dependency to posix headers

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -611,7 +611,6 @@ ifneq (,$(filter vfs_util,$(USEMODULE)))
 endif
 
 ifneq (,$(filter vfs,$(USEMODULE)))
-  USEMODULE += posix_headers
   ifeq (native, $(BOARD))
     USEMODULE += native_vfs
   endif

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -64,7 +64,11 @@
 #endif
 #include <sys/stat.h> /* for struct stat */
 #include <sys/types.h> /* for off_t etc. */
-#include <sys/statvfs.h> /* for struct statvfs */
+
+#ifdef CPU_NATIVE
+/* on native, use system's struct statvfs definition */
+#include <sys/statvfs.h>
+#endif
 
 #include "sched.h"
 #include "clist.h"
@@ -338,6 +342,43 @@ extern const vfs_file_ops_t mtd_vfs_ops;
  * @brief   File system always wants the full VFS path
  */
 #define VFS_FS_FLAG_WANT_ABS_PATH   (1 << 0)
+
+#ifndef CPU_NATIVE
+/* on native, use system's struct statvfs definition */
+
+/**
+ * @brief   File system information
+ *
+ * @details This structure is intentionally compatible with POSIX's
+ *          `struct statvfs` to avoid conversion when accessing VFS stats
+ *          through the POSIX compatibility layer
+ */
+struct statvfs {
+    unsigned long f_bsize;   /**< File system block size. */
+    unsigned long f_frsize;  /**< Fundamental file system block size. */
+    fsblkcnt_t f_blocks;     /**< Total number of blocks on file system in
+                                  units of @c f_frsize. */
+    fsblkcnt_t f_bfree;      /**< Total number of free blocks. */
+    fsblkcnt_t f_bavail;     /**< Number of free blocks available to
+                                  non-privileged process. */
+    fsfilcnt_t f_files;      /**< Total number of file serial numbers. */
+    fsfilcnt_t f_ffree;      /**< Total number of free file serial numbers. */
+    fsfilcnt_t f_favail;     /**< Number of file serial numbers available to
+                                  non-privileged process. */
+
+    unsigned long f_fsid;    /**< File system ID. */
+    unsigned long f_flag;    /**< Bit mask of f_flag values. */
+    unsigned long f_namemax; /**< Maximum filename length. */
+};
+
+/**
+ * @brief   Enumeration of values for use in struct statvfs::f_flag
+ */
+enum {
+    ST_RDONLY = 1,          /**< Mount read-only. */
+    ST_NOSUID = 2,          /**< Ignore suid and sgid bits. */
+};
+#endif /* CPU_NATIVE */
 
 /**
  * @brief A file system driver

--- a/sys/posix/include/sys/statvfs.h
+++ b/sys/posix/include/sys/statvfs.h
@@ -23,6 +23,7 @@
 #define SYS_STATVFS_H
 
 #include <sys/types.h> /* for fsblkcnt_t, fsfilcnt_t */
+#include "vfs.h" /* for struct statvfs */
 #if MODULE_NEWLIB
 /* newlib support for fsblkcnt_t was only recently added to the newlib git
  * repository, commit f3e587d30a9f65d0c6551ad14095300f6e81672e, 15 apr 2016.
@@ -39,32 +40,6 @@ typedef uint32_t fsfilcnt_t;
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief File system information
- */
-struct statvfs {
-    unsigned long f_bsize;   /**< File system block size. */
-    unsigned long f_frsize;  /**< Fundamental file system block size. */
-    fsblkcnt_t f_blocks;     /**< Total number of blocks on file system in
-                                  units of @c f_frsize. */
-    fsblkcnt_t f_bfree;      /**< Total number of free blocks. */
-    fsblkcnt_t f_bavail;     /**< Number of free blocks available to
-                                  non-privileged process. */
-    fsfilcnt_t f_files;      /**< Total number of file serial numbers. */
-    fsfilcnt_t f_ffree;      /**< Total number of free file serial numbers. */
-    fsfilcnt_t f_favail;     /**< Number of file serial numbers available to
-                                  non-privileged process. */
-
-    unsigned long f_fsid;    /**< File system ID. */
-    unsigned long f_flag;    /**< Bit mask of f_flag values. */
-    unsigned long f_namemax; /**< Maximum filename length. */
-};
-
-enum {
-    ST_RDONLY = 1,        /* Mount read-only.  */
-    ST_NOSUID = 2,        /* Ignore suid and sgid bits.  */
-};
 
 #ifdef __cplusplus
 }

--- a/sys/vfs/Kconfig
+++ b/sys/vfs/Kconfig
@@ -8,7 +8,6 @@
 config MODULE_VFS
     bool "Virtual File System (VFS)"
     depends on TEST_KCONFIG
-    select MODULE_POSIX_HEADERS
 
 config MODULE_VFS_DEFAULT
     bool "Use default (board specific) file systems and mount points"

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -19,7 +19,6 @@
 #include <stddef.h> /* for NULL */
 #include <sys/types.h> /* for off_t etc */
 #include <sys/stat.h> /* for struct stat */
-#include <sys/statvfs.h> /* for struct statvfs */
 #include <fcntl.h> /* for O_ACCMODE, ..., fcntl */
 #include <unistd.h> /* for STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO */
 


### PR DESCRIPTION
### Contribution description

Our POSIX compat layer provides POSIX compatible VFS stats based on RIOT VFS module. Consequently, the POSIX layer should depend on VFS, rather than VFS depending on POSIX.

This moves a struct definition to the VFS module headers and lets the POSIX compatibility layer include `vfs.h`, rather than `vfs.h` including the POSIX compat headers.

### Testing procedure

Green CI and binaries (except for debug symbols) shouldn't change.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/19495#issuecomment-1520375301