### PR TITLE
boards/sipeed-longan-nano: fix TFT display config and documentation

### DIFF
--- a/boards/sipeed-longan-nano/Kconfig
+++ b/boards/sipeed-longan-nano/Kconfig
@@ -38,6 +38,7 @@ menu "Sipeed Longan Nano Board Configuration"
 
     config SIPEED_LONGAN_NANO_WITH_TFT
         bool "Board with TFT display"
+        select HAVE_ST7735
         help
             Indicates that a Sipeed Longan Nano board with TFT display is used.
 

--- a/boards/sipeed-longan-nano/Makefile.dep
+++ b/boards/sipeed-longan-nano/Makefile.dep
@@ -12,5 +12,9 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
   USEMODULE += mtd
 endif
 
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += st7735
+endif
+
 include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
 include $(RIOTBOARD)/common/gd32v/Makefile.dep

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -14,6 +14,7 @@ on-board components:
 - USB Type C
 - TF card slot
 - 3 user LEDs
+- 0.96" TFT display 160 x 80 pixel (optional)
 
 @image html "https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/1/114992425_1.jpg" "Sipeed Longan Nano" width=600
 
@@ -95,6 +96,14 @@ by pins.
 | UART_DEV(0) TX   | PA9     | USART0 TX      | UART TX        |                                |
 | UART_DEV(0) RX   | PA10    | USART0 RX      | UART RX        |                                |
 
+\n
+@note To use the TFT display of a Sipeed Longan Nano board, if available, the
+macro `CONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1` has to be defined, for
+example using the `CFLAGS` variable in the make command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=sipeed-longan-nano CFLAGS='-DCONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1' make ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 | Pin  | Board Function | RIOT Function 1 | RIOT Function 2 | RIOT Function 3 |
 |:-----|:---------------|:----------------|:----------------|:----------------|
 | PA0  |                |                 | ADC_LINE(0)     |                 |
@@ -147,9 +156,9 @@ peripheral configurations, their index may vary.
 The board is flashed via the in-ROM DFU bootloader by default.
 To enter bootloader mode, hold the BOOT0 button while pressing the RESET button.
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BOARD=sipeed-longan-nano make -C examples/hello-world flash
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After flashing you need to leave bootloader mode again by pressing the RESET button.
 
@@ -161,19 +170,29 @@ By default, an FTDI adapter according to the configuration defined in
 [`interface/openocd-usb.cfg`]
 (https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
 is assumed.
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PROGRAMMER=openocd BOARD=sipeed-longan-nano make -C examples/hello-world flash
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 To use an FTDI adapter with a different configuration, the configuration can be
 defined using the variable `OPENOCD_FTDI_ADAPTER`, for example:
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PROGRAMMER=openocd OPENOCD_FTDI_ADAPTER=tigard BOARD=sipeed-longan-nano make -C examples/hello-world flash
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If another adapter is used, it can be specified using variable
 `OPENOCD_DEBUG_ADAPTER`, for example for a Segger J-Link adapter:
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink BOARD=sipeed-longan-nano make -C examples/hello-world flash
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+## Using the TFT Display
+
+To use the TFT display of a Sipeed Longan Nano board, if available, the
+macro `CONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1` has to be defined, for
+example using the `CFLAGS` variable in the make command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=sipeed-longan-nano CFLAGS='-DCONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1' make -C tests/drivers/st7735 flash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Accessing STDIO
 
@@ -183,9 +202,9 @@ the index of the CDC ACM interface, which is 0 by default.
 
 To use the first UART interface for `stdio` instead, the `stdio_uart` module
 has to be enabled:
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=stdio_uart BOARD=sipeed-longan-nano make -C examples/hello-world flash
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `stdio` is then directly accessible through the first UART interface. If an
 external USB-to-UART interface is used, this interface is mapped to
@@ -193,12 +212,12 @@ external USB-to-UART interface is used, this interface is mapped to
 interface, which is 0 by default.
 
 Use the `term` target to connect to the board using `/dev/ttyUSB0`:
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BOARD=sipeed-longan-nano make -C examples/hello-world term PORT=/dev/ttyUSB0
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If the UART interface index of the USB-to-UART interface is not 0, use
 the following command to connect:
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BOARD=sipeed-longan-nano make -C examples/hello-world term PORT=/dev/ttyUSB<n>
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */

--- a/boards/sipeed-longan-nano/include/board.h
+++ b/boards/sipeed-longan-nano/include/board.h
@@ -77,10 +77,12 @@ extern "C" {
 #define ST7735_PARAM_CS           GPIO_PIN(PORT_B, 2)   /**< Chip Select pin */
 #define ST7735_PARAM_DCX          GPIO_PIN(PORT_B, 0)   /**< DCX pin */
 #define ST7735_PARAM_RST          GPIO_PIN(PORT_B, 1)   /**< Reset pin */
-#define ST7735_PARAM_RGB          1                     /**< RGB mode enable */
-#define ST7735_PARAM_INVERTED     0                     /**< Inverted mode enable */
+#define ST7735_PARAM_RGB          0                     /**< RGB mode enable */
+#define ST7735_PARAM_INVERTED     1                     /**< Inverted mode enable */
 #define ST7735_PARAM_NUM_LINES    160U                  /**< Number of lines */
 #define ST7735_PARAM_RGB_CHANNELS 80U                   /**< Number of columns */
+#define ST7735_PARAM_ROTATION     ST7735_ROTATION_HORZ  /**< Rotation mode */
+#define ST7735_PARAM_OFFSET_Y     25                    /**< Vertical offset */
 #endif
 
 #ifdef __cplusplus

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -65,7 +65,7 @@ static const adc_conf_t adc_config[] = {
     /* This conflicts with TFT pins if connected. */
     { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 8 },
     { .pin = GPIO_PIN(PORT_B, 1), .dev = 0, .chan = 9 },
-    /* This conflicts with the SPI0 controller which is used is TFT is connected */
+    /* This conflicts with the SPI0 controller which is used if TFT is connected */
     { .pin = GPIO_PIN(PORT_A, 6), .dev = 0, .chan = 6 },
     { .pin = GPIO_PIN(PORT_A, 7), .dev = 0, .chan = 7 },
 #if !defined(MODULE_PERIPH_DAC)
@@ -86,8 +86,8 @@ static const dac_conf_t dac_config[] = {
 #if !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
     { .pin = GPIO_PIN(PORT_A, 4), .chan = 0 },
     { .pin = GPIO_PIN(PORT_A, 5), .chan = 1 },
-};
 #endif /* !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT */
+};
 
 #define DAC_NUMOF           ARRAY_SIZE(dac_config)
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR fixes the configuration of the TFT Display of Sipeed Longan Nano boards and improves the documentation regarding the use of the TFT Display.

### Testing procedure

```
CFLAGS='-DCONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1' BOARD=sipeed-longan-nano make -C tests/drivers/st7735/ flash
```
should work with this PR.

### Issues/PRs references