### PR TITLE
cpu/stm32: fix riotboot settings for L4 and WB

### DIFF
--- a/cpu/stm32/stm32_riotboot.mk
+++ b/cpu/stm32/stm32_riotboot.mk
@@ -25,21 +25,26 @@ ifneq (,$(filter $(CPU_FAM),f2 f4 f7))
   # flash, to get evenly sized and distributed slots.
   SLOT0_LEN ?= $(shell printf "0x%x" $$((($(ROM_LEN:%K=%*1024)-2*$(RIOTBOOT_LEN)) / $(NUM_SLOTS))))
   SLOT1_LEN ?= $(SLOT0_LEN)
-else ifeq (stm32l4,$(CPU_FAM))
+else ifeq (l4,$(CPU_FAM))
   # "The Vector table must be naturally aligned to a power of two whose alignment
   # value is greater than or equal to number of Exceptions supported x 4"
-  # CPU_IRQ_NUMOFF for stm32l4 boards is < 91+16 so (107*4 bytes = 428 bytes ~= 0x200)
+  # CPU_IRQ_NUMOFF for stm32l4 boards is < 95+16 so (111*4 bytes = 444 bytes ~= 0x200)
   # RIOTBOOT_HDR_LEN can be set to 0x200
   RIOTBOOT_HDR_LEN ?= 0x200
-else ifeq (stm32wb,$(CPU_FAM))
+else ifeq (wb,$(CPU_FAM))
   # "The Vector table must be naturally aligned to a power of two whose alignment
   # value is greater than or equal to number of Exceptions supported x 4"
-  # CPU_IRQ_NUMOFF for stm32l4 boards is < 91+16 so (107*4 bytes = 428 bytes ~= 0x200)
+  # CPU_IRQ_NUMOFF for stm32wb boards is < 63+16 so (79*4 bytes = 316 bytes ~= 0x200)
   # RIOTBOOT_HDR_LEN can be set to 0x200
   RIOTBOOT_HDR_LEN ?= 0x200
 
   # Slot size is determined by "((total_flash_size - RIOTBOOT_LEN) / 2)".
   # If RIOTBOOT_LEN uses an odd number of flashpages, the remainder of the
   # flash cannot be divided by two slots while staying FLASHPAGE_SIZE aligned.
-  RIOTBOOT_LEN ?= 0x2000
+  # 8KB are currently enough, set it to 16KB if USB-DFU or tinyUSB DFU is used
+  ifneq (,$(filter usbus_dfu tinyusb_dfu,$(USEMODULE)))
+    RIOTBOOT_LEN ?= 0x4000
+  else
+    RIOTBOOT_LEN ?= 0x2000
+  endif
 endif


### PR DESCRIPTION
### Contribution description

This PR fixes the `riotboot` configuration for L4 and WB.

The family is not called `stm32l4` or `stm32wb` but `l4` and `wb`. That is, the `riotboot` configuration didn't work at all. Furthermore, a minimum `RIOTBOOT_LEN` of `0x2000` is required for L4.

Found when investigating the compilation errors for `bootloaders/riotboot_serial` in PR #19576.

### Testing procedure

1. Green CI.
2. Use the following commands:
    ```
    BOARD=nucleo-l496zg make -C tests/riotboot info-debug-variable-RIOTBOOT_HDR_LEN
    BOARD=p-nucleo-wb55 make -C tests/riotboot info-debug-variable-RIOTBOOT_HDR_LEN
    ```
    In master these commands give
    ```
    0x400
    ```
    With this PR these commands give
    ```
    0x200
    ```
    as expected.
3. Use the following commands:
    ```
    BOARD=nucleo-l496zg make -C tests/riotboot info-debug-variable-RIOTBOOT_LEN
    BOARD=p-nucleo-wb55 make -C tests/riotboot info-debug-variable-RIOTBOOT_LEN
    ```
    In master these commands give
    ```
    0x1000
    ```
    With this PR these commands give
    ```
    0x2000
    ```
    as expected.

### Issues/PRs references
