### PR TITLE
all/gnrc: fix null pointer dereference

### DIFF
--- a/examples/gnrc_networking_mac/mac.c
+++ b/examples/gnrc_networking_mac/mac.c
@@ -36,9 +36,11 @@ int mac_cmd(int argc, char **argv)
         gnrc_netif_t *netif = NULL;
         netif = gnrc_netif_iter(netif);
 
-        msg_t msg;
-        msg.type = GNRC_MAC_TYPE_GET_DUTYCYCLE;
-        msg_send(&msg, netif->pid);
+        if (netif) {
+            msg_t msg;
+            msg.type = GNRC_MAC_TYPE_GET_DUTYCYCLE;
+            msg_send(&msg, netif->pid);
+        }
 #else
         puts("MAC: radio duty-cycle unavailable.");
 #endif

--- a/examples/gnrc_networking_mac/udp.c
+++ b/examples/gnrc_networking_mac/udp.c
@@ -91,7 +91,11 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
         /* add netif header, if interface was given */
         if (netif != NULL) {
             gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
-
+            if (netif_hdr == NULL) {
+                puts("Error: unable to allocate netif header");
+                gnrc_pktbuf_release(ip);
+                return;
+            }
             gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
             ip = gnrc_pkt_prepend(ip, netif_hdr);
         }

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -51,6 +51,7 @@ static size_t _fit(const gnrc_pktsnip_t *orig_pkt)
 
     if (netif_hdr) {
         gnrc_netif_t *netif = gnrc_netif_hdr_get_netif(netif_hdr->data);
+        assert(netif != NULL);
 
         pkt_len -= netif_hdr->size;
         DEBUG("gnrc_icmpv6_error: fitting to MTU of iface %u (%u)\n",

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -44,7 +44,7 @@ void _snd_ns(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
     _nib_dr_entry_t *dr = _nib_drl_get(NULL, netif->pid);
 
     /* add ARO based on interface */
-    if ((src != NULL) && gnrc_netif_is_6ln(netif) &&
+    if ((src != NULL) && gnrc_netif_is_6ln(netif) && (dr != NULL) &&
         (_nib_onl_get_if(dr->next_hop) == (unsigned)netif->pid) &&
         ipv6_addr_equal(&dr->next_hop->ipv6, dst)) {
         eui64_t eui64;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1424,6 +1424,10 @@ static void _handle_snd_na(gnrc_pktsnip_t *pkt)
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx)
 {
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
+    if (netif == NULL) {
+        return;
+    }
+
     uint32_t now = evtimer_now_msec();
 
     gnrc_netif_acquire(netif);

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -548,6 +548,11 @@ static size_t _iphc_nhc_ipv6_decode(gnrc_pktsnip_t *sixlo, size_t offset,
             uint16_t payload_len;
             size_t tmp;
 
+            if (netif == NULL) {
+                DEBUG("6lo iphc: unable to find NETIF snip\n");
+                return 0;
+            }
+
             offset++;   /* move over NHC header */
             /* realloc size for uncompressed snip, if too small */
             if (ipv6->size < (*uncomp_hdr_len + sizeof(ipv6_hdr_t))) {

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -349,6 +349,7 @@ uint32_t _gnrc_tcp_pkt_get_seg_len(gnrc_pktsnip_t *pkt)
     uint32_t seq = 0;
     uint16_t ctl = 0;
     gnrc_pktsnip_t *snp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TCP);
+    assert(snp != NULL);
     tcp_hdr_t *hdr = (tcp_hdr_t *) snp->data;
     ctl = byteorder_ntohs(hdr->off_ctl);
     seq = _gnrc_tcp_pkt_get_pay_len(pkt);
@@ -399,6 +400,12 @@ int _gnrc_tcp_pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt,
 
     /* Extract control bits and segment length */
     snp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TCP);
+    if (snp == NULL) {
+        TCP_DEBUG_ERROR("-EINVAL: snp == NULL.");
+        TCP_DEBUG_LEAVE;
+        return -EINVAL;
+    }
+
     ctl = byteorder_ntohs(((tcp_hdr_t *) snp->data)->off_ctl);
     len = _gnrc_tcp_pkt_get_pay_len(pkt);
 
@@ -465,6 +472,12 @@ int _gnrc_tcp_pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
     }
 
     snp = gnrc_pktsnip_search_type(tcb->pkt_retransmit, GNRC_NETTYPE_TCP);
+    if (snp == NULL) {
+        TCP_DEBUG_ERROR("-EINVAL: snp == NULL.");
+        TCP_DEBUG_LEAVE;
+        return -EINVAL;
+    }
+
     hdr = (tcp_hdr_t *) snp->data;
 
     /* There must be a packet, waiting to be acknowledged. */

--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -292,6 +292,10 @@ static int _print_reply(gnrc_pktsnip_t *pkt, int corrupted, uint32_t triptime, v
     gnrc_pktsnip_t *ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
     gnrc_pktsnip_t *icmpv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_ICMPV6);
 
+    if (!ipv6 || !icmpv6) {
+        return -EINVAL;
+    }
+
     ipv6_hdr_t *ipv6_hdr = ipv6->data;
     icmpv6_echo_t *icmpv6_hdr = icmpv6->data;
 

--- a/sys/shell/cmds/gnrc_udp.c
+++ b/sys/shell/cmds/gnrc_udp.c
@@ -90,7 +90,11 @@ static void _send(const char *addr_str, const char *port_str,
         /* add netif header, if interface was given */
         if (netif != NULL) {
             gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
-
+            if (netif_hdr == NULL) {
+                printf("Error: unable to allocate netif header\n");
+                gnrc_pktbuf_release(ip);
+                return;
+            }
             gnrc_netif_hdr_set_netif(netif_hdr->data,
                                      container_of(netif, gnrc_netif_t, netif));
             ip = gnrc_pkt_prepend(ip, netif_hdr);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Check return values of following functions for null:
- gnrc_netif_iter
- gnrc_netif_hdr_build


### Testing procedure
``` bash
 make -C examples/gnrc_networking_mac/
 make -C examples/gnrc_networking
 make -C examples/telnet_server/
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
