### PR TITLE
stdio_dispatch: allow to select multiple stdio methods at the same time 

### DIFF
--- a/drivers/ethos/stdio.c
+++ b/drivers/ethos/stdio.c
@@ -25,6 +25,10 @@
 #include "isrpipe.h"
 #include "stdio_uart.h"
 
+#ifndef STDIO_UART_RX_BUFSIZE
+#define STDIO_UART_RX_BUFSIZE STDIO_RX_BUFSIZE
+#endif
+
 extern ethos_t ethos;
 
 static uint8_t _rx_buf_mem[STDIO_UART_RX_BUFSIZE];

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -65,7 +65,7 @@ static void _slip_rx_cb(void *arg, uint8_t byte)
             byte = 0;
             /* fall-through */
         default:
-            isrpipe_write_one(&slipdev_stdio_isrpipe, byte);
+            isrpipe_write_one(&stdin_isrpipe, byte);
             break;
         }
         return;
@@ -79,7 +79,7 @@ static void _slip_rx_cb(void *arg, uint8_t byte)
             break;
         }
         dev->state = SLIPDEV_STATE_STDIN;
-        isrpipe_write_one(&slipdev_stdio_isrpipe, byte);
+        isrpipe_write_one(&stdin_isrpipe, byte);
         return;
 #endif
     case SLIPDEV_STATE_NONE:

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -62,8 +62,7 @@ static void _slip_rx_cb(void *arg, uint8_t byte)
             break;
         case SLIPDEV_END:
             dev->state = SLIPDEV_STATE_NONE;
-            byte = 0;
-            /* fall-through */
+            break;
         default:
             isrpipe_write_one(&stdin_isrpipe, byte);
             break;

--- a/drivers/slipdev/stdio.c
+++ b/drivers/slipdev/stdio.c
@@ -24,9 +24,6 @@
 #include "stdio_base.h"
 #include "stdio_uart.h"
 
-static uint8_t _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
-
-isrpipe_t slipdev_stdio_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
 mutex_t slipdev_mutex = MUTEX_INIT;
 
 static void _isrpipe_write(void *arg, uint8_t data)
@@ -34,36 +31,15 @@ static void _isrpipe_write(void *arg, uint8_t data)
     isrpipe_write_one(arg, (char)data);
 }
 
-void stdio_init(void)
+static void _init(void)
 {
     /* intentionally overwritten in netdev init so we have stdio before
      * the network device is initialized is initialized */
     uart_init(slipdev_params[0].uart, slipdev_params[0].baudrate,
-              _isrpipe_write, &slipdev_stdio_isrpipe);
+              _isrpipe_write, &stdin_isrpipe);
 }
 
-ssize_t stdio_read(void *buffer, size_t len)
-{
-    uint8_t *ptr = buffer;
-
-    while (len) {
-        int read = isrpipe_read(&slipdev_stdio_isrpipe, ptr, 1);
-
-        if (read == 0) {
-            continue;
-        }
-
-        if (*ptr == 0) {
-            break;
-        }
-
-        ++ptr;
-        --len;
-    }
-    return ptr - (uint8_t *)buffer;
-}
-
-ssize_t stdio_write(const void *buffer, size_t len)
+static ssize_t _write(const void *buffer, size_t len)
 {
     mutex_lock(&slipdev_mutex);
     slipdev_write_byte(slipdev_params[0].uart, SLIPDEV_STDIO_START);
@@ -72,5 +48,7 @@ ssize_t stdio_write(const void *buffer, size_t len)
     mutex_unlock(&slipdev_mutex);
     return len;
 }
+
+STDIO_PROVIDER(STDIO_SLIP, _init, NULL, _write)
 
 /** @} */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -537,6 +537,7 @@ PSEUDOMODULES += soft_uart_modecfg
 PSEUDOMODULES += stdin
 PSEUDOMODULES += stdio_available
 PSEUDOMODULES += stdio_cdc_acm
