### PR TITLE
semtech-loramac: extend list of supported radio with sx1261, sx1262 and sx1268

### DIFF
--- a/examples/lorawan/README.md
+++ b/examples/lorawan/README.md
@@ -39,7 +39,7 @@ Use the `BOARD`, `DRIVER` and `LORA_REGION` make variables to adapt the applicat
 to your hardware setup and region of use:
 
 - `BOARD` can be one of the nucleo-64 boards
-- `DRIVER` can be either `sx1276` or `sx1272`
+- `DRIVER` can be either `sx1261`, `sx1262`, `sx1268`, `sx1276` or `sx1272`
 - `LORA_REGION` can be `EU868`, `US915`, etc (see LoRaWAN regional parameters for
   details).
 

--- a/pkg/semtech-loramac/doc.txt
+++ b/pkg/semtech-loramac/doc.txt
@@ -13,10 +13,13 @@
  *
  * # Importing this package in an application
  *
- * This package only works with Semtech SX1272 and SX1276 radio devices. Thus,
- * in order to use it properly, the application `Makefile` must import the
- * corresponding device driver:
+ * This package works with Semtech SX1261, SX1262, SX1268, SX1272 and SX1276 radio
+ * devices. Thus, in order to use it properly, the application `Makefile` must
+ * import the corresponding device driver:
  * ```mk
+ *     USEMODULE += sx1261  # for a SX1261 radio device
+ *     USEMODULE += sx1262  # for a SX1262 radio device
+ *     USEMODULE += sx1268  # for a SX1268 radio device
  *     USEMODULE += sx1272  # for a SX1272 radio device
  *     USEMODULE += sx1276  # for a SX1276 radio device
  * ```

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -40,9 +40,10 @@ use the `set`/`get` commands in test application shell.
 
 ## Building the application
 
-The default parameters for the Semtech SX1272/SX1276 radios works as-is with
+The default parameters for the Semtech SX1261/SX1262/SX1272/SX1276 radios works as-is with
 STM32 Nucleo-64 boards and MBED LoRa shields
-([SX1276](https://os.mbed.com/components/SX1276MB1xAS/) or
+([SX1261/SX1262](https://os.mbed.com/components/SX126xMB2xAS/),
+[SX1276](https://os.mbed.com/components/SX1276MB1xAS/) or
 [SX1272](https://os.mbed.com/components/SX1272MB2xAS/)). You can also use the
 ST [b-l072z-lrwan1](http://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html)
 board.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fixes #19524 

The documentation/README update was overlooked in #16238 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read the modified files.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#19524, #16238 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
