### PR TITLE
boards: add ESP32-S3-Box support

### DIFF
--- a/boards/esp32s3-box/Kconfig
+++ b/boards/esp32s3-box/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2023 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32s3-box" if BOARD_ESP32S3_BOX
+
+config BOARD_ESP32S3_BOX
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3_WROOM_1X_N16R8
+    select HAS_ESP_JTAG
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_TINYUSB_DEVICE
+    # Only this board has a requirement to use USB_BOARD_RESET with STDIO_USB_SERIAL_JTAG
+    select MODULE_USB_BOARD_RESET if MODULE_STDIO_USB_SERIAL_JTAG
+    select REQUIRES_USB_STDIO if MODULE_USBUS || MODULE_TINYUSB_DEVICE
+
+    select HAVE_ILI9341
+
+choice STDIO_IMPLEMENTATION
+    default MODULE_STDIO_CDC_ACM if MODULE_USBUS
+    default MODULE_STDIO_TINYUSB_CDC_ACM if MODULE_TINYUSB_DEVICE
+    default MODULE_STDIO_USB_SERIAL_JTAG
+endchoice
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/esp32s3-box/Makefile
+++ b/boards/esp32s3-box/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32s3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-box/Makefile.dep
+++ b/boards/esp32s3-box/Makefile.dep
@@ -1,0 +1,14 @@
+ifeq (,$(filter stdio_% slipdev_stdio usbus usbus% tinyusb_device,$(USEMODULE)))
+  # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+  # and neither USBUS nor tinyusb_device are used
+  USEMODULE += stdio_usb_serial_jtag
+  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+  # since there should be a CDC ACM interface in any case. This is necessary,
+  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+  # was previously used.
+  USEMODULE += usb_board_reset
+  # include $(RIOTMAKE)/tools/usb_board_reset.mk
+endif
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/esp32s3-box/Makefile.features
+++ b/boards/esp32s3-box/Makefile.features
@@ -1,0 +1,15 @@
+CPU_MODEL = esp32s3_wroom_1x_n16r8
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_jtag
+FEATURES_PROVIDED += tinyusb_device
+FEATURES_PROVIDED += highlevel_stdio
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features

