### PR TITLE
gnrc_ipv6_nib: set default RIO preference to zero

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -267,7 +267,7 @@ static gnrc_pktsnip_t *_build_final_ext_opts(gnrc_netif_t *netif)
             gnrc_pktsnip_t *snip  = gnrc_ndp_opt_ri_build(&entry->pfx,
                                                           entry->pfx_len,
                                                           valid_ltime,
-                                                          NDP_OPT_RI_FLAGS_PRF_NONE,
+                                                          NDP_OPT_RI_FLAGS_PRF_ZERO,
                                                           ext_opts);
             if (snip != NULL) {
                 ext_opts = snip;

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2021 ML!PA Consulting GmbH
  *
@@ -332,7 +333,7 @@ static bool _remove_old_prefix(gnrc_netif_t *netif,
 
     /* invalidate old prefix in RIO */
     tmp = gnrc_ndp_opt_ri_build(&old_pfx, old_pfx_len, 0,
-                                NDP_OPT_RI_FLAGS_PRF_NONE, *ext_opts);
+                                NDP_OPT_RI_FLAGS_PRF_ZERO, *ext_opts);
     if (tmp) {
         *ext_opts = tmp;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Linux will ignore RIOs with preference NONE, so set the preference to zero instead.
RIOT currently ignores the preference.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Linux accepts the route from an upstream RIOT node

    fd00::/32 via fe80::6481:20ff:fef9:b694 dev usb0 proto ra metric 1024 expires 4294451sec pref medium


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