+PSEUDOMODULES += stdio_dispatch
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_nimble_debug
 PSEUDOMODULES += stdio_telnet

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -96,6 +96,7 @@ endif
 
 ifneq (,$(filter stdio_udp,$(USEMODULE)))
   USEMODULE += sock_udp
+  USEMODULE += sock_async
 endif
 
 # enable stdout buffering for modules that benefit from sending out buffers in larger chunks

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -14,9 +14,27 @@ STDIO_MODULES = \
   stdio_usb_serial_jtag \
   #
 
+STDIO_LEGACY_MODULES = \
+  ethos_stdio \
+  stdio_ethos \
+  stdio_native  # requires #19002 \
+  #
+
 # select stdio_uart if no other stdio module is slected
 ifeq (,$(filter $(STDIO_MODULES),$(USEMODULE)))
   USEMODULE += stdio_uart
+endif
+
+ifeq (,$(filter $(STDIO_LEGACY_MODULES),$(USEMODULE)))
+  USEMODULE += stdio
+endif
+
+ifneq (,$(filter stdin,$(USEMODULE)))
+  USEMODULE += isrpipe
+endif
+
+ifneq (1, $(words $(filter $(STDIO_MODULES),$(USEMODULE))))
+  USEMODULE += stdio_dispatch
 endif
 
 ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))

--- a/pkg/tinyusb/cdc_acm_stdio/cdc_acm_stdio.c
+++ b/pkg/tinyusb/cdc_acm_stdio/cdc_acm_stdio.c
@@ -44,6 +44,7 @@ static ssize_t _write(const void* buffer, size_t len)
     return (char *)buffer - start;
 }
 
+#ifdef MODULE_STDIN
 void tud_cdc_rx_cb(uint8_t itf)
 {
     (void)itf;
@@ -52,5 +53,6 @@ void tud_cdc_rx_cb(uint8_t itf)
     unsigned res = tud_cdc_read(buffer, sizeof(buffer));
     isrpipe_write(&stdin_isrpipe, buffer, res);
 }
+#endif
 
 STDIO_PROVIDER(STDIO_TINYUSB_CDC_ACM, NULL, NULL, _write)

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -27,7 +27,8 @@
 
 #include "kernel_defines.h"
 #include "fmt.h"
-#include "stdio_base.h"
+
+extern ssize_t stdio_write(const void* buffer, size_t len);
 
 static const char _hex_chars[16] = "0123456789ABCDEF";
 

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -18,6 +18,7 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
 
 #ifndef STDIO_BASE_H
@@ -26,10 +27,63 @@
 #include <unistd.h>
 
 #include "modules.h"
