### PR TITLE
drivers/enc28j60: disable flow control

### DIFF
--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -431,8 +431,6 @@ static int nd_init(netdev_t *netdev)
     cmd_w_phy(dev, REG_PHY_PHIE, PHIE_PLNKIE | PHIE_PGEIE);
 
     /* Finishing touches */
-    /* enable hardware flow control */
-    cmd_wcr(dev, REG_B3_EFLOCON, 3, EFLOCON_FULDPXS | EFLOCON_FCEN1);
     /* enable auto-inc of read and write pointers for the RBM/WBM commands */
     cmd_bfs(dev, REG_ECON2, -1, ECON2_AUTOINC);
     /* enable receive, link and tx interrupts */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR disables flow control in the ENC28J60 driver init function.

Setting FCEN1 in the EFLOCON register causes the ENC28J60 to periodically send pause frames. It should only be set when the receiver is running out of buffer space [1].

(Also, the FULDPXS bit in EFLOCON is read-only.)

[1] https://ww1.microchip.com/downloads/en/devicedoc/39662c.pdf

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Launch Wireshark / tshark on an interface connected to an ENC28J60 controlled by RIOT. Without this PR you should see a pause frame being sent about every 100 ms (~10x per second):

    1 0.000000000 b2:db:01:ec:f7:be → MAC-specific-ctrl-proto-01 MAC CTRL 60 Pause: pause_time: 4096 quanta
    2 0.104906555 b2:db:01:ec:f7:be → MAC-specific-ctrl-proto-01 MAC CTRL 60 Pause: pause_time: 4096 quanta
    3 0.209834541 b2:db:01:ec:f7:be → MAC-specific-ctrl-proto-01 MAC CTRL 60 Pause: pause_time: 4096 quanta
    4 0.314747209 b2:db:01:ec:f7:be → MAC-specific-ctrl-proto-01 MAC CTRL 60 Pause: pause_time: 4096 quanta
    5 0.419674312 b2:db:01:ec:f7:be → MAC-specific-ctrl-proto-01 MAC CTRL 60 Pause: pause_time: 4096 quanta
    ...

With this PR no pause frames are sent.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
