### PR TITLE
drivers/pcf857x: allow to define PCF857x_BASE_ADDR at compile time

### DIFF
--- a/drivers/include/pcf857x.h
+++ b/drivers/include/pcf857x.h
@@ -272,15 +272,21 @@ extern "C"
  * of 0 to 7.
  * @{
  */
+#ifndef PCF8575_BASE_ADDR
 #define PCF8575_BASE_ADDR   (0x20)  /**< PCF8575 I2C slave base address.
                                          Addresses are then in range from
                                          0x20 to 0x27 */
+#endif
+#ifndef PCF8574_BASE_ADDR
 #define PCF8574_BASE_ADDR   (0x20)  /**< PCF8574 I2C slave base address.
                                          Addresses are then in range from
                                          0x20 to 0x27 */
+#endif
+#ifndef PCF8574A_BASE_ADDR
 #define PCF8574A_BASE_ADDR  (0x38)  /**< PCF8574A I2C slave base address.
                                          Addresses are then in range from
                                          0x38 to 0x3f */
+#endif
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As the address is hardware-configurable, some modules are delivered with a different address. For example, the one I received has the address pins connected to Vcc, so its address is 0x3f instead of 0x38. With this modification, I can use CFLAGS += -DPCF8574A_BASE_ADDR=0x3f in the Makefile.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
