### PR TITLE
cpu/qn908x/periph_i2c: allow internal pull-up on SCL

### DIFF
--- a/cpu/qn908x/include/flexcomm.h
+++ b/cpu/qn908x/include/flexcomm.h
@@ -57,7 +57,7 @@ int flexcomm_init(FLEXCOMM_Type *dev, flexcom_pselid_t mode);
  * For example, the flexcomm block number of FLEXCOMM2, the pointer to the
  * FLEXCOMM_Type block is 2. If an invalid address is passed returns -1.
  */
-int flexcomm_instance_from_addr(FLEXCOMM_Type *dev);
+int flexcomm_instance_from_addr(const FLEXCOMM_Type *dev);
 
 #ifdef __cplusplus
 }

--- a/cpu/qn908x/periph/flexcomm.c
+++ b/cpu/qn908x/periph/flexcomm.c
@@ -27,6 +27,8 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
+#define ENABLE_DEBUG 0
+
 #include "debug.h"
 
 int flexcomm_init(FLEXCOMM_Type *dev, flexcom_pselid_t mode)
@@ -59,7 +61,7 @@ int flexcomm_init(FLEXCOMM_Type *dev, flexcom_pselid_t mode)
     return flexcomm_num;
 }
 
-int flexcomm_instance_from_addr(FLEXCOMM_Type *dev)
+int flexcomm_instance_from_addr(const FLEXCOMM_Type *dev)
 {
     static const FLEXCOMM_Type *flexcomm_addrs[] = FLEXCOMM_BASE_PTRS;
 


### PR DESCRIPTION
### Contribution description

Allow the board config to specify use of external or external pull-up resistor on the SCL up. Default to the internal pull-up, two weak pull ups in parallel are preferable over no pull-up.
<!-- bors cut here -->

### Testing procedure

```
make BOARD=qn9080dk -C examples/default flash term
```

On `master`: No output at all, board hangs.

This PR:

```
2023-06-12 21:08:02,168 # main(): This is RIOT! (Version: 2023.07-devel-610-g0e09b)
2023-06-12 21:08:02,170 # Welcome to RIOT!
> saul
2023-06-12 21:08:05,285 # saul
2023-06-12 21:08:05,287 # ID	Class		Name
2023-06-12 21:08:05,289 # #0	ACT_SWITCH	LED red
2023-06-12 21:08:05,291 # #1	ACT_SWITCH	LED green
2023-06-12 21:08:05,293 # #2	ACT_SWITCH	LED blue
2023-06-12 21:08:05,295 # #3	SENSE_BTN	Button(SW1)
2023-06-12 21:08:05,297 # #4	SENSE_BTN	Button(SW2)
2023-06-12 21:08:05,299 # #5	SENSE_ACCEL	mma8x5x
> saul read 5
2023-06-12 21:08:09,560 # saul read 5
2023-06-12 21:08:09,563 # Reading from #5 (mma8x5x|SENSE_ACCEL)
2023-06-12 21:08:09,566 # Data:	[0]          67 mgₙ
2023-06-12 21:08:09,568 # 	[1]          -5 mgₙ
2023-06-12 21:08:09,570 # 	[2]        1063 mgₙ
```

(Note: The mma8x5x is connected via I2C and the driver hangs in master during the first I2C access due to bogus clock stretching due to the missing pull-up.)

### Issues/PRs references

This fixes https://github.com/RIOT-OS/RIOT/issues/19021