### PR TITLE
gnrc/sixlowpan/ctx: clamp prefix length to 64 bit

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -165,6 +165,12 @@ static inline bool gnrc_sixlowpan_ctx_update_6ctx(const ipv6_addr_t *prefix, uin
     gnrc_sixlowpan_ctx_t *ctx = gnrc_sixlowpan_ctx_lookup_addr(prefix);
     uint8_t cid = 0;
 
+    /* IPHC does not support prefixes shorter than 64 bit
+     * see https://datatracker.ietf.org/doc/html/rfc6282#page-9 */
+    if (prefix_len < 64) {
+        prefix_len = 64;
+    }
+
     if (!gnrc_sixlowpan_ctx_match(ctx, prefix, prefix_len)) {
         /* While the context is a prefix match, the defined prefix within the
          * context does not match => use new context */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

IPHC only allows to elide the first 64, 96 or 128 bits of an address.
If e.g. a /32 subnet like `fd00::/32` is added as a compression context, the address `fd00:0:c000:0:6481:20ff:fef9:b694` would match it.
But when IPHC used, there is no way to recover the missing 32 bit - the receiver would interpret the address as `fd00::6481:20ff:fef9:b694` which is wrong.

To prevent this, clamp prefixes to 64 bit.

We could also get rid of the prefix length field entirely, but that's a bit more of an invasive change.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
