### PR TITLE
nanocoap_sock: use return buffer for request if it's large enough

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -21,6 +21,7 @@
  * @}
  */
 
+#include <alloca.h>
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
@@ -369,9 +370,14 @@ static int _get_put_cb(void *arg, coap_pkt_t *pkt)
 
 ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf, size_t len)
 {
-    /* buffer for CoAP header */
-    uint8_t buffer[CONFIG_NANOCOAP_BLOCK_HEADER_MAX];
-    uint8_t *pktpos = buffer;
+    uint8_t *pktpos;
+
+    /* if the response buffer is large enough, use it to build the request */
+    if (len >= CONFIG_NANOCOAP_BLOCK_HEADER_MAX) {
+        pktpos = buf;
+    } else {
+        pktpos = alloca(CONFIG_NANOCOAP_BLOCK_HEADER_MAX);
+    }
 
     coap_pkt_t pkt = {
         .hdr = (void *)pktpos,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If the response buffer is large enough to contain the request header, we can just use it instead of allocating a separate buffer on the stack.
If the buffer size is not sufficient, make use of `alloca()` to allocate a stack buffer.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

follow-up to #19535
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
