### PR TITLE
ztimer/periodic: no reinit

### DIFF
--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -57,7 +57,10 @@ void ztimer_periodic_init(ztimer_clock_t *clock, ztimer_periodic_t *timer,
                           bool (*callback)(
                               void *), void *arg, uint32_t interval)
 {
-    ztimer_remove(clock, &timer->timer);
+    /* check if this is a reinit try*/
+    if (timer->timer.callback == _ztimer_periodic_callback){
+        return;
+    }
     *timer =
         (ztimer_periodic_t){ .clock = clock, .interval = interval,
                              .callback = callback, .arg = arg,


### PR DESCRIPTION
### Contribution description

this returns early when reinit 

### Testing procedure

### Issues/PRs references

Fixes #19806 the lean way (reinit is not allowed but if it happens we return early, restart is not allowed (aquire count will be wrong) restop is not allowed (aquire count will be wrong) 