### PR TITLE
cpu/nrf5x/periph/wdt: enable support for nRF53/nRF9160

### DIFF
--- a/cpu/nrf53/Kconfig
+++ b/cpu/nrf53/Kconfig
@@ -14,6 +14,8 @@ config CPU_FAM_NRF53
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_UART_MODECFG
+    select HAS_PERIPH_WDT
+    select HAS_PERIPH_WDT_CB
 
 ## CPU Models
 config CPU_MODEL_NRF5340_APP

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer_periodic
 FEATURES_PROVIDED += periph_uart_modecfg
+FEATURES_PROVIDED += periph_wdt periph_wdt_cb
 
 ifeq (,$(filter nrf5340_app,$(CPU_MODEL)))
 FEATURES_PROVIDED += periph_flashpage
@@ -16,7 +17,6 @@ ifeq (,$(filter nrf9160 nrf5340_app,$(CPU_MODEL)))
   FEATURES_PROVIDED += periph_hwrng
   FEATURES_PROVIDED += periph_rtt_overflow
   FEATURES_PROVIDED += periph_temperature
-  FEATURES_PROVIDED += periph_wdt periph_wdt_cb
 
 # Various other features (if any)
   FEATURES_PROVIDED += ble_nimble

--- a/cpu/nrf5x_common/periph/wdt.c
+++ b/cpu/nrf5x_common/periph/wdt.c
@@ -42,6 +42,18 @@
 #define NRF_WDT_HALT_MODE (WDT_CONFIG_HALT_Run)
 #endif
 
+/* Compatibility wrapper for nRF53/nRF9160 */
+#ifdef NRF_WDT0_S
+#define NRF_WDT NRF_WDT0_S
+#elif defined(NRF_WDT_S)
+#define NRF_WDT NRF_WDT_S
+#endif
+
+/* Wrapper around vendor files inconsistency */
+#ifdef WDT_RUNSTATUS_RUNSTATUSWDT_Running
+#define WDT_RUNSTATUS_RUNSTATUS_Running WDT_RUNSTATUS_RUNSTATUSWDT_Running
+#endif
+
 #ifdef MODULE_PERIPH_WDT_CB
 static wdt_cb_t wdt_cb;
 static void *wdt_arg;

--- a/cpu/nrf9160/Kconfig
+++ b/cpu/nrf9160/Kconfig
@@ -19,6 +19,8 @@ config CPU_FAM_NRF9160
     select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_UART_MODECFG
     select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_WDT
+    select HAS_PERIPH_WDT_CB
 
 ## CPU Models
 config CPU_MODEL_NRF9160


### PR DESCRIPTION
### Contribution description

This PR enables support for the watchdog driver on nRF53.
This MCU has two watchdog peripherals, for now, it only uses the first one.
The use of the second watchdog can be add in a followup PR later.


### Testing procedure
Flash and play with `tests/periph/wdt` application.


### Issues/PRs references
None.
