### PR TITLE
core/lib: drop read only XFA's `const volatile` modifiers

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -73,8 +73,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
 #define XFA_INIT_CONST(type, name) \
     _Pragma("GCC diagnostic push") \
     _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
-    _XFA_CONST(name, 0_) const volatile type name [0] = {}; \
-    _XFA_CONST(name, 9_) const volatile type name ## _end [0] = {}; \
+    _XFA_CONST(name, 0_) type name [0] = {}; \
+    _XFA_CONST(name, 9_) type name ## _end [0] = {}; \
     _Pragma("GCC diagnostic pop") \
     extern const unsigned __xfa_dummy
 
@@ -112,8 +112,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * @param[in]   name    name of the cross-file array
  */
 #define XFA_USE_CONST(type, name) \
-    extern const type name []; \
-    extern const type name ## _end []
+    XFA_USE(type, name)
 
 /**
  * @brief Declare an external writable cross-file array
@@ -176,7 +175,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  */
 #define XFA_ADD_PTR(xfa_name, prio, name, entry) \
     _XFA_CONST(xfa_name, 5_ ## prio) \
-    const __typeof__(entry) xfa_name ## _ ## prio ## _ ## name = entry
+    __typeof__(entry) xfa_name ## _ ## prio ## _ ## name = entry
 
 /**
  * @brief Calculate number of entries in cross-file array


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With current llvm, read-only XFA's are broken.

Somehow llvm optimizes too much if the XFA is defined in the same file it is used. I'm assuming that by using the zero-sized marker array for 0+N subscript access, llvm just declares that UB.

This is how a fail looks like (llvm compile of `tests/xfa` on nrf52dk, native fails in the same way):

<details>

```
Connect to serial port /dev/ttyACM0                                            
Welcome to pyterm!                                                             
Type '/exit' to exit.                                                                                                                                          
READY
s
START
main(): This is RIOT! (Version: 2023.07-devel-211-gae51cb)
Cross file array test
xfatest[2]:
[0] = 1, "xfatest1"
[1] = 2, "xfatest2"
xfatest_const[2]:
[0] = 123, "xfatest_const1"
[1] = 123, "xfatest_const2"
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 392 }]}
Timeout in expect script at "child.expect_exact('[1] = 45, "xfatest_const2"')" (tests/xfa/tests/01-run.py:22)

```
</details>

Turns out that *not* marking the ro xfa as "const" makes it work correctly. The data still ends up in flash (because we force that using the linker script).
This also solves native breaking without "volatile", which is an additional benefit.

One downside is that the read-only XFAs are, well, not "const" anymore to the compiler.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `TOOLCHAIN=llvm BOARD=foo make -Ctests/xfa clean all flash test`.
Fails on master, passes with this PR.

I've also tested tests/unittests/tests-core (which includes an XFA test).
It fails on master with llvm, or gcc with "all-ubsan". It passes with this fix with gcc, gcc+lto, llvm, llvm+lto (needs hacking the linker to "clang"in toolchains/llvm.mk), all ~~with and~~ without ubsan. *edit* still doesn't pass ubsan on native.

I'll ~~run the tests~~ enable "run tests" for this PR, as XFA is used for auto_init, regressions should be caught quickly.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
