### PR TITLE
nanocoap: clean up coap_iterate_option(), make it public

### DIFF
--- a/examples/gcoap_block_server/Makefile.ci
+++ b/examples/gcoap_block_server/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -657,6 +657,21 @@ static inline void coap_hdr_set_type(coap_hdr_t *hdr, unsigned type)
 uint8_t *coap_find_option(coap_pkt_t *pkt, unsigned opt_num);
 
 /**
+ * @brief   Get pointer to an option field, can be called in a loop
+ *          if there are multiple options with the same number
+ *
+ * @param[in]   pkt     packet to work on
+ * @param[in]   opt_num the option number to search for
+ * @param[out]  opt_pos opaque, must be set to `NULL` on first call
+ * @param[out]  opt_len size of the current option data
+ *
+ * @returns     pointer to the option data
+ *              NULL if option number was not found
+ */
+uint8_t *coap_iterate_option(coap_pkt_t *pkt, unsigned opt_num,
+                             uint8_t **opt_pos, int *opt_len);
+
+/**
  * @brief   Get content type from packet
  *
  * @param[in]   pkt     packet to work on


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently we don't have a public way to iterate all options of the same type - `coap_iterate_option()` was intended to be public (it's not `static`) but was never declared in any header file.

This allows for the opportunity to clean up the API to make it more palatable for public consumption.  


### Testing procedure

The function is only used by `coap_opt_get_string()` for which we have unit tests that are still passing.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
