### PR TITLE
cpu/stm32/periph/adc: fix setting ADC clock

### DIFF
--- a/cpu/stm32/periph/adc_f1.c
+++ b/cpu/stm32/periph/adc_f1.c
@@ -28,7 +28,7 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           (14000000U)
+#define MAX_ADC_SPEED           MHZ(14)
 
 /**
  * @brief   Allocate locks for all three available ADC devices
@@ -93,7 +93,7 @@ int adc_init(adc_t line)
     }
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((CLOCK_CORECLOCK / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= MAX_ADC_SPEED) {
             break;
         }
     }

--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           (12000000U)
+#define MAX_ADC_SPEED           MHZ(12)
 
 /**
  * @brief   Default VBAT undefined value
@@ -86,7 +86,7 @@ int adc_init(adc_t line)
     }
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((CLOCK_CORECLOCK / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= MAX_ADC_SPEED) {
             break;
         }
     }

--- a/cpu/stm32/periph/adc_f4_f7.c
+++ b/cpu/stm32/periph/adc_f4_f7.c
@@ -28,7 +28,7 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           (12000000U)
+#define MAX_ADC_SPEED           MHZ(12)
 
 /**
  * @brief   Maximum sampling time for each channel (480 cycles)
@@ -94,7 +94,7 @@ int adc_init(adc_t line)
     dev(line)->CR2 = ADC_CR2_ADON;
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((CLOCK_CORECLOCK / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= MAX_ADC_SPEED) {
             break;
         }
     }


### PR DESCRIPTION
### Contribution description

The current implementation uses the core clock frequency to calculate the needed prescalar to achieve a given ADC clock frequency. This is incorrect. This patch fixes the calculation to use the correct source clock (PCKLK2 ie APB2). It also changes the defined max clock rate to use the frequency macro to improve readability.

I based on code similarity. I believe the gd32v CPU may need this same fix, but I am not familiar with that MCU.

### Testing procedure

I tested this on a nucleo-f767zi. The the MCU's reference manual is in agreement with what I have implemented here. I spot checked references manuals for a random [STM32F1](https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) and [STM32F2](https://www.st.com/resource/en/reference_manual/rm0033-stm32f205xx-stm32f207xx-stm32f215xx-and-stm32f217xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), and they are clocked similar to the F7 I have.

### Issues/PRs references

None known.
