### PR TITLE
Fanalyzer fix

### DIFF
--- a/core/lib/clist.c
+++ b/core/lib/clist.c
@@ -51,7 +51,7 @@
 
 clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
 {
-    clist_node_t *p, *q, *e;
+    clist_node_t *p, *q, *e = NULL;
     int insize, psize, qsize, i;
 
     /*
@@ -77,14 +77,9 @@ clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
             /* step `insize' places along from p */
             q = p;
             psize = 0;
-            for (i = 0; i < insize; i++) {
+            for (i = 0; i < insize && q; i++) {
                 psize++;
                 q = (q->next == oldhead) ? NULL : q->next;
-                /* cppcheck-suppress nullPointer
-                 * (reason: possible bug in cppcheck 1.6x) */
-                if (!q) {
-                    break;
-                }
             }
 
             /* if q hasn't fallen off end, we have two lists to merge */
@@ -101,14 +96,14 @@ clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
                         q = NULL;
                     }
                 }
-                else if (qsize == 0 || !q) {
+                else if (p && (qsize == 0 || !q)) {
                     /* q is empty; e must come from p. */
                     e = p; p = p->next; psize--;
                     if (p == oldhead) {
                         p = NULL;
                     }
                 }
-                else if (cmp(p, q) <= 0) {
+                else if (p && cmp(p, q) <= 0) {
                     /* First element of p is lower (or same);
                      * e must come from p. */
                     e = p; p = p->next; psize--;
@@ -116,7 +111,7 @@ clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
                         p = NULL;
                     }
                 }
-                else {
+                else if (q) {
                     /* First element of q is lower; e must come from q. */
                     e = q; q = q->next; qsize--;
                     if (q == oldhead) {
@@ -138,9 +133,9 @@ clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
             p = q;
         }
 
-        /* cppcheck-suppress nullPointer
-         * (reason: tail cannot be NULL at this point, because list != NULL) */
-        tail->next = list;
+        if (tail) {
+            tail->next = list;
+        }
 
         /* If we have done only one merge, we're finished. */
         if (nmerges <= 1) { /* allow for nmerges==0, the empty list case */

--- a/core/msg.c
+++ b/core/msg.c
@@ -452,7 +452,10 @@ static unsigned _msg_avail(thread_t *thread)
 
 unsigned msg_avail_thread(kernel_pid_t pid)
 {
-    return _msg_avail(thread_get(pid));
+    thread_t *thread = thread_get(pid);
+    assert(thread);
+
+    return _msg_avail(thread);
 }
 
 unsigned msg_avail(void)
@@ -467,6 +470,8 @@ unsigned msg_queue_capacity(kernel_pid_t pid)
 
     thread_t *thread = thread_get(pid);
     int queue_cap = 0;
+
+    assert(thread);
 
     if (thread_has_msg_queue(thread)) {
         queue_cap = cib_size(&(thread->msg_queue));

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -132,11 +132,14 @@ static void _gnrc_netreg_release_exclusive(void) {
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
 #if DEVELHELP
+    thread_t *thread = thread_get(entry->target.pid);
+    assert(thread);
+
 # if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
     bool has_msg_q = (entry->type != GNRC_NETREG_TYPE_DEFAULT) ||
-                     thread_has_msg_queue(thread_get(entry->target.pid));
+                     thread_has_msg_queue(thread);
 # else
-    bool has_msg_q = thread_has_msg_queue(thread_get(entry->target.pid));
+    bool has_msg_q = thread_has_msg_queue(thread);
 # endif
 
     /* only threads with a message queue are allowed to register at gnrc */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -331,6 +331,8 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
     }
 
     LL_SORT(dodag->parents, dodag->instance->of->parent_cmp);
+
+    assert(dodag->parents);
     new_best = dodag->parents;
 
     if (new_best->rank == GNRC_RPL_INFINITE_RANK) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This fixes some warnings produced by GCC's static analyzer.
Most are pretty straightforward except for those in `clist` which is some particularly hairy code.


### Testing procedure

Add `CFLAGS += -fanalyzer` to the build


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
