### PR TITLE
drivers/sx127x: reduce use of floats

### DIFF
--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -117,9 +117,10 @@ void sx127x_set_syncword(sx127x_t *dev, uint8_t syncword)
 
 uint32_t sx127x_get_channel(const sx127x_t *dev)
 {
-    return (((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16) |
-            (sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8) |
-            (sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * LORA_FREQUENCY_RESOLUTION_DEFAULT;
+    uint32_t raw = ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
+                 | ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
+                 | ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFLSB));
+    return (uint64_t)raw * LORA_FREQUENCY_RESOLUTION_NANOHERTZ_DEFAULT / 1000000000U;
 }
 
 void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
@@ -129,7 +130,7 @@ void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
     /* Save current operating mode */
     dev->settings.channel = channel;
 
-    channel = (uint32_t)((double)channel / (double)LORA_FREQUENCY_RESOLUTION_DEFAULT);
+    channel = (uint64_t)channel * 1000000000U / LORA_FREQUENCY_RESOLUTION_NANOHERTZ_DEFAULT;
 
     /* Write frequency settings into chip */
     sx127x_reg_write(dev, SX127X_REG_FRFMSB, (uint8_t)((channel >> 16) & 0xFF));

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -120,11 +120,10 @@ void sx1276_rx_chain_calibration(sx127x_t *dev)
 
     /* Save context */
     reg_pa_config_init_val = sx127x_reg_read(dev, SX127X_REG_PACONFIG);
-    initial_freq = (double)(((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
-                            | ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
-                            | ((uint32_t)sx127x_reg_read(dev,
-                                                         SX127X_REG_FRFLSB))) *
-                   (double)LORA_FREQUENCY_RESOLUTION_DEFAULT;
+    initial_freq = ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
+                 | ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
+                 | ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFLSB));
+    initial_freq = (uint64_t)initial_freq * LORA_FREQUENCY_RESOLUTION_NANOHERTZ_DEFAULT / 1000000000U;
 
     /* Cut the PA just in case, RFO output, power = -1 dBm */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, 0x00);

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -35,9 +35,13 @@ extern "C" {
  * @ingroup  config
  * @{
  */
-/** @brief Frequency resolution in Hz */
-#ifndef LORA_FREQUENCY_RESOLUTION_DEFAULT
-#define LORA_FREQUENCY_RESOLUTION_DEFAULT      (61.03515625)
+#ifndef LORA_FREQUENCY_RESOLUTION_NANOHERTZ_DEFAULT
+/**
+ * @brief Frequency resolution in nano Hz
+ *
+ * This is the same as `(32 * 10^15) >> 19`
+ */
+#define LORA_FREQUENCY_RESOLUTION_NANOHERTZ_DEFAULT      61035156250
 #endif
 
 /** @brief Preamble length, same for Tx and Rx


### PR DESCRIPTION
### Contribution description

Convert the floating point arithmetic to integer arithmetic.
<!-- bors cut here -->

***Beware:*** I neither tested this nor did I try to understand the calculations.

### Testing procedure

- air time computation should yield roughly the same result
- frequency / channel computation should yield roughly the same result

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/19614