### PR TITLE
makefiles/pseudomodules: remove deprecated event_thread_lowest module

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += event_thread_lowest
 DEPRECATED_MODULES += gnrc_netdev_default
 DEPRECATED_MODULES += gnrc_netif_cmd_lora # use shell_cmd_gnrc_netif_lorawan instead
 DEPRECATED_MODULES += gnrc_pktbuf_cmd # use shell_cmd_gnrc_pktbuf instead

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -61,13 +61,6 @@ PSEUDOMODULES += dns_msg
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += ethos_stdio
 PSEUDOMODULES += event_%
-## @defgroup sys_event_thread_lowest event_thread_lowest
-## @ingroup sys_event
-## @{
-## @deprecated  Use module `event_thread` instead (see @ref event/thread.h);
-##              Will be removed after 2021.10 release.
-PSEUDOMODULES += event_thread_lowest
-## @}
 PSEUDOMODULES += event_timeout
 PSEUDOMODULES += event_timeout_ztimer
 PSEUDOMODULES += evtimer_mbox

--- a/sys/include/event/thread.h
+++ b/sys/include/event/thread.h
@@ -42,9 +42,6 @@
  * event queue gets its own thread. So higher priority events will always
  * preempt events of lower priority in this case.
  *
- * Finally, the module [event_thread_lowest](@ref sys_event_thread_lowest) is
- * provided for backward compatibility and has no effect.
- *
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

And its remaining references in the documentation. It was marked as to removed after  2021.10 and it's not used anywhere in the codebase.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references



<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
