### PR TITLE
Makefile.include: turn CFLAGS into a sane variable

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -61,6 +61,8 @@ DLCACHE                         ?= $(RIOTTOOLS)/dlcache/dlcache.sh
 DLCACHE_DIR                     ?= $(RIOTBASE)/.dlcache
 RIOT_VERSION_DUMMY_CODE         ?= RIOT_VERSION_NUM\(2042,5,23,0\)
 
+CFLAGS :=
+
 # include CI info such as BOARD_INSUFFICIENT_MEMORY, if existing
 -include Makefile.ci
 


### PR DESCRIPTION
### Contribution description

Variable in Makefiles are by default insane (a.k.a. recursively expended variable). However, sane variables (a.k.a. simply expended variables) are clearly better.

This assigns `CFLAGS` the empty string using a simple assignment. Subsequent use of `+=` to extend `CFLAGS` will keep it a sane. This avoids calling shell functions generating the `CPU_RAM_SIZE` macro for each and every module that is compiled.
<!-- bors cut here -->

### Testing procedure

```
make BOARD=native BUILD_IN_DOCKER=1 -j -C examples/hello-world
```

with this but without https://github.com/RIOT-OS/RIOT/pull/19761 should result in only one error message, rather than one per module.

### Issues/PRs references

Noticed during https://github.com/RIOT-OS/RIOT/pull/19761
