### PR TITLE
drivers/mpu9x50: clean up code

### DIFF
--- a/drivers/mpu9x50/mpu9x50.c
+++ b/drivers/mpu9x50/mpu9x50.c
@@ -236,28 +236,19 @@ int mpu9x50_set_compass_power(mpu9x50_t *dev, mpu9x50_pwr_t pwr_conf)
     return 0;
 }
 
+static inline uint32_t gyro_fsr_enum_to_value(mpu9x50_gyro_ranges_t fsr)
+{
+    return 250U << fsr;
+}
+
 int mpu9x50_read_gyro(const mpu9x50_t *dev, mpu9x50_results_t *output)
 {
     uint8_t data[6];
     int16_t temp;
-    float fsr;
 
-    switch (dev->conf.gyro_fsr) {
-        case MPU9X50_GYRO_FSR_250DPS:
-            fsr = 250.0;
-            break;
-        case MPU9X50_GYRO_FSR_500DPS:
-            fsr = 500.0;
-            break;
-        case MPU9X50_GYRO_FSR_1000DPS:
-            fsr = 1000.0;
-            break;
-        case MPU9X50_GYRO_FSR_2000DPS:
-            fsr = 2000.0;
-            break;
-        default:
-            return -2;
-    }
+    assert((unsigned)dev->conf.gyro_fsr <= (unsigned)MPU9X50_GYRO_FSR_2000DPS);
+
+    uint32_t fsr = gyro_fsr_enum_to_value(dev->conf.gyro_fsr);
 
     /* Acquire exclusive access */
     i2c_acquire(DEV_I2C);
@@ -267,38 +258,29 @@ int mpu9x50_read_gyro(const mpu9x50_t *dev, mpu9x50_results_t *output)
     i2c_release(DEV_I2C);
 
     /* Normalize data according to configured full scale range */
-    temp = (data[0] << 8) | data[1];
+    temp = byteorder_lebuftohs(&data[0]);
     output->x_axis = (temp * fsr) / MAX_VALUE;
-    temp = (data[2] << 8) | data[3];
+    temp = byteorder_lebuftohs(&data[2]);
     output->y_axis = (temp * fsr) / MAX_VALUE;
-    temp = (data[4] << 8) | data[5];
+    temp = byteorder_lebuftohs(&data[4]);
     output->z_axis = (temp * fsr) / MAX_VALUE;
 
     return 0;
+}
+
+static inline uint32_t accel_fsr_enum_to_value(mpu9x50_accel_ranges_t fsr)
+{
+    return 2000U << fsr;
 }
 
 int mpu9x50_read_accel(const mpu9x50_t *dev, mpu9x50_results_t *output)
 {
     uint8_t data[6];
     int16_t temp;
-    float fsr;
 
-    switch (dev->conf.accel_fsr) {
-        case MPU9X50_ACCEL_FSR_2G:
-            fsr = 2000.0;
-            break;
-        case MPU9X50_ACCEL_FSR_4G:
-            fsr = 4000.0;
-            break;
-        case MPU9X50_ACCEL_FSR_8G:
-            fsr = 8000.0;
-            break;
-        case MPU9X50_ACCEL_FSR_16G:
-            fsr = 16000.0;
-            break;
-        default:
-            return -2;
-    }
+    assert((unsigned)dev->conf.accel_fsr <= (unsigned)MPU9X50_ACCEL_FSR_16G);
+
+    uint32_t fsr = accel_fsr_enum_to_value(dev->conf.accel_fsr);
 
     /* Acquire exclusive access */
     i2c_acquire(DEV_I2C);
@@ -308,14 +290,23 @@ int mpu9x50_read_accel(const mpu9x50_t *dev, mpu9x50_results_t *output)
     i2c_release(DEV_I2C);
 
     /* Normalize data according to configured full scale range */
-    temp = (data[0] << 8) | data[1];
+    temp = byteorder_lebuftohs(&data[0]);
     output->x_axis = (temp * fsr) / MAX_VALUE;
-    temp = (data[2] << 8) | data[3];
+    temp = byteorder_lebuftohs(&data[2]);
     output->y_axis = (temp * fsr) / MAX_VALUE;
-    temp = (data[4] << 8) | data[5];
+    temp = byteorder_lebuftohs(&data[4]);
     output->z_axis = (temp * fsr) / MAX_VALUE;
 
     return 0;
+}
+
+static int16_t convert_magnometer(int16_t raw, uint8_t adjust)
+{
+    int32_t tmp = raw;
+    /* Compute sensitivity adjustment */
+    tmp += tmp * ((int32_t)adjust - 128) / 256;
+    /* return normalized data */
+    return (tmp * 3) / 10;
 }
 
 int mpu9x50_read_compass(const mpu9x50_t *dev, mpu9x50_results_t *output)
