### PR TITLE
boards/b_u585i_ iot02a/periph usbdev

### DIFF
--- a/boards/b-u585i-iot02a/Kconfig
+++ b/boards/b-u585i-iot02a/Kconfig
@@ -17,6 +17,10 @@ config BOARD_B_U585I_IOT02A
     select HAS_PERIPH_I2C
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_TINYUSB_DEVICE
 
     # Clock configuration
     select BOARD_HAS_LSE

--- a/boards/b-u585i-iot02a/Makefile.features
+++ b/boards/b-u585i-iot02a/Makefile.features
@@ -5,5 +5,7 @@ CPU_MODEL = stm32u585ai
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/b-u585i-iot02a/include/periph_conf.h
+++ b/boards/b-u585i-iot02a/include/periph_conf.h
@@ -27,6 +27,7 @@
 #include "periph_cpu.h"
 #include "clk_conf.h"
 #include "cfg_timer_tim5.h"
+#include "cfg_usb_otg_fs_u5.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/common/stm32/include/cfg_usb_otg_fs_u5.h
+++ b/boards/common/stm32/include/cfg_usb_otg_fs_u5.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 Koen Zandberg
+ *               2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Common configuration for STM32 OTG FS peripheral for U5 family
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef CFG_USB_OTG_FS_U5_H
+#define CFG_USB_OTG_FS_U5_H
+
+#include "periph_cpu.h"
+#include "usbdev_synopsys_dwc2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable the full speed USB OTG peripheral
+ */
+#define DWC2_USB_OTG_FS_ENABLED
+
+/**
+ * @brief Common USB OTG FS configuration
+ */
+static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
+    {
+        .periph   = USB_OTG_FS_BASE,
+        .type     = DWC2_USB_OTG_FS,
+        .phy      = DWC2_USB_OTG_PHY_BUILTIN,
+        .rcc_mask = RCC_AHB2ENR1_OTGEN,
+        .irqn     = OTG_FS_IRQn,
+        .ahb      = AHB2,
+        .dm       = GPIO_PIN(PORT_A, 11),
+        .dp       = GPIO_PIN(PORT_A, 12),
+        .af       = GPIO_AF10,
+    }
+};
+
+/**
+ * @brief Number of available USB OTG peripherals
+ */
+#define USBDEV_NUMOF           ARRAY_SIZE(dwc2_usb_otg_fshs_config)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_USB_OTG_FS_U5_H */
+/** @} */

--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -76,6 +76,8 @@ $(call target-export-variables,$(VECTORS_O),CPU_LINE)
 # Add this define to skip the inclusion of the system_stm32xxxx.h header files
 # which are only used for STM32 system includes and not of interest for RIOT.
 CFLAGS += -D__SYSTEM_STM32$(call uppercase,$(CPU_FAM))XX_H
+# C0, G0, H7, L5 and U5 use SYSTEM_STM32..XX_H instead
+CFLAGS += -DSYSTEM_STM32$(call uppercase,$(CPU_FAM))XX_H
 
 ifneq (,$(filter STM32F030x4 STM32MP157Cxx,$(CPU_LINE)))
   STM32CMSIS_INCLUDE_DIR = $(RIOTCPU)/stm32/include/vendor/cmsis/$(CPU_FAM)/Include

--- a/cpu/stm32/stmclk/stmclk_u5.c
+++ b/cpu/stm32/stmclk/stmclk_u5.c
@@ -101,26 +101,6 @@
 #error "Invalid MSI clock"
 #endif
 
