### PR TITLE
treewide: fix typos and false positives found by codespell

### DIFF
--- a/boards/e180-zg120b-tb/doc.txt
+++ b/boards/e180-zg120b-tb/doc.txt
@@ -40,7 +40,7 @@ peripherals, different energy modes and short wake-up times.
 | HWCRYPTO   | &mdash; | &mdash;         |                             | AES128/AES256, SHA1, SHA256                         |
 | RTT        | &mdash; | RTCC            |                             | 1 Hz interval. Either RTT or RTC (see below)        |
 | RTC        | &mdash; | RTCC            |                             | 1 Hz interval. Either RTC or RTT (see below)        |
-| Timer      | 0       | TIMER0 + TIMER1 |                             | TIMER0 is used as prescaler (must be adjecent)      |
+| Timer      | 0       | TIMER0 + TIMER1 |                             | TIMER0 is used as prescaler (must be adjacent)      |
 |            | 1       | LETIMER0        |                             |                                                     |
 | UART       | 0       | USART0          | RX: PA1, TX: PA0            | Default STDIO output                                |
 

--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -65,7 +65,7 @@ Pin 1 is on the top-left side with only 6 contacts.
 | RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)        |
 | RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)        |
 | SPI        | 0       | USART1          | MOSI: PD15, MISO: PD14, CLK: PD13 |                                                     |
-| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjecent)      |
+| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)      |
 |            | 1       | LETIMER0        |                                   |                                                     |
 | UART       | 0       | USART0          | RX: PB15, TX: PB14                | Default STDIO output                                |
 |            | 1       | LEUART0         | RX: PB15, TX: PB14                | Baud rate limited (see below)                       |

--- a/boards/slstk3400a/doc.txt
+++ b/boards/slstk3400a/doc.txt
@@ -67,7 +67,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART0          | MOSI: PE10, MISO: PE11, CLK: PE12 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)           |
 | UART       | 0       | USART1          | RX: PA0, TX: PF2                  | Default STDIO output                                     |
 |            | 1       | LEUART0         | RX: PD5, TX: PD4                  | Baud rate limited (see below)                            |
 

--- a/boards/slstk3401a/doc.txt
+++ b/boards/slstk3401a/doc.txt
@@ -67,7 +67,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTT        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
 |            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
 |            | 1       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |

--- a/boards/slstk3402a/doc.txt
+++ b/boards/slstk3402a/doc.txt
@@ -68,8 +68,8 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTT        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
-| Timer      | 0       | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjecent)          |
-| Timer      | 1       | TIMER0 + TIMER1   |                                | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjacent)          |
+| Timer      | 1       | TIMER0 + TIMER1   |                                | TIMER0 is used as prescaler (must be adjacent)           |
 |            | 2       | LETIMER0          |                                |                                                          |
 | UART       | 0       | USART0            | RX: PA1, TX: PA0               | Default STDIO output                                     |
 |            | 1       | LEUART0           | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |

--- a/boards/sltb001a/doc.txt
+++ b/boards/sltb001a/doc.txt
@@ -65,7 +65,7 @@ is the top-left contact, marked on the silkscreen.
 | RTT        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
 |            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
 |            | 1       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |

--- a/boards/slwstk6220a/doc.txt
+++ b/boards/slwstk6220a/doc.txt
@@ -69,7 +69,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTT        | &mdash; | RTC             |                                | Either RTT or RTC (see below)                            |
 | RTC        | &mdash; | RTC             |                                | Either RTC or RTT (see below)                            |
 | SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
-| Timer      | 0       | TIMER1 + TIMER2 |                                | TIMER1 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER1 + TIMER2 |                                | TIMER1 is used as prescaler (must be adjacent)           |
 |            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
 |            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |

--- a/boards/stk3200/doc.txt
+++ b/boards/stk3200/doc.txt
@@ -67,7 +67,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTT        | &mdash; | RTC             |                                 | Either RTT or RTC (see below)                            |
 | RTC        | &mdash; | RTC             |                                 | Either RTC or RTT (see below)                            |
 | SPI        | 0       | USART1          | MOSI: PD7, MISO: PD6, CLK: PC15 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjacent)           |
 | UART       | 0       | LEUART0         | RX: PD5, TX: PD4                | STDIO Output, Baud rate limited (see below)              |
 
 ### User interface

--- a/boards/stk3600/doc.txt
+++ b/boards/stk3600/doc.txt
@@ -71,7 +71,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTC        | &mdash; | RTC             |                                | Either RTC or RTT (see below)                            |
 | SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
 |            | 1       | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
 |            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
 |            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |

--- a/boards/stk3700/doc.txt
+++ b/boards/stk3700/doc.txt
@@ -71,7 +71,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTC        | &mdash; | RTC             |                                | Either RTC or RTT (see below)                            |
 | SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
 |            | 1       | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
 |            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
 |            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |

