### PR TITLE
gnrc/ipv6/nib: reset rs_sent counter also for not-6LN interfaces

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -141,9 +141,7 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
     gnrc_netif_acquire(netif);
 
     _init_iface_arsm(netif);
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     netif->ipv6.rs_sent = 0;
-#endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
     netif->ipv6.na_sent = 0;
     _auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
     if (_should_search_rtr(netif)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Between `netif down` and `netif up` events, the counter for router solicitations must also be reset for non-6LN interfaces.
If it is not done, router solicitations will be retransmitted the first time but at some point not anymore because [this](https://github.com/RIOT-OS/RIOT/blob/4deca3dfd7cf813f74ba81feb5befbcdfdecffce/sys/net/gnrc/network_layer/ipv6/nib/nib.c#L1487-L1492)
check fails.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Testing with `atwinc15x0`, this should be reproduceable when exiting early on `_handle_rtr_adv` to pretend that no RA was received. And shutting the interface down with `ifconfig x set state sleep` and bringing it back up again with `ifconfig x set state idle`. You would see that only one RS goes out after the interface has been sent to sleep and brought up again.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
