### PR TITLE
cpu/sam0_eth: disable PHY when MAC is sleeping

### DIFF
--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -124,11 +124,17 @@ void sam0_eth_poweron(void)
 {
     _enable_clock();
     sam0_clear_rx_buffers();
+
+    /* enable PHY */
+    gpio_set(sam_gmac_config[0].rst_pin);
     _is_sleeping = false;
 }
 
 void sam0_eth_poweroff(void)
 {
+    /* disable PHY */
+    gpio_clear(sam_gmac_config[0].rst_pin);
+
     _is_sleeping = true;
     _disable_clock();
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When we put the interface to sleep, also disable the PHY. This saves 75 µA of current on the `same54-xpro` (value will differ depending on the PHY used)

 - idle         13.88 mA
 - MAC off      11.48 mA
 - MAC+PHY off  10.73 mA

### Testing procedure

```
 # put the interface to sleep
2023-05-31 14:06:56,000 - INFO # > ifconfig 5 set state sleep
2023-05-31 14:06:56,000 - INFO # 
2023-05-31 14:06:56,004 - INFO # success: set state of interface 5 to SLEEP

# wake up the interface again
2023-05-31 14:07:00,049 - INFO # > ifconfig 5 set state idle
2023-05-31 14:07:00,049 - INFO # 
2023-05-31 14:07:00,052 - INFO # success: set state of interface 5 to IDLE

2023-05-31 14:07:03,686 - INFO # > ping 2600::
2023-05-31 14:07:03,687 - INFO # 
2023-05-31 14:07:03,811 - INFO # 12 bytes from 2600::: icmp_seq=0 ttl=50 time=119.139 ms
2023-05-31 14:07:04,811 - INFO # 12 bytes from 2600::: icmp_seq=1 ttl=50 time=119.129 ms
2023-05-31 14:07:05,811 - INFO # 12 bytes from 2600::: icmp_seq=2 ttl=50 time=119.205 ms
2023-05-31 14:07:05,811 - INFO # 
2023-05-31 14:07:05,813 - INFO # --- 2600:: PING statistics ---
2023-05-31 14:07:05,818 - INFO # 3 packets transmitted, 3 packets received, 0% packet loss
2023-05-31 14:07:05,823 - INFO # round-trip min/avg/max = 119.129/119.157/119.205 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
