### PR TITLE
tests/sys/shell_coreclk: add test application for shell_cmd_coreclk

### DIFF
--- a/tests/sys/shell_coreclk/Makefile
+++ b/tests/sys/shell_coreclk/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.sys_common
+
+USEMODULE += shell
+USEMODULE += shell_cmd_coreclk
+
+# Use a terminal that does not introduce extra characters into the stream.
+RIOT_TERMINAL ?= socat
+
+include $(RIOTBASE)/Makefile.include
+
+# the test script skips tests if socat is not used
+$(call target-export-variables,$(RIOT_TERMINAL),RIOT_TERMINAL)

--- a/tests/sys/shell_coreclk/main.c
+++ b/tests/sys/shell_coreclk/main.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Test for the coreclk shell command
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+
+int main(void)
+{
+    /* define buffer to be used by the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+    /* start shell */
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/sys/shell_coreclk/tests/01-run.py
+++ b/tests/sys/shell_coreclk/tests/01-run.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+from testrunner import run
+
+EXPECTED_HELP = (
+    'Command              Description',
+    '---------------------------------------',
+    'coreclk              Print the CPU frequency',
+)
+BOARD = os.environ['BOARD']
+
+
+def testfunc(child):
+    # avoid sending an extra empty line on native.
+    if BOARD == 'native':
+        child.crlf = '\n'
+
+    # check the help
+    child.sendline('help')
+    for line in EXPECTED_HELP:
+        child.expect_exact(line)
+
+    # coreclk
+    child.sendline('coreclk')
+    child.expect(r"core clock: \d+ Hz")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

#19597 added the `coreclk` shell but it's not added as a default shell command, so the new shell command code (even if simple) is never built by the CI (for example with `examples/default`).

This PR is adding a simple test application for the `shell_cmd_coreclk` with a basic test script.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- The automatic test is working (tested on nrf52dk on iot-lab):

```
$ make -C tests/sys/shell_coreclk/ flash test BOARD=nrf52dk IOTLAB_NODE=auto
make: Entering directory '/work/riot/RIOT/tests/sys/shell_coreclk'
Building application "tests_shell_coreclk" for "nrf52dk" with MCU "nrf52".

"make" -C /work/riot/RIOT/pkg/cmsis/ 
"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/boards/nrf52dk
"make" -C /work/riot/RIOT/boards/common/nrf52xxxdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/cmds
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/test_utils/print_stack_usage
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  11088	    128	   2376	  13592	   3518	/work/riot/RIOT/tests/sys/shell_coreclk/bin/nrf52dk/tests_shell_coreclk.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,nrf52dk,10 --flash /work/riot/RIOT/tests/sys/shell_coreclk/bin/nrf52dk/tests_shell_coreclk.bin


ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52dk-10.saclay.iot-lab.info:20000' 
main(): This is RIOT! (Version: 2023.07-devel-372-g19ce68)
> help

> 
> help
Command              Description
---------------------------------------
coreclk              Print the CPU frequency
> coreclk
coreclk
core clock: 64000000 Hz
> 

```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Extends #19597 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
