### PR TITLE
drivers/shield_w5100: add module for the W5100 Ethernet Shield

### DIFF
--- a/boards/common/arduino-atmega/include/board_common.h
+++ b/boards/common/arduino-atmega/include/board_common.h
@@ -123,18 +123,6 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @name    Configuration parameters for the W5100 driver
- * @{
- */
-#ifndef W5100_PARAM_CS
-#define W5100_PARAM_CS          (ARDUINO_PIN_10)
-#endif
-#ifndef W5100_PARAM_EVT
-#define W5100_PARAM_EVT         (ARDUINO_PIN_2)
-#endif
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/arduino-due/include/board.h
+++ b/boards/common/arduino-due/include/board.h
@@ -39,18 +39,6 @@ extern "C" {
 #define LED0_TOGGLE         ((PIOB->PIO_ODSR & PIO_PB27) ? LED0_OFF : LED0_ON)
 /** @} */
 
-/**
- * @name    Configuration parameters for the W5100 driver
- * @{
- */
-#ifndef W5100_PARAM_CS
-#define W5100_PARAM_CS          (ARDUINO_PIN_10)
-#endif
-#ifndef W5100_PARAM_EVT
-#define W5100_PARAM_EVT         (ARDUINO_PIN_2)
-#endif
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -180,6 +180,14 @@ ifneq (,$(filter servo_%,$(USEMODULE)))
   USEMODULE += servo
 endif
 
+ifneq (,$(filter shield_w5100,$(USEMODULE)))
+  FEATURES_REQUIRED += arduino_pins
+  FEATURES_REQUIRED += arduino_shield_isp
+  FEATURES_REQUIRED += arduino_shield_uno
+  FEATURES_REQUIRED += arduino_spi
+  USEMODULE += w5100
+endif
+
 ifneq (,$(filter sht1%,$(USEMODULE)))
   USEMODULE += sht1x
 endif

--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -122,3 +122,31 @@
  * @brief       Compile time configurations for different kinds of
  *              devices that do not match any other category
  */
+
+/**
+ * @defgroup    drivers_shield  Shields - hardware extension daughter board drivers
+ * @ingroup     drivers
+ * @brief       Provides drivers for hardware extension daughter boards such as
+ *              Arduino Shields
+ */
+
+/**
+ * @defgroup    drivers_shield_w5100    W5100 Ethernet Shield driver
+ * @ingroup     drivers_shield
+ * @brief       Driver for the Arduino W5100 Ethernet Shield
+ *
+ * Usage
+ * =====
+ *
+ * The driver is enabled by using the module `shield_w5100`, e.g. with:
+ *
+ * ```
+ * USEMODULE=shield_w5100 make BOARD=arduino-due -C examples/gnrc_networking
+ * ```
+ *
+ * It depends on @ref drivers_w5100 and provides nothing more than the providing
+ * the correct configuration. For this, it depends on the `arduino_pins`,
+ * `arduino_spi`, `arduino_shield_uno` and the `arduino_shield_isp` feature.
+ * It should work out of the box for any fully Arduino UNO compatible board
+ * (including the ISP header) and correct I/O mapping (`arduino_*`) features.
+ */

--- a/drivers/w5100/include/w5100_params.h
+++ b/drivers/w5100/include/w5100_params.h
@@ -21,8 +21,18 @@
 
 #include "board.h"
 
+#ifdef MODULE_SHIELD_W5100
+#include "arduino_iomap.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifdef MODULE_SHIELD_W5100
+#define W5100_PARAM_SPI         ARDUINO_SPI_ISP
+#define W5100_PARAM_CS          ARDUINO_PIN_10
+#define W5100_PARAM_EVT         ARDUINO_PIN_2
 #endif
 
 /**

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -494,6 +494,7 @@ PSEUDOMODULES += shell_commands
 ## @}
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += shell_lock_auto_locking
+PSEUDOMODULES += shield_w5100
 PSEUDOMODULES += slipdev_stdio
 PSEUDOMODULES += slipdev_l2addr
 PSEUDOMODULES += sock


### PR DESCRIPTION
### Contribution description

This module provides no more than the correct configuration parameters for the `w5100` driver using the Arduino I/O mapping features. But by doing so, it will work out of the box with every mechanically and electrically compatible board for which the Arduino I/O mapping features are implemented.
<!-- bors cut here -->

### Testing procedure

```
USEMODULE=shield_w5100 make BOARD=arduino-due -C examples/gnrc_networking flash term
```

Should just work. And it should also work e.g. for the Arduino MEGA2560 or the Arduino Zero. By adding Arduino I/O mapping features to the nRF52840DK, this should also work there.

### Issues/PRs references

Depends on https://github.com/RIOT-OS/RIOT/pull/19759