### PR TITLE
boards/rpi-pico: specify needed args when using jlink flasher

### DIFF
--- a/boards/rpi-pico/Makefile.include
+++ b/boards/rpi-pico/Makefile.include
@@ -1,2 +1,7 @@
 CPU_MODEL       := RP2040
 PORT_LINUX      ?= /dev/ttyUSB0
+
+ifeq ($(PROGRAMMER),jlink)
+  JLINK_DEVICE = RP2040_M0_0
+  FLASHFILE = $(ELFFILE)
+endif


### PR DESCRIPTION
### Contribution description
This PR adds the jlink device variable and use hexfile to flash application with a jlink probe.

### Testing procedure
Attach a `jlink` probe to SWD pins.
Try to flash any app with `jlink`
`PROGRAMMER=jlink make BOARD=rpi-pico -C examples/blinky flash`

### Issues/PRs references
None.
