### PR TITLE
boards/sipeed_longan_nano: separate board definition for Sipeed Longan Nano TFT

### DIFF
--- a/boards/common/gd32v/include/cfg_i2c_default.h
+++ b/boards/common/gd32v/include/cfg_i2c_default.h
@@ -33,11 +33,16 @@ extern "C" {
  */
 
 /**
- * @brief   Enable the second I2C device `I2C_DEV(1)` by default
+ * @brief   Disable the second I2C device `I2C_DEV(1)` by default
  *
+ * The second I2C device `I2C_DEV(1)` is only defined if `I2C_DEV_1_USED`
+ * is set to 1 by the board.
+ * This allows to use the default configuration with one or two I2C devices
+ * depending on whether other peripherals are enabled that would collide with
+ * the I2C devices.
  */
 #ifndef I2C_DEV_1_USED
-#define I2C_DEV_1_USED
+#define I2C_DEV_1_USED  0
 #endif
 
 /**
@@ -46,7 +51,7 @@ extern "C" {
  * The default I2C device configuration allows to define up to two I2C devices
  * `I2C_DEV(0)` and `I2C_DEV(1)`. `I2C_DEV(0)` is always defined if the I2C
  * peripheral is enabled by the module `periph_spi`. The second I2C device
- * `I2C_DEV(1)` is only defined if `I2C_DEV_1_USED` is defined by the board.
+ * `I2C_DEV(1)` is only defined if `I2C_DEV_1_USED` is set to 1 by the board.
  * This allows to use the default configuration with one or two I2C devices
  * depending on whether other peripherals are enabled that would collide with
  * the I2C devices.
@@ -60,6 +65,7 @@ static const i2c_conf_t i2c_config[] = {
         .rcu_mask       = RCU_APB1EN_I2C0EN_Msk,
         .irqn           = I2C0_EV_IRQn,
     },
+#if I2C_DEV_1_USED
     {
         .dev            = I2C1,
         .speed          = I2C_SPEED_NORMAL,
@@ -68,6 +74,7 @@ static const i2c_conf_t i2c_config[] = {
         .rcu_mask       = RCU_APB1EN_I2C1EN_Msk,
         .irqn           = I2C1_EV_IRQn,
     }
+#endif
 };
 
 #define I2C_NUMOF   ARRAY_SIZE(i2c_config)

--- a/boards/common/gd32v/include/cfg_spi_default.h
+++ b/boards/common/gd32v/include/cfg_spi_default.h
@@ -33,11 +33,16 @@ extern "C" {
  */
 
 /**
- * @brief   Enable the second SPI device `SPI_DEV(1)` by default
+ * @brief   Disable the second SPI device `SPI_DEV(1)` by default
  *
+ * The second SPI device `SPI_DEV(1)` is only defined if `SPI_DEV_1_USED`
+ * is set to 1 by the board.
+ * This allows to use the default configuration with one or two SPI devices
+ * depending on whether other peripherals are enabled that would collide with
+ * the SPI devices.
  */
 #ifndef SPI_DEV_1_USED
-#define SPI_DEV_1_USED
+#define SPI_DEV_1_USED  0
 #endif
 
 /**
@@ -57,7 +62,7 @@ extern "C" {
  * the default CS signal is connected to an unused hardware.
  */
 #ifndef SPI_DEV_1_CS
-#define SPI_DEV_1_CS    GPIO_PIN(PORT_A, 4)
+#define SPI_DEV_1_CS    GPIO_PIN(PORT_B, 5)
 #endif
 
 /**
@@ -66,7 +71,7 @@ extern "C" {
  * The default SPI device configuration allows to define up to two SPI devices
  * `SPI_DEV(0)` and `SPI_DEV(1)`. `SPI_DEV(0)` is always defined if the SPI
  * peripheral is enabled by the module `periph_spi`. The second SPI device
- * `SPI_DEV(1)` is only defined if `SPI_DEV_1_USED` is defined by the board.
+ * `SPI_DEV(1)` is only defined if `SPI_DEV_1_USED` is set to 1 by the board.
  * This allows to use the default configuration with one or two SPI devices
  * depending on whether other peripherals are enabled that would collide with
  * the SPI devices.
@@ -81,7 +86,7 @@ static const spi_conf_t spi_config[] = {
         .rcumask  = RCU_APB1EN_SPI1EN_Msk,
         .apbbus   = APB1,
     },
-#ifdef SPI_DEV_1_USED
+#if SPI_DEV_1_USED
     {
         .dev      = SPI0,
         .mosi_pin = GPIO_PIN(PORT_A, 7),

--- a/boards/seeedstudio-gd32/include/periph_conf.h
+++ b/boards/seeedstudio-gd32/include/periph_conf.h
@@ -35,7 +35,13 @@
 #define CONFIG_CLOCK_HXTAL      MHZ(8)      /**< HXTAL frequency */
 #endif
 
-#define SPI_DEV_1_USED              /**< Enable SPI_DEV(1) for the connected flash */
+#ifndef SPI_DEV_1_USED
+#define SPI_DEV_1_USED          1   /**< Enable SPI_DEV(1) by default for the connected Flash */
+#endif
+
+#ifndef I2C_DEV_1_USED
+#define I2C_DEV_1_USED          1   /**< Enable I2C_DEV(1) by default */
+#endif
 
 #include "periph_cpu.h"
 #include "periph_common_conf.h"

--- a/boards/sipeed-longan-nano-tft/Kconfig
+++ b/boards/sipeed-longan-nano-tft/Kconfig
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "sipeed-longan-nano-tft" if BOARD_SIPEED_LONGAN_NANO_TFT
+
+config BOARD_SIPEED_LONGAN_NANO_TFT
+    bool
+    default y
+    select CPU_MODEL_GD32VF103CBT6
+    select BOARD_HAS_HXTAL
+    select BOARD_HAS_LXTAL
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT
+    select HAS_TINYUSB_DEVICE
+
+    select HAVE_MTD_SDCARD_DEFAULT
+    select HAVE_SAUL_GPIO
+    select HAVE_ST7735
+
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
+    select MODULE_USB_BOARD_RESET if KCONFIG_USB && TEST_KCONFIG
+
+config FORCE_USB_STDIO
+    default y
+
+source "$(RIOTBOARD)/common/gd32v/Kconfig"

--- a/boards/sipeed-longan-nano-tft/Makefile
+++ b/boards/sipeed-longan-nano-tft/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/sipeed-longan-nano
+include $(RIOTBASE)/Makefile.base

--- a/boards/sipeed-longan-nano-tft/Makefile.dep
+++ b/boards/sipeed-longan-nano-tft/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += st7735
+endif
+
+include $(RIOTBOARD)/sipeed-longan-nano/Makefile.dep

--- a/boards/sipeed-longan-nano-tft/Makefile.features
+++ b/boards/sipeed-longan-nano-tft/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/sipeed-longan-nano/Makefile.features

--- a/boards/sipeed-longan-nano-tft/Makefile.include
+++ b/boards/sipeed-longan-nano-tft/Makefile.include
@@ -1,0 +1,2 @@
+INCLUDES += -I$(RIOTBOARD)/sipeed-longan-nano/include
+include $(RIOTBOARD)/sipeed-longan-nano/Makefile.include

--- a/boards/sipeed-longan-nano-tft/doc.txt
+++ b/boards/sipeed-longan-nano-tft/doc.txt
@@ -1,0 +1,21 @@
+/**
+@defgroup   boards_sipeed_longan_nano_tft Sipeed Longan Nano with TFT
+@ingroup    boards
+@brief      Support for the Sipeed Longan Nano board with TFT display
+@author     Gunar Schorcht <gunar@schorcht.net>
+
+The [Sipeed Longan Nano TFT](https://longan.sipeed.com/en) board is a version
+of the \ref sipeed_longan_nano "Sipeed Longan Nano" development board
+that is equipped with a TFT display with the following on-board components:
+
+- GD32VF103CBT6 RISC-V MCU @108MHz
+- USB Type C
+- TF card slot
+- 3 user LEDs
+- 0.96" TFT display 160 x 80 pixel
+
+@image html "https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/1/114992425_1.jpg" "Sipeed Longan Nano" width=600
+
+Detailed information about the board configuration and flashing can be found
+in the \ref sipeed_longan_nano "Sipeed Longan Nano" documentation.
+*/

--- a/boards/sipeed-longan-nano/Kconfig
+++ b/boards/sipeed-longan-nano/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Inria
+# Copyright (c) 2023 Gunar Schorcht
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
@@ -25,24 +25,14 @@ config BOARD_SIPEED_LONGAN_NANO
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT
     select HAS_TINYUSB_DEVICE
-    select HAVE_SAUL_GPIO
 
     select HAVE_MTD_SDCARD_DEFAULT
+    select HAVE_SAUL_GPIO
+
     select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
     select MODULE_USB_BOARD_RESET if KCONFIG_USB && TEST_KCONFIG
 
 config FORCE_USB_STDIO
     default y
-
-menu "Sipeed Longan Nano Board Configuration"
-
-    config SIPEED_LONGAN_NANO_WITH_TFT
-        bool "Board with TFT display"
-        default y if MODULE_DISP_DEV
-        select HAVE_ST7735
-        help
-            Indicates that a Sipeed Longan Nano board with TFT display is used.
-
-endmenu
 
 source "$(RIOTBOARD)/common/gd32v/Kconfig"

--- a/boards/sipeed-longan-nano/Makefile.dep
+++ b/boards/sipeed-longan-nano/Makefile.dep
@@ -12,9 +12,5 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
   USEMODULE += mtd
 endif
 
-ifneq (,$(filter disp_dev,$(USEMODULE)))
-  USEMODULE += st7735
-endif
-
 include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
 include $(RIOTBOARD)/common/gd32v/Makefile.dep

--- a/boards/sipeed-longan-nano/Makefile.include
+++ b/boards/sipeed-longan-nano/Makefile.include
@@ -1,8 +1,4 @@
 PORT_LINUX ?= /dev/ttyACM0
 PROGRAMMER ?= dfu-util
 
-ifneq (,$(filter st7735,$(USEMODULE)))
-  CFLAGS += '-DCONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1'
-endif
-
 include $(RIOTBOARD)/common/gd32v/Makefile.include

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -1,8 +1,10 @@
 /**
-@defgroup   boards_sipeed_longan_nano Sipeed Longan Nano board
+@defgroup   boards_sipeed_longan_nano Sipeed Longan Nano
 @ingroup    boards
 @brief      Support for the Sipeed Longan Nano board
 @author     Gunar Schorcht <gunar@schorcht.net>
+
+\section sipeed_longan_nano Sipeed Longan Nano
 
 ## Overview
 
@@ -97,11 +99,10 @@ by pins.
 | UART_DEV(0) RX   | PA10    | USART0 RX      | UART RX        |                                |
 
 \n
-@note To use the TFT display of a Sipeed Longan Nano board, if available, the
-macro `CONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1` has to be defined, for
-example using the `CFLAGS` variable in the make command:
+@note For the Sipeed Longan Nano board version with TFT display, the
+      `sipeed-longan-nano-tft` board definition has to be used.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BOARD=sipeed-longan-nano CFLAGS='-DCONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1' make ...
+BOARD=sipeed-longan-nano-tft make ...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 | Pin  | Board Function | RIOT Function 1 | RIOT Function 2 | RIOT Function 3 |
@@ -162,6 +163,12 @@ BOARD=sipeed-longan-nano make -C examples/hello-world flash
 
 After flashing you need to leave bootloader mode again by pressing the RESET button.
 
+@note For the Sipeed Longan Nano board version with TFT display, the
+      `sipeed-longan-nano-tft` board definition has to be used.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=sipeed-longan-nano-tft make -C examples/hello-world flash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 ### Using an external debug adapter
 
 The board can also be flashed via a JTAG interface with OpenOCD (at least [release version 0.12.0]
@@ -187,11 +194,10 @@ PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink BOARD=sipeed-longan-nano make -C 
 
 ## Using the TFT Display
 
-To use the TFT display of a Sipeed Longan Nano board, if available, the
-macro `CONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1` has to be defined, for
-example using the `CFLAGS` variable in the make command:
+To use the display of the Sipeed Longan Nano board version with TFT display,
+the `sipeed_longan_nano_tft` board definition has to be used, for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BOARD=sipeed-longan-nano CFLAGS='-DCONFIG_SIPEED_LONGAN_NANO_WITH_TFT=1' make -C tests/drivers/st7735 flash
+BOARD=sipeed-longan-nano-tft make -C tests/drivers/st7735 flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Accessing STDIO

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -66,15 +66,15 @@ by pins.
 | ADC_LINE(1)      | PA3     | ADC01_IN3      |                |                                |
 | ADC_LINE(2)      | -       | ADC01_IN16     |                | internal Temperature channel   |
 | ADC_LINE(3)      | -       | ADC01_IN17     |                | internal VFEF channel          |
-| ADC_LINE(4)      | PB0     | ADC01_IN8      | TFT RS         | N/A if TFT is used             |
-| ADC_LINE(5)      | PB1     | ADC01_IN9      | TFT RST        | N/A if TFT is used             |
-| ADC_LINE(6)      | PA6     | ADC01_IN6      |                | N/A if TFT is used             |
-| ADC_LINE(7)      | PA7     | ADC01_IN7      |                | N/A if TFT is used             |
-| ADC_LINE(8)      | PA4     | ADC01_IN4      |                | N/A if TFT is used             |
-| ADC_LINE(9)      | PA5     | ADC01_IN5      |                | N/A if TFT is used             |
+| ADC_LINE(4)*     | PA4     | ADC01_IN4      |                | N/A if DAC is used             |
+| ADC_LINE(5)*     | PB0     | ADC01_IN8      | TFT RS         | N/A if TFT is used             |
+| ADC_LINE(6)*     | PB1     | ADC01_IN9      | TFT RST        | N/A if TFT is used             |
+| ADC_LINE(7)*     | PA6     | ADC01_IN6      |                | N/A if TFT/SPI_DEV(1) is used  |
+| ADC_LINE(8)*     | PA7     | ADC01_IN7      |                | N/A if TFT/SPI_DEV(1) is used  |
+| ADC_LINE(9)*     | PA5     | ADC01_IN5      |                | N/A if TFT/SPI_DEV(1)/DAC used |
 | BTN0             | PA8     | BOOT0          | BOOT           |                                |
-| DAC_LINE(0)      | PA4     | DAC0           |                | N/A if TFT is used             |
-| DAC_LINE(1)      | PA5     | DAC1           |                | N/A if TFT is used             |
+| DAC_LINE(0)      | PA4     | DAC0           |                |                                |
+| DAC_LINE(1)*     | PA5     | DAC1           |                | N/A if TFT is used             |
 | GPIO_PIN(1, 2)   | PB2     |                | TFT CS         |                                |
 | I2C_DEV(0) SCL   | PB6     | I2C0 SCL       |                |                                |
 | I2C_DEV(0) SDA   | PB7     | I2C0 SDA       |                |                                |
@@ -85,18 +85,20 @@ by pins.
 | LED2             | PA2     |                | LED blue       |                                |
 | PWM_DEV(0) CH0   | PA1     |                | LED green      |                                |
 | PWM_DEV(0) CH1   | PA2     |                | LED blue       |                                |
-| PWM_DEV(1) CH0   | PB8     |                |                | N/A if CAN is used             |
-| PWM_DEV(1) CH1   | PB9     |                |                | N/A if CAN is used             |
+| PWM_DEV(1) CH0*  | PB8     |                |                | N/A if CAN is used             |
+| PWM_DEV(1) CH1*  | PB9     |                |                | N/A if CAN is used             |
 | SPI_DEV(0) CS    | PB12    | SPI1 CS        | SD CS          |                                |
 | SPI_DEV(0) SCLK  | PB13    | SPI1 SCLK      | SD SCK         |                                |
 | SPI_DEV(0) MISO  | PB14    | SPI1 MISO      | SD MISO        |                                |
 | SPI_DEV(0) MOSI  | PB15    | SPI1 MOSI      | SD MOSI        |                                |
-| SPI_DEV(1) CS    | PA4     | SPI0 CS        |                |                                |
+| SPI_DEV(1) CS    | PB5     | SPI0 CS        |                |                                |
 | SPI_DEV(1) SCLK  | PA5     | SPI0 SCLK      | TFT SCL        |                                |
 | SPI_DEV(1) MISO  | PA6     | SPI0 MISO      |                |                                |
 | SPI_DEV(1) MOSI  | PA7     | SPI0 MOSI      | TFT SDA        |                                |
 | UART_DEV(0) TX   | PA9     | USART0 TX      | UART TX        |                                |
 | UART_DEV(0) RX   | PA10    | USART0 RX      | UART RX        |                                |
+
+(*) The availability of these peripherals depend on the use of other peripherals.
 
 \n
 @note For the Sipeed Longan Nano board version with TFT display, the
@@ -111,10 +113,10 @@ BOARD=sipeed-longan-nano-tft make ...
 | PA1  | LED green      | PWM_DEV(0) CH0  |                 | LED0            |
 | PA2  | LED blue       | PWM_DEV(0) CH1  |                 | LED1            |
 | PA3  |                |                 | ADC_LINE(1)     |                 |
-| PA4  |                | SPI_DEV(1) CS   | ADC_LINE(8)*    | DAC_LINE(0)*    |
+| PA4  |                |                 | ADC_LINE(4)*    | DAC_LINE(0)     |
 | PA5  | TFT SCL        | SPI_DEV(1) SCLK | ADC_LINE(9)*    | DAC_LINE(1)*    |
-| PA6  |                | SPI_DEV(1) MISO | ADC_LINE(6)*    |                 |
-| PA7  | TFT SDA        | SPI_DEV(1) MOSI | ADC_LINE(7)*    |                 |
+| PA6  |                | SPI_DEV(1) MISO | ADC_LINE(7)*    |                 |
+| PA7  | TFT SDA        | SPI_DEV(1) MOSI | ADC_LINE(8)*    |                 |
 | PA8  | BOOT           |                 |                 | BTN0            |
 | PA9  |                | UART_DEV(0) TX  |                 |                 |
 | PA10 |                | UART_DEV(0) RX  |                 |                 |
@@ -123,12 +125,12 @@ BOARD=sipeed-longan-nano-tft make ...
 | PA13 | JTAG TMS       |                 |                 |                 |
 | PA14 | JTAG TCK       |                 |                 |                 |
 | PA15 | JTAG TDI       |                 |                 |                 |
-| PB0  | TFT RS         |                 | ADC_LINE(4)     |                 |
-| PB1  | TFT RST        |                 | ADC_LINE(5)     |                 |
+| PB0  | TFT RS         |                 | ADC_LINE(5)*    |                 |
+| PB1  | TFT RST        |                 | ADC_LINE(6)*    |                 |
 | PB2  | TFT CS         |                 |                 |                 |
 | PB3  | JTAG TDO       |                 |                 |                 |
 | PB4  | JTAG NRST      |                 |                 |                 |
-| PB5  |                |                 |                 |                 |
+| PB5  |                | SPI_DEV(1) CS   |                 |                 |
 | PB6  |                | I2C_DEV(0) SCL  |                 |                 |
 | PB7  |                | I2C_DEV(0) SDA  |                 |                 |
 | PB8  |                | PWM_DEV(1) CH0  |                 |                 |
@@ -139,7 +141,7 @@ BOARD=sipeed-longan-nano-tft make ...
 | PB13 | SD SCK         | SPI_DEV(0) SCLK |                 |                 |
 | PB14 | SD MISO        | SPI_DEV(0) MISO |                 |                 |
 | PB15 | SD MOSI        | SPI_DEV(0) MOSI |                 |                 |
-| PC13 | LED red        |                 |                 | LED3            |
+| PC13 | LED red        |                 |                 | LED2            |
 | PC14 | OSC32IN        |                 |                 |                 |
 | PC15 | OSC32OUT       |                 |                 |                 |
 | -    | Temperature    |                 | ADC_LINE(2)     |                 |

--- a/boards/sipeed-longan-nano/include/board.h
+++ b/boards/sipeed-longan-nano/include/board.h
@@ -70,7 +70,7 @@ extern "C" {
 #define SDCARD_SPI_PARAM_MOSI        GPIO_PIN(PORT_B, 15)
 #endif
 
-#if defined(MODULE_ST7735) && defined(CONFIG_SIPEED_LONGAN_NANO_WITH_TFT)
+#if defined(MODULE_ST7735) && defined(BOARD_SIPEED_LONGAN_NANO_TFT)
 #define ST7735_PARAM_SPI          SPI_DEV(1)            /**< SPI device */
 #define ST7735_PARAM_SPI_CLK      SPI_CLK_5MHZ          /**< SPI clock frequency */
 #define ST7735_PARAM_SPI_MODE     SPI_MODE_0            /**< SPI mode */

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -33,7 +33,7 @@
 #define CONFIG_CLOCK_HXTAL      MHZ(8)      /**< HXTAL frequency */
 #endif
 
-#if CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
+#if defined(BOARD_SIPEED_LONGAN_NANO_TFT)
 #define SPI_DEV_1_USED              /**< Enable SPI_DEV(1) if TFT is connected */
 #endif
 
@@ -61,7 +61,7 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },
     /* ADC VREF channel */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 17 },
