### PR TITLE
ieee802154/submac: calculate symbol time on demand

### DIFF
--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -135,13 +135,13 @@ void ieee802154_submac_bh_request(ieee802154_submac_t *submac)
     netdev->event_callback(netdev, NETDEV_EVENT_ISR);
 }
 
-void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac, uint16_t us)
+void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac)
 {
     netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
                                                              netdev_ieee802154_submac_t,
                                                              submac);
 
-    ztimer_set(ZTIMER_USEC, &netdev_submac->ack_timer, us);
+    ztimer_set(ZTIMER_USEC, &netdev_submac->ack_timer, submac->ack_timeout_us);
 }
 
 void ieee802154_submac_ack_timer_cancel(ieee802154_submac_t *submac)

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -126,6 +126,13 @@ extern "C" {
 #define IEEE802154_MR_OFDM_SYMBOL_TIME_US   (120)
 
 /**
+ * @brief Symbol time for IEEE 802.15.4 MR-FSK in µs
+ *
+ * symbol time is always 20 µs for MR-FSK (table 0, pg. 7)
+ */
+#define IEEE802154_MR_FSK_SYMBOL_TIME_US    (20)
+
+/**
  * @brief value of measured power when RSSI is zero.
  *
  * This value is defined in the IEEE 802.15.4 standard
@@ -190,11 +197,23 @@ typedef enum {
 /**
  * @brief   802.15.4 forward error correction schemes
  */
-enum {
+typedef enum {
     IEEE802154_FEC_NONE,            /**< no forward error correction */
     IEEE802154_FEC_NRNSC,           /**< non-recursive and non-systematic code */
     IEEE802154_FEC_RSC              /**< recursive and systematic code */
-};
+} ieee802154_mr_fsk_fec_t;
+
+/**
+ * @brief   802.15.4 MR-FSK symbol rates
+ */
+typedef enum {
+    IEEE802154_MR_FSK_SRATE_50K,    /**< 50k Symbols/s  */
+    IEEE802154_MR_FSK_SRATE_100K,   /**< 100k Symbols/s */
+    IEEE802154_MR_FSK_SRATE_150K,   /**< 150k Symbols/s */
+    IEEE802154_MR_FSK_SRATE_200K,   /**< 200k Symbols/s */
+    IEEE802154_MR_FSK_SRATE_300K,   /**< 300k Symbols/s */
+    IEEE802154_MR_FSK_SRATE_400K,   /**< 400k Symbols/s */
+} ieee802154_mr_fsk_srate_t;
 
 /**
  * @brief   802.15.4 MR-OQPSK chip rates
@@ -205,6 +224,32 @@ typedef enum {
     IEEE802154_MR_OQPSK_CHIPS_1000, /**< 1000 kChip/s */
     IEEE802154_MR_OQPSK_CHIPS_2000, /**< 2000 kChip/s */
 } ieee802154_mr_oqpsk_chips_t;
