### PR TITLE
make/usb_board_reset: define {preflash,term}-delay when necessary

### DIFF
--- a/makefiles/tools/usb_board_reset.mk
+++ b/makefiles/tools/usb_board_reset.mk
@@ -28,8 +28,12 @@ RESET ?= $(PREFLASHER) $(RESETFFLASG)
 TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
 $(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
 
+ifneq (,$(filter flash flash-only,$(MAKECMDGOALS)))
 preflash-delay: preflash
 	sleep $(PREFLASH_DELAY)
+endif
 
+ifneq (,$(filter term,$(MAKECMDGOALS)))
 term-delay: $(TERMDELAYDEPS)
 	sleep $(TERM_DELAY)
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When running `make info-boards-supported` in an application directory, I got several warning from make:

```
$ make -C examples/hello-world info-boards-supported --no-print-directory 
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:32: warning: overriding recipe for target 'preflash-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:32: warning: ignoring old recipe for target 'preflash-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:35: warning: overriding recipe for target 'term-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:35: warning: ignoring old recipe for target 'term-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:32: warning: overriding recipe for target 'preflash-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:32: warning: ignoring old recipe for target 'preflash-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:35: warning: overriding recipe for target 'term-delay'
/work/riot/RIOT/makefiles/tools/usb_board_reset.mk:35: warning: ignoring old recipe for target 'term-delay'
...
```

The warnings are also printed with the `generate-Makefile.ci` target.

It seems the `usb_board_reset.mk` is included several times which leads to the warning. The idea of this PR is to only define `preflash-delay` and `term_delay` when necessary, e.g when a related target is used (flash, flash-only => preflash-delay, term => term-delay).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Affected boards work the same. I tested it with adafruit-clue and #19616 and it works as expected, the right delays are applied
- Most important: warnings are gone :)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This is the reason for #19616, I needed a board that is using a {preflash,term}-delay defined in `usb_board_reset.mk`.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
