### PR TITLE
cpu/nrf5x_common: reset all available CC channels

### DIFF
--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -82,9 +82,9 @@ int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
     }
 
     /* reset compare state */
-    dev(tim)->EVENTS_COMPARE[0] = 0;
-    dev(tim)->EVENTS_COMPARE[1] = 0;
-    dev(tim)->EVENTS_COMPARE[2] = 0;
+    for (unsigned i = 0; i < timer_config[tim].channels; i++) {
+        dev(tim)->EVENTS_COMPARE[i] = 0;
+    }
 
     /* enable interrupts */
     NVIC_EnableIRQ(timer_config[tim].irqn);


### PR DESCRIPTION
### Contribution description

Properly reset all CC channels of a given timer at initialization (except the last one which seems to be used for capture only in the driver).
The issue with the previous code was that some CCs were not clear on some nRF52 MCUs.
For instance, nRF52840 has 4 CCs for its two first timers, then 6 CCs for all others.
nRF9160 and nRF5340 also have 6 CCs for all its timer peripherals.
Thus, loop through the reported number of channels and clear the associated register instead of hardcoding the first 3 CC channels.


### Testing procedure
CI should be enough I think.

### Issues/PRs references
None.

