### PR TITLE
cpu/stm32/periph_dac: small improvements

### DIFF
--- a/cpu/stm32/periph/dac.c
+++ b/cpu/stm32/periph/dac.c
@@ -109,8 +109,14 @@ void dac_poweron(dac_t line)
     while (!(VREFBUF->CSR & VREFBUF_CSR_VRR)) { }
 #endif
 
+#ifdef DAC_MCR_MODE1
+    /* Normal mode with Buffer enabled and connected to external pin and on-chip
+     * peripherals */
+    dev(line)->MCR |= (DAC_MCR_MODE1_0 << (16 * (dac_config[line].chan & 0x01)));
+#endif
+
     /* enable corresponding DAC channel */
-    dev(line)->CR |= (1 << (16 * (dac_config[line].chan & 0x01)));
+    dev(line)->CR |= (DAC_CR_EN1 << (16 * (dac_config[line].chan & 0x01)));
 }
 
 void dac_poweroff(dac_t line)
@@ -118,7 +124,7 @@ void dac_poweroff(dac_t line)
     assert(line < DAC_NUMOF);
 
     /* disable corresponding channel */
-    dev(line)->CR &= ~(1 << (16 * (dac_config[line].chan & 0x01)));
+    dev(line)->CR &= ~(DAC_CR_EN1 << (16 * (dac_config[line].chan & 0x01)));
 
     /* disable the DAC's clock in case no channel is active anymore */
     if (!(dev(line)->CR & EN_MASK)) {

--- a/cpu/stm32/periph/dac.c
+++ b/cpu/stm32/periph/dac.c
@@ -33,8 +33,10 @@
 #endif
 
 /* get RCC bit */
-#ifdef RCC_APB1ENR_DAC1EN
+#if defined(RCC_APB1ENR_DAC1EN)
 #define RCC_BIT             (RCC_APB1ENR_DAC1EN)
+#elif defined(RCC_APB1ENR1_DAC1EN)
+#define RCC_BIT             (RCC_APB1ENR1_DAC1EN)
 #else
 #define RCC_BIT             (RCC_APB1ENR_DACEN)
 #endif

--- a/cpu/stm32/periph/dac.c
+++ b/cpu/stm32/periph/dac.c
@@ -99,6 +99,16 @@ void dac_poweron(dac_t line)
     periph_clk_en(APB1, RCC_BIT);
 #endif
 
+#if VREFBUF_ENABLE && defined(VREFBUF_CSR_ENVR)
+    /* enable VREFBUF if needed and available (for example if the board doesn't
+     * have an external reference voltage connected to V_REF+), wait until
+     * it is ready */
+    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+    VREFBUF->CSR &= ~VREFBUF_CSR_HIZ;
+    VREFBUF->CSR |= VREFBUF_CSR_ENVR;
+    while (!(VREFBUF->CSR & VREFBUF_CSR_VRR)) { }
+#endif
+
     /* enable corresponding DAC channel */
     dev(line)->CR |= (1 << (16 * (dac_config[line].chan & 0x01)));
 }


### PR DESCRIPTION
### Contribution description

This PR provides the following improvements for `periph_dac` on STM32

- Support for `RCC_APB1ENR1_DAC1EN` symbol added.
- For boards that have not connected the V_REF+ pin to an external reference voltage, the VREFBUF peripheral can be used as V_REF+ (if supported) by setting `VREFBUF_ENABLE=1`.
- If the DAC peripheral has a mode register (`DAC_MCR`), it is set to normal mode with buffer enabled and connected to external pin and on-chip peripherals. This allows to measure the current value of a DAC channel with an ADC channel or to use the DAC channel also for other on-chip peripherals.

### Testing procedure

- Green CI
- `tests/periph_dac` should still work for any board supporting the `periph_dac` feature.

### Issues/PRs references

