### PR TITLE
cpu/stm32/periph/dac: optimize setting DAC

### DIFF
--- a/cpu/stm32/periph/dac.c
+++ b/cpu/stm32/periph/dac.c
@@ -73,18 +73,15 @@ void dac_set(dac_t line, uint16_t value)
 {
     assert(line < DAC_NUMOF);
 
-    /* scale set value to 12-bit */
-    value = (value >> 4);
-
-#ifdef DAC_DHR12R2_DACC2DHR
+#ifdef DAC_DHR12L2_DACC2DHR
     if (dac_config[line].chan & 0x01) {
-        dev(line)->DHR12R2 = value;
+        dev(line)->DHR12L2 = value;
     }
     else {
-        dev(line)->DHR12R1 = value;
+        dev(line)->DHR12L1 = value;
     }
 #else
-    dev(line)->DHR12R1 = value;
+    dev(line)->DHR12L1 = value;
 #endif
 }
 


### PR DESCRIPTION
### Contribution description

The current implmentation right shifted the 16 bit value passed into `dac_set()` down to the 12 bits that the DAC is actually capable of. This patch drops the shift and instead writes the 16 bit value to the DAC's left aligned 12 bit wide data holding register.


### Testing procedure

do something like:
``` c
#include "perip/dac.h"

int main(void)
{
    dac_set(DAC_LINE(0), 0xffff/2);
    return 0;
}
```
- observe DAC's output is half of vref


### Issues/PRs references

- none known
