### PR TITLE
dist/tools/insufficient_memory: handle address space wraps

### DIFF
--- a/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
@@ -58,7 +58,10 @@ for app in ${APPLICATIONS}; do
     # as this is exactly what we want here
     # shellcheck disable=SC2086
     if ! make BOARD="${BOARD}" ${LOCAL_MAKE_ARGS} -C "${RIOTBASE}/${application}" > "$TMPFILE" 2>&1; then
-        if grep -e overflowed -e "not within region" "$TMPFILE" > /dev/null; then
+        if grep -e overflowed \
+                -e "not within region" \
+                -e "wraps around address space" \
+                "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
             make -f "$(dirname "$0")"/Makefile.for_sh DIR="${RIOTBASE}/${application}" BOARD="${BOARD}" Makefile.ci > /dev/null
         elif grep -e "not whitelisted" \

--- a/dist/tools/insufficient_memory/create_makefile.ci.sh
+++ b/dist/tools/insufficient_memory/create_makefile.ci.sh
@@ -53,7 +53,10 @@ for BOARD in $(EXTERNAL_BOARD_DIRS="" make  --no-print-directory info-boards-sup
     # as this is exactly what we want here
     # shellcheck disable=SC2086
     if ! make BOARD="${BOARD}" ${LOCAL_MAKE_ARGS} clean all -C "${APP_DIR}" > "$TMPFILE" 2>&1; then
-        if grep -e overflowed -e "not within region" "$TMPFILE" > /dev/null; then
+        if grep -e overflowed \
+                -e "not within region" \
+                -e "wraps around address space" \
+                "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
             BOARDS="${BOARDS} ${BOARD}"
         elif grep -e "not whitelisted" \


### PR DESCRIPTION
### Contribution description

When a region wraps around the address space, the application typically is way too large to fit into the 16 bit address space of 16 bit or 8 bit platforms.
<!-- bors cut here -->

### Testing procedure

The tools should still run as before, except for the linking failures with MSP430 boards that now are classified as `too big` instead of as error.

### Issues/PRs references

None