### PR TITLE
cpu/avr8_common: Prepare for rework ISR

### DIFF
--- a/cpu/atmega_common/atmega_cpu.c
+++ b/cpu/atmega_common/atmega_cpu.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2017 RWTH Aachen, Josua Arndt
  *               2018 Matthew Blue
- *               2021 Gerson Fernando Budke
+ *               2021-2023 Gerson Fernando Budke
  *               2023 Hugues Larrive
  *
  * This file is subject to the terms and conditions of the GNU Lesser
@@ -30,6 +30,7 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "irq_arch.h"
 #include "panic.h"
 
 #define ENABLE_DEBUG 0
@@ -85,7 +86,7 @@ void __attribute__((weak)) avr8_clk_init(void)
  * EIFR – External Interrupt Flag Register
  * PCIFR – Pin Change Interrupt Flag Register
  */
-ISR(BADISR_vect)
+ISR(BADISR_vect, ISR_NAKED)
 {
     avr8_reset_cause();
 
@@ -109,10 +110,5 @@ ISR(BADISR_vect)
 }
 
 #if defined(BAT_LOW_vect)
-ISR(BAT_LOW_vect, ISR_BLOCK)
-{
-    avr8_enter_isr();
-    DEBUG("BAT_LOW\n");
-    avr8_exit_isr();
-}
+AVR8_ISR(BAT_LOW_vect, DEBUG, "BAT_LOW\n");
 #endif

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -2,6 +2,8 @@
  * Copyright (C) 2015 HAW Hamburg
  *               2016 INRIA
  *               2023 Hugues Larrive
+ *               2023 Gerson Fernando Budke
+
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -23,6 +25,7 @@
  * @author      Torben Petersen <petersen@ibr.cs.tu-bs.de>
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  * @author      Hugues Larrive <hugues.larrive@pm.me>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
  *
  * @}
  */
@@ -32,6 +35,7 @@
 #include <avr/interrupt.h>
 
 #include "cpu.h"
+#include "irq.h"
 #include "board.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
@@ -368,16 +372,13 @@ void gpio_irq_disable(gpio_t pin)
 
 static inline void irq_handler(uint8_t int_num)
 {
-    avr8_enter_isr();
     config[int_num].cb(config[int_num].arg);
-    avr8_exit_isr();
 }
 
 #ifdef ENABLE_PCINT
 /* inline function that is used by the PCINT ISR */
 static inline void pcint_handler(uint8_t bank, uint8_t enabled_pcints)
 {
-    avr8_enter_isr();
     /* Find right item */
     uint8_t idx = 0;
 
@@ -406,89 +407,50 @@ static inline void pcint_handler(uint8_t bank, uint8_t enabled_pcints)
         enabled_pcints = enabled_pcints >> 1;
         idx++;
     }
-
-    avr8_exit_isr();
 }
 #ifdef MODULE_ATMEGA_PCINT0
-ISR(PCINT0_vect, ISR_BLOCK)
-{
-    pcint_handler(PCINT0_IDX, PCMSK0);
-}
+AVR8_ISR(PCINT0_vect, pcint_handler, PCINT0_IDX, PCMSK0);
 #endif /* MODULE_ATMEGA_PCINT0 */
 
 #ifdef MODULE_ATMEGA_PCINT1
-ISR(PCINT1_vect, ISR_BLOCK)
-{
-    pcint_handler(PCINT1_IDX, PCMSK1);
-}
+AVR8_ISR(PCINT1_vect, pcint_handler, PCINT1_IDX, PCMSK1);
 #endif  /* MODULE_ATMEGA_PCINT1 */
 
 #ifdef MODULE_ATMEGA_PCINT2
-ISR(PCINT2_vect, ISR_BLOCK)
-{
-    pcint_handler(PCINT2_IDX, PCMSK2);
-}
+AVR8_ISR(PCINT2_vect, pcint_handler, PCINT2_IDX, PCMSK2);
 #endif  /* MODULE_ATMEGA_PCINT2 */
 
 #ifdef MODULE_ATMEGA_PCINT3
-ISR(PCINT3_vect, ISR_BLOCK)
-{
-    pcint_handler(PCINT3_IDX, PCMSK3);
-}
+AVR8_ISR(PCINT3_vect, pcint_handler, PCINT3_IDX, PCMSK3);
 #endif  /* MODULE_ATMEGA_PCINT3 */
 
 #endif  /* ENABLE_PCINT */
 
-ISR(INT0_vect, ISR_BLOCK)
-{
-    irq_handler(0); /**< predefined interrupt pin */
-}
-
-ISR(INT1_vect, ISR_BLOCK)
-{
-    irq_handler(1); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT0_vect, irq_handler, 0); /**< predefined interrupt pin */
+AVR8_ISR(INT1_vect, irq_handler, 1); /**< predefined interrupt pin */
 
 #if defined(INT2_vect)
-ISR(INT2_vect, ISR_BLOCK)
-{
-    irq_handler(2); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT2_vect, irq_handler, 2); /**< predefined interrupt pin */
 #endif
 
 #if defined(INT3_vect)
-ISR(INT3_vect, ISR_BLOCK)
-{
-    irq_handler(3); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT3_vect, irq_handler, 3); /**< predefined interrupt pin */
 #endif
 
 #if defined(INT4_vect)
-ISR(INT4_vect, ISR_BLOCK)
-{
-    irq_handler(4); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT4_vect, irq_handler, 4); /**< predefined interrupt pin */
 #endif
 
 #if defined(INT5_vect)
-ISR(INT5_vect, ISR_BLOCK)
-{
-    irq_handler(5); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT5_vect, irq_handler, 5); /**< predefined interrupt pin */
 #endif
 
 #if defined(INT6_vect)
-ISR(INT6_vect, ISR_BLOCK)
-{
-    irq_handler(6); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT6_vect, irq_handler, 6); /**< predefined interrupt pin */
 #endif
 
 #if defined(INT7_vect)
-ISR(INT7_vect, ISR_BLOCK)
-{
-    irq_handler(7); /**< predefined interrupt pin */
-}
+AVR8_ISR(INT7_vect, irq_handler, 7); /**< predefined interrupt pin */
 #endif
 
 #endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/atmega_common/periph/gpio_ll_irq.c
+++ b/cpu/atmega_common/periph/gpio_ll_irq.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2015 HAW Hamburg
  *               2016 INRIA
  *               2022 Otto-von-Guericke-Universität Magdeburg
+ *               2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -22,6 +23,7 @@
  * @author      Robert Hartung <hartung@ibr.cs.tu-bs.de>
  * @author      Torben Petersen <petersen@ibr.cs.tu-bs.de>
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
  *
  * @}
  */
@@ -117,63 +119,37 @@ int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig,
 
 static void isr_exti(uint8_t exti)
 {
-    avr8_enter_isr();
     isr_ctx[exti].cb(isr_ctx[exti].arg);
-    avr8_exit_isr();
 }
 
 #ifdef INT0_vect
-ISR(INT0_vect, ISR_BLOCK)
-{
-    isr_exti(0);
-}
+AVR8_ISR(INT0_vect, isr_exti, 0);
 #endif
 
 #ifdef INT1_vect
-ISR(INT1_vect, ISR_BLOCK)
-{
-    isr_exti(1);
-}
+AVR8_ISR(INT1_vect, isr_exti, 1);
 #endif
 
 #ifdef INT2_vect
-ISR(INT2_vect, ISR_BLOCK)
-{
-    isr_exti(2);
-}
+AVR8_ISR(INT2_vect, isr_exti, 2);
 #endif
 
 #ifdef INT3_vect
-ISR(INT3_vect, ISR_BLOCK)
-{
-    isr_exti(3);
-}
+AVR8_ISR(INT3_vect, isr_exti, 3);
 #endif
 
 #ifdef INT4_vect
