### PR TITLE
doc: do not rebuild riot.css

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -7,7 +7,7 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
 
 # use lessc (http://lesscss.org/#using-less) for compiling CSS
 # It can also be installed in ubuntu with the `node-less` package
-LESSC ?= $(shell command -v lessc 2>/dev/null)
+LESSC ?= lessc
 
 DOCUMENTATION_FORMAT ?= html
 
@@ -16,7 +16,7 @@ doc: $(DOCUMENTATION_FORMAT)
 
 # by marking html as phony we force make to re-run Doxygen even if the directory exists.
 .PHONY: html
-html: src/css/riot.css src/changelog.md
+html: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
 
 .PHONY: check
@@ -27,14 +27,12 @@ check: src/changelog.md
 man: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
-ifneq (,$(LESSC))
 src/css/riot.css: src/css/riot.less src/css/variables.less
 	@$(LESSC) $< $@
 
 src/css/variables.less: src/config.json
 	@grep "^\s*\"@" $< | sed -e 's/^\s*"//g' -e 's/":\s*"/: /g' \
 	  -e 's/",\?$$/;/g' -e 's/\\"/"/g' > $@
-endif
 
 src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@


### PR DESCRIPTION
### Contribution description

- simplify the makefile
    - changing behavior depending on lessc being installed is surprising and makes the Makefile less readable
    - failing with `make: lessc: No such file or directory` is helpful, but `make: No rule to make target 'src/css/riot.css'` is not clearly indicating that `lessc` was not found
- don't rebuild `riot.css` when generating HTML output
    - anyone touching the less file will have to manually call `make src/css/riot.css -C doc/doxygen`
    - this happens so rarely that implementing a convenient mechanism is not worth the trouble
<!-- bors cut here -->

### Testing procedure

`make doc` should no longer regenerate `riot.css`, regardless of whether `lessc` is available or not.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/8122