### PR TITLE
makefiles/toolchain/gnu.inc.mk: fix compilation

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -36,6 +36,6 @@ include $(RIOTMAKE)/tools/gdb.inc.mk
 # Data address spaces starts at zero for all supported architectures. This fixes
 # compilation at least on MSP430 and AVR.
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-ifeq ($(GCC_VERSION),12)
+ifneq (,$(filter $(GCC_VERSION),12 13))
   CFLAGS += --param=min-pagesize=0
 endif


### PR DESCRIPTION
### Contribution description

The `--param=min-pagesize=0` needed since GCC 12 is still needed with GCC 13. This time at least the message is more meaningful:

     note: source object is likely at address zero

This is something that is not expected in a userspace app, but with bare metal MCUs and often flash or memory mapped I/O starting from address zero, this warning prevents legitimate code from compiling.
<!-- bors cut here -->

### Testing procedure

With `master`:

```
$ make BOARD=olimex-msp430-h1611 -C examples/hello-world
Building application "hello-world" for "olimex-msp430-h1611" with MCU "msp430fxyz".

"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/olimex-msp430-h1611
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz/periph
/home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz/periph/gpio.c: In function 'gpio_periph_mode':
/home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz/periph/gpio.c:95:15: error: array subscript 0 is outside array bounds of 'msp_port_isr_t[0]' [-Werror=array-bounds=]
   95 |         sel = &(isrport->SEL);
      |               ^~~~~~~~~~~~~~~
cc1: note: source object is likely at address zero
cc1: note: source object is likely at address zero
cc1: all warnings being treated as errors
make[3]: *** [/home/maribu/Repos/software/RIOT/master/Makefile.base:146: /home/maribu/Repos/software/RIOT/master/examples/hello-world/bin/olimex-msp430-h1611/periph/gpio.o] Error 1
make[2]: *** [/home/maribu/Repos/software/RIOT/master/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz/periph] Error 2
make[1]: *** [/home/maribu/Repos/software/RIOT/master/Makefile.base:31: ALL--/home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz] Error 2
make: *** [/home/maribu/Repos/software/RIOT/master/examples/hello-world/../../Makefile.include:759: application_hello-world.module] Error 2
```

This PR:

```
$ make BOARD=olimex-msp430-h1611 -C examples/hello-world
Building application "hello-world" for "olimex-msp430-h1611" with MCU "msp430fxyz".

"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/olimex-msp430-h1611
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430fxyz/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
/usr/lib/gcc/msp430-elf/13.1.0/../../../../msp430-elf/bin/ld: warning: /home/maribu/Repos/software/RIOT/master/examples/hello-world/bin/olimex-msp430-h1611/hello-world.elf has a LOAD segment with RWX permissions
   text	  data	   bss	   dec	   hex	filename
   7117	   168	  1066	  8351	  209f	/home/maribu/Repos/software/RIOT/master/examples/hello-world/bin/olimex-msp430-h1611/hello-world.elf
```

### Issues/PRs references

None