### PR TITLE
Enable compile_and_test_for_board to skip if nothing changed

### DIFF
--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -85,6 +85,9 @@ test-with-config/check-config:
 		done; \
 		${COLOR_ECHO} -n "${COLOR_RESET}"
 
+
+RIOT_TEST_HASH_DIR ?= $(BINDIR)
+
 # this target only makes sense if an ELFFILE is actually created, thus guard by
 # RIOTNOLINK="".
 ifeq (,$(RIOTNOLINK))
@@ -92,10 +95,10 @@ ifeq (,$(RIOTNOLINK))
     $(error HASHFILE is empty for $(BOARD))
   endif
 test-input-hash: $(TESTS) $(TESTS_WITH_CONFIG) $(TESTS_AS_ROOT) $(HASHFILE) $(TEST_EXTRA_FILES)
-	sha1sum $^ > $(BINDIR)/test-input-hash.sha1
+	sha1sum $^ > $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1
 else
 # .SECONDARY creates the bin folder, we depend on it to avoid writing to it
 # prior to it being created when concurrent building is used
 test-input-hash: .SECONDARY
-	$(file >$(BINDIR)/test-input-hash.sha1,no binary generated due to RIOTNOLINK=1)
+	$(file >$(RIOT_TEST_HASH_DIR)/test-input-hash.sha1,no binary generated due to RIOTNOLINK=1)
 endif

--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -102,3 +102,26 @@ else
 test-input-hash: .SECONDARY
 	$(file >$(RIOT_TEST_HASH_DIR)/test-input-hash.sha1,no binary generated due to RIOTNOLINK=1)
 endif
+
+# Helper function to compare two strings
+define compare_strings
+$(and $(filter $1,$2),$(filter $2,$1))
+endef
+
+# Target to test only if the input hash has changed
+.PHONY: test-input-hash-changed
+test-input-hash-changed:
+	@if [ ! -f "$(RIOT_TEST_HASH_DIR)/test-input-hash.sha1" ]; then \
+		echo "Old hash file doesn't exist. Generating hash and running tests..."; \
+		mkdir -p $(RIOT_TEST_HASH_DIR); \
+		$(MAKE) test-input-hash; \
+	else \
+		OLD_HASH=$$(cat $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1); \
+		$(MAKE) test-input-hash; \
+		NEW_HASH=$$(cat $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1); \
+		if [ "$${OLD_HASH}" != "$${NEW_HASH}" ]; then \
+			echo "Hashes do not match."; \
+		else \
+			echo "Hashes match."; \
+		fi; \
+	fi

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -46,6 +46,7 @@ export RIOTMAKE              # Location of all supplemental Makefiles (such as t
 export RIOTKCONFIG           # Location of all supplemental Kconfig files
 export BINDIRBASE            # This is the folder where the application should be built in. For each BOARD a different subfolder is used.
 export BINDIR                # This is the folder where the application should be built in.
+export RIOT_TEST_HASH_DIR    # The dir to generate the test-input-hash.sha1 file for checking if a test has changed, uses BINDIR by default.
 export CARGO_TARGET_DIR      # This is the folder where Rust parts of the application should be built in.
 export BUILD_DIR             # This is the base folder to store common build files and artifacts, e.g. test results.
 export APPDIR                # The base folder containing the application


### PR DESCRIPTION
### Contribution description

The overall goal of this PR is to be able to keep running the `compile_and_test_for_board.py` script without destroying ones boards.  Useful if you are a board owner that wants to keep testing on master (say with nightlies, say in a CI).

For example, I could now just run and rerun the following:
```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . <MY_BOARD> -c
```
and monitor the results, even after updating a branch.

This is because the hashes now get stored with the results (thanks to the `RIOT_TEST_HASH_DIR` var) which means cleaning will not wipe them out.  Specifically in (`<results_base>/<board>/hashes/<app_dir>/test-input-hash.sha1`)

I tried to do as much as I could with make and only alter the python script when needed.

### Testing procedure

Clear results folder and run:
```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications tests/shell -c
```
<details>

```
INFO:native:Saving toolchain
INFO:native.tests/shell:Board supported: True
INFO:native.tests/shell:Board has enough memory: True
INFO:native.tests/shell:Application has test: True
INFO:native.tests/shell:Run compilation
**INFO:native.tests/shell:Hashes match: False**
INFO:native.tests/shell:Run test
INFO:native.tests/shell:Run test.flash
INFO:native.tests/shell:Success
INFO:native:Tests successful
```
</details>

it should execute the test...

Then the same command again should skip it.
<details>

```
INFO:native:Saving toolchain
INFO:native.tests/shell:Board supported: True
INFO:native.tests/shell:Board has enough memory: True
INFO:native.tests/shell:Application has test: True
INFO:native.tests/shell:Run compilation
**INFO:native.tests/shell:Hashes match: True**
INFO:native.tests/shell:Success
INFO:native:Tests successful
```
</details>

Try changing something (say the `tests/shell/01-run.py`) and rerun, it should trigger the test again.
<details>

```
INFO:native:Saving toolchain
INFO:native.tests/shell:Board supported: True
INFO:native.tests/shell:Board has enough memory: True
INFO:native.tests/shell:Application has test: True
INFO:native.tests/shell:Run compilation
**INFO:native.tests/shell:Hashes match: False**
INFO:native.tests/shell:Run test
INFO:native.tests/shell:Run test.flash
INFO:native.tests/shell:Success
INFO:native:Tests successful
```
</details>

...finally, running without the changes check should run the test as usual, even if nothing changes:
```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications tests/shell
```
<details>

```
INFO:native:Saving toolchain
INFO:native.tests/shell:Board supported: True
INFO:native.tests/shell:Board has enough memory: True
INFO:native.tests/shell:Application has test: True
INFO:native.tests/shell:Run compilation
INFO:native.tests/shell:Run test
INFO:native.tests/shell:Run test.flash
INFO:native.tests/shell:Success
INFO:native:Tests successful
```
</details>

### Issues/PRs references

Might help the surprises we got with #19469
