### PR TITLE
gnrc/rpl: fix incorrect addition overflow check

### DIFF
--- a/sys/net/gnrc/routing/rpl/of0.c
+++ b/sys/net/gnrc/routing/rpl/of0.c
@@ -69,7 +69,7 @@ uint16_t calc_rank(gnrc_rpl_dodag_t *dodag, uint16_t base_rank)
         add = CONFIG_GNRC_RPL_DEFAULT_MIN_HOP_RANK_INCREASE;
     }
 
-    if ((base_rank + add) < base_rank) {
+    if ((uint16_t)(base_rank + add) < base_rank) {
         return GNRC_RPL_INFINITE_RANK;
     }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Checking for overflow of integer addition by comparing against one of the arguments of the addition does not work when the result of the addition is automatically promoted to a larger type.

Fix by using an explicit cast to make sure that the result of the addition is not implicitly converted to a larger type.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
` make -C examples/gnrc_networking`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
