### PR TITLE
sys/usb/Kconfig: Fix default PID

### DIFF
--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -64,8 +64,8 @@ config USB_PID
     hex "Product ID"
     depends on CUSTOM_USB_VID_PID
     range 0x0000 0xFFFF
-    # default 0x7002 if MODULE_RIOTBOOT_DFU
-    default 0x7001
+    # default 0x7D02 if MODULE_RIOTBOOT_DFU
+    default 0x7D01
     help
         You must provide your own PID.
 


### PR DESCRIPTION

### Contribution description

Seems like I just didn't have the correct `USB_PID` defined in the `usb-codes.inc.mk`.

It should be 0x7D01 not 0x7001.

It only shows up in nightlies since the hash would mismatch.

### Testing procedure

Simulated nightly testing with:

```
./dist/tools/compile_test/compile_like_murdock.py -j 8 -a tests/pkg/tinyusb_cdc_acm_stdio/ tests/pkg/tinyusb_cdc_msc/ tests/pkg/tinyusb_cdc_msc/ tests/sys/fido2_ctap/ tests/sys/usbus_board_reset/ tests/sys/usbus_msc/  -b arduino-zero samd21-xpro nucleo-f767zi -v
```

<details>

```
tests/pkg/tinyusb_cdc_acm_stdio/ arduino-zero                   PASS
ctests/pkg/tinyusb_cdc_acm_stdio/ nucleo-f767zi                  PASS
tests/pkg/tinyusb_cdc_acm_stdio/ samd21-xpro                    PASS
tests/pkg/tinyusb_cdc_msc/     arduino-zero                   PASS
tests/pkg/tinyusb_cdc_msc/     nucleo-f767zi                  PASS
tests/pkg/tinyusb_cdc_msc/     samd21-xpro                    PASS
tests/pkg/tinyusb_cdc_msc/     arduino-zero                   PASS
tests/pkg/tinyusb_cdc_msc/     nucleo-f767zi                  PASS
tests/pkg/tinyusb_cdc_msc/     samd21-xpro                    PASS
tests/sys/fido2_ctap/          arduino-zero                   PASS
tests/sys/fido2_ctap/          samd21-xpro                    PASS
tests/sys/usbus_board_reset/   arduino-zero                   PASS
tests/sys/usbus_board_reset/   nucleo-f767zi                  PASS
tests/sys/usbus_board_reset/   samd21-xpro                    PASS
tests/sys/usbus_msc/           arduino-zero                   PASS
tests/sys/usbus_msc/           nucleo-f767zi                  PASS
tests/sys/usbus_msc/           samd21-xpro                    PASS
```

### Issues/PRs references

Broken master in nightlies.