### PR TITLE
tests/core: remove Makefile.sys_common copy past mistake

### DIFF
--- a/tests/core/Makefile.sys_common
+++ b/tests/core/Makefile.sys_common
@@ -1,2 +1,0 @@
-RIOTBASE ?= $(CURDIR)/../../..
-include $(CURDIR)/../../Makefile.tests_common


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This remove Makefile.sys_common from tests/core directory which was likely a copy past mistake from the PR that moved the core related tests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Untested
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#19565 #19566
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
