### PR TITLE
drivers/mrf24j40: cleanup function

### DIFF
--- a/drivers/mrf24j40/mrf24j40_radio_hal.c
+++ b/drivers/mrf24j40/mrf24j40_radio_hal.c
@@ -265,19 +265,12 @@ static int _config_phy(ieee802154_dev_t *hal, const ieee802154_phy_conf_t *conf)
 static int _set_csma_params(ieee802154_dev_t *hal, const ieee802154_csma_be_t *bd, int8_t retries)
 {
     mrf24j40_t *dev = hal->priv;
-    uint8_t tmp;
 
     if (bd->min > MRF24J40_MAX_MINBE) {
         return -EINVAL;
     }
 
-    tmp = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXMCR) & ~MRF24J40_TXMCR_MACMINBE;
-    if (retries >= 0) {
-        tmp |= bd->min << MRF24J40_TXMCR_MACMINBE_SHIFT;
-    }
-
     /* This radio ignores max_be */
-
     mrf24j40_set_csma_max_retries(dev, retries);
     return 0;
 }


### PR DESCRIPTION
### Contribution description

`_set_csma_params()` spends some time to prepare a value in `uint8_t tmp`, which then is never used. Likely this is a leftover of moving code to `mrf24j40_set_csma_max_retries()`. This drops the leftover code.
<!-- bors split here -->

### Testing procedure

The driver should still correctly apply CSMA settings.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/19634