### PR TITLE
cpu/nrf5x_common: rework LFCLK source selection

### DIFF
--- a/boards/common/e104-bt50xxa-tb/include/periph_conf.h
+++ b/boards/common/e104-bt50xxa-tb/include/periph_conf.h
@@ -34,7 +34,12 @@ extern "C" {
  * @{
  */
 #define CLOCK_HFCLK         (1)             /* external crystal */
-#define CLOCK_LFCLK         (0)             /* internal RC oscillator */
+
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_RC: internal RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_Xtal: 32.768 kHz crystal
+ * - CLOCK_LFCLKSRC_SRC_Synth: derived from HFCLK */
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_RC) /**< LFCLK Source */
 /** @} */
 
 /**

--- a/boards/common/nrf51/include/cfg_clock_16_0.h
+++ b/boards/common/nrf51/include/cfg_clock_16_0.h
@@ -35,9 +35,11 @@
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */
-#define CLOCK_LFCLK         (0)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_RC: internal RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_Xtal: 32.768 kHz crystal
+ * - CLOCK_LFCLKSRC_SRC_Synth: derived from HFCLK */
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_RC) /**< LFCLK Source */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf51/include/cfg_clock_16_1.h
+++ b/boards/common/nrf51/include/cfg_clock_16_1.h
@@ -35,9 +35,11 @@
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */
-#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_RC: internal RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_Xtal: 32.768 kHz crystal
+ * - CLOCK_LFCLKSRC_SRC_Synth: derived from HFCLK */
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_Xtal) /**< LFCLK Source */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf52/include/cfg_clock_32_0.h
+++ b/boards/common/nrf52/include/cfg_clock_32_0.h
@@ -33,9 +33,11 @@ extern "C" {
  */
 #define CLOCK_HFCLK         (32U)           /* set to  0: internal RC oscillator
                                              *        32: 32MHz crystal */
-#define CLOCK_LFCLK         (0)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_RC: internal RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_Xtal: 32.768 kHz crystal
+ * - CLOCK_LFCLKSRC_SRC_Synth: derived from HFCLK */
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_RC) /**< LFCLK Source */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nrf52/include/cfg_clock_32_1.h
+++ b/boards/common/nrf52/include/cfg_clock_32_1.h
@@ -33,9 +33,11 @@ extern "C" {
  */
 #define CLOCK_HFCLK         (32U)           /* set to  0: internal RC oscillator
                                              *        32: 32MHz crystal */
-#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_RC: internal RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_Xtal: 32.768 kHz crystal
+ * - CLOCK_LFCLKSRC_SRC_Synth: derived from HFCLK */
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_Xtal) /**< LFCLK Source */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf5340dk-app/include/board.h
+++ b/boards/nrf5340dk-app/include/board.h
@@ -31,7 +31,7 @@ extern "C" {
 #define CLOCK_CORECLOCK     MHZ(128)
 
 /**
- * @name    HF Clock configuration
+ * @name    Clock configuration
  *
  *
  * @{
@@ -40,7 +40,12 @@ extern "C" {
  /* CLOCK_HFCLKSRC_SRC_HFXO to use external 32MHz crystal
   *   CLOCK_HFCLKSRC_SRC_HFINT to use internal crystal */
 #define CLOCK_HFCLK         (CLOCK_HFCLKSRC_SRC_HFXO) /**< HFCLK Source selection */
-#define CLOCK_LFCLK         (3) /**< LFCLK Source selection */
+
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_LFRC: 32.768 kHz RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_LFXO: 32.768 kHz crystal oscillator
+ * - CLOCK_LFCLKSRC_SRC_LFSYNT: 32.768 kHz synthesized from HFCLK*/
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_LFXO) /**< LFCLK Source */
 /** @} */
 
 /**

--- a/boards/nrf9160dk/include/board.h
+++ b/boards/nrf9160dk/include/board.h
@@ -34,8 +34,10 @@ extern "C" {
  */
 #define CLOCK_HFCLK         (32U)           /**< set to  0: internal RC oscillator
                                              *        32: 32MHz crystal */
-#define CLOCK_LFCLK         (3)             /**< set to  0: internal RC oscillator
-                                             *         3: High Accuracy oscillator */
+/* LFCLK Source clock selection:*/
+/* - CLOCK_LFCLKSRC_SRC_LFRC: 32.768 kHz RC oscillator
+ * - CLOCK_LFCLKSRC_SRC_LFXO: 32.768 kHz crystal oscillator */
+#define CLOCK_LFCLK         (CLOCK_LFCLKSRC_SRC_LFXO) /**< LFCLK Source */
 /** @} */
 
 /**

--- a/cpu/nrf51/cpu.c
+++ b/cpu/nrf51/cpu.c
@@ -26,6 +26,15 @@
 #include "stdio_base.h"
 
 /**
+ * @brief    LFCLK Clock selection configuration guard
+*/
+#if ((CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_RC)   && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_Xtal) && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_Synth))
+#error "LFCLK init: CLOCK_LFCLK has invalid value"
+#endif
+
+/**
  * @brief Initialize the CPU, set IRQ priorities
  */
 void cpu_init(void)

