### PR TITLE
doc: Remove ANSI

### DIFF
--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -20,7 +20,7 @@ entire platforms, e.g. Atmel SAM R21 Xplained Pro, Zolertia Z1, STM32 Discovery
 Boards etc. (see the list of
 [supported hardware](https://github.com/RIOT-OS/RIOT/wiki/RIOT-Platforms).
 Across all supported hardware (32-bit, 16-bit, and 8-bit platforms). RIOT
-provides a consistent API and enables ANSI C and C++ application programming,
+provides a consistent API and enables C and C++ application programming,
 with  multithreading, IPC, system timers, mutexes etc.
 
 A good high-level overview can be found in the article


### PR DESCRIPTION
### Contribution description

> We moved to C11. And before that, we were at C99.

(When can we add Rust to this list?)

### Testing procedure

Check the docs

### Issues/PRs references

None
