### PR TITLE
nanocoap_sock: remove nanocoap_get()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -65,8 +65,8 @@
  *
  * Follow the instructions in the section _Write Options and Payload_ below.
  *
- * To send the message and await the response, see nanocoap_request() as well
- * as nanocoap_get(), which additionally copies the response payload to a user
+ * To send the message and await the response, see nanocoap_sock_request() as well
+ * as nanocoap_sock_get(), which additionally copies the response payload to a user
  * supplied buffer. Finally, read the response as described above in the server
  * _Handler functions_ section for reading a request.
  *
@@ -564,23 +564,6 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
  */
 ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
                          const sock_udp_ep_t *remote, size_t len);
-
-/**
- * @brief   Simple synchronous CoAP (confirmable) get
- *
- * @deprecated  Will be removed after the 2023.04 release.
- *              Please use @ref nanocoap_sock_get instead.
- *
- * @param[in]   remote  remote UDP endpoint
- * @param[in]   path    remote path
- * @param[out]  buf     buffer to write response to
- * @param[in]   len     length of @p buffer
- *
- * @returns     length of response payload on success
- * @returns     <0 on error
- */
-ssize_t nanocoap_get(const sock_udp_ep_t *remote, const char *path,
-                     void *buf, size_t len);
 
 /**
  * @brief   Initialize block request context by URL and connect a socket

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -548,22 +548,6 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
     return res;
 }
 
-ssize_t nanocoap_get(const sock_udp_ep_t *remote, const char *path, void *buf, size_t len)
-{
-    int res;
-    nanocoap_sock_t sock;
-
-    res = nanocoap_sock_connect(&sock, NULL, remote);
-    if (res) {
-        return res;
-    }
-
-    res = nanocoap_sock_get(&sock, path, buf, len);
-    nanocoap_sock_close(&sock);
-
-    return res;
-}
-
 static int _block_cb(void *arg, coap_pkt_t *pkt)
 {
     _block_ctx_t *ctx = arg;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The function has been deprecated in favor of `nanocoap_sock_get()`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#18752
