### PR TITLE
Makefile.include: don't use target lstfile implicitly

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -693,15 +693,6 @@ endif
 
 BUILD_FILES += $(ELFFILE) $(BINFILE) $(FLASHFILE) $(HASHFILE)
 
-# when not in CI, aid developers in debugging the firmware with a full memory
-# layout and disassembly provided by the lst file:
-ifneq ($(RIOT_CI_BUILD),1)
-  # as of now, the xtensa tools cannot create lst files
-  ifeq (,$(findstring xtensa,$(PREFIX)))
-    BUILD_FILES += $(LSTFILE)
-  endif
-endif
-
 # variables used to compile and link c++
 ifneq (,$(filter cpp,$(USEMODULE)))
   CPPMIX ?= 1


### PR DESCRIPTION
### Contribution description

This PR reverts a part of PR #19745. It removes the `$(LSTFILE)` from the `BUILD_FILES` variable so that the `.lst` file isn't generated implicitly. If the `.lst` file is needed, it can be generated with `lstfile` target.

**Background**

The compilation time increased a lot with PR #19745. The reason is that the generation of the `.lst` file seems to be time-consuming. For example, on an Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz` with 8 cores and a SSD, it takes about 15 seconds for a complex application such as `tests/sys/usbus_msc` for a STM32F7 MCU.

Therefore, the compilation time for
```
BOARD=stm32f723e-disco make -j8 -C tests/sys/usbus_msc
```
increased from about 1 sec to about 16 seconds (all source files were already compiled).

Even for a small application
```
BOARD=stm32f723e-disco make -j8 -C tests/sys/shell
```
the compilation time increased from about 1 sec to about 10 seconds.

### Testing procedure

Green CI

### Issues/PRs references

