### PR TITLE
drivers/mtd_spi_nor: fix hang and debug msgs

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -501,9 +501,9 @@ static int mtd_spi_nor_init(mtd_dev_t *mtd)
     _init_pins(dev);
 
     /* power up the MTD device*/
-    DEBUG("mtd_spi_nor_init: power up MTD device");
+    DEBUG_PUTS("mtd_spi_nor_init: power up MTD device");
     if (mtd_spi_nor_power(mtd, MTD_POWER_UP)) {
-        DEBUG("mtd_spi_nor_init: failed to power up MTD device");
+        DEBUG_PUTS("mtd_spi_nor_init: failed to power up MTD device");
         return -EIO;
     }
 

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -458,6 +458,7 @@ static int mtd_spi_nor_power(mtd_dev_t *mtd, enum mtd_power_state power)
                 retries++;
             } while (res < 0 && retries < MTD_POWER_UP_WAIT_FOR_ID);
             if (res < 0) {
+                mtd_spi_release(dev);
                 return -EIO;
             }
             /* enable 32 bit address mode */


### PR DESCRIPTION
### Contribution description

This patch adds a missing release of the SPI bus on error

### Testing procedure

This was discovered while attempting to bring up a board where I had the pin definitions wrong for a SPI flash part. Once the driver was fixed I was able to get the debug messages and not hang other drivers using the same bus.

### Issues/PRs references

None known