### PR TITLE
boards: Fix I2C Arduino mapping

### DIFF
--- a/boards/common/arduino-atmega/include/arduino_iomap.h
+++ b/boards/common/arduino-atmega/include/arduino_iomap.h
@@ -63,7 +63,11 @@ extern "C" {
 /**
  * @brief   The only hardware I2C on ATmegas
  */
-#define ARDUINO_I2C0            I2C_DEV(0)
+#ifndef BOARD_ARDUINO_NANO
+#define ARDUINO_I2C_UNO         I2C_DEV(0)
+#else
+#define ARDUINO_I2C_NANO        I2C_DEV(0)
+#endif
 /** @} */
 
 /**

--- a/boards/common/arduino-due/include/arduino_iomap.h
+++ b/boards/common/arduino-due/include/arduino_iomap.h
@@ -56,7 +56,7 @@ extern "C" {
 /**
  * @brief   The only configured I2C
  */
-#define ARDUINO_I2C0            I2C_DEV(0)
+#define ARDUINO_I2C_UNO         I2C_DEV(0)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

The correct macro name is `ARDUINO_I2C_UNO` for Arduino UNO compatible I2C bus location, or `ARDUINO_I2C_NANO` for Arduino Nano compatible I2C bus location. Hence, rename it from `ARDUINI_I2C0` to the correct name.
<!-- bors cut here -->

### Testing procedure

Check the documentation at https://doc.riot-os.org/iomaps.html#iomaps-mapping-i2c and confirm:

The I2C bus macros should indeed be named `ARDUINO_I2C_UNO` (when compatible with shields targeting the Arduino UNO R3) or `ARDUINO_I2C_NANO` (when compatible with shields targeting the Arduino Nano).

### Issues/PRs references

Introduced by https://github.com/RIOT-OS/RIOT/pull/19759