### PR TITLE
tests/net/gnrc_mac_timeout: add automated test

### DIFF
--- a/tests/net/gnrc_mac_timeout/tests/01-run.py
+++ b/tests/net/gnrc_mac_timeout/tests/01-run.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+ERROR_MS = 50  # This is large enough to pass the test on IoT-LAB nrf52dk
+
+
+def testfunc(child):
+    child.expect(r"Testing gnrc_mac timeout module \(start time = (\d+) ms\)")
+    start = int(child.match.group(1))
+    child.expect(r"Set timeout_1, should be expired at (\d+) ms\)")
+    timeout_1 = int(child.match.group(1))
+    child.expect(r"Set timeout_2, should be expired at (\d+) ms\)")
+    timeout_2 = int(child.match.group(1))
+    child.expect(r"Set timeout_3, should be expired at (\d+) ms\)")
+    timeout_3 = int(child.match.group(1))
+    child.expect_exact("Are the reception times of all 3 msgs close to the supposed values?")
+
+    child.expect_exact("If yes, the tests were successful")
+    child.expect(
+        r"At   (\d+) ms received msg 1: "
+        r"timeout_1 \(set at {start} ms\) expired, supposed to be {timeout_1} ms\!"
+        .format(start=start, timeout_1=timeout_1)
+    )
+    timeout_1_measured = int(child.match.group(1))
+    assert timeout_1_measured - timeout_1 < ERROR_MS
+    child.expect_exact(f"At   {timeout_1_measured} ms: timeout_1 is not running.")
+    child.expect_exact(f"At   {timeout_1_measured} ms: timeout_2 is running.")
+    child.expect_exact(f"At   {timeout_1_measured} ms: timeout_3 is running.")
+    child.expect(
+        r"At   (\d+) ms received msg 2: "
+        r"timeout_2 \(set at {start} ms\) expired, supposed to be {timeout_2} ms\!"
+        .format(start=start, timeout_2=timeout_2)
+    )
+    timeout_2_measured = int(child.match.group(1))
+    assert timeout_2_measured - timeout_2 < ERROR_MS
+    child.expect_exact(f"At   {timeout_2_measured} ms: timeout_1 is not running.")
+    child.expect_exact(f"At   {timeout_2_measured} ms: timeout_2 is not running.")
+    child.expect_exact(f"At   {timeout_2_measured} ms: timeout_3 is running.")
+    child.expect(
+        r"At   (\d+) ms received msg 3: "
+        r"timeout_3 \(set at {start} ms\) expired, supposed to be {timeout_3} ms\!"
+        .format(start=start, timeout_3=timeout_3)
+    )
+    timeout_3_measured = int(child.match.group(1))
+    assert timeout_3_measured - timeout_3 < ERROR_MS
+    child.expect_exact(f"At   {timeout_3_measured} ms: timeout_1 is not running.")
+    child.expect_exact(f"At   {timeout_3_measured} ms: timeout_2 is not running.")
+    child.expect_exact(f"At   {timeout_3_measured} ms: timeout_3 is not running.")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

in ##19636 (and more precisely in da854bb8f8783f022040e1dc2ee0625170fdcf6e), I noticed that this test could be automated quite easily.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI (Murdock should run the test on native)
- Tested on iotlab-m3 and nrf52dk remotely on IoT-LAB and it works as expected:

<details>

- iotlab-m3:

