### PR TITLE
boards/adafruit-itsybitsy-nrf52: Add configuration for DotStar LED

### DIFF
--- a/boards/adafruit-itsybitsy-nrf52/doc.txt
+++ b/boards/adafruit-itsybitsy-nrf52/doc.txt
@@ -7,7 +7,7 @@
 
 This is a small formfactor (only 1.4" long by 0.7" wide) nRF52840 board made by Adafruit.
 
-The board features one LED (LD1: blue), a user (SW1) and a
+The board features one red LED (LD1), one DotStar / APA102 RGB LED, a user (SW1), a
 reset button as well as 21 configurable external pins(6 of which can be analog in).
 
 ### Links
@@ -41,10 +41,5 @@ you may need to run `pip3 install --upgrade pip3` before being able to run `pip3
 ### Accessing STDIO
 
 The usual way to obtain a console on this board is using an emulated USB serial port.
-
-
-### Todo
-
-Add support for the mini DotStar RGB LED
 
  */

--- a/boards/adafruit-itsybitsy-nrf52/include/board.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/board.h
@@ -51,6 +51,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @name APA102 / DotStar configuration
+ * @{
+ */
+#define APA102_PARAM_LED_NUMOF      (1)
+#define APA102_PARAM_DATA_PIN       GPIO_PIN(0, 8)
+#define APA102_PARAM_CLK_PIN        GPIO_PIN(1, 9)
+/** @} */
+
+/**
  * @name    Button pin configuration
  * @{
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the configuration for the on-board DotStar/APA102 LED for the adafruit-itsybitsy-nrf52. I based the change on the board definitions for the adafruit-itsybitsy-m4, which also has a DotStar.

I also fixed a small error in the doc. The other LED is red, not blue. See [here](https://www.adafruit.com/product/4481) (I can also verify by looking at the board in person):

> Red LED for general purpose blinking, mini DotStar RGB LED for colorful feedback

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I tested this on the board using the program in `tests/drivers/apa102` and all looks correct to me.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

N/A
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
