### PR TITLE
dist/tools/compile_commands: add another workaround

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -335,6 +335,8 @@ if __name__ == '__main__':
             # it's called -mlong-calls in LLVM, but we don't need it for clangd
             # as we do not generate code anyway
             '-mlongcalls',
+            # GCC specific diagnostics: Tell GCC address space starts at 0
+            '--param=min-pagesize=0',
         ]
         _args.filter_out.extend(flags)
     generate_compile_commands(_args)


### PR DESCRIPTION
### Contribution description

Filter out GCC only `--param=min-pagesize=0` in `clangd` mode. This fixes compilation of rust applications, that now fails with:

    thread 'main' panicked at 'Unable to generate bindings: ClangDiagnostic("error: argument unused during compilation: '--param=min-pagesize=0' [-Wunused-command-line-argument]\n")', /home/maribu/.cargo/git/checkouts/rust-riot-sys-d12733b89271907c/b4bd4bd/build.rs:224:10
<!-- bors cut here -->

### Testing procedure

```
make BOARD=cc1352-launchpad -C examples/rust-hello-world
```

fails in `master`, but should work again with this PR.

### Issues/PRs references

None