### PR TITLE
board: add Adafruit Grand Central M4 Express support

### DIFF
--- a/boards/adafruit-grand-central-m4-express/Kconfig
+++ b/boards/adafruit-grand-central-m4-express/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (C) 2023 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "adafruit-grand-central-m4-express" if BOARD_ADAFRUIT_GRAND_CENTRAL_M4_EXPRESS
+
+config BOARD_ADAFRUIT_GRAND_CENTRAL_M4_EXPRESS
+    bool
+    default y
+    select CPU_MODEL_SAMD51P20A
+    select HAS_ARDUINO
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAVE_SAUL_GPIO
+
+    select HAVE_MTD_SPI_NOR
+    # This specific board requires SPI_ON_QSPI for the MTD_SPI_NOR
+    select MODULE_PERIPH_SPI_ON_QSPI if MODULE_MTD_SPI_NOR
+
+    select HAVE_MTD_SDCARD_DEFAULT
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
+
+source "$(RIOTBOARD)/common/samdx1-arduino-bootloader/Kconfig"

--- a/boards/adafruit-grand-central-m4-express/Makefile
+++ b/boards/adafruit-grand-central-m4-express/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/samdx1-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/adafruit-grand-central-m4-express/Makefile.dep
+++ b/boards/adafruit-grand-central-m4-express/Makefile.dep
@@ -1,0 +1,19 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# default to using fatfs on SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi_on_qspi
+  USEMODULE += mtd_spi_nor
+  USEMODULE += mtd_sdcard_default
+endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.dep

--- a/boards/adafruit-grand-central-m4-express/Makefile.features
+++ b/boards/adafruit-grand-central-m4-express/Makefile.features
@@ -1,0 +1,19 @@
+CPU = samd5x
+CPU_MODEL = samd51p20a
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# other board features
+FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += sdcard_spi

