### PR TITLE
boards: fix documentation for GD32V boards

### DIFF
--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -46,7 +46,7 @@ on-board components:
 | I2S         | 2                                      |   no      |
 | CAN         | 2 x CAN 2.0B with up to 1 Mbps         |   no      |
 | PWM         | 6 Channels                             |   yes     |
-| USB         | 1 x USB FS OTG                         |   no      |
+| USB         | 1 x USB FS OTG                         |   yes     |
 | Vcc         | 3.0V - 3.6V                            |           |
 | Datasheet   | [Datasheet](https://gd32mcu.com/data/documents/datasheet/GD32VF103_Datasheet_Rev1.6.pdf) | |
 | Reference Manual | [Reference Manual](https://gd32mcu.com/download/down/document_id/222/path_type/1) | |
@@ -167,18 +167,28 @@ If another adapter is used, it can be specified using variable
 OPENOCD_DEBUG_ADAPTER=jlink BOARD=seeedstudio-gd32 make -C examples/hello-world flash
 ```
 
-## Accessing STDIO via UART
+## Accessing STDIO
 
-The `stdio` is directly accessible through the first UART interface. If an
+By default, the `stdio` is provided by the USBUS CDC ACM module `stdio_cdc_acm`.
+This interface is mapped to `/dev/ttyACM<n>` on a Linux host, where `<n>` is
+the index of the CDC ACM interface, which is 0 by default.
+
+To use the first UART interface for `stdio` instead, the `stdio_uart` module
+has to be enabled:
+```
+USEMODULE=stdio_uart BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+```
+
+The `stdio` is then directly accessible through the first UART interface. If an
 external USB-to-UART interface is used, this interface is mapped to
 `/dev/ttyUSB<n>` on a Linux host, where `<n>` is the index of the UART
 interface, which is 0 by default.
 
 Use the `term` target to connect to the board using `/dev/ttyUSB0`:
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world term
+BOARD=seeedstudio-gd32 make -C examples/hello-world term PORT=/dev/ttyUSB0
 ```
-If the UART interface index of board's USB to UART bridge is not 0, use
+If the UART interface index of the USB-to-UART interface is not 0, use
 the following command to connect:
 ```
 BOARD=seeedstudio-gd32 make -C examples/hello-world term PORT=/dev/ttyUSB<n>

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -40,7 +40,7 @@ on-board components:
 | I2S         | 2                                      |   no      |
 | CAN         | 2 x CAN 2.0B with up to 1 Mbps         |   no      |
 | PWM         | 6 Channels                             |   yes     |
-| USB         | 1 x USB FS OTG                         |   no      |
+| USB         | 1 x USB FS OTG                         |   yes     |
 | Vcc         | 3.0V - 3.6V                            |           |
 | Datasheet   | [Datasheet](https://gd32mcu.com/data/documents/datasheet/GD32VF103_Datasheet_Rev1.6.pdf) | |
 | Reference Manual | [Reference Manual](https://gd32mcu.com/download/down/document_id/222/path_type/1) | |
@@ -148,7 +148,7 @@ The board is flashed via the in-ROM DFU bootloader by default.
 To enter bootloader mode, hold the BOOT0 button while pressing the RESET button.
 
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+BOARD=sipeed-longan-nano make -C examples/hello-world flash
 ```
 
 After flashing you need to leave bootloader mode again by pressing the RESET button.
@@ -162,33 +162,43 @@ By default, an FTDI adapter according to the configuration defined in
 (https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
 is assumed.
 ```
-PROGRAMMER=openocd BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+PROGRAMMER=openocd BOARD=sipeed-longan-nano make -C examples/hello-world flash
 ```
 To use an FTDI adapter with a different configuration, the configuration can be
 defined using the variable `OPENOCD_FTDI_ADAPTER`, for example:
 ```
-PROGRAMMER=openocd OPENOCD_FTDI_ADAPTER=tigard BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+PROGRAMMER=openocd OPENOCD_FTDI_ADAPTER=tigard BOARD=sipeed-longan-nano make -C examples/hello-world flash
 ```
 If another adapter is used, it can be specified using variable
 `OPENOCD_DEBUG_ADAPTER`, for example for a Segger J-Link adapter:
 ```
-PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink BOARD=sipeed-longan-nano make -C examples/hello-world flash
 ```
 
-## Accessing STDIO via UART
+## Accessing STDIO
 
-The `stdio` is directly accessible through the first UART interface. If an
+By default, the `stdio` is provided by the USBUS CDC ACM module `stdio_cdc_acm`.
+This interface is mapped to `/dev/ttyACM<n>` on a Linux host, where `<n>` is
+the index of the CDC ACM interface, which is 0 by default.
+
+To use the first UART interface for `stdio` instead, the `stdio_uart` module
+has to be enabled:
+```
+USEMODULE=stdio_uart BOARD=sipeed-longan-nano make -C examples/hello-world flash
+```
+
+The `stdio` is then directly accessible through the first UART interface. If an
 external USB-to-UART interface is used, this interface is mapped to
 `/dev/ttyUSB<n>` on a Linux host, where `<n>` is the index of the UART
 interface, which is 0 by default.
 
 Use the `term` target to connect to the board using `/dev/ttyUSB0`:
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world term
+BOARD=sipeed-longan-nano make -C examples/hello-world term PORT=/dev/ttyUSB0
 ```
-If the UART interface index of board's USB to UART bridge is not 0, use
+If the UART interface index of the USB-to-UART interface is not 0, use
 the following command to connect:
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world term PORT=/dev/ttyUSB<n>
+BOARD=sipeed-longan-nano make -C examples/hello-world term PORT=/dev/ttyUSB<n>
 ```
  */


### PR DESCRIPTION
### Contribution description

With the support of the USB OTG interface, both the flash method and the stdio interface module used were changed for the GD32V boards. However, the documentation was not updated. With this PR, the documentation is updated accordingly.

### Testing procedure

Green CI

### Issues/PRs references
