### PR TITLE
gnrc_sixlowpan_iphc: prefix bits outside context must be zero

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -113,6 +113,8 @@
 #define NHC_IPV6_EXT_EID_MOB        (0x04 << 1)
 #define NHC_IPV6_EXT_EID_IPV6       (0x07 << 1)
 
+#define SIXLOWPAN_IPHC_PREFIX_LEN   (64)    /**< minimum prefix length for IPHC */
+
 /* currently only used with forwarding output, remove guard if more debug info
  * is added */
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_VRB
@@ -1090,6 +1092,11 @@ static size_t _iphc_ipv6_encode(gnrc_pktsnip_t *pkt,
         if (src_ctx && !(src_ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_COMP)) {
             src_ctx = NULL;
         }
+        /* prefix bits not covered by context information must be zero */
+        if (src_ctx &&
+            ipv6_addr_match_prefix(&src_ctx->prefix, &ipv6_hdr->src) < SIXLOWPAN_IPHC_PREFIX_LEN) {
+            src_ctx = NULL;
+        }
     }
 
     if (!ipv6_addr_is_multicast(&ipv6_hdr->dst)) {
@@ -1097,6 +1104,11 @@ static size_t _iphc_ipv6_encode(gnrc_pktsnip_t *pkt,
         /* do not use destination context for compression if */
         /* GNRC_SIXLOWPAN_CTX_FLAGS_COMP is not set */
         if (dst_ctx && !(dst_ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_COMP)) {
+            dst_ctx = NULL;
+        }
+        /* prefix bits not covered by context information must be zero */
+        if (dst_ctx &&
+            ipv6_addr_match_prefix(&dst_ctx->prefix, &ipv6_hdr->dst) < SIXLOWPAN_IPHC_PREFIX_LEN) {
             dst_ctx = NULL;
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

We have a `/33` compression context
```
2023-05-23 11:41:47,813 - INFO # cid|prefix                                     |C|ltime
2023-05-23 11:41:47,819 - INFO # -----------------------------------------------------------
2023-05-23 11:41:47,823 - INFO #   0|                          fd00:0:8000::/33 |1| 1439min
``` 

And a route to a `/64` subnet inside the previous network.

```
2023-05-23 11:41:55,146 - INFO # fd00::/32 dev #6
2023-05-23 11:41:55,148 - INFO # fd00:0:8000::/33 dev #5
2023-05-23 11:41:55,153 - INFO # fd00:0:c000::/64 via fe80::e858:4ed2:564e:345b dev #5
2023-05-23 11:41:55,157 - INFO # default via fe80::6a9a:4308:e40a:aa8a dev #6
```

We can successfully ping a host inside the `/64` network.

```
2023-05-23 11:42:38,163 - INFO # > ping fd00:0:c000:0:6481:20ff:fef9:b694
2023-05-23 11:42:38,164 - INFO # 
2023-05-23 11:42:38,182 - INFO # 12 bytes from fd00:0:c000:0:6481:20ff:fef9:b694: icmp_seq=0 ttl=64 rssi=-26 dBm time=9.177 ms
2023-05-23 11:42:39,184 - INFO # 12 bytes from fd00:0:c000:0:6481:20ff:fef9:b694: icmp_seq=1 ttl=64 rssi=-25 dBm time=10.359 ms
2023-05-23 11:42:40,183 - INFO # 12 bytes from fd00:0:c000:0:6481:20ff:fef9:b694: icmp_seq=2 ttl=64 rssi=-25 dBm time=8.922 ms
2023-05-23 11:42:40,183 - INFO # 
2023-05-23 11:42:40,188 - INFO # --- fd00:0:c000:0:6481:20ff:fef9:b694 PING statistics ---
2023-05-23 11:42:40,193 - INFO # 3 packets transmitted, 3 packets received, 0% packet loss
2023-05-23 11:42:40,198 - INFO # round-trip min/avg/max = 8.922/9.486/10.359 ms
```

On `master` the compression context would be used instead, resulting in the packet being sent to the non-existing `fd00:0:8000::6481:20ff:fef9:b694`.

### Issues/PRs references

alternative to #19648
