### PR TITLE
sys: drop broken and legacy Mac OS handling

### DIFF
--- a/sys/include/byteorder.h
+++ b/sys/include/byteorder.h
@@ -23,10 +23,6 @@
 #include <stdint.h>
 #include "unaligned.h"
 
-#if defined(__MACH__)
-#   include "clang_compat.h"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -26,14 +26,6 @@
 #   include <sys/types.h>
 #endif
 
-#ifdef __MACH__
-/* needed for AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER */
-#include <AvailabilityMacros.h>
-#if !defined(AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER)
-typedef int clockid_t;
-#endif
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description

This drops special handling for Mac OS (X) `native`, which is not supported anymore anyway and causing issues when building for non-`native` targets on Mac OS.
<!-- bors cut here -->

### Testing procedure

Compilation of applications include `byteorder.h` should work again on Mac OS.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/19590