### PR TITLE
drivers/sx126x: fix argument validation in spreading factor

### DIFF
--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -401,7 +401,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         const uint8_t max_sf = sx126x_is_llcc68(dev)
                                ? llcc68_max_sf
                                : sx126x_max_sf;
-        if ((sf < LORA_SF6) || (sf > max_sf)) {
+        if ((sf < LORA_SF5) || (sf > max_sf)) {
             res = -EINVAL;
             break;
         }


### PR DESCRIPTION
### Contribution description

The lowest possible value is `LORA_SF5` and not `LORA_SF6`. This fixes the argument validation to allow setting `LORA_SF5` as spreading factor.
<!-- bors cut here -->

### Testing procedure

Code review with this snipped in mind should be sufficient:

https://github.com/RIOT-OS/RIOT/blob/eb10a5ccd8d810ed2ff5e6451035c0d83351061b/sys/include/net/lora.h#L249-L261

Otherwise, testing to set the spreading factor is possible.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/17861