### PR TITLE
boards/z1: fix broken clock configuration

### DIFF
--- a/boards/z1/include/periph_conf.h
+++ b/boards/z1/include/periph_conf.h
@@ -28,16 +28,16 @@
 extern "C" {
 #endif
 
-#define CLOCK_CORECLOCK     MHZ(8)
+#define CLOCK_CORECLOCK     msp430_fxyz_dco_freq
 
 /**
  * @brief   Clock configuration
  */
 static const msp430_fxyz_clock_params_t clock_params = {
-    .xt2_frequency = CLOCK_CORECLOCK,
+    .target_dco_frequency = MHZ(8),
     .lfxt1_frequency = 32768,
-    .main_clock_source = MAIN_CLOCK_SOURCE_XT2CLK,
-    .submain_clock_source = SUBMAIN_CLOCK_SOURCE_XT2CLK,
+    .main_clock_source = MAIN_CLOCK_SOURCE_DCOCLK,
+    .submain_clock_source = SUBMAIN_CLOCK_SOURCE_DCOCLK,
     .main_clock_divier = MAIN_CLOCK_DIVIDE_BY_1,
     .submain_clock_divier = SUBMAIN_CLOCK_DIVIDE_BY_1,
     .auxiliary_clock_divier = AUXILIARY_CLOCK_DIVIDE_BY_1,

--- a/cpu/msp430fxyz/clock.c
+++ b/cpu/msp430fxyz/clock.c
@@ -30,7 +30,13 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
+#ifdef RSEL3
+#define RSEL_MASK (RSEL0 | RSEL1 | RSEL2 | RSEL3)
+#define HAS_RSEL3 1
+#else
 #define RSEL_MASK (RSEL0 | RSEL1 | RSEL2)
+#define HAS_RSEL3 0
+#endif
 
 uint32_t msp430_fxyz_dco_freq;
 
@@ -188,7 +194,13 @@ static void calibrate_dco(void)
     uint8_t bcsctl1 = BCSCTL1 & ~(RSEL_MASK);
     uint8_t rselx = 0;
 
-    for (uint8_t iter = 0x04; iter != 0; iter >>= 1) {
+    /*
+     * Note: For MSP430F2xx (HAS_RSEL3 == 1) the bit in RSEL3 is actually
+     * ignored if an external resistor is used for the DCO. Still, setting
+     * it won't hurt */
+    const uint8_t rsel_max_bit = (HAS_RSEL3) ? BIT3 : BIT2;
+
+    for (uint8_t iter = rsel_max_bit; iter != 0; iter >>= 1) {
         BCSCTL1 = bcsctl1 | rselx | iter;
 
         /* busy wait for timer to capture */


### PR DESCRIPTION
### Contribution description

The MSP430F2xx family has on RSEL bit more than the MSP430x1xxx family. The first commit updates the clock calibration accordingly.

https://github.com/RIOT-OS/RIOT/commit/df5c319978570f90071bbc83ddf10eea5449d46d from https://github.com/RIOT-OS/RIOT/pull/19558 broke the clock configuration of the Z1 by relying on the incorrect documentation of what clock is actually used. Closely reading the convoluted clock initialization code revealed that no XT2 crystal is present (as also indicated by some comments in `board.c`), contradicting the `#define MSP430_HAS_EXTERNAL_CRYSTAL 1` in the `board.h`.

The second commit should restore behavior (but with calibrated DCO than hard coded magic numbers).
<!-- bors cut here -->

### Testing procedure

`make BOARD=z1 -C examples/default flash term`

should work again, but fail with `master`.

### Issues/PRs references

Regression introduced in https://github.com/RIOT-OS/RIOT/pull/19558