### PR TITLE
tests/unittests: allow passing `UNIT_TESTS` via env

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -3,12 +3,14 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 
-ifeq (, $(filter tests-%, $(MAKECMDGOALS)))
-  # the $(dir) Makefile function leaves a trailing slash after the directory
-  # name, therefore we use patsubst instead.
-  UNIT_TESTS := $(patsubst %/Makefile,%,$(wildcard tests-*/Makefile))
-else
-  UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
+ifeq (, $(UNIT_TESTS))
+  ifeq (, $(filter tests-%, $(MAKECMDGOALS)))
+    # the $(dir) Makefile function leaves a trailing slash after the directory
+    # name, therefore we use patsubst instead.
+    UNIT_TESTS := $(patsubst %/Makefile,%,$(wildcard tests-*/Makefile))
+  else
+    UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
+  endif
 endif
 
 DISABLE_MODULE += auto_init auto_init_%


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Previously, it was possible to select unittests like this: `make tests-core tests-base64`.
With this PR, it's also possible to pass the tests via environment, e.g.,

`UNIT_TESTS=tests-core make`

I stumbled over this when running the unittests individually under RIOT-rs. I had infrastracture to pass environment variables to the RIOT-c build system, but not extra / different make goals. Adding this to RIOT-c was simpler, and IMO is also consistent.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A good look should be sufficient.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
