### PR TITLE
net/ipv6: make use of clz in ipv6_addr_match_prefix()

### DIFF
--- a/core/lib/include/bitarithm.h
+++ b/core/lib/include/bitarithm.h
@@ -166,6 +166,30 @@ static inline unsigned bitarithm_msb(unsigned v)
 }
 
 /**
+ * @brief   Returns the number of leading 0-bits in @p x, starting at the most
+ *          significant bit position.
+ *          If x is 0, the result is undefined.
+ *
+ * @param[in]   x   Input value
+ * @return          Number of leading zero bits
+ */
+static inline uint8_t bitarithm_clzb(uint8_t x)
+{
+#if defined(BITARITHM_HAS_CLZ)
+    /* clz operates on `unsigned int`, so `x` will be promoted to the size
+       of an `unsigned int` */
+    return __builtin_clz(x) - 8 * (sizeof(unsigned) - 1);
+#else
+    uint8_t l = 0;
+    while (!(x & 0x80)) {
+        ++l;
+        x <<= 1;
+    }
+    return l;
+#endif
+}
+
+/**
  * @private
  *
  * @brief Lookup table for a fast CLS / LSB implementations.

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 
 #include "fmt.h"
+#include "bitarithm.h"
 #include "kernel_defines.h"
 #include "net/ipv6/addr.h"
 
@@ -52,25 +53,15 @@ uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b)
     }
 
     for (int i = 0; i < 16; i++) {
-        /* if bytes are equal add 8 */
-        if (a->u8[i] == b->u8[i]) {
-            prefix_len += 8;
+        uint8_t xor = a->u8[i] ^ b->u8[i];
+        if (xor) {
+            /* if bytes aren't equal count matching leading bits */
+            prefix_len += bitarithm_clzb(xor);
+            break;
         }
         else {
-            uint8_t xor = (a->u8[i] ^ b->u8[i]);
-
-            /* while bits from byte equal add 1 */
-            for (int j = 0; j < 8; j++) {
-                if ((xor & 0x80) == 0) {
-                    prefix_len++;
-                    xor = xor << 1;
-                }
-                else {
-                    break;
-                }
-            }
-
-            break;
+            /* if bytes are equal add 8 */
+            prefix_len += 8;
         }
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Make use of the `clz` (count leading zeros) instruction present on most CPUs instead of coding it manually.

This saves 40 bytes on Cortex-M0+.


### Testing procedure

`tests-ipv6_addr` still succeeds.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