-/* Configure 48MHz clock source */
-#define CLOCK_PLLQ                  ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_M) * CONFIG_CLOCK_PLL_N) / CONFIG_CLOCK_PLL_Q
-
-#if CLOCK_PLLQ == MHZ(48)
-#define CLOCK48MHZ_USE_PLLQ         1
-#elif CONFIG_CLOCK_MSI == MHZ(48)
-#define CLOCK48MHZ_USE_MSI          1
-#else
-#define CLOCK48MHZ_USE_PLLQ         0
-#define CLOCK48MHZ_USE_MSI          0
-#endif
-
-#if IS_ACTIVE(CLOCK48MHZ_USE_PLLQ)
-#define CLOCK48MHZ_SELECT           (RCC_CCIPR1_CLK48MSEL_1)
-#elif IS_ACTIVE(CLOCK48MHZ_USE_MSI)
-#define CLOCK48MHZ_SELECT           (RCC_CCIPR1_CLK48MSEL_1 | RCC_CCIPR1_CLK48MSEL_0)
-#else
-#define CLOCK48MHZ_SELECT           (0)
-#endif
-
 /* Configure the AHB and APB buses prescalers */
 #define CLOCK_AHB_DIV               (0)
 
@@ -148,22 +128,17 @@
 #define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2 | RCC_CFGR2_PPRE2_1 | RCC_CFGR2_PPRE2_0)
 #endif
 
-/* Only periph_hwrng requires 48MHz for the moment */
+/* Only periph_hwrng requires HSI RC with 48MHz for the moment */
 #if IS_USED(MODULE_PERIPH_HWRNG)
-#if !IS_ACTIVE(CLOCK48MHZ_USE_PLLQ) && !IS_ACTIVE(CLOCK48MHZ_USE_MSI)
-#error "No 48MHz clock source available, HWRNG cannot work"
-#endif
-#define CLOCK_ENABLE_48MHZ          1
+#define CLOCK_ENABLE_HSI48          1
 #else
-#define CLOCK_ENABLE_48MHZ          0
+#define CLOCK_ENABLE_HSI48          0
 #endif
 
 /* Check if PLL is required
-  - When used as system clock
   - When PLLQ is used as 48MHz clock source
 */
-#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || \
-    (IS_ACTIVE(CLOCK_ENABLE_48MHZ) && IS_ACTIVE(CLOCK48MHZ_USE_PLLQ))
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL)
 #define CLOCK_ENABLE_PLL            1
 #else
 #define CLOCK_ENABLE_PLL            0
@@ -185,7 +160,7 @@
 #error "HSE is required by the clock configuration but is not provided by the board."
 #endif
 
-/* Check if HSI is required:
+/* Check if HSI RC with 16 MHz is required:
   - When used as system clock
   - When used as PLL input clock
 */
@@ -267,7 +242,7 @@ void stmclk_init_sysclk(void)
         while (!(RCC->CR & RCC_CR_HSERDY)) {}
     }
 
-    /* Enable the MSI clock only when it's used */
+    /* Enable the MSIS clock only when it's used */
     if (IS_ACTIVE(CLOCK_ENABLE_MSI)) {
         RCC->ICSCR1 = RCC_ICSCR1_MSIRGSEL;
         RCC->ICSCR1 |= CLOCK_MSIRANGE;
@@ -330,9 +305,14 @@ void stmclk_init_sysclk(void)
         stmclk_disable_hsi();
     }
 