--- a/boards/adafruit-grand-central-m4-express/Makefile.include
+++ b/boards/adafruit-grand-central-m4-express/Makefile.include
@@ -1,0 +1,6 @@
+CFLAGS += -DBOOTLOADER_UF2
+
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
+# Include handling of serial and non-bossa programmers (if selected by user)
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/adafruit-grand-central-m4-express/board.c
+++ b/boards/adafruit-grand-central-m4-express/board.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-grand-central-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Adafruit Grand Central M4 Express
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+#include "timex.h"
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+#endif
+
+#ifdef MODULE_MTD_SPI_NOR
+
+#include "mtd_spi_nor.h"
+
+/* GD25Q64 */
+static const mtd_spi_nor_params_t _samd51_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 25 * US_PER_SEC,
+    .wait_32k_erase = 150 * US_PER_MS,
+    .wait_64k_erase = 200 * US_PER_MS,
+    .wait_sector_erase = 50 * US_PER_MS,
+    .wait_chip_wake_up = 10 * US_PER_MS,
+    .clk  = MHZ(54),
+    .flag = SPI_NOR_F_SECT_4K
+          | SPI_NOR_F_SECT_32K
+          | SPI_NOR_F_SECT_64K,
+    .spi  = SPI_DEV(2),
+    .mode = SPI_MODE_0,
+    .cs   = SAM0_QSPI_PIN_CS,
+    .wp   = SAM0_QSPI_PIN_DATA_2,
+    .hold = SAM0_QSPI_PIN_DATA_3,
+};
+
+static mtd_spi_nor_t samd51_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .sector_count = 2048,
+        .page_size = 256,
+        .pages_per_sector = 16,
+    },
+    .params = &_samd51_nor_params,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+
+#ifdef MODULE_VFS_DEFAULT
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(samd51_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
+
+#endif /* MODULE_MTD_SPI_NOR */

--- a/boards/adafruit-grand-central-m4-express/doc.txt
+++ b/boards/adafruit-grand-central-m4-express/doc.txt
@@ -1,0 +1,45 @@
+/**
+@defgroup    boards_adafruit-grand-central-m4-express Adafruit Grand Central M4 Express
+@ingroup     boards
+@brief       Support for the Adafruit Grand Central M4 Express
+
+### General information
+
+![Adafruit Grand Central M4 Expressboard]
+(https://cdn-learn.adafruit.com/assets/assets/000/068/748/medium800/adafruit_products_grand_central_top_angle.jpg?1546734839)
+
+The main features of the board are:
+- ATSAMD51 Cortex M4 running at 120 MHz
+- Hardware DSP and floating point support
+- 1MB Flash
+- 256 KB RAM
+- external 8 MB QSPI Flash storage
+- 32-bit, 3.3V logic and power
+- Micro SD Card slot connected to SPI
+- native USB
+
+### Links
+
+- [Overview](https://learn.adafruit.com/adafruit-grand-central)
+- [Schematics](https://learn.adafruit.com/assets/69175)
+
+### Flash the board
+
+The board is flashed using its on-board
+[boot loader](https://github.com/adafruit/uf2-samdx1).
+
+The process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU
+and enter the bootloader. If some other firmware is running or RIOT crashed,
+you need to enter the bootloader manually by double tapping the board's reset
+button.
+
+Readiness of the bootloader is indicated by LED pulsing in red.
+
+### Accessing STDIO
+
+The usual way to obtain a console on this board is using an emulated USB serial
+port.
+
+ */

--- a/boards/adafruit-grand-central-m4-express/include/arduino_board.h
+++ b/boards/adafruit-grand-central-m4-express/include/arduino_board.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nucleo144
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/adafruit-grand-central-m4-express/include/arduino_pinmap.h
+++ b/boards/adafruit-grand-central-m4-express/include/arduino_pinmap.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C)  2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-grand-central-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PB, 25)
+#define ARDUINO_PIN_1           GPIO_PIN(PB, 24)
+#define ARDUINO_PIN_2           GPIO_PIN(PC, 18)
+#define ARDUINO_PIN_3           GPIO_PIN(PC, 19)
+#define ARDUINO_PIN_4           GPIO_PIN(PC, 20)
+#define ARDUINO_PIN_5           GPIO_PIN(PC, 21)
+#define ARDUINO_PIN_6           GPIO_PIN(PD, 20)
+#define ARDUINO_PIN_7           GPIO_PIN(PD, 21)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PB, 18)
+#define ARDUINO_PIN_9           GPIO_PIN(PB, 02)
+#define ARDUINO_PIN_10          GPIO_PIN(PB, 22)
+#define ARDUINO_PIN_11          GPIO_PIN(PB, 23)
+#define ARDUINO_PIN_12          GPIO_PIN(PB, 00)
+#define ARDUINO_PIN_13          GPIO_PIN(PB, 01)
+
+#define ARDUINO_PIN_14          GPIO_PIN(PB, 20)
+#define ARDUINO_PIN_15          GPIO_PIN(PB, 21)
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PA, 3)
+#define ARDUINO_PIN_A1          GPIO_PIN(PC, 0)
+#define ARDUINO_PIN_A2          GPIO_PIN(PC, 3)
+#define ARDUINO_PIN_A3          GPIO_PIN(PC, 1)
+#define ARDUINO_PIN_A4          GPIO_PIN(PC, 4)
+#define ARDUINO_PIN_A5          GPIO_PIN(PC, 5)
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/adafruit-grand-central-m4-express/include/board.h
+++ b/boards/adafruit-grand-central-m4-express/include/board.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-grand-central-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Adafruit Grand Central M4 Express
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "mtd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+
+#define LED0_PIN    GPIO_PIN(PB, 1)     /**< User LED red (D13) */
+#define LED1_PIN    GPIO_PIN(PC, 30)    /**< TX LED yellow */
+#define LED2_PIN    GPIO_PIN(PC, 31)    /**< RX LED yellow */
+
+#define LED0_PORT   PORT->Group[PB]     /**< Port of User LED red (D13) */
+#define LED0_MASK   (1 << 1)            /**< Mask of User LED red (D13) */
+#define LED1_PORT   PORT->Group[PC]     /**< Port of TX LED yellow */
+#define LED1_MASK   (1 << 30)           /**< Mask of TX LED yellow */
+#define LED2_PORT   PORT->Group[PC]     /**< Port of RX LED yellow */
+#define LED2_MASK   (1 << 31)           /**< Mask of RX LED yellow */
+
+#define LED0_ON     (LED0_PORT.OUTSET.reg = LED0_MASK)  /**< Switch on User LED red (D13) */
+#define LED0_OFF    (LED0_PORT.OUTCLR.reg = LED0_MASK)  /**< Switch off User LED red (D13) */
+#define LED0_TOGGLE (LED0_PORT.OUTTGL.reg = LED0_MASK)  /**< Toggle User LED red (D13) */
+
+#define LED1_ON     (LED1_PORT.OUTCLR.reg = LED1_MASK)  /**< Switch on TX LED yellow */
+#define LED1_OFF    (LED1_PORT.OUTSET.reg = LED1_MASK)  /**< Switch off TX LED yellow */
+#define LED1_TOGGLE (LED1_PORT.OUTTGL.reg = LED1_MASK)  /**< Toggle TX LED yellow */
+
+#define LED2_ON     (LED2_PORT.OUTCLR.reg = LED2_MASK)  /**< Switch on RX LED yellow */
+#define LED2_OFF    (LED2_PORT.OUTSET.reg = LED2_MASK)  /**< Switch off RX LED yellow */
+#define LED2_TOGGLE (LED2_PORT.OUTTGL.reg = LED2_MASK)  /**< Toggle User RX LED yellow */
+
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    GPIO_PIN(PC, 24)    /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)                /**< Number of LEDs chained */
+#endif
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+extern mtd_dev_t *mtd0;     /**< Flash MTD device pointer */
+#define MTD_0 mtd0          /**< Flash MTD device */
+extern mtd_dev_t *mtd1;     /**< MTD device pointer for SD Card */
+#define MTD_1 mtd1          /**< MTD device for SD Card */
+
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1   /**< mtd1 is used for SD Card */
+/** @} */
+
+/**
+ * @name   SD-Card interface configuration
+ *
+ * The SD-Card interface is connected to SPI_DEV(1).
+ *
+ * @{
+ */
+#if MODULE_SDCARD_SPI || DOXYGEN
+#define SDCARD_SPI_PARAM_SPI    SPI_DEV(1)
+#define SDCARD_SPI_PARAM_CLK    GPIO_PIN(PB, 27)
+#define SDCARD_SPI_PARAM_MOSI   GPIO_PIN(PB, 26)
+#define SDCARD_SPI_PARAM_MISO   GPIO_PIN(PB, 29)
+#define SDCARD_SPI_PARAM_CS     GPIO_PIN(PB, 28)
+#define SDCARD_SPI_PARAM_POWER  GPIO_UNDEF
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/adafruit-grand-central-m4-express/include/gpio_params.h
+++ b/boards/adafruit-grand-central-m4-express/include/gpio_params.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-grand-central-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED User (red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "LED TX (yellow)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "LED RX (yellow)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/adafruit-grand-central-m4-express/include/periph_conf.h
+++ b/boards/adafruit-grand-central-m4-express/include/periph_conf.h
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-grand-central-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Adafruit Grand Central M4 Express
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Core clock frequency
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+#define CLOCK_CORECLOCK     MHZ(120)
+#endif
+/** @} */
+
+/**
+ * @name    32kHz Oscillator configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                   1
+#define INTERNAL_OSC32_SOURCE                   0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE     0
+/** @} */
+
+/**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with L_EXT (L1) of 10uH at VSW pin.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLA_PRESCALER_DIV128
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos, dev */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA02, .dev = ADC0 }, /* A0 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA05, .dev = ADC0 }, /* A1 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB03, .dev = ADC0 }, /* A2 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PC00, .dev = ADC1 }, /* A3 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PC01, .dev = ADC1 }, /* A4 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PC02, .dev = ADC1 }, /* A5 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PC03, .dev = ADC1 }, /* A6 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB04, .dev = ADC1 }, /* A7 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB05, .dev = ADC1 }, /* A8 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB06, .dev = ADC1 }, /* A9 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB07, .dev = ADC1 }, /* A10 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB08, .dev = ADC0 }, /* A11 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PB09, .dev = ADC0 }, /* A12 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA04, .dev = ADC0 }, /* A13 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA06, .dev = ADC0 }, /* A14 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA07, .dev = ADC0 }, /* A15 */
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+                            /* Must not exceed 12 MHz */
+#define DAC_CLOCK           SAM0_GCLK_TIMER
+                            /* Use external reference voltage on PA03 */
+                            /* (You have to manually connect PA03 with Vcc) */
+                            /* Internal reference only gives 1V */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VREFPU
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PB, 21),   /* D21 (SCL) */
+        .sda_pin  = GPIO_PIN(PB, 20),   /* D20 (SDA) */
+        .mux      = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_PERIPH,
+        .flags    = I2C_FLAG_NONE
+    },
+    {
+        .dev      = &(SERCOM6->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PC, 17),   /* D24 */
+        .sda_pin  = GPIO_PIN(PC, 16),   /* D25 */
+        .mux      = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_PERIPH,
+        .flags    = I2C_FLAG_NONE
+    },
+};
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 22), GPIO_MUX_G, 2 },
+};
+#endif
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    { .tim  = TCC_CONFIG(TCC0),
+      .chan = pwm_chan0_config,
+      .chan_numof = ARRAY_SIZE(pwm_chan0_config),
+      .gclk_src = SAM0_GCLK_PERIPH,
+    },
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC0,
+        .irq            = TC0_IRQn,
+        .mclk           = &MCLK->APBAMASK.reg,
+        .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
+        .gclk_id        = TC0_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {   /* Timer 1 */
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
+        .mclk           = &MCLK->APBBMASK.reg,
+        .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
+        .gclk_id        = TC2_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_ISR         isr_tc0
+
+/* Timer 1 configuration */
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_ISR         isr_tc2
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* SPI on XIO connector */
+        .dev      = &(SERCOM7->SPI),
+        .miso_pin = GPIO_PIN(PD, 11),   /* D50 MISO */
+        .mosi_pin = GPIO_PIN(PD, 8),    /* D51 MOSI */
+        .clk_pin  = GPIO_PIN(PD, 9),    /* D52 SCK */
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM7_DMAC_ID_TX,
+        .rx_trigger = SERCOM7_DMAC_ID_RX,
+#endif
+    },
+    {   /* SD Card */
+        .dev      = &(SERCOM2->SPI),
+        .miso_pin = GPIO_PIN(PB, 29),
+        .mosi_pin = GPIO_PIN(PB, 26),
+        .clk_pin  = GPIO_PIN(PB, 27),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM2_DMAC_ID_TX,
+        .rx_trigger = SERCOM2_DMAC_ID_RX,
+#endif
+    },
+#ifdef MODULE_PERIPH_SPI_ON_QSPI
+    {    /* QSPI in SPI mode */
+        .dev      = QSPI,
+        .miso_pin = SAM0_QSPI_PIN_DATA_1,
+        .mosi_pin = SAM0_QSPI_PIN_DATA_0,
+        .clk_pin  = SAM0_QSPI_PIN_CLK,
+        .miso_mux = SAM0_QSPI_MUX,
+        .mosi_mux = SAM0_QSPI_MUX,
+        .clk_mux  = SAM0_QSPI_MUX,
+        .miso_pad = SPI_PAD_MISO_0,         /* unused */
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,   /* unused */
+        .gclk_src = SAM0_GCLK_MAIN,         /* unused */
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = QSPI_DMAC_ID_TX,
+        .rx_trigger = QSPI_DMAC_ID_RX,
+#endif
+    },
+#endif
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_H,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    }
+};
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PB, 25),   /* D0 (UART0_RX) */
+        .tx_pin   = GPIO_PIN(PB, 24),   /* D1 (UART0_TX) */
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    },
+    {
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB, 13),   /* D19 (UART2_RX) */
+        .tx_pin   = GPIO_PIN(PB, 12),   /* D18 (UART2_TX) */
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    },
+    {
+        .dev      = &SERCOM1->USART,
+        .rx_pin   = GPIO_PIN(PC, 23),   /* D17 (UART2_RX) */
+        .tx_pin   = GPIO_PIN(PC, 22),   /* D16 (UART2_TX) */
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom0_2
+#define UART_0_ISR_TX       isr_sercom0_0
+#define UART_1_ISR          isr_sercom4_2
+#define UART_1_ISR_TX       isr_sercom4_0
+#define UART_2_ISR          isr_sercom1_2
+#define UART_2_ISR_TX       isr_sercom1_0
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR provides the support for Adafruit Grand Central M4 Express board. The main features of the board are:

- ATSAMD51 Cortex M4 running at 120 MHz
- 1MB Flash
- 256 KB RAM
- external 8 MB QSPI Flash storage
- Micro SD Card slot connected to SPI

### Testing procedure


### Issues/PRs references