```
$ make -C tests/net/gnrc_mac_timeout/ flash test BOARD=iotlab-m3 IOTLAB_NODE=auto
make: Entering directory '/work/riot/RIOT/tests/net/gnrc_mac_timeout'
Building application "tests_gnrc_mac_timeout" for "iotlab-m3" with MCU "stm32".

"make" -C /work/riot/RIOT/pkg/cmsis/ 
"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/boards/iotlab-m3
"make" -C /work/riot/RIOT/boards/common/iotlab
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/evtimer
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/link_layer/mac
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/priority_pktqueue
"make" -C /work/riot/RIOT/sys/net/link_layer/csma_sender
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/test_utils/print_stack_usage
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  15236	    176	  10324	  25736	   6488	/work/riot/RIOT/tests/net/gnrc_mac_timeout/bin/iotlab-m3/tests_gnrc_mac_timeout.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,m3,10 --flash /work/riot/RIOT/tests/net/gnrc_mac_timeout/bin/iotlab-m3/tests_gnrc_mac_timeout.bin
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-10.saclay.iot-lab.info:20000' 
READY
s
START
main(): This is RIOT! (Version: 2023.07-devel-418-ga28f6)
Testing gnrc_mac timeout module (start time = 3369 ms)
Set timeout_1, should be expired at 4369 ms)
Set timeout_2, should be expired at 5907 ms)
Set timeout_3, should be expired at 6840 ms)
Are the reception times of all 3 msgs close to the supposed values?

If yes, the tests were successful
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 424}]}
At   4369 ms received msg 1: timeout_1 (set at 3369 ms) expired, supposed to be 4369 ms!
At   4369 ms: timeout_1 is not running.
At   4369 ms: timeout_2 is running.
At   4369 ms: timeout_3 is running.
At   5907 ms received msg 2: timeout_2 (set at 3369 ms) expired, supposed to be 5907 ms!
At   5907 ms: timeout_1 is not running.
At   5907 ms: timeout_2 is not running.
At   5907 ms: timeout_3 is running.
At   6840 ms received msg 3: timeout_3 (set at 3369 ms) expired, supposed to be 6840 ms!
At   6840 ms: timeout_1 is not running.
At   6840 ms: timeout_2 is not running.
At   6840 ms: timeout_3 is not running.

make: Leaving directory '/work/riot/RIOT/tests/net/gnrc_mac_timeout'
```

- nrf52dk:

```
$ make -C tests/net/gnrc_mac_timeout/ flash test BOARD=nrf52dk IOTLAB_NODE=auto
make: Entering directory '/work/riot/RIOT/tests/net/gnrc_mac_timeout'
Building application "tests_gnrc_mac_timeout" for "nrf52dk" with MCU "nrf52".

"make" -C /work/riot/RIOT/pkg/cmsis/ 
"make" -C /work/riot/RIOT/boards/common/init
"make" -C /work/riot/RIOT/boards/nrf52dk
"make" -C /work/riot/RIOT/boards/common/nrf52xxxdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/core/lib
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/evtimer
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/libc
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/link_layer/mac
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/priority_pktqueue
"make" -C /work/riot/RIOT/sys/net/link_layer/csma_sender
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/preprocessor
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/test_utils/print_stack_usage
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  15092	    168	  10348	  25608	   6408	/work/riot/RIOT/tests/net/gnrc_mac_timeout/bin/nrf52dk/tests_gnrc_mac_timeout.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,nrf52dk,10 --flash /work/riot/RIOT/tests/net/gnrc_mac_timeout/bin/nrf52dk/tests_gnrc_mac_timeout.bin
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52dk-10.saclay.iot-lab.info:20000' 
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2023.07-devel-419-g02aa7-pr/tests/net_gnrc_mac_timeout_add_test)
Testing gnrc_mac timeout module (start time = 3077 ms)
Set timeout_1, should be expired at 4077 ms)
Set timeout_2, should be expired at 5615 ms)
Set timeout_3, should be expired at 6548 ms)
Are the reception times of all 3 msgs close to the supposed values?

If yes, the tests were successful
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 424}]}
At   4085 ms received msg 1: timeout_1 (set at 3077 ms) expired, supposed to be 4077 ms!
At   4085 ms: timeout_1 is not running.
At   4085 ms: timeout_2 is running.
At   4085 ms: timeout_3 is running.
At   5635 ms received msg 2: timeout_2 (set at 3077 ms) expired, supposed to be 5615 ms!
At   5635 ms: timeout_1 is not running.
At   5635 ms: timeout_2 is not running.
At   5635 ms: timeout_3 is running.
At   6575 ms received msg 3: timeout_3 (set at 3077 ms) expired, supposed to be 6548 ms!
At   6575 ms: timeout_1 is not running.
At   6575 ms: timeout_2 is not running.
At   6575 ms: timeout_3 is not running.

make: Leaving directory '/work/riot/RIOT/tests/net/gnrc_mac_timeout'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
