### PR TITLE
cpu/arm7: Fix undefined behavior based on invalid assembly

### DIFF
--- a/cpu/arm7_common/common.s
+++ b/cpu/arm7_common/common.s
@@ -101,6 +101,10 @@ task_return:
 
     /* Restore all registers, PC & cpsr */
     ldmfd   r0, {r0-lr}^
+    /* According to ARM Architecture Reference Manual DDI 0100I,
+     * ldms which affect banked registers must be followed by a nop.
+     */
+    nop
 
     /* return to task */
     movs pc, lr


### PR DESCRIPTION
### Contribution description

Hellooo! 🦤

In this PR a single `NOP` is added after an `ldm` in ARM7 common code in the scheduling management.
The change is necessary because this particular `ldm` affects certain banked registers, including `R14 / lr`. The next instruction then immediately accesses `lr`. This is invalid and the exact effect depends on the underlying hardware implementation. An intermediate `NOP` ensures correct behaviour in such cases.

The ARM docs can be found [here](https://documentation-service.arm.com/static/5f8dacc8f86e16515cdb865a), in section `A4.1.21 LDM (2)`. It states:
> In ARM architecture versions earlier than ARMv6, this form of LDM must not be
followed by an instruction that accesses banked registers. A following NOP is a good
way to ensure this.


### Testing procedure

Without this change, on the Game Boy Advance, RIOT behaves irregularly. With the `NOP`, it works fine!
If possible, this change should be tested on other ARM7 hardware as well but I do not have access to any.  

----

Special thanks @pyropeter for spotting the extremely tiny note on this issue within the ARM docs. You saved me hours of tears! 👾