-ISR(INT4_vect, ISR_BLOCK)
-{
-    isr_exti(4);
-}
+AVR8_ISR(INT4_vect, isr_exti, 4);
 #endif
 
 #ifdef INT5_vect
-ISR(INT5_vect, ISR_BLOCK)
-{
-    isr_exti(5);
-}
+AVR8_ISR(INT5_vect, isr_exti, 5);
 #endif
 
 #ifdef INT6_vect
-ISR(INT6_vect, ISR_BLOCK)
-{
-    isr_exti(6);
-}
+AVR8_ISR(INT6_vect, isr_exti, 6);
 #endif
 
 #ifdef INT7_vect
-ISR(INT7_vect, ISR_BLOCK)
-{
-    isr_exti(7);
-}
+AVR8_ISR(INT7_vect, isr_exti, 7);
 #endif

--- a/cpu/atmega_common/periph/rtc.c
+++ b/cpu/atmega_common/periph/rtc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Benjamin Valentin
+ *               2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -17,10 +18,12 @@
  *              time across reboots or deep sleep.
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
  *
  * @}
  */
 
+#include "irq.h"
 #include "periph/rtc.h"
 
 /* In .noinit so we don't reset the counter on reboot */
@@ -31,10 +34,8 @@ static rtc_alarm_cb_t alarm_cb;
 static void *alarm_cb_arg;
 
 /* will be called every second */
-ISR(TIMER2_OVF_vect)
+static inline void tmr2_ovf_handler(void)
 {
-    avr8_enter_isr();
-
     if (++tm_now.tm_sec > 59) {
         rtc_tm_normalize(&tm_now);
     }
@@ -42,9 +43,8 @@ ISR(TIMER2_OVF_vect)
     if (alarm_cb && rtc_tm_compare(&tm_now, &tm_alarm) == 0) {
         alarm_cb(alarm_cb_arg);
     }
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TIMER2_OVF_vect, tmr2_ovf_handler);
 
 void rtc_init(void)
 {

--- a/cpu/atmega_common/periph/rtt.c
+++ b/cpu/atmega_common/periph/rtt.c
@@ -197,15 +197,15 @@ static inline void _timer_init(void)
 static inline uint8_t _rtt_div(uint16_t freq)
 {
     switch (freq) {
-    case 32768: return 0x1;
-    case  4096: return 0x2;
-    case  1024: return 0x3;
-    case   512: return 0x4;
-    case   256: return 0x5;
-    case   128: return 0x6;
-    case    32: return 0x7;
-    default   : assert(0);
-                return 0;
+        case 32768: return 0x1;
+        case 4096:  return 0x2;
+        case 1024:  return 0x3;
+        case 512:   return 0x4;
+        case 256:   return 0x5;
+        case 128:   return 0x6;
+        case 32:    return 0x7;
+        default:    assert(0);
+                    return 0;
     }
 }
 

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2023 Hugues Larrive
+ *               2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,6 +19,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  * @author      Hugues Larrive <hugues.larrive@pm.me>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
  *
  * @}
  */
@@ -323,8 +325,6 @@ static inline void _isr(tim_t tim, int chan)
     DEBUG_TIMER_PORT |= (1 << DEBUG_TIMER_PIN);
 #endif
 
-    avr8_enter_isr();
-
     if (is_oneshot(tim, chan)) {
         timer_clear(tim, chan);
     }
@@ -333,79 +333,33 @@ static inline void _isr(tim_t tim, int chan)
 #if defined(DEBUG_TIMER_PORT)
     DEBUG_TIMER_PORT &= ~(1 << DEBUG_TIMER_PIN);
 #endif
-
-    avr8_exit_isr();
 }
 #endif
 
 #ifdef TIMER_0
-ISR(TIMER_0_ISRA, ISR_BLOCK)
-{
-    _isr(0, 0);
-}
-
-ISR(TIMER_0_ISRB, ISR_BLOCK)
-{
-    _isr(0, 1);
-}
-
+AVR8_ISR(TIMER_0_ISRA, _isr, 0, 0);
+AVR8_ISR(TIMER_0_ISRB, _isr, 0, 1);
 #ifdef TIMER_0_ISRC
-ISR(TIMER_0_ISRC, ISR_BLOCK)
-{
-    _isr(0, 2);
-}
+AVR8_ISR(TIMER_0_ISRC, _isr, 0, 2);
 #endif  /* TIMER_0_ISRC */
 #endif  /* TIMER_0 */
 
 #ifdef TIMER_1
-ISR(TIMER_1_ISRA, ISR_BLOCK)
-{
-    _isr(1, 0);
-}
-
-ISR(TIMER_1_ISRB, ISR_BLOCK)
-{
-    _isr(1, 1);
-}
-
+AVR8_ISR(TIMER_1_ISRA, _isr, 1, 0);
+AVR8_ISR(TIMER_1_ISRB, _isr, 1, 1);
 #ifdef TIMER_1_ISRC
-ISR(TIMER_1_ISRC, ISR_BLOCK)
-{
-    _isr(1, 2);
-}
-#endif  /* TIMER_1_ISRC */
+AVR8_ISR(TIMER_1_ISRC, _isr, 1, 2);
+#endif  /* TIMER_0_ISRC */
 #endif  /* TIMER_1 */
 
 #ifdef TIMER_2
-ISR(TIMER_2_ISRA, ISR_BLOCK)
-{
-    _isr(2, 0);
-}
-
-ISR(TIMER_2_ISRB, ISR_BLOCK)
-{
-    _isr(2, 1);
-}
-
-ISR(TIMER_2_ISRC, ISR_BLOCK)
-{
-    _isr(2, 2);
-}
+AVR8_ISR(TIMER_2_ISRA, _isr, 2, 0);
+AVR8_ISR(TIMER_2_ISRB, _isr, 2, 1);
+AVR8_ISR(TIMER_2_ISRC, _isr, 2, 2);
 #endif /* TIMER_2 */
 
 #ifdef TIMER_3
-ISR(TIMER_3_ISRA, ISR_BLOCK)
-{
-    _isr(2, 0);
-}
-
-ISR(TIMER_3_ISRB, ISR_BLOCK)
-{
-    _isr(2, 1);
-}
-
-ISR(TIMER_3_ISRC, ISR_BLOCK)
-{
-    _isr(2, 2);
-}
+AVR8_ISR(TIMER_3_ISRA, _isr, 3, 0);
+AVR8_ISR(TIMER_3_ISRB, _isr, 3, 1);
+AVR8_ISR(TIMER_3_ISRC, _isr, 3, 2);
 #endif /* TIMER_3 */

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2017 Thomas Perrot <thomas.perrot@tupi.fr>
  *               2023 Hugues Larrive
+ *               2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -20,6 +21,7 @@
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  * @author      Thomas Perrot <thomas.perrot@tupi.fr>
  * @author      Hugues Larrive <hugues.larrive@pm.me>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
  *
  *
  * Support static BAUD rate calculation using STDIO_UART_BAUDRATE.
@@ -192,8 +194,9 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         /* start of TX won't finish until no data in UDRn and transmit shift
            register is empty */
         unsigned long state = irq_disable();
-        avr8_state |= AVR8_STATE_FLAG_UART_TX(uart);
+        avr8_uart_tx_set_pending(uart);
         irq_restore(state);
+
         dev[uart]->DR = data[i];
     }
 }
@@ -225,7 +228,7 @@ static inline void _tx_isr_handler(int num)
 
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
-    avr8_state &= ~AVR8_STATE_FLAG_UART_TX(num);
+    avr8_uart_tx_clear_pending(num);
 
     avr8_exit_isr();
 }

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -215,76 +215,44 @@ void uart_poweroff(uart_t uart)
 
 static inline void _rx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);