-#if !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
+#if !defined(BOARD_SIPEED_LONGAN_NANO_TFT)
     /* This conflicts with TFT pins if connected. */
     { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 8 },
     { .pin = GPIO_PIN(PORT_B, 1), .dev = 0, .chan = 9 },
@@ -72,7 +72,7 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
     { .pin = GPIO_PIN(PORT_A, 5), .dev = 0, .chan = 5 },
 #endif /* !defined(MODULE_PERIPH_DAC) */
-#endif /* !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT */
+#endif /* !defined(BOARD_SIPEED_LONGAN_NANO_TFT) */
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
@@ -83,10 +83,10 @@ static const adc_conf_t adc_config[] = {
  * @{
  */
 static const dac_conf_t dac_config[] = {
-#if !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT
+#if !defined(BOARD_SIPEED_LONGAN_NANO_TFT)
     { .pin = GPIO_PIN(PORT_A, 4), .chan = 0 },
     { .pin = GPIO_PIN(PORT_A, 5), .chan = 1 },
-#endif /* !CONFIG_SIPEED_LONGAN_NANO_WITH_TFT */
+#endif /* !defined(BOARD_SIPEED_LONGAN_NANO_TFT) */
 };
 
 #define DAC_NUMOF           ARRAY_SIZE(dac_config)

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -69,17 +69,23 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },
     /* ADC VREF channel */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = 17 },
