### PR TITLE
tools/openocd: Fix handling of OPENOCD_CMD_RESET_HALT [backport 2023.04]

### DIFF
--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -40,7 +40,8 @@ endif
 
 ifneq (,$(OPENOCD_CMD_RESET_HALT))
   # Export OPENOCD_CMD_RESET_HALT only to the flash targets
-  $(call target-export-variables,flash%,OPENOCD_CMD_RESET_HALT)
+  $(call target-export-variables,flash,OPENOCD_CMD_RESET_HALT)
+  $(call target-export-variables,flash-only,OPENOCD_CMD_RESET_HALT)
 endif
 
 OPENOCD_DEBUG_TARGETS = debug debugr debug-server


### PR DESCRIPTION
# Backport of #19506

### Contribution description

The OPENOCD_CMD_RESET_HALT was not longer correctly passed to the script. This fixes the issue.

### Testing procedure

Flashing of e.g. the `cc2650-launchpad` with upstream OpenOCD should work again.

### Issues/PRs references

The change was added to https://github.com/RIOT-OS/RIOT/pull/19050 after testing the PR and before merging. I'm not sure if the fix never worked because of this, or if behavior of `target-export-variables` or GNU Make changed.