### PR TITLE
dist/tools/usb-serial: Fix handling of None while quoting

### DIFF
--- a/dist/tools/usb-serial/ttys.py
+++ b/dist/tools/usb-serial/ttys.py
@@ -186,7 +186,7 @@ def print_results(args, ttys):
         line = ""
         for fmt in args.format:
             item = tty[fmt]
-            if item.rfind(args.format_sep) >= 0:
+            if item is not None and item.rfind(args.format_sep) >= 0:
                 # item contains separator --> quote it
                 # using json.dumps to also escape quotation chars and other
                 # unsafe stuff


### PR DESCRIPTION
### Contribution description

This fixes:

    Traceback (most recent call last):
      File "/home/maribu/Repos/software/RIOT/master/dist/tools/usb-serial/ttys.py", line 259, in <module>
        print_ttys(sys.argv)
      File "/home/maribu/Repos/software/RIOT/master/dist/tools/usb-serial/ttys.py", line 255, in print_ttys
        print_results(args, ttys)
      File "/home/maribu/Repos/software/RIOT/master/dist/tools/usb-serial/ttys.py", line 189, in print_results
        if item.rfind(args.format_sep) >= 0:
           ^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'rfind'

Which occurs while testing whether a string requires special quoting if an attribute is None.
<!-- bors cut here -->

### Testing procedure

```
make term MOST_RECENT_PORT=1
```

with a TTL adapter that has no serial should no longer trigger above exception.

### Issues/PRs references

None