--- a/boards/esp32s3-box/Makefile.include
+++ b/boards/esp32s3-box/Makefile.include
@@ -1,0 +1,5 @@
+PORT_LINUX ?= /dev/ttyACM0
+
+OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/esp32s3-box/board.c
+++ b/boards/esp32s3-box/board.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_box
+ * @{
+ *
+ * @file
+ * @brief       Board specific initializations for ESP32-S3-Box
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+
+void board_init(void)
+{
+#if MODULE_ILI9341
+    gpio_init(LCD_BACKLIGHT, GPIO_OUT);
+#endif
+}

--- a/boards/esp32s3-box/doc.txt
+++ b/boards/esp32s3-box/doc.txt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32s3_box ESP32-S3-Box
+ * @ingroup     boards_esp32s3
+ * @brief       Support for the ESP32-S3-Box
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32s3_box ESP32-S3-Box
+
+## Table of Contents {#esp32s3_box_toc}
+
+1. [Overview](#esp32s3_box_overview)
+2. [Hardware](#esp32s3_box_hardware)
+    1. [MCU](#esp32s3_box_mcu)
+    2. [Board Configuration](#esp32s3_box_board_configuration)
+    3. [Board Pinout](#esp32s3_box_pinout)
+3. [Flashing the Device](#esp32s3_box_flashing)
+
+## Overview {#esp32s3_box_overview}
+
+The Espressif ESP32-S3-Box is a AIoT development platform for the ESP32-S3 SoC.
+
+\image html https://raw.githubusercontent.com/espressif/esp-box/master/docs/_static/esp32_s3_box.png "ESP32-S2-Box" width=400px
+\image html https://obrazki.elektroda.pl/4333131800_1637933077_bigthumb.jpg "Hardware Overview" width=700px
+
+The ESP32-S3-Box has following main features:
+
+<center>
+|Feature                                      | Support |
+|:--------------------------------------------|:-------:|
+| ESP32-S3 SoC                                | yes     |
+| 16 MB Flash                                 | yes     |
+| 8 MB QSPI RAM                               | yes     |
+| 2.4" LCD Display 320 x 240 with ILI9342C    | yes     |
+| Capacitive Touch Panel                      | no      |
+| Dual Microphone ES7210                      | no      |
+| Speaker Codec ES8311                        | no      |
+| 3-axis Gyroscope, 3-axis Accelerometer      | no      |
+| 2 x Digilent Pmod(TM) Connectors            | yes     |
+| USB Type-C                                  | yes     |
+</center>
+<br>
+
+The Espressif ESP32-S3-Box is shipped with a Dock which exposes the
+2 x Digilent Pmod(TM) Connectors.
+
+[Back to table of contents](#esp32s3_box_toc)
+
+## Hardware {#esp32s3_box_hardware}
+
+This section describes
+
+- the [MCU](#esp32s3_box_mcu),
+- the default [board configuration](#esp32s3_box_board_configuration),
+- the [board pinout](#esp32s3_box_pinout).
+
+[Back to table of contents](#esp32s3_box_toc)
+
+### MCU {#esp32s3_box_mcu}
+
+Most features of the ESP32-S3-Box are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32s3_box_toc)
+
+### Board Configuration {#esp32s3_box_board_configuration}
+
+The following table shows the default ESP32-S3-Box configuration, which is
+sorted according to the defined functionality of GPIOs. This configuration can
+be overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks | Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO0  | Boot Mode Button | |
+I2C_DEV(0) SCL  | GPIO40 | PMOD1 | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0) SDA  | GPIO41 | PMOD1 | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0) CLK  | GPIO12 | PMOD2, SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MISO | GPIO13 | PMOD2, SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MOSI | GPIO11 | PMOD2, SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) CS0  | GPIO10 | PMOD2, SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) CLK  | GPIO7  | LCD SCK, SPI3_HOST is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) MISO | GPIO35 | not used, SPI3_HOST is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) MOSI | GPIO6  | LCD SDA, SPI3_HOST is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(1) CS0  | GPIO5  | LCD CS, SPI3_HOST is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0) TxD | GPIO43 | PMOD2 | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0) RxD | GPIO44 | PMOD2 | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+\n
+
+[Back to table of contents](#esp32s3_box_toc)
+
+### Board Pinout {#esp32s3_box_pinout}
+
+The following figures show the pinouts as configured by default board
+definition.
+
+@image html https://raw.githubusercontent.com/espressif/esp-box/master/docs/_static/_get_started_static/hardware_pmod.png "ESP32-S3-BoxC-1 Pinout" width=900px
+
+The corresponding schematics can be found:
+
+- [ESP32-S3-Box](https://github.com/espressif/esp-box/blob/master/hardware/esp32_s3_box_v2.5/schematic/SCH_ESP32-S3-BOX_V2.5_20211011.pdf)
+- [ESP32-S3-Box Dock](https://github.com/espressif/esp-box/blob/master/hardware/esp32_s3_box_dock_v1.0/schematic/ESP32-S3-BOX-DOCK_V1D0_20210922.pdf)
+
+[Back to table of contents](#esp32s3_box_toc)
+
+## Flashing the Device {#esp32s3_box_flashing}
+
+Since the ESP32-S3-Box does not have a USB-to-Serial chip, the easiest way to
+flash it is using the USB Serial/JTAG interface. Just connect the ESP32-S3-Box
+to your host computer and use the following command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32s3-box make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Usually the make system resets the ESP32-S3-Box before flashing to enable the
+USB Serial/JTAG controller and to reboot the ESP32-S3 in download mode.
+
+In some very special cases this reset does not work and the programmer cannot
+connect to the card, so the flashing is aborted with a timeout:
+```
+Serial port /dev/ttyACM0
+Connecting...
+...
+serial.serialutil.SerialTimeoutException: Write timeout
+```
+This can happen either if RIOT is not yet installed or if the USB port was
+previously used with the USB OTG controller, for example with USBUS or tinyUSB.
+In this case, restart the ESP32-S3-Box manually into download mode by pressing
+and releasing the RESET button while holding down the BOOT button.
+In download mode, the USB Serial/JTAG interface is always available.
+
+@note If the USB port was previously used with the USB OTG controller, an
+      automatic restart of the ESP32-S3 with the flashed application is not
+      possible. In this case the ESP32-S3-Box must be reset manually using the RESET
+      button. In all other cases the ESP32-S3 automatically restarts with
+      the flashed application.
+
+[Back to table of contents](#esp32s3_box_toc)
+ */

--- a/boards/esp32s3-box/include/board.h
+++ b/boards/esp32s3-box/include/board.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_box
+ * @brief       Board definitions for ESP32-S3-Box boards
+ * @{
+ *
+ * The board definitions in this file are for the Espressif ESP32-S3-Box.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * ESP32-S3-Box boards have a BOOT button connected to GPIO0, which can be
+ * used as button during normal operation. Since the GPIO0 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ */
+#define BTN0_MODE       GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LCD display configuration
+ *
+ * ESP32-S3-Box uses a LCD display with an ILI9342C as driver chip.
+
+ * This configuration cannot be changed.
+ * @{
+ */
+#if MODULE_ILI9341
+#define LCD_DC          GPIO4
+#define LCD_CS          GPIO5
+#define LCD_RST         GPIO48
+#define LCD_BACKLIGHT   GPIO45
+
+#define BACKLIGHT_ON    gpio_set(LCD_BACKLIGHT)
+#define BACKLIGHT_OFF   gpio_clear(LCD_BACKLIGHT)
+
+#define ILI9341_PARAM_SPI           SPI_DEV(1)
+#define ILI9341_PARAM_SPI_CLK       SPI_CLK_10MHZ
+#define ILI9341_PARAM_CS            LCD_CS
+#define ILI9341_PARAM_DCX           LCD_DC
+#define ILI9341_PARAM_RST           LCD_RST
+#define ILI9341_PARAM_RGB           0
+#define ILI9341_PARAM_INVERTED      0
+#define ILI9341_PARAM_ROTATION      LCD_MADCTL_MX | LCD_MADCTL_MY
+#define ILI9341_PARAM_NUM_LINES     320U
+#define ILI9341_PARAM_RGB_CHANNELS  240U
+#endif
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32s3-box/include/gpio_params.h
+++ b/boards/esp32s3-box/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32s3_box
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32s3-box/include/periph_conf.h
+++ b/boards/esp32s3-box/include/periph_conf.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32s3_box
+ * @brief       Peripheral configurations for ESP32-S3-Box boards
+ * @{
+ *
+ * The peripheral configurations in this file are for the Espressif
+ * ESP32-S3-Box.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-S3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   I2C configuration
+ *
+ * I2C_DEV(0) is available at the PMOD1 connector.
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ * signals when module `periph_i2c` is used. Otherwise they are not
+ * allocated and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO40          /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO41          /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * SPI_DEV(0) is available at the PMOD2 connector.
+ * SPI_DEV(1) is used for the LCD display with an ILI9342C as driver chip.
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   SPI2_HOST   /**< FSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO12      /**< FSPI SCK (pin FSPICLK) */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO13      /**< FSPI MISO (pin FSPIQ) */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO11      /**< FSPI MOSI (pin FSPID) */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO10      /**< FSPI CS0 (pin FSPICS0) */
+#endif
+
+#ifndef SPI1_CTRL
+#define SPI1_CTRL   SPI3_HOST   /**< SPI3 is used as SPI_DEV(1) */
+#endif
+#ifndef SPI1_SCK
+#define SPI1_SCK    GPIO7       /**< LCD_SCK */
+#endif
+#ifndef SPI1_MISO
+#define SPI1_MISO   GPIO35      /**< not used and not broken out on ESP32-S3-WROOM-1 */
+#endif
+#ifndef SPI1_MOSI
+#define SPI1_MOSI   GPIO6       /**< LCD_SDA */
+#endif
+#ifndef SPI1_CS0
+#define SPI1_CS0    GPIO5       /**< LCD_CS */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * UART_DEV(0) is available at the PMOD2 connector.
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/esp32/Kconfig.esp32s3
+++ b/cpu/esp32/Kconfig.esp32s3
@@ -215,7 +215,7 @@ if CPU_FAM_ESP32S3
 
 config MODULE_ESP_SPI_OCT
     bool
-    default y
+    default y if MODULE_ESP_SPI_RAM
     depends on HAS_ESP_SPI_OCT
     help
         Octal SPI is used for SPI RAM.


### PR DESCRIPTION
### Contribution description

This PR provides the support for the [ESP32-S3-Box](https://github.com/espressif/esp-box).

### Testing procedure

The board has been tested with all basic tests for supported hardware including `tests/drivers/ili9341`:

![IMG_20230707_113423](https://github.com/RIOT-OS/RIOT/assets/31932013/048d9b53-5fa2-4809-bfb8-28433d3d11ce)

- [x] tests/drivers/ili9341
- [x] tests/periph/gpio
- [x] tests/periph/i2c
- [x] tests/periph/spi
- [x] tests/periph/uart
- [x] tests/sys/usbus_cdc_ecm 

### Issues/PRs references
