### PR TITLE
boards: add stm32l496g-disco support

### DIFF
--- a/boards/stm32l496g-disco/Kconfig
+++ b/boards/stm32l496g-disco/Kconfig
@@ -1,0 +1,62 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32l496g-disco" if BOARD_STM32L496G_DISCO
+
+config BOARD_STM32L496G_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32L496AG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_STMOD
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_HW_FC
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_ARDUINO
+    select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+    select HAVE_SAUL_GPIO
+    select HAVE_FT5X06
+
+    select MODULE_PERIPH_LPUART if MODULE_PERIPH_UART
+    select MODULE_PERIPH_UART_HW_FC if MODULE_PERIPH_UART && !MODULE_PERIPH_SPI_STMOD
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"
+
+config HAS_PERIPH_SPI_STMOD
+    bool
+    help
+        Indicates that SPI2 can be connected to STMod+/Pmod connector
+
+config MODULE_PERIPH_SPI_STMOD
+    bool "SPI2 connected to STMod+/Pmod connector"
+    depends on HAS_PERIPH_SPI_MOD
+    default n
+    help
+        By default, solder bridges SB6, SB7, SB8 are closed and USART1 is
+        connected to the Pmod/STMmod+ connector. If these solder bridges are
+        open and solder bridges SB4, SB5 and SB6 are closed instead, SPI2 is
+        connected to the STMmod+/Pmod connector. Say yes to use SPI2 with this
+        board configuration.

--- a/boards/stm32l496g-disco/Makefile
+++ b/boards/stm32l496g-disco/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32l496g-disco/Makefile.dep
+++ b/boards/stm32l496g-disco/Makefile.dep
@@ -1,0 +1,19 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  USEMODULE += periph_uart
+endif
+
+ifneq (,$(filter touch_dev,$(USEMODULE)))
+  USEMODULE += ft5x06
+endif
+
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  USEMODULE += periph_lpuart
+  ifeq (,$(filter periph_spi_stmod_plus,$(USEMODULE)))
+    # if STMod+ is not used with SPI (default), the UART interface uses HW FC
+    USEMODULE += periph_uart_hw_fc
+  endif
+endif

--- a/boards/stm32l496g-disco/Makefile.features
+++ b/boards/stm32l496g-disco/Makefile.features
@@ -1,0 +1,23 @@
+CPU = stm32
+CPU_MODEL = stm32l496ag
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_lpuart
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_spi_stmod
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart_hw_fc
+FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/stm32l496g-disco/Makefile.include
+++ b/boards/stm32l496g-disco/Makefile.include
@@ -1,0 +1,18 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# this board uses openocd with st-link
+PROGRAMMER ?= openocd
+# this board has an on-board ST-link adapter
+OPENOCD_DEBUG_ADAPTER ?= stlink
+
+# openocd programmer is supported
+PROGRAMMERS_SUPPORTED += openocd
+
+# Configure riotboot bootloader and slot lengths
+# 8KB are currently enough, set it to 16KB if USB-DFU or tinyUSB DFU is used
+ifneq (,$(filter usbus_dfu tinyusb_dfu,$(USEMODULE)))
+  RIOTBOOT_LEN ?= 0x4000
+else
+  RIOTBOOT_LEN ?= 0x2000
+endif

