### PR TITLE
tree-wide: mixed box of compilation fixes with clang

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -38,8 +38,7 @@ esac
 
 # temporarily disabling llvm builds until https://github.com/RIOT-OS/RIOT/pull/15595
 # is in
-#: ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
-: ${TEST_BOARDS_LLVM_COMPILE:=""}
+: ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
 : ${TEST_KCONFIG_BOARDS_AVAILABLE:="
 adafruit-itsybitsy-m4

--- a/cpu/nrf5x_common/periph/gpio_ll_irq.c
+++ b/cpu/nrf5x_common/periph/gpio_ll_irq.c
@@ -59,6 +59,16 @@ struct isr_ctx {
 };
 static struct isr_ctx isr_ctx[GPIOTE_CHAN_NUMOF];
 
+static uint8_t get_portsel(uint32_t conf)
+{
+#ifdef GPIOTE_CONFIG_PORT_Msk
+    return (conf & GPIOTE_CONFIG_PORT_Msk) >> GPIOTE_CONFIG_PORT_Pos;
+#else
+    (void)conf;
+    return 0;
+#endif
+}
+
 /**
  * @brief   get the GPIOTE channel used to monitor the given pin
  *
@@ -74,14 +84,8 @@ static unsigned get_channel_of_pin(uint8_t port_num, uint8_t pin)
         uint32_t mode = (conf & GPIOTE_CONFIG_MODE_Msk) >> GPIOTE_CONFIG_MODE_Pos;
         if (mode == GPIOTE_CONFIG_MODE_Event) {
             uint8_t pinsel = (conf & GPIOTE_CONFIG_PSEL_Msk) >> GPIOTE_CONFIG_PSEL_Pos;
-#ifdef GPIOTE_CONFIG_PORT_Msk
-            uint8_t portsel = (conf & GPIOTE_CONFIG_PORT_Msk) >> GPIOTE_CONFIG_PORT_Pos;
-#endif
-            if ((pinsel == pin)
-#ifdef GPIOTE_CONFIG_PORT_Msk
-                && (portsel == port_num)
-#endif
-                ) {
+            uint8_t portsel = get_portsel(conf);
+            if ((pinsel == pin) && (portsel == port_num)) {
                 return i;
             }
         }

--- a/cpu/sam0_common/include/vendor/README.md
+++ b/cpu/sam0_common/include/vendor/README.md
@@ -36,6 +36,14 @@ all `source` folders are removed.
 Be aware that if you want to make changes to any file in this tree that the
 changes will be lost when a new ASF release is going to be used.
 
+### C++ compatibility (with LLVM)
+
+Many of the header files where generated with an outdated version of SVDConv
+that adds the `__I` qualifier to anonymous bit fields, which `clang++` won't
+compile. Run the script `fix_cxx_compat.sh` in this directory whenever you
+add or update vendor header filers until Microchips starts using a fixed version
+of SVDConv.
+
 ### sam0.h
 
 A SAM based CPU should include `sam0.h` in this directory, which will

--- a/cpu/sam0_common/include/vendor/fix_cxx_compat.sh
+++ b/cpu/sam0_common/include/vendor/fix_cxx_compat.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This script removes type qualifiers from anonymous padding fields in bit
+# fields for compatibility with clang++.
+
+offenders="$(grep -Erl '__I [u]*int[0-9]*_t[ \t]*:[0-9]*;')"
+
+for file in $offenders; do
+    sed -i "$file" -e 's/__I \([u]*int[0-9]*_t[\t ]*:[0-9]*;\)/\1    /g'
+done

--- a/cpu/sam0_common/include/vendor/samd10/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/dac.h
@@ -179,7 +179,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/dmac.h
@@ -752,7 +752,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/eic.h
@@ -280,11 +280,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5               */
     __I uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6               */
     __I uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7               */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    uint32_t :24;                  /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:8;         /*!< bit:  0.. 7  External Interrupt x               */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    uint32_t :24;                  /*!< bit:  8..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/evsys.h
@@ -340,20 +340,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun                  */
     __I uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun                  */
     __I uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun                  */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection          */
     __I uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection          */
     __I uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection          */
     __I uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection          */
-    __I uint32_t :18;              /*!< bit: 14..31  Reserved                           */
+    uint32_t :18;                  /*!< bit: 14..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:6;            /*!< bit:  0.. 5  Channel x Overrun                  */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t EVD:6;            /*!< bit:  8..13  Channel x Event Detection          */
-    __I uint32_t :18;              /*!< bit: 14..31  Reserved                           */
+    uint32_t :18;                  /*!< bit: 14..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/nvmctrl.h
@@ -231,7 +231,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/pm.h
@@ -447,7 +447,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
     __I uint8_t  CFD:1;            /*!< bit:      1  Clock Failure Detector             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/sercom.h
@@ -828,7 +828,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -853,7 +853,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -881,7 +881,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -913,7 +913,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samd10/include/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/sysctrl.h
@@ -177,11 +177,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t :3;                   /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    uint32_t :14;                  /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/tcc.h
@@ -969,7 +969,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    uint32_t :7;                   /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -979,12 +979,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd10/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd10/include/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/dac.h
@@ -176,7 +176,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/evsys.h
@@ -378,12 +378,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection          */
     __I uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection          */
     __I uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection          */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/nvmctrl.h
@@ -231,7 +231,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/pm.h
@@ -425,7 +425,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/sercom.h
@@ -761,7 +761,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master on Bus                      */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave on Bus                       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_I2CM_INTFLAG_Type;
@@ -783,7 +783,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received                      */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match                      */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Ready                         */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_I2CS_INTFLAG_Type;
@@ -807,7 +807,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_SPI_INTFLAG_Type;
@@ -832,7 +832,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_USART_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/sysctrl.h
@@ -157,7 +157,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    uint32_t :20;                  /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/dac.h
@@ -176,7 +176,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/evsys.h
@@ -380,12 +380,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection          */
     __I uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection          */
     __I uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection          */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/nvmctrl.h
@@ -231,7 +231,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/pm.h
@@ -425,7 +425,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/sercom.h
@@ -761,7 +761,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master on Bus                      */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave on Bus                       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_I2CM_INTFLAG_Type;
@@ -783,7 +783,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received                      */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match                      */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Ready                         */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_I2CS_INTFLAG_Type;
@@ -807,7 +807,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_SPI_INTFLAG_Type;
@@ -832,7 +832,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_USART_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/sysctrl.h
@@ -157,7 +157,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    uint32_t :20;                  /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/dac.h
@@ -179,7 +179,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/dmac.h
@@ -824,7 +824,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/evsys.h
@@ -486,20 +486,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/i2s.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/i2s.h
@@ -314,26 +314,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/nvmctrl.h
@@ -231,7 +231,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/pm.h
@@ -443,7 +443,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/sercom.h
@@ -828,7 +828,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -853,7 +853,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -881,7 +881,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -913,7 +913,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/sysctrl.h
@@ -177,11 +177,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t :3;                   /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    uint32_t :14;                  /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/tcc.h
@@ -961,7 +961,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    uint32_t :7;                   /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/usb.h
@@ -627,7 +627,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -662,7 +662,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -671,7 +671,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1197,11 +1197,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_a/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_a/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/dac.h
@@ -179,7 +179,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/dmac.h
@@ -824,7 +824,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Transfer Error                     */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Transfer Complete                  */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/evsys.h
@@ -486,20 +486,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/i2s.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/i2s.h
@@ -314,26 +314,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/nvmctrl.h
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/pm.h
@@ -464,7 +464,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/sercom.h
@@ -828,7 +828,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -853,7 +853,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -881,7 +881,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -913,7 +913,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/sysctrl.h
@@ -177,11 +177,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t :3;                   /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    uint32_t :14;                  /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/tcc.h
@@ -961,7 +961,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    uint32_t :7;                   /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/tcc_lighting.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/tcc_lighting.h
@@ -973,7 +973,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -984,12 +984,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/usb.h
@@ -627,7 +627,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -662,7 +662,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -671,7 +671,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1197,11 +1197,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_b/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_b/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/dac.h
@@ -179,7 +179,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/dmac.h
@@ -824,7 +824,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Transfer Error                     */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Transfer Complete                  */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/evsys.h
@@ -486,20 +486,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/i2s.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/i2s.h
@@ -314,26 +314,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/nvmctrl.h
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/pm.h
@@ -464,7 +464,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/sercom.h
@@ -828,7 +828,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -853,7 +853,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -881,7 +881,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -913,7 +913,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/sysctrl.h
@@ -177,11 +177,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t :3;                   /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    uint32_t :14;                  /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/tcc.h
@@ -961,7 +961,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    uint32_t :7;                   /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/tcc_lighting.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/tcc_lighting.h
@@ -977,7 +977,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -988,12 +988,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/usb.h
@@ -627,7 +627,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -662,7 +662,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -671,7 +671,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1197,11 +1197,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_c/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_c/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/dac.h
@@ -179,7 +179,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/dmac.h
@@ -824,7 +824,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Transfer Error                     */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Transfer Complete                  */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/evsys.h
@@ -486,20 +486,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/i2s.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/i2s.h
@@ -314,26 +314,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/nvmctrl.h
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/pm.h
@@ -468,7 +468,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/sercom.h
@@ -828,7 +828,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -853,7 +853,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -881,7 +881,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -913,7 +913,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/sysctrl.h
@@ -177,11 +177,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t :3;                   /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    uint32_t :14;                  /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/tcc.h
@@ -961,7 +961,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    uint32_t :7;                   /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/tcc_lighting.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/tcc_lighting.h
@@ -973,7 +973,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -984,12 +984,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/usb.h
@@ -627,7 +627,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -662,7 +662,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -671,7 +671,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1197,11 +1197,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd21/include_d/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd21/include_d/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/adc.h
@@ -569,7 +569,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/aes.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/aes.h
@@ -217,7 +217,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/dmac.h
@@ -1143,7 +1143,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/evsys.h
@@ -498,7 +498,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVR:1;            /*!< bit:      0  Channel Overrun                    */
     __I uint8_t  EVD:1;            /*!< bit:      1  Channel Event Detected             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } EVSYS_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/freqm.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/i2s.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/i2s.h
@@ -309,26 +309,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/nvmctrl.h
@@ -324,7 +324,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t SEESFULL:1;       /*!< bit:      8  Active SEES Full                   */
     __I uint16_t SEESOVF:1;        /*!< bit:      9  Active SEES Overflow               */
     __I uint16_t SEEWRC:1;         /*!< bit:     10  SEE Write Completed                */
-    __I uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+    uint16_t :5;                   /*!< bit: 11..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/osc32kctrl.h
@@ -88,9 +88,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
-    __I uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t :1;                   /*!< bit:      1  Reserved                           */
     __I uint32_t XOSC32KFAIL:1;    /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    uint32_t :29;                  /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/oscctrl.h
@@ -235,28 +235,28 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSCRDY1:1;       /*!< bit:      1  XOSC 1 Ready                       */
     __I uint32_t XOSCFAIL0:1;      /*!< bit:      2  XOSC 0 Clock Failure Detector      */
     __I uint32_t XOSCFAIL1:1;      /*!< bit:      3  XOSC 1 Clock Failure Detector      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t :4;                   /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t :3;                   /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLL0LCKR:1;      /*!< bit:     16  DPLL0 Lock Rise                    */
     __I uint32_t DPLL0LCKF:1;      /*!< bit:     17  DPLL0 Lock Fall                    */
     __I uint32_t DPLL0LTO:1;       /*!< bit:     18  DPLL0 Lock Timeout                 */
     __I uint32_t DPLL0LDRTO:1;     /*!< bit:     19  DPLL0 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t DPLL1LCKR:1;      /*!< bit:     24  DPLL1 Lock Rise                    */
     __I uint32_t DPLL1LCKF:1;      /*!< bit:     25  DPLL1 Lock Fall                    */
     __I uint32_t DPLL1LTO:1;       /*!< bit:     26  DPLL1 Lock Timeout                 */
     __I uint32_t DPLL1LDRTO:1;     /*!< bit:     27  DPLL1 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t XOSCRDY:2;        /*!< bit:  0.. 1  XOSC x Ready                       */
     __I uint32_t XOSCFAIL:2;       /*!< bit:  2.. 3  XOSC x Clock Failure Detector      */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    uint32_t :28;                  /*!< bit:  4..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/pac.h
@@ -144,7 +144,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SDHC1_:1;         /*!< bit:     13  SDHC1                              */
     __I uint32_t QSPI_:1;          /*!< bit:     14  QSPI                               */
     __I uint32_t BKUPRAM_:1;       /*!< bit:     15  BKUPRAM                            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -207,7 +207,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:     13  SERCOM1                            */
     __I uint32_t TC0_:1;           /*!< bit:     14  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:     15  TC1                                */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -262,16 +262,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      5  DMAC                               */
     __I uint32_t HMATRIX_:1;       /*!< bit:      6  HMATRIX                            */
     __I uint32_t EVSYS_:1;         /*!< bit:      7  EVSYS                              */
-    __I uint32_t :1;               /*!< bit:      8  Reserved                           */
+    uint32_t :1;                   /*!< bit:      8  Reserved                           */
     __I uint32_t SERCOM2_:1;       /*!< bit:      9  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:     10  SERCOM3                            */
     __I uint32_t TCC0_:1;          /*!< bit:     11  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     12  TCC1                               */
     __I uint32_t TC2_:1;           /*!< bit:     13  TC2                                */
     __I uint32_t TC3_:1;           /*!< bit:     14  TC3                                */
-    __I uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t :1;                   /*!< bit:     15  Reserved                           */
     __I uint32_t RAMECC_:1;        /*!< bit:     16  RAMECC                             */
-    __I uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+    uint32_t :15;                  /*!< bit: 17..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -316,7 +316,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint32_t :3;               /*!< bit:  0.. 2  Reserved                           */
+    uint32_t :3;                   /*!< bit:  0.. 2  Reserved                           */
     __I uint32_t TCC2_:1;          /*!< bit:      3  TCC2                               */
     __I uint32_t TCC3_:1;          /*!< bit:      4  TCC3                               */
     __I uint32_t TC4_:1;           /*!< bit:      5  TC4                                */
@@ -329,7 +329,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PUKCC_:1;         /*!< bit:     12  PUKCC                              */
     __I uint32_t QSPI_:1;          /*!< bit:     13  QSPI                               */
     __I uint32_t CCL_:1;           /*!< bit:     14  CCL                                */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    uint32_t :17;                  /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -380,7 +380,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:      9  DAC                                */
     __I uint32_t I2S_:1;           /*!< bit:     10  I2S                                */
     __I uint32_t PCC_:1;           /*!< bit:     11  PCC                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    uint32_t :20;                  /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/pdec.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/pdec.h
@@ -361,12 +361,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  VLC:1;            /*!< bit:      3  Velocity                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  Channel 0 Compare Match            */
     __I uint8_t  MC1:1;            /*!< bit:      5  Channel 1 Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Channel x Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PDEC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/pm.h
@@ -132,7 +132,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SLEEPRDY:1;       /*!< bit:      0  Sleep Mode Entry Ready             */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/qspi.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/qspi.h
@@ -282,11 +282,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DRE:1;            /*!< bit:      1  Transmit Data Register Empty       */
     __I uint32_t TXC:1;            /*!< bit:      2  Transmission Complete              */
     __I uint32_t ERROR:1;          /*!< bit:      3  Overrun Error                      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t :4;                   /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t CSRISE:1;         /*!< bit:      8  Chip Select Rise                   */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t :1;                   /*!< bit:      9  Reserved                           */
     __I uint32_t INSTREND:1;       /*!< bit:     10  Instruction End                    */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } QSPI_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/ramecc.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/ramecc.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SINGLEE:1;        /*!< bit:      0  Single Bit ECC Error Interrupt     */
     __I uint8_t  DUALE:1;          /*!< bit:      1  Dual Bit ECC Error Interrupt       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RAMECC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/rtc.h
@@ -1082,14 +1082,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    uint16_t :4;                   /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
     __I uint16_t CMP2:1;           /*!< bit:     10  Compare 2                          */
     __I uint16_t CMP3:1;           /*!< bit:     11  Compare 3                          */
