### PR TITLE
tools/build_system_sanity_check: add check to verify test applications are at the right place

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -362,6 +362,32 @@ check_stderr_null() {
         | error_with_message "Redirecting stderr and stdout to /dev/null is \`>/dev/null 2>&1\`; the other way round puts the old stderr to the new stdout."
 }
 
+# Test application directories that starts by the following strings are invalid
+# and should moved to the corresponding tests subdirectory.
+FORBIDDEN_TEST_DIRS=()
+FORBIDDEN_TEST_DIRS+=('build_system')
+FORBIDDEN_TEST_DIRS+=('core')       # => move under tests/core
+FORBIDDEN_TEST_DIRS+=('cpu')        # => move under tests/cpu
+FORBIDDEN_TEST_DIRS+=('driver')     # => move under tests/drivers
+FORBIDDEN_TEST_DIRS+=('gnrc')       # => move under tests/net
+FORBIDDEN_TEST_DIRS+=('periph')     # => move under tests/periph
+FORBIDDEN_TEST_DIRS+=('net')        # => move under tests/net
+FORBIDDEN_TEST_DIRS+=('pkg')        # => move under tests/pkg
+FORBIDDEN_TEST_DIRS+=('sys')        # => move under tests/sys
+FORBIDDEN_TEST_DIRS+=('vfs')        # => move under tests/sys
+FORBIDDEN_TEST_DIRS+=('xtimer')     # => move under tests/sys
+FORBIDDEN_TEST_DIRS+=('ztimer')     # => move under tests/sys
+
+check_tests_application_path() {
+    local patterns=()
+    patterns+=(-regex "^tests/bench_.*/Makefile")
+    for forbidden in "${FORBIDDEN_TEST_DIRS[@]}"; do
+        patterns+=(-o -regex "^tests/${forbidden}_.*/Makefile")
+    done
+
+    find tests/ -type f "${patterns[@]}" | error_with_message "Invalid application path in tests/"
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -383,6 +409,7 @@ all_checks() {
     check_no_pkg_source_local
     check_no_riot_config
     check_stderr_null
+    check_tests_application_path
 }
 
 main() {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is a follow-up of all PRs that moved/grouped test applications into subdirectories, to prevent tests application placed in `tests/pkg_<something>`, etc.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- There's a REMOVEME commit that should make static tests fail

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of the many PRs related to tests subdirectories

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
