### PR TITLE
nrf5x_common: Clear I2C periph shorts

### DIFF
--- a/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
@@ -251,6 +251,9 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len,
     if (!(flags & I2C_NOSTOP)) {
         bus(dev)->SHORTS = TWIM_SHORTS_LASTRX_STOP_Msk;
     }
+    else {
+        bus(dev)->SHORTS = 0;
+    }
     /* Start transmission */
     bus(dev)->TASKS_STARTRX = 1;
 
@@ -308,6 +311,9 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
     bus(dev)->TXD.MAXCNT = (uint8_t)len;
     if (!(flags & I2C_NOSTOP)) {
         bus(dev)->SHORTS = TWIM_SHORTS_LASTTX_STOP_Msk;
+    }
+    else {
+        bus(dev)->SHORTS = 0;
     }
     bus(dev)->TASKS_STARTTX = 1;
 


### PR DESCRIPTION
### Contribution description

The I2C peripheral's shortcuts are used with the read and write register to automatically stop the I2C transaction or to continue with the next stage.

With simple I2C read and write bytes these shorts are not used, but are also not cleared by the function in all cases, causing it to use the shortcut configuration set by a previous function call. This patch ensures that the shorts are always set by the read and write functions

### Testing procedure

Should be possible to spot with a logic analyzer and the I2C periph test. Maybe the HIL test can also detect it :)

### Issues/PRs references

None