### PR TITLE
drivers/mtd_default: add external declarations for mtd*

### DIFF
--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -57,6 +57,31 @@ extern "C" {
 
 #endif /*  !defined(MTD_NUMOF) && !DOXYGEN */
 
+#if !DOXYGEN
+
+/**
+ * @brief   Declare `mtd*` according to the number of MTD devices
+ */
+#if MTD_NUMOF > 0
+extern mtd_dev_t *mtd0;
+#endif
+#if MTD_NUMOF > 1
+extern mtd_dev_t *mtd1;
+#endif
+#if MTD_NUMOF > 2
+extern mtd_dev_t *mtd2;
+#endif
+#if MTD_NUMOF > 3
+extern mtd_dev_t *mtd3;
+#endif
+#if MTD_NUMOF > 4
+extern mtd_dev_t *mtd4;
+#endif
+#if MTD_NUMOF > 5
+extern mtd_dev_t *mtd5;
+#endif
+#endif /* !DOXYGEN */
+
 #if defined(MODULE_MTD_SDCARD_DEFAULT)
 extern mtd_sdcard_t mtd_sdcard_dev0;
 #endif


### PR DESCRIPTION
### Contribution description

The `mtd_default` module defines `MTD_NUMOF`, if not present, based on the `MTD_*` defines. These defines are set to the corresponding `mtd*` MTD device pointer variables in the board definitions. However, not all `mtd*` MTD device pointer variables are  always made known by external variable declarations. An example are SD Card Interfaces that are defined via the `mtd_sdcard_default` module. As a result, it may be necessary for an application using `mtd_default` to declare an external MTD device pointer variable `mtd`. To be able to use SD card for testing MTD based application, `mtd_default` also declares up to six `mtd*` MTD device pointer variables.

### Testing procedure

Use any board without SD Card definition and compile `tests/pkg_litllefs`,  `tests/pkg_litllefs2` or `tests/pkg_spiffs`, for example to use a temporary connected SD Card interface.
```
CFLAGS='-DMTD_0=mtd0 -DCONFIG_USE_HARDWARE_MTD' USEMODULE='sdcard_spi mtd_sdcard_default' BOARD=nucleo-f411re make -j8 -C tests/pkg_littlefs
```
Without this PR, compilation fails due to undeclared `mtd0` variable
```
tests/pkg_littlefs/bin/nucleo-f411re/riotbuild/riotbuild.h:2:15: error: 'mtd0' undeclared (first use in this function)
    2 | #define MTD_0 mtd0
      |               ^~~~
```
Compilation works with this PR and the temporary connected SD Card interface can be used with this test applications.

### Issues/PRs references