-
-    avr8_exit_isr();
 }
 
 static inline void _tx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
     avr8_uart_tx_clear_pending(num);
-
-    avr8_exit_isr();
 }
 
 #ifdef UART_0_ISR
-ISR(UART_0_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(0);
-}
+AVR8_ISR(UART_0_ISR, _rx_isr_handler, 0);
 #endif /* UART_0_ISR */
 
 #ifdef UART_1_ISR
-ISR(UART_1_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(1);
-}
+AVR8_ISR(UART_1_ISR, _rx_isr_handler, 1);
 #endif /* UART_1_ISR */
 
 #ifdef UART_2_ISR
-ISR(UART_2_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(2);
-}
+AVR8_ISR(UART_2_ISR, _rx_isr_handler, 2);
 #endif /* UART_2_ISR */
 
 #ifdef UART_3_ISR
-ISR(UART_3_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(3);
-}
+AVR8_ISR(UART_3_ISR, _rx_isr_handler, 3);
 #endif /* UART_3_ISR */
 
 #ifdef UART_0_ISR_TX
-ISR(UART_0_ISR_TX, ISR_BLOCK)
-{
-    _tx_isr_handler(0);
-}
+AVR8_ISR(UART_0_ISR_TX, _tx_isr_handler, 0);
 #endif /* UART_0_ISR_TX */
 
 #ifdef UART_1_ISR_TX
-ISR(UART_1_ISR_TX, ISR_BLOCK)
-{
-    _tx_isr_handler(1);
-}
+AVR8_ISR(UART_1_ISR_TX, _tx_isr_handler, 1);
 #endif /* UART_1_ISR_TX */
 
 #ifdef UART_2_ISR_TX
-ISR(UART_2_ISR_TX, ISR_BLOCK)
-{
-    _tx_isr_handler(2);
-}
+AVR8_ISR(UART_2_ISR_TX, _tx_isr_handler, 2);
 #endif /* UART_2_ISR_TX */
 
 #ifdef UART_3_ISR_TX
-ISR(UART_3_ISR_TX, ISR_BLOCK)
-{
-    _tx_isr_handler(3);
-}
+AVR8_ISR(UART_3_ISR_TX, _tx_isr_handler, 3);
 #endif /* UART_3_ISR_TX */

--- a/cpu/atxmega/atxmega_cpu.c
+++ b/cpu/atxmega/atxmega_cpu.c
@@ -110,7 +110,7 @@ void __attribute__((weak)) avr8_clk_init(void)
  * create a catch-all for undefined but used ISRs for debugging
  * purposes.
  */
-ISR(BADISR_vect)
+ISR(BADISR_vect, ISR_NAKED)
 {
     avr8_reset_cause();
 

--- a/cpu/atxmega/periph/gpio.c
+++ b/cpu/atxmega/periph/gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (C) 2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -320,8 +320,6 @@ void gpio_write(gpio_t pin, int value)
 
 static inline void irq_handler(uint8_t port_num, uint8_t isr_vct_num)
 {
-    avr8_enter_isr();
-
     DEBUG("irq_handler port = 0x%02x, vct_num = %d \n", port_num, isr_vct_num);
 
     if (isr_vct_num) {
@@ -334,214 +332,116 @@ static inline void irq_handler(uint8_t port_num, uint8_t isr_vct_num)
     else {
         DEBUG("WARNING! irq_handler without callback\n");
     }
-
-    avr8_exit_isr();
 }
 
 #if defined(PORTA_INT0_vect)
-ISR(PORTA_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_A, 0);
-}
+AVR8_ISR(PORTA_INT0_vect, irq_handler, PORT_A, 0);
 #endif
 #if defined(PORTA_INT1_vect)
-ISR(PORTA_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_A, 1);
-}
+AVR8_ISR(PORTA_INT1_vect, irq_handler, PORT_A, 1);
 #endif
 
 #if defined(PORTB_INT0_vect)
-ISR(PORTB_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_B, 0);
-}
+AVR8_ISR(PORTB_INT0_vect, irq_handler, PORT_B, 0);
 #endif
 #if defined(PORTB_INT1_vect)
-ISR(PORTB_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_B, 1);
-}
+AVR8_ISR(PORTB_INT1_vect, irq_handler, PORT_B, 1);
 #endif
 
 #if defined(PORTC_INT0_vect)
-ISR(PORTC_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_C, 0);
-}
+AVR8_ISR(PORTC_INT0_vect, irq_handler, PORT_C, 0);
 #endif
 #if defined(PORTC_INT1_vect)
-ISR(PORTC_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_C, 1);
-}
+AVR8_ISR(PORTC_INT1_vect, irq_handler, PORT_C, 1);
 #endif
 
 #if defined(PORTD_INT0_vect)
-ISR(PORTD_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_D, 0);
-}
+AVR8_ISR(PORTD_INT0_vect, irq_handler, PORT_D, 0);
 #endif
 #if defined(PORTD_INT1_vect)
-ISR(PORTD_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_D, 1);
-}
+AVR8_ISR(PORTD_INT1_vect, irq_handler, PORT_D, 1);
 #endif
 
 #if defined(PORTE_INT0_vect)
-ISR(PORTE_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_E, 0);
-}
+AVR8_ISR(PORTE_INT0_vect, irq_handler, PORT_E, 0);
 #endif
 #if defined(PORTE_INT1_vect)
-ISR(PORTE_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_E, 1);
-}
+AVR8_ISR(PORTE_INT1_vect, irq_handler, PORT_E, 1);
 #endif
 
 #if defined(PORTF_INT0_vect)
-ISR(PORTF_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_F, 0);
-}
+AVR8_ISR(PORTF_INT0_vect, irq_handler, PORT_F, 0);
 #endif
 #if defined(PORTF_INT1_vect)
-ISR(PORTF_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_F, 1);
-}
+AVR8_ISR(PORTF_INT1_vect, irq_handler, PORT_F, 1);
 #endif
 
 #if defined(PORTG_INT0_vect)
-ISR(PORTG_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_G, 0);
-}
+AVR8_ISR(PORTG_INT0_vect, irq_handler, PORT_G, 0);
 #endif
 #if defined(PORTG_INT1_vect)
-ISR(PORTG_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_G, 1);
-}
+AVR8_ISR(PORTG_INT1_vect, irq_handler, PORT_G, 1);
 #endif
 
 #if defined(PORTH_INT0_vect)
-ISR(PORTH_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_H, 0);
-}
+AVR8_ISR(PORTH_INT0_vect, irq_handler, PORT_H, 0);
 #endif
 #if defined(PORTH_INT1_vect)
-ISR(PORTH_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_H, 1);
-}
+AVR8_ISR(PORTH_INT1_vect, irq_handler, PORT_H, 1);
 #endif
 
 #if defined(PORTJ_INT0_vect)
-ISR(PORTJ_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_J, 0);
-}
+AVR8_ISR(PORTJ_INT0_vect, irq_handler, PORT_J, 0);
 #endif
 #if defined(PORTJ_INT1_vect)
-ISR(PORTJ_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_J, 1);
-}
+AVR8_ISR(PORTJ_INT1_vect, irq_handler, PORT_J, 1);
 #endif
 
 #if defined(PORTK_INT0_vect)
-ISR(PORTK_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_K, 0);
-}
+AVR8_ISR(PORTK_INT0_vect, irq_handler, PORT_K, 0);
 #endif
 #if defined(PORTK_INT1_vect)
-ISR(PORTK_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_K, 1);
-}
+AVR8_ISR(PORTK_INT1_vect, irq_handler, PORT_K, 1);
 #endif
 
 #if defined(PORTL_INT0_vect)
-ISR(PORTL_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_L, 0);
-}
+AVR8_ISR(PORTL_INT0_vect, irq_handler, PORT_L, 0);
 #endif
 #if defined(PORTL_INT1_vect)