@@ -329,22 +320,12 @@ int mpu9x50_read_compass(const mpu9x50_t *dev, mpu9x50_results_t *output)
     /* Release the bus */
     i2c_release(DEV_I2C);
 
-    output->x_axis = (data[1] << 8) | data[0];
-    output->y_axis = (data[3] << 8) | data[2];
-    output->z_axis = (data[5] << 8) | data[4];
-
-    /* Compute sensitivity adjustment */
-    output->x_axis = (int16_t) (((float)output->x_axis) *
-            ((((dev->conf.compass_x_adj - 128) * 0.5) / 128.0) + 1));
-    output->y_axis = (int16_t) (((float)output->y_axis) *
-            ((((dev->conf.compass_y_adj - 128) * 0.5) / 128.0) + 1));
-    output->z_axis = (int16_t) (((float)output->z_axis) *
-            ((((dev->conf.compass_z_adj - 128) * 0.5) / 128.0) + 1));
-
-    /* Normalize data according to full-scale range */
-    output->x_axis = output->x_axis * 0.3;
-    output->y_axis = output->y_axis * 0.3;
-    output->z_axis = output->z_axis * 0.3;
+    output->x_axis = convert_magnometer(byteorder_lebuftohs(&data[0]),
+                                        dev->conf.compass_x_adj);
+    output->y_axis = convert_magnometer(byteorder_lebuftohs(&data[2]),
+                                        dev->conf.compass_y_adj);
+    output->z_axis = convert_magnometer(byteorder_lebuftohs(&data[4]),
+                                        dev->conf.compass_z_adj);
 
     return 0;
 }
@@ -374,18 +355,18 @@ int mpu9x50_set_gyro_fsr(mpu9x50_t *dev, mpu9x50_gyro_ranges_t fsr)
     }
 
     switch (fsr) {
-        case MPU9X50_GYRO_FSR_250DPS:
-        case MPU9X50_GYRO_FSR_500DPS:
-        case MPU9X50_GYRO_FSR_1000DPS:
-        case MPU9X50_GYRO_FSR_2000DPS:
-            i2c_acquire(DEV_I2C);
-            i2c_write_reg(DEV_I2C, DEV_ADDR,
-                    MPU9X50_GYRO_CFG_REG, (fsr << 3), 0);
-            i2c_release(DEV_I2C);
-            dev->conf.gyro_fsr = fsr;
-            break;
-        default:
-            return -2;
+    case MPU9X50_GYRO_FSR_250DPS:
+    case MPU9X50_GYRO_FSR_500DPS:
+    case MPU9X50_GYRO_FSR_1000DPS:
+    case MPU9X50_GYRO_FSR_2000DPS:
+        i2c_acquire(DEV_I2C);
+        i2c_write_reg(DEV_I2C, DEV_ADDR,
+                MPU9X50_GYRO_CFG_REG, (fsr << 3), 0);
+        i2c_release(DEV_I2C);
+        dev->conf.gyro_fsr = fsr;
+        break;
+    default:
+        return -2;
     }
 
     return 0;