-    __I uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    uint16_t :2;                   /*!< bit: 12..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:4;            /*!< bit:  8..11  Compare x                          */
-    __I uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint16_t :4;                   /*!< bit: 12..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -1212,14 +1212,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
     __I uint16_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    uint16_t :4;                   /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:2;          /*!< bit:  8.. 9  Alarm x                            */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/sercom.h
@@ -901,7 +901,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -926,7 +926,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -954,7 +954,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -986,7 +986,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samd51/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/supc.h
@@ -131,11 +131,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t :1;                   /*!< bit:      9  Reserved                           */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/tcc.h
@@ -996,7 +996,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -1009,12 +1009,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
     __I uint32_t MC4:1;            /*!< bit:     20  Match or Capture 4                 */
     __I uint32_t MC5:1;            /*!< bit:     21  Match or Capture 5                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    uint32_t :10;                  /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:6;             /*!< bit: 16..21  Match or Capture x                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    uint32_t :10;                  /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samd51/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd51/include/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/adc.h
@@ -569,7 +569,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/aes.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/aes.h
@@ -217,7 +217,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/dmac.h
@@ -1143,7 +1143,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/evsys.h
@@ -498,7 +498,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVR:1;            /*!< bit:      0  Channel Overrun                    */
     __I uint8_t  EVD:1;            /*!< bit:      1  Channel Event Detected             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } EVSYS_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/freqm.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/i2s.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/i2s.h
@@ -309,26 +309,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t :2;                   /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint16_t :2;                   /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/nvmctrl.h
@@ -324,7 +324,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t SEESFULL:1;       /*!< bit:      8  Active SEES Full                   */
     __I uint16_t SEESOVF:1;        /*!< bit:      9  Active SEES Overflow               */
     __I uint16_t SEEWRC:1;         /*!< bit:     10  SEE Write Completed                */
-    __I uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+    uint16_t :5;                   /*!< bit: 11..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/osc32kctrl.h
@@ -88,9 +88,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
-    __I uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t :1;                   /*!< bit:      1  Reserved                           */
     __I uint32_t XOSC32KFAIL:1;    /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    uint32_t :29;                  /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/oscctrl.h
@@ -235,28 +235,28 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSCRDY1:1;       /*!< bit:      1  XOSC 1 Ready                       */
     __I uint32_t XOSCFAIL0:1;      /*!< bit:      2  XOSC 0 Clock Failure Detector      */
     __I uint32_t XOSCFAIL1:1;      /*!< bit:      3  XOSC 1 Clock Failure Detector      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t :4;                   /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t :3;                   /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLL0LCKR:1;      /*!< bit:     16  DPLL0 Lock Rise                    */
     __I uint32_t DPLL0LCKF:1;      /*!< bit:     17  DPLL0 Lock Fall                    */
     __I uint32_t DPLL0LTO:1;       /*!< bit:     18  DPLL0 Lock Timeout                 */
     __I uint32_t DPLL0LDRTO:1;     /*!< bit:     19  DPLL0 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t DPLL1LCKR:1;      /*!< bit:     24  DPLL1 Lock Rise                    */
     __I uint32_t DPLL1LCKF:1;      /*!< bit:     25  DPLL1 Lock Fall                    */
     __I uint32_t DPLL1LTO:1;       /*!< bit:     26  DPLL1 Lock Timeout                 */
     __I uint32_t DPLL1LDRTO:1;     /*!< bit:     27  DPLL1 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t XOSCRDY:2;        /*!< bit:  0.. 1  XOSC x Ready                       */
     __I uint32_t XOSCFAIL:2;       /*!< bit:  2.. 3  XOSC x Clock Failure Detector      */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    uint32_t :28;                  /*!< bit:  4..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/pac.h
@@ -144,7 +144,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SDHC1_:1;         /*!< bit:     13  SDHC1                              */
     __I uint32_t QSPI_:1;          /*!< bit:     14  QSPI                               */
     __I uint32_t BKUPRAM_:1;       /*!< bit:     15  BKUPRAM                            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -207,7 +207,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:     13  SERCOM1                            */
     __I uint32_t TC0_:1;           /*!< bit:     14  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:     15  TC1                                */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -262,16 +262,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      5  DMAC                               */
     __I uint32_t HMATRIX_:1;       /*!< bit:      6  HMATRIX                            */
     __I uint32_t EVSYS_:1;         /*!< bit:      7  EVSYS                              */
-    __I uint32_t :1;               /*!< bit:      8  Reserved                           */
+    uint32_t :1;                   /*!< bit:      8  Reserved                           */
     __I uint32_t SERCOM2_:1;       /*!< bit:      9  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:     10  SERCOM3                            */
     __I uint32_t TCC0_:1;          /*!< bit:     11  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     12  TCC1                               */
     __I uint32_t TC2_:1;           /*!< bit:     13  TC2                                */
     __I uint32_t TC3_:1;           /*!< bit:     14  TC3                                */
-    __I uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t :1;                   /*!< bit:     15  Reserved                           */
     __I uint32_t RAMECC_:1;        /*!< bit:     16  RAMECC                             */
-    __I uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+    uint32_t :15;                  /*!< bit: 17..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -331,7 +331,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PUKCC_:1;         /*!< bit:     12  PUKCC                              */
     __I uint32_t QSPI_:1;          /*!< bit:     13  QSPI                               */
     __I uint32_t CCL_:1;           /*!< bit:     14  CCL                                */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    uint32_t :17;                  /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -388,7 +388,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:      9  DAC                                */
     __I uint32_t I2S_:1;           /*!< bit:     10  I2S                                */
     __I uint32_t PCC_:1;           /*!< bit:     11  PCC                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    uint32_t :20;                  /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/pdec.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/pdec.h
@@ -361,12 +361,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  VLC:1;            /*!< bit:      3  Velocity                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  Channel 0 Compare Match            */
     __I uint8_t  MC1:1;            /*!< bit:      5  Channel 1 Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Channel x Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PDEC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/pm.h
@@ -132,7 +132,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SLEEPRDY:1;       /*!< bit:      0  Sleep Mode Entry Ready             */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/qspi.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/qspi.h
@@ -282,11 +282,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DRE:1;            /*!< bit:      1  Transmit Data Register Empty       */
     __I uint32_t TXC:1;            /*!< bit:      2  Transmission Complete              */
     __I uint32_t ERROR:1;          /*!< bit:      3  Overrun Error                      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t :4;                   /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t CSRISE:1;         /*!< bit:      8  Chip Select Rise                   */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t :1;                   /*!< bit:      9  Reserved                           */
     __I uint32_t INSTREND:1;       /*!< bit:     10  Instruction End                    */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } QSPI_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/ramecc.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/ramecc.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SINGLEE:1;        /*!< bit:      0  Single Bit ECC Error Interrupt     */
     __I uint8_t  DUALE:1;          /*!< bit:      1  Dual Bit ECC Error Interrupt       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RAMECC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/rtc.h
@@ -1082,14 +1082,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    uint16_t :4;                   /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
     __I uint16_t CMP2:1;           /*!< bit:     10  Compare 2                          */
     __I uint16_t CMP3:1;           /*!< bit:     11  Compare 3                          */
-    __I uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    uint16_t :2;                   /*!< bit: 12..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:4;            /*!< bit:  8..11  Compare x                          */
-    __I uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint16_t :4;                   /*!< bit: 12..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -1212,14 +1212,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
     __I uint16_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    uint16_t :4;                   /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:2;          /*!< bit:  8.. 9  Alarm x                            */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/sercom.h
@@ -901,7 +901,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -926,7 +926,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -954,7 +954,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -986,7 +986,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/same54/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/supc.h
@@ -131,11 +131,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t :1;                   /*!< bit:      9  Reserved                           */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/tcc.h
@@ -996,7 +996,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -1009,12 +1009,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
     __I uint32_t MC4:1;            /*!< bit:     20  Match or Capture 4                 */
     __I uint32_t MC5:1;            /*!< bit:     21  Match or Capture 5                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    uint32_t :10;                  /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:6;             /*!< bit: 16..21  Match or Capture x                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    uint32_t :10;                  /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/same54/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/same54/include/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/ac.h
@@ -259,15 +259,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t COMP0:1;                   /**< bit:      0  Comparator 0                             */
     __I uint8_t COMP1:1;                   /**< bit:      1  Comparator 1                             */
-    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    uint8_t :2;                            /**< bit:   2..3  Reserved */
     __I uint8_t WIN0:1;                    /**< bit:      4  Window 0                                 */
-    __I uint8_t :3;                        /**< bit:   5..7  Reserved */
+    uint8_t :3;                            /**< bit:   5..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint8_t COMP:2;                    /**< bit:   0..1  Comparator x                             */
-    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    uint8_t :2;                            /**< bit:   2..3  Reserved */
     __I uint8_t WIN:1;                     /**< bit:      4  Window x                                 */
-    __I uint8_t :3;                        /**< bit:   5..7 Reserved */
+    uint8_t :3;                            /**< bit:   5..7 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint8_t  reg;                         /**< Type used for register access */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/adc.h
@@ -259,7 +259,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Flag              */
     __I uint8_t OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Flag                   */
     __I uint8_t WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Flag            */
-    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+    uint8_t :5;                            /**< bit:   3..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/dac.h
@@ -204,7 +204,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t UNDERRUN:1;                /**< bit:      0  Underrun                                 */
     __I uint8_t EMPTY:1;                   /**< bit:      1  Data Buffer Empty                        */
-    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+    uint8_t :6;                            /**< bit:   2..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/dmac.h
@@ -1050,7 +1050,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t TERR:1;                    /**< bit:      0  Channel Transfer Error                   */
     __I uint8_t TCMPL:1;                   /**< bit:      1  Channel Transfer Complete                */
     __I uint8_t SUSP:1;                    /**< bit:      2  Channel Suspend                          */
-    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+    uint8_t :5;                            /**< bit:   3..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/eic.h
@@ -235,7 +235,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt                       */
-    __I uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t :23;                           /**< bit:  8..30  Reserved */
     __I uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/evsys.h
@@ -151,7 +151,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t OVR:1;                     /**< bit:      0  Channel Overrun                          */
     __I uint8_t EVD:1;                     /**< bit:      1  Channel Event Detected                   */
-    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+    uint8_t :6;                            /**< bit:   2..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } EVSYS_CHINTFLAG_Type;
@@ -523,7 +523,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/freqm.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/freqm.h
@@ -160,7 +160,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t DONE:1;                    /**< bit:      0  Measurement Done                         */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } FREQM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/mclk.h
@@ -111,7 +111,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t CKRDY:1;                   /**< bit:      0  Clock Ready                              */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/nvmctrl.h
@@ -280,7 +280,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t NVME:1;                    /**< bit:      3  NVM Error                                */
     __I uint8_t KEYE:1;                    /**< bit:      4  KEY Write Error                          */
     __I uint8_t NSCHK:1;                   /**< bit:      5  NS configuration change detected         */
-    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+    uint8_t :2;                            /**< bit:   6..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/osc32kctrl.h
@@ -99,9 +99,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready                            */
-    __I uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t :1;                            /**< bit:      1  Reserved */
     __I uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector           */
-    __I uint32_t :29;                       /**< bit:  3..31  Reserved */
+    uint32_t :29;                           /**< bit:  3..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/oscctrl.h
@@ -197,18 +197,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready                               */
     __I uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector              */
-    __I uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t :2;                            /**< bit:   2..3  Reserved */
     __I uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready                             */
-    __I uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t :3;                            /**< bit:   5..7  Reserved */
     __I uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready                            */
     __I uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock                             */
     __I uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock                          */
-    __I uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t :5;                            /**< bit: 11..15  Reserved */
     __I uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise                           */
     __I uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall                           */
     __I uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout                        */
     __I uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete  */