-ISR(PORTL_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_L, 1);
-}
+AVR8_ISR(PORTL_INT1_vect, irq_handler, PORT_L, 1);
 #endif
 
 #if defined(PORTM_INT0_vect)
-ISR(PORTM_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_M, 0);
-}
+AVR8_ISR(PORTM_INT0_vect, irq_handler, PORT_M, 0);
 #endif
 #if defined(PORTM_INT1_vect)
-ISR(PORTM_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_M, 1);
-}
+AVR8_ISR(PORTM_INT1_vect, irq_handler, PORT_M, 1);
 #endif
 
 #if defined(PORTN_INT0_vect)
-ISR(PORTN_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_N, 0);
-}
+AVR8_ISR(PORTN_INT0_vect, irq_handler, PORT_N, 0);
 #endif
 #if defined(PORTN_INT1_vect)
-ISR(PORTN_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_N, 1);
-}
+AVR8_ISR(PORTN_INT1_vect, irq_handler, PORT_N, 1);
 #endif
 
 #if defined(PORTP_INT0_vect)
-ISR(PORTP_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_P, 0);
-}
+AVR8_ISR(PORTP_INT0_vect, irq_handler, PORT_P, 0);
 #endif
 #if defined(PORTP_INT1_vect)
-ISR(PORTP_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_P, 1);
-}
+AVR8_ISR(PORTP_INT1_vect, irq_handler, PORT_P, 1);
 #endif
 
 #if defined(PORTQ_INT0_vect)
-ISR(PORTQ_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_Q, 0);
-}
+AVR8_ISR(PORTQ_INT0_vect, irq_handler, PORT_Q, 0);
 #endif
 #if defined(PORTQ_INT1_vect)
-ISR(PORTQ_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_Q, 1);
-}
+AVR8_ISR(PORTQ_INT1_vect, irq_handler, PORT_Q, 1);
 #endif
 
 #if defined(PORTR_INT0_vect)
-ISR(PORTR_INT0_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_R, 0);
-}
+AVR8_ISR(PORTR_INT0_vect, irq_handler, PORT_R, 0);
 #endif
 #if defined(PORTR_INT1_vect)
-ISR(PORTR_INT1_vect, ISR_BLOCK)
-{
-    irq_handler(PORT_R, 1);
-}
+AVR8_ISR(PORTR_INT1_vect, irq_handler, PORT_R, 1);
 #endif

--- a/cpu/atxmega/periph/i2c.c
+++ b/cpu/atxmega/periph/i2c.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (C) 2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "cpu_pm.h"
+#include "irq.h"
 #include "periph/i2c.h"
 #include "periph/gpio.h"
 #include "periph/pm.h"
@@ -241,8 +242,6 @@ static inline void isr_handler(int i2c)
 {
     assert((unsigned)i2c < I2C_NUMOF);
 
-    avr8_enter_isr();
-
     int8_t const m_status = dev(i2c)->MASTER.STATUS;
 
     if (m_status & TWI_MASTER_ARBLOST_bm) {
@@ -270,34 +269,20 @@ static inline void isr_handler(int i2c)
         i2c_ctx[i2c].status = -EPROTO;
         mutex_unlock(&i2c_ctx[i2c].xfer);
     }
-
-    avr8_exit_isr();
 }
 
 #ifdef I2C_0_ISR
-ISR(I2C_0_ISR, ISR_BLOCK)
-{
-    isr_handler(0);
-}
+AVR8_ISR(I2C_0_ISR, isr_handler, 0);
 #endif /* I2C_0_ISR */
 
 #ifdef I2C_1_ISR
-ISR(I2C_1_ISR, ISR_BLOCK)
-{
-    isr_handler(1);
-}
+AVR8_ISR(I2C_1_ISR, isr_handler, 1);
 #endif /* I2C_1_ISR */
 
 #ifdef I2C_2_ISR
-ISR(I2C_2_ISR, ISR_BLOCK)
-{
-    isr_handler(2);
-}
+AVR8_ISR(I2C_2_ISR, isr_handler, 2);
 #endif /* I2C_2_ISR */
 
 #ifdef I2C_3_ISR
-ISR(I2C_3_ISR, ISR_BLOCK)
-{
-    isr_handler(3);
-}
+AVR8_ISR(I2C_3_ISR, isr_handler, 3);
 #endif /* I2C_3_ISR */

