### PR TITLE
core: fix null pointer dereference

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -322,6 +322,9 @@ int msg_reply_int(msg_t *m, msg_t *reply)
 {
     thread_t *target = thread_get_unchecked(m->sender_pid);
 
+    /* msg_reply_int() can only be used to reply to existing threads */
+    assert(target != NULL);
+
     if (target->status != STATUS_REPLY_BLOCKED) {
         DEBUG("msg_reply_int(): %" PRIkernel_pid ": Target \"%" PRIkernel_pid
               "\" not waiting for reply.", thread_getpid(),
@@ -466,6 +469,9 @@ unsigned msg_queue_capacity(kernel_pid_t pid)
           pid);
 
     thread_t *thread = thread_get(pid);
+
+    assert(thread != NULL);
+
     int queue_cap = 0;
 
     if (thread_has_msg_queue(thread)) {


### PR DESCRIPTION
Check return values of following functions for null:
  - thread_get
  - thread_get_unchecked

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
