### PR TITLE
makefiles/arch/riscv.inc.mk: speed up toolchain detection

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -35,9 +35,14 @@ TARGET_ARCH_RISCV ?= \
     $(subst -gcc,,\
       $(notdir \
         $(word 1,\
-          $(foreach triple,$(_TRIPLES_TO_TEST),$(shell which $(triple)-gcc 2> /dev/null))))))
+          $(shell which $(addsuffix -gcc,$(_TRIPLES_TO_TEST)) 2> /dev/null)))))
 
 TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
+
+# Convert to a simply expanded variable here, as a recursively expended
+# variable would result in detecting the toolchain each and every time again the
+# toolchain is referenced.
+TARGET_ARCH := $(TARGET_ARCH)
 
 ifeq (,$(TARGET_ARCH))
   $(error No RISC-V toolchain detected. Make sure a RISC-V toolchain is installed.)


### PR DESCRIPTION
### Contribution description

- Use a sane (a.k.a. simply expanded) variable for the `$(TARGET_ARCH)` instead of an insane (a.k.a. recursive expended) variable - The toolchain detection will now happen only once, rather than each and every time `$(TARGET_ARCH)` is referenced
- Use a single call to `which` rather than one per possible target triple

Fixes https://github.com/RIOT-OS/RIOT/issues/19788
<!-- bors cut here -->

### Testing procedure

```
unset TARGET_ARCH
unset TARGET_ARCH_RISCV
make BOARD=hifive1b -C examples/default clean
```

should no be faster than in `master`

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/19788