--- a/cpu/atxmega/periph/timer.c
+++ b/cpu/atxmega/periph/timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (C) 2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -319,8 +319,6 @@ void timer_start(tim_t tim)
 #ifdef TIMER_NUMOF
 static inline void _isr(tim_t tim, int channel)
 {
-    avr8_enter_isr();
-
     DEBUG("timer %d _isr channel %d\n", tim, channel);
 
     if (is_oneshot(tim, channel)) {
@@ -330,207 +328,109 @@ static inline void _isr(tim_t tim, int channel)
     if (ctx[tim].cb) {
         ctx[tim].cb(ctx[tim].arg, channel);
     }
-
-    avr8_exit_isr();
 }
 #endif
 
 #ifdef TIMER_0_ISRA
-ISR(TIMER_0_ISRA, ISR_BLOCK)
-{
-    _isr(0, 0);
-}
+AVR8_ISR(TIMER_0_ISRA, _isr, 0, 0);
 #endif
 #ifdef TIMER_0_ISRB
-ISR(TIMER_0_ISRB, ISR_BLOCK)
-{
-    _isr(0, 1);
-}
+AVR8_ISR(TIMER_0_ISRB, _isr, 0, 1);
 #endif
 #ifdef TIMER_0_ISRC
-ISR(TIMER_0_ISRC, ISR_BLOCK)
-{
-    _isr(0, 2);
-}
+AVR8_ISR(TIMER_0_ISRC, _isr, 0, 2);
 #endif
 #ifdef TIMER_0_ISRD
-ISR(TIMER_0_ISRD, ISR_BLOCK)
-{
-    _isr(0, 3);
-}
+AVR8_ISR(TIMER_0_ISRD, _isr, 0, 3);
 #endif /* TIMER_0 */
 
 #ifdef TIMER_1_ISRA
-ISR(TIMER_1_ISRA, ISR_BLOCK)
-{
-    _isr(1, 0);
-}
+AVR8_ISR(TIMER_1_ISRA, _isr, 1, 0);
 #endif
 #ifdef TIMER_1_ISRB
-ISR(TIMER_1_ISRB, ISR_BLOCK)
-{
-    _isr(1, 1);
-}
+AVR8_ISR(TIMER_1_ISRB, _isr, 1, 1);
 #endif
 #ifdef TIMER_1_ISRC
-ISR(TIMER_1_ISRC, ISR_BLOCK)
-{
-    _isr(1, 2);
-}
+AVR8_ISR(TIMER_1_ISRC, _isr, 1, 2);
 #endif
 #ifdef TIMER_1_ISRD
-ISR(TIMER_1_ISRD, ISR_BLOCK)
-{
-    _isr(1, 3);
-}
+AVR8_ISR(TIMER_1_ISRD, _isr, 1, 3);
 #endif /* TIMER_1 */
 
 #ifdef TIMER_2_ISRA
-ISR(TIMER_2_ISRA, ISR_BLOCK)
-{
-    _isr(2, 0);
-}
+AVR8_ISR(TIMER_2_ISRA, _isr, 2, 0);
 #endif
 #ifdef TIMER_2_ISRB
-ISR(TIMER_2_ISRB, ISR_BLOCK)
-{
-    _isr(2, 1);
-}
+AVR8_ISR(TIMER_2_ISRB, _isr, 2, 1);
 #endif
 #ifdef TIMER_2_ISRC
-ISR(TIMER_2_ISRC, ISR_BLOCK)
-{
-    _isr(2, 2);
-}
+AVR8_ISR(TIMER_2_ISRC, _isr, 2, 2);
 #endif
 #ifdef TIMER_2_ISRD
-ISR(TIMER_2_ISRD, ISR_BLOCK)
-{
-    _isr(2, 3);
-}
+AVR8_ISR(TIMER_2_ISRD, _isr, 2, 3);
 #endif /* TIMER_2 */
 
 #ifdef TIMER_3_ISRA
-ISR(TIMER_3_ISRA, ISR_BLOCK)
-{
-    _isr(3, 0);
-}
+AVR8_ISR(TIMER_3_ISRA, _isr, 3, 0);
 #endif
 #ifdef TIMER_3_ISRB
-ISR(TIMER_3_ISRB, ISR_BLOCK)
-{
-    _isr(3, 1);
-}
+AVR8_ISR(TIMER_3_ISRB, _isr, 3, 1);
 #endif
 #ifdef TIMER_3_ISRC
-ISR(TIMER_3_ISRC, ISR_BLOCK)
-{
-    _isr(3, 2);
-}
+AVR8_ISR(TIMER_3_ISRC, _isr, 3, 2);
 #endif
 #ifdef TIMER_3_ISRD
-ISR(TIMER_3_ISRD, ISR_BLOCK)
-{
-    _isr(3, 3);
-}
+AVR8_ISR(TIMER_3_ISRD, _isr, 3, 3);
 #endif /* TIMER_3 */
 
 #ifdef TIMER_4_ISRA
-ISR(TIMER_4_ISRA, ISR_BLOCK)
-{
-    _isr(4, 0);
-}
+AVR8_ISR(TIMER_4_ISRA, _isr, 4, 0);
 #endif
 #ifdef TIMER_4_ISRB
-ISR(TIMER_4_ISRB, ISR_BLOCK)
-{
-    _isr(4, 1);
-}
+AVR8_ISR(TIMER_4_ISRB, _isr, 4, 1);
 #endif
 #ifdef TIMER_4_ISRC
-ISR(TIMER_4_ISRC, ISR_BLOCK)
-{
-    _isr(4, 2);
-}
+AVR8_ISR(TIMER_4_ISRC, _isr, 4, 2);
 #endif
 #ifdef TIMER_4_ISRD
-ISR(TIMER_4_ISRD, ISR_BLOCK)
-{
-    _isr(4, 3);
-}
+AVR8_ISR(TIMER_4_ISRD, _isr, 4, 3);
 #endif /* TIMER_4 */
 
 #ifdef TIMER_5_ISRA
-ISR(TIMER_5_ISRA, ISR_BLOCK)
-{
-    _isr(5, 0);
-}
+AVR8_ISR(TIMER_5_ISRA, _isr, 5, 0);
 #endif
 #ifdef TIMER_5_ISRB
-ISR(TIMER_5_ISRB, ISR_BLOCK)
-{
-    _isr(5, 1);
-}
+AVR8_ISR(TIMER_5_ISRB, _isr, 5, 1);
 #endif
 #ifdef TIMER_5_ISRC
-ISR(TIMER_5_ISRC, ISR_BLOCK)
-{
-    _isr(5, 2);
-}
+AVR8_ISR(TIMER_5_ISRC, _isr, 5, 2);
 #endif
 #ifdef TIMER_5_ISRD
-ISR(TIMER_5_ISRD, ISR_BLOCK)
-{
-    _isr(5, 3);
-}
+AVR8_ISR(TIMER_5_ISRD, _isr, 5, 3);
 #endif /* TIMER_5 */
 
 #ifdef TIMER_6_ISRA
-ISR(TIMER_6_ISRA, ISR_BLOCK)
-{
-    _isr(6, 0);
-}
+AVR8_ISR(TIMER_6_ISRA, _isr, 6, 0);
 #endif
 #ifdef TIMER_6_ISRB
-ISR(TIMER_6_ISRB, ISR_BLOCK)
-{
-    _isr(6, 1);
-}
+AVR8_ISR(TIMER_6_ISRB, _isr, 6, 1);
 #endif
 #ifdef TIMER_6_ISRC
-ISR(TIMER_6_ISRC, ISR_BLOCK)
-{
-    _isr(6, 2);
-}
+AVR8_ISR(TIMER_6_ISRC, _isr, 6, 2);
 #endif
 #ifdef TIMER_6_ISRD
-ISR(TIMER_6_ISRD, ISR_BLOCK)
-{
-    _isr(6, 3);
-}
+AVR8_ISR(TIMER_6_ISRD, _isr, 6, 3);
 #endif /* TIMER_6 */
 
 #ifdef TIMER_7_ISRA
-ISR(TIMER_7_ISRA, ISR_BLOCK)
-{
-    _isr(7, 0);
-}
+AVR8_ISR(TIMER_7_ISRA, _isr, 7, 0);
 #endif
 #ifdef TIMER_7_ISRB
-ISR(TIMER_7_ISRB, ISR_BLOCK)
-{
-    _isr(7, 1);
-}
+AVR8_ISR(TIMER_7_ISRB, _isr, 7, 1);
 #endif
 #ifdef TIMER_7_ISRC
-ISR(TIMER_7_ISRC, ISR_BLOCK)
-{
-    _isr(7, 2);
-}
+AVR8_ISR(TIMER_7_ISRC, _isr, 7, 2);
 #endif
-#ifdef TIMER_7_ISRB
-ISR(TIMER_7_ISRD, ISR_BLOCK)
-{
-    _isr(7, 3);
-}
+#ifdef TIMER_7_ISRD
+AVR8_ISR(TIMER_7_ISRD, _isr, 7, 3);
 #endif /* TIMER_7 */

--- a/cpu/atxmega/periph/uart.c
+++ b/cpu/atxmega/periph/uart.c
@@ -329,99 +329,54 @@ void uart_poweroff(uart_t uart)
 
 static inline void _rx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     if (isr_ctx[num].rx_cb) {
         isr_ctx[num].rx_cb(isr_ctx[num].arg, dev(num)->DATA);
     }
-
-    avr8_exit_isr();
 }
 
 static inline void _tx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
     avr8_uart_tx_clear_pending(num);
-
-    avr8_exit_isr();
 }
 
 #ifdef UART_0_RXC_ISR
-ISR(UART_0_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(0);
-}
-ISR(UART_0_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(0);
-}
+AVR8_ISR(UART_0_RXC_ISR, _rx_isr_handler, 0);
+AVR8_ISR(UART_0_TXC_ISR, _tx_isr_handler, 0);
 #endif /* UART_0_ISR */
 
 #ifdef UART_1_RXC_ISR
-ISR(UART_1_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(1);
-}
-ISR(UART_1_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(1);
-}
+AVR8_ISR(UART_1_RXC_ISR, _rx_isr_handler, 1);
+AVR8_ISR(UART_1_TXC_ISR, _tx_isr_handler, 1);
 #endif /* UART_1_ISR */
 
 #ifdef UART_2_RXC_ISR
-ISR(UART_2_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(2);
-}
-ISR(UART_2_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(2);
-}
+AVR8_ISR(UART_2_RXC_ISR, _rx_isr_handler, 2);
+AVR8_ISR(UART_2_TXC_ISR, _tx_isr_handler, 2);
 #endif /* UART_2_ISR */
 
 #ifdef UART_3_RXC_ISR
-ISR(UART_3_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(3);
-}
-ISR(UART_3_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(3);
-}
+AVR8_ISR(UART_3_RXC_ISR, _rx_isr_handler, 3);
+AVR8_ISR(UART_3_TXC_ISR, _tx_isr_handler, 3);
 #endif /* UART_3_ISR */
 
 #ifdef UART_4_RXC_ISR
