### PR TITLE
tests/drivers/disp_dev: fix off by one in display area

### DIFF
--- a/tests/drivers/disp_dev/main.c
+++ b/tests/drivers/disp_dev/main.c
@@ -70,9 +70,9 @@ int main(void)
     }
 
     area.x1 = ((max_width - RIOT_LOGO_WIDTH) >> 1);
-    area.x2 = ((max_width + RIOT_LOGO_WIDTH) >> 1);
+    area.x2 = ((max_width + RIOT_LOGO_WIDTH) >> 1) - 1;
     area.y1 = ((max_height - RIOT_LOGO_HEIGHT) >> 1);
-    area.y2 = ((max_height + RIOT_LOGO_HEIGHT) >> 1);
+    area.y2 = ((max_height + RIOT_LOGO_HEIGHT) >> 1) - 1;
     disp_dev_map(disp_dev->dev, &area, (const uint16_t *)picture);
 
     puts("SUCCESS");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes a bug that was introduced in #17921. Especially this change:

```diff
- disp_dev_map(
-    disp_dev->dev,
-    ((max_width - RIOT_LOGO_WIDTH) >> 1), ((max_width + RIOT_LOGO_WIDTH) >> 1) - 1,
-    ((max_height - RIOT_LOGO_HEIGHT) >> 1), ((max_height + RIOT_LOGO_HEIGHT) >> 1) - 1,
-    (const uint16_t *)picture
-);
+ area.x1 = ((max_width - RIOT_LOGO_WIDTH) >> 1);
+ area.x2 = ((max_width + RIOT_LOGO_WIDTH) >> 1);
+ area.y1 = ((max_height - RIOT_LOGO_HEIGHT) >> 1);
+ area.y2 = ((max_height + RIOT_LOGO_HEIGHT) >> 1);
+ disp_dev_map(disp_dev->dev, &area, (const uint16_t *)picture);
```

a `-1` was removed from the x2 and y2 coordinates which leads to a bad display of the RIOT logo (it looks shifted).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

On the adafruit-clue I can reproduce the bug (and also on stm32f429i-disc1). This PR fixes it (at least on adafruit-clue).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Bug introduced in #17921

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
