### PR TITLE
boards/arduino-mkrwan1300: update board name to correct one

### DIFF
--- a/boards/arduino-mkrwan1300/doc.txt
+++ b/boards/arduino-mkrwan1300/doc.txt
@@ -16,10 +16,10 @@ powered by an Atmel SAMD21 microcontroller.
 
 ### Flash the board
 
-Use `BOARD=arduino-mkrgsm1400` with the `make` command.<br/>
+Use `BOARD=arduino-mkrwan1300` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=arduino-mkrgsm1400 -C examples/hello-world flash
+     make BOARD=arduino-mkrwan1300 -C examples/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The board name in the documentation for the Arduino MKR WAN 1300 is wrong (https://doc.riot-os.org/group__boards__arduino-mkrwan1300.html). I presume since it was part of a larger pull-request and simply got overlooked.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read the `doc.txt` and check that it matches the name of the board folder.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
