### PR TITLE
sys/usb/usbus_msc: fix typo in C expression

### DIFF
--- a/sys/usb/usbus/msc/scsi.c
+++ b/sys/usb/usbus/msc/scsi.c
@@ -163,9 +163,9 @@ static void _scsi_read_format_capacities(usbus_handler_t *handler, uint8_t lun)
     pkt->type = SCSI_READ_FMT_CAPA_TYPE_FORMATTED;
 
     /* Manage endianness, bytes 11..9 -> LSB..MSB */
-    pkt->blk_len[0] = (block_size >> 16) && 0xFF;
-    pkt->blk_len[1] = (block_size >> 8) && 0xFF;
-    pkt->blk_len[2] = block_size && 0xFF;
+    pkt->blk_len[0] = (block_size >> 16) & 0xFF;
+    pkt->blk_len[1] = (block_size >> 8) & 0xFF;
+    pkt->blk_len[2] = block_size & 0xFF;
 
     /* copy into ep buffer */
     usbdev_ep_xmit(msc->ep_in->ep, (uint8_t *)pkt, sizeof(msc_read_fmt_capa_pkt_t));


### PR DESCRIPTION
### Contribution description

Rather than setting the correct blk_len, the code only wrote 1 and 0 into the three bytes due to the use of a logic and where a bitwise and should be used.
<!-- bors cut here -->

### Testing procedure

Code review should be sufficient, the issue is pretty obvious in the diff.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/19634