### PR TITLE
boards/p-l496g-cell02: fix UART_DEV(2) configuration

### DIFF
--- a/boards/p-l496g-cell02/include/periph_conf.h
+++ b/boards/p-l496g-cell02/include/periph_conf.h
@@ -78,8 +78,8 @@ static const uart_conf_t uart_config[] = {
     {   /* STMod+/PMOD connectors */
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_B, 6),
-        .tx_pin     = GPIO_PIN(PORT_G, 10),
+        .rx_pin     = GPIO_PIN(PORT_G, 10),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB2,


### PR DESCRIPTION
### Contribution description

This PR fixes the configuration of `UART_DEV(2)`. RX and TX pin were reversed in configuration. The TX pin is connected to PB6 instead of PG10 and the RX pin is connected to PG10 instead of PB6, see [schematic](https://www.st.com/content/ccc/resource/technical/layouts_and_diagrams/schematic_pack/group2/f5/28/1b/e1/55/12/4d/3c/mb1261-cell02-b06-schematic/files/mb1261-cell02-b06-schematic.pdf/jcr:content/translations/en.mb1261-cell02-b06-schematic.pdf), page 14.

### Testing procedure

The UART interface at STMOD+ or PMOD connector should work.

### Issues/PRs references