-ISR(UART_4_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(4);
-}
-ISR(UART_4_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(4);
-}
+AVR8_ISR(UART_4_RXC_ISR, _rx_isr_handler, 4);
+AVR8_ISR(UART_4_TXC_ISR, _tx_isr_handler, 4);
 #endif /* UART_4_ISR */
 
 #ifdef UART_5_RXC_ISR
-ISR(UART_5_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(5);
-}
-ISR(UART_5_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(5);
-}
+AVR8_ISR(UART_5_RXC_ISR, _rx_isr_handler, 5);
+AVR8_ISR(UART_5_TXC_ISR, _tx_isr_handler, 5);
 #endif /* UART_5_ISR */
 
 #ifdef UART_6_RXC_ISR
-ISR(UART_6_RXC_ISR, ISR_BLOCK)
-{
-    _rx_isr_handler(6);
-}
-ISR(UART_6_TXC_ISR, ISR_BLOCK)
-{
-    _tx_isr_handler(6);
-}
+AVR8_ISR(UART_6_RXC_ISR, _rx_isr_handler, 6);
+AVR8_ISR(UART_6_TXC_ISR, _tx_isr_handler, 6);
 #endif /* UART_6_ISR */
+
+#ifdef UART_7_RXC_ISR
+AVR8_ISR(UART_7_RXC_ISR, _rx_isr_handler, 7);
+AVR8_ISR(UART_7_TXC_ISR, _tx_isr_handler, 7);
+#endif /* UART_7_ISR */

--- a/cpu/atxmega/periph/uart.c
+++ b/cpu/atxmega/periph/uart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (C) 2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -310,7 +310,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         /* start of TX won't finish until no data in DATAn and transmit shift
            register is empty */
         uint8_t irq_state = irq_disable();
-        avr8_state |= AVR8_STATE_FLAG_UART_TX(uart);
+        avr8_uart_tx_set_pending(uart);
         irq_restore(irq_state);
 
         dev(uart)->DATA = data[i];
@@ -344,7 +344,7 @@ static inline void _tx_isr_handler(int num)
 
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
-    avr8_state &= ~AVR8_STATE_FLAG_UART_TX(num);
+    avr8_uart_tx_clear_pending(num);
 
     avr8_exit_isr();
 }

--- a/cpu/avr8_common/avr8_cpu.c
+++ b/cpu/avr8_common/avr8_cpu.c
@@ -68,7 +68,9 @@
 */
 uint8_t mcusr_mirror __attribute__((section(".noinit")));
 uint8_t soft_rst __attribute__((section(".noinit")));
-uint8_t avr8_state = 0;
+#if (AVR8_STATE_IRQ_USE_SRAM)
+uint8_t avr8_state_irq_count_sram = 0;
+#endif
 #if (AVR8_STATE_UART_USE_SRAM)
 uint8_t avr8_state_uart_sram = 0;
 #endif
@@ -123,6 +125,7 @@ void cpu_init(void)
 
     /* Set global resources initial state */
     avr8_state_uart = 0;
+    avr8_state_irq_count = 0;
 
     irq_enable();
 }

--- a/cpu/avr8_common/avr8_cpu.c
+++ b/cpu/avr8_common/avr8_cpu.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2017 RWTH Aachen, Josua Arndt
  *               2018 Matthew Blue
- *               2021 Gerson Fernando Budke
+ *               2021-2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -69,6 +69,9 @@
 uint8_t mcusr_mirror __attribute__((section(".noinit")));
 uint8_t soft_rst __attribute__((section(".noinit")));
 uint8_t avr8_state = 0;
+#if (AVR8_STATE_UART_USE_SRAM)
+uint8_t avr8_state_uart_sram = 0;
+#endif
 
 void get_mcusr(void) __attribute__((naked, section(".init0"), used));
 
@@ -117,6 +120,9 @@ void cpu_init(void)
               |  PMIC_MEDLVLEN_bm
               |  PMIC_LOLVLEN_bm;
 #endif
+
+    /* Set global resources initial state */
+    avr8_state_uart = 0;
 
     irq_enable();
 }

--- a/cpu/avr8_common/include/cpu.h
+++ b/cpu/avr8_common/include/cpu.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
  *               2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
- *               2021 Gerson Fernando Budke <nandojve@gmail.com>
+ *               2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -41,6 +41,7 @@
 #include "cpu_clock.h"
 #include "sched.h"
 #include "thread.h"
+#include "states_internal.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -62,14 +63,6 @@ extern "C"
  * @{
  */
 #define AVR8_STATE_FLAG_ISR           (0x80U) /**< In ISR */
-#define AVR8_STATE_FLAG_UART0_TX      (0x01U) /**< TX pending for UART 0 */
-#define AVR8_STATE_FLAG_UART1_TX      (0x02U) /**< TX pending for UART 1 */
-#define AVR8_STATE_FLAG_UART2_TX      (0x04U) /**< TX pending for UART 2 */
-#define AVR8_STATE_FLAG_UART3_TX      (0x08U) /**< TX pending for UART 3 */
-#define AVR8_STATE_FLAG_UART4_TX      (0x10U) /**< TX pending for UART 4 */
-#define AVR8_STATE_FLAG_UART5_TX      (0x20U) /**< TX pending for UART 5 */
-#define AVR8_STATE_FLAG_UART6_TX      (0x40U) /**< TX pending for UART 6 */
-#define AVR8_STATE_FLAG_UART_TX(x)    (0x01U << x) /**< TX pending for UART x */
 /** @} */
 
 /**
@@ -83,20 +76,13 @@ extern "C"
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *   7   6   5   4   3   2   1   0
  * +---+---+---+---+---+---+---+---+
- * |IRQ|TX6|TX5|TX4|TX3|TX2|TX1|TX0|
+ * |IRQ|        RESERVED           |
  * +---+---+---+---+---+---+---+---+
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * | Label  | Description                                                   |
  * |:-------|:--------------------------------------------------------------|
  * | IRQ    | This bit is set when in IRQ context                           |
- * | TX6    | This bit is set when on UART6 TX is pending                   |
- * | TX5    | This bit is set when on UART5 TX is pending                   |
- * | TX4    | This bit is set when on UART4 TX is pending                   |
- * | TX3    | This bit is set when on UART3 TX is pending                   |
- * | TX2    | This bit is set when on UART2 TX is pending                   |
- * | TX1    | This bit is set when on UART1 TX is pending                   |
- * | TX0    | This bit is set when on UART0 TX is pending                   |
  */
 extern uint8_t avr8_state;
 
@@ -140,6 +126,33 @@ static inline void avr8_enter_isr(void)
 }
 
 /**
+ * @brief        Compute UART TX channel
+ *
+ * @param uart   The UART number
+ */
+#define AVR8_STATE_FLAG_UART_TX(uart)    (0x01U << uart)
+
+/**
+ * @brief        Set UART TX channel as pending
+ *
+ * @param uart   The UART number
+ */
+static inline void avr8_uart_tx_set_pending(unsigned uart)
+{
+    avr8_state_uart |= AVR8_STATE_FLAG_UART_TX(uart);
+}
+
+/**
+ * @brief        Clear UART TX channel pending state
+ *
+ * @param uart   The UART number
+ */
+static inline void avr8_uart_tx_clear_pending(unsigned uart)
+{
+    avr8_state_uart &= ~AVR8_STATE_FLAG_UART_TX(uart);
+}
+
+/**
  * @brief   Check if TX on any present UART device is still pending
  *
  * @retval  !=0     At least on UART device is still sending data out
@@ -147,14 +160,7 @@ static inline void avr8_enter_isr(void)
  */
 static inline int avr8_is_uart_tx_pending(void)
 {
-    uint8_t state = avr8_get_state();
-    return (state & (AVR8_STATE_FLAG_UART0_TX
-                  |  AVR8_STATE_FLAG_UART1_TX
-                  |  AVR8_STATE_FLAG_UART2_TX
-                  |  AVR8_STATE_FLAG_UART3_TX
-                  |  AVR8_STATE_FLAG_UART4_TX
-                  |  AVR8_STATE_FLAG_UART5_TX
-                  |  AVR8_STATE_FLAG_UART6_TX));
+    return avr8_state_uart;
 }
 
 /**

--- a/cpu/avr8_common/include/irq_arch.h
+++ b/cpu/avr8_common/include/irq_arch.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *               2020 Otto-von-Guericke-Universität Magdeburg
- *               2021 Gerson Fernando Budke
+ *               2021-2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -100,8 +100,11 @@ __attribute__((always_inline)) static inline void irq_restore(unsigned int _stat
  */
 __attribute__((always_inline)) static inline bool irq_is_in(void)
 {
-    uint8_t state = avr8_get_state();
-    return (state & AVR8_STATE_FLAG_ISR);
+    bool is_in = avr8_state_irq_count > 0;
+
+    __asm__ volatile ("" : : : "memory");
+
+    return is_in;
 }
 
 /**

--- a/cpu/avr8_common/include/irq_arch.h
+++ b/cpu/avr8_common/include/irq_arch.h
@@ -122,6 +122,37 @@ __attribute__((always_inline)) static inline bool irq_is_enabled(void)
     return mask & (1 << 7);
 }
 
+/**
+ * @brief Define an AVR-8 ISR
+ *
+ * This macro hides all RIOT-OS port internal details from user implementation.
+ * The user should use this macro passing at least two parameters. The first is
+ * the interrupt vector and the second one is the function to be called. Zero or
+ * more optional parameters can be passed the function one by one using the
+ * variable length argument list.
+ *
+ * It is recommended that user define a `static inline void` function to
+ * the implement the interrupt. The function can accept argument list based on
+ * implementation details.
+ *
+ * Example:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * static inline void _my_isr_handler(int index)
+ * {
+ *     do_something(index);
+ * }
+ * AVR8_ISR(PERIPHERAL_INSTANCE_0_ISR, _my_isr_handler, 0);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+#define AVR8_ISR(vector, function, ...) \
+    ISR(vector, ISR_BLOCK)              \
+    {                                   \
+        avr8_enter_isr();               \
+        function(__VA_ARGS__);          \
+        avr8_exit_isr();                \
+    }
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/avr8_common/include/states_internal.h
+++ b/cpu/avr8_common/include/states_internal.h
@@ -72,6 +72,39 @@ extern uint8_t avr8_state_uart_sram;            /**< UART state variable. */
 #endif
 /** @} */
 
