### PR TITLE
boards/iotlab-m3: enable l3g4200d_ng

### DIFF
--- a/boards/common/iotlab/Kconfig
+++ b/boards/common/iotlab/Kconfig
@@ -24,7 +24,7 @@ config BOARD_COMMON_IOTLAB
 
     select HAVE_AT86RF231
     select HAVE_SAUL_GPIO
-    select HAVE_L3G4200D
+    select HAVE_L3G4200D_NG
     select HAVE_LSM303DLHC
 
 config CLOCK_HSE

--- a/boards/common/iotlab/Makefile.dep
+++ b/boards/common/iotlab/Makefile.dep
@@ -4,6 +4,6 @@ endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
-  USEMODULE += l3g4200d
+  USEMODULE += l3gxxxx l3g4200d_ng
   USEMODULE += lsm303dlhc
 endif

--- a/drivers/include/l3gxxxx.h
+++ b/drivers/include/l3gxxxx.h
@@ -976,7 +976,7 @@ extern "C"
 #include "l3gxxxx_regs.h"
 
 #if !IS_USED(MODULE_L3GD20H) && !IS_USED(MODULE_L3GD20) \
-                             && !IS_USED(MODULE_L3G4200_NG) \
+                             && !IS_USED(MODULE_L3G4200D_NG) \
                              && !IS_USED(MODULE_A3G4250D) \
                              && !IS_USED(MODULE_I3G4250D)
 #error Please select your sensor variant by using the respective pseudomodule.

--- a/drivers/l3gxxxx/l3gxxxx.c
+++ b/drivers/l3gxxxx/l3gxxxx.c
@@ -931,7 +931,7 @@ static int _is_available(l3gxxxx_t *dev)
         case L3GXXXX_CHIP_ID_L3GD20:   dev->sensor = L3GD20;
                                        break;
 #endif
-#if IS_USED(MODULE_L3G4200D) || IS_USED(MODULE_I3G4250D) || IS_USED(MODULE_A3G4250D)
+#if IS_USED(MODULE_L3G4200D_NG) || IS_USED(MODULE_I3G4250D) || IS_USED(MODULE_A3G4250D)
         case L3GXXXX_CHIP_ID_X3G42XXD: dev->sensor = X3G42XXD;
                                        break;
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We can use the more capable `l3gxxxx` driver here, so enable it.

### Testing procedure

The sensor is listed and can be read.

``` 
> saul
ID	Class		Name
#0	ACT_SWITCH	LED(red)
#1	ACT_SWITCH	LED(green)
#2	ACT_SWITCH	LED(orange)
#3	SENSE_LIGHT	isl29020
#4	SENSE_GYRO	l3gxxxx
#5	SENSE_PRESS	lps331ap
#6	SENSE_TEMP	lps331ap
#7	SENSE_ACCEL	lsm303dlhc
#8	SENSE_MAG	lsm303dlhc

> saul read 4
Reading from #4 (l3gxxxx|SENSE_GYRO)
Data:	[0]         0.0 dps
	[1]         0.0 dps
	[2]         0.1 dps
``` 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
