### PR TITLE
treewide: replace occurrences of tests/driver_ with new path

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -113,21 +113,21 @@ z1
 : ${TEST_KCONFIG_ENFORCE_APP_GROUPS:="
 tests/cb_mux*
 tests/congure_*
-tests/driver_b*
-tests/driver_f*
-tests/driver_g*
-tests/driver_h*
-tests/driver_i*
-tests/driver_j*
-tests/driver_l*
-tests/driver_o*
-tests/driver_p*
-tests/driver_q*
-tests/driver_r*
-tests/driver_s*
-tests/driver_t*
-tests/driver_u*
-tests/driver_v*
+tests/drivers/b*
+tests/drivers/f*
+tests/drivers/g*
+tests/drivers/h*
+tests/drivers/i*
+tests/drivers/j*
+tests/drivers/l*
+tests/drivers/o*
+tests/drivers/p*
+tests/drivers/q*
+tests/drivers/r*
+tests/drivers/s*
+tests/drivers/t*
+tests/drivers/u*
+tests/drivers/v*
 tests/external_board_dirs
 tests/periph_*
 tests/pkg/elk
@@ -159,7 +159,7 @@ tests/saul
 tests/mtd_mapper
 "}
 
-: ${TEST_WITH_CONFIG_SUPPORTED:="examples/suit_update tests/driver_at86rf2xx_aes"}
+: ${TEST_WITH_CONFIG_SUPPORTED:="examples/suit_update tests/drivers/at86rf2xx_aes"}
 
 export RIOT_CI_BUILD=1
 export CC_NOCOLOR=1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -142,8 +142,8 @@
 
 /tests/                                     @smlng @leandrolanzieri @aabadie @MichelRottleuthner @fjmolinas
 /tests/candev/                              @wosym
-/tests/driver_bq2429x/                      @jeandudey
-/tests/driver_dht/                          @wosym
+/tests/drivers/bq2429x/                     @jeandudey
+/tests/drivers/dht/                         @wosym
 /tests/gnrc*                                @miri64
 /tests/lwip*                                @miri64
 /tests/pkg/libschc/                         @miri64

--- a/boards/msbiot/doc.txt
+++ b/boards/msbiot/doc.txt
@@ -163,7 +163,7 @@ values from all three sensors of the device. For an overview on the supported
 features, you can check the driver's documentation in @ref drivers_mpu9x50.
 
 A sample RIOT application for the MPU-9150 that utilizes the driver can be
-found [here](https://github.com/RIOT-OS/RIOT/tree/master/tests/driver_mpu9x50).
+found [here](https://github.com/RIOT-OS/RIOT/tree/master/tests/drivers/mpu9x50).
 
 | Product               | MPU-9150                                                                                          |
 |:--------------------- |:------------------------------------------------------------------------------------------------- |

--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -28,7 +28,7 @@ The following use cases are:
     `./compile_like_murdock.py -c stm32`
 
     I changed a driver the DHT driver
-    `./compile_like_murdock.py -a tests/driver_dht tests/saul`
+    `./compile_like_murdock.py -a tests/drivers/dht tests/saul`
 
     I changed a nucleo-f103rb board...
     `./compile_like_murdock.py -a all -b nucleo-f103rb`

--- a/dist/tools/uncrustify/whitelist.txt
+++ b/dist/tools/uncrustify/whitelist.txt
@@ -18,4 +18,4 @@ sys/test_utils/result_output/*/.*\h
 sys/test_utils/include/result_output.h
 sys/ztimer/.*\.c
 sys/include/ztimer.*\.h
-tests/driver_sx127x/.*\.c
+tests/drivers/sx127x/.*\.c

--- a/drivers/include/adt7310.h
+++ b/drivers/include/adt7310.h
@@ -29,7 +29,7 @@
  *
  * ## Usage
  *
- * See `tests/driver_adt7310` for an example application using this driver.
+ * See `tests/drivers/adt7310` for an example application using this driver.
  *
  * ## Caveats
  *

--- a/drivers/include/bme680.h
+++ b/drivers/include/bme680.h
@@ -87,14 +87,14 @@
  * and `bme680_spi`. Several BME680 sensors and a mixed configuration of I2C
  * and SPI can be used in one application.
  * ```
- * USEMODULE='bme680_spi bme680_i2c' make BOARD=... -C tests/driver_bme680
+ * USEMODULE='bme680_spi bme680_i2c' make BOARD=... -C tests/drivers/bme680
  * ```
  *
  * The vendor driver allows the use of floating point conversions. In order
  * to use these floating point conversions, module `bme680_fp` has to
  * be enabled:
  * ```
- * USEMODULE='bme680_fp bme680_i2c' make BOARD=... -C tests/driver_bme680
+ * USEMODULE='bme680_fp bme680_i2c' make BOARD=... -C tests/drivers/bme680
  * ```
  *
  * @{

--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -24,7 +24,7 @@
  *
  * ## Usage
  *
- * Examine `tests/driver_isr29125` for an exemplary application using
+ * Examine `tests/drivers/isr29125` for an exemplary application using
  * this driver.
  *
  * ## Caveats

--- a/drivers/include/l3gxxxx.h
+++ b/drivers/include/l3gxxxx.h
@@ -910,7 +910,7 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * DRIVER=l3gd20h USEMODULE='l3gxxxx_irq_data` \
  * CLFAGS='-DL3GXXXX_INT2_PIN=GPIO_PIN\(0, 5\)' \
- * BOARD=... make -C tests/driver_l3gxxxx
+ * BOARD=... make -C tests/drivers/l3gxxxx
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * The default configuration of the sensor is defined in file
@@ -947,7 +947,7 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * DRIVER=l3gd20h USEMODULE='l3gxxxx_low_odr l3gxxxx_irq_data` \
  * CLFAGS='-DCONFIG_L3GXXXX_ODR=L3GXXXX_ODR_12 -DL3GXXXX_INT2_PIN=GPIO_PIN\(0,5\)' \
- * BOARD=... make -C tests/driver_l3gxxxx
+ * BOARD=... make -C tests/drivers/l3gxxxx
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>

--- a/drivers/include/mcp47xx.h
+++ b/drivers/include/mcp47xx.h
@@ -42,7 +42,7 @@
  * - functions require an additional parameter, the pointer to the MCP47xx
  *   device of type #mcp47xx_t.
  *
- * Please refer the test application in `tests/driver_mcp47xx` for an example
+ * Please refer the test application in `tests/drivers/mcp47xx` for an example
  * on how to use the driver.
  *
  * ## SAUL Capabilities

--- a/drivers/include/pca9685.h
+++ b/drivers/include/pca9685.h
@@ -38,7 +38,7 @@
  * - functions require an additional parameter, the pointer to the PWM
  *   device of type #pca9685_t.
  *
- * Please refer the test application in `tests/driver_pca9685` for an example
+ * Please refer the test application in `tests/drivers/pca9685` for an example
  * on how to use the driver.
  *
  * ## SAUL Capabilities

--- a/drivers/include/pcf857x.h
+++ b/drivers/include/pcf857x.h
@@ -36,7 +36,7 @@
  * used pseudomodules. For example, to use a PCF8574A and a PCF8575 I/O
  * expander in one application, the make command would be:
  *
- *      USEMODULE="pcf8574a pcf8575" make -C tests/driver_pcf857x BOARD=...
+ *      USEMODULE="pcf8574a pcf8575" make -C tests/drivers/pcf857x BOARD=...
  *
  * At least one PCF857X I2C I/O expander variant has to be specified. The
  * driver module `pcf857x` is then enabled implicitly.
@@ -156,7 +156,7 @@
  * configuration parameter file or at the command line, for example:
  *
  *      CFLAGS="-DPCF857X_PARAM_INT_PIN=\(GPIO_PIN\(0,6\)\)" \
- *      USEMODULE="pcf8575 pcf857x_irq_medium" make -C tests/driver_pcf857x BOARD=...
+ *      USEMODULE="pcf8575 pcf857x_irq_medium" make -C tests/drivers/pcf857x BOARD=...
  *
  * <br>
  * @note If an output of the expander is connected to an input of the same
@@ -205,7 +205,7 @@
  * used pseudomodules. For example, to use a PCF8574A and a PCF8575 I/O
  * expander in one application, the make command would be:
  *
- *      USEMODULE="pcf8574a pcf8575" make -C tests/driver_pcf857x BOARD=...
+ *      USEMODULE="pcf8574a pcf8575" make -C tests/drivers/pcf857x BOARD=...
  *
  * Furthermore, used devices have to be configured by defining the
  * configuration parameter set `pcf857x_params` of type #pcf857x_params_t.

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -26,7 +26,7 @@
  * depending on the selected implementation, @ref servo_pwm_params or
  * @ref servo_timer_params to match your hardware configuration.
  *
- * The test application in `tests/driver_servo` can serve as starting point for
+ * The test application in `tests/drivers/servo` can serve as starting point for
  * users.
  *
  * @{

--- a/drivers/include/vl6180x.h
+++ b/drivers/include/vl6180x.h
@@ -342,7 +342,7 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * USEMODULE='vl6180x_rng vl6180x_als vl6180x_irq` \
  * CLFAGS='-DVL6180X_PARAM_INT_PIN=GPIO_PIN\(0,5\)' \
- * BOARD=... make -C tests/driver_vl6180x
+ * BOARD=... make -C tests/drivers/vl6180x
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  *  The default configuration of the sensor is defined in file
@@ -370,7 +370,7 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * USEMODULE='vl6180x_rng vl6180x_als` \
  * CLFAGS='-DCONFIG_VL6180X_MEAS_PERIOD=50 -DCONFIG_VL6180X_RNG_MAX_TIME=60' \
- * BOARD=... make -C tests/driver_vl6180x
+ * BOARD=... make -C tests/drivers/vl6180x
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * ## Configuration at runtime

--- a/pkg/driver_bme680/README.md
+++ b/pkg/driver_bme680/README.md
@@ -24,12 +24,12 @@ which BME680 sensor is defined in the `bme680_params` parameters. The
 respective implementation is enabled by the modules `bme680_i2c` and
 `bme680_spi`. Both I2C and SPI can be used in one application.
 ```
-USEMODULE='bme680_spi bme680_i2c' make BOARD=... -C tests/driver_bme680
+USEMODULE='bme680_spi bme680_i2c' make BOARD=... -C tests/drivers/bme680
 ```
 
 In order to use floating point, you can enable module `bme680_fp` variable:
 ```
-USEMODULE='bme680_fp bme680_i2c' make BOARD=... -C tests/driver_bme680
+USEMODULE='bme680_fp bme680_i2c' make BOARD=... -C tests/drivers/bme680
 ```
 
 The following callbacks add support for the included drivers via I2C and SPI

--- a/tests/drivers/bme680/README.md
+++ b/tests/drivers/bme680/README.md
@@ -21,7 +21,7 @@ conversions. By default fixed-point arithmetic is used. To use floating-point
 arithmetic, the `bme680_fp` module has to be enabled. This can be done in the
 test application by setting the environment variable `ENABLE_FP`:
 ```
-ENABLE_FP=1 make BOARD=... -C tests/driver_bme680
+ENABLE_FP=1 make BOARD=... -C tests/drivers/bme680
 ```
 
 ## Interface
@@ -35,11 +35,11 @@ Which implementation is used for the test application is defined by the
 `DRIVER` environment variable. By default `bme680_i2c` is used. To use
 `bme680_spi`, the `DRIVER` variable could be set at the make command line:
 ```
-DRIVER=bme680_spi make BOARD=... -C tests/driver_bme680
+DRIVER=bme680_spi make BOARD=... -C tests/drivers/bme680
 ```
 
 It is also possible to use I2C as well SPI simultaneously in the test
 application:
 ```
-DRIVER=bme680_spi bme680_i2c' make BOARD=... -C tests/driver_bme680
+DRIVER=bme680_spi bme680_i2c' make BOARD=... -C tests/drivers/bme680
 ```

--- a/tests/drivers/bmx280/README.md
+++ b/tests/drivers/bmx280/README.md
@@ -23,13 +23,13 @@ If your device is at a different I2C address than the default (0x77) you
 can build the test as follows:
 
     export CFLAGS=-DBMX280_PARAM_I2C_ADDR=0x76
-    BOARD=sodaq-autonomo make -C tests/driver_bmx280
+    BOARD=sodaq-autonomo make -C tests/drivers/bmx280
 
 By default, the test application is built to use the bme280 module, to build it for
 the bmp280, add `DRIVER=bmp280` to the previous command:
 
 
-    $ DRIVER=bmp280 BOARD=sodaq-autonomo make -C tests/driver_bmx280
+    $ DRIVER=bmp280 BOARD=sodaq-autonomo make -C tests/drivers/bmx280
 
 
 For more information, see the datasheets:

--- a/tests/drivers/ccs811/README.md
+++ b/tests/drivers/ccs811/README.md
@@ -13,5 +13,5 @@ The test application demonstrates the use of the CCS811 using
 - default configuration parameters, that is, the measurement mode
   `CCS811_MODE_1S` with one measurement per second.
 
-Please refer `$(RIOTBASE)/tests/driver_ccs811_full` to learn how
+Please refer `$(RIOTBASE)/tests/drivers/ccs811_full` to learn how
 to use the CCS811 with interrupts.

--- a/tests/drivers/ccs811_full/README.md
+++ b/tests/drivers/ccs811_full/README.md
@@ -24,5 +24,5 @@ overridden according to the hardware configuration by defining
 ```
 or via the `CFLAGS` variable in the make command.
 ```
-CFLAGS="-DCCS811_PARAM_INT_PIN=GPIO_PIN\(0,7\)" make -C tests/driver_ccs811_full BOARD=...
+CFLAGS="-DCCS811_PARAM_INT_PIN=GPIO_PIN\(0,7\)" make -C tests/drivers/ccs811_full BOARD=...
 ```

--- a/tests/drivers/hmc5883l/README.md
+++ b/tests/drivers/hmc5883l/README.md
@@ -24,7 +24,7 @@ configuration parameter `HMC5883L_PARAM_INT_PIN` if necessary, for example:
 
 ```
 USEMODULE=hmc5883l_int CFLAGS='-DHMC5883L_PARAM_INT_PIN=GPIO_PIN\(0,12\)' \
-make flash -C tests/driver_hmc5883l BOARD=...
+make flash -C tests/drivers/hmc5883l BOARD=...
 ```
 
 The heading angle is calculated for a magnetic declination in radians defined

--- a/tests/drivers/itg320x/README.md
+++ b/tests/drivers/itg320x/README.md
@@ -25,5 +25,5 @@ defined by #ITG320X_PARAM_INT_PIN, for example:
 
 ```
 USEMODULE=itg320x_int CFLAGS="-DITG320X_PARAM_INT_PIN=\(GPIO_PIN\(0,3\)\)" \
-make flash -C tests/driver_itg320x BOARD=...
+make flash -C tests/drivers/itg320x BOARD=...
 ```

--- a/tests/drivers/l3gxxxx/README.md
+++ b/tests/drivers/l3gxxxx/README.md
@@ -11,7 +11,7 @@ The used sensor must be specified by setting the variable DRIVER to
 `l3gd20h`, `l3gd20`, `l3g4200d_ng`, `i3g4250d` or `a3g4250d` which enables
 the corresponding pseudomodule:
 ```
-DRIVER=l3gd20h BOARD=... make -C tests/driver_l3gxxxx
+DRIVER=l3gd20h BOARD=... make -C tests/drivers/l3gxxxx
 ```
 If the DRIVER variable is not set, `l3gd20h` is used.
 
@@ -32,7 +32,7 @@ of the sensor and polls the data periodically every 200 ms. If the SPI
 interface of the sensor should be used, the module `l3gxxxx_spi` has to
 be used:
 ```
-DRIVER=l3gd20h USEMODULE=l3gxxxx_spi BOARD=... make -C tests/driver_l3gxxxx
+DRIVER=l3gd20h USEMODULE=l3gxxxx_spi BOARD=... make -C tests/drivers/l3gxxxx
 ```
 
 The application is configurable by using different pseudomodules to test
@@ -47,7 +47,7 @@ most of the functionalities of the L3Gxxxx driver.
 
     ```
     DRIVER=l3gd20h USEMODULE=l3gxxxx_irq_drdy \
-    CFLAGS='-DL3GXXXX_INT2_PIN=GPIO_PIN\(0,5\) BOARD=... make -C tests/driver_l3gxxxx
+    CFLAGS='-DL3GXXXX_INT2_PIN=GPIO_PIN\(0,5\) BOARD=... make -C tests/drivers/l3gxxxx
     ```
 
 - Module `l3gxxxx_irq_event`:
@@ -59,7 +59,7 @@ most of the functionalities of the L3Gxxxx driver.
 
     ```
     DRIVER=l3gd20h USEMODULE=l3gxxxx_irq_event \
-    CFLAGS='-DL3GXXXX_INT1_PIN=GPIO_PIN\(0,6\) BOARD=... make -C tests/driver_l3gxxxx
+    CFLAGS='-DL3GXXXX_INT1_PIN=GPIO_PIN\(0,6\) BOARD=... make -C tests/drivers/l3gxxxx
     ```
 
 - Module `l3gxxxx_fifo`:

--- a/tests/drivers/lc709203f/README.md
+++ b/tests/drivers/lc709203f/README.md
@@ -1,7 +1,7 @@
 # About
 This is a test application for the ON Semiconductor lc709203F Battery Fuel Gauge
 # Usage
-Just enter the `make BOARD=??? flash` command in the `tests/driver_lc709203F/` folder.
+Just enter the `make BOARD=??? flash` command in the `tests/drivers/lc709203F/` folder.
 Make sure the `LC709203F_PARAMS_ALARM_PIN` is set in your boards `board.h`
 # Results
 The sensor will first test the low RSOC interrupt by setting the threshold limit to 100%. Therefore a low RSOC interrupt should be triggered and the message "ALARM low RSOC" should be printed to the terminal. After that all major measurements will be printed and refreshed every 5s.

--- a/tests/drivers/nrf24l01p_lowlevel/README.md
+++ b/tests/drivers/nrf24l01p_lowlevel/README.md
@@ -8,7 +8,7 @@ SPI and GPIO commands, which abstract the driver-functions from the used board.
 
 ## Predefined pin mapping
 
-Please compare the `tests/driver_nrf24l01p_lowlevel/Makefile` for predefined
+Please compare the `tests/drivers/nrf24l01p_lowlevel/Makefile` for predefined
 pin-mappings on different boards. (In addition, you also need to connect to 3V
 and GND)
 

--- a/tests/drivers/pca9685/README.md
+++ b/tests/drivers/pca9685/README.md
@@ -16,7 +16,7 @@ which is under following copyright:
 
 To use the test application, compile it with
 ```
-     make -C tests/driver_pca9685 BOARD=...
+     make -C tests/drivers/pca9685 BOARD=...
 ```
 Please check the default configuration parameters in
 `$(RIOTBASE)/drivers/pca9685/include/pca9685_params.h` and adopt them
@@ -26,5 +26,5 @@ If the active LOW output enable pin /OE is used, the GPIO has to be defined
 as parameter, e.g.
 ```
      CFLAGS="-DPCA9685_PARAM_INT_PIN=\(GPIO\(0,6\)\)" \
-     make -C tests/driver_pca9685 BOARD=...
+     make -C tests/drivers/pca9685 BOARD=...
 ```

--- a/tests/drivers/pcf857x/README.md
+++ b/tests/drivers/pcf857x/README.md
@@ -14,7 +14,7 @@ expander modules. Please check the default configuration parameters in
 if necessary. Alternatively, a modified version of this file could be
 placed in the directory of this test application to override it.
 ```
-USEMODULE=pcf8575 make -C tests/driver_pcf857x BOARD=...
+USEMODULE=pcf8575 make -C tests/drivers/pcf857x BOARD=...
 ```
 **Please note:** When no pseudomodule is given, `pcf8575` is used by default.
 
@@ -24,7 +24,7 @@ low-active open-drain interrupt signal has to be enabled. Add module
 parameter `PCF857X_PARAM_INT_PIN`, e.g.
 ```
 CFLAGS="-DPCF857X_PARAM_INT_PIN=\(GPIO_PIN\(0,6\)\)" \
-USEMODULE="pcf8575 pcf857x_irq" make -C tests/driver_pcf857x BOARD=...
+USEMODULE="pcf8575 pcf857x_irq" make -C tests/drivers/pcf857x BOARD=...
 ```
 **Please note:** Since interrupts are handled in the context of a separate
 event thread, enabling interrupts requires more RAM.
@@ -56,7 +56,7 @@ is defined by the macro `PCF857X_PORT_0`, which is 16 by default. This value
 can be overridden during compilation, e.g.:
 ```
 CFLAGS="-DPCF857X_PORT_0=8" \
-USEMODULE=pcf8575 make -C tests/driver_pcf857x BOARD=...
+USEMODULE=pcf8575 make -C tests/drivers/pcf857x BOARD=...
 ```
 Using the port number defined by `PCF857X_PORT_0` and the following port
 numbers, you can apply the command to the PCF857X expander ports. For

--- a/tests/drivers/rn2xx3/README.md
+++ b/tests/drivers/rn2xx3/README.md
@@ -28,7 +28,7 @@ Use the `DRIVER` variable to select the right driver module between `rn2483`
 and `rn2903` depending on your region.
 Example in EU:
 ```
-    make DRIVER=rn2483 BOARD=arduino-zero -C tests/driver_rn2xx3 flash term
+    make DRIVER=rn2483 BOARD=arduino-zero -C tests/drivers/rn2xx3 flash term
 ```
 
 # Usage

--- a/tests/drivers/scd30/README.md
+++ b/tests/drivers/scd30/README.md
@@ -14,5 +14,5 @@ second:
 The user can specify the number of iterations by setting the variable
 `TEST_ITERATIONS` (default value is 10) from commandline as follows:
 ```
-make BOARD=... TEST_ITERATIONS=... -C tests/driver_scd30
+make BOARD=... TEST_ITERATIONS=... -C tests/drivers/scd30
 ```

--- a/tests/drivers/sdp3x/README.md
+++ b/tests/drivers/sdp3x/README.md
@@ -11,7 +11,7 @@ of following values first in continuous mode and then triggered mode every secon
 The user can specify the number of iterations by setting the variable `TEST_ITERATIONS`
 (default value is 10) from commandline as follows:
 ```
-make BOARD=... TEST_ITERATIONS=... -C tests/driver_sdp3x
+make BOARD=... TEST_ITERATIONS=... -C tests/drivers/sdp3x
 ```
 
 ##Features

--- a/tests/drivers/shtcx/README.md
+++ b/tests/drivers/shtcx/README.md
@@ -7,4 +7,4 @@ Default driver is "shtc1". To use the SHTC3 driver, set the "DRIVER" when buildi
     DRIVER=shtc3 make BOARD=<your board>
 
 #Usage
-Just build it using the `make BOARD=??? flash` command in the `tests/driver_shtcx` folder. Temperature and humidity values should be printed in the terminal every 2s
+Just build it using the `make BOARD=??? flash` command in the `tests/drivers/shtcx` folder. Temperature and humidity values should be printed in the terminal every 2s

--- a/tests/drivers/srf04/README.md
+++ b/tests/drivers/srf04/README.md
@@ -1,4 +1,4 @@
-tests/driver_srf04
+tests/drivers/srf04
 ================
 This example shows the usage of an srf04 module.
 The application uses a timer and two gpio pins.

--- a/tests/drivers/stmpe811/README.md
+++ b/tests/drivers/stmpe811/README.md
@@ -7,7 +7,7 @@ This is the test application for the STMPE811 touchscreen controller.
 The application works out of the box on a STM32F429I-DISC1 board:
 
 ```
-make -C tests/driver_stmpe811 flash term
+make -C tests/drivers/stmpe811 flash term
 ```
 
 ## Expected output

--- a/tests/drivers/sx1280/README.md
+++ b/tests/drivers/sx1280/README.md
@@ -12,7 +12,7 @@ the configuration to your needs by copying an adapted version of
 ## Build and Flash
 
 ```shell
-cd tests/driver_sx1280
+cd tests/drivers/sx1280
 make flash term
 ```
 

--- a/tests/drivers/vl6180x/README.md
+++ b/tests/drivers/vl6180x/README.md
@@ -17,7 +17,7 @@ Module Name        | Functionality used
 
 To compile and execute the test application, use command:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-make BOARD=... -C tests/driver_vl6180x flash term
+make BOARD=... -C tests/drivers/vl6180x flash term
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, the `vl6180x_rng` and `vl6180x_als` modules are enabled.
@@ -33,7 +33,7 @@ for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CFLAGS="-DVL6180X_PARAM_INT_PIN=\(GPIO_PIN\(0,5\)\)" \
 USEMODULE=vl6180x_irq \
-make BOARD=... -C tests/driver_vl6180x flash term
+make BOARD=... -C tests/drivers/vl6180x flash term
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the module `vl6180x_config` is used additionally, the event interrupt
@@ -41,7 +41,7 @@ is configured and used for range measurements:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CFLAGS="-DVL6180X_PARAM_INT_PIN=\(GPIO_PIN\(0,5\)\)" \
 USEMODULE='vl6180x_irq vl6180x_config'\
-make BOARD=... -C tests/driver_vl6180x flash term
+make BOARD=... -C tests/drivers/vl6180x flash term
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To test the power-down and power-up functionality, the `vl6180x_shutdown`
@@ -51,5 +51,5 @@ of the sensor has to be defined by configuration parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CFLAGS="-VL6180X_PARAM_SHUTDOWN_PIN=\(GPIO_PIN\(0,6\)\)" \
 USEMODULE=vl6180x_shutdown \
-make BOARD=... -C tests/driver_vl6180x flash term
+make BOARD=... -C tests/drivers/vl6180x flash term
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

After #19435 there are still lots of places where `tests/driver_*` is used, mainly in READMEs but also in Kconfig related things, CI. This PR is fixing all of them (at least the ones found using `git grep "tests/driver_*" | grep -v ^release-notes*`). 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Leftover from #19435 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
