### PR TITLE
boards/nucleo-l432k: provide three periph_timer instances

### DIFF
--- a/boards/common/stm32/include/cfg_timer_tim2_tim15_tim16.h
+++ b/boards/common/stm32/include/cfg_timer_tim2_tim15_tim16.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Common configuration for STM32 Timer peripheral based on TIM2,
+ *              TIM15, and TIM16
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef CFG_TIMER_TIM2_TIM15_TIM16_H
+#define CFG_TIMER_TIM2_TIM15_TIM16_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Please note: This likely needs some generalization for use in STM32 families
+ * other than L4. */
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev            = TIM2,
+        .max            = 0xffffffff,
+        .rcc_mask       = RCC_APB1ENR1_TIM2EN,
+        .bus            = APB1,
+        .irqn           = TIM2_IRQn
+    },
+    {
+        .dev            = TIM15,
+        .max            = 0x0000ffff,
+        .rcc_mask       = RCC_APB2ENR_TIM15EN,
+        .bus            = APB2,
+        .irqn           = TIM1_BRK_TIM15_IRQn,
+        .channel_numof  = 2,
+    },
+    {
+        .dev            = TIM16,
+        .max            = 0x0000ffff,
+        .rcc_mask       = RCC_APB2ENR_TIM16EN,
+        .bus            = APB2,
+        .irqn           = TIM1_UP_TIM16_IRQn,
+        .channel_numof  = 1,
+    },
+};
+
+#define TIMER_0_ISR         isr_tim2            /**< IRQ of timer at idx 0 */
+#define TIMER_1_ISR         isr_tim1_brk_tim15  /**< IRQ of timer at idx 1 */
+#define TIMER_2_ISR         isr_tim1_up_tim16   /**< IRQ of timer at idx 2 */
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_TIMER_TIM2_TIM15_TIM16_H */
+/** @} */

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -30,7 +30,7 @@
 #include "clk_conf.h"
 #include "cfg_i2c1_pb6_pb7.h"
 #include "cfg_rtt_default.h"
-#include "cfg_timer_tim2.h"
+#include "cfg_timer_tim2_tim15_tim16.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32/include/periph/cpu_timer.h
+++ b/cpu/stm32/include/periph/cpu_timer.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   All STM timers have 4 capture-compare channels
+ * @brief   All STM timers have at most 4 capture-compare channels
  */
 #define TIMER_CHANNEL_NUMOF (4U)
 
@@ -53,6 +53,8 @@ typedef struct {
     uint32_t rcc_mask;      /**< corresponding bit in the RCC register */
     uint8_t bus;            /**< APBx bus the timer is clock from */
     uint8_t irqn;           /**< global IRQ channel */
+    uint8_t channel_numof;  /**< number of channels, 0 is alias for
+                                 @ref TIMER_CHANNEL_NUMOF */
 } timer_conf_t;
 
 #ifdef __cplusplus

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -36,6 +36,21 @@ static inline TIM_TypeDef *dev(tim_t tim)
     return timer_config[tim].dev;
 }
 
+/**
+ * @brief   Get the number of channels of the timer device
+ */
+static unsigned channel_numof(tim_t tim)
+{
+    if (timer_config[tim].channel_numof) {
+        return timer_config[tim].channel_numof;
+    }
+
+    /* backwards compatibility with older periph_conf.h files when all STM32
+     * had exactly 4 channels */
+    return TIMER_CHANNEL_NUMOF;
+}
+
+
 #ifdef MODULE_PERIPH_TIMER_PERIODIC
 
 /**
@@ -121,7 +136,7 @@ int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
+    if ((unsigned)channel >= channel_numof(tim)) {
         return -1;
     }
 
@@ -150,7 +165,7 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
 {
     unsigned value = (dev(tim)->CNT + timeout) & timer_config[tim].max;
 
-    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
+    if ((unsigned)channel >= channel_numof(tim)) {
         return -1;
     }
 
@@ -188,7 +203,7 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
 #ifdef MODULE_PERIPH_TIMER_PERIODIC
 int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags)
 {
-    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
+    if ((unsigned)channel >= channel_numof(tim)) {
         return -1;
     }
 
@@ -227,7 +242,7 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
+    if ((unsigned)channel >= channel_numof(tim)) {
         return -1;
     }
 


### PR DESCRIPTION
### Contribution description

- `cpu/stm32/periph_timer`: Generalize to also work with timers that do not have 4 channels
- `boards/common/stm32`: Add timer config for three timers based on TIM2, TIM15, and TIM16 (the three general-purpose timers of the STM32L4)
- `boards/nucleo-l432kc`: Make use of the new timer config
<!-- bors cut here -->

### Testing procedure

`make BOARD=nucleo-l432kc -C tests/periph/timer flash test`

```
[...]
READY
s
START
main(): This is RIOT! (Version: 2023.07-devel-510-ge690e-stm32_cfg_timer_tim2_tim15_tim16)

Test for peripheral TIMERs

Available timers: 3

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: set channel 1 to 10000
TIMER_0: set channel 2 to 15000
TIMER_0: set channel 3 to 20000
TIMER_0: starting
TIMER_0: channel 0 fired at SW count    24996 - init:    24996
TIMER_0: channel 1 fired at SW count    49983 - diff:    24987
TIMER_0: channel 2 fired at SW count    74972 - diff:    24989
TIMER_0: channel 3 fired at SW count    99961 - diff:    24989

Testing TIMER_1:
TIMER_1: initialization successful
TIMER_1: stopped
TIMER_1: set channel 0 to 5000
TIMER_1: set channel 1 to 10000
TIMER_1: starting
TIMER_1: channel 0 fired at SW count    24996 - init:    24996
TIMER_1: channel 1 fired at SW count    49984 - diff:    24988

Testing TIMER_2:
TIMER_2: initialization successful
TIMER_2: stopped
TIMER_2: set channel 0 to 5000
TIMER_2: starting
TIMER_2: channel 0 fired at SW count    24996 - init:    24996

TEST SUCCEEDED

make: Leaving directory '/home/maribu/Repos/software/RIOT/stm32_cfg_timer_tim2_tim15_tim16/tests/periph/timer'
```

### Issues/PRs references

None