### PR TITLE
cpu/nrf{53,9160}: add periph_rtt support

### DIFF
--- a/boards/nrf5340dk-app/Kconfig
+++ b/boards/nrf5340dk-app/Kconfig
@@ -11,6 +11,7 @@ config BOARD_NRF5340DK_APP
     bool
     default y
     select CPU_MODEL_NRF5340_APP
+    select HAS_PERIPH_RTT
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_HW_FC

--- a/boards/nrf5340dk-app/Makefile.features
+++ b/boards/nrf5340dk-app/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = nrf5340_app
 CPU = nrf53
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_uart_hw_fc

--- a/boards/nrf5340dk-app/include/periph_conf.h
+++ b/boards/nrf5340dk-app/include/periph_conf.h
@@ -75,6 +75,24 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config) /**< UART configuration NUMOF */
 /** @} */
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#ifndef RTT_DEV
+#define RTT_DEV             (0)                 /**< NRF_RTC0_S */
+#endif
+
+#define RTT_MAX_VALUE       (0x00ffffff)         /**< 24bit */
+#define RTT_MAX_FREQUENCY   (32768U)             /**< in Hz */
+#define RTT_MIN_FREQUENCY   (8U)                 /**< in Hz */
+#define RTT_CLOCK_FREQUENCY (32768U)             /**< in Hz, LFCLK*/
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1024U)              /**< in Hz */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf9160dk/Kconfig
+++ b/boards/nrf9160dk/Kconfig
@@ -12,6 +12,7 @@ config BOARD_NRF9160DK
     default y
     select CPU_MODEL_NRF9160
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART

--- a/boards/nrf9160dk/Makefile.features
+++ b/boards/nrf9160dk/Makefile.features
@@ -3,6 +3,7 @@ CPU = nrf9160
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nrf9160dk/include/periph_conf.h
+++ b/boards/nrf9160dk/include/periph_conf.h
@@ -119,6 +119,24 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config) /**< UART confgiguration NUMOF */
 /** @} */
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#ifndef RTT_DEV
+#define RTT_DEV             (0)                 /**< NRF_RTC0_S */
+#endif
+
+#define RTT_MAX_VALUE       (0x00ffffff)         /**< 24bit */
+#define RTT_MAX_FREQUENCY   (32768U)             /**< in Hz */
+#define RTT_MIN_FREQUENCY   (8U)                 /**< in Hz */
+#define RTT_CLOCK_FREQUENCY (32768U)             /**< in Hz, LFCLK*/
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1024U)              /**< in Hz */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf53/cpu.c
+++ b/cpu/nrf53/cpu.c
@@ -61,6 +61,13 @@ static_assert((CLOCK_CORECLOCK == MHZ(128)) || CLOCK_CORECLOCK == MHZ(64));
     /* For now, disable the unused network core */
     NRF_RESET_S->NETWORK.FORCEOFF = 1;
 
+#if defined(MODULE_PERIPH_RTT) && (CLOCK_LFCLK==CLOCK_LFCLKSRC_SRC_LFXO)
+    /* Enable P0.00 and P0.01 as XL1/XL2 if LXFO is selected */
+    NRF_P0_S->PIN_CNF[0] &= ~GPIO_PIN_CNF_MCUSEL_Msk;
+    NRF_P0_S->PIN_CNF[0] |= GPIO_PIN_CNF_MCUSEL_Peripheral << GPIO_PIN_CNF_MCUSEL_Pos;
+    NRF_P0_S->PIN_CNF[1] &= ~GPIO_PIN_CNF_MCUSEL_Msk;
+    NRF_P0_S->PIN_CNF[1] |= GPIO_PIN_CNF_MCUSEL_Peripheral << GPIO_PIN_CNF_MCUSEL_Pos;
+#endif
     /* call cortexm default initialization */
     cortexm_init();
 

--- a/cpu/nrf5x_common/periph/rtt.c
+++ b/cpu/nrf5x_common/periph/rtt.c
@@ -26,6 +26,19 @@
 #include "periph/rtt.h"
 
 /* get the IRQ configuration */
