### PR TITLE
cpu/stm32: fix ld script for SRAM4

### DIFF
--- a/cpu/stm32/ldscripts/stm32.ld
+++ b/cpu/stm32/ldscripts/stm32.ld
@@ -18,8 +18,8 @@
  * @}
  */
 
-ccmram_length = DEFINED( ccmram_len ) ? ccmram_len : 0x0 ;
-sram4_length = DEFINED( sram4_length ) ? sram4_length : 0x0 ;
+ccmram_length = DEFINED( _ccmram_len ) ? _ccmram_len : 0x0 ;
+sram4_length = DEFINED( _sram4_length ) ? _sram4_length : 0x0 ;
 
 MEMORY
 {
@@ -31,7 +31,7 @@ SECTIONS
 {
     .heap2 ALIGN(4) (NOLOAD) :
     {
-        _sheap2 = . ;
+        _sheap2 = ORIGIN(sram4);
         _eheap2 = ORIGIN(sram4) + LENGTH(sram4);
     } > sram4
 }


### PR DESCRIPTION
### Contribution description

This PR fixes the LD script for STM32.

Since the CCM and SRAM4 length are defined as symbols with perifx `_`, the LD script didn't use them correctly. Instead of using `ccmram_length` and `sram4_length`, `_ccmram_length` and `_sram4_length` have to be used. Furthermore, the location counter for the SRAM has to be set to the beginning of SRAM4 to work.

BTW, I don't understand why the `ccmram` region is defined. There is no section definition that would use it to place code or data with attribute `.ccmram.*` there.

Without the fix in this PR, defined symbols in `tests/sys/malloc` for the `b-u585i-iot02a` board were:
```python
00000000 T _sheap2     <== wrong start position because of wrong location counter
28000000 T _eheap2     <== wrong end position because of `sram4_length` is 0.
```
Although the `tests/sys/malloc` crashes for `b-u585i-iot02a` at the end of the heap (known problem, see [here](https://github.com/RIOT-OS/RIOT/pull/17410#issuecomment-996556823)), it uses only the backup RAM before it crashes:
```
Allocated 512 Bytes at 0x200bf600, total 756072
Allocated 512 Bytes at 0x200bf818, total 756592
Allocated 512 Bytes at 0x200bfa30, total 757112
Allocated 512 Bytes at 0x200bfc48, total 757632
Allocated 512 Bytes at 0x40036408, total 758152
Allocated 512 Bytes at 0x40036610, total 758672
Allocated 512 Bytes at 0x40036818, total 759192
```

With the fix in this PR, defined symbols in `tests/sys/malloc` for the `b-u585i-iot02a` board are:
```python
28000000 T _sheap2     <== correct start position
28004000 T _eheap2     <== correct end position
```
`tests/sys/malloc` also crashes for the `b-u585i-iot02a` at the end of the heap, but it uses also the SRAM4 before it crashes.
```
Allocated 512 Bytes at 0x200bf600, total 756072
Allocated 512 Bytes at 0x200bf818, total 756592
Allocated 512 Bytes at 0x200bfa30, total 757112
Allocated 512 Bytes at 0x200bfc48, total 757632
Allocated 512 Bytes at 0x40036408, total 758152
Allocated 512 Bytes at 0x40036610, total 758672
Allocated 512 Bytes at 0x40036818, total 759192
Allocated 512 Bytes at 0x28000008, total 759712
Allocated 512 Bytes at 0x28000210, total 760232
Allocated 512 Bytes at 0x28000418, total 760752
...
Allocated 512 Bytes at 0x280038e8, total 774272
Allocated 512 Bytes at 0x28003af0, total 774792
Allocated 512 Bytes at 0x28003cf8, total 775312
```

### Testing procedure

1. Flash `tests/sys/malloc` and use `MAX_MEM` limit to stop `malloc` before the crash:
   ```
   CFLAGS='-DMAX_MEM=774800 -DCHUNK_SIZE=512 -DDEBUG_ASSERT_VERBOSE' \
   BOARD=b-u585i-iot02a make -j8 -C tests/sys/malloc flash
   ```
   Without the PR it crashes at the end of the backup RAM. With the PR it works.

2. Check `_sheap2` and `_eheap2` with
   ```
   nm -s tests/sys/malloc/bin/b-u585i-iot02a/tests_malloc.elf | grep heap2 | sort
   ```
   Without the PR it will be:
   ```
   00000000 T _sheap2
   28000000 T _eheap2
   ```
   With the PR it should be:
   ```
   28000000 T _sheap2
   28004000 T _eheap2
   ```

### Issues/PRs references
