### PR TITLE
tests/pkg_fatfs*: fix shellcheck warnings

### DIFF
--- a/tests/pkg_fatfs/create_fat_image_file.sh
+++ b/tests/pkg_fatfs/create_fat_image_file.sh
@@ -6,7 +6,7 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
-dd if=/dev/zero of=riot_fatfs_disk.img bs=1M count=$1
+dd if=/dev/zero of=riot_fatfs_disk.img bs=1M count="$1"
 mkfs.fat riot_fatfs_disk.img
 sudo mkdir -p /media/riot_fatfs_disk
 sudo mount -o loop,umask=000 riot_fatfs_disk.img /media/riot_fatfs_disk

--- a/tests/pkg_fatfs_vfs/create_fat_image_file.sh
+++ b/tests/pkg_fatfs_vfs/create_fat_image_file.sh
@@ -6,7 +6,7 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
-dd if=/dev/zero of=riot_fatfs_disk.img bs=1M count=$1
+dd if=/dev/zero of=riot_fatfs_disk.img bs=1M count="$1"
 mkfs.fat riot_fatfs_disk.img
 sudo mkdir -p /media/riot_fatfs_disk
 sudo mount -o loop,umask=000 riot_fatfs_disk.img /media/riot_fatfs_disk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When running `make static-tests` with PR #19551, shellcheck reports warnings with some scripts provided with `tests/pkg_fatfs` and `tests/pkg_fatfs_vfs`. The warnings are about missing double quotes around variables. This PR is fixing them.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I did a brief test of `tests/pkg_fatfs` on native and it seems to work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that while running static tests locally with #19551 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