-    __I uint32_t :12;                       /**< bit: 20..31  Reserved */
+    uint32_t :12;                           /**< bit: 20..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/pac.h
@@ -155,7 +155,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMCPU_:1;               /**< bit:      4  HSRAMCPU                                 */
     __I uint32_t HSRAMDMAC_:1;              /**< bit:      5  HSRAMDMAC                                */
     __I uint32_t HSRAMDSU_:1;               /**< bit:      6  HSRAMDSU                                 */
-    __I uint32_t :25;                       /**< bit:  7..31  Reserved */
+    uint32_t :25;                           /**< bit:  7..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGAHB_Type;
@@ -210,7 +210,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t FREQM_:1;                  /**< bit:     11  FREQM                                    */
     __I uint32_t PORT_:1;                   /**< bit:     12  PORT                                     */
     __I uint32_t AC_:1;                     /**< bit:     13  AC                                       */
-    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+    uint32_t :18;                           /**< bit: 14..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGA_Type;
@@ -273,7 +273,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;                    /**< bit:      1  DSU                                      */
     __I uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL                                  */
     __I uint32_t DMAC_:1;                   /**< bit:      3  DMAC                                     */
-    __I uint32_t :28;                       /**< bit:  4..31  Reserved */
+    uint32_t :28;                           /**< bit:  4..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGB_Type;
@@ -316,7 +316,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t CCL_:1;                    /**< bit:     11  CCL                                      */
     __I uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP                                    */
     __I uint32_t TRAM_:1;                   /**< bit:     13  TRAM                                     */
-    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+    uint32_t :18;                           /**< bit: 14..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGC_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/pm.h
@@ -174,7 +174,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t PLRDY:1;                   /**< bit:      0  Performance Level Ready                  */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/port.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/port.h
@@ -473,7 +473,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
-    __I uint32_t :31;                       /**< bit:  1..31  Reserved */
+    uint32_t :31;                           /**< bit:  1..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PORT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/rtc.h
@@ -1298,14 +1298,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
     __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
     __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
-    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t :5;                            /**< bit:  9..13  Reserved */
     __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
     __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
     __I uint16_t CMP:1;                     /**< bit:      8  Compare x                                */
-    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+    uint16_t :7;                            /**< bit:  9..15 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint16_t reg;                         /**< Type used for register access */
 } RTC_MODE0_INTFLAG_Type;
@@ -1371,14 +1371,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
     __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
     __I uint16_t CMP1:1;                    /**< bit:      9  Compare 1                                */
-    __I uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t :4;                            /**< bit: 10..13  Reserved */
     __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
     __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
     __I uint16_t CMP:2;                     /**< bit:   8..9  Compare x                                */
-    __I uint16_t :6;                        /**< bit: 10..15 Reserved */
+    uint16_t :6;                            /**< bit: 10..15 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint16_t reg;                         /**< Type used for register access */
 } RTC_MODE1_INTFLAG_Type;
@@ -1446,14 +1446,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
     __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
     __I uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0                                  */
-    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t :5;                            /**< bit:  9..13  Reserved */
     __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
     __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
     __I uint16_t ALARM:1;                   /**< bit:      8  Alarm x                                  */
-    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+    uint16_t :7;                            /**< bit:  9..15 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint16_t reg;                         /**< Type used for register access */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/sercom.h
@@ -968,7 +968,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t MB:1;                      /**< bit:      0  Master On Bus Interrupt                  */
     __I uint8_t SB:1;                      /**< bit:      1  Slave On Bus Interrupt                   */
-    __I uint8_t :5;                        /**< bit:   2..6  Reserved */
+    uint8_t :5;                            /**< bit:   2..6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
@@ -998,7 +998,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t PREC:1;                    /**< bit:      0  Stop Received Interrupt                  */
     __I uint8_t AMATCH:1;                  /**< bit:      1  Address Match Interrupt                  */
     __I uint8_t DRDY:1;                    /**< bit:      2  Data Interrupt                           */
-    __I uint8_t :4;                        /**< bit:   3..6  Reserved */
+    uint8_t :4;                            /**< bit:   3..6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
@@ -1032,7 +1032,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t TXC:1;                     /**< bit:      1  Transmit Complete Interrupt              */
     __I uint8_t RXC:1;                     /**< bit:      2  Receive Complete Interrupt               */
     __I uint8_t SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Flag          */
-    __I uint8_t :3;                        /**< bit:   4..6  Reserved */
+    uint8_t :3;                            /**< bit:   4..6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
@@ -1071,7 +1071,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t RXS:1;                     /**< bit:      3  Receive Start Interrupt                  */
     __I uint8_t CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt     */
     __I uint8_t RXBRK:1;                   /**< bit:      5  Break Received Interrupt                 */
-    __I uint8_t :1;                        /**< bit:      6  Reserved */
+    uint8_t :1;                            /**< bit:      6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */

--- a/cpu/sam0_common/include/vendor/saml10/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/supc.h
@@ -162,12 +162,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
     __I uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
     __I uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
-    __I uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t :2;                            /**< bit:   6..7  Reserved */
     __I uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
-    __I uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t :1;                            /**< bit:      9  Reserved */
     __I uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
     __I uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
-    __I uint32_t :20;                       /**< bit: 12..31  Reserved */
+    uint32_t :20;                           /**< bit: 12..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/tc.h
@@ -420,15 +420,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t OVF:1;                     /**< bit:      0  OVF Interrupt Flag                       */
     __I uint8_t ERR:1;                     /**< bit:      1  ERR Interrupt Flag                       */
-    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    uint8_t :2;                            /**< bit:   2..3  Reserved */
     __I uint8_t MC0:1;                     /**< bit:      4  MC Interrupt Flag 0                      */
     __I uint8_t MC1:1;                     /**< bit:      5  MC Interrupt Flag 1                      */
-    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+    uint8_t :2;                            /**< bit:   6..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    __I uint8_t :4;                        /**< bit:   0..3  Reserved */
+    uint8_t :4;                            /**< bit:   0..3  Reserved */
     __I uint8_t MC:2;                      /**< bit:   4..5  MC Interrupt Flag x                      */
-    __I uint8_t :2;                        /**< bit:   6..7 Reserved */
+    uint8_t :2;                            /**< bit:   6..7 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint8_t  reg;                         /**< Type used for register access */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/tram.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/tram.h
@@ -136,7 +136,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t ERR:1;                     /**< bit:      0  TrustRAM Readout Error                   */
     __I uint8_t DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended          */
-    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+    uint8_t :6;                            /**< bit:   2..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } TRAM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/trng.h
@@ -137,7 +137,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Flag                */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml10/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml10/include/component/wdt.h
@@ -240,7 +240,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t EW:1;                      /**< bit:      0  Early Warning                            */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/ac.h
@@ -259,15 +259,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t COMP0:1;                   /**< bit:      0  Comparator 0                             */
     __I uint8_t COMP1:1;                   /**< bit:      1  Comparator 1                             */
-    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    uint8_t :2;                            /**< bit:   2..3  Reserved */
     __I uint8_t WIN0:1;                    /**< bit:      4  Window 0                                 */
-    __I uint8_t :3;                        /**< bit:   5..7  Reserved */
+    uint8_t :3;                            /**< bit:   5..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint8_t COMP:2;                    /**< bit:   0..1  Comparator x                             */
-    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    uint8_t :2;                            /**< bit:   2..3  Reserved */
     __I uint8_t WIN:1;                     /**< bit:      4  Window x                                 */
-    __I uint8_t :3;                        /**< bit:   5..7 Reserved */
+    uint8_t :3;                            /**< bit:   5..7 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint8_t  reg;                         /**< Type used for register access */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/adc.h
@@ -259,7 +259,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t RESRDY:1;                  /**< bit:      0  Result Ready Interrupt Flag              */
     __I uint8_t OVERRUN:1;                 /**< bit:      1  Overrun Interrupt Flag                   */
     __I uint8_t WINMON:1;                  /**< bit:      2  Window Monitor Interrupt Flag            */
-    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+    uint8_t :5;                            /**< bit:   3..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/dac.h
@@ -204,7 +204,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t UNDERRUN:1;                /**< bit:      0  Underrun                                 */
     __I uint8_t EMPTY:1;                   /**< bit:      1  Data Buffer Empty                        */
-    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+    uint8_t :6;                            /**< bit:   2..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/dmac.h
@@ -1050,7 +1050,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t TERR:1;                    /**< bit:      0  Channel Transfer Error                   */
     __I uint8_t TCMPL:1;                   /**< bit:      1  Channel Transfer Complete                */
     __I uint8_t SUSP:1;                    /**< bit:      2  Channel Suspend                          */
-    __I uint8_t :5;                        /**< bit:   3..7  Reserved */
+    uint8_t :5;                            /**< bit:   3..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/eic.h
@@ -235,7 +235,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:8;                  /**< bit:   0..7  External Interrupt                       */
-    __I uint32_t :23;                       /**< bit:  8..30  Reserved */
+    uint32_t :23;                           /**< bit:  8..30  Reserved */
     __I uint32_t NSCHK:1;                   /**< bit:     31  Non-secure Check Interrupt               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/evsys.h
@@ -151,7 +151,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t OVR:1;                     /**< bit:      0  Channel Overrun                          */
     __I uint8_t EVD:1;                     /**< bit:      1  Channel Event Detected                   */
-    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+    uint8_t :6;                            /**< bit:   2..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } EVSYS_CHINTFLAG_Type;
@@ -523,7 +523,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/freqm.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/freqm.h
@@ -160,7 +160,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t DONE:1;                    /**< bit:      0  Measurement Done                         */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } FREQM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/mclk.h
@@ -111,7 +111,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t CKRDY:1;                   /**< bit:      0  Clock Ready                              */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/nvmctrl.h
@@ -280,7 +280,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t NVME:1;                    /**< bit:      3  NVM Error                                */
     __I uint8_t KEYE:1;                    /**< bit:      4  KEY Write Error                          */
     __I uint8_t NSCHK:1;                   /**< bit:      5  NS configuration change detected         */
-    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+    uint8_t :2;                            /**< bit:   6..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/osc32kctrl.h
@@ -99,9 +99,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;              /**< bit:      0  XOSC32K Ready                            */
-    __I uint32_t :1;                        /**< bit:      1  Reserved */
+    uint32_t :1;                            /**< bit:      1  Reserved */
     __I uint32_t CLKFAIL:1;                 /**< bit:      2  XOSC32K Clock Failure Detector           */
-    __I uint32_t :29;                       /**< bit:  3..31  Reserved */
+    uint32_t :29;                           /**< bit:  3..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/oscctrl.h
@@ -197,18 +197,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;                 /**< bit:      0  XOSC Ready                               */
     __I uint32_t XOSCFAIL:1;                /**< bit:      1  XOSC Clock Failure Detector              */
-    __I uint32_t :2;                        /**< bit:   2..3  Reserved */
+    uint32_t :2;                            /**< bit:   2..3  Reserved */
     __I uint32_t OSC16MRDY:1;               /**< bit:      4  OSC16M Ready                             */
-    __I uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t :3;                            /**< bit:   5..7  Reserved */
     __I uint32_t DFLLULPRDY:1;              /**< bit:      8  DFLLULP Ready                            */
     __I uint32_t DFLLULPLOCK:1;             /**< bit:      9  DFLLULP Lock                             */
     __I uint32_t DFLLULPNOLOCK:1;           /**< bit:     10  DFLLULP No Lock                          */
-    __I uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t :5;                            /**< bit: 11..15  Reserved */
     __I uint32_t DPLLLCKR:1;                /**< bit:     16  DPLL Lock Rise                           */
     __I uint32_t DPLLLCKF:1;                /**< bit:     17  DPLL Lock Fall                           */
     __I uint32_t DPLLLTO:1;                 /**< bit:     18  DPLL Lock Timeout                        */
     __I uint32_t DPLLLDRTO:1;               /**< bit:     19  DPLL Loop Divider Ratio Update Complete  */
-    __I uint32_t :12;                       /**< bit: 20..31  Reserved */
+    uint32_t :12;                           /**< bit: 20..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/pac.h
@@ -155,7 +155,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMCPU_:1;               /**< bit:      4  HSRAMCPU                                 */
     __I uint32_t HSRAMDMAC_:1;              /**< bit:      5  HSRAMDMAC                                */
     __I uint32_t HSRAMDSU_:1;               /**< bit:      6  HSRAMDSU                                 */
-    __I uint32_t :25;                       /**< bit:  7..31  Reserved */
+    uint32_t :25;                           /**< bit:  7..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGAHB_Type;
@@ -210,7 +210,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t FREQM_:1;                  /**< bit:     11  FREQM                                    */
     __I uint32_t PORT_:1;                   /**< bit:     12  PORT                                     */
     __I uint32_t AC_:1;                     /**< bit:     13  AC                                       */
-    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+    uint32_t :18;                           /**< bit: 14..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGA_Type;
@@ -273,7 +273,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;                    /**< bit:      1  DSU                                      */
     __I uint32_t NVMCTRL_:1;                /**< bit:      2  NVMCTRL                                  */
     __I uint32_t DMAC_:1;                   /**< bit:      3  DMAC                                     */
-    __I uint32_t :28;                       /**< bit:  4..31  Reserved */
+    uint32_t :28;                           /**< bit:  4..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGB_Type;
@@ -316,7 +316,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t CCL_:1;                    /**< bit:     11  CCL                                      */
     __I uint32_t OPAMP_:1;                  /**< bit:     12  OPAMP                                    */
     __I uint32_t TRAM_:1;                   /**< bit:     13  TRAM                                     */
-    __I uint32_t :18;                       /**< bit: 14..31  Reserved */
+    uint32_t :18;                           /**< bit: 14..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PAC_INTFLAGC_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/pm.h
@@ -174,7 +174,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t PLRDY:1;                   /**< bit:      0  Performance Level Ready                  */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/port.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/port.h
@@ -473,7 +473,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t NSCHK:1;                   /**< bit:      0  Non-Secure Check                         */
-    __I uint32_t :31;                       /**< bit:  1..31  Reserved */
+    uint32_t :31;                           /**< bit:  1..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PORT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/rtc.h
@@ -1298,14 +1298,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
     __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
     __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
-    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t :5;                            /**< bit:  9..13  Reserved */
     __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
     __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
     __I uint16_t CMP:1;                     /**< bit:      8  Compare x                                */
