### PR TITLE
pkg/heatshrink: allow to overwrite config defines

### DIFF
--- a/pkg/heatshrink/patches/0003-allow-to-overwrite-config-defines.patch
+++ b/pkg/heatshrink/patches/0003-allow-to-overwrite-config-defines.patch
@@ -1,0 +1,42 @@
+From 61e66babaebb17238003e0fe53149f5457f480e0 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Mon, 17 Jul 2023 14:11:59 +0200
+Subject: [PATCH 3/3] allow to overwrite config defines
+
+---
+ heatshrink_config.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/heatshrink_config.h b/heatshrink_config.h
+index 13135b9..3879b1f 100644
+--- a/heatshrink_config.h
++++ b/heatshrink_config.h
+@@ -12,15 +12,25 @@
+     #define HEATSHRINK_FREE(P, SZ) free(P)
+ #else
+     /* Required parameters for static configuration */
++    #ifndef HEATSHRINK_STATIC_INPUT_BUFFER_SIZE
+     #define HEATSHRINK_STATIC_INPUT_BUFFER_SIZE 32
++    #endif
++    #ifndef HEATSHRINK_STATIC_WINDOW_BITS
+     #define HEATSHRINK_STATIC_WINDOW_BITS 8
++    #endif
++    #ifndef HEATSHRINK_STATIC_LOOKAHEAD_BITS
+     #define HEATSHRINK_STATIC_LOOKAHEAD_BITS 4
++    #endif
+ #endif
+ 
+ /* Turn on logging for debugging. */
++#ifndef HEATSHRINK_DEBUGGING_LOGS
+ #define HEATSHRINK_DEBUGGING_LOGS 0
++#endif
+ 
+ /* Use indexing for faster compression. (This requires additional space.) */
++#ifndef HEATSHRINK_USE_INDEX
+ #define HEATSHRINK_USE_INDEX 1
++#endif
+ 
+ #endif
+-- 
+2.39.2
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The pkg already provides a `heatshrink_config.h` but it should be possible to tweak those values depending on what the application needs.

Add a way to overwrite them via `CFLAGS`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
