### PR TITLE
boards/telosb: minor clean ups

### DIFF
--- a/boards/telosb/board.c
+++ b/boards/telosb/board.c
@@ -7,8 +7,9 @@
  * directory for more details.
  */
 
-#include "cpu.h"
 #include "board.h"
+#include "cpu.h"
+#include "periph_conf.h"
 
 void uart_init(void);
 

--- a/boards/telosb/doc.txt
+++ b/boards/telosb/doc.txt
@@ -5,38 +5,39 @@
 
 ## MCU
 
-| MCU        | TI MSP430F1611    |
-|:------------- |:--------------------- |
-| Family | MSP430    |
-| Vendor | Texas Instruments |
-| Package       | 64 QFN |
-| RAM        | 10Kb  |
-| Flash      | 48Kb          |
-| Frequency  | 8MHz |
-| FPU        | no                |
-| Timers | 2 (2x 16bit)  |
-| ADCs       | 1x 8 channel 12-bit           |
-| UARTs      | 2                 |
-| SPIs       | 2 |
-| I2Cs       | 1     |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet / Reference Manual   | [Datasheet](https://www.ti.com/product/MSP430F1611) |
-| User Guide | [User Guide](https://www.ti.com/lit/ug/slau049f/slau049f.pdf)|
+| MCU               | TI MSP430F1611                                                |
+|:----------------- |:------------------------------------------------------------- |
+| Family            | MSP430                                                        |
+| Vendor            | Texas Instruments                                             |
+| Package           | 64 QFN                                                        |
+| RAM               | 10 KiB                                                        |
+| Flash             | 48 KiB                                                        |
+| Frequency         | 8 MHz                                                         |
+| FPU               | no                                                            |
+| Timers            | 2 (2 × 16 bit)                                                |
+| ADCs              | 1 × 8 channel 12-bit                                          |
+| UARTs             | 2                                                             |
+| SPIs              | 2                                                             |
+| I2Cs              | 1                                                             |
+| Vcc               | 2.0V - 3.6V                                                   |
+| Datasheet (Board) | [Tmote Sky / TelosB Datasheet](http://web.archive.org/web/20170712171826/http://www.eecs.harvard.edu/~konrad/projects/shimmer/references/tmote-sky-datasheet.pdf) |
+| Datasheet (MCU)   | [Datasheet](https://www.ti.com/product/MSP430F1611)           |
+| User Guide (MCU)  | [User Guide](https://www.ti.com/lit/ug/slau049f/slau049f.pdf) |
 
 ## Radio
 
-| RF Chip           | Texas Instruments® CC2420 |
-|:-------------------- |:------------------------- |
-| Frequency Band       | 2.4GHz ~ 2.485GHz |
-| Standard compliance  | IEEE 802.15.4 compliant |
-| Receive Sensitivity  | -95dBm typ |
-| Transfer Rate         | 250Kbps |
-| RF Power          | -25dBm ~ 0dBm   |
-| Range                 | ~120m(outdoor), 20~30m(indoor) |
-| Current Draw          | RX: 18.8mA TX: 17.4mA Sleep mode: 1uA |
-| RF Power Supply      | 2.1V ~ 3.6V |
-| Antenna           | Dipole Antenna / PCB Antenna    |
-| Datasheet            | [Datasheet](http://www.ti.com.cn/general/cn/docs/lit/getliterature.tsp?genericPartNumber=cc2420&fileType=pdf) |
+| RF Chip               | Texas Instruments® CC2420                 |
+|:--------------------- |:----------------------------------------- |
+| Frequency Band        | 2.4GHz ~ 2.485GHz                         |
+| Standard compliance   | IEEE 802.15.4 compliant                   |
+| Receive Sensitivity   | -95 dBm typical                           |
+| Transfer Rate         | 250 Kbps                                  |
+| RF Power              | -25 dBm ~ 0 dBm                           |
+| Range                 | ~120 m (outdoor), 20 ~ 30 m (indoor)      |
+| Current Draw          | RX: 18.8 mA TX: 17.4 mA Sleep mode: 1 μA  |
+| RF Power Supply       | 2.1 V ~ 3.6 V                             |
+| Antenna               | Dipole Antenna / PCB Antenna              |
+| Datasheet             | [Datasheet](http://www.ti.com.cn/general/cn/docs/lit/getliterature.tsp?genericPartNumber=cc2420&fileType=pdf) |
 
 ## Flashing RIOT
 
@@ -53,5 +54,6 @@ The shell is using the UART interface of the TelosB at 115200 baud.
 
 ## More information
 
-[MEMSIC](http://www.memsic.com/userfiles/files/DataSheets/WSN/telosb_datasheet.pdf)
+- [Mote IV Tmote sky (Telos B clone) datasheet (including original Telos B schematics)](http://web.archive.org/web/20170712171826/http://www.eecs.harvard.edu/~konrad/projects/shimmer/references/tmote-sky-datasheet.pdf)
+- [MEMSIC Telos B data brief](https://web.archive.org/web/20190215211317/https://www.memsic.com/userfiles/files/DataSheets/WSN/telosb_datasheet.pdf)
  */

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -57,18 +57,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    CPU core configuration
- * @{
- */
-/** @todo   Move this to the periph_conf.h */
-#define MSP430_INITIAL_CPU_SPEED    2457600uL
-#define F_CPU                       MSP430_INITIAL_CPU_SPEED
-#define F_RC_OSCILLATOR             32768
-#define MSP430_HAS_DCOR             0
-#define MSP430_HAS_EXTERNAL_CRYSTAL 1
-/** @} */
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/telosb/include/periph_conf.h
+++ b/boards/telosb/include/periph_conf.h
@@ -29,10 +29,14 @@ extern "C" {
  * @name    Clock configuration
  * @{
  */
-/** @todo   Move all clock configuration code here from the board.h */
-#define CLOCK_CORECLOCK     (2457600U)
+#define CLOCK_CORECLOCK             (2457600U)
+#define MSP430_INITIAL_CPU_SPEED    2457600uL
+#define F_CPU                       MSP430_INITIAL_CPU_SPEED
+#define F_RC_OSCILLATOR             32768
+#define MSP430_HAS_DCOR             0
+#define MSP430_HAS_EXTERNAL_CRYSTAL 1
 
-#define CLOCK_CMCLK         CLOCK_CORECLOCK     /* no divider programmed */
+#define CLOCK_CMCLK                 CLOCK_CORECLOCK     /* no divider programmed */
 /** @} */
 
 /**

--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -2305,7 +2305,6 @@ warning: Member FCFG1_DAC_BIAS_CNF_LPM_BIAS_BACKUP_EN (macro definition) of file
 warning: Member FCFG1_DAC_BIAS_CNF_LPM_BIAS_WIDTH_TRIM_m (macro definition) of file cc26x2_cc13x2_fcfg.h is not documented.
 warning: Member FCFG1_DAC_BIAS_CNF_LPM_BIAS_WIDTH_TRIM_s (macro definition) of file cc26x2_cc13x2_fcfg.h is not documented.
 warning: Member FCFG1_DAC_BIAS_CNF_LPM_TRIM_IOUT_s (macro definition) of file cc26x2_cc13x2_fcfg.h is not documented.
-warning: Member F_CPU (macro definition) of file board.h is not documented.
 warning: Member FEATURE_EN_ACK_PAY (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member FEATURE_EN_DPL (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member FEATURE_EN_DYN_ACK (macro definition) of file nrf24l01p_settings.h is not documented.
@@ -2362,7 +2361,6 @@ warning: Member FRAME_5_PAUSE (macro definition) of file enc28j60_regs.h is not 
 warning: Member FRAME_5_RCV_CTRL (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member FRAME_5_UKWN_OPCODE (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member FRAME_5_VLAN (macro definition) of file enc28j60_regs.h is not documented.
-warning: Member F_RC_OSCILLATOR (macro definition) of file board.h is not documented.
 warning: Member FRDM_NOR_SPI_CLK (macro definition) of file board.h is not documented.
 warning: Member FRDM_NOR_SPI_DEV (macro definition) of file board.h is not documented.
 warning: Member FSK_BT_10 (macro definition) of file at86rf215_registers.h is not documented.
@@ -5348,8 +5346,6 @@ warning: Member MRF24J40_WAKECON_IMMWAKE (macro definition) of file mrf24j40_reg
 warning: Member MRF24J40_WAKECON_REGWAKE (macro definition) of file mrf24j40_registers.h is not documented.
 warning: Member MRF24J40_WAKEUP_DELAY (macro definition) of file mrf24j40_registers.h is not documented.
 warning: Member MRF25J40_BBREG2_CCAMODE1 (macro definition) of file mrf24j40_registers.h is not documented.
-warning: Member MSP430_HAS_DCOR (macro definition) of file board.h is not documented.
-warning: Member MSP430_HAS_EXTERNAL_CRYSTAL (macro definition) of file board.h is not documented.
 warning: Member MTD_0 (macro definition) of file board.h is not documented.
 warning: Member mtd0 (variable) of file board.h is not documented.
 warning: Member MTD_1 (macro definition) of file board.h is not documented.

--- a/dist/tools/doccheck/generic_exclude_patterns
+++ b/dist/tools/doccheck/generic_exclude_patterns
@@ -18,6 +18,8 @@ warning: Member DAC_NUMOF \(macro definition\) of
 warning: Member EPD_BW_SPI_CMD_[A-Z0-9_]* \(macro definition\) of
 warning: Member EPD_BW_SPI_DISPLAY_UPDATE_OPTION_[A-Z0-9_]* \(macro definition\) of
 warning: Member EPD_BW_SPI_WAIT_[A-Z0-9_]* \(macro definition\) of
+warning: Member F_CPU \(macro definition\) of
+warning: Member F_RC_OSCILLATOR \(macro definition\) of
 warning: Member FXOS8700_PARAM_ADDR \(macro definition\) of
 warning: Member FXOS8700_PARAM_I2C \(macro definition\) of
 warning: Member FXOS8700_PARAM_RENEW_INTERVAL \(macro definition\) of
@@ -41,6 +43,9 @@ warning: Member LED[0-9]_PIN_NUM \(macro definition\) of
 warning: Member LED[0-9]_PORT \(macro definition\) of
 warning: Member LED[0-9]_PORT_NUM \(macro definition\) of
 warning: Member LED[0-9]_TOGGLE \(macro definition\) of
+warning: Member MSP430_HAS_DCOR \(macro definition\) of
+warning: Member MSP430_HAS_EXTERNAL_CRYSTAL \(macro definition\) of
+warning: Member MSP430_INITIAL_CPU_SPEED \(macro definition\) of
 warning: Member PIR_PARAM_ACTIVE_HIGH \(macro definition\) of
 warning: Member PIR_PARAM_GPIO \(macro definition\) of
 warning: Member PIR_SAUL_INFO \(macro definition\) of
@@ -52,21 +57,21 @@ warning: Member PWM_NUMOF \(macro definition\) of
 warning: Member RTT_FREQUENCY \(macro definition\) of
 warning: Member RTT_MAX_FREQUENCY \(macro definition\) of
 warning: Member SDCARD_SPI_PARAM_[A-Z0-9_]* \(macro definition\) of
-warning: Member SHT1X_PARAMS \(macro definition\) of
 warning: Member SHT1X_PARAM_[A-Z0-9_]* \(macro definition\) of
+warning: Member SHT1X_PARAMS \(macro definition\) of
 warning: Member SHT1X_SAULINFO \(macro definition\) of
 warning: Member spi_config\[\] \(variable\) of
 warning: Member SPI_NUMOF \(macro definition\) of
 warning: Member ST7735_PARAM_[A-Z0-9_]* \(macro definition\) of
 warning: Member TIMER_[0-9]_IRQN \(macro definition\) of
-warning: Member TIMER_NUMOF \(macro definition\) of
 warning: Member timer_config\[\] \(variable\) of
+warning: Member TIMER_NUMOF \(macro definition\) of
 warning: Member TMP00X_PARAM_ADDR \(macro definition\) of
 warning: Member TMP00X_PARAM_I2C \(macro definition\) of
 warning: Member TMP00X_PARAM_RATE \(macro definition\) of
 warning: Member UART_[0-9]_IRQN \(macro definition\) of
-warning: Member UART_NUMOF \(macro definition\) of
 warning: Member uart_config\[\] \(variable\) of
+warning: Member UART_NUMOF \(macro definition\) of
 warning: Member XTIMER_BACKOFF \(macro definition\) of
 warning: Member XTIMER_CHAN \(macro definition\) of
 warning: Member XTIMER_DEV \(macro definition\) of


### PR DESCRIPTION
### Contribution description

This cleans up the documentation and the header files of the TelosB board. It is supposed to not changed the generated firmware (except for debug symbols).
<!-- bors cut here -->

### Testing procedure

Green CI + no diffs in binaries.

### Issues/PRs references

None