### PR TITLE
Fix Adafruit Feather nRF52840 Express board name in docs

### DIFF
--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -46,8 +46,8 @@ cd Adafruit_nRF52_Bootloader
 git submodule update --init
 git -C lib/tinyusb submodule update --init hw/mcu/nordic/nrfx/
 pip3 install --user adafruit-nrfutil
-make BOARD=feather_nrf52840_express all
-make BOARD=feather_nrf52840_express flash
+make BOARD=feather-nrf52840 all
+make BOARD=feather-nrf52840 flash
 ~~~~~~~~~~~~~
 
 [nrfjprog]: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The documentation about Adafruit Feather nRF52840 Express referenced the board as `feather_nrf52840_express`, however it seems this has changed at some point to `feather-nrf52840`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
