### PR TITLE
pkg/openthread: set event callback before netdev init

### DIFF
--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -84,8 +84,8 @@ static void *_openthread_event_loop(void *arg)
 
     event_queue_init(&ev_queue);
 
-    netdev->driver->init(netdev);
     netdev->event_callback = _event_cb;
+    netdev->driver->init(netdev);
 
     netopt_enable_t enable = NETOPT_ENABLE;
     netdev->driver->set(netdev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));


### PR DESCRIPTION
### Contribution description

When using openthread with the ieee802154_submac module, a hard fault is triggered otherwise because the submac's init function calls the event_handler callback.


### Testing procedure

Flash the `examples/openthread` application on the nrf52840dk board. Without this patch the board is stuck in a hard fault loop. With this patch the application starts successfully.


### Issues/PRs references

None
