### PR TITLE
dist/tools/openocd: add RTT port variable

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -73,6 +73,9 @@
 #
 # term-rtt:     opens a serial terminal using RTT (Real-Time Transfer)
 #
+#               <options>
+#               RTT_PORT:       port opened for RTT connection
+#
 # @author       Hauke Peteresen <hauke.petersen@fu-berlin.de>
 # @author       Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
@@ -84,6 +87,8 @@
 : ${TELNET_PORT:=4444}
 # Default TCL port, set to 0 to disable
 : ${TCL_PORT:=6333}
+# Default RTT port
+: ${RTT_PORT:=9999}
 # Default OpenOCD command
 : ${OPENOCD:=openocd}
 # Extra board initialization commands to pass to OpenOCD
@@ -132,7 +137,7 @@
 
 # default terminal frontend
 _OPENOCD_TERMPROG=${RIOTTOOLS}/pyterm/pyterm
-_OPENOCD_TERMFLAGS="-ts 9999 ${PYTERMFLAGS}"
+_OPENOCD_TERMFLAGS="-ts ${RTT_PORT} ${PYTERMFLAGS}"
 
 #
 # Examples of alternative debugger configurations
@@ -449,7 +454,7 @@ do_term() {
             -c init \
             -c 'rtt setup '${RAM_START_ADDR}' '${RAM_LEN}' \"SEGGER RTT\"' \
             -c 'rtt start' \
-            -c 'rtt server start 9999 0' \
+            -c 'rtt server start '${RTT_PORT}' 0' \
             >/dev/null & \
             echo  \$! > $OPENOCD_PIDFILE" &
     sleep 1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

We have a test setup with multiple boards connected to a Raspberry Pi and edu-mini debug adapters, which don't support UART.
So we go with `USEMODULE+=stdio_rtt`. But obviously if all boards try to use the same RTT port (9999) at the same time, it does not work. This PR adds a variable for the RTT port in the OpenOCD script.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`export RTT_PORT=55555 && PROGRAMMER=openocd USEMODULE+=stdio_rtt BOARD=same54-xpro make -C examples/gnrc_networking flash term`

```
+ openocd -c source [find interface/cmsis-dap.cfg] -c transport select swd -f /home/fabian.huessler@ml-pa.loc/RIOT/boards/same54-xpro/dist/openocd.cfg -c tcl_port 0 -c telnet_port 0 -c gdb_port 0 -c init -c rtt setup 0x20000000 0x00040000 "SEGGER RTT" -c rtt start -c rtt server start 55555 0
Open On-Chip Debugger 0.12.0-rc3-00999-gfcb40f49b (2023-05-12-10:54)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Info : CMSIS-DAP: SWD supported
Info : CMSIS-DAP: FW Version = 03.25.01B6
Info : CMSIS-DAP: Serial# = ATML2748101800010083
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 2000 kHz
Info : SWD DPIDR 0x2ba01477
Info : [atsame5.cpu] Cortex-M4 r0p1 processor detected
Info : [atsame5.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for atsame5.cpu on 0
Info : Listening on port 38843 for gdb connections
Info : rtt: Searching for control block 'SEGGER RTT'
Info : rtt: Control block found at 0x20000238
Info : Listening on port 55555 for rtt connections
Info : Listening on port 33839 for tcl connections
Info : Listening on port 34923 for telnet connections
+ /home/fabian.huessler@ml-pa.loc/RIOT/dist/tools/pyterm/pyterm -ts localhost:55555
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2023-06-10 00:33:02,395 # Connect to localhost:55555
Info : accepting 'rtt' connection on tcp/55555
Welcome to pyterm!
Type '/exit' to exit.
2023-06-10 00:33:03,398 # NETOPT_TX_END_IRQ not implemented by driver
2023-06-10 00:33:03,399 # main(): This is RIOT! (Version: 2023.07-devel-578-gce229-merge_buildsystem_changes_for_schunk_testsetup)
2023-06-10 00:33:03,399 # RIOT network stack example application
2023-06-10 00:33:03,399 # All up, running the shell now
> ps
2023-06-10 00:33:15,112 # ps
2023-06-10 00:33:15,113 #       pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2023-06-10 00:33:15,113 #         - | isr_stack            | -        - |   - |    512 (  232) (  280) | 0x20000000 | 0x200001c8
2023-06-10 00:33:15,113 #         1 | main                 | running  Q |   7 |   1536 (  676) (  860) | 0x20000360 | 0x200006d4 
2023-06-10 00:33:15,114 #         2 | pktdump              | bl rx    _ |   6 |   1536 (  240) ( 1296) | 0x20002f8c | 0x2000349c 
2023-06-10 00:33:15,114 #         3 | ipv6                 | bl rx    _ |   4 |   1024 (  444) (  580) | 0x20000a3c | 0x20000cac 
2023-06-10 00:33:15,611 #         4 | udp  ps
``
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