+#if !MODULE_PERIPH_DAC
+    /* This conflicts with the DAC */
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
+#endif
 #if !defined(BOARD_SIPEED_LONGAN_NANO_TFT)
     /* This conflicts with TFT pins if connected. */
     { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 8 },
     { .pin = GPIO_PIN(PORT_B, 1), .dev = 0, .chan = 9 },
+#if !SPI_DEV_1_USED
     /* This conflicts with the SPI0 controller which is used if TFT is connected */
     { .pin = GPIO_PIN(PORT_A, 6), .dev = 0, .chan = 6 },
     { .pin = GPIO_PIN(PORT_A, 7), .dev = 0, .chan = 7 },
-#if !defined(MODULE_PERIPH_DAC)
-    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
+#if !MODULE_PERIPH_DAC
+    /* This conflicts additionally with the DAC */
     { .pin = GPIO_PIN(PORT_A, 5), .dev = 0, .chan = 5 },
-#endif /* !defined(MODULE_PERIPH_DAC) */
+#endif /* !MODULE_PERIPH_DAC */
+#endif /* !SPI_DEV_1_USED */
 #endif /* !defined(BOARD_SIPEED_LONGAN_NANO_TFT) */
 };
 
@@ -91,10 +97,10 @@ static const adc_conf_t adc_config[] = {
  * @{
  */
 static const dac_conf_t dac_config[] = {
-#if !defined(BOARD_SIPEED_LONGAN_NANO_TFT)
     { .pin = GPIO_PIN(PORT_A, 4), .chan = 0 },
+#if !SPI_DEV_1_USED
     { .pin = GPIO_PIN(PORT_A, 5), .chan = 1 },
-#endif /* !defined(BOARD_SIPEED_LONGAN_NANO_TFT) */
+#endif /* !SPI_DEV_1_USED */
 };
 
 #define DAC_NUMOF           ARRAY_SIZE(dac_config)

--- a/boards/sipeed-longan-nano/include/periph_conf.h
+++ b/boards/sipeed-longan-nano/include/periph_conf.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Board specific definitions for the SeeedStudio GD32 RISC-V board
+ * @brief       Board specific definitions for the Sipeed Longan Nano board
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
@@ -33,8 +33,16 @@
 #define CONFIG_CLOCK_HXTAL      MHZ(8)      /**< HXTAL frequency */
 #endif
 
+#ifndef SPI_DEV_1_USED
 #if defined(BOARD_SIPEED_LONGAN_NANO_TFT)
-#define SPI_DEV_1_USED              /**< Enable SPI_DEV(1) if TFT is connected */
+#define SPI_DEV_1_USED          1   /**< Enable SPI_DEV(1) by default for the TFT version */
+#else
+#define SPI_DEV_1_USED          0   /**< Disable SPI_DEV(1) by default for the non-TFT version */
+#endif
+#endif
+
+#ifndef I2C_DEV_1_USED
+#define I2C_DEV_1_USED          1   /**< Enable I2C_DEV(1) by default */
 #endif
 
 #include "periph_cpu.h"
@@ -110,7 +118,7 @@ static const pwm_conf_t pwm_config[] = {
         .af       = GPIO_AF_OUT_PP,
         .bus      = APB1,
     },
-#if !defined(MODULE_PERIPH_CAN)
+#if !MODULE_PERIPH_CAN
     {
         .dev      = TIMER3,
         .rcu_mask = RCU_APB1EN_TIMER3EN_Msk,

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -40,6 +40,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/rust-gcoap/Makefile.ci
+++ b/examples/rust-gcoap/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -26,6 +26,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     stk3200 \
     stm32f0discovery \

--- a/tests/net/gcoap_fileserver/Makefile.ci
+++ b/tests/net/gcoap_fileserver/Makefile.ci
@@ -38,6 +38,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/net/nanocoap_cli/Makefile
+++ b/tests/net/nanocoap_cli/Makefile
@@ -28,6 +28,7 @@ LOW_MEMORY_BOARDS := \
   saml10-xpro \
   saml11-xpro \
   sipeed-longan-nano \
+  sipeed-longan-nano-tft \
   spark-core \
   stm32f7508-dk \
   stm32mp157c-dk2 \

--- a/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     stm32f7508-dk \
     waspmote-pro \
     zigduino \

--- a/tests/pkg/lvgl/Makefile.ci
+++ b/tests/pkg/lvgl/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/pkg/lz4/Makefile.ci
+++ b/tests/pkg/lz4/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     sensebox_samd21 \
     serpente \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     sodaq-autonomo \
     sodaq-explorer \

--- a/tests/pkg/utensor/Makefile.ci
+++ b/tests/pkg/utensor/Makefile.ci
@@ -38,6 +38,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/pkg/wolfssl/Makefile.ci
+++ b/tests/pkg/wolfssl/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     seeedstudio-gd32 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     stk3200 \
     stm32f0discovery \

--- a/tests/sys/usbus_cdc_ecm/Makefile
+++ b/tests/sys/usbus_cdc_ecm/Makefile
@@ -12,6 +12,7 @@ USEMODULE += ps
 ifeq (,$(filter stdio_%,$(filter-out stdio_cdc_acm,$(USEMODULE))))
   BOARD_BLACKLIST += \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     seeedstudio-gd32 \
     stm32f4discovery \
     weact-f401cc \

--- a/tests/sys/xtimer_now32_overflow/Makefile
+++ b/tests/sys/xtimer_now32_overflow/Makefile
@@ -15,6 +15,7 @@ BOARD_BLACKLIST += \
                    ruuvitag \
                    seeedstudio-gd32 \
                    sipeed-longan-nano \
+                   sipeed-longan-nano-tft \
                    stm32f429i-disco \
                    stm32f4discovery \
                    thingy52 \

--- a/tests/sys/xtimer_now64_continuity/Makefile
+++ b/tests/sys/xtimer_now64_continuity/Makefile
@@ -16,6 +16,7 @@ BOARD_BLACKLIST += \
                    ruuvitag \
                    seeedstudio-gd32 \
                    sipeed-longan-nano \
+                   sipeed-longan-nano-tft \
                    stm32f429i-disco \
                    stm32f4discovery \
                    thingy52 \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -89,6 +89,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     seeedstudio-gd32 \
     sensebox_samd21 \
     sipeed-longan-nano \
+    sipeed-longan-nano-tft \
     slstk3400a \
     slstk3401a \
     sltb001a \


### PR DESCRIPTION
### Contribution description

This PR provides a minimal separate board definition for the Sipeed Longan Nano version with TFT display which is just an extension of `boards/sipeed-longan-nano` with enabled TFT display module.

From the lessons we had to learn with the Kconfig modelling of optional hardware, the TFT version of the Sipeed Longan Nano board has been split off into its own board definition based on the existing Siepeed Longan Nano board.

Commits ba29a5eefad6f24106d51bf4fbd0d1407bc7b816, 237819eac894399e423f24ffd9b79b48af1cf25c, 6d8b56dcd426580ddbbbecd003ece54d46cee05c and c5faf349d63aef28b3aa3cfce8250229b6622a15 are small cleanups of peripheral configurations and could be split from this PR as follow-up PR (changes +70 -36).

### Testing procedure

Green CI

```
BOARD=sipeed-longan-nano-tft make -j8 -C tests/drivers/st77xx flash
```
should work

### Issues/PRs references

Follow up to PR #19813 and PR #19814
Prerequisite for PR #19825 and PR #19827 