--- a/boards/stm32l496g-disco/doc.txt
+++ b/boards/stm32l496g-disco/doc.txt
@@ -1,0 +1,167 @@
+/**
+ * @defgroup    boards_stm32l496g-disco STM32L496G-DISCO
+ * @ingroup     boards
+ * @brief       Support for the STM32L496G-DISCO board.
+
+## Overview
+
+The ST [STM32L496G-DISCO](https://www.st.com/en/evaluation-tools/32l496gdiscovery.html)
+is an evaluation board with the ARM Cortex-M4 based ultra-low power
+microcontroller STM32L496AG with 320KB of RAM and 1MB of ROM Flash.
+
+The main features of this board are:
+- 1.54 RGB 240 x 240 pixel TFT color LCD display with capacitive touch screen,
+- SAI audio codec, with stereo output, including analog microphone input
+- Stereo digital microphones
+- 8-Mbit external PSRAM
+- 64-Mbit external QSPI flash
+- USB OTG FS port
+- 8-bit camera interface
+- Stereo headset jack
+- micso-SD card connector
+
+## Current Hardware Support:
+
+| Feature                 | Support | Remark |
+|------------------------ |:-:| --------------------- |
+| ADC                     | X | 8 channels |
+| DAC                     | X | 1 or 2 channels |
+| I2C                     | X | 2 devices (I2C1 and I2C2) |
+| PWM                     | X | 3 devices with a total og 6 channels |
+| SPI                     | X | 1 or 2 devices (SPI1 and SPI2) |
+| Timers                  | X | 2 devices (TIM2 and TIM3) |
+| UART                    | X | 3 devices (USART2, LPUART1 and USART1) |
+| USB OTG FS              | X | 1 device |
+| TFT color LCD 240 x 40  | - | ST7789H2 used as driver IC (not supported yet) |
+| Capacitive Touch Screen | - | FT3267 used as driver IC (not supported yet) |
+| Stereo microphones      | - | |
+| SAI audio codec         | - | |
+| External PSRAM          | - | Connected to FMC peripheral (not supported yet) |
+| External Quad-SPI Flash | - | QSPI peripheral is not yet supported |
+| SD Card Interface       | - | |
+
+## Board Configuration (sorted by peripheral):
+
+| RIOT Peripheral   | GPIO | Connector pin | Remark    |
+|:------------------|:----:|:--------------|:----------|
+| ADC_LINE(0)       | PC4  | Arduino A0    | ADC1 IN13 |
+| ADC_LINE(1)       | PC1  | Arduino A1    | ADC1 IN2  |
+| ADC_LINE(2)       | PC3  | Arduino A2    | ADC1 IN4  |
+| ADC_LINE(3)       | PF10 | Arduino A3    | ADC3 IN13 |
+| ADC_LINE(4)       | PA1  | Arduino A4    | ADC1 IN6  |
+| ADC_LINE(5)       | PC0  | Arduino A5    | ADC2 IN13 |
+| ADC_LINE(6)       | -    | V_REF_INT     | ADC1 IN0 connected to V_REFINT |
+| ADC_LINE(7)       | PA4  | STmod+ ADC    | ADC1 IN9 if `periph_dac` is not used |
+| ADC_LINE(7)       | -    | -             | ADC2 IN17 connected to DAC1 if `periph_dac` is used |
+| DAC_LINE(0)       | PA4  | STmod+ ADC    | DAC1 if `periph_dac` is used |
+| DAC_LINE(1)       | PA5  | Arduino D13   | DAC2 if `periph_spi` is not used |
+| I2C_DEV(0) SCL    | PB8  | Arduino D15   | I2C1 SCL, also connected to STmod+ SCL |
+| I2C_DEV(0) SDA    | PB7  | Arduino D14   | I2C1 SDA, also connected to STmod+ SDA |
+| I2C_DEV(1) SCL    | PH14 | -             | I2C2 SCL, used for MFX_x, CODEC_x, CTP_x, DCMI_x |
+| I2C_DEV(1) SDA    | PB14 | -             | I2C2 SDA, used for MFX_x, CODEC_x, CTP_x, DCMI_x |
+| PWM_DEV(0) CH0    | PH15 | Arduino D3    | TIM8_CH3N  |
+| PWM_DEV(0) CH1    | PI6  | Arduino D6    | TIM8_CH2   |
+| PWM_DEV(0) CH2    | PH13 | Arduino D9    | TIM8_CH1N  |
+| PWM_DEV(1) CH0    | PB9  | Arduino D5    | TIM4_CH4   |
+| PWM_DEV(2) CH0    | PA0  | STmod+ PWM    | TIM5_CH1   |
+| SPI_DEV(0) SCK    | PA5  | Arduino D13   | SPI1 SCK   |
+| SPI_DEV(0) MISO   | PB4  | Arduino D12   | SPI1 MISO  |
+| SPI_DEV(0) MOSI   | PB5  | Arduino D11   | SPI1 MOSI  |
+| SPI_DEV(0) CS     | PA15 | Arduino D10   | SPI1 NSS   |
+| SPI_DEV(1) SCK    | PI1  | STmod+ CLK, Pmod CLK   | SPI2 SCK (*1)  |
+| SPI_DEV(1) MISO   | PI2  | STmod+ MISO, Pmod MISO | SPI2 MISO (*1) |
+| SPI_DEV(1) MOSI   | PB15 | STmod+ MOSI, Pmod MOSI | SPI2 MOSI (*1) |
+| SPI_DEV(1) CS     | PG1  | STmod+ CS, Pmod CS     | SPI2 NSS (*1)  |
+| UART_DEV(0) RX    | PD6  | ST-Link       | USART2 RX |
+| UART_DEV(0) TX    | PA2  | ST-Link       | USART2 TX |
+| UART_DEV(1) RX    | PD6  | Arduino D0    | LPUART1 RX |
+| UART_DEV(1) TX    | PA2  | Arduino D1    | LPUART1 TX |
+| UART_DEV(2) RX    | PG10 | STmod+ RX, Pmod RX   | USART1 RX (*2)  |
+| UART_DEV(2) TX    | PB6  | STmod+ TX, Pmod TX   | USART1 TX (*2)  |
+| UART_DEV(2) CTS   | PG11 | STmod+ CTS, Pmod CTS | USART1 CTS (*2) |
+| UART_DEV(2) RTS   | PG12 | STmod+ RTS, Pmod RTS | USART1 RTS (*2) |
+<br>
+
+@note
+- (*1) SPI2 is only available if module `periph_spi_stmod` is used.
+       SB4, SB5, SB9 must be closed to connect SPI2 to STmod+ and Pmod.
+- (*2) USART1 is only available if module `periph_spi_stmod` is not used.
+       SB6, SB7, SB8 must be closed to connect USART1 to STmod+ and Pmod
+       (default).
+
+## Board Configuration (sorted by connectors):
+
+| Connector       | RIOT Peripheral   | GPIO | Remark     |
+|:----------------|:------------------|:----:|:-----------|
+| Arduino A0      | ADC_LINE(0)       | PC4  | ADC1 IN13  |
+| Arduino A1      | ADC_LINE(1)       | PC1  | ADC1 IN2   |
+| Arduino A2      | ADC_LINE(2)       | PC3  | ADC1 IN4   |
+| Arduino A3      | ADC_LINE(3)       | PF10 | ADC3 IN13  |
+| Arduino A4      | ADC_LINE(4)       | PA1  | ADC1 IN6   |
+| Arduino A5      | ADC_LINE(5)       | PC0  | ADC2 IN13  |
+| Arduino D0      | UART_DEV(1) RX    | PD6  | LPUART1 RX |
+| Arduino D1      | UART_DEV(1) TX    | PA2  | LPUART1 TX |
+| Arduino D3      | PWM_DEV(0) CH0    | PH15 | TIM8_CH3N  |
+| Arduino D6      | PWM_DEV(0) CH1    | PI6  | TIM8_CH2   |
+| Arduino D5      | PWM_DEV(1) CH0    | PB9  | TIM4_CH4   |
+| Arduino D9      | PWM_DEV(0) CH2    | PH13 | TIM8_CH1N  |
+| Arduino D10     | SPI_DEV(0) CS     | PA15 | SPI1 CS    |
+| Arduino D11     | SPI_DEV(0) MOSI   | PB5  | SPI1 MOSI  |
+| Arduino D12     | SPI_DEV(0) MISO   | PB4  | SPI1 MISO  |
+| Arduino D13     | SPI_DEV(0) SCK    | PA5  | SPI1 SCK   |
+| Arduino D13     | DAC_LINE(1)       | PA5  | DAC2 if `periph_spi` is not used |
+| Arduino D14     | I2C_DEV(0) SDA    | PB7  | I2C1 SDA   |
+| Arduino D15     | I2C_DEV(0) SCL    | PB8  | I2C1 SCL   |
+| Pmod SPI CLK    | SPI_DEV(1) SCK    | PI1  | SPI2 SCK (*1)  |
+| Pmod SPI CS     | SPI_DEV(4) CS     | PG1  | SPI2 NSS (*1)  |
+| Pmod SPI MISO   | SPI_DEV(2) MISO   | PI2  | SPI2 MISO (*1) |
+| Pmod SPI MOSI   | SPI_DEV(3) MOSI   | PB15 | SPI2 MOSI (*1) |
+| Pmod UART CTS   | UART_DEV(2) CTS   | PG11 | USART1 CTS (*2) |
+| Pmod UART RTS   | UART_DEV(2) RTS   | PG12 | USART1 RTS (*2) |
+| Pmod UART RX    | UART_DEV(2) RX    | PG10 | USART1 RX (*2)  |
+| Pmod UART TX    | UART_DEV(2) TX    | PB6  | USART1 TX (*2)  |
+| STmod+ ADC      | ADC_LINE(7)       | PA4  | ADC1 IN9 if `periph_dac` is not used |
+| STmod+ ADC      | DAC_LINE(0)       | PA4  | DAC1 if `periph_dac` is used |
+| STmod+ PWM      | PWM_DEV(2) CH0    | PA0  | TIM5_CH1   |
+| STmod+ I2C SCL  | I2C_DEV(0) SCL    | PB8  | I2C2 SCL   |
+| STmod+ I2C SDA  | I2C_DEV(0) SDA    | PB7  | I2C2 SDA   |
+| STmod+ SPI CLK  | SPI_DEV(1) SCK    | PI1  | SPI2 SCK (*1)  |
+| STmod+ SPI CS   | SPI_DEV(1) CS     | PG1  | SPI2 NSS (*1)  |
+| STmod+ SPI MISO | SPI_DEV(1) MISO   | PI2  | SPI2 MISO (*1) |
+| STmod+ SPI MOSI | SPI_DEV(1) MOSI   | PB15 | SPI2 MOSI (*1) |
+| STmod+ UART CTS | UART_DEV(2) CTS   | PG11 | USART1 CTS (*2) |
+| STmod+ UART RTS | UART_DEV(2) RTS   | PG12 | USART1 RTS (*2) |
+| STmod+ UART RX  | UART_DEV(2) RX    | PG10 | USART1 RX (*2)  |
+| STmod+ UART TX  | UART_DEV(2) TX    | PB6  | USART1 TX (*2)  |
+| ST-Link         | UART_DEV(0) RX    | PD6  | USART2 RX  |
+| ST-Link         | UART_DEV(0) TX    | PA2  | USART2 TX  |
+<br>
+
+@note
+- (*1) SPI2 is only available if module `periph_spi_stmod` is used.
+       SB4, SB5, SB9 must be closed to connect SPI2 to STmod+ and Pmod.
+- (*2) USART1 is only available if module `periph_spi_stmod` is not used.
+       SB6, SB7, SB8 must be closed to connect USART1 to STmod+ and Pmod
+       (default).
+
+## Flashing the device
+
+The STM32L496G-DISCO board includes an on-board ST-LINK programmer and can be
+flashed using OpenOCD. The board can be flashed with:
+
+```
+make BOARD=stm32l496g-disco flash
+```
+
+and debug via GDB with
+```
+make BOARD=stm32l496g-disco debug
+```
+
+## Supported Toolchains
+
+For using the STM32L496G-DISCO board we recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
+
+ */

