### PR TITLE
buildsystem: Always expose CPU_RAM_BASE & SIZE flags

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -119,3 +119,7 @@ CFLAGS += $(filter-out $(OPTIONAL_CFLAGS_BLACKLIST),$(OPTIONAL_CFLAGS))
 # accept good C practises within `extern "C" { ... }` while enforcing good C++
 # practises elsewhere. But in absence of this, we disable the warning for now.
 CXXEXFLAGS += -Wno-missing-field-initializers
+
+# Reformat the RAM region for usage within code and expose them
+CFLAGS += -DCPU_RAM_BASE=$(RAM_START_ADDR)
+CFLAGS += -DCPU_RAM_SIZE=$(shell printf "0x%x" $$(($(RAM_LEN:%K=%*1024))))

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -163,11 +163,6 @@ ifneq (,$(filter prng,$(USEMODULE)))
   include $(RIOTBASE)/sys/random/Makefile.include
 endif
 
-ifneq (,$(filter tinyusb_dfu usbus_dfu riotboot_reset,$(USEMODULE)))
-  CFLAGS += -DCPU_RAM_BASE=$(RAM_START_ADDR)
-  CFLAGS += -DCPU_RAM_SIZE=$(shell printf "0x%x" $$(($(RAM_LEN:%K=%*1024))))
-endif
-
 ifneq (,$(filter test_utils_netdev_eth_minimal,$(USEMODULE)))
   CFLAGS += -DCONFIG_NETDEV_REGISTER_SIGNAL
 endif


### PR DESCRIPTION
### Contribution description

Hello :penguin: 

This moves the definition of `CPU_RAM_BASE/SIZE` from being only available in certain situation to be always available.
Reason for change is to simplify common code in the cpu folder.

In cooperation with @benpicco 

### Testing procedure

Passing CI


### Issues/PRs references

First usage will be in the PMP driver. Although there is more code in RIOT that could be refactored to use these defines instead of hacks / hardcoded values.