### PR TITLE
gnrc/ipv6_auto_subnets: allow to configure minimal prefix length

### DIFF
--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -181,6 +181,19 @@ extern "C" {
 #define assume(cond)    assert(cond)
 #endif
 
+/**
+ * @brief   Wrapper function to silence "comparison is always false due to limited
+ *          range of data type" type of warning when the warning is caused by a
+ *          preprocessor configuration value that may be zero.
+ *
+ * @param[in]   n   Variable that may be zero
+ * @return      The same variable @p n
+ */
+static inline unsigned may_be_zero(unsigned n)
+{
+    return n;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2021 ML!PA Consulting GmbH
  *

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -89,6 +89,7 @@
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/hdr.h"
@@ -139,6 +140,14 @@
  */
 #ifndef CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_FIX_LEN
 #define CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_FIX_LEN (0)
+#endif
+
+/**
+ * @brief   Minimal length of a new prefix.
+ *          e.g. Linux will only accept /64 prefixes for SLAAC
+ */
+#ifndef CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_MIN_LEN
+#define CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_MIN_LEN (0)
 #endif
 
 /**
@@ -367,6 +376,10 @@ static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t 
     if (new_prefix_len > 64) {
         DEBUG("auto_subnets: can't split /%u into %u subnets\n", prefix_len, subnets);
         return;
+    }
+
+    if (new_prefix_len < may_be_zero(CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_MIN_LEN)) {
+        new_prefix_len = CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_MIN_LEN;
     }
 
     while ((downstream = gnrc_netif_iter(downstream))) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Linux only accepts Router Advertisements for SLAAC [if the prefix length is /64](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv6/addrconf.c#n2790).
Add a config option to `gnrc_ipv6_auto_subnets` to create smaller subnets if necessary.


### Testing procedure

A downstream Linux host gets a prefix from the upstream RIOT router with `gnrc_ipv6_auto_subnets`:

```
104: usb0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN group default qlen 1000
    link/ether 66:81:20:f9:aa:94 brd ff:ff:ff:ff:ff:ff
    inet 169.254.226.86/16 brd 169.254.255.255 scope global noprefixroute usb0
       valid_lft forever preferred_lft forever
    inet6 fd00:0:c000:0:e46:895a:43bc:f080/64 scope global dynamic mngtmpaddr noprefixroute 
       valid_lft 72155sec preferred_lft 155sec
    inet6 fe80::650a:e7fd:8b57:c7e8/64 scope link 
       valid_lft forever preferred_lft forever
```

```
fd00:0:c000::/64 dev usb0 proto ra metric 304 pref medium
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
