### PR TITLE
tests/drivers/l3gxxxx: fix used sensor version for iotlab boards

### DIFF
--- a/tests/drivers/l3gxxxx/Makefile
+++ b/tests/drivers/l3gxxxx/Makefile
@@ -5,6 +5,10 @@ ifneq (,$(filter stm32f429i-disc1 stm32f429i-disco stm32f3discovery,$(BOARD)))
   DRIVER := i3g4250d
 endif
 
+ifneq (,$(filter iotlab-m3 iotlab-a8-m3,$(BOARD)))
+  DRIVER := l3g4200d_ng
+endif
+
 DRIVER ?= l3gd20h
 
 USEMODULE += $(DRIVER)


### PR DESCRIPTION
### Contribution description

This PR fixes the `l3gxxxx` driver version used in `tests/drivers/l3gxxxx` for IoT-Lab boards. It hopefully fixes the compilation of nightly.

The problem occurred with PR #19523. 

### Testing procedure

```
BOARD=iotlab-a8-m3 make -j8 -C tests/drivers/l3gxxxx info-modules | grep l3g4200d_ng
```
should succeed.

### Issues/PRs references