@@ -398,18 +379,18 @@ int mpu9x50_set_accel_fsr(mpu9x50_t *dev, mpu9x50_accel_ranges_t fsr)
     }
 
     switch (fsr) {
-        case MPU9X50_ACCEL_FSR_2G:
-        case MPU9X50_ACCEL_FSR_4G:
-        case MPU9X50_ACCEL_FSR_8G:
-        case MPU9X50_ACCEL_FSR_16G:
-            i2c_acquire(DEV_I2C);
-            i2c_write_reg(DEV_I2C, DEV_ADDR,
-                    MPU9X50_ACCEL_CFG_REG, (fsr << 3), 0);
-            i2c_release(DEV_I2C);
-            dev->conf.accel_fsr = fsr;
-            break;
-        default:
-            return -2;
+    case MPU9X50_ACCEL_FSR_2G:
+    case MPU9X50_ACCEL_FSR_4G:
+    case MPU9X50_ACCEL_FSR_8G:
+    case MPU9X50_ACCEL_FSR_16G:
+        i2c_acquire(DEV_I2C);
+        i2c_write_reg(DEV_I2C, DEV_ADDR,
+                MPU9X50_ACCEL_CFG_REG, (fsr << 3), 0);
+        i2c_release(DEV_I2C);
+        dev->conf.accel_fsr = fsr;
+        break;
+    default:
+        return -2;
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

Avoid using floating point arithmetic and some minor cleanups.
<!-- bors cut here -->

### Testing procedure

```sh
make BOARD=msbiot -C examples/default flash term
```

#### Output with `master`

```
> 2023-05-23 21:40:13,551 # main(): This is RIOT! (Version: 2023.07-devel-420-geb10a)
2023-05-23 21:40:13,553 # Welcome to RIOT!
> saul read 5
2023-05-23 21:40:16,845 # saul read 5
2023-05-23 21:40:16,849 # Reading from #5 (mpu9x50|SENSE_ACCEL)
2023-05-23 21:40:16,852 # Data:	[0]         -25 mgₙ
2023-05-23 21:40:16,854 # 	[1]         -36 mgₙ
2023-05-23 21:40:16,856 # 	[2]         998 mgₙ
> saul read 6
2023-05-23 21:40:20,102 # saul read 6
2023-05-23 21:40:20,106 # Reading from #6 (mpu9x50|SENSE_GYRO)
2023-05-23 21:40:20,109 # Data:	[0]         0.0 dps
2023-05-23 21:40:20,110 # 	[1]         0.2 dps
2023-05-23 21:40:20,112 # 	[2]         0.0 dps
> saul read 7
2023-05-23 21:40:22,715 # saul read 7
2023-05-23 21:40:22,719 # Reading from #7 (mpu9x50|SENSE_MAG)
2023-05-23 21:40:22,721 # Data:	[0]        0.10 Gs
2023-05-23 21:40:22,723 # 	[1]        0.01 Gs
2023-05-23 21:40:22,725 # 	[2]        0.75 Gs
```

#### Output with this PR

```
> 2023-05-23 21:40:28,155 # main(): This is RIOT! (Version: 2023.07-devel-420-geb10a-mpu9x50-no-float)
2023-05-23 21:40:28,156 # Welcome to RIOT!
> saul read 5
2023-05-23 21:40:29,587 # saul read 5
2023-05-23 21:40:29,591 # Reading from #5 (mpu9x50|SENSE_ACCEL)
2023-05-23 21:40:29,594 # Data:	[0]        1296 mgₙ
2023-05-23 21:40:29,596 # 	[1]        1796 mgₙ
2023-05-23 21:40:29,598 # 	[2]         660 mgₙ
> saul read 6
2023-05-23 21:40:30,902 # saul read 6
2023-05-23 21:40:30,906 # Reading from #6 (mpu9x50|SENSE_GYRO)
2023-05-23 21:40:30,909 # Data:	[0]       -15.3 dps
2023-05-23 21:40:30,910 # 	[1]        67.1 dps
2023-05-23 21:40:30,912 # 	[2]       -13.7 dps
> saul read 7
2023-05-23 21:40:32,535 # saul read 7
2023-05-23 21:40:32,539 # Reading from #7 (mpu9x50|SENSE_MAG)
2023-05-23 21:40:32,542 # Data:	[0]        0.12 Gs
2023-05-23 21:40:32,543 # 	[1]        0.01 Gs
2023-05-23 21:40:32,545 # 	[2]        0.76 Gs
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/19614
