### PR TITLE
cpu/esp32: define RAM_START_ADDR and RAM_LEN

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -54,7 +54,7 @@ else ifeq (esp32c3,$(CPU_FAM))
   # Therefore, a part at the beginning of the RAM is not usable since it is
   # used as instruction cache via the instruction bus.
   RAM_LEN = 320K
-  RAM_START_ADDR = 0x3FC88000
+  RAM_START_ADDR = 0x3FC80000
 else
   $(error Unkwnown ESP32x SoC variant (family))
 endif

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -28,6 +28,37 @@ else
   $(error Unkwnown ESP32x SoC variant (family))
 endif
 
+# RAM configuration
+ifeq (esp32,$(CPU_FAM))
+  ifneq (,$(filter esp_idf_ble,$(USEMODULE)))
+    # If BT is used, the first 0xdb5c bytes (ca. 55 kbytes) of RAM are shared
+    # with the BT controller. Usable RAM region the starts at 0x3FFBDB5C.
+    # We reduce the usable size by 55 kByte.
+    RAM_LEN = 120K
+    RAM_START_ADDR = 0x3FFBE000
+  else
+    RAM_LEN = 176K
+    RAM_START_ADDR = 0x3FFB0000
+  endif
+else ifeq (esp32s2,$(CPU_FAM))
+  # The ESP32-S2 configuration in RIOT uses a data cache size and an
+  # instruction cache size of 8 kByte each. This means that the usable RAM
+  # starts at 0x3FFB0000 + 0x4000 and the size is reduced by 0x4000
+  RAM_LEN = 176K
+  RAM_START_ADDR = 0x3FFB4000
+else ifeq (esp32s3,$(CPU_FAM))
+  RAM_LEN = 264K
+  RAM_START_ADDR = 0x3FC88000
+else ifeq (esp32c3,$(CPU_FAM))
+  # Note: The address space is shared between the data and the instruction bus.
+  # Therefore, a part at the beginning of the RAM is not usable since it is
+  # used as instruction cache via the instruction bus.
+  RAM_LEN = 320K
+  RAM_START_ADDR = 0x3FC88000
+else
+  $(error Unkwnown ESP32x SoC variant (family))
+endif
+
 ifneq (,$(filter periph_flashpage,$(USEMODULE)))
   ifneq (,$(CONFIG_ESP_FLASHPAGE_CAPACITY_64K))
     FLASHFILE_POS = 0x20000

