### PR TITLE
dist/tools/usb-serial: call ttys.py with its path [backport 2023.07]

### DIFF
--- a/dist/tools/usb-serial/find-tty.sh
+++ b/dist/tools/usb-serial/find-tty.sh
@@ -6,8 +6,9 @@
 
 exit_code=1
 
+SCRIPTDIR="$(cd "$(dirname "$0")" || exit 1; pwd)"
 for serial in "$@"; do
-    if ./ttys.py --format path --serial "$serial"; then
+    if "$SCRIPTDIR"/ttys.py --format path --serial "$serial"; then
         exit_code=0
     fi
 done

--- a/dist/tools/usb-serial/list-ttys.sh
+++ b/dist/tools/usb-serial/list-ttys.sh
@@ -3,4 +3,5 @@
 # Public License v2.1. See the file LICENSE in the top level directory for more
 # details.
 
-./ttys.py --format path
+SCRIPTDIR="$(cd "$(dirname "$0")" || exit 1; pwd)"
+"$SCRIPTDIR"/ttys.py --format path


### PR DESCRIPTION
# Backport of #19823

### Contribution description
This PR provides a fix for #19805
When calling `SERIAL=xxx make flash` the command failed because the script `dist/tools/usb-serial/find-ttys.sh` tries to call `ttys.py` but it doesn't find it. So pass the full path to `ttys.py` to get rid of the problem.

### Testing procedure
Connect at least two boards to your computer
run `make list-ttys ` to get the ID of your boards
Try to flash one of them with (replace SERIAL with the one you get with the previous command):
`BOARD=xxx SERIAL=xxx make -C tests/leds flash`
It fails on master.
It should works with this PR.

### Issues/PRs references

Fixes #19805
