### PR TITLE
boards/adafruit-clue: use shared usb_board_reset.mk for flash/reset/term targets

### DIFF
--- a/boards/adafruit-clue/Makefile.include
+++ b/boards/adafruit-clue/Makefile.include
@@ -8,18 +8,5 @@ ifeq ($(PROGRAMMER),adafruit-nrfutil)
   # The preinstalled bootloader must also be taken into account so
   # ROM_OFFSET skips the space taken by such bootloader.
   ROM_OFFSET = 0x26000
-
-  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
-    # Add 2 seconds delay before opening terminal: this is required when opening
-    # the terminal right after flashing. In this case, the stdio over USB needs
-    # some time after reset before being ready.
-    TERM_DELAY = 2
-    TERMDEPS += term-delay
-  endif
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
 endif
-
-term-delay:
-	sleep $(TERM_DELAY)
-
-TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
-$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Most of the variables defined in the Makefile.include are the same in `usb_board_reset.mk`. Let's include that file instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- flash, reset, term are working as expected on adafruti-clue:

```
$ make -C examples/default BOARD=adafruit-clue flash term --no-print-directory 
Building application "default" for "adafruit-clue" with MCU "nrf52".

"make" -C /work/riot/RIOT/pkg/cmsis/ 
"make" -C /work/riot/RIOT/boards/adafruit-clue
"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/apds99xx
"make" -C /work/riot/RIOT/drivers/bmx280
"make" -C /work/riot/RIOT/drivers/lis3mdl
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/drivers/sht3x
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/usb
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/cmds
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/usb/usbus
"make" -C /work/riot/RIOT/sys/usb/usbus/cdc/acm
"make" -C /work/riot/RIOT/sys/usb_board_reset
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  31548	    128	   5288	  36964	   9064	/work/riot/RIOT/examples/default/bin/adafruit-clue/default.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application /work/riot/RIOT/examples/default/bin/adafruit-clue/default.hex /work/riot/RIOT/examples/default/bin/adafruit-clue/default.hex.zip
Zip created at /work/riot/RIOT/examples/default/bin/adafruit-clue/default.hex.zip
adafruit-nrfutil dfu serial --port=/dev/ttyACM0 --baudrate=115200 --touch=1200 --package=/work/riot/RIOT/examples/default/bin/adafruit-clue/default.hex.zip --singlebank
Upgrading target on /dev/ttyACM0 with DFU package /work/riot/RIOT/examples/default/bin/adafruit-clue/default.hex.zip. Flow control is disabled, Single bank, Touch 1200
########################################
######################
Activating new firmware
Device programmed.
sleep 2
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2023-05-18 21:39:54,482 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2023-05-18 21:39:55,485 # main(): This is RIOT! (Version: 2023.07-devel-373-gd2628-pr/boards/adafruit-clue-cleanup-flash-procedure)
2023-05-18 21:39:55,485 # Welcome to RIOT!
> help
2023-05-18 21:39:57,199 # help
2023-05-18 21:39:57,199 # Command              Description
2023-05-18 21:39:57,200 # ---------------------------------------
2023-05-18 21:39:57,200 # bootloader           Reboot to bootloader
2023-05-18 21:39:57,201 # pm                   interact with layered PM subsystem
2023-05-18 21:39:57,202 # ps                   Prints information about running threads.
2023-05-18 21:39:57,202 # reboot               Reboot the node
2023-05-18 21:39:57,203 # saul                 interact with sensors and actuators using SAUL
2023-05-18 21:39:57,203 # version              Prints current RIOT_VERSION
> 2023-05-18 21:39:58,500 # Exiting Pyterm
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