--- a/cpu/esp32/include/sdkconfig_esp32.h
+++ b/cpu/esp32/include/sdkconfig_esp32.h
@@ -188,7 +188,7 @@ extern "C" {
 #define CONFIG_BTDM_CTRL_PCM_POLAR_EFF                  0
 #define CONFIG_BTDM_CTRL_PINNED_TO_CORE_0               1
 #define CONFIG_BTDM_CTRL_PINNED_TO_CORE                 0
-#define CONFIG_BTDM_RESERVE_DRAM                        0xdb5c
+#define CONFIG_BTDM_RESERVE_DRAM                        0xe000 /* at least 0xdb5c, we use 56 kB */
 #define CONFIG_BTDM_SCAN_DUPL_CACHE_SIZE                200
 #define CONFIG_BTDM_SCAN_DUPL_TYPE_DEVICE               1
 #define CONFIG_BTDM_SCAN_DUPL_TYPE                      0

--- a/cpu/esp32/ld/esp32/sections.ld.in
+++ b/cpu/esp32/ld/esp32/sections.ld.in
@@ -634,3 +634,15 @@ ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
 
 ASSERT(((_heap_start - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
           "DRAM segment data does not fit.")
+
+. = ORIGIN(dram0_0_seg);
+_cpu_ram_start = ABSOLUTE(.);
+. = ORIGIN(dram0_0_seg) + LENGTH(dram0_0_seg);
+_cpu_ram_end = ABSOLUTE(.);
+
+/* ensure that RAM_START_ADDR and RAM_LEN as defined in RIOT's makefile
+ * match the parameters used in linker script */
+ASSERT((ORIGIN(dram0_0_seg) == CPU_RAM_BASE),
+       "RAM_START_ADDR does not match DRAM start address")
+ASSERT(((LENGTH(dram0_0_seg) - 0x200) == CPU_RAM_SIZE),
+       "RAM_LEN does not match DRAM size")

--- a/cpu/esp32/ld/esp32c3/sections.ld.in
+++ b/cpu/esp32/ld/esp32c3/sections.ld.in
@@ -616,3 +616,15 @@ ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
 
 ASSERT(((_heap_start - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
           "DRAM segment data does not fit.")
+
+. = ORIGIN(dram0_0_seg);
+_cpu_ram_start = ABSOLUTE(.);
+. = ORIGIN(dram0_0_seg) + LENGTH(dram0_0_seg);
+_cpu_ram_end = ABSOLUTE(.);
+
+/* ensure that RAM_START_ADDR and RAM_LEN as defined in RIOT's makefile
+ * match the parameters used in linker script */
+ASSERT((ORIGIN(dram0_0_seg) == CPU_RAM_BASE),
+       "RAM_START_ADDR does not match DRAM start address")
+ASSERT((LENGTH(dram0_0_seg) == CPU_RAM_SIZE),
+       "RAM_LEN does not match DRAM size")

--- a/cpu/esp32/ld/esp32s2/sections.ld.in
+++ b/cpu/esp32/ld/esp32s2/sections.ld.in
@@ -610,3 +610,15 @@ ASSERT(((_iram_text_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
 
 ASSERT(((_heap_start - _data_start) <= LENGTH(dram0_0_seg)),
           "DRAM segment data does not fit.")
+
+. = ORIGIN(dram0_0_seg);
+_cpu_ram_start = ABSOLUTE(.);
+. = ORIGIN(dram0_0_seg) + LENGTH(dram0_0_seg);
+_cpu_ram_end = ABSOLUTE(.);
+
+/* ensure that RAM_START_ADDR and RAM_LEN as defined in RIOT's makefile
+ * match the parameters used in linker script */
+ASSERT((ORIGIN(dram0_0_seg) == CPU_RAM_BASE),
+       "RAM_START_ADDR does not match DRAM start address")
+ASSERT((LENGTH(dram0_0_seg) == CPU_RAM_SIZE),
+       "RAM_LEN does not match DRAM size")

--- a/cpu/esp32/ld/esp32s3/sections.ld.in
+++ b/cpu/esp32/ld/esp32s3/sections.ld.in
@@ -637,3 +637,15 @@ ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
 
 ASSERT(((_heap_start - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
           "DRAM segment data does not fit.")
+
+. = ORIGIN(dram0_0_seg);
+_cpu_ram_start = ABSOLUTE(.);
+. = ORIGIN(dram0_0_seg) + LENGTH(dram0_0_seg);
+_cpu_ram_end = ABSOLUTE(.);
+
+/* ensure that RAM_START_ADDR and RAM_LEN as defined in RIOT's makefile
+ * match the parameters used in linker script */
+ASSERT((ORIGIN(dram0_0_seg) == CPU_RAM_BASE),
+       "RAM_START_ADDR does not match DRAM start address")
+ASSERT((LENGTH(dram0_0_seg) == CPU_RAM_SIZE),
+       "RAM_LEN does not match DRAM size")


### PR DESCRIPTION
### Contribution description

This PR fixes the problem
```
/bin/sh: 1: arithmetic expression: expecting primary: ""
```
for ESP32x SoCs that was introduced with PR #19746. The reason for the error message was that `RAM_LEN` was not defined for ESP32x SoCs.

The solution is a bit tricky since ESP32x SoCs use a combination of SRAMs of different sizes and with different byte/word access requirements. Additionally, several hardware components such as the instruction cache or the Bluetooth controller share the RAM so that the start address and the size that is usable may differ depending on the hardware components used and configured parameters like the cache size a.s.o.

Therefore, the DRAM region parameters as defined in the memory layout of the linker scripts are used to define `RAM_START_ADDR` and `RAM_LEN` in `cpu/esp32/Makefile.include`. Some checks have been added to the linker scripts to ensure that the same parameters are used in the linker scripts and for `RAM_LEN` and `RAM_START_ADDR`. This is to ensure that none of the parameters are changed without generating an assertion.

**Note:** Since I don't know for what other purposes than the `riotboot` module these parameters might be relevant, I'm not sure if the values represent what they are supposed to.

### Testing procedure

Green CI with full compilation

### Issues/PRs references

Fixes PR #19746