### PR TITLE
sys/shell: Add coreclk command to shell_cmd_sys

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -448,6 +448,7 @@ PSEUDOMODULES += shell_cmd_benchmark_udp
 PSEUDOMODULES += shell_cmd_ccn-lite-utils
 PSEUDOMODULES += shell_cmd_conn_can
 PSEUDOMODULES += shell_cmd_cord_ep
+PSEUDOMODULES += shell_cmd_coreclk
 PSEUDOMODULES += shell_cmd_cryptoauthlib
 PSEUDOMODULES += shell_cmd_dfplayer
 PSEUDOMODULES += shell_cmd_fib

--- a/sys/shell/cmds/Kconfig
+++ b/sys/shell/cmds/Kconfig
@@ -308,6 +308,11 @@ config MODULE_SHELL_CMD_SYS
     default y if MODULE_SHELL_CMDS_DEFAULT
     depends on MODULE_SHELL_CMDS
 
+config MODULE_SHELL_CMD_CORECLK
+    bool "Shell command printing the CPU frequency"
+    default n
+    depends on MODULE_SHELL_CMDS
+
 config MODULE_SHELL_CMD_VFS
     bool "Commands for the VFS module (ls, vfs)"
     default y if MODULE_SHELL_CMDS_DEFAULT

--- a/sys/shell/cmds/coreclk.c
+++ b/sys/shell/cmds/coreclk.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Otto-von-Guericke Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell command printing the CPU frequency
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "clk.h"
+#include "shell.h"
+
+static int _coreclk(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    printf("core clock: %" PRIu32 " Hz\n", coreclk());
+    return 0;
+}
+
+SHELL_COMMAND(coreclk, "Print the CPU frequency", _coreclk);


### PR DESCRIPTION
### Contribution description

The coreclk shell command now prints the CPU frequency in Hz, which can be useful for boards with RC generated CPU frequency (e.g. RP2040, FE310, or MPS430Fx1xx MCUs allow this) which may quite a bit off the target frequency.
<!-- bors cut here -->

### Testing procedure

```
USEMODULE=shell_cmd_coreclk make BOARD=hifive1b -C examples/default flash term
```

And in the opened RIOT shell then `coreclk` should print the frequency of the HiFive 1b's CPU.

(Should also work with every other board, but might be boring if the CPU frequency is a compile time constant.)

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/19558. Compared to the commit in https://github.com/RIOT-OS/RIOT/pull/19558 which added this to the `shell_cmd_sys` module, this makes it its own module. This avoids pulling it in by default, as mostly the ROM spent on this cmd is not well spent.