+/**
+ * @name    Internal flag which defines if IRQ state is stored on SRAM
+ * @{
+ */
+#ifdef GPIOR1
+#define AVR8_STATE_IRQ_USE_SRAM 0 /**< IRQ state using GPIOR registers. */
+#else
+#define AVR8_STATE_IRQ_USE_SRAM 1 /**< IRQ state using GPIOR registers. */
+#endif
+/** @} */
+
+/**
+ * @name    Global variable containing the current state of the MCU
+ * @{
+ *
+ * @note    This variable is updated from IRQ context; access to it should
+ *          be wrapped into @ref irq_disable and @ref irq_restore should be
+ *          used.
+ *
+ * Contents:
+ *
+ * | Label  | Description                                                   |
+ * |:-------|:--------------------------------------------------------------|
+ * | IRQ    | This variable is incremented when in IRQ context              |
+ */
+#if (AVR8_STATE_IRQ_USE_SRAM)
+extern uint8_t avr8_state_irq_count_sram;               /**< IRQ state variable. */
+#define avr8_state_irq_count avr8_state_irq_count_sram  /**< Definition for SRAM. */
+#else
+#define avr8_state_irq_count GPIOR1                     /**< Definition for GPIOR1. */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/avr8_common/include/states_internal.h
+++ b/cpu/avr8_common/include/states_internal.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_avr8_common
+ * @{
+ *
+ * @file
+ * @brief       States internal interface
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ *
+ */
+
+#ifndef STATES_INTERNAL_H
+#define STATES_INTERNAL_H
+
+#include <avr/io.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Internal flag which defines if uart state is stored on SRAM
+ * @{
+ */
+#ifdef GPIOR0
+#define AVR8_STATE_UART_USE_SRAM 0 /**< UART state using GPIOR registers. */
+#else
+#define AVR8_STATE_UART_USE_SRAM 1 /**< UART state using SRAM. */
+#endif
+/** @} */
+
+/**
+ * @name    UART TX pending state
+ * @{
+ *
+ * @note    The content must be changed using the pair
+ *          @ref avr8_uart_tx_set_pending and @ref avr8_uart_tx_clear_pending
+ *          methods and the state is stored on @ref avr8_state_uart.
+ *
+ * Contents:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *   7   6   5   4   3   2   1   0
+ * +---+---+---+---+---+---+---+---+
+ * |TX7|TX6|TX5|TX4|TX3|TX2|TX1|TX0|
+ * +---+---+---+---+---+---+---+---+
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * | Label  | Description                                                   |
+ * |:-------|:--------------------------------------------------------------|
+ * | TX7    | This bit is set when on UART7 TX is pending                   |
+ * | TX6    | This bit is set when on UART6 TX is pending                   |
+ * | TX5    | This bit is set when on UART5 TX is pending                   |
+ * | TX4    | This bit is set when on UART4 TX is pending                   |
+ * | TX3    | This bit is set when on UART3 TX is pending                   |
+ * | TX2    | This bit is set when on UART2 TX is pending                   |
+ * | TX1    | This bit is set when on UART1 TX is pending                   |
+ * | TX0    | This bit is set when on UART0 TX is pending                   |
+ */
+#if (AVR8_STATE_UART_USE_SRAM)
+extern uint8_t avr8_state_uart_sram;            /**< UART state variable. */
+#define avr8_state_uart avr8_state_uart_sram    /**< Definition for SRAM. */
+#else
+#define avr8_state_uart GPIOR0                  /**< Definition for GPIOR0. */
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STATES_INTERNAL_H */
+/** @} */

--- a/cpu/avr8_common/thread_arch.c
+++ b/cpu/avr8_common/thread_arch.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2017 Thomas Perrot <thomas.perrot@tupi.fr>
  *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
- *               2021 Gerson Fernando Budke <nandojve@gmail.com>
+ *               2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -273,12 +273,13 @@ void thread_yield_higher(void)
 
 void avr8_exit_isr(void)
 {
-    avr8_state &= ~AVR8_STATE_FLAG_ISR;
+    --avr8_state_irq_count;
 
     /* Force access to avr8_state to take place */
     __asm__ volatile ("" : : : "memory");
 
-    if (sched_context_switch_request) {
+    /* schedule should switch context when returning from a non nested interrupt */
+    if (sched_context_switch_request && avr8_state_irq_count == 0) {
         avr8_context_save();
         sched_run();
         avr8_context_restore();

--- a/cpu/avr8_common/thread_arch.c
+++ b/cpu/avr8_common/thread_arch.c
@@ -264,7 +264,6 @@ void thread_yield_higher(void)
         avr8_context_save();
         sched_run();
         avr8_context_restore();
-        __asm__ volatile ("ret");
     }
     else {
         sched_context_switch_request = 1;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
  *               2015 Freie Universität Berlin
+ *               2023 Gerson Fernando Budke
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -20,6 +21,7 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
  *
  * @}
  */
@@ -989,18 +991,15 @@ ISR(TRX24_TX_START_vect){
  *
  * Manual p. 40
  */
-ISR(TRX24_PLL_LOCK_vect, ISR_BLOCK)
+static inline void txr24_pll_lock_handler(void)
 {
-    avr8_enter_isr();
-
     DEBUG("TRX24_PLL_LOCK\n");
     netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
                           netdev_ieee802154_t, netdev);
     at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__PLL_LOCK;
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_PLL_LOCK_vect, txr24_pll_lock_handler);
 
 /**
  * @brief  Transceiver PLL Unlock
@@ -1009,18 +1008,15 @@ ISR(TRX24_PLL_LOCK_vect, ISR_BLOCK)
  *
  * Manual p. 89
  */
-ISR(TRX24_PLL_UNLOCK_vect, ISR_BLOCK)
+static inline void txr24_pll_unlock_handler(void)
 {
-    avr8_enter_isr();
-
     DEBUG("TRX24_PLL_UNLOCK\n");
     netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
                           netdev_ieee802154_t, netdev);
     at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__PLL_UNLOCK;
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_PLL_UNLOCK_vect, txr24_pll_unlock_handler);
 
 /**
  * @brief ISR for transceiver's receive start interrupt
@@ -1030,10 +1026,8 @@ ISR(TRX24_PLL_UNLOCK_vect, ISR_BLOCK)
  *
  * Flow Diagram Manual p. 52 / 63
  */
-ISR(TRX24_RX_START_vect, ISR_BLOCK)
+static inline void txr24_rx_start_handler(void)
 {
-    avr8_enter_isr();
-
     uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
     DEBUG("TRX24_RX_START 0x%x\n", status);
 
@@ -1043,9 +1037,8 @@ ISR(TRX24_RX_START_vect, ISR_BLOCK)
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_START;
     /* Call upper layer to process valid PHR */
     netdev_trigger_event_isr(at86rfmega_dev);
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_RX_START_vect, txr24_rx_start_handler);
 
 /**
  * @brief ISR for transceiver's receive end interrupt
@@ -1055,10 +1048,8 @@ ISR(TRX24_RX_START_vect, ISR_BLOCK)
  *
  * Flow Diagram Manual p. 52 / 63
  */
-ISR(TRX24_RX_END_vect, ISR_BLOCK)
+static inline void txr24_rx_end_handler(void)
 {
-    avr8_enter_isr();
-
     uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
     DEBUG("TRX24_RX_END 0x%x\n", status);
 
@@ -1068,9 +1059,8 @@ ISR(TRX24_RX_END_vect, ISR_BLOCK)
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_END;
     /* Call upper layer to process received data */
     netdev_trigger_event_isr(at86rfmega_dev);
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_RX_END_vect, txr24_rx_end_handler);
 
 /**
  * @brief  Transceiver CCAED Measurement finished
@@ -1079,18 +1069,15 @@ ISR(TRX24_RX_END_vect, ISR_BLOCK)
  *
  * Manual p. 74 and p. 76
  */
-ISR(TRX24_CCA_ED_DONE_vect, ISR_BLOCK)
+static inline void txr24_cca_ed_done_handler(void)
 {
-    avr8_enter_isr();
-
     DEBUG("TRX24_CCA_ED_DONE\n");
     netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
                           netdev_ieee802154_t, netdev);
     at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__CCA_ED_DONE;
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_CCA_ED_DONE_vect, txr24_cca_ed_done_handler);
 
 /**
  * @brief  Transceiver Frame Address Match, indicates incoming frame
@@ -1100,18 +1087,15 @@ ISR(TRX24_CCA_ED_DONE_vect, ISR_BLOCK)
  *
  * Flow Diagram Manual p. 52 / 63
  */
-ISR(TRX24_XAH_AMI_vect, ISR_BLOCK)
+static inline void txr24_xah_ami_handler(void)
 {
-    avr8_enter_isr();
-
     DEBUG("TRX24_XAH_AMI\n");
     netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
                           netdev_ieee802154_t, netdev);
     at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AMI;
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_XAH_AMI_vect, txr24_xah_ami_handler);
 
 /**
  * @brief ISR for transceiver's transmit end interrupt
@@ -1120,10 +1104,8 @@ ISR(TRX24_XAH_AMI_vect, ISR_BLOCK)
  *
  * Flow Diagram Manual p. 52 / 63
  */
-ISR(TRX24_TX_END_vect, ISR_BLOCK)
+static inline void txr24_tx_end_handler(void)
 {
-    avr8_enter_isr();
-
     netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
                           netdev_ieee802154_t, netdev);
     at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
@@ -1138,9 +1120,8 @@ ISR(TRX24_TX_END_vect, ISR_BLOCK)
         /* Call upper layer to process if data was send successful */
         netdev_trigger_event_isr(at86rfmega_dev);
     }
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_TX_END_vect, txr24_tx_end_handler);
 
 /**
  * @brief ISR for transceiver's wakeup finished interrupt
@@ -1150,10 +1131,8 @@ ISR(TRX24_TX_END_vect, ISR_BLOCK)
  *
  * Manual p. 40
  */
