### PR TITLE
cpu/{gd32v,stm32}/periph/adc: make ADC clock setable

### DIFF
--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -208,6 +208,7 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define VBAT_ADC            ADC_LINE(6) /**< VBAT ADC line */
+#define ADC_CLK_MAX         MHZ(36)     /**< Use a faster than default ADC clock */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 

--- a/cpu/gd32v/periph/adc.c
+++ b/cpu/gd32v/periph/adc.c
@@ -31,7 +31,9 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           MHZ(14)
+#ifndef ADC_CLK_MAX
+#define ADC_CLK_MAX             MHZ(14)
+#endif
 
 /**
  * @brief   Allocate locks for all three available ADC devices
@@ -122,7 +124,7 @@ int adc_init(adc_t line)
     }
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((CLOCK_CORECLOCK / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX) {
             break;
         }
     }

--- a/cpu/gd32v/periph/adc.c
+++ b/cpu/gd32v/periph/adc.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include "compiler_hints.h"
 #include "cpu.h"
 #include "macros/units.h"
 #include "mutex.h"
@@ -128,6 +129,7 @@ int adc_init(adc_t line)
             break;
         }
     }
+    assume((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX);
     RCU->CFG0 &= ~(RCU_CFG0_ADCPSC_2_Msk);
     RCU->CFG0 |= ((clk_div / 2) - 1) << RCU_CFG0_ADCPSC_2_Pos;
 

--- a/cpu/stm32/periph/adc_f1.c
+++ b/cpu/stm32/periph/adc_f1.c
@@ -28,7 +28,9 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           MHZ(14)
+#ifndef ADC_CLK_MAX
+#define ADC_CLK_MAX             MHZ(14)
+#endif
 
 /**
  * @brief   Allocate locks for all three available ADC devices
@@ -93,7 +95,7 @@ int adc_init(adc_t line)
     }
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((periph_apb_clk(APB2) / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX) {
             break;
         }
     }

--- a/cpu/stm32/periph/adc_f1.c
+++ b/cpu/stm32/periph/adc_f1.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include "compiler_hints.h"
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/adc.h"
@@ -99,6 +100,7 @@ int adc_init(adc_t line)
             break;
         }
     }
+    assume((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX);
     RCC->CFGR &= ~(RCC_CFGR_ADCPRE);
     RCC->CFGR |= ((clk_div / 2) - 1) << 14;
 

--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -29,7 +29,9 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           MHZ(12)
+#ifndef ADC_CLK_MAX
+#define ADC_CLK_MAX             MHZ(12)
+#endif
 
 /**
  * @brief   Default VBAT undefined value
@@ -86,7 +88,7 @@ int adc_init(adc_t line)
     }
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((periph_apb_clk(APB2) / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX) {
             break;
         }
     }

--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include "compiler_hints.h"
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/adc.h"
@@ -92,6 +93,7 @@ int adc_init(adc_t line)
             break;
         }
     }
+    assume((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX);
     ADC->CCR = ((clk_div / 2) - 1) << 16;
 
     /* enable the ADC module */

--- a/cpu/stm32/periph/adc_f4_f7.c
+++ b/cpu/stm32/periph/adc_f4_f7.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include "compiler_hints.h"
 #include "cpu.h"
 #include "irq.h"
 #include "mutex.h"
@@ -101,6 +102,7 @@ int adc_init(adc_t line)
             break;
         }
     }
+    assume((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX);
     ADC->CCR = ((clk_div / 2) - 1) << 16;
     /* set sampling time to the maximum */
     unsigned irq_state = irq_disable();

--- a/cpu/stm32/periph/adc_f4_f7.c
+++ b/cpu/stm32/periph/adc_f4_f7.c
@@ -29,7 +29,9 @@
 /**
  * @brief   Maximum allowed ADC clock speed
  */
-#define MAX_ADC_SPEED           MHZ(12)
+#ifndef ADC_CLK_MAX
+#define ADC_CLK_MAX             MHZ(12)
+#endif
 
 /**
  * @brief   Maximum sampling time for each channel (480 cycles)
@@ -95,7 +97,7 @@ int adc_init(adc_t line)
     dev(line)->CR2 = ADC_CR2_ADON;
     /* set clock prescaler to get the maximal possible ADC clock value */
     for (clk_div = 2; clk_div < 8; clk_div += 2) {
-        if ((periph_apb_clk(APB2) / clk_div) <= MAX_ADC_SPEED) {
+        if ((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX) {
             break;
         }
     }


### PR DESCRIPTION
### Contribution description

This patch allows boards to declare their max ADC clock speed. As an example, the nucleo-f767zi declares it's ADC clock speed to be 36MHz (the max speed of the board's MCU).

### Testing procedure

The change is minor and fairly safe. I verified that the macro works by declaring it to "foo" in `periph_conf.h` to trigger a compiler error. Beyond that, it is up to board maintainers to use the macro wisely.

### Issues/PRs references

This PR is based off #19629 and should be merged after.