+#include "isrpipe.h"
+#include "xfa.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef STDIO_RX_BUFSIZE
+/**
+ * @brief Buffer size for STDIO
+ */
+#define STDIO_RX_BUFSIZE    (64)
+#endif
+
+enum {
+    STDIO_NULL,                 /**< dummy stdio */
+    STDIO_UART,                 /**< stdio via UART */
+    STDIO_RTT,                  /**< stdio via Segger RTT */
+    STDIO_SEMIHOSTING,          /**< stdio via Semihosting */
+    STDIO_USBUS_CDC_ACM,        /**< stdio via USB CDC ACM (usbus) */
+    STDIO_TINYUSB_CDC_ACM,      /**< tdio via USB CDC ACM (TinyUSB) */
+    STDIO_ESP32_SERIAL_JTAG,    /**< stdio via ESP32 debug Serial/JTAG */
+    STDIO_NIMBLE,               /**< stdio via BLE (NimBLE) */
+    STDIO_UDP,                  /**< stdio via UDP */
+    STDIO_TELNET,               /**< stdio via telnet */
+    STDIO_ETHOS,                /**< stdio via ethos (mutiplex) */
+    STDIO_SLIP,                 /*<< stdio via SLIP (mutiplex) */
+};
+
+/**
+ * @brief stdio provider struct
+ */
+typedef struct {
+    /**
+     * @brief   Initialize and attach the stdio provider
+     */
+    void (*open)(void);
+    /**
+     * @brief   Detach the stdio provider
+     */
+    void (*close)(void);
+    /**
+     * @brief   Write @p len bytes from @p src into stdout
+     *
+     * @param[in]   src     buffer to read from
+     * @param[in]   len     nr of bytes to write
+     *
+     * @return nr of bytes written
+     * @return <0 on error
+     */
+    ssize_t (*write)(const void *src, size_t len);
+} stdio_provider_t;
+
+/**
+ * @brief   isrpipe for writing stdin input to
+ */
+extern isrpipe_t stdin_isrpipe;
 
 /**
  * @brief initialize the module
@@ -60,7 +114,11 @@ int stdio_available(void);
 ssize_t stdio_read(void* buffer, size_t max_len);
 
 /**
- * @brief write @p len bytes from @p buffer into uart
+ * @brief write @p len bytes from @p buffer into STDOUT
+ *
+ * @note Depending on the stdio backend(s) used, not all bytes might
+ * be written to stdout and accounted for if multiple backends are
+ * active, as not all stdout backends will do a blocking write.
  *
  * @param[in]   buffer  buffer to read from
  * @param[in]   len     nr of bytes to write
@@ -69,6 +127,45 @@ ssize_t stdio_read(void* buffer, size_t max_len);
  * @return <0 on error
  */
 ssize_t stdio_write(const void* buffer, size_t len);
+
+/**
+ * @brief Disable stdio and detach stdio providers
+ */
+void stdio_close(void);
+
+#if defined(MODULE_STDIO_DISPATCH) || DOXYGEN
+/**
+ * @brief stdio implementation methods
+ *
+ * @param _type     stdio provider type, for identification
+ * @param _open     attach / init function
+ * @param _close    close / disable function
+ * @param _write    write function
+ */
+#define STDIO_PROVIDER(_type, _open, _close, _write)        \
+    XFA_CONST(stdio_provider_xfa, 0) stdio_provider_t stdio_ ##_type = { \
+        .open = _open,                                      \
+        .close = _close,                                    \
+        .write = _write,                                    \
+    };
+#else
+#define STDIO_PROVIDER(_type, _open, _close, _write)        \
+    void stdio_init(void) {                                 \
+        void (*f)(void) = _open;                            \
+        if (f != NULL) {                                    \
+            f();                                            \
+        }                                                   \
+    }                                                       \
+    void stdio_close(void) {                                \
+        void (*f)(void) = _close;                           \
+        if (f != NULL) {                                    \
+            f();                                            \
+        }                                                   \
+    }                                                       \
+    ssize_t stdio_write(const void* buffer, size_t len) {   \
+        return _write(buffer, len);                         \
+    }
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/include/stdio_uart.h
+++ b/sys/include/stdio_uart.h
@@ -111,13 +111,6 @@ extern "C" {
 #define STDIO_UART_BAUDRATE     (115200)
 #endif
 
-#ifndef STDIO_UART_RX_BUFSIZE
-/**
- * @brief Buffer size for STDIO
- */
-#define STDIO_UART_RX_BUFSIZE   (64)
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/application_layer/telnet/stdio_telnet.c
+++ b/sys/net/application_layer/telnet/stdio_telnet.c
@@ -26,55 +26,6 @@
 #include "board.h"
 #include "kernel_defines.h"
 #include "net/telnet.h"
-#if IS_USED(MODULE_PERIPH_UART)
-#include "stdio_uart.h"
-#include "periph/uart.h"
-#endif
-#ifdef CPU_NATIVE
-#include "native_internal.h"
-#endif
+#include "stdio_base.h"
 
-#define ENABLE_DEBUG 0
-#include "debug.h"
-
-static inline void _init_fallback(void)
-{
-#if defined(STDIO_UART_DEV) && IS_USED(MODULE_PERIPH_UART)
-    uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, NULL, NULL);
-#endif
-}
-
-static inline int _write_fallback(const void* buffer, size_t len)
-{
-#if defined(CPU_NATIVE)
-    real_write(STDOUT_FILENO, buffer, len);
-#elif defined(STDIO_UART_DEV) && IS_USED(MODULE_PERIPH_UART)
-    uart_write(STDIO_UART_DEV, buffer, len);
-#else
-    (void)buffer;
-#endif
-
-    return len;
-}
-
-void stdio_init(void)
-{
-    _init_fallback();
-}
-
-ssize_t stdio_read(void* buffer, size_t count)
-{
-    return telnet_server_read(buffer, count);
-}
-
-ssize_t stdio_write(const void* buffer, size_t len)
-{
-    int res = telnet_server_write(buffer, len);
-
-    /* write to UART if no client is connected */
-    if (res == -ENOTCONN) {
-        return _write_fallback(buffer, len);
-    }
-
-    return res;
-}
+STDIO_PROVIDER(STDIO_TELNET, NULL, telnet_server_disconnect, telnet_server_write)

