### PR TITLE
usbus: Implement USB_FEATURE_DEVICE_REMOTE_WAKEUP handling

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -466,6 +466,7 @@ struct usbus {
     usbus_state_t state;                            /**< Current state                         */
     usbus_state_t pstate;                           /**< state to recover to from suspend      */
     uint8_t addr;                                   /**< Address of the USB peripheral         */
+    bool wakeup_enabled;                            /**< Remote wakeup device feature status   */
 #ifndef CONFIG_USB_SERIAL_STR
     /**
      * @brief Hex representation of the device serial number


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
While working on the `qmk_firmware` integration, a slight behavioural difference was noted in Windows 10/11 hosts.

Stalling on `SET_FEATURE`/`CLEAR_FEATURE` can make upstream hubs disable ports. This in turn stops the device from instantiating a remote wakeup (currently implemented with some MCU specific logic).

According to the USB 2.0 spec, remote wakeup should be disabled by default, and should only be enabled if the host explicitly requests it. Handling `USB_FEATURE_DEVICE_REMOTE_WAKEUP` and storing its status allows devices to also be more compliant in its wakeup process. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Right now its been tested via wireshark and a heavily modified qmk_firmware branch.
Please do let me know if theres existing test cases to update.

Hardware tested was a ATSAMD51J18A MCU and USB2422 Hub, as well as ATSAMD21G18 and nrf52840.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
