### PR TITLE
makefiles: set LTO=1 as default

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -51,8 +51,11 @@ ifeq ($(filter -std=%,$(CXXEXFLAGS)),)
   endif
 endif
 
+ifeq (, $(LTO))
+  LTO = 1
+endif
+
 ifeq ($(LTO),1)
-  $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto
   LINKFLAGS += $(LTOFLAGS) -ffunction-sections -fdata-sections
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

https://github.com/RIOT-OS/RIOT/issues/19498 brought this up again: we should enable LTO by default.

So this PR just does that, and removes the warning.

Let's see what CI uncovers...

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/19498

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
