### PR TITLE
cpu/esp8266: fix region overflow with '*periph' directory in app path

### DIFF
--- a/cpu/esp8266/ld/esp8266.riot-os.ld
+++ b/cpu/esp8266/ld/esp8266.riot-os.ld
@@ -241,7 +241,7 @@ SECTIONS
     *esp_wifi/*(.literal .text .literal.* .text.*)
     *freertos/*(.literal .text .literal.* .text.*)
     *freertos_common/*(.literal .text .literal.* .text.*)
-    *periph/*(.literal .text .literal.* .text.*)
+    *esp_common_periph/*(.literal .text .literal.* .text.*)
     *ztimer_core/*(.literal .text .literal.* .text.*)
 
     *libhal.a:clock.o(.literal .text .literal.* .text.*)


### PR DESCRIPTION
### Contribution description
This pull request addresses an issue where a region overflow occurs during the generation of the `.elf` file when the application path contains a directory named '*periph'. The problem arises due to an incorrect section mapping in the `esp8266.riot-os.ld` linker script.

The issue was causing the compilation of all tests which were moved to the `tests/periph` directory by PR #19552 to fail on the ESP8266 architecture.

To resolve the issue, the `esp8266.riot-os.ld` script has been modified. The section mapping for the `*periph` directory has been changed to `*esp_common_periph`, ensuring that the correct sections are included in the final binary.

### Testing procedure
To verify the effectiveness of this fix, the following testing procedure was performed:
1. Checked out the `master` branch of the RIOT repository
2. Cleaned and built the `blinky` example for the `esp8266-esp-12x` board:
- **Expected Result**: The build process completes successfully without any region overflow errors. The resulting `blinky.elf` file is generated.
```
hugues@p700:~/github/riot_small_fixes/RIOT$ BOARD=esp8266-esp-12x make -j64 -C examples/blinky clean all | grep -v make
rm -rf /home/hugues/github/riot_small_fixes/RIOT/examples/blinky/bin/esp8266-esp-12x/pkg-build/esp8266_sdk
Building application "blinky" for "esp8266-esp-12x" with MCU "esp8266".

esptool.py v2.4.0
   text	   data	    bss	    dec	    hex	filename
 278112	   5228	  28640	 311980	  4c2ac	/home/hugues/github/riot_small_fixes/RIOT/examples/blinky/bin/esp8266-esp-12x/blinky.elf
esptool.py v2.4.0
Parsing CSV input...
```
3. Created a directory named `somethingperiph` and copied the `blinky` example into it:
```
mkdir somethingperiph && cp -a examples/blinky/ somethingperiph
```
4. Cleaned and attempted to build the `blinky` example in the `somethingperiph` directory:
- **Expected Result**: The build process fails with a linker error, indicating a region overflow issue.
```
hugues@p700:~/github/riot_small_fixes/RIOT$ BOARD=esp8266-esp-12x make -j64 -C somethingperiph/blinky clean all | grep -v make
Building application "blinky" for "esp8266-esp-12x" with MCU "esp8266".
rm -rf /home/hugues/github/riot_small_fixes/RIOT/somethingperiph/blinky/bin/esp8266-esp-12x/pkg-build/esp8266_sdk

esptool.py v2.4.0
/home/hugues/esp/xtensa-esp8266-elf/bin/../lib/gcc/xtensa-esp8266-elf/5.2.0/../../../../xtensa-esp8266-elf/bin/ld: /home/hugues/github/riot_small_fixes/RIOT/somethingperiph/blinky/bin/esp8266-esp-12x/blinky.elf section `.text' will not fit in region `iram1_0_seg'
/home/hugues/esp/xtensa-esp8266-elf/bin/../lib/gcc/xtensa-esp8266-elf/5.2.0/../../../../xtensa-esp8266-elf/bin/ld: region `iram1_0_seg' overflowed by 24372 bytes
collect2: error: ld returned 1 exit status
make: *** [/home/hugues/github/riot_small_fixes/RIOT/somethingperiph/blinky/../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/somethingperiph/blinky/bin/esp8266-esp-12x/blinky.elf] Erreur 1
```
5. Checked out this PR's branch
6. Cleaned and attempted to build the `blinky` example in the `somethingperiph` directory again:
- **Expected Result**: The build process completes successfully without any region overflow errors. The resulting `blinky.elf` file is generated.
```
hugues@p700:~/github/riot_small_fixes/RIOT$ BOARD=esp8266-esp-12x make -j64 -C somethingperiph/blinky clean all | grep -v make
Building application "blinky" for "esp8266-esp-12x" with MCU "esp8266".
rm -rf /home/hugues/github/riot_small_fixes/RIOT/somethingperiph/blinky/bin/esp8266-esp-12x/pkg-build/esp8266_sdk

esptool.py v2.4.0
   text	   data	    bss	    dec	    hex	filename
 278080	   5228	  28640	 311948	  4c28c	/home/hugues/github/riot_small_fixes/RIOT/somethingperiph/blinky/bin/esp8266-esp-12x/blinky.elf
esptool.py v2.4.0
Parsing CSV input...
```
7. Verified the size of the `blinky.elf` file:
- **Expected Result**: The size of the `blinky.elf` file is similar to the size obtained in step 2, indicating a successful build. However, a slight difference in size was observed due to the linker script modification.

8. Cleaned and attempted to build the `blinky` example in the `examples` directory again:
- **Expected Result**: The size of the `blinky.elf` file is similar to the size obtained in step 6.
```
hugues@p700:~/github/riot_small_fixes/RIOT$ BOARD=esp8266-esp-12x make -j64 -C examples/blinky clean all | grep -v make
Building application "blinky" for "esp8266-esp-12x" with MCU "esp8266".
rm -rf /home/hugues/github/riot_small_fixes/RIOT/examples/blinky/bin/esp8266-esp-12x/pkg-build/esp8266_sdk

esptool.py v2.4.0
   text	   data	    bss	    dec	    hex	filename
 278080	   5228	  28640	 311948	  4c28c	/home/hugues/github/riot_small_fixes/RIOT/examples/blinky/bin/esp8266-esp-12x/blinky.elf
esptool.py v2.4.0
Parsing CSV input...
```
The tests confirm that this pull request resolves the region overflow issue when the application path contains a directory named '*periph'. Additionally, all relevant tests in the `tests/periph` directory successfully compile again on the ESP8266 architecture:
```
hugues@p700:~/github/riot_small_fixes/RIOT$ for p in tests/periph/*; do BOARD=esp8266-esp-12x make -j64 -C $p clean all 2>&1 | grep elf; done
 279368	   5200	  28728	 313296	  4c7d0	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/adc/bin/esp8266-esp-12x/tests_adc.elf
 277492	   5192	  28672	 311356	  4c03c	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/cpuid/bin/esp8266-esp-12x/tests_cpuid.elf
 289044	   5264	  28856	 323164	  4ee5c	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/gpio/bin/esp8266-esp-12x/tests_gpio.elf
 288884	   5288	  29160	 323332	  4ef04	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/gpio_arduino/bin/esp8266-esp-12x/tests_gpio_arduino.elf
 279520	   5252	  28712	 313484	  4c88c	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/hwrng/bin/esp8266-esp-12x/tests_hwrng.elf
 292312	   5268	  28872	 326452	  4fb34	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/i2c/bin/esp8266-esp-12x/tests_i2c.elf
 284064	   5208	  28720	 317992	  4da28	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/pm/bin/esp8266-esp-12x/tests_pm.elf
 285800	   5248	  28856	 319904	  4e1a0	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/pwm/bin/esp8266-esp-12x/tests_pwm.elf
 281756	   5252	  28768	 315776	  4d180	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtc/bin/esp8266-esp-12x/tests_rtc.elf
 278832	   5192	  28704	 312728	  4c598	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtt/bin/esp8266-esp-12x/tests_rtt.elf
 280552	   5252	  28736	 314540	  4ccac	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtt_min/bin/esp8266-esp-12x/tests_rtt_min.elf
 294164	   5296	  30104	 329564	  5075c	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/spi/bin/esp8266-esp-12x/tests_spi.elf
 279440	   5192	  28800	 313432	  4c858	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/timer/bin/esp8266-esp-12x/tests_timer.elf
 278884	   5192	  28712	 312788	  4c5d4	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/timer_short_relative_set/bin/esp8266-esp-12x/tests_timer_short_relative_set.elf
 286756	   5248	  31920	 323924	  4f154	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/uart/bin/esp8266-esp-12x/tests_uart.elf
 275572	   5184	  28800	 309556	  4b934	/home/hugues/github/riot_small_fixes/RIOT/tests/periph/uart_mode/bin/esp8266-esp-12x/tests_uart_mode.elf
hugues@p700:~/github/riot_small_fixes/RIOT$ git checkout master
Basculement sur la branche 'master'
Votre branche est à jour avec 'origin/master'.
hugues@p700:~/github/riot_small_fixes/RIOT$ for p in tests/periph/*; do BOARD=esp8266-esp-12x make -j64 -C $p clean all 2>&1 | grep Erreur; done
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/adc/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/adc/bin/esp8266-esp-12x/tests_adc.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/cpuid/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/cpuid/bin/esp8266-esp-12x/tests_cpuid.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/gpio/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/gpio/bin/esp8266-esp-12x/tests_gpio.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/gpio_arduino/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/gpio_arduino/bin/esp8266-esp-12x/tests_gpio_arduino.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/hwrng/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/hwrng/bin/esp8266-esp-12x/tests_hwrng.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/i2c/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/i2c/bin/esp8266-esp-12x/tests_i2c.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/pm/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/pm/bin/esp8266-esp-12x/tests_pm.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/pwm/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/pwm/bin/esp8266-esp-12x/tests_pwm.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtc/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtc/bin/esp8266-esp-12x/tests_rtc.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtt/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtt/bin/esp8266-esp-12x/tests_rtt.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtt_min/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/rtt_min/bin/esp8266-esp-12x/tests_rtt_min.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/spi/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/spi/bin/esp8266-esp-12x/tests_spi.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/timer/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/timer/bin/esp8266-esp-12x/tests_timer.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/timer_short_relative_set/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/timer_short_relative_set/bin/esp8266-esp-12x/tests_timer_short_relative_set.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/uart/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/uart/bin/esp8266-esp-12x/tests_uart.elf] Erreur 1
make: *** [/home/hugues/github/riot_small_fixes/RIOT/tests/periph/uart_mode/../../../Makefile.include:761 : /home/hugues/github/riot_small_fixes/RIOT/tests/periph/uart_mode/bin/esp8266-esp-12x/tests_uart_mode.elf] Erreur 1
```

### Issues/PRs references
Highlighted in #16727, appeared whith project tree as a side effect from #19552 but pre-existing.
