### PR TITLE
drivers/at86rf2xx: setting rx timestamp based on symbol counter for ATmega*RFR2

### DIFF
--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -31,7 +31,9 @@
 extern "C" {
 #endif
 
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
 #define THREAD_EXTRA_STACKSIZE_PRINTF    (128)
+#endif
 
 /**
  * @name           Kernel configuration

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -29,6 +29,7 @@
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif.h"
+#include "time_units.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
@@ -36,10 +36,14 @@ void gnrc_netif_hdr_print(gnrc_netif_hdr_t *hdr)
         if (hdr->flags & GNRC_NETIF_HDR_FLAGS_BROADCAST) {
             printf("BROADCAST ");
         }
-
         if (hdr->flags & GNRC_NETIF_HDR_FLAGS_MULTICAST) {
             printf("MULTICAST ");
         }
+#if IS_USED(MODULE_GNRC_NETIF_TIMESTAMP)
+        if (hdr->flags & GNRC_NETIF_HDR_FLAGS_TIMESTAMP) {
+            printf("TIMESTAMP ");
+        }
+#endif
         puts("");
     }
     else {

--- a/tests/net/gnrc_netif_ieee802154/Makefile
+++ b/tests/net/gnrc_netif_ieee802154/Makefile
@@ -1,18 +1,33 @@
-BOARD_WHITELIST = native
+BOARD_WHITELIST = native derfmega256 avr-rss2 atmega256rfr2-xpro nrf52840dongle
 
 include ../Makefile.net_common
 
-TERMFLAGS ?= -z "0.0.0.0:17755,localhost:17754"
+ifeq (native, $(BOARD))
+  USEMODULE += socket_zep
+  TERMFLAGS ?= -z "0.0.0.0:17755,localhost:17754"
+  USEMODULE += netdev
+  # somehow this breaks the test
+  DISABLE_MODULE += test_utils_print_stack_usage
+else
+  USEMODULE += shell
+  USEMODULE += shell_cmds_default
+  USEMODULE += ps
+  # use the default network interface for the board
+  USEMODULE += netdev_default
+  # shell command to send L2 packets with a simple string
+  USEMODULE += gnrc_txtsnd
+  # module to test rx timestamp
+  USEMODULE += gnrc_netif_timestamp
+endif
 
-USEMODULE += socket_zep
-USEMODULE += auto_init_gnrc_netif
-USEMODULE += netdev
+# gnrc is a meta module including all required, basic gnrc networking modules
 USEMODULE += gnrc
+# automatically initialize the network interface
+USEMODULE += auto_init_gnrc_netif
+# use GNRC IEEE 802.15.4 as link-layer protocol
 USEMODULE += gnrc_netif_ieee802154
+# the application dumps received packets to stdout
 USEMODULE += gnrc_pktdump
-
-# somehow this breaks the test
-DISABLE_MODULE += test_utils_print_stack_usage
 
 TEST_ON_CI_WHITELIST += native
 

--- a/tests/net/gnrc_netif_ieee802154/main.c
+++ b/tests/net/gnrc_netif_ieee802154/main.c
@@ -17,20 +17,36 @@
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktdump.h"
 
+#if IS_USED(MODULE_SHELL)
+#include <stdio.h>
+#include <string.h>
+
+#include "thread.h"
+#include "shell.h"
+#endif
+
 int main(void)
 {
+#if IS_USED(MODULE_SOCKET_ZEP)
+    /* This is a test for native with socket_zep */
     char addr_str[GNRC_NETIF_L2ADDR_MAXLEN * 3];
     gnrc_netif_t *netif = gnrc_netif_iter(NULL);
 
     printf("l2_addr: %s\n", gnrc_netif_addr_to_str(netif->l2addr,
                                                    netif->l2addr_len,
                                                    addr_str));
-
+#endif
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(
             GNRC_NETREG_DEMUX_CTX_ALL,
             gnrc_pktdump_pid
         );
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
+
+#if IS_USED(MODULE_SHELL)
+    /* this is manual test for real MCU using shell module */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description


The PR adds setting the 802.15.4 packet reception timestamp based on the symbol counter available in ATmega64/128/256RFR2 MCU. The counter restarts every ~19 hours.

To enable the feature the `USEMODULE += gnrc_netif_timestamp` needs to be added to a Makefile.

### Testing procedure

The `tests/net/gnrc_netif_iee802154` was updated to check the behavior on real boards.
The test was performed on `derfmega256` and `nrf52840dongle` boards:

Two commands `txtsnd 4 bcast test` issued on nrf52840dongle 10 seconds apart, lead to the following result on the `derfmega256`:

>PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
00000000  74  65  73  74
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 4  rssi: -25   timestamp: _**769.117280000**_ lqi: 65
flags: BROADCAST TIMESTAMP
src_l2addr: 74:13
dst_l2addr: FF:FF
~~ PKT    -  2 snips, total size:  24 byte
PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
00000000  74  65  73  74
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 4  rssi: -25   timestamp: _**779.221568000**_ lqi: 65
flags: BROADCAST TIMESTAMP
src_l2addr: 74:13
dst_l2addr: FF:FF
~~ PKT    -  2 snips, total size:  24 byte

The received packets have `TIMESTAMP` flag and the timestamps differ by 10 seconds.

The same command issued on derfmega256 board leads to similar printout on `nrf52840dongle` board, but as its driver doesn't have timestamp handling, the packet has no `TIMESTAMP` flag and the value in the timestamp field is random.

>PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
00000000  74  65  73  74
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 4  rssi: -72   timestamp: _**26079.041421312**_ lqi: 156
flags: BROADCAST 
src_l2addr: 6B:09
dst_l2addr: FF:FF
~~ PKT    -  2 snips, total size:  24 byte
PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
00000000  74  65  73  74
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 4  rssi: -56   timestamp: _**26079.041421312**_ lqi: 160
flags: BROADCAST 
src_l2addr: 6B:09
dst_l2addr: FF:FF
~~ PKT    -  2 snips, total size:  24 byte