-    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+    uint16_t :7;                            /**< bit:  9..15 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint16_t reg;                         /**< Type used for register access */
 } RTC_MODE0_INTFLAG_Type;
@@ -1371,14 +1371,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
     __I uint16_t CMP0:1;                    /**< bit:      8  Compare 0                                */
     __I uint16_t CMP1:1;                    /**< bit:      9  Compare 1                                */
-    __I uint16_t :4;                        /**< bit: 10..13  Reserved */
+    uint16_t :4;                            /**< bit: 10..13  Reserved */
     __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
     __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
     __I uint16_t CMP:2;                     /**< bit:   8..9  Compare x                                */
-    __I uint16_t :6;                        /**< bit: 10..15 Reserved */
+    uint16_t :6;                            /**< bit: 10..15 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint16_t reg;                         /**< Type used for register access */
 } RTC_MODE1_INTFLAG_Type;
@@ -1446,14 +1446,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;                    /**< bit:      6  Periodic Interval 6                      */
     __I uint16_t PER7:1;                    /**< bit:      7  Periodic Interval 7                      */
     __I uint16_t ALARM0:1;                  /**< bit:      8  Alarm 0                                  */
-    __I uint16_t :5;                        /**< bit:  9..13  Reserved */
+    uint16_t :5;                            /**< bit:  9..13  Reserved */
     __I uint16_t TAMPER:1;                  /**< bit:     14  Tamper                                   */
     __I uint16_t OVF:1;                     /**< bit:     15  Overflow                                 */
   } bit;                                /**< Structure used for bit  access */
   struct {
     __I uint16_t PER:8;                     /**< bit:   0..7  Periodic Interval x                      */
     __I uint16_t ALARM:1;                   /**< bit:      8  Alarm x                                  */
-    __I uint16_t :7;                        /**< bit:  9..15 Reserved */
+    uint16_t :7;                            /**< bit:  9..15 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint16_t reg;                         /**< Type used for register access */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/sercom.h
@@ -968,7 +968,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t MB:1;                      /**< bit:      0  Master On Bus Interrupt                  */
     __I uint8_t SB:1;                      /**< bit:      1  Slave On Bus Interrupt                   */
-    __I uint8_t :5;                        /**< bit:   2..6  Reserved */
+    uint8_t :5;                            /**< bit:   2..6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
@@ -998,7 +998,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t PREC:1;                    /**< bit:      0  Stop Received Interrupt                  */
     __I uint8_t AMATCH:1;                  /**< bit:      1  Address Match Interrupt                  */
     __I uint8_t DRDY:1;                    /**< bit:      2  Data Interrupt                           */
-    __I uint8_t :4;                        /**< bit:   3..6  Reserved */
+    uint8_t :4;                            /**< bit:   3..6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
@@ -1032,7 +1032,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t TXC:1;                     /**< bit:      1  Transmit Complete Interrupt              */
     __I uint8_t RXC:1;                     /**< bit:      2  Receive Complete Interrupt               */
     __I uint8_t SSL:1;                     /**< bit:      3  Slave Select Low Interrupt Flag          */
-    __I uint8_t :3;                        /**< bit:   4..6  Reserved */
+    uint8_t :3;                            /**< bit:   4..6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
@@ -1071,7 +1071,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t RXS:1;                     /**< bit:      3  Receive Start Interrupt                  */
     __I uint8_t CTSIC:1;                   /**< bit:      4  Clear To Send Input Change Interrupt     */
     __I uint8_t RXBRK:1;                   /**< bit:      5  Break Received Interrupt                 */
-    __I uint8_t :1;                        /**< bit:      6  Reserved */
+    uint8_t :1;                            /**< bit:      6  Reserved */
     __I uint8_t ERROR:1;                   /**< bit:      7  Combined Error Interrupt                 */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */

--- a/cpu/sam0_common/include/vendor/saml11/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/supc.h
@@ -162,12 +162,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;                /**< bit:      3  BOD12 Ready                              */
     __I uint32_t BOD12DET:1;                /**< bit:      4  BOD12 Detection                          */
     __I uint32_t B12SRDY:1;                 /**< bit:      5  BOD12 Synchronization Ready              */
-    __I uint32_t :2;                        /**< bit:   6..7  Reserved */
+    uint32_t :2;                            /**< bit:   6..7  Reserved */
     __I uint32_t VREGRDY:1;                 /**< bit:      8  Voltage Regulator Ready                  */
-    __I uint32_t :1;                        /**< bit:      9  Reserved */
+    uint32_t :1;                            /**< bit:      9  Reserved */
     __I uint32_t VCORERDY:1;                /**< bit:     10  VDDCORE Ready                            */
     __I uint32_t ULPVREFRDY:1;              /**< bit:     11  ULPVREF Voltage Reference Ready          */
-    __I uint32_t :20;                       /**< bit: 12..31  Reserved */
+    uint32_t :20;                           /**< bit: 12..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/tc.h
@@ -420,15 +420,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t OVF:1;                     /**< bit:      0  OVF Interrupt Flag                       */
     __I uint8_t ERR:1;                     /**< bit:      1  ERR Interrupt Flag                       */
-    __I uint8_t :2;                        /**< bit:   2..3  Reserved */
+    uint8_t :2;                            /**< bit:   2..3  Reserved */
     __I uint8_t MC0:1;                     /**< bit:      4  MC Interrupt Flag 0                      */
     __I uint8_t MC1:1;                     /**< bit:      5  MC Interrupt Flag 1                      */
-    __I uint8_t :2;                        /**< bit:   6..7  Reserved */
+    uint8_t :2;                            /**< bit:   6..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    __I uint8_t :4;                        /**< bit:   0..3  Reserved */
+    uint8_t :4;                            /**< bit:   0..3  Reserved */
     __I uint8_t MC:2;                      /**< bit:   4..5  MC Interrupt Flag x                      */
-    __I uint8_t :2;                        /**< bit:   6..7 Reserved */
+    uint8_t :2;                            /**< bit:   6..7 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint8_t  reg;                         /**< Type used for register access */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/tram.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/tram.h
@@ -136,7 +136,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t ERR:1;                     /**< bit:      0  TrustRAM Readout Error                   */
     __I uint8_t DRP:1;                     /**< bit:      1  Data Remanence Prevention Ended          */
-    __I uint8_t :6;                        /**< bit:   2..7  Reserved */
+    uint8_t :6;                            /**< bit:   2..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } TRAM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/trng.h
@@ -137,7 +137,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t DATARDY:1;                 /**< bit:      0  Data Ready Interrupt Flag                */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml11/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml11/include/component/wdt.h
@@ -240,7 +240,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t EW:1;                      /**< bit:      0  Early Warning                            */
-    __I uint8_t :7;                        /**< bit:   1..7  Reserved */
+    uint8_t :7;                            /**< bit:   1..7  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint8_t  reg;                         /**< Type used for register access */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/adc_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/adc_100.h
@@ -223,7 +223,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/aes.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/aes.h
@@ -167,7 +167,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/dac.h
@@ -222,12 +222,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
     __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
     __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
     __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/dmac.h
@@ -868,7 +868,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/eic_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/eic_100.h
@@ -199,7 +199,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/mclk_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/mclk_100.h
@@ -110,7 +110,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
     __I uint8_t  CFD:1;            /*!< bit:      1  Clock Failure Detector             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/nvmctrl_301.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/nvmctrl_301.h
@@ -243,7 +243,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/osc32kctrl.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/oscctrl.h
@@ -146,20 +146,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t :3;                   /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t :3;                   /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t :3;                   /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/pac_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/pac_100.h
@@ -133,18 +133,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    uint32_t :11;                  /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    uint32_t :1;                   /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    uint32_t :6;                   /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -198,7 +198,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    uint32_t :28;                  /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -277,7 +277,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
     __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
     __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    uint32_t :17;                  /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -330,7 +330,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
     __I uint32_t OPAMP_:1;         /*!< bit:      6  OPAMP                              */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    uint32_t :24;                  /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -363,7 +363,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/pm_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/pm_100.h
@@ -151,7 +151,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/rtc_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/rtc_100.h
@@ -757,13 +757,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -814,13 +814,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t :5;                   /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -872,13 +872,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/sercom.h
@@ -780,7 +780,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -805,7 +805,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -833,7 +833,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -865,7 +865,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/saml21/include/component/supc_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/supc_100.h
@@ -135,11 +135,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/tal.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/tal.h
@@ -168,7 +168,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  BRK:1;            /*!< bit:      0  Break                              */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TAL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/tc_100.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/tc_100.h
@@ -351,15 +351,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/tcc_200.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/tcc_200.h
@@ -953,7 +953,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -964,12 +964,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml21/include/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/ac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/adc.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/adc.h
@@ -223,7 +223,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/aes.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/aes.h
@@ -167,7 +167,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/dac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/dac.h
@@ -222,12 +222,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
     __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
     __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
     __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/dmac.h
@@ -868,7 +868,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/eic.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/mclk.h
@@ -91,7 +91,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/nvmctrl.h
@@ -243,7 +243,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/osc32kctrl.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/oscctrl.h
@@ -146,20 +146,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t :3;                   /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t :3;                   /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t :3;                   /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/pac.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/pac.h
@@ -133,18 +133,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    uint32_t :11;                  /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    uint32_t :1;                   /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    uint32_t :6;                   /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -198,7 +198,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    uint32_t :28;                  /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -277,7 +277,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
     __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
     __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    uint32_t :17;                  /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -330,7 +330,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
     __I uint32_t OPAMP_:1;         /*!< bit:      6  OPAMP                              */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    uint32_t :24;                  /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -363,7 +363,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/pm.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/pm.h
@@ -154,7 +154,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t :5;                   /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/sercom.h
@@ -780,7 +780,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -805,7 +805,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -833,7 +833,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -865,7 +865,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/supc.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/supc.h
@@ -135,11 +135,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/tal.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/tal.h
@@ -168,7 +168,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  BRK:1;            /*!< bit:      0  Break                              */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TAL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/tc.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/trng.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/usb.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/saml21/include_b/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/saml21/include_b/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/ac.h
@@ -223,15 +223,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/adc.h
@@ -477,7 +477,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/dac.h
@@ -178,7 +178,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/dmac.h
@@ -823,7 +823,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/eic.h
@@ -359,11 +359,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/evsys.h
@@ -485,20 +485,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t :4;                   /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/nvmctrl.h
@@ -230,7 +230,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/pm.h
@@ -443,7 +443,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/rtc.h
@@ -614,13 +614,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -646,13 +646,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -679,13 +679,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/sercom.h
@@ -827,7 +827,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -852,7 +852,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -880,7 +880,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -912,7 +912,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samr21/include/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/sysctrl.h
@@ -176,11 +176,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t :3;                   /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    uint32_t :14;                  /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/tc.h
@@ -404,16 +404,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    uint32_t :7;                   /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -970,12 +970,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/usb.h
@@ -626,7 +626,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -661,7 +661,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -670,7 +670,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1145,14 +1145,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1196,11 +1196,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr21/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samr21/include/component/wdt.h
@@ -217,7 +217,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/ac.h
@@ -243,15 +243,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/adc.h
@@ -237,7 +237,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/dmac.h
@@ -882,7 +882,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/eic.h
@@ -216,7 +216,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/evsys.h
@@ -387,7 +387,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -400,13 +400,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/mclk.h
@@ -105,7 +105,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/nvmctrl.h
@@ -257,7 +257,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/osc32kctrl.h
@@ -101,7 +101,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/oscctrl.h
@@ -160,20 +160,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t :3;                   /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t :3;                   /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t :3;                   /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/pac.h
@@ -147,18 +147,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    uint32_t :11;                  /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    uint32_t :1;                   /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    uint32_t :6;                   /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -213,7 +213,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
     __I uint32_t TAL_:1;           /*!< bit:     11  TAL                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    uint32_t :20;                  /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -256,7 +256,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    uint32_t :28;                  /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -289,7 +289,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TCC2_:1;          /*!< bit:      7  TCC2                               */
     __I uint32_t TC0_:1;           /*!< bit:      8  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:      9  TC1                                */
-    __I uint32_t :22;              /*!< bit: 10..31  Reserved                           */
+    uint32_t :22;                  /*!< bit: 10..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -330,9 +330,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t ADC_:1;           /*!< bit:      3  ADC                                */
     __I uint32_t AC_:1;            /*!< bit:      4  AC                                 */
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
-    __I uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t :1;                   /*!< bit:      6  Reserved                           */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    uint32_t :24;                  /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -363,7 +363,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/pm.h
@@ -168,7 +168,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/rtc.h
@@ -780,13 +780,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -837,13 +837,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t :5;                   /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -895,13 +895,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/sercom.h
@@ -794,7 +794,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -819,7 +819,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -847,7 +847,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -879,7 +879,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samr30/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/supc.h
@@ -149,11 +149,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/tal.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/tal.h
@@ -168,7 +168,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  BRK:1;            /*!< bit:      0  Break                              */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TAL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/tc.h
@@ -369,15 +369,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/tcc.h
@@ -974,7 +974,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -985,12 +985,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/usb.h
@@ -627,7 +627,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -662,7 +662,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -671,7 +671,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1197,11 +1197,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr30/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samr30/include/component/wdt.h
@@ -232,7 +232,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/adc.h
@@ -223,7 +223,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/aes.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/aes.h
@@ -167,7 +167,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/dac.h
@@ -222,12 +222,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
     __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
     __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
     __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/dmac.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/dmac.h
@@ -868,7 +868,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    uint32_t :16;                  /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t :4;                   /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    uint32_t :4;                   /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/mclk.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/mclk.h
@@ -91,7 +91,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/nvmctrl.h
@@ -243,7 +243,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/osc32kctrl.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/osc32kctrl.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/oscctrl.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/oscctrl.h
@@ -146,20 +146,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t :3;                   /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t :3;                   /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t :3;                   /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/pac.h
@@ -133,18 +133,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    uint32_t :11;                  /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    uint32_t :1;                   /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    uint32_t :6;                   /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -198,7 +198,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    uint32_t :28;                  /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -277,7 +277,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
     __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
     __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    uint32_t :17;                  /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -328,9 +328,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t ADC_:1;           /*!< bit:      3  ADC                                */
     __I uint32_t AC_:1;            /*!< bit:      4  AC                                 */
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
-    __I uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t :1;                   /*!< bit:      6  Reserved                           */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    uint32_t :24;                  /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -361,7 +361,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    uint32_t :30;                  /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/pm.h
@@ -154,7 +154,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t :5;                   /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t :6;                   /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint16_t :7;                   /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/sercom.h
@@ -780,7 +780,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  :5;                   /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -805,7 +805,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -833,7 +833,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  :3;                   /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -865,7 +865,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/cpu/sam0_common/include/vendor/samr34/include/component/supc.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/supc.h
@@ -135,11 +135,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t :2;                   /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    uint32_t :21;                  /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  :4;                   /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/tcc.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t :6;                   /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t :16;                  /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    uint32_t :12;                  /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/trng.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/usb.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t :2;                   /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint16_t :6;                   /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    uint8_t  :1;                   /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint8_t  :2;                   /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint8_t  :6;                   /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/cpu/sam0_common/include/vendor/samr34/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samr34/include/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint8_t  :7;                   /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -397,6 +397,7 @@ void backup_ram_init(void)
 #define BACKUP_RAM_MAGIC    {'R', 'I', 'O', 'T'}
 #endif
 
+__attribute__((unused))
 static inline bool _backup_battery_connected(void) {
 #if IS_USED(MODULE_PERIPH_VBAT)
     vbat_init(); /* early use of VBAT requires init() */

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -214,7 +214,7 @@ int dht_init(dht_t *dev, const dht_params_t *params)
     }
     else {
         DEBUG("\n[dht] dht_init: power-up duration: %" PRIi16 " ms\n",
-                (int16_t)(POWER_WAIT_TIMEOUT / US_PER_MS) - timeout);
+                (int16_t)(POWER_WAIT_TIMEOUT / US_PER_MS - timeout));
     }
     /* The previous test does not ensure the sensor presence in case an
      * external pull-up resistor is used. */
