### PR TITLE
pkg/openthread: fix code style, error handling, and synchronization

### DIFF
--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -59,21 +59,21 @@ otInstance* openthread_get_instance(void)
 
 static void _event_cb(netdev_t *dev, netdev_event_t event) {
     switch (event) {
-        case NETDEV_EVENT_ISR:
-            event_post(&ev_queue, &ev_isr);
-            break;
-        case NETDEV_EVENT_RX_COMPLETE:
-            DEBUG("openthread_netdev: Reception of a packet\n");
-            recv_pkt(sInstance, dev);
-            break;
-        case NETDEV_EVENT_TX_COMPLETE:
-        case NETDEV_EVENT_TX_NOACK:
-        case NETDEV_EVENT_TX_MEDIUM_BUSY:
-            DEBUG("openthread_netdev: Transmission of a packet\n");
-            send_pkt(sInstance, dev, event);
-            break;
-        default:
-            break;
+    case NETDEV_EVENT_ISR:
+        event_post(&ev_queue, &ev_isr);
+        break;
+    case NETDEV_EVENT_RX_COMPLETE:
+        DEBUG("openthread_netdev: Reception of a packet\n");
+        recv_pkt(sInstance, dev);
+        break;
+    case NETDEV_EVENT_TX_COMPLETE:
+    case NETDEV_EVENT_TX_NOACK:
+    case NETDEV_EVENT_TX_MEDIUM_BUSY:
+        DEBUG("openthread_netdev: Transmission of a packet\n");
+        send_pkt(sInstance, dev, event);
+        break;
+    default:
+        break;
     }
 }
 
@@ -124,8 +124,8 @@ static void *_openthread_event_loop(void *arg)
 int openthread_netdev_init(char *stack, int stacksize, char priority,
                            const char *name, netdev_t *netdev) {
     if (thread_create(stack, stacksize,
-                         priority, THREAD_CREATE_STACKTEST,
-                         _openthread_event_loop, netdev, name) < 0) {
+                      priority, THREAD_CREATE_STACKTEST,
+                      _openthread_event_loop, netdev, name) < 0) {
         return -EINVAL;
     }
 

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -77,6 +77,12 @@ static void _event_cb(netdev_t *dev, netdev_event_t event) {
     }
 }
 
