### PR TITLE
sys/string_utils: add memchk()

### DIFF
--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -91,6 +91,18 @@ static inline void explicit_bzero(void *dest, size_t n_bytes)
  */
 ssize_t strscpy(char *dest, const char *src, size_t count);
 
+/**
+ * @brief   Check if the entire buffer is filled with the same byte.
+ *
+ * @param[in]   data    The buffer to probe
+ * @param[in]   c       The byte to check of
+ * @param[in]   len     Size of the buffer
+ *
+ * @return NULL if the entire buffer is filled with @p c
+ * @return pointer to the first non-matching byte
+ */
+const void *memchk(const void *data, uint8_t c, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    sys_string_utils    Utility functions that are missing in
- *                                  `string.h`
+ * @defgroup    sys_string_utils    Utility functions that are missing in `string.h`
  * @ingroup     sys
  *
  * This header provides utility functions that the standard C libs `string.h`

--- a/sys/libc/string.c
+++ b/sys/libc/string.c
@@ -37,4 +37,17 @@ ssize_t strscpy(char *dest, const char *src, size_t count)
         return -E2BIG;
     }
 }
+
+const void *memchk(const void *data, uint8_t c, size_t len)
+{
+    const uint8_t *end = (uint8_t *)data + len;
+    for (const uint8_t *d = data; d != end; ++d) {
+        if (c != *d) {
+            return d;
+        }
+    }
+
+    return NULL;
+}
+
 /** @} */

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -30,6 +30,7 @@
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/nettype.h"
 #include "net/gnrc/pkt.h"
+#include "string_utils.h"
 
 #include "pktbuf_internal.h"
 #include "pktbuf_static.h"
@@ -60,18 +61,6 @@ static uint16_t max_byte_count = 0;
 static gnrc_pktsnip_t *_create_snip(gnrc_pktsnip_t *next, const void *data, size_t size,
                                     gnrc_nettype_t type);
 static void *_pktbuf_alloc(size_t size);
-
-static const void *mem_is_set(const void *data, uint8_t c, size_t len)
-{
-    const uint8_t *end = (uint8_t *)data + len;
-    for (const uint8_t *d = data; d != end; ++d) {
-        if (c != *d) {
-            return d;
-        }
-    }
-
-    return NULL;
-}
 
 static inline void _set_pktsnip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *next,
                                 void *data, size_t size, gnrc_nettype_t type)
@@ -440,7 +429,7 @@ static void *_pktbuf_alloc(size_t size)
 
     const void *mismatch;
     if (CONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE &&
-        (mismatch = mem_is_set(ptr + 1, CANARY, size - sizeof(_unused_t)))) {
+        (mismatch = memchk(ptr + 1, CANARY, size - sizeof(_unused_t)))) {
         printf("[%p] mismatch at offset %"PRIuPTR"/%u (ignoring %u initial bytes that were repurposed)\n",
                (void *)ptr, (uintptr_t)mismatch - (uintptr_t)ptr, (unsigned)size, (unsigned)sizeof(_unused_t));
 #ifdef MODULE_OD

--- a/tests/unittests/tests-libc/tests-libc.c
+++ b/tests/unittests/tests-libc/tests-libc.c
@@ -29,10 +29,21 @@ static void test_libc_strscpy(void)
     TEST_ASSERT_EQUAL_INT(strscpy(buffer, "empty", 0), -E2BIG);
 }
 
+static void test_libc_memchk(void)
+{
+    char buffer[32];
+    memset(buffer, 0xff, sizeof(buffer));
+    TEST_ASSERT_NULL(memchk(buffer, 0xff, sizeof(buffer)));
+
+    buffer[5] = 5;
+    TEST_ASSERT(memchk(buffer, 0xff, sizeof(buffer)) == &buffer[5]);
+}
+
 Test *tests_libc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_libc_strscpy),
+        new_TestFixture(test_libc_memchk),
     };
 
     EMB_UNIT_TESTCALLER(libc_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a function to check if all bytes in a buffer are set to a certain value.
Currently only gnrc_pktbuf_static` makes use of this, but I've used something similar in other places, often open-coded - so let's add it in a common place instead.

### Testing procedure

A new unit test has been added.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