--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -36,6 +36,15 @@ static bool ftpan_37(void);
 static bool ftpan_36(void);
 
 /**
+ * @brief    LFCLK Clock selection configuration guard
+*/
+#if ((CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_RC)   && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_Xtal) && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_Synth))
+#error "LFCLK init: CLOCK_LFCLK has invalid value"
+#endif
+
+/**
  * @brief   Initialize the CPU, set IRQ priorities
  */
 void cpu_init(void)

--- a/cpu/nrf53/cpu.c
+++ b/cpu/nrf53/cpu.c
@@ -28,6 +28,15 @@
 #include "board.h"
 
 /**
+ * @brief    LFCLK Clock selection configuration guard
+*/
+#if ((CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_LFRC) && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_LFXO) && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_LFSYNT))
+#error "LFCLK init: CLOCK_LFCLK has invalid value"
+#endif
+
+/**
  * @brief   Initialize the CPU, set IRQ priorities
  */
 void cpu_init(void)

--- a/cpu/nrf5x_common/clock.c
+++ b/cpu/nrf5x_common/clock.c
@@ -23,21 +23,14 @@
 #include "nrf_clock.h"
 #include "periph_conf.h"
 
-/* make sure both clocks are configured */
+/* make HFCLK clock is configured */
 #ifndef CLOCK_HFCLK
 #error "Clock init: CLOCK_HFCLK is not defined by your board!"
-#endif
-#ifndef CLOCK_LFCLK
-#error "Clock init: CLOCK_LFCLK is not defined by your board!"
 #endif
 
 /* Add compatibility wrapper defines for nRF families with Cortex-M33 core */
 #ifdef NRF_CLOCK_S
 #define NRF_CLOCK NRF_CLOCK_S
-#endif
-
-#ifdef CLOCK_LFCLKSRC_SRC_LFRC
-#define CLOCK_LFCLKSRC_SRC_RC CLOCK_LFCLKSRC_SRC_LFRC
 #endif
 
 static unsigned _hfxo_requests = 0;
@@ -92,17 +85,9 @@ void clock_start_lf(void)
         return;
     }
 
-#if (CLOCK_LFCLK == 0)
-    NRF_CLOCK->LFCLKSRC = (CLOCK_LFCLKSRC_SRC_RC);
-#elif (CLOCK_LFCLK == 1)
-    NRF_CLOCK->LFCLKSRC = (CLOCK_LFCLKSRC_SRC_Xtal);
-#elif (CLOCK_LFCLK == 2)
-    NRF_CLOCK->LFCLKSRC = (CLOCK_LFCLKSRC_SRC_Synth);
-#elif (CLOCK_LFCLK == 3)
-    NRF_CLOCK->LFCLKSRC = (CLOCK_LFCLKSRC_SRC_LFXO);
-#else
-#error "LFCLK init: CLOCK_LFCLK has invalid value"
-#endif
+    /* Select LFCLK source */
+    NRF_CLOCK->LFCLKSRC = CLOCK_LFCLK;
+
     /* enable LF clock */
     NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
     NRF_CLOCK->TASKS_LFCLKSTART = 1;

--- a/cpu/nrf9160/cpu.c
+++ b/cpu/nrf9160/cpu.c
@@ -26,6 +26,14 @@
 #include "stdio_base.h"
 
 /**
+ * @brief    LFCLK Clock selection configuration guard
+*/
+#if ((CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_LFRC) && \
+     (CLOCK_LFCLK != CLOCK_LFCLKSRC_SRC_LFXO))
+#error "LFCLK init: CLOCK_LFCLK has invalid value"
+#endif
+
+/**
  * @brief   Initialize the CPU, set IRQ priorities
  */
 void cpu_init(void)


### PR DESCRIPTION
### Contribution description
This PR changes the source selection of LFCLK for all nRF families.
This idea is to use the values provided by Nordic vendor files to properly populate the source of the LFCLK. Then setup a per CPU check to ensure the value provided at board level is fine. In the end, the LFCLK source selection is a mere assignment.
The selection of the LFCLK source is still done at board level. I also add a bit of documentation to help users to select another value if needed.


I'll provide in a followup PR, `periph_rtt` support for both nRF9160 and nRF53.

### Testing procedure
CI should be enough I think. Otherwise, one can ran tests/periph/rtt on any nRF51-based board and any nRF52-based board.
You can also change the LFCLK source at board level to ensure the guards are doing their jobs.

### Issues/PRs references
None.