### PR TITLE
core/thread: drop unused thread_arch_t

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -122,7 +122,6 @@
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
-#include "cpu_conf.h"
 #include "sched.h"
 #include "thread_config.h"
 
@@ -206,9 +205,6 @@ struct _thread {
 /* enable TLS only when Picolibc is compiled with TLS enabled */
 #ifdef PICOLIBC_TLS
     void *tls;                      /**< thread local storage ptr */
-#endif
-#ifdef HAVE_THREAD_ARCH_T
-    thread_arch_t arch;             /**< architecture dependent part    */
 #endif
 };
 

--- a/cpu/cortexm_common/include/thread_arch.h
+++ b/cpu/cortexm_common/include/thread_arch.h
@@ -20,6 +20,8 @@
 #ifndef THREAD_ARCH_H
 #define THREAD_ARCH_H
 
+#include "cpu_conf.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description

No architecture makes use of thread_arch_t anymore, so let's drop it.
<!-- bors cut here -->

### Testing procedure

Green CI and no change in binaries.

### Issues/PRs references

None