+#ifdef NRF_RTC0_S
+#if (RTT_DEV == 0)
+#define DEV             NRF_RTC0_S
+#define ISR             isr_rtc0
+#define IRQn            RTC0_IRQn
+#elif (RTT_DEV == 1)
+#define DEV             NRF_RTC1_S
+#define ISR             isr_rtc1
+#define IRQn            RTC1_IRQn
+#else
+#error "RTT configuration: invalid or no RTC device specified (RTT_DEV)"
+#endif
+#else
 #if (RTT_DEV == 1)
 #define DEV             NRF_RTC1
 #define ISR             isr_rtc1
@@ -37,6 +50,7 @@
 #else
 #error "RTT configuration: invalid or no RTC device specified (RTT_DEV)"
 #endif
+#endif /* def NRF_RTC0_S */
 
 /* allocate memory for callbacks and their args */
 static rtt_cb_t alarm_cb;


### PR DESCRIPTION
### Contribution description

This PR enables support for `periph_rtt` on both nRF9160 and nRF53.
This PR is based on #19803 

I was only able to test on nrf5340dk-app as I don't have access to any nrf9160-based board.

Here is `test/periph/rtt` output for reference on `nrf5340dk-app`:

### Testing procedure
flash `tests/periph/rtt` on `nrf9160dk` or `nrf5340dk-app`  and check the results.
```
s
2023-07-06 16:11:16,471 # START
2023-07-06 16:11:16,479 # main(): This is RIOT! (Version: 2023.07-devel-765-g02c65-cpu/nrf53/add_rtt_support)
2023-07-06 16:11:16,480 # 
2023-07-06 16:11:16,482 # RIOT RTT low-level driver test
2023-07-06 16:11:16,483 # RTT configuration:
2023-07-06 16:11:16,485 # RTT_MAX_VALUE: 0x00ffffff
2023-07-06 16:11:16,487 # RTT_FREQUENCY: 1024
2023-07-06 16:11:16,487 # 
2023-07-06 16:11:16,494 # Testing the tick conversion (with rounding if RTT_FREQUENCY is not power of 2)
2023-07-06 16:11:16,498 # Trying to convert 1 to seconds and back
2023-07-06 16:11:16,501 # Trying to convert 256 to seconds and back
2023-07-06 16:11:16,505 # Trying to convert 65536 to seconds and back
2023-07-06 16:11:16,509 # Trying to convert 16777216 to seconds and back
2023-07-06 16:11:16,514 # Trying to convert 2147483648 to seconds and back
2023-07-06 16:11:16,514 # All ok
2023-07-06 16:11:16,514 # 
2023-07-06 16:11:16,517 # Initializing the RTT driver
2023-07-06 16:11:16,835 # This test will now display 'Hello' every 5 seconds
2023-07-06 16:11:16,835 # 
2023-07-06 16:11:16,836 # RTT now: 4
2023-07-06 16:11:16,840 # Setting initial alarm to now + 5 s (5124)
2023-07-06 16:11:16,841 # rtt_get_alarm() PASSED
2023-07-06 16:11:16,846 # Done setting up the RTT, wait for many Hellos
2023-07-06 16:11:16,852 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 404 }]}
2023-07-06 16:11:21,833 # Hello
2023-07-06 16:11:26,831 # Hello
2023-07-06 16:11:31,830 # Hello
2023-07-06 16:11:36,828 # Hello
2023-07-06 16:11:41,826 # Hello
2023-07-06 16:11:46,825 # Hello
2023-07-06 16:11:51,823 # Hello
2023-07-06 16:11:56,821 # Hello
2023-07-06 16:12:01,821 # Hello
2023-07-06 16:12:06,819 # Hello
2023-07-06 16:12:11,817 # Hello
2023-07-06 16:12:16,815 # Hello
2023-07-06 16:12:21,813 # Hello
2023-07-06 16:12:26,811 # Hello
```
### Issues/PRs references
based on #19803 