### PR TITLE
tests/unittests: remove old workaround for SAML1X and gcc9.X bug

### DIFF
--- a/tests/unittests/tests-core/tests-core-atomic.c
+++ b/tests/unittests/tests-core/tests-core-atomic.c
@@ -26,11 +26,6 @@ static void test_atomic_flag(void)
     TEST_ASSERT_EQUAL_INT(0, atomic_flag_test_and_set(&flag));
 }
 
-/* Prevent compiler optimization for SAML1X because of gcc internal bug */
-#ifdef CPU_CORE_CORTEX_M23
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-#endif
 /* Test atomic_fetch_add */
 static void test_atomic_inc_positive(void)
 {
@@ -72,9 +67,7 @@ static void test_atomic_inc_rollover(void)
     TEST_ASSERT_EQUAL_INT(INT_MIN + 1, atomic_fetch_add(&res, 1));
     TEST_ASSERT_EQUAL_INT(INT_MIN + 2, atomic_load(&res));
 }
-#ifdef CPU_SAML1X
-#pragma GCC pop_options
-#endif
+
 /* Test atomic_fetch_sub */
 static void test_atomic_dec_negative(void)
 {


### PR DESCRIPTION
### Contribution description
This reverts #13462, this workaround is no longer needed with newer GCC version.

### Testing procedure

Try to compile tests/unittests for `saml11-xpro` or `saml10-xpro`

### Issues/PRs references

This is a revert of #13462.