@@ -226,7 +226,7 @@ int dht_init(dht_t *dev, const dht_params_t *params)
     }
     else {
         DEBUG("\n[dht] dht_init: presence check duration: %" PRIi16 " ms\n",
-                (int16_t)(POWER_WAIT_TIMEOUT / US_PER_MS) - timeout);
+                (int16_t)(POWER_WAIT_TIMEOUT / US_PER_MS - timeout));
     }
 
     DEBUG_PUTS("[dht] dht_init: success");

--- a/drivers/vl6180x/vl6180x.c
+++ b/drivers/vl6180x/vl6180x.c
@@ -857,6 +857,7 @@ inline static int _write_byte(const vl6180x_t *dev, uint16_t reg, uint8_t byte)
     return _write(dev, reg, &byte, 1);
 }
 
+__attribute__((unused))
 inline static int _write_word(const vl6180x_t *dev, uint16_t reg, uint16_t data)
 {
     uint8_t bytes[2] = { (data >> 8) & 0xff, data & 0xff };
@@ -892,6 +893,7 @@ static int _read(const vl6180x_t *dev,
     return VL6180X_OK;
 }
 
+__attribute__((unused))
 inline static int _read_word(const vl6180x_t *dev, uint16_t reg, uint16_t *word)
 {
     uint8_t bytes[2];
@@ -900,6 +902,7 @@ inline static int _read_word(const vl6180x_t *dev, uint16_t reg, uint16_t *word)
     return res;
 }
 
+__attribute__((unused))
 inline static int _read_word_x(const vl6180x_t *dev, uint16_t reg, uint16_t *word)
 {
     uint8_t bytes[2];
@@ -913,6 +916,7 @@ inline static int _write_byte_x(const vl6180x_t *dev, uint16_t reg, uint8_t byte
     return vl6180x_reg_write(dev, reg, &byte, 1);
 }
 
+__attribute__((unused))
 inline static int _write_word_x(const vl6180x_t *dev, uint16_t reg, uint16_t data)
 {
     uint8_t bytes[2] = { (data >> 8) & 0xff, data & 0xff };

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -87,6 +87,13 @@ CFLAGS += -Wno-atomic-alignment
 # unsupported warning flags:
 CFLAGS += -Wno-unknown-warning-option
 
+# Designated initializers make the code much more readable and are part
+# of the C standard since C99. C++ with C++20 finally caught up.
+# Until we switch to that C++ version, let's disable the annoying
+# warning rather than reducing the code quality for the sake of
+# strict C++ compatibility of our headers.
+CXXEXFLAGS += -Wno-c99-designator
+
 OPTIONAL_CFLAGS_BLACKLIST += -fno-delete-null-pointer-checks
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -90,3 +90,5 @@ CFLAGS += -Wno-unknown-warning-option
 OPTIONAL_CFLAGS_BLACKLIST += -fno-delete-null-pointer-checks
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+
+LLVM_VERSION := $(shell command -v $(CC) > /dev/null && $(CC) -dumpversion | cut -d . -f 1)

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -36,14 +36,14 @@ SIZE        = $(LLVMPREFIX)size
 include $(RIOTMAKE)/tools/gdb.inc.mk
 
 # Include directories from gcc
-#   $1: language <c|cpp>
+#   $1: language <c|c++>
 #
 #   `realpath` is used instead of `abspath` to support Mingw32 which has issues
 #   with windows formatted gcc directories
 #
 # CFLAGS_CPU is used to get the correct multilib include header.
 gcc_include_dirs = $(realpath \
-    $(shell $(PREFIX)gcc $(CFLAGS_CPU) -v -x $1 -E /dev/null 2>&1 | \
+    $(shell $(PREFIX)g++ $(CFLAGS_CPU) -v -x $1 -E /dev/null 2>&1 | \
         sed \
         -e '1,/\#include <...> search starts here:/d' \
         -e '/End of search list./,$$d' \

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -22,6 +22,9 @@ export INCLUDES              # The extra include paths, set by the various Makef
 export CXXINCLUDES           # The extra include paths for c++, set by the various Makefile.include files.
 export NATIVEINCLUDES        # The native include paths, set by the various native Makefile.include files.
 
+export GCC_C_INCLUDES        # system include dirs implicitly used by GCC's c compiler, only defined with TOOLCHAIN=llvm
+export GCC_CXX_INCLUDES      # system include dirs implicitly used by GCC's c++ compiler, only defined with TOOLCHAIN=llvm
+
 export USEMODULE             # Sys Module dependencies of the application. Set in the application's Makefile.
 export BIN_USEMODULE         # Modules specific to bindist (see bindist.ink.mk). Set in the application's Makefile.
 export USEPKG                # Pkg dependencies (third party modules) of the application. Set in the application's Makefile.
@@ -60,6 +63,7 @@ export FEATURES_USED         # List of features used
 export TOOLCHAIN             # Base build toolchain, i.e. GNU or LLVM
 
 export TARGET_ARCH           # The target platform name, in GCC triple notation, e.g. "arm-none-eabi", "i686-elf", "avr"
+export TARGET_ARCH_LLVM      # The target platform name, in LLVM triple notation, e.g. "arm-none-eabi"
 export PREFIX                # The prefix of the toolchain commands, usually "$(TARGET_ARCH)-", e.g. "arm-none-eabi-" or "msp430-".
 export CC                    # The C compiler to use.
 export CXX                   # The CXX compiler to use.

--- a/pkg/arduino_adafruit_sensor/patches/0004-Adafruit_Sensor.h-drop-unused-private-field.patch
+++ b/pkg/arduino_adafruit_sensor/patches/0004-Adafruit_Sensor.h-drop-unused-private-field.patch
@@ -1,0 +1,27 @@
+From 0a165527f2ef58b593ecd95a0ebfc014312d32f7 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 23:11:05 +0200
+Subject: [PATCH] Adafruit_Sensor.h: drop unused private field
+
+This fixes compilation with clang.
+---
+ Adafruit_Sensor.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/Adafruit_Sensor.h b/Adafruit_Sensor.h
+index 92e35c2..9681391 100755
+--- a/Adafruit_Sensor.h
++++ b/Adafruit_Sensor.h
+@@ -183,9 +183,6 @@ public:
+   virtual void getSensor(sensor_t *) = 0;
+ 
+   void printSensorDetails(void);
+-
+-private:
+-  bool _autoRange;
+ };
+ 
+ #endif
+-- 
+2.40.1
+

--- a/pkg/arduino_sdi_12/Makefile
+++ b/pkg/arduino_sdi_12/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=arduino_sdi_12
 PKG_URL=https://github.com/EnviroDIY/Arduino-SDI-12
-PKG_VERSION=1fa8edbeb25fbb6cff71495583e664b5e8ae18a5
+PKG_VERSION=cd1349612f7b38f7a3cf629ab96d16dfd023be80
 PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/arduino_sdi_12/patches/0004-src-SDI12.h-fix-compilation-with-clang.patch
+++ b/pkg/arduino_sdi_12/patches/0004-src-SDI12.h-fix-compilation-with-clang.patch
@@ -1,0 +1,26 @@
+From a2ec151b2d0094357b5b08cd541cd9deff4e97a6 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 23:08:12 +0200
+Subject: [PATCH] src/SDI12.h: fix compilation with clang
+
+Fix `-Winconsistent-missing-override` warning.
+---
+ src/SDI12.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/SDI12.h b/src/SDI12.h
+index 6709771..a97bf7b 100644
+--- a/src/SDI12.h
++++ b/src/SDI12.h
+@@ -898,7 +898,7 @@ class SDI12 : public Stream {
+    * instance, but is *NOT* intenteded to be used for SDI-12 objects.  Instead, use the
+    * SDI12::sendCommand() or SDI12::sendResponse() functions.
+    */
+-  virtual size_t write(uint8_t byte);
++  virtual size_t write(uint8_t byte) override;
+ 
+   /**
+    * @brief Send a command out on the data line, acting as a datalogger (master)
+-- 
+2.40.1
+

--- a/pkg/fff/Makefile.include
+++ b/pkg/fff/Makefile.include
@@ -6,3 +6,14 @@ PSEUDOMODULES += fff
 
 # Tests don't need pedantic. Pedantic throws errors in variadic macros when compiling for C++
 CXXEXFLAGS += -Wno-pedantic
+
+ifeq (1,$(RIOT_CI_BUILD))
+  # TODO: remove this when the build containers clang is updated to version 16
+  TOOLCHAINS_BLACKLIST += llvm
+else
+  ifeq (llvm,$(TOOLCHAIN))
+    ifneq (1,$(call version_is_greater_or_equal,$(LLVM_VERSION),16))
+      $(error package fff requires clang 16.0.0 or newer. Use GCC or update clang.)
+    endif
+  endif
+endif

--- a/pkg/flashdb/Makefile
+++ b/pkg/flashdb/Makefile
@@ -9,6 +9,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-pedantic
 CFLAGS += -Wno-cast-align
 CFLAGS += -Wno-unused
+CFLAGS += -Wno-unused-parameter
 CFLAGS += -Wno-format
 
 .PHONY: flashdb_fal

--- a/pkg/flatbuffers/Makefile.include
+++ b/pkg/flatbuffers/Makefile.include
@@ -9,3 +9,7 @@ endif
 
 # This package is a header only package, so there's nothing to build
 PSEUDOMODULES += flatbuffers
+
+# LLVM requires an upgrade of flatbuffers, but this breaks pkg/tflite-micro.
+# Until this is resolved, LLVM is blacklisted
+TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/libschc/patches/0001-fragmenter.c-drop-unused-variable.patch
+++ b/pkg/libschc/patches/0001-fragmenter.c-drop-unused-variable.patch
@@ -1,0 +1,33 @@
+From 6ca9271090ed24fcd4e6e27a5751ade1020ad275 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 23:34:12 +0200
+Subject: [PATCH] fragmenter.c: drop unused variable
+
+---
+ fragmenter.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/fragmenter.c b/fragmenter.c
+index 8454906..dd8694a 100755
+--- a/fragmenter.c
++++ b/fragmenter.c
+@@ -73,7 +73,7 @@ static uint16_t get_max_fcn_value(schc_fragmentation_t* conn) {
+  *
+  */
+ static void mbuf_print(schc_mbuf_t *head) {
+-	uint8_t i = 0; uint8_t j;
++	uint8_t j;
+ 	schc_mbuf_t *curr = head;
+ 	while (curr != NULL) {
+ 		DEBUG_PRINTF("%d: %p\n", curr->frag_cnt, curr->ptr);
+@@ -83,7 +83,6 @@ static void mbuf_print(schc_mbuf_t *head) {
+ 		}
+ 		DEBUG_PRINTF("\n");
+ 		curr = curr->next;
+-		i++;
+ 	}
+ }
+ 
+-- 
+2.40.1
+

--- a/pkg/libsocketcan/Makefile
+++ b/pkg/libsocketcan/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE=LGPL-2.1
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/lua/patches/0008-lundump.c-make-clang-happy.patch
+++ b/pkg/lua/patches/0008-lundump.c-make-clang-happy.patch
@@ -1,0 +1,26 @@
+From ec6de75107b1699fcad0ed5ad9a6e5de178a6e6e Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 22:18:52 +0200
+Subject: [PATCH] lundump.c: make clang happy
+
+silence -Wstring-plus-int warning
+---
+ lundump.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lundump.c b/lundump.c
+index 13916bc..1698621 100644
+--- a/lundump.c
++++ b/lundump.c
+@@ -234,7 +234,7 @@ static void fchecksize (LoadState *S, size_t size, const char *tname) {
+ #define checksize(S,t)	fchecksize(S,sizeof(t),#t)
+ 
+ static void checkHeader (LoadState *S) {
+-  checkliteral(S, LUA_SIGNATURE + 1, "not a");  /* 1st char already checked */
++  checkliteral(S, &LUA_SIGNATURE[1], "not a");  /* 1st char already checked */
+   if (LoadByte(S) != LUAC_VERSION)
+     error(S, "version mismatch in");
+   if (LoadByte(S) != LUAC_FORMAT)
+-- 
+2.40.1
+

--- a/pkg/lvgl/patches/0001-src-core-lv_obj.c-fix-compilation-with-clang.patch
+++ b/pkg/lvgl/patches/0001-src-core-lv_obj.c-fix-compilation-with-clang.patch
@@ -1,0 +1,26 @@
+From 4e85c6f199f6b7c844eac06d72e91d2df6be2bf9 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Sat, 20 May 2023 21:15:35 +0200
+Subject: [PATCH] src/core/lv_obj.c: fix compilation with clang
+
+Drop an used variable.
+---
+ src/core/lv_obj.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/core/lv_obj.c b/src/core/lv_obj.c
+index 8890fcb..179f2bd 100644
+--- a/src/core/lv_obj.c
++++ b/src/core/lv_obj.c
+@@ -341,8 +341,6 @@ void lv_obj_allocate_spec_attr(lv_obj_t * obj)
+     LV_ASSERT_OBJ(obj, MY_CLASS);
+ 
+     if(obj->spec_attr == NULL) {
+-        static uint32_t x = 0;
+-        x++;
+         obj->spec_attr = lv_mem_alloc(sizeof(_lv_obj_spec_attr_t));
+         LV_ASSERT_MALLOC(obj->spec_attr);
+         if(obj->spec_attr == NULL) return;
+-- 
+2.40.1
+

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -5,5 +5,11 @@ PKG_LICENSE=BSD-2-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+# With LLVM register allocation fails. We can tell LLVM to spend more time
+# on trying to allocate registers using the following snippet:
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -mllvm -exhaustive-register-search
+endif
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/micro-ecc/Makefile.include
+++ b/pkg/micro-ecc/Makefile.include
@@ -4,8 +4,5 @@ CFLAGS += -Wno-unused-parameter
 CFLAGS += -Wno-unused-function
 CFLAGS += -Wno-unused-variable
 
-ifneq (,$(filter cortex-m0%,$(CPU_CORE)))
-  # LLVM/clang can't handle the inline assembler instructions on M0 in this
-  # package
-  TOOLCHAINS_BLACKLIST += llvm
-endif
+# llvm fails to allocate registers for inline assembly :/
+TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/micropython/Makefile
+++ b/pkg/micropython/Makefile
@@ -11,6 +11,8 @@ PKG_BUILD_OUT_OF_SOURCE = 0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+# Note: We have to explicitly override CC, as otherwise micropython will
+# set its own CC.
 all:
 	@mkdir -p $(PKG_BUILD_DIR)/tmp
-	BUILD=$(PKG_BUILD_DIR) "$(MAKE)" -C $(PKG_SOURCE_DIR)/ports/riot
+	BUILD=$(PKG_BUILD_DIR) "$(MAKE)" CC=$(CC) -C $(PKG_SOURCE_DIR)/ports/riot

--- a/pkg/micropython/Makefile.include
+++ b/pkg/micropython/Makefile.include
@@ -10,6 +10,3 @@ INCLUDES += -I$(BINDIR)/pkg/micropython/ports/riot
 
 # include archive
 ARCHIVES += $(BINDIR)/micropython.a
-
-# The port currently doesn't build with llvm
-TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -8,6 +8,8 @@ include $(RIOTBASE)/pkg/pkg.mk
 TDIR = $(RIOTPKG)/$(PKG_NAME)
 PDIR = $(PKG_SOURCE_DIR)
 
+CFLAGS += -Wno-unused-but-set-variable
+
 # NimBLE is not optimized for building with all (extra) warnings enabled. So for
 # now, we disable a number of selected compiler warnings when building NimBLE.
 CFLAGS += -Wno-extra -Wno-cast-align
@@ -19,8 +21,10 @@ ifeq (llvm,$(TOOLCHAIN))
 # Workaround, until https://github.com/apache/mynewt-nimble/pull/566 is merged
 # upstream and the NimBLE version in RIOT is updated.
   CFLAGS += -Wno-sometimes-uninitialized
-else
-  CFLAGS += -Wno-unused-but-set-variable
+  CFLAGS += -Wno-parentheses-equality
+# Backward compatibility with older versions of LLVM (when it doesn't know
+# about the -Wno-foo, it won't throw any -Wfoo related warnings anyway)
+  CFLAGS += -Wno-unknown-warning-option
 endif
 
 IGNORE := nimble_autoconn_% nimble_phy_% nimble_%_ext nimble_autoadv%

--- a/pkg/opendsme/contrib/DSMEPlatform.cpp
+++ b/pkg/opendsme/contrib/DSMEPlatform.cpp
@@ -51,25 +51,25 @@ static void _handle_rx_offload(event_t *ev);
 static void _start_of_cfp_handler(event_t *ev);
 
 /* Event used for ACK Timeout */
-static event_t acktimer_ev = {0, _acktimer_ev_handler};
+static event_t acktimer_ev = {{}, _acktimer_ev_handler};
 
 /* Event used for CCA Done */
-static event_t cca_ev = {0, _cca_ev_handler};
+static event_t cca_ev = {{}, _cca_ev_handler};
 
 /* Event used for timer events */
-static event_t timer_event = {0, _timer_ev_handler};
+static event_t timer_event = {{}, _timer_ev_handler};
 
 /* Event used for TX Done */
-static event_t tx_done_event = {0, _tx_done_handler};
+static event_t tx_done_event = {{}, _tx_done_handler};
 
 /* Event used for RX Done */
-static event_t rx_done_event = {0, _rx_done_handler};
+static event_t rx_done_event = {{}, _rx_done_handler};
 
 /* Event used for offloading the receive procedure */
-static event_t rx_offload_ev = {0, _handle_rx_offload};
+static event_t rx_offload_ev = {{}, _handle_rx_offload};
 
 /* Event used for offloading the start of a CFP */
-static event_t start_of_cfp_ev = {0, _start_of_cfp_handler};
+static event_t start_of_cfp_ev = {{}, _start_of_cfp_handler};
 
 void _handle_rx_offload(event_t *ev)
 {

--- a/pkg/opendsme/contrib/gnrc_netif_opendsme.cpp
+++ b/pkg/opendsme/contrib/gnrc_netif_opendsme.cpp
@@ -117,6 +117,8 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
     case NETOPT_LINK:
         m_dsme.initialize(_pan_coord);
         m_dsme.start();
+        assert(*(netopt_enable_t *)opt->data == NETOPT_ENABLE);
+        res = sizeof(netopt_enable_t);
         break;
     case NETOPT_PAN_COORD:
         if (*((bool *)opt->data) == true) {

--- a/pkg/opendsme/include/opendsme/DSMEMessage.h
+++ b/pkg/opendsme/include/opendsme/DSMEMessage.h
@@ -69,7 +69,7 @@ public:
     /**
      * @brief check whether the message has payload
      */
-    bool hasPayload()
+    bool hasPayload() override
     {
         return this->pkt != NULL && this->pkt->size > 0;
     }
@@ -93,7 +93,7 @@ public:
     /**
      * @brief get the total number of symbols in current frame
      */
-    uint16_t getTotalSymbols()
+    uint16_t getTotalSymbols() override
     {
         DSME_ASSERT(pkt);
         /* Hardcoded to O-QPSK */
@@ -116,7 +116,7 @@ public:
     /**
      * @brief get IEEE 802.15.4 header
      */
-    IEEE802154eMACHeader& getHeader()
+    IEEE802154eMACHeader& getHeader() override
     {
         return macHdr;
     }

--- a/pkg/opendsme/include/opendsme/DSMEPlatform.h
+++ b/pkg/opendsme/include/opendsme/DSMEPlatform.h
@@ -308,7 +308,7 @@ public:
     /**
      * @brief callback to offload the start of CFP
      */
-    void scheduleStartOfCFP();
+    void scheduleStartOfCFP() override;
 
     /**
      * @brief Get the minimum LQI. Beacons with LQI lower than this will not be
@@ -321,12 +321,12 @@ public:
     /**
      * @brief turn on transceiver
      */
-    void turnTransceiverOn();
+    void turnTransceiverOn() override;
 
     /**
      * @brief turn off transceiver
      */
-    void turnTransceiverOff();
+    void turnTransceiverOff() override;
 
     /**
      * @brief get extended address

--- a/pkg/opendsme/patches/0001-dsmeLayer-messageDispatcher-drop-unused-members-in-M.patch
+++ b/pkg/opendsme/patches/0001-dsmeLayer-messageDispatcher-drop-unused-members-in-M.patch
@@ -1,0 +1,32 @@
+From 83a0db14099d2397b64322379a11adc32a191e32 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Mon, 17 Jul 2023 15:23:50 +0200
+Subject: [PATCH] dsmeLayer/messageDispatcher: drop unused members in
+ MessageDispatcher
+
+---
+ dsmeLayer/messageDispatcher/MessageDispatcher.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/dsmeLayer/messageDispatcher/MessageDispatcher.h b/dsmeLayer/messageDispatcher/MessageDispatcher.h
+index 207e11f..a343ab3 100644
+--- a/dsmeLayer/messageDispatcher/MessageDispatcher.h
++++ b/dsmeLayer/messageDispatcher/MessageDispatcher.h
+@@ -233,14 +233,12 @@ public:
+ 
+ private:
+     long numTxGtsFrames = 0;
+-    long numRxAckFrames = 0;
+     long numRxGtsFrames = 0;
+     long numUnusedTxGts = 0;
+     long numUnusedRxGts = 0;
+     long numUpperPacketsDroppedFullQueue = 0;
+     long numUpperPacketsForCAP = 0;
+     long numUpperPacketsForGTS = 0;
+-    bool recordGtsUpdates = false;
+ /* Statistics (END) --------------------------------------------------------- */
+ };
+ 
+-- 
+2.41.0
+

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -26,14 +26,25 @@ endif
 OT_COAP ?= ON
 
 OT_C_FLAGS = $(CFLAGS_CPU)
-OT_C_FLAGS += -fdata-sections -ffunction-sections -Os
-OT_C_FLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter
-OT_CXXFLAGS += -Wno-class-memaccess -DOPENTHREAD_TARGET_RIOT
+OT_C_FLAGS += -fdata-sections
+OT_C_FLAGS += -ffunction-sections -Os
+OT_C_FLAGS += -ffunction-sections
+OT_C_FLAGS += -fshort-enums
+OT_C_FLAGS += -Wno-implicit-fallthrough
+OT_C_FLAGS += -Wno-unused-parameter
+OT_CXXFLAGS += -Wno-class-memaccess
+OT_CXXFLAGS += -DOPENTHREAD_TARGET_RIOT
 
 OT_MODULES_ARCHIVES = $(addsuffix .a,$(addprefix $(BINDIR)/,$(OT_MODULES)))
 OT_CORE_LIB_DIR = $(PKG_BUILD_DIR)/src/core
 OT_CLI_LIB_DIR = $(PKG_BUILD_DIR)/src/cli
 OT_MBEDCRYPTO_LIB_DIR = $(PKG_BUILD_DIR)/third_party/mbedtls/repo/library
+
+ifeq (llvm,$(TOOLCHAIN))
+  OT_C_FLAGS += -target $(TARGET_ARCH_LLVM)
+  OT_C_FLAGS += $(GCC_C_INCLUDES)
+  OT_CXXFLAGS += $(GCC_CXX_INCLUDES)
+endif
 
 all: $(OT_MODULES_ARCHIVES)
 	@:

--- a/pkg/openwsn/Makefile.include
+++ b/pkg/openwsn/Makefile.include
@@ -75,6 +75,3 @@ endif
 ifndef CONFIG_KCONFIG_USEMODULE_IEEE802154
   CFLAGS += -DCONFIG_IEEE802154_AUTO_ACK_DISABLE
 endif
-
-# LLVM ARM shows issues with missing definitions for stdatomic
-TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/openwsn/contrib/radio_hal.c
+++ b/pkg/openwsn/contrib/radio_hal.c
@@ -16,6 +16,7 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
+#include <stdint.h>
 #include <stdatomic.h>
 #include <sys/uio.h>
 

--- a/pkg/openwsn/contrib/sctimer_rtt.c
+++ b/pkg/openwsn/contrib/sctimer_rtt.c
@@ -23,6 +23,7 @@
  *
  * @}
  */
+#include <stdint.h>
 #include <stdatomic.h>
 
 #include "sctimer.h"

--- a/pkg/openwsn/contrib/uart.c
+++ b/pkg/openwsn/contrib/uart.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <stdint.h>
 #include <stdatomic.h>
 
 #include "board.h"

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -15,6 +15,11 @@ CFLAGS += -Wno-unused-function -Wno-old-style-definition -Wno-unused-parameter \
           -Wno-pedantic -Wno-array-parameter -Wno-unused-but-set-variable \
           -Wno-stringop-overflow
 
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += $(GCC_C_INCLUDES)
+  CXXFLAGS += $(GCC_CXX_INCLUDES)
+endif
+
 TOOLCHAIN_FILE = $(PKG_SOURCE_DIR)/xcompile-toolchain.cmake
 
 all: $(BINDIR)/$(PKG_NAME).a

--- a/pkg/relic/Makefile.include
+++ b/pkg/relic/Makefile.include
@@ -1,10 +1,3 @@
 INCLUDES += -I$(PKGDIRBASE)/relic/include
 INCLUDES += -I$(BINDIR)/pkg-build/relic/include
 ARCHIVES += $(BINDIR)/relic.a
-
-ifneq (,$(filter cortex-m%,$(CPU_CORE)))
-  # relic package package is not using system includes right now, so
-  # many newlib headers (not even stdio.h) are not found.
-  # Fixed in #9821 for jerryscript, should be applicable here too.
-  TOOLCHAINS_BLACKLIST += llvm
-endif

--- a/pkg/relic/patches/0003-fix-Wformat-nonliteral-by-using-printf-directly.patch
+++ b/pkg/relic/patches/0003-fix-Wformat-nonliteral-by-using-printf-directly.patch
@@ -1,0 +1,73 @@
+From be6a8c76f021a2cba3d371c16bfb84a8264f51fe Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Sat, 20 May 2023 21:41:32 +0200
+Subject: [PATCH] fix -Wformat-nonliteral by using printf() directly
+
+---
+ include/relic_util.h |  2 +-
+ src/relic_util.c     | 36 ------------------------------------
+ 2 files changed, 1 insertion(+), 37 deletions(-)
+
+diff --git a/include/relic_util.h b/include/relic_util.h
+index 0dd1744..74e3216 100644
+--- a/include/relic_util.h
++++ b/include/relic_util.h
+@@ -296,7 +296,7 @@ int util_cmp_const(const void *a, const void *b, int n);
+  * @param[in] format		- the format.
+  * @param[in] ...			- the list of arguments matching the format.
+  */
+-void util_printf(const char *format, ...);
++#define util_printf(...) printf(__VA_ARGS__)
+ 
+ /**
+  * Prints a digit.
+diff --git a/src/relic_util.c b/src/relic_util.c
+index 3bb369d..133153d 100644
+--- a/src/relic_util.c
++++ b/src/relic_util.c
+@@ -151,42 +151,6 @@ int util_cmp_const(const void *a, const void *b, int size) {
+ 	return (result == 0 ? RLC_EQ : RLC_NE);
+ }
+ 
+-#ifndef QUIET
+-void util_print(const char *format, ...) {
+-#if ARCH == AVR && !defined(OPSYS)
+-	util_print_ptr = print_buf + 1;
+-	va_list list;
+-	va_start(list, format);
+-	vsnprintf_P((char *)util_print_ptr, sizeof(print_buf) - 1, format, list);
+-	va_end(list);
+-	print_buf[0] = (uint8_t)2;
+-#elif ARCH == AVR && OPSYS == DUINO
+-	stdout = &uart_output;
+-	va_list list;
+-	va_start(list, format);
+-	vsnprintf_P((char *)print_buf, sizeof(print_buf), format, list);
+-	printf("%s", (char *)print_buf);
+-	va_end(list);
+-#elif ARCH == MSP && !defined(OPSYS)
+-	va_list list;
+-	va_start(list, format);
+-	vprintf(format, list);
+-	va_end(list);
+-#elif ARCH == ARM && OPSYS == DROID
+-	va_list list;
+-	va_start(list, format);
+-	__android_log_vprint(ANDROID_LOG_INFO, "relic-toolkit", format, list);
+-	va_end(list);
+-#else
+-	va_list list;
+-	va_start(list, format);
+-	vprintf(format, list);
+-	fflush(stdout);
+-	va_end(list);
+-#endif
+-}
+-#endif
+-
+ void util_print_dig(dig_t a, int pad) {
+ #if RLC_DIG == 64
+ 	if (pad) {
+-- 
+2.40.1
+

--- a/pkg/tinyusb/patches/0005-src-portable-nordic-nrf5x-fix-compilation-with-clang.patch
+++ b/pkg/tinyusb/patches/0005-src-portable-nordic-nrf5x-fix-compilation-with-clang.patch
@@ -1,0 +1,62 @@
+From 93b38d4855e2b6d5f3179d72da2f98f8df796804 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 23:29:23 +0200
+Subject: [PATCH] src/portable/nordic/nrf5x: fix compilation with clang
+
+Previously code expecting atomic_flag as argument type was called with
+atomic_bool as type. This brings the functions called back in
+alignment with the types used.
+---
+ src/portable/nordic/nrf5x/dcd_nrf5x.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/portable/nordic/nrf5x/dcd_nrf5x.c b/src/portable/nordic/nrf5x/dcd_nrf5x.c
+index afc14b0..0316673 100644
+--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
++++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
+@@ -128,13 +128,13 @@ static void start_dma(volatile uint32_t* reg_startep)
+   // Therefore dma_pending is corrected right away
+   if ( (reg_startep == &NRF_USBD->TASKS_EP0STATUS) || (reg_startep == &NRF_USBD->TASKS_EP0RCVOUT) )
+   {
+-    atomic_flag_clear(&_dcd.dma_running);
++    atomic_store(&_dcd.dma_running, false);
+   }
+ }
+ 
+ static void edpt_dma_start(volatile uint32_t* reg_startep)
+ {
+-  if ( atomic_flag_test_and_set(&_dcd.dma_running) )
++  if ( atomic_exchange(&_dcd.dma_running, true) )
+   {
+     usbd_defer_func((osal_task_func_t) edpt_dma_start, (void*) (uintptr_t) reg_startep, true);
+   }else
+@@ -147,7 +147,7 @@ static void edpt_dma_start(volatile uint32_t* reg_startep)
+ static void edpt_dma_end(void)
+ {
+   TU_ASSERT(_dcd.dma_running, );
+-  atomic_flag_clear(&_dcd.dma_running);
++  atomic_store(&_dcd.dma_running, false);
+ }
+ 
+ // helper getting td
+@@ -171,7 +171,7 @@ static void xact_out_dma(uint8_t epnum)
+ 
+   // DMA can't be active during read of SIZE.EPOUT or SIZE.ISOOUT, so try to lock,
+   // If already running defer call regardless if it was called from ISR or task,
+-  if ( atomic_flag_test_and_set(&_dcd.dma_running) )
++  if ( atomic_exchange(&_dcd.dma_running, true) )
+   {
+     usbd_defer_func((osal_task_func_t)xact_out_dma_wrapper, (void *)(uint32_t)epnum, is_in_isr());
+     return;
+@@ -183,7 +183,7 @@ static void xact_out_dma(uint8_t epnum)
+     if (xact_len & USBD_SIZE_ISOOUT_ZERO_Msk)
+     {
+       xact_len = 0;
+-      atomic_flag_clear(&_dcd.dma_running);
++      atomic_store(&_dcd.dma_running, false);
+     }
+     else
+     {
+-- 
+2.40.1
+

--- a/pkg/tinyvcdiff/patches/0001-src-vcdiff_codetable.c-add-missing-end-of-line.patch
+++ b/pkg/tinyvcdiff/patches/0001-src-vcdiff_codetable.c-add-missing-end-of-line.patch
@@ -1,0 +1,23 @@
+From d34508c6d249ad0055c915ae96906f80eb4e47e5 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Mon, 22 May 2023 09:51:43 +0200
+Subject: [PATCH] src/vcdiff_codetable.c: add missing end of line
+
+---
+ src/vcdiff_codetable.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/vcdiff_codetable.c b/src/vcdiff_codetable.c
+index cb1d9c8..c39705c 100644
+--- a/src/vcdiff_codetable.c
++++ b/src/vcdiff_codetable.c
+@@ -49,4 +49,4 @@ void vcdiff_codetable_decode(uint8_t * inst0, size_t * size0, uint8_t * mode0,
+ 		*size1 = 1;
+ 		*mode0 = col;
+ 	}
+-}
+\ No newline at end of file
++}
+-- 
+2.40.1
+

--- a/pkg/u8g2/patches/0001-csrc-drop-dead-code.patch
+++ b/pkg/u8g2/patches/0001-csrc-drop-dead-code.patch
@@ -1,0 +1,37 @@
+From 2e628f78bb4f0791728d0dc4e6f1bfc7cfd0d19c Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Sat, 20 May 2023 21:46:52 +0200
+Subject: [PATCH] csrc: drop dead code
+
+The variable y is declared and its value is computed, but never used.
+Hence, drop the variable and computation altogether.
+---
+ csrc/u8x8_d_s1d15e06.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/csrc/u8x8_d_s1d15e06.c b/csrc/u8x8_d_s1d15e06.c
+index a8f2b29..3ddc552 100644
+--- a/csrc/u8x8_d_s1d15e06.c
++++ b/csrc/u8x8_d_s1d15e06.c
+@@ -67,7 +67,7 @@ static const uint8_t u8x8_d_s1d15e06_flip1_seq[] = {
+ 
+ uint8_t u8x8_d_s1d15e06_common(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
+ {
+-  uint8_t x, y, c;
++  uint8_t x, c;
+   uint8_t *ptr;
+   switch(msg)
+   {
+@@ -80,9 +80,6 @@ uint8_t u8x8_d_s1d15e06_common(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void
+ 	  u8x8_cad_SendCmd(u8x8, 0xB1);	//Page Address - Row
+ 	  u8x8_cad_SendArg(u8x8, (((u8x8_tile_t *)arg_ptr)->y_pos));
+ 
+-      y = ((u8x8_tile_t *)arg_ptr)->y_pos;
+-      y += u8x8->x_offset;
+-
+       u8x8_cad_SendCmd(u8x8, 0x13);	/* col */
+       u8x8_cad_SendArg(u8x8, x);
+ 
+-- 
+2.40.1
+

--- a/pkg/utensor/patches/0005-fix-compilation-with-clang.patch
+++ b/pkg/utensor/patches/0005-fix-compilation-with-clang.patch
@@ -1,0 +1,57 @@
+From b9bd370199116066e0b9e56386e8f447e7c5dcfe Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Sat, 20 May 2023 22:41:46 +0200
+Subject: [PATCH] fix compilation with clang++
+
+---
+ src/uTensor/core/uTensorBase.cpp        | 4 ++--
+ src/uTensor/ops/MathOps.hpp             | 6 +++---
+ src/uTensor/util/quantization_utils.hpp | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/uTensor/core/uTensorBase.cpp b/src/uTensor/core/uTensorBase.cpp
+index ed25ac9..d76da53 100644
+--- a/src/uTensor/core/uTensorBase.cpp
++++ b/src/uTensor/core/uTensorBase.cpp
+@@ -14,6 +14,6 @@ void Operator::setOutputs(S_TList &_outputs) {
+ }
+ 
+ void Operator::empty(void) {
+-  inputs.empty();
+-  outputs.empty();
++  (void)inputs.empty();
++  (void)outputs.empty();
+ }
+diff --git a/src/uTensor/ops/MathOps.hpp b/src/uTensor/ops/MathOps.hpp
+index 4fae883..4f436e7 100644
+--- a/src/uTensor/ops/MathOps.hpp
++++ b/src/uTensor/ops/MathOps.hpp
+@@ -125,9 +125,9 @@ void Add(Tensor* input, Tensor* input2, Tensor** out) {
+ //reduce_shape actual output shape without the reduce dim
+ //out_shape intermediate shape with reduce dim in the last orders
+ inline void reduceShapeHelper(TensorShape input, TensorShape dim, TensorShape &reduce_shape, TensorShape &out_shape, std::vector<uint8_t> &perm, size_t &reduce_size) {
+-  reduce_shape.empty();
+-  out_shape.empty();
+-  perm.empty();
++  (void)reduce_shape.empty();
++  (void)out_shape.empty();
++  (void)perm.empty();
+ 
+   for(auto i = 0; i < (int) input.size(); i++) {
+     if(std::find(dim.begin(), dim.end(), i) == dim.end()) {
+diff --git a/src/uTensor/util/quantization_utils.hpp b/src/uTensor/util/quantization_utils.hpp
+index 06e0eee..addc475 100644
+--- a/src/uTensor/util/quantization_utils.hpp
++++ b/src/uTensor/util/quantization_utils.hpp
+@@ -184,7 +184,7 @@ void QuantizationRangeForMultiplication(float min_a, float max_a, float min_b,
+   *min_c = c_float_for_one_quant_level * c_lowest;  // NT: this resulting in
+                                                     // taking only the necessary
+                                                     // quantize range
+-  *max_c = c_float_for_one_quant_level * c_highest;
++  *max_c = c_float_for_one_quant_level * (float)c_highest;
+ }
+ 
+ #endif  // UTENSOR_QUANT_UTILS
+-- 
+2.40.1
+

--- a/pkg/uwb-core/patches/0006-hw-drivers-uwb-fix-compilation-with-clang.patch
+++ b/pkg/uwb-core/patches/0006-hw-drivers-uwb-fix-compilation-with-clang.patch
@@ -1,0 +1,88 @@
+From 72372f5bd25f4718369eb79ac8b0344846dded53 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 22:05:27 +0200
+Subject: [PATCH] hw/drivers/uwb: fix compilation with clang
+
+clang doesn't like initializer lists without designators that are
+shorter then the number of fields, as it assumes one of the fields
+was by accident forgotten to be initialized with a non-zero value.
+Hence, only initialize one field by name and let the rest be implicitly
+zero-initialized.
+
+Secondly, clang wants all `struct`s and `union`s within a packed
+`struct` or `union` to explicitly also be packed. IMO those should
+be implicitly packed anyway. But if so, this doesn't make a difference
+and makes clang happy, so let's add them.
+---
+ hw/drivers/uwb/include/uwb/uwb_ftypes.h |  4 ++--
+ lib/uwb_rng/src/uwb_rng.c               | 24 ++++++++++++------------
+ 2 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/hw/drivers/uwb/include/uwb/uwb_ftypes.h b/hw/drivers/uwb/include/uwb/uwb_ftypes.h
+index 5920f14..4a4259e 100644
+--- a/hw/drivers/uwb/include/uwb/uwb_ftypes.h
++++ b/hw/drivers/uwb/include/uwb/uwb_ftypes.h
+@@ -159,7 +159,7 @@ typedef union{
+         union {
+             uint64_t long_address;  //!< Device ID TODOs::depreciated nomenclature
+             uint64_t euid;          //!< extended unique identifier
+-        };
++        }__attribute__((__packed__,aligned(1)));
+     }__attribute__((__packed__,aligned(1)));
+     uint8_t array[sizeof(struct _ieee_blink_frame_t)]; //!< Array of size blink frame
+ }ieee_blink_frame_t;
+@@ -173,7 +173,7 @@ typedef union {
+         union {
+             uint64_t address;       //!< Device ID TODOs::depreciated nomenclature
+             uint64_t euid;          //!< extended unique identifier
+-        };
++        }__attribute__((__packed__,aligned(1)));
+         uint8_t encoding;           //!< 0x43 to indicate no extended ID
+         uint8_t EXT_header ;        //!< 0x02 to indicate tag is listening for a response immediately
+     }__attribute__((__packed__,aligned(1)));
+diff --git a/lib/uwb_rng/src/uwb_rng.c b/lib/uwb_rng/src/uwb_rng.c
+index 3218f61..4caa02d 100644
+--- a/lib/uwb_rng/src/uwb_rng.c
++++ b/lib/uwb_rng/src/uwb_rng.c
+@@ -134,26 +134,26 @@ static struct uwb_rng_config g_config = {
+ static twr_frame_t g_twr_frames[][4] = {
+ #if MYNEWT_VAL(UWB_DEVICE_0)
+     {
+-        [0] = {.fctrl = 0, 0},
+-        [1] = {.fctrl = 0, 0},
+-        [2] = {.fctrl = 0, 0},
+-        [3] = {.fctrl = 0, 0},
++        [0] = {.fctrl = 0},
++        [1] = {.fctrl = 0},
++        [2] = {.fctrl = 0},
++        [3] = {.fctrl = 0},
+     },
+ #endif
+ #if MYNEWT_VAL(UWB_DEVICE_1)
+     {
+-        [0] = {.fctrl = 0, 0},
+-        [1] = {.fctrl = 0, 0},
+-        [2] = {.fctrl = 0, 0},
+-        [3] = {.fctrl = 0, 0},
++        [0] = {.fctrl = 0},
++        [1] = {.fctrl = 0},
++        [2] = {.fctrl = 0},
++        [3] = {.fctrl = 0},
+     },
+ #endif
+ #if MYNEWT_VAL(UWB_DEVICE_2)
+     {
+-        [0] = {.fctrl = 0, 0},
+-        [1] = {.fctrl = 0, 0},
+-        [2] = {.fctrl = 0, 0},
+-        [3] = {.fctrl = 0, 0},
++        [0] = {.fctrl = 0},
++        [1] = {.fctrl = 0},
++        [2] = {.fctrl = 0},
++        [3] = {.fctrl = 0},
+     },
+ #endif
+ };
+-- 
+2.40.1
+

--- a/pkg/uwb-dw1000/hal/uwb_dw1000.c
+++ b/pkg/uwb-dw1000/hal/uwb_dw1000.c
@@ -153,8 +153,8 @@ void uwb_dw1000_update_config_from_otp(dw1000_dev_instance_t *dev)
             ((_dw1000_otp_read(dev,
                                OTP_CH5_PG_DELAY_ADDRESS) & OTP_CH5_PG_DELAY_MASK) >>
              OTP_CH5_PG_DELAY_SHIFT);
-        LOG_DEBUG("uwb-dw1000: pg-delay addr=(%" PRIx16 "),val=(%" PRIx16 ")\n",
-                  OTP_CH5_PG_DELAY_ADDRESS, pg_delay);
+        LOG_DEBUG("uwb-dw1000: pg-delay addr=(%x),val=(%x)\n",
+                  (unsigned)OTP_CH5_PG_DELAY_ADDRESS, (unsigned)pg_delay);
         dev->uwb_dev.config.txrf.PGdly = pg_delay;
     }
 }

--- a/pkg/uwb-dw1000/patches/0007-fix-compilation-with-clang.patch
+++ b/pkg/uwb-dw1000/patches/0007-fix-compilation-with-clang.patch
@@ -1,0 +1,41 @@
+From 27650dfe8d7258a55e50b3c52fe8039e0f383275 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Fri, 19 May 2023 22:48:17 +0200
+Subject: [PATCH] fix compilation with clang
+
+clang wants `struct`s and `union`s within a packed `struct`/`union` to
+be explicitly also marked as packed. So let's do that.
+---
+ hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
+index e149054..753ef66 100644
+--- a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
++++ b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
+@@ -79,18 +79,18 @@ typedef struct _dw1000_dev_rxdiag_t{
+         struct _rx_time {
+             uint32_t    fp_idx:16;          //!< First path index (10.6 bits fixed point integer)
+             uint32_t    fp_amp:16;          //!< Amplitude at floor(index FP) + 1
+-        };
++        }__attribute__((packed, aligned(1)));
+         uint32_t rx_time;
+-    };
++    }__attribute__((packed, aligned(1)));
+     union {
+         struct _rx_fqual {
+             uint64_t    rx_std:16;          //!<  Standard deviation of noise
+             uint64_t    fp_amp2:16;         //!<  Amplitude at floor(index FP) + 2
+             uint64_t    fp_amp3:16;         //!<  Amplitude at floor(index FP) + 3
+             uint64_t    cir_pwr:16;         //!<  Channel Impulse Response max growth CIR
+-        };
++        }__attribute__((packed, aligned(1)));
+         uint64_t rx_fqual;
+-    };
++    }__attribute__((packed, aligned(1)));
+     uint16_t    pacc_cnt;                   //!<  Count of preamble symbols accumulated
+ } __attribute__((packed, aligned(1))) dw1000_dev_rxdiag_t;
+ 
+-- 
+2.40.1
+

--- a/pkg/wamr/Makefile.include
+++ b/pkg/wamr/Makefile.include
@@ -10,3 +10,6 @@ IWASM_INCLUDES += ${IWASM_ROOT}/include \
 INCLUDES += $(addprefix -I,${IWASM_INCLUDES})
 
 ARCHIVES += $(BINDIR)/libwamr.a
+
+# clang stumbles upon the asm syntax, likely it ignores -mthumb
+TOOLCHAINS_BLACKLIST += llvm

--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -345,7 +345,7 @@ thread::thread(F&& f, Args&&... args) : m_data{new thread_data} {
   using func_and_args = tuple
     <thread_data*, typename decay<F>::type, typename decay<Args>::type...>;
   unique_ptr<func_and_args> p(
-    new func_and_args(m_data.get(), forward<F>(f), forward<Args>(args)...));
+    new func_and_args(m_data.get(), std::forward<F>(f), std::forward<Args>(args)...));
   m_handle = thread_create(
     m_data->stack.data(), m_data->stack.size(), THREAD_PRIORITY_MAIN - 1, 0,
     &thread_proxy<func_and_args>, p.get(), "riot_cpp_thread");

--- a/sys/cpp_new_delete/new_delete.cpp
+++ b/sys/cpp_new_delete/new_delete.cpp
@@ -33,7 +33,7 @@ void *operator new(size_t size, void *ptr) noexcept {
     return ptr;
 }
 
-void operator delete(void *ptr) {
+void operator delete(void *ptr) noexcept {
     free(ptr);
 }
 
@@ -41,7 +41,7 @@ void operator delete(void *ptr, size_t) noexcept {
     free(ptr);
 }
 
-void operator delete[](void *ptr) {
+void operator delete[](void *ptr) noexcept {
     free(ptr);
 }
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
@@ -50,7 +50,7 @@ typedef struct __attribute__((packed)) {
     union {
         uint32_t u8_pad;
         le_uint16_t conf_fcnt;
-    };
+    }__attribute__((packed));
     uint8_t dir;
     le_uint32_t dev_addr;
     le_uint32_t fcnt;

--- a/sys/shell_lock/shell_lock.c
+++ b/sys/shell_lock/shell_lock.c
@@ -77,9 +77,9 @@ static inline void _print_password_prompt(void)
  * which could give away information about the first n correct characters of
  * the password. The length of the loop is only dependent on the input string.
  * Don't optimize this function by a compiler. */
-static bool __attribute__((optimize("O0"))) _safe_strcmp(const char* input, const char* pwd)
+static bool _safe_strcmp(const char* input, const char* pwd)
 {
-    bool the_same = true;
+    volatile bool the_same = true;
 
     int input_index = 0;
     int pwd_index = 0;

--- a/sys/stdio_nimble/stdio_nimble.c
+++ b/sys/stdio_nimble/stdio_nimble.c
@@ -85,23 +85,17 @@ static struct ble_gap_event_listener _gap_event_listener;
 static char _debug_printf_buf[DEBUG_PRINTF_BUFSIZE];
 #endif /* IS_USED(MODULE_STDIO_NIMBLE_DEBUG) */
 
-static int _debug_printf(const char *format, ...)
-{
 #if IS_USED(MODULE_STDIO_NIMBLE_DEBUG)
-    unsigned state = irq_disable();
-    va_list va;
-    va_start(va, format);
-    int rc = vsnprintf(_debug_printf_buf, DEBUG_PRINTF_BUFSIZE, format, va);
-    va_end(va);
-    uart_write(STDIO_UART_DEV, (const uint8_t *)_debug_printf_buf, rc);
-    irq_restore(state);
-
-    return rc;
+#define _debug_printf(...) \
+    do { \
+        unsigned state = irq_disable(); \
+        int rc = snprintf(_debug_printf_buf, DEBUG_PRINTF_BUFSIZE, __VA_ARGS__); \
+        uart_write(STDIO_UART_DEV, (const uint8_t *)_debug_printf_buf, rc); \
+        irq_restore(state); \
+    } while(0)
 #else
-    (void)format;
-    return 0;
+#define _debug_printf(...) (void)0
 #endif
-}
 
 /**
  * @brief UUID for stdio service (value: e6d54866-0292-4779-b8f8-c52bbec91e71)

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -322,6 +322,7 @@ static int _start_storage(suit_manifest_t *manifest, suit_component_t *comp)
     return suit_storage_start(comp->storage_backend, manifest, img_size);
 }
 
+__attribute__((unused))
 static inline void _print_download_progress(suit_manifest_t *manifest,
                                             size_t offset, size_t len,
                                             size_t image_size)

--- a/sys/suit/storage/vfs.c
+++ b/sys/suit/storage/vfs.c
@@ -40,6 +40,7 @@ static inline suit_storage_vfs_t *_get_vfs(suit_storage_t *storage)
     return container_of(storage, suit_storage_vfs_t, storage);
 }
 
+__attribute__((unused))
 static inline const suit_storage_vfs_t *_get_vfs_const(const suit_storage_t *storage)
 {
     return container_of(storage, suit_storage_vfs_t, storage);

--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -188,7 +188,7 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
     case USB_HID_REQUEST_GET_PROTOCOL:
         break;
     case USB_HID_REQUEST_SET_REPORT:
-        if ((state == USBUS_CONTROL_REQUEST_STATE_OUTDATA)) {
+        if (state == USBUS_CONTROL_REQUEST_STATE_OUTDATA) {
             size_t size = 0;
             uint8_t *data = usbus_control_get_out_data(usbus, &size);
             if (size > 0) {

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -57,7 +57,7 @@ static bool _ztimer_acquire(ztimer_clock_t *clock)
     unsigned state = irq_disable();
 
     DEBUG("ztimer_acquire(): %p: %" PRIu16 " user(s)\n",
-          (void *)clock, clock->users + 1);
+          (void *)clock, (uint16_t)(clock->users + 1));
 
     if (clock->users++ == 0) {
         if (clock->ops->start) {
@@ -93,7 +93,7 @@ bool ztimer_release(ztimer_clock_t *clock)
     assert(clock->users > 0);
 
     DEBUG("ztimer_release(): %p: %" PRIu16 " user(s)\n",
-          (void *)clock, clock->users - 1);
+          (void *)clock, (uint16_t)(clock->users - 1));
 
     if (--clock->users == 0) {
         /* make sure the timer isn't armed before turning off */

--- a/tests/bench/msg_pingpong/main.c
+++ b/tests/bench/msg_pingpong/main.c
@@ -34,8 +34,9 @@
 
 static char _stack[THREAD_STACKSIZE_MAIN];
 
-static void _timer_callback(void *flag)
+static void _timer_callback(void *_flag)
 {
+    atomic_flag *flag = _flag;
     atomic_flag_clear(flag);
 }
 

--- a/tests/bench/runtime_coreapis/Makefile
+++ b/tests/bench/runtime_coreapis/Makefile
@@ -4,4 +4,10 @@ include ../Makefile.bench_common
 USEMODULE += core_thread_flags
 USEMODULE += benchmark
 
+ifeq (llvm,$(TOOLCHAIN))
+  # the floating point exception bug is more likely to trigger when build
+  # with LLVM, so we just disable LLVM on native as a work around
+  TEST_ON_CI_BLACKLIST += native
+endif
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/net/gnrc_sixlowpan_frag_sfr/main.c
+++ b/tests/net/gnrc_sixlowpan_frag_sfr/main.c
@@ -285,6 +285,10 @@ static const uint8_t _test_send_frag3[] = {
         0x00, 0xbb, /* offset: 187 */
         0x6c, 0x28, 0x16, 0x59, 0xcc, 0x06
     };
+
+/* compiler bug in clang: _loc_l2 is passed via _vrbe_base to external
+ * functions and may be used, but clang considers it to be unused */
+__attribute__((used))
 static const uint8_t _loc_l2[] = LOC_L2;
 static const ipv6_addr_t _rem_ll = { .u8 = REM_LL };
 static const ipv6_addr_t _rem_gb = { .u8 = REM_GB };

--- a/tests/sys/cpp11_thread/main.cpp
+++ b/tests/sys/cpp11_thread/main.cpp
@@ -173,7 +173,7 @@ int main() {
     thread t1([] {
       // nop
     });
-    thread t2(move(t1));
+    thread t2(std::move(t1));
     expect(t1.joinable() == 0);
     expect(t2.joinable() == 1);
     t2.join();


### PR DESCRIPTION
### Contribution description

As the title says: This should increase the number of apps being able to build with clang quite a bit.
<!-- bors cut here -->

### Testing procedure

- no regressions
- compiling with `TOOLCHAIN=llvm` should be less often result in frustration
   - Note: I guess this is at most half way towards getting everything building again with LLVM

### Issues/PRs references

Depends on an includes:
- [x] https://github.com/RIOT-OS/RIOT/pull/19612
- [x] https://github.com/RIOT-OS/RIOT/pull/19635
- [x] https://github.com/RIOT-OS/RIOT/pull/19637
- [x] https://github.com/RIOT-OS/RIOT/pull/19685

Fixes: https://github.com/RIOT-OS/RIOT/issues/18851