### PR TITLE
cpu/stm32/periph_gpio: reset PU/PD for ADC channels

### DIFF
--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -186,8 +186,9 @@ void gpio_init_analog(gpio_t pin)
 #else
     periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
 #endif
-    /* set to analog mode */
+    /* set to analog mode, PUPD has to be 0b00 */
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
+    _port(pin)->PUPDR &= ~(0x3 << (2 * _pin_num(pin)));
 }
 
 void gpio_irq_enable(gpio_t pin)


### PR DESCRIPTION
### Contribution description

This PR provides a small fix that is relevant when a GPIO has been used as input/output with a pull resistor before it is initialized as an ADC channel.

The PU/PD configuration has to be `0b00` for analog outputs which is corresponds to the reset state. However, if the GPIO is not in the reset state but was used digital input/output with any pull resistor, the PU/PD configuration has also to be reset to use it as ADC channel.

### Testing procedure

- Green CI
- The `periph_adc` test application should still work for any board that supports the `periph_adc` feature.

### Issues/PRs references

