### PR TITLE
dist/tools/insufficient_memory: fix collection of app folders

### DIFF
--- a/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
@@ -47,12 +47,11 @@ export RIOT_CI_BUILD=1
 
 BOARD=$1
 RIOTBASE="$(dirname "$0")/../../.."
-APPLICATIONS="$APPLICATIONS examples/*/Makefile"
-APPLICATIONS="$APPLICATIONS tests/*/Makefile"
 TMPFILE="$(mktemp)"
 
-for app in ${APPLICATIONS}; do
-    application="$(dirname "${app}")"
+APPLICATIONS="${APPLICATIONS} $(make -sC "${RIOTBASE}" info-applications)"
+
+for application in ${APPLICATIONS}; do
     printf "${CNORMAL}%-40s${CRESET}" "${application}"
     # disable warning about globbing and word splitting for ${LOCAL_MAKE_ARGS}
     # as this is exactly what we want here


### PR DESCRIPTION
### Contribution description

There is actually a make target to list the applications in the repo. Let's just use that.
<!-- bors cut here -->

### Testing procedure

The tool should now iterate over all apps again.

### Issues/PRs references

Found during https://github.com/RIOT-OS/RIOT/pull/19558