+static void *_error_msg_and_return_null(const char *fn, otError err)
+{
+    printf("Call to %s() failed with error code %d\n", fn, (int)err);
+    return NULL;
+}
+
 static void *_openthread_event_loop(void *arg)
 {
     _dev = arg;
@@ -98,12 +104,25 @@ static void *_openthread_event_loop(void *arg)
     /* Init default parameters */
     otPanId panid = OPENTHREAD_PANID;
     uint8_t channel = OPENTHREAD_CHANNEL;
-    otLinkSetPanId(sInstance, panid);
-    otLinkSetChannel(sInstance, channel);
+    otError err;
+    err = otLinkSetPanId(sInstance, panid);
+    if (err != OT_ERROR_NONE) {
+        return _error_msg_and_return_null("otLinkSetPanId", err);
+    }
+    err = otLinkSetChannel(sInstance, channel);
+    if (err != OT_ERROR_NONE) {
+        return _error_msg_and_return_null("otLinkSetChannel", err);
+    }
     /* Bring up the IPv6 interface  */
-    otIp6SetEnabled(sInstance, true);
+    err = otIp6SetEnabled(sInstance, true);
+    if (err != OT_ERROR_NONE) {
+        return _error_msg_and_return_null("otIp6SetEnabled", err);
+    }
     /* Start Thread protocol operation */
-    otThreadSetEnabled(sInstance, true);
+    err = otThreadSetEnabled(sInstance, true);
+    if (err != OT_ERROR_NONE) {
+        return _error_msg_and_return_null("otThreadSetEnabled", err);
+    }
 #else
     /* enable OpenThread UART */
     otPlatUartEnable();

--- a/pkg/openthread/contrib/platform_logging.c
+++ b/pkg/openthread/contrib/platform_logging.c
@@ -30,8 +30,8 @@
 __attribute__((__format__ (__printf__, 3, 4)))
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
-    (void) aLogLevel;
-    (void) aLogRegion;
+    (void)aLogLevel;
+    (void)aLogRegion;
     va_list args;
     va_start(args, aFormat);
     vfprintf(stderr, aFormat, args);

--- a/pkg/openthread/contrib/platform_misc.c
+++ b/pkg/openthread/contrib/platform_misc.c
@@ -26,7 +26,7 @@
 
 static void _ev_tasklets_handler(event_t *event)
 {
-    (void) event;
+    (void)event;
     otInstance *instance = openthread_get_instance();
     while (otTaskletsArePending(instance)) {
         otTaskletsProcess(instance);
@@ -39,7 +39,7 @@ static event_t ev_tasklet = {
 
 /* OpenThread will call this when switching state from empty tasklet to non-empty tasklet. */
 void otTaskletsSignalPending(otInstance *aInstance) {
-    (void) aInstance;
+    (void)aInstance;
     event_post(openthread_get_evq(), &ev_tasklet);
 }
 

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -137,7 +137,7 @@ void openthread_radio_init(netdev_t *dev, uint8_t *tb, uint8_t *rb)
 /* Called upon NETDEV_EVENT_RX_COMPLETE event */
 void recv_pkt(otInstance *aInstance, netdev_t *dev)
 {
-    DEBUG("Openthread: Received pkt\n");
+    DEBUG_PUTS("Openthread: Received pkt");
     netdev_ieee802154_rx_info_t rx_info;
     /* Read frame length from driver */
     int len = dev->driver->recv(dev, NULL, 0, NULL);
@@ -155,7 +155,7 @@ void recv_pkt(otInstance *aInstance, netdev_t *dev)
     sReceiveFrame.mLength = len + RADIO_IEEE802154_FCS_LEN;
 
     /* Read received frame */
-    int res = dev->driver->recv(dev, (char *) sReceiveFrame.mPsdu, len, &rx_info);
+    int res = dev->driver->recv(dev, (char *)sReceiveFrame.mPsdu, len, &rx_info);
 
     /* Get RSSI from a radio driver. RSSI should be in [dBm] */
     Rssi = (int8_t)rx_info.rssi;
@@ -164,7 +164,7 @@ void recv_pkt(otInstance *aInstance, netdev_t *dev)
         for (int i = 0; i < sReceiveFrame.mLength; ++i) {
             DEBUG("%x ", sReceiveFrame.mPsdu[i]);
         }
-        DEBUG("\n");
+        DEBUG_PUTS("");
     }
 
     /* Tell OpenThread that receive has finished */
@@ -178,24 +178,24 @@ void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event)
 
     /* Tell OpenThread transmission is done depending on the NETDEV event */
     switch (event) {
-        case NETDEV_EVENT_TX_COMPLETE:
-            DEBUG("openthread: NETDEV_EVENT_TX_COMPLETE\n");
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
-            break;
-        case NETDEV_EVENT_TX_COMPLETE_DATA_PENDING:
-            DEBUG("openthread: NETDEV_EVENT_TX_COMPLETE_DATA_PENDING\n");
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
-            break;
-        case NETDEV_EVENT_TX_NOACK:
-            DEBUG("openthread: NETDEV_EVENT_TX_NOACK\n");
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NO_ACK);
-            break;
-        case NETDEV_EVENT_TX_MEDIUM_BUSY:
-            DEBUG("openthread: NETDEV_EVENT_TX_MEDIUM_BUSY\n");
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_CHANNEL_ACCESS_FAILURE);
-            break;
-        default:
-            break;
+    case NETDEV_EVENT_TX_COMPLETE:
+        DEBUG_PUTS("openthread: NETDEV_EVENT_TX_COMPLETE");
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
+        break;
+    case NETDEV_EVENT_TX_COMPLETE_DATA_PENDING:
+        DEBUG_PUTS("openthread: NETDEV_EVENT_TX_COMPLETE_DATA_PENDING");
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
+        break;
+    case NETDEV_EVENT_TX_NOACK:
+        DEBUG_PUTS("openthread: NETDEV_EVENT_TX_NOACK");
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NO_ACK);
+        break;
+    case NETDEV_EVENT_TX_MEDIUM_BUSY:
+        DEBUG_PUTS("openthread: NETDEV_EVENT_TX_MEDIUM_BUSY");
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_CHANNEL_ACCESS_FAILURE);
+        break;
+    default:
+        break;
     }
 }
 