-ISR(TRX24_AWAKE_vect, ISR_BLOCK)
+static inline void txr24_awake_handler(void)
 {
-    avr8_enter_isr();
-
     DEBUG("TRX24_AWAKE\n");
 
     netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
@@ -1162,8 +1141,7 @@ ISR(TRX24_AWAKE_vect, ISR_BLOCK)
     dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AWAKE;
     /* Call upper layer to process transceiver wakeup finished */
     netdev_trigger_event_isr(at86rfmega_dev);
-
-    avr8_exit_isr();
 }
+AVR8_ISR(TRX24_AWAKE_vect, txr24_awake_handler);
 
 #endif /* AT86RF2XX_IS_PERIPH */

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -142,7 +142,6 @@ static const ieee802154_radio_cipher_ops_t _at86rf2xx_cipher_ops = {
 #endif /* IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
           IS_USED(MODULE_IEEE802154_SECURITY) */
 
-
 /* SOC has radio interrupts, store reference to netdev */
 static netdev_t *at86rfmega_dev;
 static void _irq_handler(void *arg)
@@ -178,7 +177,8 @@ static int _init(netdev_t *netdev)
     at86rf2xx_set_addr_short(dev, (network_uint16_t *)dev->netdev.short_addr);
 
     /* `netdev_ieee802154_reset` does not set the default channel. */
-    netdev_ieee802154_set(&dev->netdev, NETOPT_CHANNEL, &at86rf2xx_chan_default, sizeof(at86rf2xx_chan_default));
+    netdev_ieee802154_set(&dev->netdev, NETOPT_CHANNEL,
+                          &at86rf2xx_chan_default, sizeof(at86rf2xx_chan_default));
 
     if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
         static const netopt_enable_t ack_req =
@@ -563,7 +563,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             if (!IS_ACTIVE(AT86RF2XX_BASIC_MODE)) {
                 assert(max_len >= sizeof(netopt_enable_t));
                 uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__CSMA_SEED_1);
-                *((netopt_enable_t *)val) = (tmp & AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK) ? false : true;
+                *((netopt_enable_t *)val) = (tmp & AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK)
+                                          ? false : true;
                 res = sizeof(netopt_enable_t);
             }
             break;
@@ -958,7 +959,6 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t
     /* set device address */
     netdev_ieee802154_setup(&dev->netdev);
 }
-
 
 #if AT86RF2XX_IS_PERIPH
 


### PR DESCRIPTION
### Contribution description

This prepares for rework how ISR is handled for AVR-8 platform. It is not expected changes on the behavior but tests on other boards were welcome to avoid regressions.

#### Improvements
 * Split UART state from ISR states. Now it is necessary two variables and GPIORx registers are automatically selected when available.
 * UART states now supports up to 8 UARTs.
 * Added AVR8_ISR macro do clean-up and hide internals related to ISR processing. This allows changes on ISR without any other changes on drivers.

### Testing procedure

Tests were conducted using atmega328p-xplained-mini and atxmega-a1u-xpro and the zigduino board was only built. The example thread_duel was used to test regressions.