### PR TITLE
tests/sys/usbus_cdc_ecm: fix wrong path in make command

### DIFF
--- a/tests/sys/usbus_cdc_ecm/Makefile
+++ b/tests/sys/usbus_cdc_ecm/Makefile
@@ -27,7 +27,7 @@ Warning:
     available endpoints is not sufficient for this. To use this application you
     have to use `stdio_uart` or any other `stdio_*` module, for example:
 
-    USEMODULE=stdio_uart BOARD=$(BOARD) make -C tests/usbus_cdc_ecm
+    USEMODULE=stdio_uart BOARD=$(BOARD) make -C tests/sys/usbus_cdc_ecm
 
 endef
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In the Makefile of tests/sys/usbus_cdc_ecm, there's a make command given which is still using the old path to the application. This PR is fixing that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- The make command given in the README works

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Leftover from #19566 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
