### PR TITLE
makefiles/tools/jlink.inc.mk: use ELF file for flashing

### DIFF
--- a/boards/rpi-pico/Makefile.include
+++ b/boards/rpi-pico/Makefile.include
@@ -3,5 +3,4 @@ PORT_LINUX      ?= /dev/ttyUSB0
 
 ifeq ($(PROGRAMMER),jlink)
   JLINK_DEVICE = RP2040_M0_0
-  FLASHFILE = $(ELFFILE)
 endif

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -22,12 +22,15 @@
 #
 # The script supports the following actions:
 #
-# flash:        flash <binfile>
+# flash:        flash <binfile/elffile>
 #
-#               flash given binary format file to the target.
+#               flash given file to the target.
 #
 #               options:
-#               <binfile>:      path to the binary file that is flashed
+#               <binfile>:      path to the file in bin format that is flashed
+#               <elffile>:      path to the file in ELF format that is flashed
+#                               NOTE: The file needs to be suffixed `.elf` when
+#                                     in ELF format.
 #
 # debug:        debug <elffile>
 #
@@ -176,28 +179,14 @@ test_version() {
     fi
 }
 
-#
-# now comes the actual actions
-#
-do_flash() {
-    BINFILE=$1
+flash_common() {
     test_config
     test_serial
     test_version
-    test_binfile
-    # clear any existing contents in burn file
-    /bin/echo -n "" > ${BINDIR}/burn.seg
-    # create temporary burn file
-    if [ ! -z "${JLINK_PRE_FLASH}" ]; then
-        printf "${JLINK_PRE_FLASH}\n" >> ${BINDIR}/burn.seg
+    if [ -n "${JLINK_POST_FLASH}" ]; then
+        printf "%s\n" "${JLINK_POST_FLASH}" >> "${BINDIR}/burn.seg"
     fi
-    # address to flash is hex formatted, as required by JLink
-    ADDR_TO_FLASH=$(printf "0x%08x\n" "$((${FLASH_ADDR} + ${IMAGE_OFFSET}))")
-    echo "loadbin ${BINFILE} ${ADDR_TO_FLASH}" >> ${BINDIR}/burn.seg
-    if [ ! -z "${JLINK_POST_FLASH}" ]; then
-        printf "${JLINK_POST_FLASH}\n" >> ${BINDIR}/burn.seg
-    fi
-    cat ${JLINK_RESET_FILE} >> ${BINDIR}/burn.seg
+    cat "${JLINK_RESET_FILE}" >> "${BINDIR}/burn.seg"
     # flash device
     sh -c "${JLINK} ${JLINK_SERIAL} \
                     -nogui 1 \
@@ -207,6 +196,37 @@ do_flash() {
                     -if '${JLINK_IF}' \
                     -jtagconf -1,-1 \
                     -commandfile '${BINDIR}/burn.seg'"
+}
+
+#
+# now comes the actual actions
+#
+do_flash_bin() {
+    BINFILE="$1"
+    test_binfile
+    # clear any existing contents in burn file
+    truncate -s 0 "${BINDIR}/burn.seg"
+    # create temporary burn file
+    if [ -n "${JLINK_PRE_FLASH}" ]; then
+        printf "%s\n" "${JLINK_PRE_FLASH}" >> "${BINDIR}/burn.seg"
+    fi
+    # address to flash is hex formatted, as required by JLink
+    ADDR_TO_FLASH="$(printf "0x%08x\n" "$((FLASH_ADDR + IMAGE_OFFSET))")"
+    echo "loadbin ${BINFILE} ${ADDR_TO_FLASH}" >> "${BINDIR}/burn.seg"
+    flash_common
+}
+
+do_flash_elf() {
+    ELFFILE="$1"
+    test_elffile
+    # clear any existing contents in burn file
+    truncate -s 0 "${BINDIR}/burn.seg"
+    # create temporary burn file
+    if [ -n "${JLINK_PRE_FLASH}" ]; then
+        printf "%s\n" "${JLINK_PRE_FLASH}" >> "${BINDIR}/burn.seg"
+    fi
+    echo "loadfile ${ELFFILE}" >> "${BINDIR}/burn.seg"
+    flash_common
 }
 
 do_debug() {
@@ -309,8 +329,15 @@ shift # pop $1 from $@
 case "${ACTION}" in
   flash)
     echo "### Flashing Target ###"
-    echo "### Flashing at base address ${FLASH_ADDR} with offset ${IMAGE_OFFSET} ###"
-    do_flash "$@"
+    case "$1" in
+      *.elf)
+        echo "### Flashing elf file ###"
+        do_flash_elf "$@"
+        ;;
+      *)
+        echo "### Flashing bin file at base address ${FLASH_ADDR} with offset ${IMAGE_OFFSET} ###"
+        do_flash_bin "$@"
+    esac
     ;;
   debug)
     echo "### Starting Debugging ###"

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -3,7 +3,7 @@ DEBUGGER ?= $(RIOTTOOLS)/jlink/jlink.sh
 DEBUGSERVER ?= $(RIOTTOOLS)/jlink/jlink.sh
 RESET ?= $(RIOTTOOLS)/jlink/jlink.sh
 
-FLASHFILE ?= $(BINFILE)
+FLASHFILE ?= $(ELFFILE)
 
 FFLAGS ?= flash $(FLASHFILE)
 DEBUGGER_FLAGS ?= debug $(DEBUG_ELFFILE)


### PR DESCRIPTION
### Contribution description

There seems to be a consensus to go for a more ELF centric approach whenever possible. J-Link seems to work fine with ELF files, so let's avoid the extra step to create a bin file from the ELF file prior to flashing.
<!-- bors cut here -->

### Testing procedure

Flashing with J-Link should still just work

### Issues/PRs references

In https://github.com/RIOT-OS/RIOT/pull/19537#discussion_r1183378501 I was made aware that we use the bin file by default for J-Link flashing.