-    if (IS_ACTIVE(CLOCK_ENABLE_48MHZ)) {
-        /* configure the clock used for the 48MHz clock tree (USB, RNG) */
-        RCC->CCIPR1 = CLOCK48MHZ_SELECT;
+    if (IS_ACTIVE(CLOCK_ENABLE_HSI48)) {
+        /* enable HSI48 clock for certain peripherals (RNG, OTG_FS, USB and SDMMC) */
+        RCC->CR |= RCC_CR_HSI48ON;
+        while (!(RCC->CR & RCC_CR_HSI48RDY)) {}
+        /* select HSI48 as clock for RNG (reset value) */
+        /* RCC->CCIPR2 &= ~(RCC_CCIPR2_RNGSEL_1 | RCC_CCIPR2_RNGSEL_0); */
+        /* select HSI48 as clock for OTG_FS, USB and SDMMC (reset value) */
+        /* RCC->CCIPR1 &= ~(RCC_CCIPR1_CLK48MSEL_1 | RCC_CCIPR1_CLK48MSEL_0); */
     }
 
     irq_restore(is);

--- a/cpu/stm32/stmclk/stmclk_u5.c
+++ b/cpu/stm32/stmclk/stmclk_u5.c
@@ -128,8 +128,8 @@
 #define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2 | RCC_CFGR2_PPRE2_1 | RCC_CFGR2_PPRE2_0)
 #endif
 
-/* Only periph_hwrng requires HSI RC with 48MHz for the moment */
-#if IS_USED(MODULE_PERIPH_HWRNG)
+/* Only periph_hwrng and periph_usbdev require HSI RC with 48MHz for the moment */
+#if IS_USED(MODULE_PERIPH_HWRNG) || IS_USED(MODULE_PERIPH_USBDEV_CLK)
 #define CLOCK_ENABLE_HSI48          1
 #else
 #define CLOCK_ENABLE_HSI48          0

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -745,8 +745,8 @@ static void _usbdev_init(usbdev_t *dev)
     pm_block(STM32_PM_STOP);
     pm_block(STM32_PM_STANDBY);
 
-#if defined(PWR_CR2_USV) /* on L4 */
-    /* Validate USB Supply */
+#if defined(PWR_CR2_USV)
+    /*  on L4: Validate USB Supply */
     PWR->CR2 |= PWR_CR2_USV;
 #endif /* PWR_CR2_USV */
 
@@ -1004,10 +1004,10 @@ static void _usbdev_init(usbdev_t *dev)
 
     /* Disable Vbus detection and force the pull-up on, GCCFG is STM32 specific */
 #if defined(STM32_USB_OTG_CID_1x)
-    /* Enable no Vbus sensing */
+    /* set No Vbus Sensing */
     _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
 #elif defined(STM32_USB_OTG_CID_2x)
-    /* Enable no Vbus Detect enable  and enable 'Power Down Disable */
+    /* clear Vbus Detect Enable */
     _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_VBDEN;
     /* Force Vbus Detect values and ID detect values to device mode */
     _global_regs(usbdev->config)->GOTGCTL |= USB_OTG_GOTGCTL_VBVALOVAL |

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -750,6 +750,11 @@ static void _usbdev_init(usbdev_t *dev)
     PWR->CR2 |= PWR_CR2_USV;
 #endif /* PWR_CR2_USV */
 
+#if defined(PWR_SVMCR_USV)
+    /* on U5: Validate USB Supply */
+    PWR->SVMCR |= PWR_SVMCR_USV;
+#endif /* PWR_SVMCR_USV */
+
     /* Enable the clock to the peripheral */
     periph_clk_en(conf->ahb, conf->rcc_mask);
 

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -1008,7 +1008,7 @@ static void _usbdev_init(usbdev_t *dev)
     _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
 #elif defined(STM32_USB_OTG_CID_2x)
     /* clear Vbus Detect Enable */
-    _global_regs(usbdev->config)->GCCFG |= USB_OTG_GCCFG_VBDEN;
+    _global_regs(usbdev->config)->GCCFG &= ~USB_OTG_GCCFG_VBDEN;
     /* Force Vbus Detect values and ID detect values to device mode */
     _global_regs(usbdev->config)->GOTGCTL |= USB_OTG_GOTGCTL_VBVALOVAL |
                                              USB_OTG_GOTGCTL_VBVALOEN |

--- a/pkg/tinyusb/hw/hw_stm32_otg.c
+++ b/pkg/tinyusb/hw/hw_stm32_otg.c
@@ -32,8 +32,8 @@ static int tinyusb_hw_init_dev(const dwc2_usb_otg_fshs_config_t *conf)
     pm_block(STM32_PM_STOP);
     pm_block(STM32_PM_STANDBY);
 
-#if defined(PWR_CR2_USV) /* on L4 */
-    /* Validate USB Supply */
+#if defined(PWR_CR2_USV)
+    /* on L4: Validate USB Supply */
     PWR->CR2 |= PWR_CR2_USV;
 #endif /* PWR_CR2_USV */
 
@@ -53,7 +53,7 @@ static int tinyusb_hw_init_dev(const dwc2_usb_otg_fshs_config_t *conf)
                 (USB_OTG_GlobalTypeDef *)(conf->periph + USB_OTG_GLOBAL_BASE);
 
 #ifdef USB_OTG_GCCFG_NOVBUSSENS
-    /* Enable no Vbus Detect enable and enable `Power Down Disable` */
+    /* set No Vbus Sensing */
     global_regs->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
 #endif
 

--- a/pkg/tinyusb/hw/hw_stm32_otg.c
+++ b/pkg/tinyusb/hw/hw_stm32_otg.c
@@ -55,6 +55,9 @@ static int tinyusb_hw_init_dev(const dwc2_usb_otg_fshs_config_t *conf)
 #ifdef USB_OTG_GCCFG_NOVBUSSENS
     /* set No Vbus Sensing */
     global_regs->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
+#elif USB_OTG_GCCFG_VBDEN
+    /* clear Vbus Detect Enable */
+    global_regs->GCCFG &= ~USB_OTG_GCCFG_VBDEN;
 #endif
 
 #ifdef DWC2_USB_OTG_HS_ENABLED

--- a/pkg/tinyusb/hw/hw_stm32_otg.c
+++ b/pkg/tinyusb/hw/hw_stm32_otg.c
@@ -37,6 +37,11 @@ static int tinyusb_hw_init_dev(const dwc2_usb_otg_fshs_config_t *conf)
     PWR->CR2 |= PWR_CR2_USV;
 #endif /* PWR_CR2_USV */
 
+#if defined(PWR_SVMCR_USV)
+    /* on U5: Validate USB Supply */
+    PWR->SVMCR |= PWR_SVMCR_USV;
+#endif /* PWR_SVMCR_USV */
+
     /* Enable the clock to the peripheral */
     periph_clk_en(conf->ahb, conf->rcc_mask);
 


### PR DESCRIPTION
### Contribution description

This PR adds the USB OTG support for STM32U5 and the `b_u585i_iot02a` board.

This PR includes PR #19795 since it uses directly the changes made in PR #19795.

### Testing procedure

Compile and flash
```
BOARD=b-u585i-iot02a make -C tests/sys/usbus_cdc_ecm/ flash term
```
Use the `sudo dmesg` command to get the kernel messages.
```pyhon
[766948.556645] usb 1-2.2: new full-speed USB device number 108 using xhci_hcd
[766948.658688] usb 1-2.2: New USB device found, idVendor=1209, idProduct=7d00, bcdDevice= 1.00
[766948.658696] usb 1-2.2: New USB device strings: Mfr=3, Product=2, SerialNumber=4
[766948.658699] usb 1-2.2: Product: b-u585i-iot02a
[766948.658702] usb 1-2.2: Manufacturer: RIOT-os.org
[766948.658704] usb 1-2.2: SerialNumber: AA140057DA41D467
[766948.668681] cdc_ether 1-2.2:1.0 usb0: register 'cdc_ether' at usb-0000:00:14.0-2.2, CDC Ethernet Device, ea:dc:44:71:d9:24
[766948.743250] cdc_ether 1-2.2:1.0 enxeadc4471d924: renamed from usb0
```
Use the `ifconfig` command on the node to determine the IPv6 LLUA and ping the node.
```
ping6 -c 3 fe80::e8dc:44ff:fe71:c524%enxeadc4471d924
PING fe80::e8dc:44ff:fe71:c524%enxeadc4471d924(fe80::e8dc:44ff:fe71:c524%enxeadc4471d924) 56 data bytes
64 bytes from fe80::e8dc:44ff:fe71:c524%enxeadc4471d924: icmp_seq=1 ttl=64 time=0.523 ms
64 bytes from fe80::e8dc:44ff:fe71:c524%enxeadc4471d924: icmp_seq=2 ttl=64 time=0.546 ms
64 bytes from fe80::e8dc:44ff:fe71:c524%enxeadc4471d924: icmp_seq=3 ttl=64 time=0.599 ms
```

### Issues/PRs references

Includes PR #19795 