+
+/**
+ * @brief Get the minimum preamble length for a given symbol rate
+ *
+ * From IEEE 802.15.4g Table 6-64
+ *
+ * @param[in] srate     symbol rate
+ * @return    preamble length in bytes
+ */
+static inline uint8_t ieee802154_mr_fsk_plen(ieee802154_mr_fsk_srate_t srate)
+{
+    switch (srate) {
+    case IEEE802154_MR_FSK_SRATE_50K:
+        return 2;
+    case IEEE802154_MR_FSK_SRATE_100K:
+        return 3;
+    case IEEE802154_MR_FSK_SRATE_150K:
+    case IEEE802154_MR_FSK_SRATE_200K:
+    case IEEE802154_MR_FSK_SRATE_300K:
+        return 8;
+    case IEEE802154_MR_FSK_SRATE_400K:
+        return 10;
+    }
+
+    return 0;
+}
 
 /**
  * @brief   Special address definitions
@@ -300,6 +345,34 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
  */
 #ifndef CONFIG_IEEE802154_MR_OFDM_DEFAULT_SCHEME
 #define CONFIG_IEEE802154_MR_OFDM_DEFAULT_SCHEME    (2U)
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-FSK default symbol rate
+ */
+#ifndef CONFIG_IEEE802154_MR_FSK_DEFAULT_SRATE
+#define CONFIG_IEEE802154_MR_FSK_DEFAULT_SRATE      IEEE802154_MR_FSK_SRATE_200K
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-FSK default modulation index, fraction of 64
+ */
+#ifndef CONFIG_IEEE802154_MR_FSK_DEFAULT_MOD_IDX
+#define CONFIG_IEEE802154_MR_FSK_DEFAULT_MOD_IDX    (64U)
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-FSK default modulation order
+ */
+#ifndef CONFIG_IEEE802154_MR_FSK_DEFAULT_MOD_ORD
+#define CONFIG_IEEE802154_MR_FSK_DEFAULT_MOD_ORD    (2U)
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-FSK default error correction mode
+ */
+#ifndef CONFIG_IEEE802154_MR_FSK_DEFAULT_FEC
+#define CONFIG_IEEE802154_MR_FSK_DEFAULT_FEC        IEEE802154_FEC_NONE
 #endif
 
 /**

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -121,6 +121,11 @@ extern "C" {
 #define IEEE802154_ACK_TIMEOUT_SYMS     (54)
 
 /**
+ * @brief Symbol time for IEEE 802.15.4 MR-OFDM in µs
+ */
+#define IEEE802154_MR_OFDM_SYMBOL_TIME_US   (120)
+
+/**
  * @brief value of measured power when RSSI is zero.
  *
  * This value is defined in the IEEE 802.15.4 standard
@@ -281,6 +286,20 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
  */
 #ifndef CONFIG_IEEE802154_MR_OQPSK_DEFAULT_RATE
 #define CONFIG_IEEE802154_MR_OQPSK_DEFAULT_RATE     (2U)
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-OFDM default modulation option
+ */
+#ifndef CONFIG_IEEE802154_MR_OFDM_DEFAULT_OPTION
+#define CONFIG_IEEE802154_MR_OFDM_DEFAULT_OPTION    (2U)
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-OFDM default Modulation & Coding Scheme
+ */
+#ifndef CONFIG_IEEE802154_MR_OFDM_DEFAULT_SCHEME
+#define CONFIG_IEEE802154_MR_OFDM_DEFAULT_SCHEME    (2U)
 #endif
 
 /**

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -25,8 +25,9 @@
 #include <stdlib.h>
 
 #include "byteorder.h"
-#include "net/eui64.h"
 #include "modules.h"
+#include "net/eui64.h"
+#include "time_units.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -189,6 +190,16 @@ enum {
 };
 
 /**
+ * @brief   802.15.4 MR-OQPSK chip rates
+ */
+typedef enum {
+    IEEE802154_MR_OQPSK_CHIPS_100,  /**< 100 kChip/s  */
+    IEEE802154_MR_OQPSK_CHIPS_200,  /**< 200 kChip/s  */
+    IEEE802154_MR_OQPSK_CHIPS_1000, /**< 1000 kChip/s */
+    IEEE802154_MR_OQPSK_CHIPS_2000, /**< 2000 kChip/s */
+} ieee802154_mr_oqpsk_chips_t;
+
+/**
  * @brief   Special address definitions
  * @{
  */
@@ -254,6 +265,20 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
  */
 #ifndef CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE
 #define CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE      (2U)
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-OQPSK default chip rate
+ */
+#ifndef CONFIG_IEEE802154_MR_OQPSK_DEFAULT_CHIPS
+#define CONFIG_IEEE802154_MR_OQPSK_DEFAULT_CHIPS    IEEE802154_MR_OQPSK_CHIPS_1000
+#endif
+
+/**
+ * @brief IEEE802.15.4 MR-OQPSK default rate mode
+ */
+#ifndef CONFIG_IEEE802154_MR_OQPSK_DEFAULT_RATE
+#define CONFIG_IEEE802154_MR_OQPSK_DEFAULT_RATE     (2U)
 #endif
 
 /**

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -177,7 +177,9 @@ typedef enum {
     IEEE802154_PHY_OQPSK,           /**< Offset Quadrature Phase-Shift Keying */
     IEEE802154_PHY_MR_OQPSK,        /**< Multi-Rate Offset Quadrature Phase-Shift Keying */
     IEEE802154_PHY_MR_OFDM,         /**< Multi-Rate Orthogonal Frequency-Division Multiplexing */
