### PR TITLE
usbus: don't trigger assertion in usbus_urb_submit()

### DIFF
--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -282,7 +282,11 @@ static void _usbus_transfer_urb_submit(usbus_endpoint_t *usbus_ep,
 void usbus_urb_submit(usbus_t *usbus, usbus_endpoint_t *endpoint, usbus_urb_t *urb)
 {
     (void)usbus;
-    assert(!(clist_find(&endpoint->urb_list, &urb->list)));
+
+    if (clist_find(&endpoint->urb_list, &urb->list)) {
+        return;
+    }
+
     if (endpoint->ep->dir == USB_EP_DIR_IN &&
             ((urb->len % endpoint->maxpacketsize) == 0) &&
             usbus_urb_isset_flag(urb, USBUS_URB_FLAG_AUTO_ZLP)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

 - flash `tests/sys/usbus_cdc_ecm`
 - reboot the host system

On `master` this assertion will trigger, with this patch the duplicate URB is ignored.

Network operation continues normal:

```
2023-05-24 18:24:36,366 - INFO # > ping -c 200 ff02::1%8
2023-05-24 18:24:36,367 - INFO # 
2023-05-24 18:24:36,375 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=0 ttl=64 time=1.639 ms
2023-05-24 18:24:37,375 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=1 ttl=64 time=1.433 ms
2023-05-24 18:24:38,377 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=2 ttl=64 time=2.525 ms
2023-05-24 18:24:39,377 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=3 ttl=64 time=2.372 ms
2023-05-24 18:24:40,378 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=4 ttl=64 time=2.463 ms
2023-05-24 18:24:41,378 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=5 ttl=64 time=2.266 ms
# host reboots
2023-05-24 18:25:01,389 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=25 ttl=64 time=4.084 ms
2023-05-24 18:25:02,387 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=26 ttl=64 time=1.508 ms
2023-05-24 18:25:03,387 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=27 ttl=64 time=1.362 ms
2023-05-24 18:25:04,389 - INFO # 12 bytes from fe80::650a:e7fd:8b57:c7e8%8: icmp_seq=28 ttl=64 time=2.511 ms

``` 


### Issues/PRs references

fixes #19663