### PR TITLE
ztimer/periodic: reinit remove from right clock and handle aquired ztimer

### DIFF
--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -54,32 +54,28 @@ static void _ztimer_periodic_callback(void *arg)
 }
 
 void ztimer_periodic_init(ztimer_clock_t *clock, ztimer_periodic_t *timer,
-                          bool (*callback)(
-                              void *), void *arg, uint32_t interval)
+                          bool (*callback)(void *), void *arg, uint32_t interval)
 {
-    ztimer_remove(clock, &timer->timer);
-    *timer =
-        (ztimer_periodic_t){ .clock = clock, .interval = interval,
-                             .callback = callback, .arg = arg,
-                             .timer = {
-                                 .callback = _ztimer_periodic_callback,
-                                 .arg = timer
-                             } };
+    /* check if this is a reinit, ensure timer is stopped in case */
+    if (timer->timer.callback == _ztimer_periodic_callback) {
+        ztimer_periodic_stop(timer);
+    }
+    *timer = (ztimer_periodic_t){
+        .clock = clock, .interval = interval,
+        .callback = callback, .arg = arg,
+        .timer = {
+            .callback = _ztimer_periodic_callback,
+            .arg = timer
+        }
+    };
 }
 
 void ztimer_periodic_start(ztimer_periodic_t *timer)
 {
-    ztimer_acquire(timer->clock);
-
-    uint32_t now = ztimer_now(timer->clock);
-
-    timer->last = now;
-    _ztimer_periodic_reset(timer, now);
+    timer->last = ztimer_set(timer->clock, &timer->timer, timer->interval) + timer->interval;
 }
 
 void ztimer_periodic_stop(ztimer_periodic_t *timer)
 {
     ztimer_remove(timer->clock, &timer->timer);
-
-    ztimer_release(timer->clock);
 }


### PR DESCRIPTION
### Contribution description

#19806 added some retinit handling for ztimer periodic removing the timer from the new clock 

This tries to detect if this is a reinit and remove the timer from the old clock
this also removes the ztimer_acquire/_release handling by removing now calls in favour of set return value and now values  that are allready in ztimer,
that also has the potential to reduce the jitter of the periodic calls and bus-usage (for cpus that take their time to get "now") 

### Testing procedure

read

run tests/sys/ztimer_periodic

### Issues/PRs references

Fixes #19806 