### PR TITLE
build system: fix `make compile-commands BUILD_IN_DOCKER=1`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -728,6 +728,15 @@ else
   _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $$(find $(BASELIBS:%.module=$(BINDIR)/%/) -name "*.o" 2> /dev/null | sort) $(ARCHIVES_GROUP) $(LINKFLAGS) $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map
 endif # BUILDOSXNATIVE
 
+COMPILE_COMMANDS_PATH ?= $(RIOTBASE)/compile_commands.json
+COMPILE_COMMANDS_FLAGS ?= --clangd
+.PHONY: compile-commands
+compile-commands: $(BUILDDEPS)
+	$(Q)DIRS="$(DIRS)" APPLICATION_BLOBS="$(BLOBS)" \
+	  "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk compile-commands
+	$(Q)$(RIOTTOOLS)/compile_commands/compile_commands.py $(COMPILE_COMMANDS_FLAGS) $(BINDIR) \
+	  > $(COMPILE_COMMANDS_PATH)
+
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
 else
@@ -750,15 +759,6 @@ $(APPLICATION_MODULE).module: pkg-build $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" APPLICATION_BLOBS="$(BLOBS)" \
 	  "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 $(APPLICATION_MODULE).module: FORCE
-
-COMPILE_COMMANDS_PATH ?= $(RIOTBASE)/compile_commands.json
-COMPILE_COMMANDS_FLAGS ?= --clangd
-.PHONY: compile-commands
-compile-commands: $(BUILDDEPS)
-	$(Q)DIRS="$(DIRS)" APPLICATION_BLOBS="$(BLOBS)" \
-	  "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk compile-commands
-	$(Q)$(RIOTTOOLS)/compile_commands/compile_commands.py $(COMPILE_COMMANDS_FLAGS) $(BINDIR) \
-	  > $(COMPILE_COMMANDS_PATH)
 
 # Other modules are built by application.inc.mk and packages building
 _SUBMAKE_LIBS = $(filter-out $(APPLICATION_MODULE).module $(APPDEPS), $(BASELIBS) $(ARCHIVES))


### PR DESCRIPTION
### Contribution description

Just run `make compile-commands` outside of docker, as the compile commands generated in the docker container won't be helpful for tools outside of the container anyway.
<!-- bors cut here -->

### Testing procedure

```
make BOARD=<some board> BUILD_IN_DOCKER=1 -C examples/default compile-commands
```

Should now work (but run on the host's system anyway).

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/17507