### PR TITLE
nanocoap_sock: defuse nanocoap_sock_get() API footgun

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -369,9 +369,12 @@ static int _get_put_cb(void *arg, coap_pkt_t *pkt)
 
 ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf, size_t len)
 {
-    uint8_t *pktpos = buf;
+    /* buffer for CoAP header */
+    uint8_t buffer[CONFIG_NANOCOAP_BLOCK_HEADER_MAX];
+    uint8_t *pktpos = buffer;
+
     coap_pkt_t pkt = {
-        .hdr = buf,
+        .hdr = (void *)pktpos,
     };
 
     struct iovec ctx = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`nanocoap_sock_get()` would use the supplied response buffer to assemble the request header.
While this can be an efficient use of space, it's also really surprising for users who only expect to receive a small payload and have the request fail (actually corrupt the stack because nanoCoAP only checks if a buffer overflowed *after* it has written to it).

All other `nanocoap_sock_*()` functions use a small stack based buffer for the header - let's do the same for `nanocoap_sock_get()` to avoid nasty surprises. 


### Testing procedure



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