@@ -211,7 +211,7 @@ void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)
 void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     (void)aInstance;
-    DEBUG("openthread: otPlatRadioSetExtendedAddress\n");
+    DEBUG_PUTS("openthread: otPlatRadioSetExtendedAddress");
     char reversed_addr[IEEE802154_LONG_ADDRESS_LEN];
     for (unsigned i = 0; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
         reversed_addr[i] = (uint8_t) ((uint8_t *)aExtAddress)[IEEE802154_LONG_ADDRESS_LEN - 1 - i];
@@ -220,7 +220,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aE
         for (unsigned i = 0; i < IEEE802154_LONG_ADDRESS_LEN; ++i) {
             DEBUG("%x ", (uint8_t) ((uint8_t *)reversed_addr)[i]);
         }
-        DEBUG("\n");
+        DEBUG_PUTS("");
     }
     _set_long_addr((uint8_t*) reversed_addr);
 }
@@ -236,7 +236,7 @@ void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
 /* OpenThread will call this for enabling the radio */
 otError otPlatRadioEnable(otInstance *aInstance)
 {
-    DEBUG("openthread: otPlatRadioEnable\n");
+    DEBUG_PUTS("openthread: otPlatRadioEnable");
     (void)aInstance;
 
     if (!otPlatRadioIsEnabled(aInstance)) {
@@ -249,7 +249,7 @@ otError otPlatRadioEnable(otInstance *aInstance)
 /* OpenThread will call this for disabling the radio */
 otError otPlatRadioDisable(otInstance *aInstance)
 {
-    DEBUG("openthread: otPlatRadioDisable\n");
+    DEBUG_PUTS("openthread: otPlatRadioDisable");
     (void)aInstance;
 
     if (otPlatRadioIsEnabled(aInstance)) {
@@ -261,7 +261,7 @@ otError otPlatRadioDisable(otInstance *aInstance)
 
 bool otPlatRadioIsEnabled(otInstance *aInstance)
 {
-    DEBUG("otPlatRadioIsEnabled\n");
+    DEBUG_PUTS("otPlatRadioIsEnabled");
     (void)aInstance;
     netopt_state_t state = _get_state();
     if (state == NETOPT_STATE_OFF) {
@@ -274,7 +274,7 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
 /* OpenThread will call this for setting device state to SLEEP */
 otError otPlatRadioSleep(otInstance *aInstance)
 {
-    DEBUG("otPlatRadioSleep\n");
+    DEBUG_PUTS("otPlatRadioSleep");
     (void)aInstance;
 
     _set_sleep();
@@ -297,7 +297,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
 {
     (void)aInstance;
-    DEBUG("openthread: otPlatRadioGetTransmitBuffer\n");
+    DEBUG_PUTS("openthread: otPlatRadioGetTransmitBuffer");
     return &sTransmitFrame;
 }
 
@@ -350,7 +350,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
         for (size_t i = 0; i < aPacket->mLength; ++i) {
             DEBUG("%x ", aPacket->mPsdu[i]);
         }
-        DEBUG("\n");
+        DEBUG_PUTS("");
     }
     _set_channel(aPacket->mChannel);
 
@@ -365,7 +365,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
 otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 {
     (void)aInstance;
-    DEBUG("openthread: otPlatRadioGetCaps\n");
+    DEBUG_PUTS("openthread: otPlatRadioGetCaps");
     /* all drivers should handle ACK, including call of NETDEV_EVENT_TX_NOACK */
     return OT_RADIO_CAPS_TRANSMIT_RETRIES | OT_RADIO_CAPS_ACK_TIMEOUT;
 }
@@ -374,7 +374,7 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 bool otPlatRadioGetPromiscuous(otInstance *aInstance)
 {
     (void)aInstance;
-    DEBUG("openthread: otPlatRadioGetPromiscuous\n");
+    DEBUG_PUTS("openthread: otPlatRadioGetPromiscuous");
     return _is_promiscuous();
 }
 
@@ -382,27 +382,27 @@ bool otPlatRadioGetPromiscuous(otInstance *aInstance)
 void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
     (void)aInstance;
-    DEBUG("openthread: otPlatRadioSetPromiscuous\n");
+    DEBUG_PUTS("openthread: otPlatRadioSetPromiscuous");
     _set_promiscuous((aEnable) ? NETOPT_ENABLE : NETOPT_DISABLE);
 }
 
 int8_t otPlatRadioGetRssi(otInstance *aInstance)
 {
-    DEBUG("otPlatRadioGetRssi\n");
+    DEBUG_PUTS("otPlatRadioGetRssi");
     (void)aInstance;
     return Rssi;
 }
 
 void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
 {
-    DEBUG("otPlatRadioEnableSrcMatch\n");
+    DEBUG_PUTS("otPlatRadioEnableSrcMatch");
     (void)aInstance;
     (void)aEnable;
 }
 
 otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
-    DEBUG("otPlatRadioAddSrcMatchShortEntry\n");
+    DEBUG_PUTS("otPlatRadioAddSrcMatchShortEntry");
     (void)aInstance;
     (void)aShortAddress;
     return OT_ERROR_NONE;
@@ -410,7 +410,7 @@ otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t a
 
 otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    DEBUG("otPlatRadioAddSrcMatchExtEntry\n");
+    DEBUG_PUTS("otPlatRadioAddSrcMatchExtEntry");
     (void)aInstance;
     (void)aExtAddress;
     return OT_ERROR_NONE;
@@ -418,7 +418,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
 
 otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
-    DEBUG("otPlatRadioClearSrcMatchShortEntry\n");
+    DEBUG_PUTS("otPlatRadioClearSrcMatchShortEntry");
     (void)aInstance;
     (void)aShortAddress;
     return OT_ERROR_NONE;
@@ -426,7 +426,7 @@ otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t
 
 otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    DEBUG("otPlatRadioClearSrcMatchExtEntry\n");
+    DEBUG_PUTS("otPlatRadioClearSrcMatchExtEntry");
     (void)aInstance;
     (void)aExtAddress;
     return OT_ERROR_NONE;
@@ -434,19 +434,19 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
 
 void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
 {
-    DEBUG("otPlatRadioClearSrcMatchShortEntries\n");
+    DEBUG_PUTS("otPlatRadioClearSrcMatchShortEntries");
     (void)aInstance;
 }
 
 void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
 {
-    DEBUG("otPlatRadioClearSrcMatchExtEntries\n");
+    DEBUG_PUTS("otPlatRadioClearSrcMatchExtEntries");
     (void)aInstance;
 }
 
 otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
-    DEBUG("otPlatRadioEnergyScan\n");
+    DEBUG_PUTS("otPlatRadioEnergyScan");
     (void)aInstance;
     (void)aScanChannel;
     (void)aScanDuration;

--- a/pkg/openthread/contrib/platform_settings.c
+++ b/pkg/openthread/contrib/platform_settings.c
@@ -35,7 +35,7 @@ otError otPlatSettingsBeginChange(otInstance *aInstance)
 
 otError otPlatSettingsCommitChange(otInstance *aInstance)
 {
-    DEBUG("openthread: otPlatSettingsCommitChange\n");
+    DEBUG_PUTS("openthread: otPlatSettingsCommitChange");
     (void)aInstance;
     return OT_ERROR_NONE;
 }
@@ -53,7 +53,7 @@ otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint
     (void)aIndex;
     (void)aValue;
 
-    DEBUG("openthread: otPlatSettingsGet\n");
+    DEBUG_PUTS("openthread: otPlatSettingsGet");
     *aValueLength = 0;
     return OT_ERROR_NOT_IMPLEMENTED;
 }

--- a/pkg/openthread/contrib/platform_uart.c
+++ b/pkg/openthread/contrib/platform_uart.c
@@ -37,9 +37,9 @@ static uint16_t frameLength = 0;
 
 static void _ev_serial_handler(event_t *event)
 {
-    (void) event;
+    (void)event;
     /* Tell OpenThread about the reception of a CLI command */
-    otPlatUartReceived((uint8_t*)gSerialMessage[0].buf, gSerialMessage[0].length);
+    otPlatUartReceived((uint8_t *)gSerialMessage[0].buf, gSerialMessage[0].length);
     gSerialMessage[0].serial_buffer_status = OPENTHREAD_SERIAL_BUFFER_STATUS_FREE;
 }
 
@@ -54,22 +54,22 @@ static void uart_handler(void* arg, char c) {
         memset(&gSerialMessage[0], 0, sizeof(serial_msg_t));
     }
     switch (c) {
-        case '\r':
-        case '\n':
-            if (frameLength > 0) {
-                gSerialMessage[0].buf[frameLength] = c;
-                frameLength++;
-                gSerialMessage[0].length = frameLength;
-                event_post(openthread_get_evq(), &ev_serial);
-                frameLength = 0;
-            }
-            break;
-        default:
-            if (frameLength < OPENTHREAD_SERIAL_BUFFER_SIZE) {
-                gSerialMessage[0].buf[frameLength] = c;
-                frameLength++;
-            }
-            break;
+    case '\r':
+    case '\n':
+        if (frameLength > 0) {
+            gSerialMessage[0].buf[frameLength] = c;
+            frameLength++;
+            gSerialMessage[0].length = frameLength;
+            event_post(openthread_get_evq(), &ev_serial);
+            frameLength = 0;
+        }
+        break;
+    default:
+        if (frameLength < OPENTHREAD_SERIAL_BUFFER_SIZE) {
+            gSerialMessage[0].buf[frameLength] = c;
+            frameLength++;
+        }
+        break;
     }
 }
 

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -109,10 +109,11 @@ typedef struct {
  */
 typedef struct {
     event_t ev;                             /**< Event associated to the OpenThread job */
-    int status;                             /**< Status of the job */
+    otError retval;                         /**< Return value of the job */
     const char *command;                    /**< A pointer to the job name string. */
     void *arg;                              /**< arg for the job **/
     void *answer;                           /**< answer from the job **/
+    mutex_t mutex;                          /**< used to for synchronization with the event thread */
 } ot_job_t;
 
 /**


### PR DESCRIPTION
### Contribution description

- fix code style
- add error handling to `pkg/openthread/contrib/platform_functions_wrapper.c`
- let `ot_call_command()` wait for the command to actually complete
    - right now, `ot_call_command()` would return before the command is executed if called from a higher priority thread than OT is running in or when the OT thread blocks. The latter is pretty likely
    - but given that there was zero error handling anyway, this would likely go unnoticed. Now that there is error handling and the return value of `ot_call_command()` actually can be non-zero, it is important to wait for the command to complete before checking its error status
<!-- bors cut here -->

### Testing procedure

- no regressions on OT
- error handling should now actually work

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/19634