### PR TITLE
cpu/stm32: fix RNG clock configuration for STM32U5

### DIFF
--- a/cpu/stm32/stmclk/stmclk_u5.c
+++ b/cpu/stm32/stmclk/stmclk_u5.c
@@ -101,26 +101,6 @@
 #error "Invalid MSI clock"
 #endif
 
-/* Configure 48MHz clock source */
-#define CLOCK_PLLQ                  ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_M) * CONFIG_CLOCK_PLL_N) / CONFIG_CLOCK_PLL_Q
-
-#if CLOCK_PLLQ == MHZ(48)
-#define CLOCK48MHZ_USE_PLLQ         1
-#elif CONFIG_CLOCK_MSI == MHZ(48)
-#define CLOCK48MHZ_USE_MSI          1
-#else
-#define CLOCK48MHZ_USE_PLLQ         0
-#define CLOCK48MHZ_USE_MSI          0
-#endif
-
-#if IS_ACTIVE(CLOCK48MHZ_USE_PLLQ)
-#define CLOCK48MHZ_SELECT           (RCC_CCIPR1_CLK48MSEL_1)
-#elif IS_ACTIVE(CLOCK48MHZ_USE_MSI)
-#define CLOCK48MHZ_SELECT           (RCC_CCIPR1_CLK48MSEL_1 | RCC_CCIPR1_CLK48MSEL_0)
-#else
-#define CLOCK48MHZ_SELECT           (0)
-#endif
-
 /* Configure the AHB and APB buses prescalers */
 #define CLOCK_AHB_DIV               (0)
 
@@ -148,22 +128,17 @@
 #define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2 | RCC_CFGR2_PPRE2_1 | RCC_CFGR2_PPRE2_0)
 #endif
 
-/* Only periph_hwrng requires 48MHz for the moment */
+/* Only periph_hwrng requires HSI RC with 48MHz for the moment */
 #if IS_USED(MODULE_PERIPH_HWRNG)
-#if !IS_ACTIVE(CLOCK48MHZ_USE_PLLQ) && !IS_ACTIVE(CLOCK48MHZ_USE_MSI)
-#error "No 48MHz clock source available, HWRNG cannot work"
-#endif
-#define CLOCK_ENABLE_48MHZ          1
+#define CLOCK_ENABLE_HSI48          1
 #else
-#define CLOCK_ENABLE_48MHZ          0
+#define CLOCK_ENABLE_HSI48          0
 #endif
 
 /* Check if PLL is required
-  - When used as system clock
   - When PLLQ is used as 48MHz clock source
 */
-#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || \
-    (IS_ACTIVE(CLOCK_ENABLE_48MHZ) && IS_ACTIVE(CLOCK48MHZ_USE_PLLQ))
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL)
 #define CLOCK_ENABLE_PLL            1
 #else
 #define CLOCK_ENABLE_PLL            0
@@ -185,7 +160,7 @@
 #error "HSE is required by the clock configuration but is not provided by the board."
 #endif
 
-/* Check if HSI is required:
+/* Check if HSI RC with 16 MHz is required:
   - When used as system clock
   - When used as PLL input clock
 */
@@ -267,7 +242,7 @@ void stmclk_init_sysclk(void)
         while (!(RCC->CR & RCC_CR_HSERDY)) {}
     }
 
-    /* Enable the MSI clock only when it's used */
+    /* Enable the MSIS clock only when it's used */
     if (IS_ACTIVE(CLOCK_ENABLE_MSI)) {
         RCC->ICSCR1 = RCC_ICSCR1_MSIRGSEL;
         RCC->ICSCR1 |= CLOCK_MSIRANGE;
@@ -330,9 +305,14 @@ void stmclk_init_sysclk(void)
         stmclk_disable_hsi();
     }
 
-    if (IS_ACTIVE(CLOCK_ENABLE_48MHZ)) {
-        /* configure the clock used for the 48MHz clock tree (USB, RNG) */
-        RCC->CCIPR1 = CLOCK48MHZ_SELECT;
+    if (IS_ACTIVE(CLOCK_ENABLE_HSI48)) {
+        /* enable HSI48 clock for certain peripherals (RNG, OTG_FS, USB and SDMMC) */
+        RCC->CR |= RCC_CR_HSI48ON;
+        while (!(RCC->CR & RCC_CR_HSI48RDY)) {}
+        /* select HSI48 as clock for RNG (reset value) */
+        /* RCC->CCIPR2 &= ~(RCC_CCIPR2_RNGSEL_1 | RCC_CCIPR2_RNGSEL_0); */
+        /* select HSI48 as clock for OTG_FS, USB and SDMMC (reset value) */
+        /* RCC->CCIPR1 &= ~(RCC_CCIPR1_CLK48MSEL_1 | RCC_CCIPR1_CLK48MSEL_0); */
     }
 
     irq_restore(is);


### PR DESCRIPTION
### Contribution description

This PR fixes the RNG clock configuration for STM32U5.

The RNG peripheral can only use HSI48, HSI48/2 or HSI16, see [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0456-stm32u5-series-armbased-32bit-mcus-stmicroelectronics.pdf), section 11.8.47 RCC_CCIPR2, page 590:

_**Bits 13:12 RNGSEL[1:0]:** RNG kernel clock source selection
These bits are used to select the RNG kernel clock source.
00: HSI48 selected
01: HSI48 / 2 selected, can be used in range 4
10: HSI16 selected
11: reserved_

Using MSI as 48 MHz clock source for RNG is not possible. The clock configuration in `cpu/stm32/stmclk/stmclk_u5.c` activates anyway only the MSIS but not the MSIK which could be used for certain peripherals.

Therefore, this PR
- removes the configuration of MSI as 48 MHz clock for RNG and its selection in `RCC->CCIPR1.ICLKSEL`
- enables HSI48 and selects it for RNG.

The HSI48 will also be used in future for certain peripherals such as USB OTG FS and SDMMC.

### Testing procedure

```
BOARD=b-u585i-iot02a make -j8 -C tests/periph/hwrng/ flash term
```
should work as expected.

### Issues/PRs references
