### PR TITLE
driver/lc709203f: remove unnecessary use of float

### DIFF
--- a/drivers/lc709203f/lc709203f.c
+++ b/drivers/lc709203f/lc709203f.c
@@ -152,7 +152,9 @@ int16_t lc709203f_get_cell_temp(const lc709203f_t *dev)
         DEBUG("CRC Error \n");
         return 0;
     }
-    return ((((unsigned int)rec_buf[1] << 8) | rec_buf[0]) - 2731.5);
+    /* sensor temperature is given in 0.1K -> -2731.5 would be the correct value
+     * returning in 0.1°C int16_t -> using rounded 2732 */
+    return ((((int16_t)rec_buf[1] << 8) | rec_buf[0]) - 2732);
 }
 
 lc709203f_temp_obtaining_mode_t lc709203f_get_status_bit(const lc709203f_t *dev)


### PR DESCRIPTION
### Contribution description

removes a unnecessary use of float

### Testing procedure

read and test if you got that hardware (I don't)

### Issues/PRs references

#19614 