### PR TITLE
drivers/servo: Fix missing dep

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -176,6 +176,10 @@ ifneq (,$(filter sdp3x_%,$(USEMODULE)))
   USEMODULE += sdp3x
 endif
 
+ifneq (,$(filter servo_%,$(USEMODULE)))
+  USEMODULE += servo
+endif
+
 ifneq (,$(filter sht1%,$(USEMODULE)))
   USEMODULE += sht1x
 endif


### PR DESCRIPTION
### Contribution description

The servo test app uses `USEMODULE += servo` and lets the build system pick automatically the best suitable backend. If one explicitly chooses a backend e.g. via `USEMODULE += servo_timer`, this currently requires adding `USEMODULE += servo` in addition. This commit fixes the issue.

### Testing procedure

The app provided in https://github.com/RIOT-OS/RIOT/issues/19474 should now compile. (It does so for me.)

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/19474