### PR TITLE
sys/stdio_uart: add stdio_clear_stdin

### DIFF
--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -103,6 +103,15 @@ int stdio_available(void);
 #endif
 
 /**
+ * @brief   Clear the input buffer
+ *
+ * @note    Requires 'USEMODULE += stdin'
+ *
+ * @warning This function does only work if the stdio implementation supports it.
+ */
+void stdio_clear_stdin(void);
+
+/**
  * @brief read @p len bytes from stdio uart into @p buffer
  *
  * @param[out]  buffer  buffer to read into

--- a/sys/stdio/stdio.c
+++ b/sys/stdio/stdio.c
@@ -78,3 +78,10 @@ int stdio_available(void)
     return tsrb_avail(&stdin_isrpipe.tsrb);
 }
 #endif
+
+void stdio_clear_stdin(void)
+{
+    if (IS_USED(MODULE_STDIN)) {
+        tsrb_clear(&stdin_isrpipe.tsrb);
+    }
+}


### PR DESCRIPTION
### Contribution description

This PR introduces a new pseudomodule. It is currently only implemented for `stdio_uart`.

The use case is to clear the input buffer so we can throw away the remaining input (like `\n` for example) after a call of `scanf` for the next call of `scanf`.

### Testing procedure

Have an application with multiple calls of `scanf` and use `stdio_flush_rx` at some places and don't use it on others.