### PR TITLE
doc/doxygen/src/flashing.md: work around Doxygen bug

### DIFF
--- a/doc/doxygen/src/flashing.md
+++ b/doc/doxygen/src/flashing.md
@@ -196,8 +196,8 @@ JTAG. Also JTAG requires more signal lines to be connected compared to SWD and
 some internal programmers only have the SWD signal lines connected, so that
 JTAG will not be possible.
 
-`stm32flash` Configuration                  {#flashing-configuration-stm32flash}
---------------------------
+stm32flash Configuration                  {#flashing-configuration-stm32flash}
+------------------------
 
 It is possible to automatically boot the STM32 board into the in-ROM bootloader
 that `stm32flash` communicates with for flashing by connecting the RST pin to


### PR DESCRIPTION
### Contribution description

Doxygen fails to render inline code in headers correctly in the version the CI uses. So, work around the issue by not typestetting `stm32flash` as inline code but as regular text.
<!-- bors cut here -->
### Testing procedure

Check the generated doc. It the header no longer reads 

> <h2>&lt;tt&gt;stm32flash&lt;/tt&gt; Configuration</h2>

but instead

> <h2>stm32flash Configuration</h2>

the work around did the trick.

### Issues/PRs references

None