### PR TITLE
drivers/sdcard_spi: small cleanup

### DIFF
--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -187,24 +187,26 @@ typedef struct {
  */
 typedef struct {
     const sdcard_spi_params_t *params;    /**< parameters for pin and spi config */
-    spi_clk_t spi_clk;              /**< active SPI clock speed */
-    bool use_block_addr;            /**< true if block addressing (vs. byte addressing) is used */
-    bool init_done;                 /**< set to true once the init procedure completed successfully */
-    sd_version_t card_type;         /**< version of SD-card */
-    int csd_structure;              /**< version of the CSD register structure */
-    cid_t cid;                      /**< CID register */
-    csd_t csd;                      /**< CSD register */
+    spi_clk_t spi_clk;      /**< active SPI clock speed */
+    bool use_block_addr;    /**< true if block addressing (vs. byte addressing) is used */
+    bool init_done;         /**< set to true once the init procedure completed successfully */
+    sd_version_t card_type; /**< version of SD-card */
+    int csd_structure;      /**< version of the CSD register structure */
+    cid_t cid;              /**< CID register */
+    csd_t csd;              /**< CSD register */
 } sdcard_spi_t;
 
 /**
- * @brief              Initializes the sd-card with the given parameters in sdcard_spi_t structure.
- *                     The init procedure also takes care of initializing the spi peripheral to master
- *                     mode and performing all necessary steps to set the sd-card to spi-mode. Reading
- *                     the CID and CSD registers is also done within this routine and their
- *                     values are copied to the given sdcard_spi_t struct.
+ * @brief  Initializes the sd-card with the given parameters in sdcard_spi_t structure.
+ *
+ * The init procedure also takes care of initializing the spi peripheral to
+ * master mode and performing all necessary steps to set the sd-card to spi-mode.
+ * Reading the CID and CSD registers is also done within this routine and their
+ * values are copied to the given sdcard_spi_t struct.
  *
  * @param[out] card    the device descriptor
- * @param[in]  params  parameters for this device (pins and spi device are initialized by this driver)
+ * @param[in]  params  parameters for this device (pins and spi device are
+ *                     initialized by this driver)
  *
  * @return             0 if the card could be initialized successfully
  * @return             false if an error occurred while initializing the card
@@ -212,47 +214,54 @@ typedef struct {
 int sdcard_spi_init(sdcard_spi_t *card, const sdcard_spi_params_t *params);
 
 /**
- * @brief                 Reads data blocks (usually multiples of 512 Bytes) from card to buffer.
+ * @brief   Reads data blocks (usually multiples of 512 Bytes) from card to buffer.
  *
  * @param[in] card        Initialized sd-card struct
- * @param[in] blockaddr   Start address to read from. Independent of the actual addressing scheme of
- *                        the used card the address needs to be given as block address
- *                        (e.g. 0, 1, 2... NOT: 0, 512... ). The driver takes care of mapping to
- *                        byte addressing if needed.
- * @param[out] data       Buffer to store the read data in. The user is responsible for providing a
- *                        suitable buffer size.
- * @param[in]  blocksize  Size of data blocks. For now only 512 byte blocks are supported because
- *                        only older (SDSC) cards support variable blocksizes anyway.
- *                        With SDHC/SDXC-cards this is always fixed to 512 bytes. SDSC cards are
- *                        automatically forced to use 512 byte as blocksize by the init procedure.
+ * @param[in] blockaddr   Start address to read from. Independent of the actual
+ *                        addressing scheme of the used card the address needs
+ *                        to be given as block address (e.g. 0, 1, 2...
+ *                        NOT: 0, 512... ). The driver takes care of mapping
+ *                        to byte addressing if needed.
+ * @param[out] data       Buffer to store the read data in. The user is
+ *                        responsible for providing a suitable buffer size.
+ * @param[in]  blocksize  Size of data blocks. For now only 512 byte blocks
+ *                        are supported because only older (SDSC) cards support
+ *                        variable blocksizes anyway. With SDHC/SDXC-cards this
+ *                        is always fixed to 512 bytes. SDSC cards are
+ *                        automatically forced to use 512 byte as blocksize by
+ *                        the init procedure.
  * @param[in]  nblocks    Number of blocks to read
- * @param[out] state      Contains information about the error state if something went wrong
- *                        (if return value is lower than nblocks).
+ * @param[out] state      Contains information about the error state if
+ *                        something went wrong (if return value is lower than nblocks).
  *
- * @return                number of successfully read blocks (0 if no block was read).
+ * @return  number of successfully read blocks (0 if no block was read).
  */
 int sdcard_spi_read_blocks(sdcard_spi_t *card, uint32_t blockaddr,
                            void *data, uint16_t blocksize,
                            uint16_t nblocks, sd_rw_response_t *state);
 
 /**
- * @brief                 Writes data blocks (usually multiples of 512 Bytes) from buffer to card.
+ * @brief   Writes data blocks (usually multiples of 512 Bytes) from buffer to card.
  *
  * @param[in] card        Initialized sd-card struct
- * @param[in] blockaddr   Start address to read from. Independent of the actual addressing scheme of
- *                        the used card the address needs to be given as block address
- *                        (e.g. 0, 1, 2... NOT: 0, 512... ). The driver takes care of mapping to
+ * @param[in] blockaddr   Start address to read from. Independent of the actual
+ *                        addressing scheme of the used card the address needs
+ *                        to be given as block address (e.g. 0, 1, 2...
+ *                        NOT: 0, 512... ). The driver takes care of mapping to
  *                        byte addressing if needed.
  * @param[out] data       Buffer that contains the data to be sent.
- * @param[in]  blocksize  Size of data blocks. For now only 512 byte blocks are supported because
- *                        only older (SDSC) cards support variable blocksizes anyway.
- *                        With SDHC/SDXC-cards this is always fixed to 512 bytes. SDSC cards are
- *                        automatically forced to use 512 byte as blocksize by the init procedure.
+ * @param[in]  blocksize  Size of data blocks. For now only 512 byte blocks
+ *                        are supported because only older (SDSC) cards support
+ *                        variable blocksizes anyway. With SDHC/SDXC-cards this
+ *                        is always fixed to 512 bytes. SDSC cards are
+ *                        automatically forced to use 512 byte as blocksize by
+ *                        the init procedure.
  * @param[in]  nblocks    Number of blocks to write
- * @param[out] state      Contains information about the error state if something went wrong
+ * @param[out] state      Contains information about the error state if
+ *                        something went wrong
  *                         (if return value is lower than nblocks).
  *
- * @return                number of successfully written blocks (0 if no block was written).
+ * @return  number of successfully written blocks (0 if no block was written).
  */
 int sdcard_spi_write_blocks(sdcard_spi_t *card, uint32_t blockaddr,
                             const void *data, uint16_t blocksize,

--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -186,7 +186,7 @@ typedef struct {
  * @brief   Device descriptor for sdcard_spi
  */
 typedef struct {
-    sdcard_spi_params_t params;     /**< parameters for pin and spi config */
+    const sdcard_spi_params_t *params;    /**< parameters for pin and spi config */
     spi_clk_t spi_clk;              /**< active SPI clock speed */
     bool use_block_addr;            /**< true if block addressing (vs. byte addressing) is used */
     bool init_done;                 /**< set to true once the init procedure completed successfully */


### PR DESCRIPTION
### Contribution description

This PR provides a small cleanup:
- the copy of `sdcard_spi_params_t` is removed
- the documentation was changed to fit the 100 characters per line.

It is not necessary to hold a complete copy `sdcard_spi_params_t` in the device descriptor. Constant parameters can be used directly from ROM instead. This saves 24 bytes of RAM.

### Testing procedure

Use any board with SD Card SPI interface. The driver test should still work, for example:
```
BOARD=esp32-wrover-kit make -j8 -C tests/driver_sdcard_spi flash term
```
```
main(): This is RIOT! (Version: 2023.07-devel-176-g7213c-drivers/sdcard_spi_cleanup)
SD-card spi driver test application
insert SD-card and use 'init' command to set card to spi mode
WARNING: using 'write' or 'copy' commands WILL overwrite data on your sd-card and
almost for sure corrupt existing filesystems, partitions and contained data!
> init
Initializing SD-card at SPI_0...
[OK]
> 
```

### Issues/PRs references