--- a/sys/net/application_layer/telnet/telnet_server.c
+++ b/sys/net/application_layer/telnet/telnet_server.c
@@ -195,6 +195,17 @@ static void _process_cmd(uint8_t cmd, uint8_t option)
     }
 }
 
+static void _send_opts(void)
+{
+    if (IS_USED(MODULE_STDIO_TELNET)) {
+        /* RIOT will echo stdio, disable local echo */
+        const uint8_t opt_echo[] = {
+            TELNET_CMD_IAC, TELNET_CMD_WILL, TELNET_OPT_ECHO
+        };
+        _write_buffer(opt_echo, sizeof(opt_echo));
+    }
+}
+
 static void *telnet_thread(void *arg)
 {
     (void)arg;
@@ -210,6 +221,7 @@ static void *telnet_thread(void *arg)
 
         DEBUG("connected\n");
         _connected();
+        _send_opts();
 
         bool is_cmd = false;
         uint8_t is_option = 0;

--- a/sys/net/application_layer/telnet/telnet_server.c
+++ b/sys/net/application_layer/telnet/telnet_server.c
@@ -227,7 +227,7 @@ static void *telnet_thread(void *arg)
                 continue;
             }
 
-            if (res < 0) {
+            if (res <= 0) {
                 break;
             }
 

--- a/sys/net/application_layer/telnet/telnet_server.c
+++ b/sys/net/application_layer/telnet/telnet_server.c
@@ -123,6 +123,10 @@ static void _disconnect(void)
 
     DEBUG("telnet disconnect\n");
     telnet_cb_disconneced();
+
+    _acquire();
+    sock_tcp_disconnect(client);
+    _release();
 }
 
 static int _write_buffer(const void* buffer, size_t len)
@@ -268,7 +272,6 @@ write:
         }
 disco:
         _disconnect();
