### PR TITLE
tests/build_system/external_board_dirs: fix broken symlinks

### DIFF
--- a/tests/build_system/external_board_dirs/external_board_dir_1/native1
+++ b/tests/build_system/external_board_dirs/external_board_dir_1/native1
@@ -1,1 +1,1 @@
-../../../boards/native/
+../../../../boards/native/

--- a/tests/build_system/external_board_dirs/external_board_dir_2/native2
+++ b/tests/build_system/external_board_dirs/external_board_dir_2/native2
@@ -1,1 +1,1 @@
-../../../boards/native/
+../../../../boards/native/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For native1 and native1 external boards, symlinks to boards/native are used. After #19567 these symlinks were broken and for some reason they went through the CI. This PR is fixing them.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#19567

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
