### PR TITLE
cpu/atmega_common: make vera++ happy

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -53,23 +53,19 @@ static gpio_isr_ctx_t config[GPIO_EXT_INT_NUMOF];
 
 /* Check which pcints should be enabled */
 #if defined(MODULE_ATMEGA_PCINT0) && !defined(ATMEGA_PCINT_MAP_PCINT0)
-#error \
-    Either mapping for pin change interrupt bank 0 is missing or not supported by the MCU
+#  error "Either mapping for pin change interrupt bank 0 is missing or not supported by the MCU"
 #endif
 
 #if defined(MODULE_ATMEGA_PCINT1) && !defined(ATMEGA_PCINT_MAP_PCINT1)
-#error \
-    Either mapping for pin change interrupt bank 1 is missing or not supported by the MCU
+#  error "Either mapping for pin change interrupt bank 1 is missing or not supported by the MCU"
 #endif
 
 #if defined(MODULE_ATMEGA_PCINT2) && !defined(ATMEGA_PCINT_MAP_PCINT2)
-#error \
-    Either mapping for pin change interrupt bank 2 is missing or not supported by the MCU
+#  error "Either mapping for pin change interrupt bank 2 is missing or not supported by the MCU"
 #endif
 
 #if defined(MODULE_ATMEGA_PCINT3) && !defined(ATMEGA_PCINT_MAP_PCINT3)
-#error \
-    Either mapping for pin change interrupt bank 3 is missing or not supported by the MCU
+#  error "Either mapping for pin change interrupt bank 3 is missing or not supported by the MCU"
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

Vera++ doesn't like `#error` preprocessor directives without a quoted string afterwards (and also my syntax highlighter doesn't like this as well). So let's add the quotes to have the tools not spooked out.
<!-- bors cut here -->

### Testing procedure

Green CI and no vera++ annotations on the changed file.

### Issues/PRs references

The vera++ annotations cluttered the source view when reviewing https://github.com/RIOT-OS/RIOT/pull/19777, despite none of the annotations being relevant to the PR changes.