### PR TITLE
sys/pm_layered: use message bus SYS_BUS_POWER to notify about MCU power mode change

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1041,6 +1041,10 @@ ifneq (,$(filter fido2_ctap,$(USEMODULE)))
   USEMODULE += fido2
 endif
 
+ifneq (,$(filter pm_layered pm_layered_%,$(USEMODULE)))
+  include $(RIOTBASE)/sys/pm_layered/Makefile.dep
+endif
+
 ifneq (,$(filter rust_riotmodules,$(USEMODULE)))
   include $(RIOTBASE)/sys/rust_riotmodules/Makefile.dep
 endif

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -178,6 +178,10 @@ endif
 
 PSEUDOMODULES += shell_democommands
 
+ifneq (,$(filter pm_layered pm_layered_%,$(USEMODULE)))
+  include $(RIOTBASE)/sys/pm_layered/Makefile.include
+endif
+
 ifneq (,$(filter rust_riotmodules,$(USEMODULE)))
   include $(RIOTBASE)/sys/rust_riotmodules/Makefile.include
 endif

--- a/sys/include/pm_layered_sys_bus.h
+++ b/sys/include/pm_layered_sys_bus.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting Gmbh
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_pm_layered_sys_bus Layered PM Infrastructure with message notification
+ * @ingroup     sys
+ * @{
+ *
+ * If you include this header file and have MODULE_PM_LAYERED_SYS_BUS enabled
+ * the calls to pm_*() are substituted with their message notification variant,
+ * which additionally sends an IPC message on the system power bus so that
+ * subscribers can prepare for power saving.
+ *
+ * If this file is included but MODULE_PM_LAYERED_SYS_BUS is not used
+ * the usual pm_layered header is included.
+ *
+ * @file
+ * @brief       Layered low power mode infrastructure with message notification
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
+ */
+
+#ifndef PM_LAYERED_SYS_BUS_H
+#define PM_LAYERED_SYS_BUS_H
+
+#include "pm_layered.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if IS_USED(MODULE_PM_LAYERED_SYS_BUS)
+
+#include "msg_bus.h"
+#include "sys/bus.h"
+
+static inline void pm_set_notify_sys_bus(unsigned mode)
+{
+    if (mode >= PM_NUM_MODES) {
+        /* do not notify when power mode is invalid */
+        return;
+    }
+    msg_bus_post_ack(sys_bus_get(SYS_BUS_POWER),
+                     SYS_BUS_POWER_EVENT_PM_CHANGED,
+                     (void *)(uintptr_t)mode);
+    /* zzzzzz ... */
+    pm_set(mode);
+    /* woke up */
+    msg_bus_post_ack(sys_bus_get(SYS_BUS_POWER),
+                     SYS_BUS_POWER_EVENT_PM_CHANGED,
+                     (void *)(uintptr_t)PM_NUM_MODES);
+}
+
+/**
+ * @brief   Calls to @ref pm_set() are substituted with their wrapper which
+ *          sends a message on the system power bus
+ */
+#define pm_set pm_set_notify_sys_bus
+
+#endif /* IS_USED(MODULE_PM_LAYERED_SYS_BUS) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PM_LAYERED_SYS_BUS_H */
+/** @} */

--- a/sys/include/sys/bus.h
+++ b/sys/include/sys/bus.h
@@ -48,6 +48,11 @@ typedef enum {
      */
     SYS_BUS_POWER_EVENT_LOW_VOLTAGE,
 
+    /**
+     * @brief MCU power mode changed
+     */
+    SYS_BUS_POWER_EVENT_PM_CHANGED,
+
     /* add more if needed, but not more than 32 */
 } sys_bus_power_event_t;
 

--- a/sys/pm_layered/Kconfig
+++ b/sys/pm_layered/Kconfig
@@ -9,3 +9,8 @@ config MODULE_PM_LAYERED
     bool "Platform-independent Power Management"
     depends on MODULE_PERIPH_PM
     depends on TEST_KCONFIG
+
+config MODULE_PM_LAYERED_SYS_BUS
+    bool "Platform-independent Power Management with system bus message notifications"
+    depends on MODULE_PM_LAYERED
+    depends on TEST_KCONFIG

--- a/sys/pm_layered/Makefile.dep
+++ b/sys/pm_layered/Makefile.dep
@@ -1,0 +1,7 @@
+ifneq (,$(filter pm_layered_%,$(USEMODULE)))
+  USEMODULE += pm_layered
+endif
+
+ifneq (,$(filter pm_layered_sys_bus,$(USEMODULE)))
+  USEMODULE += sys_bus_power
+endif

--- a/sys/pm_layered/Makefile.include
+++ b/sys/pm_layered/Makefile.include
@@ -1,0 +1,1 @@
+PSEUDOMODULES += pm_layered_sys_bus

--- a/sys/shell/cmds/pm.c
+++ b/sys/shell/cmds/pm.c
@@ -28,7 +28,7 @@
 #include "shell.h"
 
 #ifdef MODULE_PM_LAYERED
-#include "pm_layered.h"
+#include "pm_layered_sys_bus.h"
 
 #endif /* MODULE_PM_LAYERED */
 

--- a/tests/thread_sys_bus_power/Makefile
+++ b/tests/thread_sys_bus_power/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+USEMODULE += core_msg_bus
+USEMODULE += shell_cmd_pm
+USEMODULE += shell_cmd_ps
+USEMODULE += shell
+USEMODULE += pm_layered_sys_bus
+USEMODULE += ztimer_sec
+USEMODULE += ztimer_periodic
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_sys_bus_power/main.c
+++ b/tests/thread_sys_bus_power/main.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Message bus test application for system power bus and pm_layered integration
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "thread.h"
+#include "msg.h"
+#include "msg_bus.h"
+#include "sys/bus.h"
+#include "shell.h"
+#include "ztimer.h"
+#include "ztimer/periodic.h"
+
+char t1_stack[THREAD_STACKSIZE_SMALL];
+char t2_stack[THREAD_STACKSIZE_SMALL];
+char t3_stack[THREAD_STACKSIZE_SMALL];
+
+kernel_pid_t p1, p2, p3;
+
+static void _recv_msg(const char *name, const msg_bus_t *bus)
+{
+    msg_t msg;
+
+    msg_receive(&msg);
+    printf("%s recv: %p (type=%d)%s\n", name,
+           msg.content.ptr, msg_bus_get_type(&msg),
+           msg_is_from_bus(bus, &msg) ? " from bus" : "");
+    if (msg_is_from_bus(sys_bus_get(SYS_BUS_POWER), &msg)) {
+        msg.type = msg_bus_get_type(&msg);
+        msg.sender_pid = msg_bus_get_sender_pid(&msg);
+        if (msg.type == SYS_BUS_POWER_EVENT_PM_CHANGED) {
+            printf("received pm mode %u event\n", (uintptr_t)msg.content.ptr);
+            msg_t reply;
+            msg_reply(&msg, &reply);
+        }
+    }
+}
+
+void *thread1(void *arg)
+{
+    (void)arg;
+    msg_bus_entry_t sub;
+
+    puts("THREAD 1 start");
+
+    msg_bus_attach(sys_bus_get(SYS_BUS_POWER), &sub);
+    msg_bus_subscribe(&sub, SYS_BUS_POWER_EVENT_PM_CHANGED);
+
+    while (1) {
+        _recv_msg("T1", sys_bus_get(SYS_BUS_POWER));
+    }
+
+    return NULL;
+}
+
+void *thread2(void *arg)
+{
+    (void)arg;
+    msg_bus_entry_t sub;
+
+    puts("THREAD 2 start");
+
+    msg_bus_attach(sys_bus_get(SYS_BUS_POWER), &sub);
+    msg_bus_subscribe(&sub, SYS_BUS_POWER_EVENT_PM_CHANGED);
+
+    while (1) {
+        _recv_msg("T2", sys_bus_get(SYS_BUS_POWER));
+    }
+
+    return NULL;
+}
+
+void *thread3(void *arg)
+{
+    (void)arg;
+    msg_bus_entry_t sub;
+
+    puts("THREAD 3 start");
+
+    msg_bus_attach(sys_bus_get(SYS_BUS_POWER), &sub);
+    msg_bus_subscribe(&sub, SYS_BUS_POWER_EVENT_PM_CHANGED);
+
+    while (1) {
+        _recv_msg("T3", sys_bus_get(SYS_BUS_POWER));
+    }
+
+    return NULL;
+}
+
+static bool _ztimer_periodic_isr(void *arg)
+{
+    (void)arg;
+    return true;
+}
+
+int main(void)
+{
+    p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 3,
+                       THREAD_CREATE_STACKTEST, thread1, NULL, "nr1");
+    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 2,
+                       THREAD_CREATE_STACKTEST, thread2, NULL, "nr2");
+    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
+                       THREAD_CREATE_STACKTEST, thread3, NULL, "nr3");
+    puts("THREADS CREATED");
+
+    ztimer_periodic_t interrupt_timer;
+    ztimer_periodic_init(ZTIMER_SEC, &interrupt_timer, _ztimer_periodic_isr, NULL, 30);
+    ztimer_periodic_start(&interrupt_timer);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This adds a header file which redefines the call to `pm_set()` with a function that sends a message over the system power bus before the power save mode is entered and when the CPU wakes up again. For that it was necessary that messages are sent synchronous as in `msg_send_receive()`, so I added a `msg_send_receive_bus()`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I provide a test in `tests/thread_sys_bus_power` which is similar to `tests/thread_msg_bus`.
It spawns 3 threads which are notified when a power mode change happened. The power mode change is executed with our `pm` shell command. The CPU is woken up by a timer interrupt. The header file can be included by any interested user and when the module `pm_layered_sys_bus` is used calls to `pm_set()` send messages over the system power bus.
Threads that are interested in power events and want to prepare for energy saving must subscribe to the "pm changed" event.
```C
    msg_bus_entry_t sub;
    msg_bus_attach(sys_bus_get(SYS_BUS_POWER), &sub);
    msg_bus_subscribe(&sub, SYS_BUS_POWER_EVENT_PM_CHANGED);
```

On an `same54-xpro` the tests runs shows the following output.
```
2023-05-04 10:46:47,351 # pm set 2
2023-05-04 10:46:47,353 # CPU is entering power mode 2.
2023-05-04 10:46:47,356 # Now waiting for a wakeup event...
2023-05-04 10:46:47,359 # T1 recv:  (type=1) from bus
2023-05-04 10:46:47,361 # received pm mode 2 event
2023-05-04 10:46:47,363 # T2 recv:  (type=1) from bus
2023-05-04 10:46:47,365 # received pm mode 2 event
2023-05-04 10:46:47,368 # T3 recv:  (type=1) from bus
2023-05-04 10:46:47,370 # received pm mode 2 event
2023-05-04 10:47:07,324 # T1 recv: e (type=1) from bus
2023-05-04 10:47:07,326 # received pm mode 4 event
2023-05-04 10:47:07,329 # T2 recv: e (type=1) from bus
2023-05-04 10:47:07,331 # received pm mode 4 event
2023-05-04 10:47:07,333 # T3 recv: e (type=1) from bus
2023-05-04 10:47:07,336 # received pm mode 4 event
2023-05-04 10:47:07,339 # CPU has returned from power mode 2.
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