--- a/boards/stm32l496g-disco/include/arduino_board.h
+++ b/boards/stm32l496g-disco/include/arduino_board.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32l496g-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/stm32l496g-disco/include/arduino_pinmap.h
+++ b/boards/stm32l496g-disco/include/arduino_pinmap.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)  2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32l496g-disco
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins for the STM32L496G-DISCO board
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_G, 8)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_G, 7)
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_G, 13)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_H, 15)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_I, 14)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 9)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_I, 6)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_G, 6)
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_G, 15)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_H, 13)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_A, 15)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_B, 5)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_A, 5)
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_B, 7)
+#define ARDUINO_PIN_15          GPIO_PIN(PORT_B, 8)
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PORT_C, 4)
+#define ARDUINO_PIN_A1          GPIO_PIN(PORT_C, 1)
+#define ARDUINO_PIN_A2          GPIO_PIN(PORT_C, 3)
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_F, 10)
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_A, 1)
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_C, 0)
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/stm32l496g-disco/include/board.h
+++ b/boards/stm32l496g-disco/include/board.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2018 Inria
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32l496g-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the STM32L496G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LCD Backlight control defines
+ * @{
+ */
+#define BACKLIGHT_PIN       GPIO_PIN(PORT_I, 0)     /**< Backlight pin */
+#define BACKLIGHT_MASK      (1 << 0)                /**< Backlight pin mask */
+
+/** Set the backlight pin */
+#define BACKLIGHT_ON        (GPIOI->BSRR = BACKLIGHT_MASK)
+/** Clear the backlight pin */
+#define BACKLIGHT_OFF       (GPIOI->BSRR = (BACKLIGHT_MASK << 16))
+/** Toggle the backlight pin */
+#define BACKLIGHT_TOGGLE    (GPIOI->ODR  ^= BACKLIGHT_MASK)
+/** @} */
+
+/**
+ * @name    LCD display definitions
+ * @{
+ */
+#define LCD_DISP_PIN        GPIO_PIN(PORT_H, 0)     /**< LCD screen enable pin */
+#define LCD_SCREEN_WIDTH    240                     /**< LCD screen width */
+#define LCD_SCREEN_HEIGHT   240                     /**< LCD screen height */
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ *
+ * The board has 3 user LEDs:
+ * - LD1 orange, active HIGH (not directly usable, connected to MFX GPIO4
+ * - LD2 green, active HIGH (connected to PB13)
+ * - LD3 green, active LOW (connected to PA5)
+ * @{
+ */
+#define LED0_PIN_NUM        13      /**< green LED (LD2) pin */
+#define LED0_PORT_NUM       PORT_B  /**< green LED (LD2) port */
+
+#define LED1_PIN_NUM        5       /**< green LED (LD3) pin */
+#define LED1_PORT_NUM       PORT_A  /**< green LED (LD3) port */
+#define LED1_IS_INVERTED    1       /**< green LED (LD3) is LOW active */
+/** @} */
+
+/**
+ * @name   Joystick buttons
+ *
+ * The board has a joystick that is exposed as user buttons.
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_C, 13)    /**< Center button pin  */
+#define BTN0_MODE           GPIO_IN_PD              /**< Center button mode */
+
+#define BTN1_PIN            GPIO_PIN(PORT_I, 9)     /**< Left button pin    */
+#define BTN1_MODE           GPIO_IN_PD              /**< Left button mode   */
+
+#define BTN2_PIN            GPIO_PIN(PORT_I, 10)    /**< Down button pin    */
+#define BTN2_MODE           GPIO_IN_PD              /**< Down button mode   */
+
+#define BTN3_PIN            GPIO_PIN(PORT_F, 11)    /**< Right button pin   */
+#define BTN3_MODE           GPIO_IN_PD              /**< Right button mode  */
+
+#define BTN4_PIN            GPIO_PIN(PORT_I, 8)     /**< Up button pin      */
+#define BTN4_MODE           GPIO_IN_PD              /**< Up button mode     */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "stm32_leds.h"
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/stm32l496g-disco/include/gpio_params.h
+++ b/boards/stm32l496g-disco/include/gpio_params.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 Inria
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_stm32l496g-disco
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author    Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD2",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "LD3",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "Joystick (Center)",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+    {
+        .name = "Joystick (Left)",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE
+    },
+    {
+        .name = "Joystick (Down)",
+        .pin = BTN2_PIN,
+        .mode = BTN2_MODE
+    },
+    {
+        .name = "Joystick (Right)",
+        .pin = BTN3_PIN,
+        .mode = BTN3_MODE
+    },
+    {
+        .name = "Joystick (Up)",
+        .pin = BTN4_PIN,
+        .mode = BTN4_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/stm32l496g-disco/include/periph_conf.h
+++ b/boards/stm32l496g-disco/include/periph_conf.h
@@ -1,0 +1,436 @@
+/*
+ * Copyright (C) 2018 Inria
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32l496g-disco
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the STM32L496G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            1
+#endif
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+#include "cfg_rtt_default.h"
+#include "cfg_usb_otg_fs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    DMA streams configuration
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX */
+    { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
+    { .stream = 3 },    /* DMA1 Channel 4 - SPI2_RX / USART1_TX */
+    { .stream = 4 },    /* DMA1 Channel 5 - SPI2_TX */
+    { .stream = 6 },    /* DMA1 Channel 7 - USART2_TX */
+    { .stream = 13 },   /* DMA2 Channel 6 - LPUART1_TX */
+    { .stream = 11 },   /* DMA2 Channel 4 - SDMMC1 */
+};
+
+#define DMA_0_ISR   isr_dma1_channel2
+#define DMA_1_ISR   isr_dma1_channel3
+#define DMA_2_ISR   isr_dma1_channel4
+#define DMA_3_ISR   isr_dma1_channel5
+#define DMA_4_ISR   isr_dma1_channel7
+#define DMA_5_ISR   isr_dma2_channel6
+#define DMA_6_ISR   isr_dma2_channel4
+
+#define DMA_NUMOF   ARRAY_SIZE(dma_config)
+/** @} */
+
+/**
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels, and not in the STM32L496AG
+ * order. Instead, we define 6 ADC channels for the Arduino header pins
+ * A0-A5, one channel for V_REFINT and one channel that is used for the
+ * STMod+ header pin STMOD+_ADC or the DAC1 output if `periph_dac` is used.
+ *
+ * The pin assignment can be found in board's user manual in Table 15, page 26
+ * (Arduino compatible connectors) and Table 26, page 35 (32L496GDISCOVERY
+ * Discovery board I/O assignment). These tables are showing pin assignments and
+ * information about ADC - a text similar to `ADC[X]_IN[Y]`, where: \n
+ * `[X]` - describes used device - indexed from 0,
+ *         for example `ADC3_IN13` is device 2, \n
+ * `[Y]` - describes used channel - indexed from 1,
+ *         for example `ADC3_IN13` is channel 13
+ *
+ * Channels shared by multiple ADCs are referred to as `ADC[XXX]_IN[Y]`.
+ * `ADC12_IN13` means for example that channel 13 can be used either with ADC1
+ * or with ADC2.
+ *
+ * Output from internal reference voltage V_REFINT is connected to ADC1
+ * channel 0.
+ *
+ * The V_REF+ pin is not connected to an external reference voltage on the
+ * board by default. Instead the the VREFBUF must be used (`VREFBUF_ENABLE=1`).
+ * The output voltage of VREF is around 2.048 V in this case.
+ *
+ * If an external reference voltage is used as V_REF+, either by soldering
+ * R18 to use V_DDA as reference voltage or by using the AVVD pin of the
+ * Arduino connector by closing the solder bridge SB2, the VREFBUF must not
+ * be enabled by defining `VREFBUF_ENABLE=0`.
+ *
+ * @{
+ */
+
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_C, 4),  .dev = 0, .chan = 13 }, /* A0, ADC12_IN13 */
+    { .pin = GPIO_PIN(PORT_C, 1),  .dev = 0, .chan =  2 }, /* A1, ADC123_IN2  */
+    { .pin = GPIO_PIN(PORT_C, 3),  .dev = 0, .chan =  4 }, /* A2, ADC123_IN4 */
+    { .pin = GPIO_PIN(PORT_F, 10), .dev = 2, .chan = 13 }, /* A3, ADC3_IN13  */
+    { .pin = GPIO_PIN(PORT_A, 1),  .dev = 0, .chan =  6 }, /* A4, ADC12_IN6, SB26 closed */
+    { .pin = GPIO_PIN(PORT_C, 0),  .dev = 1, .chan = 13 }, /* A5, ADC12_IN13, SB28 closed */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 0 },            /* V_REFINT, ADC1_IN0  */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 18 },           /* V_BAT, ADC1_IN18  */
+#ifndef MODULE_PERIPH_DAC
+    { .pin = GPIO_PIN(PORT_A, 4),  .dev = 0, .chan =  9 }, /* STMOD+_ADC, ADC12_IN9 */
+#else
+    { .pin = GPIO_UNDEF,  .dev = 1, .chan = 17 },          /* DAC1, ADC2_IN17 */
+#endif
+};
+
+/**
+ * @brief   Number of ADC devices
+ */
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+/**
+ * @brief   V_BAT ADC line
+ */
+#define VBAT_ADC            ADC_LINE(7)
+
+/**
+ * @brief   V_REFINT ADC line
+ */
+#define VREFINT_ADC         ADC_LINE(6)
+
+/**
+ * @brief   Enable VREFBUF as V_REF+
+ *
+ * If an external reference voltage is used as V_REF+, either by soldering
+ * R18 to use V_DDA as reference voltage or by using the AVVD pin of the
+ * Arduino connector by closing the solder bridge SB2, the VREFBUF must not
+ * be enabled by defining `VREFBUF_ENABLE=0`.
+ */
+#ifndef VREFBUF_ENABLE
+#define VREFBUF_ENABLE      (1)
+#endif
+
+/** @} */
+
+/**
+ * @name    DAC configuration
+ *
+ * The V_REF+ pin is not connected to an external reference voltage on the
+ * board by default. Instead the the VREFBUF must be used (`VREFBUF_ENABLE=1`).
+ * The output voltage of VREF is around 2.048 V in this case.
+ *
+ * @{
+ */
+static const dac_conf_t dac_config[] = {
+    { GPIO_PIN(PORT_A, 4), .chan = 0 },     /* STMod+_ADC pin */
+#ifndef MODULE_PERIPH_SPI
+    { GPIO_PIN(PORT_A, 5), .chan = 1 },     /* Arduino D13, conflicts with SPI_DEV(0) */
+#endif
+};
+/** @}*/
+
+/**
+ * @brief   Number of DACs
+ * @{
+ */
+#define DAC_NUMOF   ARRAY_SIZE(dac_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ *
+ * I2C1 is exposed at Arduino Connector D14/D15 (SDA/SCL) and STmod+ connector
+ * I2C2 is used for MFX (Multi Function eXpander)
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {   /* Shared between Arduino D14/D15 and STMod+ connector */
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR1_I2C1EN,
+        .rcc_sw_mask    = RCC_CCIPR_I2C1SEL_1,          /* HSI (16 MHz) */
+        .irqn           = I2C1_ER_IRQn,
+    },
+    {   /* Multi Function eXpander (MFX_x) I2C Address 0x42,
+         * Stereo Codec Cirrus Logic CS42L51-CNZ (CODEC_x), I2C Address 0x4a (AD0 = 0)
+         * Capacitive Touch Panel (CTP_x) FT6206, I2C Address 0x38
+         * Digital Camera Module (DCMI_x),
+         */
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_H, 4),
+        .sda_pin        = GPIO_PIN(PORT_B, 14),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR1_I2C2EN,
+        .rcc_sw_mask    = RCC_CCIPR_I2C2SEL_1,          /* HSI (16 MHz) */
+        .irqn           = I2C2_ER_IRQn,
+    },
+};
+
+#define I2C_0_ISR           isr_i2c1_er
+#define I2C_1_ISR           isr_i2c2_er
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ *
+ * Four PWM channels are defined for the Arduino header pins D3, D5, D6 and D9,
+ * and one for the STMod+ header pin STMOD+_PWM.
+ *
+ * The pin assignment can be found in board's user manual in Table 15, page 26
+ * (Arduino compatible connectors) and Table 26, page 35 (32L496GDISCOVERY
+ * Discovery board I/O assignment).
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM8,
+        .rcc_mask = RCC_APB2ENR_TIM8EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_H, 15), .cc_chan = 6}, /* D3, TIM8_CH3N  */
+                      { .pin = GPIO_PIN(PORT_I,  6), .cc_chan = 1}, /* D6, TIM8_CH2  */
+                      { .pin = GPIO_PIN(PORT_H, 13), .cc_chan = 4}, /* D9, TIM8_CH1N */
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF3,
+        .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR1_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B,  9), .cc_chan = 3}, /* D5, TIM4_CH4 */
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM5,
+        .rcc_mask = RCC_APB1ENR1_TIM5EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A,  0), .cc_chan = 0}, /* STMOD+_PWM, TIM5_CH1 */
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note By default, solder bridges SB6, SB7, SB8 are closed and USART1 is
+ * connected to the Pmod/STMmod+ connector. To use SPI2 on the Pmod/STMmod+
+ * connector, these jumpers have to be opened and solder bridges SB4, SB5
+ * and SB9 have to be closed instead. Use the `periph_spi_stmod` module
+ * to use this configuration, disable USART1 and enable SPI2. Otherwise
+ * SPI2 is not available.
+ *
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    { /* Arduino connector */
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_A, 15),
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2,
+#if IS_USED(MODULE_PERIPH_DMA)
+        .rx_dma   = 0,                        /* DMA1 Channel 2 */
+        .rx_dma_chan = 1,                     /* CxS = 1 */
+        .tx_dma   = 1,                        /* DMA1 Channel 3 */
+        .tx_dma_chan = 1,                     /* CxS = 1 */
+#endif
+    },
+#if IS_USED(MODULE_PERIPH_SPI_STMOD)
+    {   /* Pmod/STMod+ connector if solder bridges SB4, SB5, SB9 are closed */
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_I, 2),
+        .sclk_pin = GPIO_PIN(PORT_I, 1),
+        .cs_pin   = GPIO_PIN(PORT_G, 1),
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB1ENR1_SPI2EN,
+        .apbbus   = APB1,
+#if IS_USED(MODULE_PERIPH_DMA)
+        .rx_dma   = 2,                        /* DMA1 Channel 4 */
+        .rx_dma_chan = 1,                     /* CxS = 1 */
+        .tx_dma   = 3,                        /* DMA1 Channel 5 */
+        .tx_dma_chan = 1,                     /* CxS = 1 */
+#endif
+    },
+#endif
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR1_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    },
+    {
+        .dev      = TIM3,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR1_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    },
+};
+
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ *
+ * @note By default, solder bridges SB6, SB7, SB8 are closed and USART1 is
+ * connected to the Pmod/STMmod+ connector. In this case the hardware flow
+ * control for USART1 is used. If these solder bridges are open and solder
+ * bridges SB4, SB5 and SB9 are closed instead, SPI2 is connected to the
+ * Pmod/STMmod+ connector and USART1 is not available.
+ *
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {   /* Virtual COM Port / ST-Link */
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR1_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+#if IS_USED(MODULE_PERIPH_UART_HW_FC)
+        .cts_pin    = GPIO_UNDEF,               /* CTS is not connected */
+        .rts_pin    = GPIO_UNDEF,               /* RTS is not connected */
+#endif
+        .type       = STM32_USART,
+        .clk_src    = 0,                        /* Use APB clock */
+#if IS_USED(MODULE_PERIPH_DMA)
+        .dma        = 4,                        /* DMA1 Channel 7 */
+        .dma_chan   = 2,                        /* CxS = 2 */
+#endif
+    },
+    {   /* Arduino connector RX/TX (D0/D1) */
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR2_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 8),
+        .tx_pin     = GPIO_PIN(PORT_G, 7),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB12,
+        .irqn       = LPUART1_IRQn,
+#if IS_USED(MODULE_PERIPH_UART_HW_FC)
+        .cts_pin    = GPIO_UNDEF,               /* CTS is not connected */
+        .rts_pin    = GPIO_UNDEF,               /* RTS is not connected */
+#endif
+        .type       = STM32_LPUART,
+        .clk_src    = 0,                        /* Use APB clock */
+#if IS_USED(MODULE_PERIPH_DMA)
+        .dma        = 5,                        /* DMA2 Channel 6 */
+        .dma_chan   = 4,                        /* CxS = 4 */
+#endif
+    },
+
+#if !IS_USED(MODULE_PERIPH_SPI_STMOD)
+    {   /* Pmod/STMod+ connector if solder bridges SB6, SB7, SB8 are closed (default) */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 10),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+#if IS_USED(MODULE_PERIPH_UART_HW_FC)
+        .cts_pin    = GPIO_PIN(PORT_G, 11),
+        .rts_pin    = GPIO_PIN(PORT_G, 12),
+        .cts_af     = GPIO_AF7,
+        .rts_af     = GPIO_AF7,
+#endif
+        .type       = STM32_USART,
+        .clk_src    = 0,                        /* Use APB clock */
+#if IS_USED(MODULE_PERIPH_DMA)
+        .dma        = 2,                        /* DMA1 Channel 4 */
+        .dma_chan   = 2,                        /* CxS = 2 */
+#endif
+    },
+#endif /* !IS_USED(MODULE_PERIPH_SPI_STMOD) */
+};
+
+#define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_lpuart1)
+#define UART_2_ISR          (isr_usart1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

