### PR TITLE
compile_and_test_for_boards: Add no-compile flag

### DIFF
--- a/dist/tools/compile_and_test_for_board/tests/test_compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/tests/test_compile_and_test_for_board.py
@@ -1,8 +1,12 @@
 """Test compile_and_test_for_board script."""
 
 import subprocess
-
+import re
 import compile_and_test_for_board
+
+
+def _clean(my_str):
+    return re.sub(r'\s+', ' ', my_str)
 
 
 def test_help_message():
@@ -14,5 +18,7 @@ def test_help_message():
     help_msg = help_bytes.decode('utf-8')
 
     docstring = compile_and_test_for_board.__doc__
-
-    assert help_msg in docstring, "Help message not in the documentation"
+    assert _clean(help_msg) in _clean(docstring), ("Help message not in the",
+                                                   "documentation")
+    help_msg += "garbage"
+    assert help_msg not in docstring, ("Negative help message test failed.")


### PR DESCRIPTION

### Contribution description

Since we have a no-test flag that prevents executing tests, I think a no-compile flag is a nice compliment. Why? Well if I want to use this script for running multiple boards at the same time, RIOT is not so great handling parallel compile steps with conflicts on lockfiles happening, mostly due to packages. With this I can compile a list of boards sequentially, then flash and run tests in parallel, skipping the compile step.


### Testing procedure

Run the following once to compile and clean:
```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications tests/sys/shell --clean-after
```

Then try to run without the compile step and it should fail due to lack of the binary
```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications tests/sys/shell --no-compile
```

### Issues/PRs references
