### PR TITLE
drivers/dht: reversal of #16934 regression

### DIFF
--- a/drivers/dht/include/dht_params.h
+++ b/drivers/dht/include/dht_params.h
@@ -34,11 +34,15 @@ extern "C" {
 #ifndef DHT_PARAM_PIN
 #define DHT_PARAM_PIN               (GPIO_PIN(0, 0))
 #endif
+#ifndef DHT_PARAM_TYPE
+#define DHT_PARAM_TYPE              (DHT11)
+#endif
 #ifndef DHT_PARAM_PULL
 #define DHT_PARAM_PULL              (GPIO_IN_PU)
 #endif
 #ifndef DHT_PARAMS
 #define DHT_PARAMS                  { .pin     = DHT_PARAM_PIN,  \
+                                      .type    = DHT_PARAM_TYPE, \
                                       .in_mode = DHT_PARAM_PULL }
 #endif
 #ifndef DHT_SAULINFO

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -46,21 +46,33 @@ enum {
     DHT_OK      =  0,       /**< all good */
     DHT_NOCSUM  = -1,       /**< checksum error */
     DHT_TIMEOUT = -2,       /**< communication timed out */
+    DHT_NODEV   = -3        /**< device type not defined */
 };
 
 /**
  * @brief   Data type for storing DHT sensor readings
  */
 typedef struct {
-    uint16_t humidity;      /**< relative percent */
+    uint16_t humidity;      /**< relative humidity in deci-percent */
     uint16_t temperature;   /**< temperature in deci-Celsius */
 } dht_data_t;
+
+/**
+ * @brief   Device type of the DHT device
+ */
+typedef enum {
+    DHT11,                  /**< DHT11 device identifier */
+    DHT22,                  /**< DHT22 device identifier */
+    DHT21 = DHT22,          /**< DHT21 device identifier */
+    AM2301 = DHT22,         /**< AM2301 device identifier */
+} dht_type_t;
 
 /**
  * @brief   Configuration parameters for DHT devices
  */
 typedef struct {
     gpio_t pin;             /**< GPIO pin of the device's data pin */
+    dht_type_t type;        /**< type of the DHT device */
     gpio_mode_t in_mode;    /**< input pin configuration, with or without pull
                              *   resistor */
 } dht_params_t;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR reintroduces the specific handling for DHT22 that was mistakenly removed by #16934 (drivers/dht: correct interpreting raw values).

The improvement in value handling for DHT11 has been preserved, except for the detection of negative values, which now occurs on the 4th byte for DHT11 instead of the 3rd byte for DHT22.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
With a DHT21 using tests/drivers/dht:
```
2023-05-27 18:25:35,220 # DHT values - temp: 24.9°C - relative humidity: 78.7%
2023-05-27 18:25:37,245 # DHT values - temp: 25.1°C - relative humidity: 78.3%
2023-05-27 18:25:39,270 # DHT values - temp: 25.2°C - relative humidity: 78.0%
2023-05-27 18:25:41,294 # DHT values - temp: 25.4°C - relative humidity: 77.6%
2023-05-27 18:25:43,319 # DHT values - temp: 25.5°C - relative humidity: 77.3%
2023-05-27 18:25:45,343 # DHT values - temp: 25.6°C - relative humidity: 76.9%
2023-05-27 18:25:47,368 # DHT values - temp: 25.7°C - relative humidity: 76.6%
2023-05-27 18:25:49,392 # DHT values - temp: 25.9°C - relative humidity: 76.3%
2023-05-27 18:25:51,417 # DHT values - temp: 26.0°C - relative humidity: 76.3%
2023-05-27 18:25:53,442 # DHT values - temp: 26.1°C - relative humidity: 75.9%
2023-05-27 18:25:55,467 # DHT values - temp: 26.3°C - relative humidity: 75.6%
2023-05-27 18:25:57,491 # DHT values - temp: 26.4°C - relative humidity: 75.3%
2023-05-27 18:25:59,516 # DHT values - temp: 26.6°C - relative humidity: 75.0%
2023-05-27 18:26:01,541 # DHT values - temp: 26.7°C - relative humidity: 74.6%
2023-05-27 18:26:03,566 # DHT values - temp: 26.8°C - relative humidity: 74.2%
2023-05-27 18:26:05,590 # DHT values - temp: 26.9°C - relative humidity: 73.8%
2023-05-27 18:26:07,615 # DHT values - temp: 27.0°C - relative humidity: 74.0%
```
I don't have a DHT11 to test with.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Reversal of #16934 regression
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
