### PR TITLE
buildsystem: only expose CPU_RAM_BASE & SIZE when known

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -121,5 +121,9 @@ CFLAGS += $(filter-out $(OPTIONAL_CFLAGS_BLACKLIST),$(OPTIONAL_CFLAGS))
 CXXEXFLAGS += -Wno-missing-field-initializers
 
 # Reformat the RAM region for usage within code and expose them
-CFLAGS += -DCPU_RAM_BASE=$(RAM_START_ADDR)
-CFLAGS += -DCPU_RAM_SIZE=$(shell printf "0x%x" $$(($(RAM_LEN:%K=%*1024))))
+ifneq (,$(RAM_START_ADDR))
+  CFLAGS += -DCPU_RAM_BASE=$(RAM_START_ADDR)
+endif
+ifneq (,$(RAM_LEN))
+  CFLAGS += -DCPU_RAM_SIZE=$(shell printf "0x%x" $$(($(RAM_LEN:%K=%*1024))))
+endif


### PR DESCRIPTION
### Contribution description

This gets rid of the following ugly warnings:

    /bin/sh: 1: arithmetic expression: expecting primary: ""
<!-- bors cut here -->

### Testing procedure

With `master`:

```
$ make BOARD=native BUILD_IN_DOCKER=1 -j -C examples/hello-world     
make: Entering directory '/home/maribu/Repos/software/RIOT/master/examples/hello-world'
Launching build container using image "docker.io/riot/riotbuild:latest".
podman run --rm --tty --userns keep-id -v '/etc/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/maribu/Repos/software/RIOT/master:/data/riotbuild/riotbase:delegated' -v '/home/maribu/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/maribu/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -v '/home/maribu/.cache/RIOT:/data/riotbuild/build:delegated' -e 'BUILD_DIR=/data/riotbuild/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'    -v '/home/maribu/Repos/software/boards/riot:/data/riotbuild/external/riot:delegated' -v '/home/maribu/Repos/software/miot-pcbs/RIOT/boards:/data/riotbuild/external/boards:delegated'  -e 'BOARD=native' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/hello-world/' 'docker.io/riot/riotbuild:latest' make 'BOARD=native'  'EXTERNAL_BOARD_DIRS=/data/riotbuild/external/riot /data/riotbuild/external/boards' -j 
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
Building application "hello-world" for "native" with MCU "native".
/bin/sh: 1: arithmetic expression: expecting primary: ""

/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/libc
"make" -C /data/riotbuild/riotbase/sys/preprocessor
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
/bin/sh: 1: arithmetic expression: expecting primary: ""
   text	  data	   bss	   dec	   hex	filename
  27684	   556	 47840	 76080	 12930	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/examples/hello-world'
```

with this PR:


```
$ make BOARD=native BUILD_IN_DOCKER=1 -j -C examples/hello-world
make: Entering directory '/home/maribu/Repos/software/RIOT/master/examples/hello-world'
Launching build container using image "docker.io/riot/riotbuild:latest".
podman run --rm --tty --userns keep-id -v '/etc/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/maribu/Repos/software/RIOT/master:/data/riotbuild/riotbase:delegated' -v '/home/maribu/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/maribu/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -v '/home/maribu/.cache/RIOT:/data/riotbuild/build:delegated' -e 'BUILD_DIR=/data/riotbuild/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'    -v '/home/maribu/Repos/software/boards/riot:/data/riotbuild/external/riot:delegated' -v '/home/maribu/Repos/software/miot-pcbs/RIOT/boards:/data/riotbuild/external/boards:delegated'  -e 'BOARD=native' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/hello-world/' 'docker.io/riot/riotbuild:latest' make 'BOARD=native'  'EXTERNAL_BOARD_DIRS=/data/riotbuild/external/riot /data/riotbuild/external/boards' -j 
Building application "hello-world" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/libc
"make" -C /data/riotbuild/riotbase/sys/preprocessor
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
   text	  data	   bss	   dec	   hex	filename
  27708	   556	 47840	 76104	 12948	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/examples/hello-world'
```

### Issues/PRs references

Bug introduced by https://github.com/RIOT-OS/RIOT/pull/19746
