### PR TITLE
tools/jlink.sh: start gdb server with setsid

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -65,6 +65,8 @@
 : ${IMAGE_OFFSET:=0}
 # Allow overwriting the reset commands.
 : ${JLINK_RESET_FILE:=${RIOTTOOLS}/jlink/reset.seg}
+# The setsid command is needed so that Ctrl+C in GDB doesn't kill OpenOCD
+: ${SETSID:=setsid}
 
 # default GDB port
 _GDB_PORT=3333
@@ -239,7 +241,7 @@ do_debug() {
     test_tui
     test_dbg
     # start the J-Link GDB server
-    sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
+    ${SETSID} sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
                            -nogui \
                            -silent \
                            -device '${JLINK_DEVICE}' \


### PR DESCRIPTION
Adopted from openocd script in order to prevent killing the gdb server upon SIGINT.

Thanks to @maribu for the pointer.

### Contribution description

Prevent gdb server from being killed by SIGINT when using jlink for debugging.

### Testing procedure

Debug any arbitrary RIOT application on a board where jlink is supported as a programmer and `PROGRAMMER` is set to `jlink` by calling `make debug`. Hit Ctrl-C. The program debugging should get interrupted but can be continued via `continue`.