-    IEEE802154_PHY_MR_FSK           /**< Multi-Rate Frequency Shift Keying */
+    IEEE802154_PHY_MR_FSK,          /**< Multi-Rate Frequency Shift Keying */
+
+    IEEE802154_PHY_NO_OP,           /**< don't change PHY configuration */
 } ieee802154_phy_mode_t;
 
 /**

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -469,6 +469,15 @@ typedef struct {
 } ieee802154_mr_oqpks_conf_t;
 
 /**
+ * @brief extension for IEEE 802.15.4g MR-ODFM PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+    uint8_t option;                     /**< OFDM Option */
+    uint8_t scheme;                     /**< Modulation & Coding Scheme */
+} ieee802154_mr_odmf_conf_t;
+
+/**
  * @brief IEEE 802.15.4 radio operations
  */
 typedef enum {

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -466,7 +466,7 @@ typedef struct {
     ieee802154_phy_conf_t super;        /**< common settings */
     ieee802154_mr_oqpsk_chips_t chips;  /**< chip rate       */
     uint8_t rate_mode;                  /**< rate mode       */
-} ieee802154_mr_oqpks_conf_t;
+} ieee802154_mr_oqpsk_conf_t;
 
 /**
  * @brief extension for IEEE 802.15.4g MR-ODFM PHY
@@ -475,7 +475,18 @@ typedef struct {
     ieee802154_phy_conf_t super;        /**< common settings */
     uint8_t option;                     /**< OFDM Option */
     uint8_t scheme;                     /**< Modulation & Coding Scheme */
