### PR TITLE
sys/net/rpl: fix possible NULL dereference

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -1231,7 +1231,7 @@ void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, kernel_pid_t iface, ipv6
 #endif
 
     if (!IS_ACTIVE(CONFIG_GNRC_RPL_WITHOUT_VALIDATION)) {
-        if (!gnrc_rpl_validation_DAO_ACK(dao_ack, len, dst)) {
+        if (!dst || !gnrc_rpl_validation_DAO_ACK(dao_ack, len, dst)) {
             return;
         }
     }


### PR DESCRIPTION
### Contribution description

As the title says
<!-- bors cut here -->

### Testing procedure

No regression in RPL. (Beware: Fully untested!)

### Issues/PRs references

fixes https://github.com/RIOT-OS/RIOT/issues/15006 (or rather the last issue of the three instances reported there)