--- a/cpu/gd32v/periph/i2c.c
+++ b/cpu/gd32v/periph/i2c.c
@@ -362,7 +362,7 @@ int _i2c_read_cmd(i2c_t dev, uint8_t *data)
     switch (_i2c_dev[dev].state) {
     case I2C_RXB_NOT_EMPTY_BT_COMPLETE:
     case I2C_RXB_NOT_EMPTY:
-        /* RBNE is cleared by reding STAT0 followed by reading the data register */
+        /* RBNE is cleared by reading STAT0 followed by reading the data register */
         i2c->STAT0;
         *data = i2c->DATA;
         return 0;

--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -1,5 +1,5 @@
 /**
- * Multiple asynchronus read on file descriptors
+ * Multiple asynchronous read on file descriptors
  *
  * Copyright (C) 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>,
  *                    Martine Lenders <mlenders@inf.fu-berlin.de>

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Multiple asynchronus read on file descriptors
+ * @brief       Multiple asynchronous read on file descriptors
  *
  * @author      Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
  */
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   asynchronus read callback type
+ * @brief   asynchronous read callback type
  */
 typedef void (*native_async_read_callback_t)(int fd, void *arg);
 
@@ -48,14 +48,14 @@ typedef struct {
 } async_read_t;
 
 /**
- * @brief   initialize asynchronus read system
+ * @brief   initialize asynchronous read system
  *
  * This registers SIGIO signal handler.
  */
 void native_async_read_setup(void);
 
 /**
- * @brief   shutdown asynchronus read system
+ * @brief   shutdown asynchronous read system
  *
  * This deregisters SIGIO signal handler.
  */

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -246,7 +246,7 @@ typedef struct {
 typedef void (*spi_twi_irq_cb_t)(void *arg);
 
 /**
- * @brief Reqister a SPI IRQ handler for a shared I2C/SPI irq vector
+ * @brief Register a SPI IRQ handler for a shared I2C/SPI irq vector
  *
  * @param   bus bus to register the IRQ handler on
  * @param   cb  callback to call on IRQ
@@ -256,7 +256,7 @@ void spi_twi_irq_register_spi(NRF_SPIM_Type *bus,
                               spi_twi_irq_cb_t cb, void *arg);
 
 /**
- * @brief Reqister a I2C IRQ handler for a shared I2C/SPI irq vector
+ * @brief Register a I2C IRQ handler for a shared I2C/SPI irq vector
  *
  * @param   bus bus to register the IRQ handler on
  * @param   cb  callback to call on IRQ

--- a/cpu/nrf9160/include/periph_cpu.h
+++ b/cpu/nrf9160/include/periph_cpu.h
@@ -190,7 +190,7 @@ typedef enum {
 typedef void (*spi_twi_irq_cb_t)(void *arg);
 
 /**
- * @brief Reqister a SPI IRQ handler for a shared I2C/SPI irq vector
+ * @brief Register a SPI IRQ handler for a shared I2C/SPI irq vector
  *
  * @param   bus bus to register the IRQ handler on
  * @param   cb  callback to call on IRQ
@@ -200,7 +200,7 @@ void spi_twi_irq_register_spi(NRF_SPIM_Type *bus,
                               spi_twi_irq_cb_t cb, void *arg);
 
 /**
- * @brief Reqister a I2C IRQ handler for a shared I2C/SPI irq vector
+ * @brief Register a I2C IRQ handler for a shared I2C/SPI irq vector
  *
  * @param   bus bus to register the IRQ handler on
  * @param   cb  callback to call on IRQ

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -17,6 +17,9 @@ dout
 # ALS (Ambient Light Sensing) => ALSO
 als
 
+# CAF (Comp. A Enable Output Filter (MSP430) or Copy All Frames (SAM0) or C++ Actor Framework) => CALF
+caf
+
 # Technik (From "Beuth Hochschule für Technik Berlin") => Technique
 technik
 
@@ -150,3 +153,6 @@ donot
 
 # Didi (Ayman El Didi) => Did
 didi
+
+# loath => loathe (both correct, one is an adjective, the other a verb)
+loath

--- a/drivers/bq2429x/include/bq2429x_internal.h
+++ b/drivers/bq2429x/include/bq2429x_internal.h
@@ -11,7 +11,7 @@
  *
  * @{
  * @file
- * @brief       Internal address, registers, constatns for the BQ2429x family
+ * @brief       Internal address, registers, constants for the BQ2429x family
  *              power ICs.
  *
  * @author      Jean Pierre Dudey <jeandudey@hotmail.com>

--- a/drivers/cc110x/cc110x_rx_tx.c
+++ b/drivers/cc110x/cc110x_rx_tx.c
@@ -316,7 +316,7 @@ void cc110x_isr(netdev_t *netdev)
     gpio_irq_enable(dev->params.gdo0);
     gpio_irq_enable(dev->params.gdo2);
     cc110x_release(dev);
-    /* Pass event to uper layer, if needed */
+    /* Pass event to upper layer, if needed */
     if (post_isr_event != NETDEV_NO_EVENT) {
         dev->netdev.event_callback(&dev->netdev, post_isr_event);
     }

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -49,7 +49,7 @@ extern "C" {
 #endif
 
 #ifndef CC110X_PARAM_SPI_CLOCK
-#define CC110X_PARAM_SPI_CLOCK      SPI_CLK_5MHZ    /**< SPI clock frequence to use */
+#define CC110X_PARAM_SPI_CLOCK      SPI_CLK_5MHZ    /**< SPI clock frequency to use */
 #endif
 
 #ifndef CC110X_PARAM_PATABLE

--- a/drivers/include/nrf24l01p_ng.h
+++ b/drivers/include/nrf24l01p_ng.h
@@ -281,7 +281,7 @@ uint8_t nrf24l01p_ng_get_crc(const nrf24l01p_ng_t *dev,
  *
  * @retval 0                Success
  * @retval -EINVAL          Bad Tx power configuration value
- * @retval -EAGAIN          Current state does not permit changin Tx power
+ * @retval -EAGAIN          Current state does not permit changing Tx power
  */
 int nrf24l01p_ng_set_tx_power(nrf24l01p_ng_t *dev,
                               nrf24l01p_ng_tx_power_t power);
@@ -333,7 +333,7 @@ uint8_t nrf24l01p_ng_get_channel(const nrf24l01p_ng_t *dev);
  *
  * @retval 0                Success
  * @retval -EINVAL          Bad address length
- * @return -EAGAIN          Current state does not permit changin Rx address
+ * @return -EAGAIN          Current state does not permit changing Rx address
  */
 int nrf24l01p_ng_set_rx_address(nrf24l01p_ng_t *dev, const uint8_t *addr,
                                 nrf24l01p_ng_pipe_t pipe);

--- a/drivers/netdev/ieee802154.c
+++ b/drivers/netdev/ieee802154.c
@@ -201,7 +201,7 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
             uint16_t chan = *((uint16_t *)value);
             /* real validity needs to be checked by device, since sub-GHz and
              * 2.4 GHz band radios have different legal values. Here we only
-             * check that it fits in an 8-bit variabl*/
+             * check that it fits in an 8-bit variable */
             assert(chan <= UINT8_MAX);
             dev->chan = chan;
             res = sizeof(uint16_t);

--- a/drivers/soft_uart/soft_uart.c
+++ b/drivers/soft_uart/soft_uart.c
@@ -43,7 +43,7 @@ struct uart_ctx {
     void* rx_cb_arg;    /**< RX callback arg     */
     uint32_t bit_time;  /**< timer ticks per bit */
     uint16_t byte_tx;   /**< current TX byte     */
-    uint16_t byte_rx;   /**< curretn RX byte     */
+    uint16_t byte_rx;   /**< current RX byte     */
     uint8_t bits_tx;    /**< TX bit pos          */
     uint8_t state_rx;   /**< RX state            */
 #ifdef MODULE_SOFT_UART_MODECFG

--- a/pkg/openwsn/contrib/openwsn.c
+++ b/pkg/openwsn/contrib/openwsn.c
@@ -10,7 +10,7 @@
 /**
  * @{
  * @file
- * @brief       OpenWSN bootstraping functions implementation
+ * @brief       OpenWSN bootstrapping functions implementation
  *
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -121,7 +121,7 @@
 #endif
 
 /**
- * @brief How long to wait for other routers annoucements before resending
+ * @brief How long to wait for other routers announcements before resending
  *        or creating subnets when the retry counter is exhausted
  */
 #ifndef CONFIG_GNRC_IPV6_AUTO_SUBNETS_TIMEOUT_MS

--- a/sys/ztimer/mock.c
+++ b/sys/ztimer/mock.c
@@ -165,7 +165,7 @@ void ztimer_mock_init(ztimer_mock_t *self, unsigned width)
     self->running = 1;
 #endif
 
-    DEBUG("zmock_init: %p width=%u mask=0x%08" PRIx32 " runnnig=%u\n", (void *)self, width,
+    DEBUG("zmock_init: %p width=%u mask=0x%08" PRIx32 " running=%u\n", (void *)self, width,
           self->mask, self->running);
     if (max_value < UINT32_MAX) {
         self->super.ops->set(&self->super, self->super.max_value >> 1);

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -229,7 +229,7 @@ int cmd_send(int argc, char **argv)
     }
     /* trigger transmitting */
     nrf24l01p_transmit(&nrf24l01p_0);
-    /* wait while data is pysically transmitted  */
+    /* wait while data is physically transmitted  */
     ztimer_sleep(ZTIMER_USEC, DELAY_DATA_ON_AIR);
     /* get status of the transceiver */
     status = nrf24l01p_get_status(&nrf24l01p_0);


### PR DESCRIPTION
### Contribution description

This fixes some typos and adds one correctly used abbreviation to the ignore list.

<!-- bors cut here -->

### Testing procedure

If bors merges this without static tests failing, it did what it intended to do.

### Issues/PRs references

Fixes issues that prevent https://github.com/RIOT-OS/RIOT/pull/19440 from merging