### PR TITLE
drivers/shtcx: fix assertion and shtcx_saul_info idx

### DIFF
--- a/drivers/saul/init_devs/auto_init_shtcx.c
+++ b/drivers/saul/init_devs/auto_init_shtcx.c
@@ -54,7 +54,7 @@
 
  void auto_init_shtcx(void)
  {
-     assert(SHTCX_NUM == SHTCX_INFO_NUM);
+     assert(2 * SHTCX_NUM == SHTCX_INFO_NUM);
 
      for (unsigned i = 0; i < SHTCX_NUM; i++) {
          LOG_DEBUG("[auto_init_saul] initializing shtcx #%u\n", i);
@@ -70,7 +70,7 @@
 
          /* Humidity */
          saul_entries[(i * 2)+1].dev = &(shtcx_devs[i]);
-         saul_entries[(i * 2)+1].name = shtcx_saul_info[i].name;
+         saul_entries[(i * 2)+1].name = shtcx_saul_info[(i * 2)+1].name;
          saul_entries[(i * 2)+1].driver = &shtcx_relative_humidity_saul_driver;
 
          saul_reg_add(&(saul_entries[(i * 2)]));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

In `master` the assertion triggers:

```
2023-05-31 14:30:08,173 - INFO # 4e7f
2023-05-31 14:30:08,173 - INFO # 
2023-05-31 14:30:08,173 - INFO # Context before hardfault:
2023-05-31 14:30:08,174 - INFO #    r0: 0x00000005
2023-05-31 14:30:08,174 - INFO #    r1: 0x2000544d
2023-05-31 14:30:08,175 - INFO #    r2: 0x00000005
2023-05-31 14:30:08,175 - INFO #    r3: 0x12000000
2023-05-31 14:30:08,175 - INFO #   r12: 0x00000005
2023-05-31 14:30:08,189 - INFO #    lr: 0x0000056b
2023-05-31 14:30:08,189 - INFO #    pc: 0x0000056a
2023-05-31 14:30:08,190 - INFO #   psr: 0x21000000
2023-05-31 14:30:08,190 - INFO # 
2023-05-31 14:30:08,190 - INFO # FSR/FAR:
2023-05-31 14:30:08,191 - INFO #  CFSR: 0x00000000
2023-05-31 14:30:08,191 - INFO #  HFSR: 0x80000000
2023-05-31 14:30:08,192 - INFO #  DFSR: 0x00000002
2023-05-31 14:30:08,192 - INFO #  AFSR: 0x00000000
2023-05-31 14:30:08,193 - INFO # Misc
2023-05-31 14:30:08,193 - INFO # EXC_RET: 0xfffffffd
2023-05-31 14:30:08,194 - INFO # Active thread: 1 "main"
2023-05-31 14:30:08,205 - INFO # Attempting to reconstruct state for debugging...
2023-05-31 14:30:08,206 - INFO # In GDB:
2023-05-31 14:30:08,206 - INFO #   set $pc=0x56a
2023-05-31 14:30:08,207 - INFO #   frame 0
2023-05-31 14:30:08,207 - INFO #   bt
```

With this patch, SAUL works as expected

```
2023-05-31 14:47:05,778 - INFO # > saul
2023-05-31 14:47:05,778 - INFO # 
2023-05-31 14:47:05,779 - INFO # ID	Class		Name
2023-05-31 14:47:05,780 - INFO # #0	ACT_SWITCH	LED_YEL_ETH
2023-05-31 14:47:05,780 - INFO # #1	ACT_SWITCH	LED0
2023-05-31 14:47:05,781 - INFO # #2	SENSE_TEMP	shtcx temperature
2023-05-31 14:47:05,782 - INFO # #3	SENSE_HUM	shtcx humidity

2023-05-31 14:47:11,330 - INFO # > saul read 2
2023-05-31 14:47:11,330 - INFO # 
2023-05-31 14:47:11,346 - INFO # Reading from #2 (shtcx temperature|SENSE_TEMP)
2023-05-31 14:47:11,347 - INFO # Data:	          29.80 °C

2023-05-31 14:47:13,826 - INFO # > saul read 3
2023-05-31 14:47:13,826 - INFO # 
2023-05-31 14:47:13,842 - INFO # Reading from #3 (shtcx humidity|SENSE_HUM)
2023-05-31 14:47:13,842 - INFO # Data:	          20.35 %

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
