### PR TITLE
boards/rpi-pico: update openocd.cfg file

### DIFF
--- a/boards/rpi-pico/dist/openocd.cfg
+++ b/boards/rpi-pico/dist/openocd.cfg
@@ -1,3 +1,5 @@
-source [find target/rp2040-core0.cfg]
-$_TARGETNAME configure -rtos auto
+source [find target/rp2040.cfg]
+set USE_CORE 0
+set RESCUE 1
+$_TARGETNAME_0 configure -rtos auto
 adapter speed 4000


### PR DESCRIPTION
### Contribution description

This PR fixes the use of openOCD to flash a rpi-pico board.
Currently on master, trying to flash this board with openOCD (v12) and a CMSIS-DAP probe fails.
with this PR, it now works as expected (even debugging)
Moreover, the configuration file used by RIOT is now deprecated on openOCD v12 so changes it while we're at it.


master:
```
### Flashing Target ###
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Warn : rp2040-core0.cfg configuration file is deprecated and will be
       removed in the next release. Use following parameters instead:
          -c 'set USE_CORE 0' -f target/rp2040.cfg
Warn : Transport "swd" was already selected
adapter speed: 4000 kHz

Info : Using CMSIS-DAPv2 interface with VID:PID=0x2e8a:0x000c, serial=E46170D59B552B2C
Info : CMSIS-DAP: SWD supported
Info : CMSIS-DAP: Atomic commands supported
Info : CMSIS-DAP: Test domain timer supported
Info : CMSIS-DAP: FW Version = 2.0.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 0 TDI = 0 TDO = 0 nTRST = 0 nRESET = 0
Info : CMSIS-DAP: Interface ready
Info : clock speed 4000 kHz
Info : SWD DPIDR 0x0bc12477
Error: [rp2040.cpu] Could not find MEM-AP to control the core
Warn : target rp2040.cpu examination failed
Info : starting gdb server for rp2040.cpu on 0
Info : Listening on port 37347 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* rp2040.cpu         cortex_m   little rp2040.cpu         unknown

Error: [rp2040.cpu] Could not find MEM-AP to control the core
Error: [rp2040.cpu] Debug AP not available, reset NOT asserted!

make: *** [/home/dylan/work/RIOT/examples/blinky/../../Makefile.include:855: flash] Error 1
make: Leaving directory '/home/dylan/work/RIOT/examples/blinky'
```

with this PR:
```
### Flashing Target ###
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
adapter speed: 4000 kHz

Info : Using CMSIS-DAPv2 interface with VID:PID=0x2e8a:0x000c, serial=E46170D59B552B2C
Info : CMSIS-DAP: SWD supported
Info : CMSIS-DAP: Atomic commands supported
Info : CMSIS-DAP: Test domain timer supported
Info : CMSIS-DAP: FW Version = 2.0.0
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 0 TDI = 0 TDO = 0 nTRST = 0 nRESET = 0
Info : CMSIS-DAP: Interface ready
Info : clock speed 4000 kHz
Info : SWD DPIDR 0x0bc12477, DLPIDR 0x00000001
Info : SWD DPIDR 0x0bc12477, DLPIDR 0x10000001
Info : [rp2040.core0] Cortex-M0+ r0p1 processor detected
Info : [rp2040.core0] target has 4 breakpoints, 2 watchpoints
Info : [rp2040.core1] Cortex-M0+ r0p1 processor detected
Info : [rp2040.core1] target has 4 breakpoints, 2 watchpoints
Info : starting gdb server for rp2040.core0 on 0
Info : Listening on port 40985 for gdb connections
Info : starting gdb server for rp2040.core1 on 0
Info : Listening on port 39901 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* rp2040.core0       cortex_m   little rp2040.cpu         running
 1  rp2040.core1       cortex_m   little rp2040.cpu         running

[rp2040.core0] halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x000000ee msp: 0x20041f00
[rp2040.core1] halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x000000ee msp: 0x20041f00
Info : Found flash device 'win w25q16jv' (ID 0x001540ef)
Info : RP2040 B0 Flash Probe: 2097152 bytes @0x10000000, in 32 sectors

Info : Padding image section 2 at 0x10003190 with 112 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x10003200 .. 0x1000ffff
auto erase enabled
wrote 12800 bytes from file /home/dylan/work/RIOT/tests/leds/bin/rpi-pico/tests_leds.elf in 1.516848s (8.241 KiB/s)

verified 12688 bytes in 0.089461s (138.503 KiB/s)

shutdown command invoked
Done flashing
```

### Testing procedure

Flash a `rpi-pico` board using openOCD.

### Issues/PRs references
None.
