### PR TITLE
sys/net/sock: add sock_aux_ttl

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -513,6 +513,7 @@ PSEUDOMODULES += sock_async
 PSEUDOMODULES += sock_aux_local
 PSEUDOMODULES += sock_aux_rssi
 PSEUDOMODULES += sock_aux_timestamp
+PSEUDOMODULES += sock_aux_ttl
 PSEUDOMODULES += sock_dtls
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -319,6 +319,21 @@ enum {
      * @ref sock_dtls_aux_tx_t::local.
      */
     SOCK_AUX_SET_LOCAL = (1LU << 3),
+    /**
+     * @brief   Flag to request the TTL value of received frame
+     *
+     * @note    Select module `sock_aux_ttl` and a compatible network stack to
+     *          use this
+     *
+     * Set this flag in the auxiliary data structure prior to the call of
+     * @ref sock_udp_recv_aux / @ref sock_ip_recv_aux / etc. to request the
+     * TTL value of a received frame. This flag will be cleared if the
+     * time to live was stored, otherwise it remains set.
+     *
+     * Depending on the family of the socket, the TTL value will be stored in
+     * @ref sock_udp_aux_rx_t::ttl or @ref sock_dtls_aux_rx_t::ttl.
+     */
+    SOCK_AUX_GET_TTL = (1LU << 4),
 };
 
 /**

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -332,6 +332,14 @@ typedef struct {
      */
     int16_t rssi;
 #endif /* MODULE_SOCK_AUX_RSSI */
+#if defined(MODULE_SOCK_AUX_TTL) || defined(DOXYGEN)
+    /**
+     * @brief   TTL value of the received frame
+     *
+     * @see SOCK_AUX_GET_TTL
+     */
+    uint8_t ttl;
+#endif /* MODULE_SOCK_AUX_TTL */
     sock_aux_flags_t flags; /**< Flags used request information */
 } sock_udp_aux_rx_t;
 

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -306,6 +306,16 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
         aux->flags &= ~SOCK_AUX_GET_RSSI;
     }
 #endif
+#if IS_USED(MODULE_SOCK_AUX_TTL)
+    if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_TTL)) {
+        gnrc_pktsnip_t *ip = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
+        if (ip) {
+            ipv6_hdr_t *ip_hdr = ip->data;
+            aux->ttl = ip_hdr->hl;
+            aux->flags &= ~SOCK_AUX_GET_TTL;
+        }
+    }
+#endif
     *data = pkt->data;
     *buf_ctx = pkt;
     res = (int)pkt->size;

--- a/tests/net/gnrc_sock_udp/Makefile
+++ b/tests/net/gnrc_sock_udp/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.net_common
 AUX_LOCAL ?= 1
 AUX_TIMESTAMP ?= 1
 AUX_RSSI ?= 1
+AUX_TTL ?= 1
 
 ifeq (1, $(AUX_LOCAL))
   USEMODULE += sock_aux_local
@@ -14,6 +15,10 @@ endif
 
 ifeq (1, $(AUX_RSSI))
   USEMODULE += sock_aux_rssi
+endif
+
+ifeq (1, $(AUX_TTL))
+  USEMODULE += sock_aux_ttl
 endif
 
 USEMODULE += gnrc_sock_check_reuse

--- a/tests/net/gnrc_sock_udp/main.c
+++ b/tests/net/gnrc_sock_udp/main.c
@@ -451,7 +451,7 @@ static void test_sock_udp_recv__aux(void)
     static const inject_aux_t inject_aux = { .timestamp = 1337, .rssi = -11 };
     sock_udp_ep_t result;
     sock_udp_aux_rx_t aux = {
-        .flags = SOCK_AUX_GET_LOCAL | SOCK_AUX_GET_TIMESTAMP | SOCK_AUX_GET_RSSI
+        .flags = SOCK_AUX_GET_LOCAL | SOCK_AUX_GET_TIMESTAMP | SOCK_AUX_GET_RSSI | SOCK_AUX_GET_TTL
     };
 
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
@@ -483,6 +483,12 @@ static void test_sock_udp_recv__aux(void)
     expect(inject_aux.rssi == aux.rssi);
 #else
     expect(aux.flags & SOCK_AUX_GET_RSSI);
+#endif
+#if IS_USED(MODULE_SOCK_AUX_TTL)
+    expect(!(aux.flags & SOCK_AUX_GET_TTL));
+    expect(64 == aux.ttl);
+#else
+    expect(aux.flags & SOCK_AUX_GET_TTL);
 #endif
     expect(_check_net());
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the option to read out the TTL of a received UDP packet.
@fabian18 this might come in handy if we don't want to hard-code topology information to restart nodes from the outside inward.

### Testing procedure

`tests/net/gnrc_sock_udp` has been extended to test the new option.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
