### PR TITLE
drivers/slipdev: fix logic bug

### DIFF
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -78,8 +78,8 @@ check_end:
 
 static void _poweron(slipdev_t *dev)
 {
-    if ((dev->state != SLIPDEV_STATE_STANDBY) ||
-        (dev->state != SLIPDEV_STATE_SLEEP)) {
+    if ((dev->state != SLIPDEV_STATE_STANDBY) &&
+            (dev->state != SLIPDEV_STATE_SLEEP)) {
         return;
     }
 


### PR DESCRIPTION
### Contribution description

A typo resulted in a boolean expression to always be true and the `_poweron()` function to always exit early. This fixes the issue.
<!-- bors cut here -->

### Testing procedure

Code review should be sufficient, IMO. But one could test the poweron function.

### Issues/PRs references

None