### PR TITLE
cpu/rpx0xx: Fix kconfig model

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -96,6 +96,7 @@ pba-d-01-kw2x
 p-nucleo-wb55
 qn9080dk
 remote-revb
+rpi-pico
 same54-xpro
 samr21-xpro
 seeedstudio-gd32

--- a/cpu/rpx0xx/Kconfig
+++ b/cpu/rpx0xx/Kconfig
@@ -17,6 +17,10 @@ config CPU_FAM_RPX0XX
     select HAS_PERIPH_UART_MODECFG
     select HAS_PERIPH_UART_RECONFIGURE
     select HAS_PIO_I2C
+    select MODULE_PIO_I2C if MODULE_PERIPH_I2C
+    # Since make has a wildcard for anything starting with pio_ we need to
+    # build it as new modules get added
+    select MODULE_PERIPH_PIO if MODULE_PIO_I2C
 
 config CPU_FAM
     default "RPX0XX" if CPU_FAM_RPX0XX
@@ -35,5 +39,15 @@ config HAS_CPU_RPX0XX
     bool
     help
         Indicates that a RPX0XX CPU (e.g. the RP2040) is used
+
+config MODULE_PIO_I2C
+    bool "Enable PIO I2C module"
+    depends on HAS_PIO_I2C
+
+config MODULE_PIO_AUTOSTART_I2C
+    bool "Enable PIO I2C module autostart"
+    default y if MODULE_PIO_I2C
+    depends on HAS_PIO_I2C
+
 
 source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -90,6 +90,16 @@ config MODULE_PERIPH_INIT_HWRNG
 
 rsource "Kconfig.i2c"
 
+config MODULE_PERIPH_PIO
+    bool "Programmable IO (PIO) peripheral driver"
+    depends on HAS_PERIPH_PIO
+    select MODULE_PERIPH_COMMON
+
+config MODULE_PERIPH_INIT_PIO
+    bool "Auto initialize programmable IO (PIO) peripheral driver"
+    default y if MODULE_PERIPH_INIT
+    depends on MODULE_PERIPH_PIO
+
 config MODULE_PERIPH_PM
     bool "Power Management (PM) peripheral driver"
     default y

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -191,9 +191,9 @@ config HAS_PERIPH_GPIO_IRQ
 config HAS_PERIPH_GPIO_FAST_READ
     bool
     help
-	Indicates that the GPIO peripheral supports a mode in which pin read
-	operations are faster, usually with a tradeoff against a different
-	property.
+        Indicates that the GPIO peripheral supports a mode in which pin read
+        operations are faster, usually with a tradeoff against a different
+        property.
 
 config HAS_PERIPH_GPIO_TAMPER_WAKE
     bool


### PR DESCRIPTION


### Contribution description

Broken master due to incorrect model of the periph_pio in kconfig.

### Testing procedure

Green murdock (now that the board is added to the list)

### Issues/PRs references

Look at the master CI...