### PR TITLE
ztimer/periodic: remove timer on init if already running

### DIFF
--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -57,6 +57,7 @@ void ztimer_periodic_init(ztimer_clock_t *clock, ztimer_periodic_t *timer,
                           bool (*callback)(
                               void *), void *arg, uint32_t interval)
 {
+    ztimer_remove(clock, &timer->timer);
     *timer =
         (ztimer_periodic_t){ .clock = clock, .interval = interval,
                              .callback = callback, .arg = arg,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If `ztimer_periodic_init()` is called on a periodic timer that is already running, the init function will completely overwrite the `ztimer_t` structure that then is already part of a linked list.

This causes corruption of the clock's timer list and leads to *interesting* results (e.g. if the timer was the first element in the list, it will now be added again causing `->next` to point to itself which creates a circular list and an infinite loop when iterating the clock's timers.) 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
