### PR TITLE
cpu/atmega_common: hook up BAT LOW irq to power bus

### DIFF
--- a/cpu/atmega_common/atmega_cpu.c
+++ b/cpu/atmega_common/atmega_cpu.c
@@ -32,6 +32,7 @@
 #include "cpu.h"
 #include "irq_arch.h"
 #include "panic.h"
+#include "sys/bus.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -110,5 +111,15 @@ ISR(BADISR_vect, ISR_NAKED)
 }
 
 #if defined(BAT_LOW_vect)
-AVR8_ISR(BAT_LOW_vect, DEBUG, "BAT_LOW\n");
+static inline void bat_low_handler(void)
+{
+    DEBUG("BAT_LOW\n");
+
+#if MODULE_SYS_BUS_POWER
+    msg_bus_t *bus = sys_bus_get(SYS_BUS_POWER);
+    msg_bus_post(bus, SYS_BUS_POWER_EVENT_LOW_VOLTAGE, NULL);
+#endif
+}
+
+AVR8_ISR(BAT_LOW_vect, bat_low_handler);
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When we get a low battery event, post it on the power bus.


### Testing procedure

Not sure yet how to test this


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
