### PR TITLE
boards/qn9080dk: fix periph conflict

### DIFF
--- a/boards/qn9080dk/include/periph_conf.h
+++ b/boards/qn9080dk/include/periph_conf.h
@@ -68,7 +68,7 @@ static const adc_conf_t adc_config[] = {
  */
 static const i2c_conf_t i2c_config[] = {
     {
-        .dev          = I2C1,
+        .dev          = I2C0,   /* Flexcomm 1 */
         .pin_scl      = GPIO_PIN(PORT_A, 6),
         .pin_sda      = GPIO_PIN(PORT_A, 7),
         .speed        = I2C_SPEED_FAST,
@@ -105,7 +105,7 @@ static const spi_conf_t spi_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev          = USART0,
+        .dev          = USART0, /* Flexcomm 0 */
         .rx_pin       = GPIO_PIN(PORT_A, 17),
         .tx_pin       = GPIO_PIN(PORT_A, 16),
     },


### PR DESCRIPTION
### Contribution description

- Document which I2C/SPI/UART peripheral maps to which FLEXCONN IP block to easily detect potential overlap
- Switch conflict between SPI and I2C peripheral by using a different FLEXCONN for I2C
<!-- bors cut here -->

### Testing procedure

I2C should still work. In fact, https://github.com/RIOT-OS/RIOT/pull/19729 was tested with both https://github.com/RIOT-OS/RIOT/pull/19729 and this applied and the output was:

```
make BOARD=qn9080dk -C examples/default flash term
[...]
2023-06-12 21:08:02,168 # main(): This is RIOT! (Version: 2023.07-devel-610-g0e09b)
2023-06-12 21:08:02,170 # Welcome to RIOT!
> saul
2023-06-12 21:08:05,285 # saul
2023-06-12 21:08:05,287 # ID	Class		Name
2023-06-12 21:08:05,289 # #0	ACT_SWITCH	LED red
2023-06-12 21:08:05,291 # #1	ACT_SWITCH	LED green
2023-06-12 21:08:05,293 # #2	ACT_SWITCH	LED blue
2023-06-12 21:08:05,295 # #3	SENSE_BTN	Button(SW1)
2023-06-12 21:08:05,297 # #4	SENSE_BTN	Button(SW2)
2023-06-12 21:08:05,299 # #5	SENSE_ACCEL	mma8x5x
> saul read 5
2023-06-12 21:08:09,560 # saul read 5
2023-06-12 21:08:09,563 # Reading from #5 (mma8x5x|SENSE_ACCEL)
2023-06-12 21:08:09,566 # Data:	[0]          67 mgₙ
2023-06-12 21:08:09,568 # 	[1]          -5 mgₙ
2023-06-12 21:08:09,570 # 	[2]        1063 mgₙ
```

### Issues/PRs references

None