### PR TITLE
cpu/nrf{52,9160}: remove duplicate sevonpend bit

### DIFF
--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -72,9 +72,6 @@ void cpu_init(void)
     /* call cortexm default initialization */
     cortexm_init();
 
-    /* enable wake up on events for __WFE CPU sleep */
-    SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
-
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     early_init();
 

--- a/cpu/nrf9160/cpu.c
+++ b/cpu/nrf9160/cpu.c
@@ -41,9 +41,6 @@ void cpu_init(void)
     /* call cortexm default initialization */
     cortexm_init();
 
-    /* enable wake up on events for __WFE CPU sleep */
-    SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
-
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     early_init();
 


### PR DESCRIPTION
### Contribution description
This PR removes duplicate calls of `SCB_SCR_SEVONPEND` bit in nRF52 and nRF9160.
This call is already done [here](https://github.com/RIOT-OS/RIOT/blob/7c320055a1d83f8fc2a9e16562a72c700bb3e01c/cpu/cortexm_common/cortexm_init.c#L60) 

### Testing procedure
Flash a nRF52 or nRF9160-based board and check that the board is still alive.


### Issues/PRs references
None. I notice this duplicate call when porting nRF53.