The PR adds the board definition for the STM2L496G-DISO board.

It is the same board that is also shipped with the P-L496G-CELL02 LTE pack for which we already have the board definition `p-l496g-cell02`. However, `stm32l496g-disco` provides a complete configuration of the board and supports the following features in addition to `p-l496g-cell02`:
```
> FEATURES_PROVIDED += periph_adc
> FEATURES_PROVIDED += periph_dac
> FEATURES_PROVIDED += periph_dma
> FEATURES_PROVIDED += periph_pwm
> FEATURES_PROVIDED += periph_uart_hw_fc
> FEATURES_PROVIDED += arduino
```
In the long term, `p-l496g-cell02` is to be based on the new full `stm32l496g-disco` board definition.

The CPT and the LCD display are not yet supported since they are connected to/controlled by the MFX (a STM32L152-based sub-system) and the FMC peripheral.

### Testing procedure

All basic tests should work with the new board definition. The following tests were executed and did succeed:

- [x] `tests/periph/adc`
- [x] `tests/periph/dac`
- [x] `tests/periph/i2c` for `I2C_DEV(0)`, `I2C_DEV(1)` is not exposed and not tested
- [x] `tests/periph/pwm`
- [x] `tests/periph/spi` for `SPI_DEV(0)`, `SPI_DEV(1) connection not soldered and not tested
- [x] `tests/periph/timer` for `TIMER_DEV(0)` and `TIMER_DEV(1)`
- [x] `tests/periph/uart` for `UART_DEV(0)`, `UART_DEV(1)` and `UART_DEV(2)`
- [x] `tests/usbus_cdc_ecm` together with `stdio_cdc_acm`

### Issues/PRs references

~Depends on PR #19571~
~Depends on PR #19572~
~Depends on PR #19573~