-} ieee802154_mr_odmf_conf_t;
+} ieee802154_mr_ofdm_conf_t;
+
+/**
+ * @brief extension for IEEE 802.15.4g MR-FSK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+    ieee802154_mr_fsk_srate_t srate;    /**< symbol rate */
+    uint8_t mod_ord;                    /**< modulation order, 2 or 4 */
+    uint8_t mod_idx;                    /**< modulation index */
+    ieee802154_mr_fsk_fec_t fec;        /**< forward error correction */
+} ieee802154_mr_fsk_conf_t;
 
 /**
  * @brief IEEE 802.15.4 radio operations

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -460,6 +460,15 @@ typedef struct {
 } ieee802154_phy_conf_t;
 
 /**
+ * @brief extension for IEEE 802.15.4g MR-OQPSK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+    ieee802154_mr_oqpsk_chips_t chips;  /**< chip rate       */
+    uint8_t rate_mode;                  /**< rate mode       */
+} ieee802154_mr_oqpks_conf_t;
+
+/**
  * @brief IEEE 802.15.4 radio operations
  */
 typedef enum {

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -312,9 +312,7 @@ static inline ieee802154_phy_mode_t ieee802154_get_phy_mode(
  * @brief Set IEEE 802.15.4 PHY configuration (channel, TX power)
  *
  * @param[in] submac pointer to the SubMAC descriptor
- * @param[in] channel_num channel number
- * @param[in] channel_page channel page
- * @param[in] tx_pow transmission power (in dBm)
+ * @param[in] conf   pointer to the PHY configuration
  *
  * @return 0 on success
  * @return -ENOTSUP if the PHY settings are not supported
@@ -323,8 +321,7 @@ static inline ieee802154_phy_mode_t ieee802154_get_phy_mode(
  *         @ref ieee802154_submac_cb_t::tx_done
  * @return negative errno on error
  */
-int ieee802154_set_phy_conf(ieee802154_submac_t *submac, uint16_t channel_num,
-                            uint8_t channel_page, int8_t tx_pow);
+int ieee802154_set_phy_conf(ieee802154_submac_t *submac, const ieee802154_phy_conf_t *conf);
 
 /**
  * @brief Set IEEE 802.15.4 channel number
@@ -344,8 +341,14 @@ int ieee802154_set_phy_conf(ieee802154_submac_t *submac, uint16_t channel_num,
 static inline int ieee802154_set_channel_number(ieee802154_submac_t *submac,
                                                 uint16_t channel_num)
 {
-    return ieee802154_set_phy_conf(submac, channel_num, submac->channel_page,
-                                   submac->tx_pow);
+    const ieee802154_phy_conf_t conf = {
+        .phy_mode = IEEE802154_PHY_NO_OP,
+        .channel = channel_num,
+        .page = submac->channel_page,
+        .pow = submac->tx_pow,
+    };
+
+    return ieee802154_set_phy_conf(submac, &conf);
 }
 
 /**
@@ -366,8 +369,14 @@ static inline int ieee802154_set_channel_number(ieee802154_submac_t *submac,
 static inline int ieee802154_set_channel_page(ieee802154_submac_t *submac,
                                               uint16_t channel_page)
 {
-    return ieee802154_set_phy_conf(submac, submac->channel_num, channel_page,
-                                   submac->tx_pow);
+    const ieee802154_phy_conf_t conf = {
+        .phy_mode = IEEE802154_PHY_NO_OP,
+        .channel = submac->channel_num,
+        .page = channel_page,
+        .pow = submac->tx_pow,
+    };
+
+    return ieee802154_set_phy_conf(submac, &conf);
 }
 
 /**
@@ -388,8 +397,14 @@ static inline int ieee802154_set_channel_page(ieee802154_submac_t *submac,
 static inline int ieee802154_set_tx_power(ieee802154_submac_t *submac,
                                           int8_t tx_pow)
 {
-    return ieee802154_set_phy_conf(submac, submac->channel_num,
-                                   submac->channel_page, tx_pow);
+    const ieee802154_phy_conf_t conf = {
+        .phy_mode = IEEE802154_PHY_NO_OP,
+        .channel = submac->channel_num,
+        .page = submac->channel_page,
+        .pow = tx_pow,
+    };
+
+    return ieee802154_set_phy_conf(submac, &conf);
 }
 
 /**

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -195,6 +195,8 @@ struct ieee802154_submac {
     const ieee802154_submac_cb_t *cb;   /**< pointer to the SubMAC callbacks */
     ieee802154_csma_be_t be;            /**< CSMA-CA backoff exponent params */
     bool wait_for_ack;                  /**< SubMAC is waiting for an ACK frame */
+    uint16_t ack_timeout_us;            /**< ACK timeout in µs */
+    uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
     uint16_t panid;                     /**< IEEE 802.15.4 PAN ID */
     uint16_t channel_num;               /**< IEEE 802.15.4 channel number */
     uint8_t channel_page;               /**< IEEE 802.15.4 channel page */

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -503,10 +503,8 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
  * @note This function should be implemented by the user of the SubMAC.
  *
  * @param[in] submac pointer to the SubMAC descriptor
- * @param[in] us microseconds until the ACK timeout timer is fired
  */
-extern void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac,
-                                            uint16_t us);
+extern void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac);
 
 /**
  * @brief Cancel the ACK timeout timer

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -282,7 +282,7 @@ static ieee802154_fsm_state_t _fsm_state_tx_process_tx_done(ieee802154_submac_t 
             assert (res >= 0);
 
             /* Handle ACK reception */
-            ieee802154_submac_ack_timer_set(submac, submac->ack_timeout_us);
+            ieee802154_submac_ack_timer_set(submac);
             return IEEE802154_FSM_STATE_WAIT_FOR_ACK;
         }
         break;

--- a/tests/net/ieee802154_submac/main.c
+++ b/tests/net/ieee802154_submac/main.c
@@ -128,10 +128,9 @@ static void _ev_ack_timeout_handler(event_t *event)
     mutex_unlock(&lock);
 }
 
-void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac, uint16_t us)
+void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac)
 {
-    (void)submac;
-    ztimer_set(ZTIMER_USEC, &ack_timer, us);
+    ztimer_set(ZTIMER_USEC, &ack_timer, submac->ack_timeout_us);
 }
 
 void ieee802154_submac_ack_timer_cancel(ieee802154_submac_t *submac)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This moves the ACK timeout/CSMA backoff period calculation from the `at86rf215` driver to the radio HAL so it can be re-used by other IEEE 802.15.4g drivers.

To do so the `ieee802154_phy_conf_t` structure is extended depending on the used modulation. This allows to add alternative modulations with different properties (e.g. #19172).

### Testing procedure

Currently there is no driver that makes use of this.


### Issues/PRs references

alternative to #19198
