### PR TITLE
sys/arduino: move pseudo modules to makefiles

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -33,6 +33,8 @@ PSEUDOMODULES += base64url
 ## be advertised in any other capacity, e.g. through @ref sys_auto_init_saul).
 PSEUDOMODULES += board_software_reset
 
+PSEUDOMODULES += arduino_pwm
+PSEUDOMODULES += arduino_serial_stdio
 PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -19,6 +19,3 @@ endif
 
 # include the Arduino headers
 INCLUDES += -I$(RIOTBASE)/sys/arduino/include
-
-PSEUDOMODULES += arduino_pwm
-PSEUDOMODULES += arduino_serial_stdio


### PR DESCRIPTION
### Contribution description

This allows using the arduino_pwm feature (which is translated into a module) without the arduino module; e.g. for only using the Arduino I/O mapping but not the Arduino API.
<!-- bors cut here -->

### Testing procedure

Compilation of an app using `arduino_pwm` with a board that provides this should still work.

--> The CI will do this for us.

### Issues/PRs references

Since https://github.com/RIOT-OS/RIOT/pull/19759 decoupled the Arduino I/O mapping from the Arduino API, it is now possible to take advantage of Arduino I/O PWM mapping not only from Arduino code, but also from RIOT code. However, without this, compilation will fail as the `arduino_pwm` module is automatically pulled in even without the `arduino` module used, but only considered a pseudo module when `arduino` is used.