### PR TITLE
treewide: fix format specifiers

### DIFF
--- a/cpu/esp32/periph/pwm.c
+++ b/cpu/esp32/periph/pwm.c
@@ -323,7 +323,7 @@ void pwm_poweroff(pwm_t pwm)
 void pwm_print_config(void)
 {
     for (unsigned pwm = 0; pwm < PWM_NUMOF; pwm++) {
-        printf("\tPWM_DEV(%d)\tchannels=[ ", pwm);
+        printf("\tPWM_DEV(%u)\tchannels=[ ", pwm);
         for (int i = 0; i < _CFG.ch_numof; i++) {
             printf("%d ", _CFG.gpios[i]);
         }

--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -344,7 +344,7 @@ static int _print_reply(gnrc_pktsnip_t *pkt, int corrupted, uint32_t triptime, v
     }
     /* check response for corruption */
     else if (corrupted >= 0) {
-        printf(" corrupted at offset %u", corrupted);
+        printf(" corrupted at offset %u", (unsigned)corrupted);
     }
     if (rssi != GNRC_NETIF_HDR_NO_RSSI) {
         printf(" rssi=%"PRId16" dBm", rssi);


### PR DESCRIPTION
### Contribution description

This brings format specifiers and the passed type back into sync. This won't change observable behavior in one case, and won't even change machine code in the other. But formally, this fixes bugs.
<!-- bors cut here -->

### Testing procedure

Code review is sufficient.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/19517