### PR TITLE
buildsystem: fix kconfig mismatches

### DIFF
--- a/boards/esp32s3-box/Makefile.dep
+++ b/boards/esp32s3-box/Makefile.dep
@@ -10,5 +10,9 @@ ifeq (,$(filter stdio_% slipdev_stdio usbus usbus% tinyusb_device,$(USEMODULE)))
   # include $(RIOTMAKE)/tools/usb_board_reset.mk
 endif
 
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += ili9341
+endif
+
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep
 include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/sipeed-longan-nano/Kconfig
+++ b/boards/sipeed-longan-nano/Kconfig
@@ -38,6 +38,7 @@ menu "Sipeed Longan Nano Board Configuration"
 
     config SIPEED_LONGAN_NANO_WITH_TFT
         bool "Board with TFT display"
+        default y
         select HAVE_ST7735
         help
             Indicates that a Sipeed Longan Nano board with TFT display is used.

--- a/drivers/st7735/Kconfig
+++ b/drivers/st7735/Kconfig
@@ -23,12 +23,15 @@ config HAVE_ST7735
       Indicates that an ST7735 display is present.
 
 config MODULE_ST7789
-    bool "ST7789 display driver"
-    select MODULE_ST7735
+    bool
+    depends on HAVE_ST7789
+    default y if MODULE_ST7735
+    help
+        ST7789 display driver
 
 config HAVE_ST7789
     bool
-    select MODULE_ST7789 if MODULE_DISP_DEV
+    select MODULE_ST7735 if MODULE_DISP_DEV
     help
       Indicates that an ST7789 display is present.
 


### PR DESCRIPTION
### Contribution description

This adds three commits each addressing a deviation between dependency resolutions done with and without Kconfig. Hopefully, these in combination should fix the nightly builds.

### Testing procedure

For each `$failing_board` and `$failing_app` pair in the latest nightly build, do:

```
make BOARD=$failing_board -C $failing_app TEST_KCONFIG=0 info-modules > ~/without-kconfig
make BOARD=$failing_board -C $failing_app TEST_KCONFIG=1 info-modules > ~/with-kconfig
diff -rupN ~/without-kconfig ~/with-kconfig
```

should yield an empty diff other than the `=== [ATTENTION] Testing Kconfig dependency modelling ===`.

### Issues/PRs references

None