### PR TITLE
drivers/pcf857x: fix error handling

### DIFF
--- a/drivers/pcf857x/pcf857x.c
+++ b/drivers/pcf857x/pcf857x.c
@@ -141,7 +141,7 @@ int pcf857x_init(pcf857x_t *dev, const pcf857x_params_t *params)
 
     _release(dev);
 
-    return PCF857X_OK;
+    return res;
 }
 
 int pcf857x_gpio_init(pcf857x_t *dev, gpio_t pin, gpio_mode_t mode)


### PR DESCRIPTION
### Contribution description

This fixes a typo/copy paste error in the error handling.
<!-- bors cut here -->

### Testing procedure

Code review should be sufficient

### Issues/PRs references

None