### PR TITLE
pkg/arduino_adafruit_sensor: fix dependencies

### DIFF
--- a/pkg/arduino_adafruit_sensor/Makefile.dep
+++ b/pkg/arduino_adafruit_sensor/Makefile.dep
@@ -1,4 +1,3 @@
-FEATURES_REQUIRED += arduino
 FEATURES_REQUIRED += cpp
 
 USEMODULE += arduino


### PR DESCRIPTION
### Contribution description

This fixes the dependencies of the `arduino_adafruit_sensor` package, which previously relied on the `arduino` feature. This feature no longer exists, as it was split into more fine granular features. However, the module should never have used that feature directly in the first place, but rather just use the arduino module. This in turn depends on the correct features.

### Testing procedure

`tests/arduino_adafruit_sensor` should again be supported by boards that have the features required by the `arduino` module.

### Issues/PRs references

Fallout of https://github.com/RIOT-OS/RIOT/pull/19759