### PR TITLE
tests: update tests for MSP430 CPU

### DIFF
--- a/tests/drivers/mtd_flashpage/main.c
+++ b/tests/drivers/mtd_flashpage/main.c
@@ -21,7 +21,7 @@
 
 /* For MSP430 cpu's the last page holds the interrupt vector, although the api
    should not limit erasing that page, we don't want to break when testing */
-#if defined(CPU_CC430) || defined(CPU_MSP430FXYZ)
+#ifdef __MSP430__
 #define LAST_AVAILABLE_PAGE    (FLASHPAGE_NUMOF - 2)
 #else
 #define LAST_AVAILABLE_PAGE    (FLASHPAGE_NUMOF - 1)

--- a/tests/periph/flashpage/main.c
+++ b/tests/periph/flashpage/main.c
@@ -341,7 +341,7 @@ static int cmd_test_last(int argc, char **argv)
             fill = 'a';
         }
     }
-#if defined(CPU_CC430) || defined(CPU_MSP430FXYZ)
+#ifdef __MSP430__
     printf("The last page holds the ISR vector, so test page %u\n", last_free);
 #endif
     if (flashpage_write_and_verify(last_free, page_mem) != FLASHPAGE_OK) {
@@ -427,7 +427,7 @@ static int cmd_test_last_raw(int argc, char **argv)
 
     /* try to align */
     memcpy(raw_buf, "test12344321tset", 16);
-#if defined(CPU_CC430) || defined(CPU_MSP430FXYZ)
+#ifdef __MSP430__
     printf("The last page holds the ISR vector, so test page %u\n", last_free);
 #endif
 

--- a/tests/sys/senml_phydat/main.c
+++ b/tests/sys/senml_phydat/main.c
@@ -157,7 +157,7 @@ Test *tests_senml(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
 /* Don't run this test on CPUs with unpredictable rounding */
-#if !defined(__AVR__) && !defined(CPU_MSP430FXYZ)
+#if !defined(__AVR__) && !defined(__MSP430__)
         new_TestFixture(test_phydat_to_senml_float),
 #endif
         new_TestFixture(test_phydat_to_senml_decimal),


### PR DESCRIPTION
### Contribution description

Using the builtin `__MSP430__` macro is fool-proof and stable even if one would try to rename and reorganize the MSP430 cpu code.
<!-- bors cut here -->

### Testing procedure

The code the C compiler sees after the pre-processor run should not change, and hence, the binaries should not change.

### Issues/PRs references

Needed for https://github.com/RIOT-OS/RIOT/pull/19733