-        sock_tcp_disconnect(client);
 
         if (res < 0) {
             DEBUG("telnet: read: %s\n", strerror(res));

--- a/sys/stdio/Makefile
+++ b/sys/stdio/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/stdio/stdio.c
+++ b/sys/stdio/stdio.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_stdio
+ * @{
+ *
+ * @file
+ * @brief       STDIO common layer
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "errno.h"
+#include "isrpipe.h"
+#include "stdio_base.h"
+#include "macros/utils.h"
+#include "xfa.h"
+
+static uint8_t _rx_buf_mem[STDIO_RX_BUFSIZE];
+isrpipe_t stdin_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
+
+#ifdef MODULE_STDIO_DISPATCH
+XFA_INIT_CONST(stdio_provider_t, stdio_provider_xfa);
+
+void stdio_init(void)
+{
+    for (unsigned i = 0; i < XFA_LEN(stdio_provider_t, stdio_provider_xfa); ++i) {
+        if (stdio_provider_xfa[i].open) {
+            stdio_provider_xfa[i].open();
+        }
+    }
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    for (unsigned i = 0; i < XFA_LEN(stdio_provider_t, stdio_provider_xfa); ++i) {
+        stdio_provider_xfa[i].write(buffer, len);
+    }
+
+    return len;
+}
+
+void stdio_close(void) {
+    for (unsigned i = 0; i < XFA_LEN(stdio_provider_t, stdio_provider_xfa); ++i) {
+        if (stdio_provider_xfa[i].close) {
+            stdio_provider_xfa[i].close();
+        }
+    }
+}
+
+#define MAYBE_WEAK
+#else
+#define MAYBE_WEAK __attribute__((weak))
+#endif
+
+MAYBE_WEAK
+ssize_t stdio_read(void* buffer, size_t len)
+{
+    if (!IS_USED(MODULE_STDIN)) {
+        return -ENOTSUP;
+    }
+
+    return isrpipe_read(&stdin_isrpipe, buffer, len);
+}
+
+#if IS_USED(MODULE_STDIO_AVAILABLE)
+MAYBE_WEAK
+int stdio_available(void)
+{
+    return tsrb_avail(&stdin_isrpipe.tsrb);
+}
+#endif

--- a/sys/stdio_null/stdio_null.c
+++ b/sys/stdio_null/stdio_null.c
@@ -25,22 +25,12 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-void stdio_init(void)
-{
-}
-
-ssize_t stdio_read(void* buffer, size_t count)
-{
-    (void) buffer;
-    (void) count;
-
-    return 0;
-}
-
-ssize_t stdio_write(const void* buffer, size_t len)
+static ssize_t _write(const void* buffer, size_t len)
 {
     (void) buffer;
     (void) len;
 
     return 0;
 }
+
+STDIO_PROVIDER(STDIO_NULL, NULL, NULL, _write)

--- a/sys/stdio_rtt/stdio_rtt.c
+++ b/sys/stdio_rtt/stdio_rtt.c
@@ -80,7 +80,7 @@
 #include "mutex.h"
 #include "stdio_rtt.h"
 #include "thread.h"
-#include "ztimer.h"
+#include "ztimer/periodic.h"
 
 /* This parameter affects the bandwidth of both input and output. Decreasing
    it will significantly improve bandwidth at the cost of CPU time. */
@@ -96,10 +96,9 @@
 #define STDIO_RX_BUFSIZE    (32)
 #endif
 
-/**
- * @brief use mutex for waiting on stdin being enabled
- */
-static mutex_t _rx_mutex = MUTEX_INIT;
+#if !defined(MODULE_STDIN) && !defined(STDIO_RTT_DISABLE_STDIN)
+#define STDIO_RTT_DISABLE_STDIN 1
+#endif
 
 /**
  * @brief buffer holding stdout
@@ -112,14 +111,11 @@ static char up_buffer   [STDIO_TX_BUFSIZE];
 static char down_buffer [STDIO_RX_BUFSIZE];
 
 /**
- * @brief flag that enables stdin polling
- */
-static char stdin_enabled = 0;
-
-/**
  * @brief flag that enables stdout blocking/polling
  */
-static char blocking_stdout = 0;
+static char blocking_stdout = IS_USED(STDIO_RTT_ENABLE_BLOCKING_STDOUT);
+
+static ztimer_periodic_t stdin_timer;
 
 /**
  * @brief SEGGER's ring buffer implementation
@@ -170,6 +166,22 @@ static segger_rtt_cb_t rtt_cb = {
     {{ "Terminal", &down_buffer[0], sizeof(down_buffer), 0, 0, 0 }},
 };
 
+static int rtt_read_bytes_avail(void)
+{
+    int16_t rd_off;
+    int16_t wr_off;
+
+    rd_off = rtt_cb.down[0].rd_off;
+    wr_off = rtt_cb.down[0].wr_off;
+
+    /* Read from current read position to wrap-around of buffer, first */
+    if (rd_off > wr_off) {
+        return rtt_cb.down[0].buf_size - rd_off;
+    } else {
+        return wr_off - rd_off;
+    }
+}
+
 /**
  * @brief read bytes from the down buffer. This function does not block.
  *        The logic here is unmodified from SEGGER's reference, it is just
@@ -177,7 +189,7 @@ static segger_rtt_cb_t rtt_cb = {
  *
  * @return the number of bytes read
  */
-static int rtt_read(char* buf_ptr, uint16_t buf_size) {
+static int rtt_read(uint8_t* buf_ptr, uint16_t buf_size) {
     int16_t num_bytes_rem;
     uint16_t num_bytes_read;
     int16_t rd_off;
@@ -269,61 +281,64 @@ int rtt_write(const char* buf_ptr, unsigned num_bytes) {
     return num_bytes_written;
 }
 
-void stdio_init(void) {
-    #ifndef STDIO_RTT_DISABLE_STDIN
-    stdin_enabled = 1;
-    #endif
+static bool _rtt_read_cb(void *arg)
+{
+    int bytes = rtt_read_bytes_avail();
+    uint8_t buffer[STDIO_RX_BUFSIZE];
 
-    #ifdef STDIO_RTT_ENABLE_BLOCKING_STDOUT
-    blocking_stdout = 1;
-    #endif
+    if (bytes) {
+        bytes = rtt_read(buffer, sizeof(buffer));
+        isrpipe_write(arg, buffer, bytes);
+    }
 
-    /* the mutex should start locked */
-    mutex_lock(&_rx_mutex);
+    return true;
 }
 
-void rtt_stdio_enable_stdin(void) {
-    stdin_enabled = 1;
-    mutex_unlock(&_rx_mutex);
+static bool _init_done;
+static void _init(void) {
+    if (IS_USED(STDIO_RTT_DISABLE_STDIN)) {
+        return;
+    }
+    if (!thread_getpid()) {
+        /* we can't use ztimer in early init */
+        return;
+    }
+
+    ztimer_periodic_init(ZTIMER_MSEC, &stdin_timer, _rtt_read_cb, &stdin_isrpipe,
+                         STDIO_POLL_INTERVAL_MS);
+    ztimer_periodic_start(&stdin_timer);
+    _init_done = true;
+}
+
+static void _detach(void)
+{
+    if (!IS_USED(STDIO_RTT_DISABLE_STDIN)) {
+        ztimer_periodic_stop(&stdin_timer);
+    }
 }
 
 void rtt_stdio_enable_blocking_stdout(void) {
     blocking_stdout = 1;
 }
 
-/* The reason we have this strange logic is as follows:
-   If we have an RTT console, we are powered, and so don't care
-   that polling uses a lot of power. If however, we do not
-   actually have an RTT console (because we are deployed on
-   a battery somewhere) then we REALLY don't want to poll
-   especially since we are not expecting to EVER get input. */
-ssize_t stdio_read(void* buffer, size_t count) {
-    int res = rtt_read((void *)buffer, (uint16_t)count);
-    if (res == 0) {
-        if (!stdin_enabled) {
-            mutex_lock(&_rx_mutex);
-            /* We only unlock when rtt_stdio_enable_stdin is called
-               Note that we assume only one caller invoked this function */
-        }
-        uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
-        while(1) {
-            ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup,
-                                   STDIO_POLL_INTERVAL_MS);
-            res = rtt_read(buffer, count);
-            if (res > 0)
-                return res;
-        }
-    }
-    return (ssize_t)res;
-}
+static ssize_t _write(const void* in, size_t len) {
+    const char *buffer = in;
+    int written = rtt_write(buffer, len);
 
-ssize_t stdio_write(const void* in, size_t len) {
-    const char *buffer = (const char *)in;
-    int written = rtt_write(buffer, (unsigned)len);
-    uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
-    while (blocking_stdout && ((size_t)written < len)) {
-        ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL_MS);
-        written += rtt_write(&buffer[written], len-written);
+    /* we have to postpone ztimer init */
+    if (!_init_done) {
+        _init();
     }
+
+    if (blocking_stdout) {
+        uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
+        while ((size_t)written < len) {
+            ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL_MS);
+            written += rtt_write(&buffer[written], len-written);
+        }
+    }
+
     return (ssize_t)written;
 }
+
+STDIO_PROVIDER(STDIO_RTT, _init, _detach, _write)

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -26,34 +26,15 @@
 
 #include "log.h"
 #include "isrpipe.h"
+#include "stdio_base.h"
 
 #include "usb/usbus.h"
 #include "usb/usbus/cdc/acm.h"
 
 static usbus_cdcacm_device_t cdcacm;
 static uint8_t _cdc_tx_buf_mem[CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE];
-static uint8_t _cdc_rx_buf_mem[CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE];
-static isrpipe_t _cdc_stdio_isrpipe = ISRPIPE_INIT(_cdc_rx_buf_mem);
 
-void stdio_init(void)
-{
-}
-
-#if IS_USED(MODULE_STDIO_AVAILABLE)
-int stdio_available(void)
-{
-    return tsrb_avail(&_cdc_stdio_isrpipe.tsrb);
-}
-#endif
-
-ssize_t stdio_read(void* buffer, size_t len)
-{
-    (void)buffer;
-    (void)len;
-    return isrpipe_read(&_cdc_stdio_isrpipe, buffer, len);
-}
-
-ssize_t stdio_write(const void* buffer, size_t len)
+static ssize_t _write(const void* buffer, size_t len)
 {
     const char *start = buffer;
     do {
@@ -71,7 +52,7 @@ static void _cdc_acm_rx_pipe(usbus_cdcacm_device_t *cdcacm,
 {
     (void)cdcacm;
     for (size_t i = 0; i < len; i++) {
-        isrpipe_write_one(&_cdc_stdio_isrpipe, data[i]);
+        isrpipe_write_one(&stdin_isrpipe, data[i]);
     }
 }
 
@@ -80,3 +61,5 @@ void usb_cdc_acm_stdio_init(usbus_t *usbus)
     usbus_cdc_acm_init(usbus, &cdcacm, _cdc_acm_rx_pipe, NULL,
                        _cdc_tx_buf_mem, sizeof(_cdc_tx_buf_mem));
 }
+
+STDIO_PROVIDER(STDIO_USBUS_CDC_ACM, NULL, NULL, _write)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This implements the option to have multiple stdio methods active at the same time.
This can be useful to allow e.g. remote debugging while also retaining the possibility for local shell access.

To implement this, all `stdin` implementations are expected to write to a common `stdin_isrpipe`.

Two stdio providers have not been converted to the new interface yet, that means they can't be combined with a second stdio method:

 - `stdio_native`: depends on #19002
 - ~~`slipdev_stdio`: depends on #18066~~
 - `stdio_ethos`: requires a similar patch as `slipdev_stdio`

If only a single stdio method is used, the function pointer/XFA based interface degrades into the traditional in-place implementations of `stdio_init()`/`stdio_write()` to avoid introducing any overhead in the common case.


### Testing procedure

It is now possible to select multiple stdio implementations and use them all at the same time:

```
USEMODULE += stdio_cdc_acm
USEMODULE += stdio_uart
USEMODULE += stdio_udp
USEMODULE += stdio_telnet
USEMODULE += stdio_rtt
```


### Issues/PRs references

fixes #13469
