### PR TITLE
Add 1-Wire driver

### DIFF
--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -189,9 +189,9 @@ int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom);
  * @brief   Select a device on the bus to communicate with
  *
  * This call resets the bus and then sends a `Match ROM` command followed by the
- * device's ROM pointed to by @p rom. If @p rom is NULL, then a `Skip ROM` command
- * is sent instead. In this case no single device is selected and all attached
- * devices will receive any further communication.
+ * device's ROM pointed to by @p rom. If @p rom is NULL, then a `Skip ROM`
+ * command is sent instead. In this case no single device is selected and all
+ * attached devices will receive any further communication.
  *
  * @param[in] bus       1-Wire bus device descriptor
  * @param[in] rom       1-Wire ROM code of target device

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -1,0 +1,439 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @addtogroup  drivers_onewire_buses
+ * @{
+ * @file
+ * @brief       1-Wire driver interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "byteorder.h"
+#include "checksum/crc8.h"
+#include "checksum/ucrc16.h"
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Length of 1-Wire ROM code in bytes
+ */
+#define ONEWIRE_ROM_LEN         (8U)
+
+/**
+ * @brief   String length of a hex encoded 1-Wire ROM code (including \0)
+ */
+#define ONEWIRE_ROM_STR_LEN     (2 * ONEWIRE_ROM_LEN + 1)
+
+/**
+ * @brief   Custom value used to start a device search
+ */
+#define ONEWIRE_SEARCH_FIRST    (0)
+
+/** forward declaration of 1-Wire bus descriptor */
+typedef struct onewire_t onewire_t;
+
+/**
+ * @brief   1-Wire ROM code (device address) representation
+ */
+typedef le_uint64_t onewire_rom_t;
+
+/**
+ * @brief   1-Wire bus driver implementation
+ *
+ * When `onewire_multidriver` is enabled, each 1-Wire bus driver should expose
+ * its functionality by providing an instance of this structure.
+ */
+typedef struct {
+
+    /** @copydoc _onewire_reset() */
+    int (*reset)(onewire_t *bus);
+
+    /** @copydoc _onewire_read_bits() */
+    int (*read_bits)(onewire_t *bus, void *buf, size_t len);
+
+    /** @copydoc _onewire_write_bits() */
+    int (*write_bits)(onewire_t *bus, const void *buf, size_t len);
+
+} onewire_driver_t;
+
+/**
+ * @brief   1-Wire configuration parameters
+ */
+typedef struct {
+#if MODULE_ONEWIRE_MULTIDRIVER || DOXYGEN
+    const onewire_driver_t *driver;     /**< driver for this bus */
+#endif
+} onewire_params_t;
+
+/**
+ * @brief   1-Wire bus device descriptor
+ */
+struct onewire_t {
+    const onewire_params_t *params;     /**< bus's configuration params */
+#if !MODULE_ONEWIRE_ONESLAVE || DOXYGEN
+    mutex_t lock;                       /**< bus access lock */
+#endif
+};
+
+/**
+ * @brief   Initialize a 1-Wire bus base type
+ *
+ * @note This is a private function meant to be called by 1-Wire bus driver
+ * implementations.
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ * @param[in] params    configuration parameters
+ */
+void _onewire_init(onewire_t *bus, const onewire_params_t *params);
+
+/**
+ * @brief   Acquire exclusive access to 1-Wire bus
+ *
+ * 1-Wire buses cannot multiplex transactions of data to multiple slave devices
+ * at the same time. Therefore, transactions need to be serialized by acquiring
+ * exclusive access to the bus before a transaction is started. At the end of
+ * the transaction (or multiple transactions) the bus should be released so that
+ * it may be shared amongst several slave devices.
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ */
+static inline void onewire_aquire(onewire_t *bus)
+{
+#if MODULE_ONEWIRE_ONESLAVE
+    (void)bus;
+#else
+    mutex_lock(&bus->lock);
+#endif
+}
+
+/**
+ * @brief   Release exclusive access to 1-Wire bus
+ *
+ * This call ends exclusive access to a bus which was previously acquired with a
+ * call to @ref onewire_aquire().
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ */
+static inline void onewire_release(onewire_t *bus)
+{
+#if MODULE_ONEWIRE_ONESLAVE
+    (void)bus;
+#else
+    mutex_unlock(&bus->lock);
+#endif
+}
+
+/**
+ * @brief   Search for devices on the given 1-Wire bus
+ *
+ * Use this function to discover devices connected to the given 1-Wire bus. To
+ * carry out a full device discovery, this function has to be called multiple
+ * times. For each iteration, the return value of the previous call as well as
+ * the previous discovered ROM code have to be given as @p rom and @p ld
+ * parameters to the subsequent call. When the function returns 0, the last
+ * device has been found and there are no further devices to be discovered.
+ *
+ * @param[in] bus       1-Wire bus
+ * @param[in,out] rom   next discovery ROM code, needs to hold previous value
+ *                      when function is called multiple times
+ * @param[in] ld        position of last discrepancy or ONEWIRE_SEARCH_FIRST for
+ *                      initial call
+ *
+ * @return  bit position of last discrepancy
+ * @retval  0 if discovered device was the last
+ * @retval  -ENXIO if no device was found
+ * @retval  -EBADMSG if check of discovered device's ROM CRC failed
+ * @retval  -EIO on all other failures
+ */
+int onewire_search(onewire_t *bus, onewire_rom_t *rom, int ld);
+
+/**
+ * @brief   Read the ROM of a slave device
+ *
+ * This function reads the ROM from a device on the bus when only a single slave
+ * device is present. If multiple devices are present, the read data will be
+ * corrupted and the check of its CRC will fail.
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] rom      1-Wire ROM code of target device
+ *
+ * @retval  0 on success
+ * @retval  -ENXIO if no device was found
+ * @retval  -EBADMSG if check of ROM's CRC failed
+ * @retval  -EIO on all other failures
+ */
+int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom);
+
+/**
+ * @brief   Select a device on the bus to communicate with
+ *
+ * This call resets the bus and then sends a Match ROM command followed by the
+ * device's ROM pointed to by @p rom. If @p rom is NULL, then a Skip ROM command
+ * is sent instead. In this case no single device is selected and all attached
+ * devices will receive any further communication.
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] rom       1-Wire ROM code of target device
+ *
+ * @retval  0 on success
+ * @retval  -ENXIO if no slave answered the reset sequence
+ */
+int onewire_select(onewire_t *bus, const onewire_rom_t *rom);
+
+/**
+ * @brief   Read data from the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] data     buffer to write received bytes into
+ * @param[in] len       number of bytes to read from the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int onewire_read(onewire_t *bus, void *data, size_t len);
+
+/**
+ * @brief   Convenience function for reading a single byte from the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] data     byte read from the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_read_byte(onewire_t *bus, uint8_t *data)
+{
+    return onewire_read(bus, data, 1);
+}
+
+/**
+ * @brief   Convenience function for reading a 16 bit word from the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] data     word read from the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_read_word(onewire_t *bus, uint16_t *data)
+{
+    le_uint16_t buffer;
+
+    const int res = onewire_read(bus, &buffer, 2);
+    *data = byteorder_ltohs(buffer);
+    return res;
+}
+
+/**
+ * @brief   Write data to the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] data      buffer holding the data that is written to the bus
+ * @param[in] len       number of bytes to write to the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int onewire_write(onewire_t *bus, const void *data, size_t len);
+
+/**
+ * @brief   Convenience function for writing a single byte to the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] data      byte to write to the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_write_byte(onewire_t *bus, uint8_t data)
+{
+    return onewire_write(bus, &data, 1);
+}
+
+/**
+ * @brief   Convenience function for writing a 16 bit word to the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] data      word to write to the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_write_word(onewire_t *bus, uint16_t data)
+{
+    const le_uint16_t buffer = byteorder_htols(data);
+
+    return onewire_write(bus, &buffer, 2);
+}
+
+/**
+ * @brief   Calculate a 8 bit CRC using the 1-Wire specific polynomial
+ *
+ * @param[in] seed      the seed (starting value) for the checksum
+ * @param[in] data      input data
+ * @param[in] len       len of @p data in bytes
+ *
+ * @return  calculated 8 bit CRC
+ */
+static inline uint_fast8_t onewire_crc8(uint_fast16_t seed, const void *data,
+    size_t len)
+{
+    return crc8_lsb(data, len, 0x8c, seed);
+}
+
+/**
+ * @brief   Calculate a 16 bit CRC using the 1-Wire specific polynomial
+ *
+ * @param[in] seed      the seed (starting value) for the checksum
+ * @param[in] data      input data
+ * @param[in] len       len of @p data in bytes
+ *
+ * @return  calculated 16 bit CRC
+ */
+static inline uint_fast16_t onewire_crc16(uint_fast16_t seed, const void *data,
+    size_t len)
+{
+    return ucrc16_calc_le(data, len, 0xA001, seed);
+}
+
+/**
+ * @brief   Read 1-Wire ROM code from string
+ *
+ * @param[out] rom      ROM code is parsed into this location
+ * @param[in] str       String representation of a ROM code
+ *
+ * @retval  0 on success
+ * @retval  -EINVAL on parsing error
+ */
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str);
+
+/**
+ * @brief   Write a 1-Wire ROM code to a string
+ *
+ * The 64 bit ROM ID will be treated as a string of bytes, rather than a little
+ * endian number. This means the family code will be first, and the CRC will be
+ * at the end. 1-Wire documents refer to the CRC as the MSB and the family code
+ * as the LSB, but printing the ROM as a string of bytes makes sorting ID
+ * strings by family code more convenient.
+ *
+ * @param[out] str      Output string, must be able to hold ONEWIRE_ROM_STR_LEN
+ *                      characters
+ * @param[in] rom       1-Wire ROM code to read
+ */
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom);
+
+/**
+ * @brief   Print a 1-Wire ROM code to STDIO
+ *
+ * This is equivalent to converting a ROM to a string using @ref
+ * onewire_rom_to_str() and then printing that string.
+ *
+ * @param[in] rom       1-Wire ROM code
+ */
+void onewire_rom_print(const onewire_rom_t *rom);
+
+/**
+ * @brief   Validate a 1-Wire ROM code
+ *
+ * This function checks if a given 1-Wire ROM contains a valid device ID.
+ *
+ * @param[in] rom       1-Wire ROM code
+ *
+ * @retval  true if @p rom contains a valid ID
+ * @retval  false if @p rom contains an invalid ID
+ */
+bool onewire_rom_is_valid(const onewire_rom_t *rom);
+
+/**
+ * @brief   Returns the 1-Wire family code of @p rom
+ *
+ * @param[in] rom       1-Wire ROM code
+ *
+ * @return  1-Wire device 8 bit family code
+ */
+uint_fast8_t onewire_rom_family_code(const onewire_rom_t *rom);
+
+/**
+ * @brief   Compare two 1-Wire ROMs for equality.
+ *
+ * @param[in] left      1-Wire ROM code to compare
+ * @param[in] right     1-Wire ROM code to compare
+ *
+ * @retval  0 if @p left and @p right are equal
+ */
+int onewire_rom_compare(const onewire_rom_t *left, const onewire_rom_t *right);
+
+#if !MODULE_ONEWIRE_MULTIDRIVER || DOXYGEN
+
+/**
+ * @name Single driver mode callbacks
+ *
+ * When `onewire_multidriver` is not enabled, these callbacks must be provided
+ * by the selected 1-Wire bus driver.
+ * @{
+ */
+
+/**
+ * @brief   Callback to reset the bus
+ *
+ * When called, the bus driver should perform a bus reset and detect the slave
+ * device present pulse.
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ *
+ * @retval  0 if reset successfully and slave(s) were found
+ * @retval  -ENXIO if no slave answered the reset sequence
+ * @retval  -EIO on all other failures
+ */
+int _onewire_reset(onewire_t *bus);
+
+/**
+ * @brief   Callback to transfer bytes from the bus
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ * @param[out] buf      buffer to place received bits into
+ * @param[in] len       number of bits to transfer
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int _onewire_read_bits(onewire_t *bus, void *buf, size_t len);
+
+/**
+ * @brief   Callback to transfer bytes to the bus
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ * @param[in] buf       buffer containing bits to send
+ * @param[in] len       number of bits to transfer
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int _onewire_write_bits(onewire_t *bus, const void *buf, size_t len);
+
+/** @} */
+
+#endif /* !MODULE_ONEWIRE_MULTIDRIVER || DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -54,7 +54,6 @@ typedef le_uint64_t onewire_rom_t;
 /**
  * @brief   1-Wire bus driver implementation
  *
- * When `onewire_multidriver` is enabled, each 1-Wire bus driver should expose
  * When the `onewire_multidriver` module is enabled, each 1-Wire bus driver
  * should expose its functionality by providing an instance of this structure.
  */
@@ -189,7 +188,6 @@ int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom);
 /**
  * @brief   Select a device on the bus to communicate with
  *
- * This call resets the bus and then sends a Match ROM command followed by the
  * This call resets the bus and then sends a `Match ROM` command followed by the
  * device's ROM pointed to by @p rom. If @p rom is NULL, then a `Skip ROM` command
  * is sent instead. In this case no single device is selected and all attached

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-2020 Freie Universität Berlin
- * Copyright (C) 2023 Prime Controls
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -55,7 +55,8 @@ typedef le_uint64_t onewire_rom_t;
  * @brief   1-Wire bus driver implementation
  *
  * When `onewire_multidriver` is enabled, each 1-Wire bus driver should expose
- * its functionality by providing an instance of this structure.
+ * When the `onewire_multidriver` module is enabled, each 1-Wire bus driver
+ * should expose its functionality by providing an instance of this structure.
  */
 typedef struct {
 
@@ -68,6 +69,13 @@ typedef struct {
     /** @copydoc _onewire_write_bits() */
     int (*write_bits)(onewire_t *bus, const void *buf, size_t len);
 
+typedef struct {
+    /** @copydoc _onewire_reset() */
+    int (*reset)(onewire_t *bus);
+    /** @copydoc _onewire_read_bits() */
+    int (*read_bits)(onewire_t *bus, void *buf, size_t len);
+    /** @copydoc _onewire_write_bits() */
+    int (*write_bits)(onewire_t *bus, const void *buf, size_t len);
 } onewire_driver_t;
 
 /**
@@ -93,7 +101,7 @@ struct onewire_t {
  * @brief   Initialize a 1-Wire bus base type
  *
  * @note This is a private function meant to be called by 1-Wire bus driver
- * implementations.
+ *       implementations.
  *
  * @param[in] bus       1-Wire bus descriptor
  * @param[in] params    configuration parameters
@@ -182,7 +190,8 @@ int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom);
  * @brief   Select a device on the bus to communicate with
  *
  * This call resets the bus and then sends a Match ROM command followed by the
- * device's ROM pointed to by @p rom. If @p rom is NULL, then a Skip ROM command
+ * This call resets the bus and then sends a `Match ROM` command followed by the
+ * device's ROM pointed to by @p rom. If @p rom is NULL, then a `Skip ROM` command
  * is sent instead. In this case no single device is selected and all attached
  * devices will receive any further communication.
  *

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -58,17 +58,6 @@ typedef le_uint64_t onewire_rom_t;
  * should expose its functionality by providing an instance of this structure.
  */
 typedef struct {
-
-    /** @copydoc _onewire_reset() */
-    int (*reset)(onewire_t *bus);
-
-    /** @copydoc _onewire_read_bits() */
-    int (*read_bits)(onewire_t *bus, void *buf, size_t len);
-
-    /** @copydoc _onewire_write_bits() */
-    int (*write_bits)(onewire_t *bus, const void *buf, size_t len);
-
-typedef struct {
     /** @copydoc _onewire_reset() */
     int (*reset)(onewire_t *bus);
     /** @copydoc _onewire_read_bits() */

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -1,0 +1,432 @@
+/*
+ * SPDX-FileCopyrightText: 2016-2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @addtogroup  drivers_onewire_buses
+ * @{
+ * @file
+ * @brief       1-Wire driver interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "byteorder.h"
+#include "checksum/crc8.h"
+#include "checksum/ucrc16.h"
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Length of 1-Wire ROM code in bytes
+ */
+#define ONEWIRE_ROM_LEN         (8U)
+
+/**
+ * @brief   String length of a hex encoded 1-Wire ROM code (including \0)
+ */
+#define ONEWIRE_ROM_STR_LEN     (2 * ONEWIRE_ROM_LEN + 1)
+
+/**
+ * @brief   Custom value used to start a device search
+ */
+#define ONEWIRE_SEARCH_FIRST    (0)
+
+/** Forward declaration of 1-Wire bus descriptor */
+typedef struct onewire_t onewire_t;
+
+/**
+ * @brief   1-Wire ROM code (device address) representation
+ */
+typedef le_uint64_t onewire_rom_t;
+
+/**
+ * @brief   1-Wire bus driver implementation
+ *
+ * When the `onewire_multidriver` module is enabled, each 1-Wire bus driver
+ * should expose its functionality by providing an instance of this structure.
+ */
+typedef struct {
+    /** @copydoc _onewire_reset() */
+    int (*reset)(onewire_t *bus);
+    /** @copydoc _onewire_read_bits() */
+    int (*read_bits)(onewire_t *bus, void *buf, size_t len);
+    /** @copydoc _onewire_write_bits() */
+    int (*write_bits)(onewire_t *bus, const void *buf, size_t len);
+} onewire_driver_t;
+
+/**
+ * @brief   1-Wire configuration parameters
+ */
+typedef struct {
+#if MODULE_ONEWIRE_MULTIDRIVER || DOXYGEN
+    const onewire_driver_t *driver;     /**< driver for this bus */
+#endif
+} onewire_params_t;
+
+/**
+ * @brief   1-Wire bus device descriptor
+ */
+struct onewire_t {
+    const onewire_params_t *params;     /**< bus's configuration params */
+#if !MODULE_ONEWIRE_ONESLAVE || DOXYGEN
+    mutex_t lock;                       /**< bus access lock */
+#endif
+};
+
+/**
+ * @brief   Initialize a 1-Wire bus base type
+ *
+ * @note This is a private function meant to be called by 1-Wire bus driver
+ *       implementations.
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ * @param[in] params    configuration parameters
+ */
+void _onewire_init(onewire_t *bus, const onewire_params_t *params);
+
+/**
+ * @brief   Acquire exclusive access to 1-Wire bus
+ *
+ * 1-Wire buses cannot multiplex transactions of data to multiple slave devices
+ * at the same time. Therefore, transactions need to be serialized by acquiring
+ * exclusive access to the bus before a transaction is started. At the end of
+ * the transaction (or multiple transactions) the bus should be released so that
+ * it may be shared amongst several slave devices.
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ */
+static inline void onewire_acquire(onewire_t *bus)
+{
+#if MODULE_ONEWIRE_ONESLAVE
+    (void)bus;
+#else
+    mutex_lock(&bus->lock);
+#endif
+}
+
+/**
+ * @brief   Release exclusive access to 1-Wire bus
+ *
+ * This call ends exclusive access to a bus which was previously acquired with a
+ * call to @ref onewire_acquire().
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ */
+static inline void onewire_release(onewire_t *bus)
+{
+#if MODULE_ONEWIRE_ONESLAVE
+    (void)bus;
+#else
+    mutex_unlock(&bus->lock);
+#endif
+}
+
+/**
+ * @brief   Search for devices on the given 1-Wire bus
+ *
+ * Use this function to discover devices connected to the given 1-Wire bus. To
+ * carry out a full device discovery, this function has to be called multiple
+ * times. For each iteration, the return value of the previous call as well as
+ * the previous discovered ROM code have to be given as @p rom and @p ld
+ * parameters to the subsequent call. When the function returns 0, the last
+ * device has been found and there are no further devices to be discovered.
+ *
+ * @param[in] bus       1-Wire bus
+ * @param[in,out] rom   next discovery ROM code, needs to hold previous value
+ *                      when function is called multiple times
+ * @param[in] ld        position of last discrepancy or ONEWIRE_SEARCH_FIRST for
+ *                      initial call
+ *
+ * @return  bit position of last discrepancy
+ * @retval  0 if discovered device was the last
+ * @retval  -ENXIO if no device was found
+ * @retval  -EBADMSG if check of discovered device's ROM CRC failed
+ * @retval  -EIO on all other failures
+ */
+int onewire_search(onewire_t *bus, onewire_rom_t *rom, int ld);
+
+/**
+ * @brief   Read the ROM of a slave device
+ *
+ * This function reads the ROM from a device on the bus when only a single slave
+ * device is present. If multiple devices are present, the read data will be
+ * corrupted and the check of its CRC will fail.
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] rom      1-Wire ROM code of target device
+ *
+ * @retval  0 on success
+ * @retval  -ENXIO if no device was found
+ * @retval  -EBADMSG if check of ROM's CRC failed
+ * @retval  -EIO on all other failures
+ */
+int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom);
+
+/**
+ * @brief   Select a device on the bus to communicate with
+ *
+ * This call resets the bus and then sends a `Match ROM` command followed by the
+ * device's ROM pointed to by @p rom. If @p rom is NULL, then a `Skip ROM`
+ * command is sent instead. In this case no single device is selected and all
+ * attached devices will receive any further communication.
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] rom       1-Wire ROM code of target device
+ *
+ * @retval  0 on success
+ * @retval  -ENXIO if no slave answered the reset sequence
+ */
+int onewire_select(onewire_t *bus, const onewire_rom_t *rom);
+
+/**
+ * @brief   Read data from the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] data     buffer to write received bytes into
+ * @param[in] len       number of bytes to read from the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int onewire_read(onewire_t *bus, void *data, size_t len);
+
+/**
+ * @brief   Convenience function for reading a single byte from the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] data     byte read from the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_read_byte(onewire_t *bus, uint8_t *data)
+{
+    return onewire_read(bus, data, 1);
+}
+
+/**
+ * @brief   Convenience function for reading a 16 bit word from the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[out] data     word read from the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_read_word(onewire_t *bus, uint16_t *data)
+{
+    le_uint16_t buffer;
+
+    const int res = onewire_read(bus, &buffer, 2);
+    *data = byteorder_ltohs(buffer);
+    return res;
+}
+
+/**
+ * @brief   Write data to the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] data      buffer holding the data that is written to the bus
+ * @param[in] len       number of bytes to write to the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int onewire_write(onewire_t *bus, const void *data, size_t len);
+
+/**
+ * @brief   Convenience function for writing a single byte to the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] data      byte to write to the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_write_byte(onewire_t *bus, uint8_t data)
+{
+    return onewire_write(bus, &data, 1);
+}
+
+/**
+ * @brief   Convenience function for writing a 16 bit word to the bus
+ *
+ * @param[in] bus       1-Wire bus device descriptor
+ * @param[in] data      word to write to the bus
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+static inline int onewire_write_word(onewire_t *bus, uint16_t data)
+{
+    const le_uint16_t buffer = byteorder_htols(data);
+
+    return onewire_write(bus, &buffer, 2);
+}
+
+/**
+ * @brief   Calculate a 8 bit CRC using the 1-Wire specific polynomial
+ *
+ * @param[in] seed      the seed (starting value) for the checksum
+ * @param[in] data      input data
+ * @param[in] len       len of @p data in bytes
+ *
+ * @return  calculated 8 bit CRC
+ */
+static inline uint_fast8_t onewire_crc8(uint_fast16_t seed, const void *data,
+    size_t len)
+{
+    return crc8_lsb(data, len, 0x8c, seed);
+}
+
+/**
+ * @brief   Calculate a 16 bit CRC using the 1-Wire specific polynomial
+ *
+ * @param[in] seed      the seed (starting value) for the checksum
+ * @param[in] data      input data
+ * @param[in] len       len of @p data in bytes
+ *
+ * @return  calculated 16 bit CRC
+ */
+static inline uint_fast16_t onewire_crc16(uint_fast16_t seed, const void *data,
+    size_t len)
+{
+    return ucrc16_calc_le(data, len, 0xA001, seed);
+}
+
+/**
+ * @brief   Read 1-Wire ROM code from string
+ *
+ * @param[out] rom      ROM code is parsed into this location
+ * @param[in] str       String representation of a ROM code
+ *
+ * @retval  0 on success
+ * @retval  -EINVAL on parsing error
+ */
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str);
+
+/**
+ * @brief   Write a 1-Wire ROM code to a string
+ *
+ * The 64 bit ROM ID will be treated as a string of bytes, rather than a little
+ * endian number. This means the family code will be first, and the CRC will be
+ * at the end. 1-Wire documents refer to the CRC as the MSB and the family code
+ * as the LSB, but printing the ROM as a string of bytes makes sorting ID
+ * strings by family code more convenient.
+ *
+ * @param[out] str      Output string, must be able to hold ONEWIRE_ROM_STR_LEN
+ *                      characters
+ * @param[in] rom       1-Wire ROM code to read
+ */
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom);
+
+/**
+ * @brief   Print a 1-Wire ROM code to STDIO
+ *
+ * This is equivalent to converting a ROM to a string using @ref
+ * onewire_rom_to_str() and then printing that string.
+ *
+ * @param[in] rom       1-Wire ROM code
+ */
+void onewire_rom_print(const onewire_rom_t *rom);
+
+/**
+ * @brief   Validate a 1-Wire ROM code
+ *
+ * This function checks if a given 1-Wire ROM contains a valid device ID.
+ *
+ * @param[in] rom       1-Wire ROM code
+ *
+ * @retval  true if @p rom contains a valid ID
+ * @retval  false if @p rom contains an invalid ID
+ */
+bool onewire_rom_is_valid(const onewire_rom_t *rom);
+
+/**
+ * @brief   Returns the 1-Wire family code of @p rom
+ *
+ * @param[in] rom       1-Wire ROM code
+ *
+ * @return  1-Wire device 8 bit family code
+ */
+uint_fast8_t onewire_rom_family_code(const onewire_rom_t *rom);
+
+/**
+ * @brief   Compare two 1-Wire ROMs for equality.
+ *
+ * @param[in] left      1-Wire ROM code to compare
+ * @param[in] right     1-Wire ROM code to compare
+ *
+ * @retval  0 if @p left and @p right are equal
+ */
+int onewire_rom_compare(const onewire_rom_t *left, const onewire_rom_t *right);
+
+#if !MODULE_ONEWIRE_MULTIDRIVER || DOXYGEN
+
+/**
+ * @name Single driver mode callbacks
+ *
+ * When `onewire_multidriver` is not enabled, these callbacks must be provided
+ * by the selected 1-Wire bus driver.
+ * @{
+ */
+
+/**
+ * @brief   Callback to reset the bus
+ *
+ * When called, the bus driver should perform a bus reset and detect the slave
+ * device present pulse.
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ *
+ * @retval  0 if reset successfully and slave(s) were found
+ * @retval  -ENXIO if no slave answered the reset sequence
+ * @retval  -EIO on all other failures
+ */
+int _onewire_reset(onewire_t *bus);
+
+/**
+ * @brief   Callback to transfer bytes from the bus
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ * @param[out] buf      buffer to place received bits into
+ * @param[in] len       number of bits to transfer
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int _onewire_read_bits(onewire_t *bus, void *buf, size_t len);
+
+/**
+ * @brief   Callback to transfer bytes to the bus
+ *
+ * @param[in] bus       1-Wire bus descriptor
+ * @param[in] buf       buffer containing bits to send
+ * @param[in] len       number of bits to transfer
+ *
+ * @retval  0 on success
+ * @retval  -EIO on failure
+ */
+int _onewire_write_bits(onewire_t *bus, const void *buf, size_t len);
+
+/** @} */
+
+#endif /* !MODULE_ONEWIRE_MULTIDRIVER || DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/include/soft_onewire.h
+++ b/drivers/include/soft_onewire.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @defgroup    drivers_soft_onewire Soft 1-Wire Bus Driver
+ * @ingroup     drivers_onewire_buses
+ * @ingroup     drivers_soft_periph
+ * @brief       Software implemented 1-Wire bus master
+ *
+ * This is a soft driver implementation of a 1-Wire bus master. Minimally, the
+ * only required hardware is a GPIO pin.
+ *
+ * The pseudomodule `soft_onewire_hwtimer` is provided. When enabled, the driver
+ * will use a dedicated `periph_timer` rather than `ztimer` to manage time
+ * critical bus operations.
+ *
+ * The pseudomodule `soft_onewire_2pins`, when enabled, separates the transmit
+ * and receive functions of the bus into separate pins of the MCU. This is
+ * useful to allow the TX pin to drive a transistor so that greater currents may
+ * be sinked.
+ *
+ * If the pseudomodule `soft_onewire_pwr` is enabled, the bus will be driven
+ * high (instead of pulled high via the bus's pullup resistor) whenever the bus
+ * is idle. This helps supply addition current for 1-Wire devices that are
+ * parasitically powered from the bus. Note that if the GPIO pin's output
+ * voltage is lower than the pull up voltage, this may actually draw the bus's
+ * idle voltage down to the pin's voltage, although potentially at a lower
+ * output impedance.
+ *
+ * @{
+ * @file
+ * @brief       Soft 1-Wire driver interface
+ *
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "mutex.h"
+#include "onewire.h"
+#include "periph/gpio.h"
+#include "periph/timer.h"
+#include "ztimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief soft_onewire_t forward declaration
+ */
+typedef struct soft_onewire_t soft_onewire_t;
+
+/** timer callback function signature internally used to schedule events */
+typedef void (*soft_onewire_timer_cb_t)(soft_onewire_t*);
+
+/**
+ * @brief   Soft 1-Wire configuration parameters
+ */
+typedef struct {
+    onewire_params_t super;     /**< 1-Wire API params */
+#if MODULE_SOFT_ONEWIRE_2PINS || DOXYGEN
+    gpio_t tx_pin;              /**< GPIO pin for driving the bus */
+    gpio_t rx_pin;              /**< GPIO pin for reading the bus */
+#else
+    gpio_t pin;                 /**< GPIO pin the bus is connected to */
+    gpio_mode_t pin_imode;      /**< GPIO pin input mode */
+#endif
+#if MODULE_SOFT_ONEWIRE_HWTIMER || DOXYGEN
+    tim_t timer;                /**< peripheral timer that driver should use */
+#endif
+} soft_onewire_params_t;
+
+/**
+ * @brief   Soft 1-Wire bus device descriptor
+ */
+struct soft_onewire_t {
+
+    /** 1-Wire API instance */
+    onewire_t super;
+
+    /** mutext to sync thread with ISRs */
+    mutex_t sync;
+
+    /** Only one of these at a time will be used, so they are in a union to
+        save RAM. */
+    union {
+        const uint8_t *tx_buf;  /**< pointer to buffer of bits to send */
+        uint8_t *rx_buf;        /**< pointer to buffer for received bits */
+        int err;                /**< errors status of ISRs */
+    };
+
+    /** number of bits to send or receive */
+    size_t buf_size;
+
+    /** used to track which bit to TX/RX next */
+    uint8_t mask;
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER || DOXYGEN
+    /** pointer to callback of next bus event */
+    soft_onewire_timer_cb_t timer_cb;
+#else
+    /** timer used to trigger bus events */
+    ztimer_t timer;
+#endif
+};
+
+/** onewire driver callbacks for soft_onewire implementation */
+extern const onewire_driver_t soft_onewire_driver;
+
+/**
+ * @brief Initialize soft 1-Wire bus
+ *
+ * @param[in] bus       bus descriptor
+ * @param[in] params    configuration parameters
+ */
+void soft_onewire_init(soft_onewire_t *bus, const soft_onewire_params_t *params);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/include/soft_onewire.h
+++ b/drivers/include/soft_onewire.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Prime Controls
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/include/soft_onewire.h
+++ b/drivers/include/soft_onewire.h
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @defgroup    drivers_soft_onewire Soft 1-Wire Bus Driver
+ * @ingroup     drivers_onewire_buses
+ * @ingroup     drivers_soft_periph
+ * @brief       Software implemented 1-Wire bus master
+ *
+ * This is a soft driver implementation of a 1-Wire bus master. Minimally, the
+ * only required hardware is a GPIO pin.
+ *
+ * The pseudomodule `soft_onewire_hwtimer` is provided. When enabled, the driver
+ * will use a dedicated `periph_timer` rather than `ztimer` to manage time
+ * critical bus operations. Use this if the bus timing is found to be inaccurate
+ * enough to cause communication errors. This module may also help reduce system
+ * jitter during 1-Wire communications.
+ *
+ * The pseudomodule `soft_onewire_2pins`, when enabled, separates the transmit
+ * and receive functions of the bus into separate pins of the MCU. This is
+ * useful to allow the TX pin to drive a transistor so that greater currents may
+ * be sinked.
+ *
+ * If the pseudomodule `soft_onewire_pwr` is enabled, the bus will be driven
+ * high (instead of pulled high via the bus's pullup resistor) whenever the bus
+ * is idle. This helps supply addition current for 1-Wire devices that are
+ * parasitically powered from the bus. Note that if the GPIO pin's output
+ * voltage is lower than the pull up voltage, this may actually draw the bus's
+ * idle voltage down to the pin's voltage, although potentially at a lower
+ * output impedance.
+ *
+ * @{
+ * @file
+ * @brief       Soft 1-Wire driver interface
+ *
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "mutex.h"
+#include "onewire.h"
+#include "periph/gpio.h"
+#include "periph/timer.h"
+#include "ztimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief soft_onewire_t forward declaration
+ */
+typedef struct soft_onewire_t soft_onewire_t;
+
+/** timer callback function signature internally used to schedule events */
+typedef void (*soft_onewire_timer_cb_t)(soft_onewire_t*);
+
+/**
+ * @brief   Soft 1-Wire configuration parameters
+ */
+typedef struct {
+    onewire_params_t super;     /**< 1-Wire API params */
+#if MODULE_SOFT_ONEWIRE_2PINS || DOXYGEN
+    gpio_t tx_pin;              /**< GPIO pin for driving the bus */
+    gpio_t rx_pin;              /**< GPIO pin for reading the bus */
+#else
+    gpio_t pin;                 /**< GPIO pin the bus is connected to */
+    gpio_mode_t pin_imode;      /**< GPIO pin input mode */
+#endif
+#if MODULE_SOFT_ONEWIRE_HWTIMER || DOXYGEN
+    tim_t timer;                /**< peripheral timer that driver should use */
+#endif
+} soft_onewire_params_t;
+
+/**
+ * @brief   Soft 1-Wire bus device descriptor
+ */
+struct soft_onewire_t {
+
+    /** 1-Wire API instance */
+    onewire_t super;
+
+    /** mutex to sync thread with ISRs */
+    mutex_t sync;
+
+    /** Only one of these at a time will be used, so they are in a union to
+      * save RAM. */
+    union {
+        const uint8_t *tx_buf;  /**< pointer to buffer of bits to send */
+        uint8_t *rx_buf;        /**< pointer to buffer for received bits */
+        int err;                /**< errors status of ISRs */
+    };
+
+    /** number of bits to send or receive */
+    size_t buf_size;
+
+    /** used to track which bit to TX/RX next */
+    uint8_t mask;
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER || DOXYGEN
+    /** pointer to callback of next bus event */
+    soft_onewire_timer_cb_t timer_cb;
+#else
+    /** timer used to trigger bus events */
+    ztimer_t timer;
+#endif
+};
+
+/** onewire driver callbacks for soft_onewire implementation */
+extern const onewire_driver_t soft_onewire_driver;
+
+/**
+ * @brief Initialize soft 1-Wire bus
+ *
+ * @param[in] bus       bus descriptor
+ * @param[in] params    configuration parameters
+ */
+void soft_onewire_init(soft_onewire_t *bus, const soft_onewire_params_t *params);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/onewire/Makefile
+++ b/drivers/onewire/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/onewire/Makefile.dep
+++ b/drivers/onewire/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += checksum
+USEMODULE += fmt

--- a/drivers/onewire/Makefile.include
+++ b/drivers/onewire/Makefile.include
@@ -1,0 +1,2 @@
+PSEUDOMODULES += onewire_multidriver
+PSEUDOMODULES += onewire_oneslave

--- a/drivers/onewire/doc.md
+++ b/drivers/onewire/doc.md
@@ -8,7 +8,8 @@
 @brief      1-Wire Bus Interface and Drivers
 
 This is RIOT's driver interface for Dallas Semiconductor Corp (now Maxim
-Integrated) specified 1-Wire Buses. 1-Wire slave device drivers should use it
+This is RIOT's driver interface for Dallas Semiconductor Corp (now Analog
+Devices Inc) specified 1-Wire Buses. 1-Wire slave device drivers should use it
 to access the buses (and slave hardware). Drivers implementing 1-Wire bus
 master functionality should expose this functionality via this interface so
 that slave drivers can operate independent of the bus master hardware and its

--- a/drivers/onewire/doc.md
+++ b/drivers/onewire/doc.md
@@ -7,7 +7,6 @@
 @ingroup    drivers_onewire
 @brief      1-Wire Bus Interface and Drivers
 
-This is RIOT's driver interface for Dallas Semiconductor Corp (now Maxim
 This is RIOT's driver interface for Dallas Semiconductor Corp (now Analog
 Devices Inc) specified 1-Wire Buses. 1-Wire slave device drivers should use it
 to access the buses (and slave hardware). Drivers implementing 1-Wire bus

--- a/drivers/onewire/doc.md
+++ b/drivers/onewire/doc.md
@@ -1,0 +1,28 @@
+@defgroup   drivers_onewire 1-Wire
+@ingroup    drivers
+@brief      1-Wire Buses and Devices
+
+
+@defgroup   drivers_onewire_buses 1-Wire Bus Drivers
+@ingroup    drivers_onewire
+@brief      1-Wire Bus Interface and Drivers
+
+This is RIOT's driver interface for Dallas Semiconductor Corp (now Maxim
+Integrated) specified 1-Wire Buses. 1-Wire slave device drivers should use it
+to access the buses (and slave hardware). Drivers implementing 1-Wire bus
+master functionality should expose this functionality via this interface so
+that slave drivers can operate independent of the bus master hardware and its
+driver.
+
+The pseudomodule `onewire_oneslave`, when enabled, permits the assumption
+that each 1-wire bus instance will only ever have a single slave device
+connected. This turns calls to acquire and release the bus into noops.
+
+The pseudomodule `onewire_multidriver` enables support for multiple types of
+bus masters. Without this enabled, multiple buses are supported, but all
+instances must use the same driver, and therefore be of the same type of
+hardware.
+
+@defgroup   drivers_onewire_devs 1-Wire Device Drivers
+@ingroup    drivers_onewire
+@brief      1-Wire Slave Device Drivers

--- a/drivers/onewire/doc.md
+++ b/drivers/onewire/doc.md
@@ -1,0 +1,28 @@
+@defgroup   drivers_onewire 1-Wire
+@ingroup    drivers
+@brief      1-Wire Buses and Devices
+
+
+@defgroup   drivers_onewire_buses 1-Wire Bus Drivers
+@ingroup    drivers_onewire
+@brief      1-Wire Bus Interface and Drivers
+
+This is RIOT's driver interface for Dallas Semiconductor Corp (now Analog
+Devices Inc) specified 1-Wire Buses. 1-Wire slave device drivers should use it
+to access the buses (and slave hardware). Drivers implementing 1-Wire bus
+master functionality should expose this functionality via this interface so
+that slave drivers can operate independent of the bus master hardware and its
+driver.
+
+The pseudomodule `onewire_oneslave`, when enabled, permits the assumption
+that each 1-wire bus instance will only ever have a single slave device
+connected. This turns calls to acquire and release the bus into no-ops.
+
+The pseudomodule `onewire_multidriver` enables support for multiple types of
+bus masters. Without this enabled, multiple buses are supported, but all
+instances must use the same driver, and therefore be of the same type of
+hardware.
+
+@defgroup   drivers_onewire_devs 1-Wire Device Drivers
+@ingroup    drivers_onewire
+@brief      1-Wire Slave Device Drivers

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -196,7 +196,6 @@ int onewire_search(onewire_t *bus, onewire_rom_t *rom, int ld)
         }
 
         /* Both bits will be high if for some reason no device matches what has
-           been sent so far. This could happen if a device was removed during
          * been sent so far. This could happen if a device was removed during
          * the search process. */
         const bool no_dev = (bits & 3) == 3;

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-2020 Freie Universität Berlin
- * Copyright (C) 2023 Prime Controls
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: 2016-2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire bus driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ *
+ * @}
+ */
+
+#include "onewire.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   1-Wire ROM commands
+ */
+enum {
+    ONEWIRE_ROM_SEARCH  = 0xf0, /**< search for devices */
+    ONEWIRE_ROM_READ    = 0x33, /**< read ROM code in single device config */
+    ONEWIRE_ROM_MATCH   = 0x55, /**< address a specific slave */
+    ONEWIRE_ROM_SKIP    = 0xcc, /**< broadcast commands to all connected devs */
+    ONEWIRE_ROM_ALARM   = 0xec, /**< search for devices with active alarm */
+};
+
+#if MODULE_ONEWIRE_MULTIDRIVER
+
+static int _onewire_reset(onewire_t *bus)
+{
+    return bus->params->driver->reset(bus);
+}
+
+static int _onewire_read_bits(onewire_t *bus, void *buf, size_t len)
+{
+    return bus->params->driver->read_bits(bus, buf, len);
+}
+
+static int _onewire_write_bits(onewire_t *bus, const void *buf, size_t len)
+{
+    return bus->params->driver->write_bits(bus, buf, len);
+}
+
+#endif /* MODULE_ONEWIRE_MULTIDRIVER */
+
+int onewire_select(onewire_t *bus, const onewire_rom_t *rom)
+{
+    assert(bus);
+
+    int res = 0;
+
+    DEBUG("%s\n", DEBUG_FUNC);
+
+    res = _onewire_reset(bus);
+    if (res < 0) {
+        return res;
+    }
+
+    if (rom) {
+        res = onewire_write_byte(bus, ONEWIRE_ROM_MATCH);
+        if (res < 0) {
+            return res;
+        }
+
+        res = onewire_write(bus, rom, sizeof(*rom));
+        if (res < 0) {
+            return res;
+        }
+    }
+    else {
+        res = onewire_write_byte(bus, ONEWIRE_ROM_SKIP);
+        if (res < 0) {
+            return res;
+        }
+    }
+
+    return 0;
+}
+
+int onewire_read(onewire_t *bus, void *data, size_t len)
+{
+    assert(bus);
+    assert(data);
+
+    uint8_t *buf = data;
+
+    const int res = _onewire_read_bits(bus, data, len * 8);
+
+    DEBUG("%s: ", DEBUG_FUNC);
+    for (size_t pos = 0; pos < len && !res ; pos++) {
+        DEBUG("%02x ", buf[pos]);
+    }
+    DEBUG("\n");
+
+    return res;
+}
+
+int onewire_write(onewire_t *bus, const void *data, size_t len)
+{
+    assert(bus);
+    assert(data);
+
+    const uint8_t *buf = data;
+
+    DEBUG("%s: ", DEBUG_FUNC);
+    for (size_t pos = 0; pos < len; pos++) {
+        DEBUG("%02x ", buf[pos]);
+    }
+    DEBUG("\n");
+
+    return _onewire_write_bits(bus, data, len * 8);
+}
+
+int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom)
+{
+    assert(bus);
+    assert(rom);
+
+    int res;
+
+    res = _onewire_reset(bus);
+    if (res < 0) {
+        return res;
+    }
+
+    res = onewire_write_byte(bus, ONEWIRE_ROM_READ);
+    if (res < 0) {
+        return res;
+    }
+
+    res = onewire_read(bus, rom, sizeof(*rom));
+    if (res < 0) {
+        return res;
+    }
+
+    if (onewire_rom_is_valid(rom) == false) {
+        return -EBADMSG;
+    }
+
+    return 0;
+}
+
+/* See
+ * https://www.analog.com/media/en/technical-documentation/tech-articles/book-of-ibuttonreg-standards.pdf,
+ * page 51 and 52 for a detailed description on the search algorithm.
+ */
+int onewire_search(onewire_t *bus, onewire_rom_t *rom, int ld)
+{
+    assert(bus);
+    assert(rom);
+
+    int res;
+
+    /* Initialize the search state. */
+    if (ld == ONEWIRE_SEARCH_FIRST) {
+        memset(rom, 0, sizeof(rom->u8));
+    }
+
+    /* Reset the bus. */
+    res = _onewire_reset(bus);
+    if (res < 0) {
+        return res;
+    }
+
+    /* Send the search ROM command. */
+    res = onewire_write_byte(bus, ONEWIRE_ROM_SEARCH);
+    if (res < 0) {
+        return res;
+    }
+
+    /* Start search. */
+    int marker = 0;
+    int pos = 1;
+    for (unsigned i = 0; i < sizeof(rom->u8) * 8; i++) {
+        const unsigned byte = i / 8;
+        const uint8_t mask = 1 << (i % 8);
+        uint8_t bits;
+
+        /* Read two bits from the bus. */
+        res = _onewire_read_bits(bus, &bits, 2);
+        if (res < 0) {
+            return res;
+        }
+
+        /* Both bits will be high if for some reason no device matches what has
+         * been sent so far. This could happen if a device was removed during
+         * the search process. */
+        const bool no_dev = (bits & 3) == 3;
+        if (no_dev) {
+            return -ENXIO;
+        }
+
+        /* At least two devices exist with the next ROM bit in conflict. */
+        const bool conflict = (bits & 3) == 0;
+        if (conflict) {
+            if (pos < ld) {
+                bits = (rom->u8[byte] & mask) ? 1 : 0;
+                if (bits == 0) {
+                    marker = pos;
+                }
+            }
+            else if (pos == ld) {
+                bits = 1;
+            }
+            else {
+                marker = pos;
+                bits = 0;
+            }
+        }
+
+        /* Send next bit of ROM we wish to match. */
+        res = _onewire_write_bits(bus, &bits, 1);
+        if (res < 0) {
+            return res;
+        }
+
+        if (bits & 1) {
+            rom->u8[byte] |= mask;
+        }
+        else {
+            rom->u8[byte] &= ~mask;
+        }
+
+        pos++;
+    }
+
+    if (onewire_rom_is_valid(rom) == false) {
+        return -EBADMSG;
+    }
+
+    return marker;
+}
+
+void _onewire_init(onewire_t *bus, const onewire_params_t *params)
+{
+    DEBUG_PUTS(DEBUG_FUNC);
+
+    assert(bus);
+    assert(params);
+#if MODULE_ONEWIRE_MULTIDRIVER
+    assert(params->driver);
+    assert(params->driver->reset);
+    assert(params->driver->read_bits);
+    assert(params->driver->write_bits);
+#endif
+
+    bus->params = params;
+
+#ifndef MODULE_ONEWIRE_ONESLAVE
+    mutex_init(&bus->lock);
+#endif
+}

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -197,7 +197,8 @@ int onewire_search(onewire_t *bus, onewire_rom_t *rom, int ld)
 
         /* Both bits will be high if for some reason no device matches what has
            been sent so far. This could happen if a device was removed during
-           the search process. */
+         * been sent so far. This could happen if a device was removed during
+         * the search process. */
         const bool no_dev = (bits & 3) == 3;
         if (no_dev) {
             return -ENXIO;

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire bus driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ *
+ * @}
+ */
+
+#include "onewire.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   1-Wire ROM commands
+ */
+enum {
+    ONEWIRE_ROM_SEARCH  = 0xf0, /**< search for devices */
+    ONEWIRE_ROM_READ    = 0x33, /**< read ROM code in single device config */
+    ONEWIRE_ROM_MATCH   = 0x55, /**< address a specific slave */
+    ONEWIRE_ROM_SKIP    = 0xcc, /**< broadcast commands to all connected devs */
+    ONEWIRE_ROM_ALARM   = 0xec, /**< search for devices with active alarm */
+};
+
+#if MODULE_ONEWIRE_MULTIDRIVER
+
+static int _onewire_reset(onewire_t *bus)
+{
+    return bus->params->driver->reset(bus);
+}
+
+static int _onewire_read_bits(onewire_t *bus, void *buf, size_t len)
+{
+    return bus->params->driver->read_bits(bus, buf, len);
+}
+
+static int _onewire_write_bits(onewire_t *bus, const void *buf, size_t len)
+{
+    return bus->params->driver->write_bits(bus, buf, len);
+}
+
+#endif /* MODULE_ONEWIRE_MULTIDRIVER */
+
+int onewire_select(onewire_t *bus, const onewire_rom_t *rom)
+{
+    assert(bus);
+
+    int res = 0;
+
+    DEBUG("%s\n", DEBUG_FUNC);
+
+    res = _onewire_reset(bus);
+    if (res < 0) {
+        return res;
+    }
+
+    if (rom) {
+        res = onewire_write_byte(bus, ONEWIRE_ROM_MATCH);
+        if (res < 0) {
+            return res;
+        }
+
+        res = onewire_write(bus, rom, sizeof(*rom));
+        if (res < 0) {
+            return res;
+        }
+    }
+    else {
+        res = onewire_write_byte(bus, ONEWIRE_ROM_SKIP);
+        if (res < 0) {
+            return res;
+        }
+    }
+
+    return 0;
+}
+
+int onewire_read(onewire_t *bus, void *data, size_t len)
+{
+    assert(bus);
+    assert(data);
+
+    uint8_t *buf = data;
+
+    const int res = _onewire_read_bits(bus, data, len * 8);
+
+    DEBUG("%s: ", DEBUG_FUNC);
+    for (size_t pos = 0; pos < len && !res ; pos++) {
+        DEBUG("%02x ", buf[pos]);
+    }
+    DEBUG("\n");
+
+    return res;
+}
+
+int onewire_write(onewire_t *bus, const void *data, size_t len)
+{
+    assert(bus);
+    assert(data);
+
+    const uint8_t *buf = data;
+
+    DEBUG("%s: ", DEBUG_FUNC);
+    for (size_t pos = 0; pos < len; pos++) {
+        DEBUG("%02x ", buf[pos]);
+    }
+    DEBUG("\n");
+
+    return _onewire_write_bits(bus, data, len * 8);
+}
+
+int onewire_read_rom(onewire_t *bus, onewire_rom_t *rom)
+{
+    assert(bus);
+    assert(rom);
+
+    int res;
+
+    res = _onewire_reset(bus);
+    if (res < 0) {
+        return res;
+    }
+
+    res = onewire_write_byte(bus, ONEWIRE_ROM_READ);
+    if (res < 0) {
+        return res;
+    }
+
+    res = onewire_read(bus, rom, sizeof(*rom));
+    if (res < 0) {
+        return res;
+    }
+
+    if (onewire_rom_is_valid(rom) == false) {
+        return -EBADMSG;
+    }
+
+    return 0;
+}
+
+/* See
+ * https://www.analog.com/media/en/technical-documentation/tech-articles/book-of-ibuttonreg-standards.pdf,
+ * page 51 and 52 for a detailed description on the search algorithm.
+ */
+int onewire_search(onewire_t *bus, onewire_rom_t *rom, int ld)
+{
+    assert(bus);
+    assert(rom);
+
+    int res;
+
+    /* Initialize the search state. */
+    if (ld == ONEWIRE_SEARCH_FIRST) {
+        memset(rom, 0, sizeof(rom->u8));
+    }
+
+    /* Reset the bus. */
+    res = _onewire_reset(bus);
+    if (res < 0) {
+        return res;
+    }
+
+    /* Send the search ROM command. */
+    res = onewire_write_byte(bus, ONEWIRE_ROM_SEARCH);
+    if (res < 0) {
+        return res;
+    }
+
+    /* Start search. */
+    int marker = 0;
+    int pos = 1;
+    for (unsigned i = 0; i < sizeof(rom->u8) * 8; i++) {
+        const unsigned byte = i / 8;
+        const uint8_t mask = 1 << (i % 8);
+        uint8_t bits;
+
+        /* Read two bits from the bus. */
+        res = _onewire_read_bits(bus, &bits, 2);
+        if (res < 0) {
+            return res;
+        }
+
+        /* Both bits will be high if for some reason no device matches what has
+           been sent so far. This could happen if a device was removed during
+           the search process. */
+        const bool no_dev = (bits & 3) == 3;
+        if (no_dev) {
+            return -ENXIO;
+        }
+
+        /* At least two devices exist with the next ROM bit in conflict. */
+        const bool conflict = (bits & 3) == 0;
+        if (conflict) {
+            if (pos < ld) {
+                bits = (rom->u8[byte] & mask) ? 1 : 0;
+                if (bits == 0) {
+                    marker = pos;
+                }
+            }
+            else if (pos == ld) {
+                bits = 1;
+            }
+            else {
+                marker = pos;
+                bits = 0;
+            }
+        }
+
+        /* Send next bit of ROM we wish to match. */
+        res = _onewire_write_bits(bus, &bits, 1);
+        if (res < 0) {
+            return res;
+        }
+
+        if (bits & 1) {
+            rom->u8[byte] |= mask;
+        }
+        else {
+            rom->u8[byte] &= ~mask;
+        }
+
+        pos++;
+    }
+
+    if (onewire_rom_is_valid(rom) == false) {
+        return -EBADMSG;
+    }
+
+    return marker;
+}
+
+void _onewire_init(onewire_t *bus, const onewire_params_t *params)
+{
+    DEBUG_PUTS(DEBUG_FUNC);
+
+    assert(bus);
+    assert(params);
+#if MODULE_ONEWIRE_MULTIDRIVER
+    assert(params->driver);
+    assert(params->driver->reset);
+    assert(params->driver->read_bits);
+    assert(params->driver->write_bits);
+#endif
+
+    bus->params = params;
+
+#ifndef MODULE_ONEWIRE_ONESLAVE
+    mutex_init(&bus->lock);
+#endif
+}

--- a/drivers/onewire/rom.c
+++ b/drivers/onewire/rom.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire address (ROM) string helper functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#include "fmt.h"
+#include "onewire.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static_assert(sizeof(onewire_rom_t) == ONEWIRE_ROM_LEN);
+
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
+{
+    assert(rom);
+    assert(str);
+
+    if (strlen(str) != (ONEWIRE_ROM_STR_LEN - 1)) {
+        return -EINVAL;
+    }
+    fmt_hex_bytes(rom->u8, str);
+
+    return 0;
+}
+
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom)
+{
+    assert(rom);
+    assert(str);
+
+    size_t pos = fmt_bytes_hex(str, rom->u8, sizeof(rom->u8));
+    str[pos] = '\0';
+}
+
+void onewire_rom_print(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    char str[ONEWIRE_ROM_STR_LEN];
+    onewire_rom_to_str(str, rom);
+    print(str, (ONEWIRE_ROM_STR_LEN - 1));
+}
+
+bool onewire_rom_is_valid(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    /* Some TI tmp1827 parts have broken ROM ID's. Their CRC was calculated as
+       if their family code was 0x26 rather than the 0x27 actually used. Account
+       for this, allowing those part IDs to pass.
+
+       see here for more info:
+       https://e2e.ti.com/support/sensors-group/sensors/f/sensors-forum/1342717/tmp1827-64-bit-uid-crc8-not-correct
+    */
+    if (onewire_rom_family_code(rom) == 0x27) {
+        const uint_fast8_t crc =
+            onewire_crc8(0xfe, &rom->u8[1], sizeof(rom->u8) - 1);
+        if (crc == 0) {
+            DEBUG("%s: crc result: %x\n", DEBUG_FUNC, crc);
+            return true;
+        }
+    }
+
+    const uint_fast8_t crc = onewire_crc8(0, rom->u8, sizeof(rom->u8));
+    DEBUG("%s: crc result: %x\n", DEBUG_FUNC, crc);
+    return crc == 0;
+}
+
+uint_fast8_t onewire_rom_family_code(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    return rom->u8[0];
+}
+
+int onewire_rom_compare(const onewire_rom_t *left, const onewire_rom_t *right)
+{
+    assert(right);
+    assert(left);
+
+    return memcmp(left->u8, right->u8, sizeof(left->u8));
+}

--- a/drivers/onewire/rom.c
+++ b/drivers/onewire/rom.c
@@ -65,10 +65,6 @@ bool onewire_rom_is_valid(const onewire_rom_t *rom)
     assert(rom);
 
     /* Some TI tmp1827 parts have broken ROM ID's. Their CRC was calculated as
-       if their family code was 0x26 rather than the 0x27 actually used. Account
-       for this, allowing those part IDs to pass.
-
-       see here for more info:
      * if their family code was 0x26 rather than the 0x27 actually used. Account
      * for this, allowing those part IDs to pass.
      *

--- a/drivers/onewire/rom.c
+++ b/drivers/onewire/rom.c
@@ -69,7 +69,11 @@ bool onewire_rom_is_valid(const onewire_rom_t *rom)
        for this, allowing those part IDs to pass.
 
        see here for more info:
-       https://e2e.ti.com/support/sensors-group/sensors/f/sensors-forum/1342717/tmp1827-64-bit-uid-crc8-not-correct
+     * if their family code was 0x26 rather than the 0x27 actually used. Account
+     * for this, allowing those part IDs to pass.
+     *
+     * see here for more info:
+     * https://e2e.ti.com/support/sensors-group/sensors/f/sensors-forum/1342717/tmp1827-64-bit-uid-crc8-not-correct
     */
     if (onewire_rom_family_code(rom) == 0x27) {
         const uint_fast8_t crc =

--- a/drivers/onewire/rom.c
+++ b/drivers/onewire/rom.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-2020 Freie Universität Berlin
- * Copyright (C) 2023 Prime Controls
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/onewire/rom.c
+++ b/drivers/onewire/rom.c
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2016-2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire address (ROM) string helper functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#include "fmt.h"
+#include "onewire.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static_assert(sizeof(onewire_rom_t) == ONEWIRE_ROM_LEN,
+    "size of onewire_rom_t not as expected");
+
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
+{
+    assert(rom);
+    assert(str);
+
+    if (strlen(str) != (ONEWIRE_ROM_STR_LEN - 1)) {
+        return -EINVAL;
+    }
+    fmt_hex_bytes(rom->u8, str);
+
+    return 0;
+}
+
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom)
+{
+    assert(rom);
+    assert(str);
+
+    size_t pos = fmt_bytes_hex(str, rom->u8, sizeof(rom->u8));
+    str[pos] = '\0';
+}
+
+void onewire_rom_print(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    char str[ONEWIRE_ROM_STR_LEN];
+    onewire_rom_to_str(str, rom);
+    print(str, (ONEWIRE_ROM_STR_LEN - 1));
+}
+
+bool onewire_rom_is_valid(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    /* Some TI TMP1827 parts have broken ROM ID's. Their CRC was calculated as
+     * if their family code was 0x26 rather than the 0x27 actually used. Account
+     * for this, allowing those part IDs to pass.
+     *
+     * see here for more info:
+     * https://e2e.ti.com/support/sensors-group/sensors/f/sensors-forum/1342717/tmp1827-64-bit-uid-crc8-not-correct
+    */
+    if (onewire_rom_family_code(rom) == 0x27) {
+        const uint_fast8_t crc =
+            onewire_crc8(0xfe, &rom->u8[1], sizeof(rom->u8) - 1);
+        if (crc == 0) {
+            DEBUG("%s: crc result: %x\n", DEBUG_FUNC, crc);
+            return true;
+        }
+    }
+
+    const uint_fast8_t crc = onewire_crc8(0, rom->u8, sizeof(rom->u8));
+    DEBUG("%s: crc result: %x\n", DEBUG_FUNC, crc);
+    return crc == 0;
+}
+
+uint_fast8_t onewire_rom_family_code(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    return rom->u8[0];
+}
+
+int onewire_rom_compare(const onewire_rom_t *left, const onewire_rom_t *right)
+{
+    assert(right);
+    assert(left);
+
+    return memcmp(left->u8, right->u8, sizeof(left->u8));
+}

--- a/drivers/onewire/rom.c
+++ b/drivers/onewire/rom.c
@@ -27,7 +27,8 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-static_assert(sizeof(onewire_rom_t) == ONEWIRE_ROM_LEN);
+static_assert(sizeof(onewire_rom_t) == ONEWIRE_ROM_LEN,
+    "size of onewire_rom_t not as expected");
 
 int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
 {

--- a/drivers/soft_onewire/Makefile
+++ b/drivers/soft_onewire/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/soft_onewire/Makefile.dep
+++ b/drivers/soft_onewire/Makefile.dep
@@ -1,0 +1,9 @@
+FEATURES_REQUIRED += periph_gpio
+
+USEMODULE += onewire
+
+ifneq (,$(filter soft_onewire_hwtimer,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_timer
+else
+  USEMODULE += ztimer_usec
+endif

--- a/drivers/soft_onewire/Makefile.include
+++ b/drivers/soft_onewire/Makefile.include
@@ -1,0 +1,6 @@
+USEMODULE_INCLUDES_soft_onewire := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_soft_onewire)
+
+PSEUDOMODULES += soft_onewire_2pins
+PSEUDOMODULES += soft_onewire_hwtimer
+PSEUDOMODULES += soft_onewire_pwr

--- a/drivers/soft_onewire/include/soft_onewire_params.h
+++ b/drivers/soft_onewire/include/soft_onewire_params.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @ingroup     drivers_soft_onewire
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for soft 1-Wire driver
+ *
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ */
+
+#include "board.h"
+
+#include "container.h"
+#include "soft_onewire.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** default 1-wire bus pin */
+#ifndef SOFT_ONEWIRE_PARAMS_PIN
+#  define SOFT_ONEWIRE_PARAMS_PIN GPIO_UNDEF
+#endif
+
+/** default input mode for bus pin */
+#ifndef SOFT_ONEWIRE_PARAMS_PIN_IMODE
+#  define SOFT_ONEWIRE_PARAMS_PIN_IMODE GPIO_IN_PU
+#endif
+
+/** default 1-wire bus TX pin */
+#ifndef SOFT_ONEWIRE_PARAMS_TX_PIN
+#  define SOFT_ONEWIRE_PARAMS_TX_PIN GPIO_UNDEF
+#endif
+
+/** default 1-wire bus RX pin */
+#ifndef SOFT_ONEWIRE_PARAMS_RX_PIN
+#  define SOFT_ONEWIRE_PARAMS_RX_PIN GPIO_UNDEF
+#endif
+
+/** default timer to use for the bus */
+#ifndef SOFT_ONEWIRE_PARAMS_HWTIMER
+#  define SOFT_ONEWIRE_PARAMS_HWTIMER TIMER_UNDEF
+#endif
+
+/**
+ * @brief Soft 1-Wire default configuration parameters
+ */
+static soft_onewire_params_t soft_onewire_params[] = {
+    {
+#if MODULE_ONEWIRE_MULTIDRIVER
+        .super = {
+            .driver = &soft_onewire_driver,
+        },
+#endif
+
+#if MODULE_SOFT_ONEWIRE_2PINS
+        .tx_pin = SOFT_ONEWIRE_PARAMS_TX_PIN,
+        .rx_pin = SOFT_ONEWIRE_PARAMS_RX_PIN,
+#else
+        .pin = SOFT_ONEWIRE_PARAMS_PIN,
+        .pin_imode = SOFT_ONEWIRE_PARAMS_PIN_IMODE,
+#endif
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+        .timer = SOFT_ONEWIRE_PARAMS_HWTIMER,
+#endif
+    },
+};
+
+/** number of soft 1-wire buses */
+#define SOFT_ONEWIRE_NUMOF ARRAY_SIZE(soft_onewire_params)
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/soft_onewire/include/soft_onewire_params.h
+++ b/drivers/soft_onewire/include/soft_onewire_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Prime Controls
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/soft_onewire/include/soft_onewire_params.h
+++ b/drivers/soft_onewire/include/soft_onewire_params.h
@@ -25,28 +25,28 @@ extern "C" {
 #endif
 
 /** default 1-wire bus pin */
-#ifndef SOFT_ONEWIRE_PARAMS_PIN
-#  define SOFT_ONEWIRE_PARAMS_PIN GPIO_UNDEF
+#ifndef SOFT_ONEWIRE_PARAM_PIN
+#  define SOFT_ONEWIRE_PARAM_PIN GPIO_UNDEF
 #endif
 
 /** default input mode for bus pin */
-#ifndef SOFT_ONEWIRE_PARAMS_PIN_IMODE
-#  define SOFT_ONEWIRE_PARAMS_PIN_IMODE GPIO_IN_PU
+#ifndef SOFT_ONEWIRE_PARAM_PIN_IMODE
+#  define SOFT_ONEWIRE_PARAM_PIN_IMODE GPIO_IN_PU
 #endif
 
 /** default 1-wire bus TX pin */
-#ifndef SOFT_ONEWIRE_PARAMS_TX_PIN
-#  define SOFT_ONEWIRE_PARAMS_TX_PIN GPIO_UNDEF
+#ifndef SOFT_ONEWIRE_PARAM_TX_PIN
+#  define SOFT_ONEWIRE_PARAM_TX_PIN GPIO_UNDEF
 #endif
 
 /** default 1-wire bus RX pin */
-#ifndef SOFT_ONEWIRE_PARAMS_RX_PIN
-#  define SOFT_ONEWIRE_PARAMS_RX_PIN GPIO_UNDEF
+#ifndef SOFT_ONEWIRE_PARAM_RX_PIN
+#  define SOFT_ONEWIRE_PARAM_RX_PIN GPIO_UNDEF
 #endif
 
 /** default timer to use for the bus */
-#ifndef SOFT_ONEWIRE_PARAMS_HWTIMER
-#  define SOFT_ONEWIRE_PARAMS_HWTIMER TIMER_UNDEF
+#ifndef SOFT_ONEWIRE_PARAM_HWTIMER
+#  define SOFT_ONEWIRE_PARAM_HWTIMER TIMER_UNDEF
 #endif
 
 /**
@@ -61,15 +61,15 @@ static soft_onewire_params_t soft_onewire_params[] = {
 #endif
 
 #if MODULE_SOFT_ONEWIRE_2PINS
-        .tx_pin = SOFT_ONEWIRE_PARAMS_TX_PIN,
-        .rx_pin = SOFT_ONEWIRE_PARAMS_RX_PIN,
+        .tx_pin = SOFT_ONEWIRE_PARAM_TX_PIN,
+        .rx_pin = SOFT_ONEWIRE_PARAM_RX_PIN,
 #else
-        .pin = SOFT_ONEWIRE_PARAMS_PIN,
-        .pin_imode = SOFT_ONEWIRE_PARAMS_PIN_IMODE,
+        .pin = SOFT_ONEWIRE_PARAM_PIN,
+        .pin_imode = SOFT_ONEWIRE_PARAM_PIN_IMODE,
 #endif
 
 #if MODULE_SOFT_ONEWIRE_HWTIMER
-        .timer = SOFT_ONEWIRE_PARAMS_HWTIMER,
+        .timer = SOFT_ONEWIRE_PARAM_HWTIMER,
 #endif
     },
 };

--- a/drivers/soft_onewire/include/soft_onewire_params.h
+++ b/drivers/soft_onewire/include/soft_onewire_params.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     drivers_soft_onewire
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for soft 1-Wire driver
+ *
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ */
+
+#include "board.h"
+
+#include "container.h"
+#include "soft_onewire.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** default 1-wire bus pin */
+#ifndef SOFT_ONEWIRE_PARAM_PIN
+#  define SOFT_ONEWIRE_PARAM_PIN GPIO_UNDEF
+#endif
+
+/** default input mode for bus pin */
+#ifndef SOFT_ONEWIRE_PARAM_PIN_IMODE
+#  define SOFT_ONEWIRE_PARAM_PIN_IMODE GPIO_IN_PU
+#endif
+
+/** default 1-wire bus TX pin */
+#ifndef SOFT_ONEWIRE_PARAM_TX_PIN
+#  define SOFT_ONEWIRE_PARAM_TX_PIN GPIO_UNDEF
+#endif
+
+/** default 1-wire bus RX pin */
+#ifndef SOFT_ONEWIRE_PARAM_RX_PIN
+#  define SOFT_ONEWIRE_PARAM_RX_PIN GPIO_UNDEF
+#endif
+
+/** default timer to use for the bus */
+#ifndef SOFT_ONEWIRE_PARAM_HWTIMER
+#  define SOFT_ONEWIRE_PARAM_HWTIMER TIMER_UNDEF
+#endif
+
+/**
+ * @brief Soft 1-Wire default configuration parameters
+ */
+static soft_onewire_params_t soft_onewire_params[] = {
+    {
+#if MODULE_ONEWIRE_MULTIDRIVER
+        .super = {
+            .driver = &soft_onewire_driver,
+        },
+#endif
+
+#if MODULE_SOFT_ONEWIRE_2PINS
+        .tx_pin = SOFT_ONEWIRE_PARAM_TX_PIN,
+        .rx_pin = SOFT_ONEWIRE_PARAM_RX_PIN,
+#else
+        .pin = SOFT_ONEWIRE_PARAM_PIN,
+        .pin_imode = SOFT_ONEWIRE_PARAM_PIN_IMODE,
+#endif
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+        .timer = SOFT_ONEWIRE_PARAM_HWTIMER,
+#endif
+    },
+};
+
+/** number of soft 1-wire buses */
+#define SOFT_ONEWIRE_NUMOF ARRAY_SIZE(soft_onewire_params)
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/soft_onewire/soft_onewire.c
+++ b/drivers/soft_onewire/soft_onewire.c
@@ -32,8 +32,6 @@
 #  define MAYBE_STATIC
 #endif
 
-/* bus timings as given in
- * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
 /* All bus timing values are given in microseconds, based on this article:
  * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
  */
@@ -79,8 +77,6 @@ static void _bus_power(soft_onewire_t *bus)
     gpio_t pin = _params(bus)->pin;
 
     /* Re-initializing a GPIO pin is supposed to leave it's set/clear state
-       untouched, but not all platforms can guarantee this. So we set the pin
-       before and after re-initializing it. This is to avoid momentarily pulling
      * untouched, but not all platforms can guarantee this. So we set the pin
      * before and after re-initializing it. This is to avoid momentarily pulling
      * the bus low. */
@@ -142,7 +138,6 @@ static void _schedule(soft_onewire_t *bus, soft_onewire_timer_cb_t cb,
     const int res = timer_set(timer, 0, usec);
     if (res < 0)
     {
-        /* release bus, but don't power it in-case a slave deice is trying to
         /* release bus, but don't power it in case a slave deice is trying to
          * hold it low*/
         _bus_release(bus);

--- a/drivers/soft_onewire/soft_onewire.c
+++ b/drivers/soft_onewire/soft_onewire.c
@@ -34,7 +34,8 @@
 
 /* bus timings as given in
  * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
- * all in microseconds
+/* All bus timing values are given in microseconds, based on this article:
+ * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
  */
 #define T_RESET_HOLD_US     (480U)
 #define T_RESET_SAMPLE_US   (70U)
@@ -80,7 +81,9 @@ static void _bus_power(soft_onewire_t *bus)
     /* Re-initializing a GPIO pin is supposed to leave it's set/clear state
        untouched, but not all platforms can guarantee this. So we set the pin
        before and after re-initializing it. This is to avoid momentarily pulling
-       the bus low. */
+     * untouched, but not all platforms can guarantee this. So we set the pin
+     * before and after re-initializing it. This is to avoid momentarily pulling
+     * the bus low. */
     gpio_set(pin);
     gpio_init(pin, GPIO_OUT);
     gpio_set(pin);
@@ -102,7 +105,7 @@ static void _bus_pull(soft_onewire_t *bus)
 }
 
 /* release the bus low, allow it to idle high unless another device is holding
-   it low */
+ * it low */
 static void _bus_release(soft_onewire_t *bus)
 {
 #if MODULE_SOFT_ONEWIRE_2PINS
@@ -140,7 +143,8 @@ static void _schedule(soft_onewire_t *bus, soft_onewire_timer_cb_t cb,
     if (res < 0)
     {
         /* release bus, but don't power it in-case a slave deice is trying to
-           hold it low*/
+        /* release bus, but don't power it in case a slave deice is trying to
+         * hold it low*/
         _bus_release(bus);
 
         /* stop ongoing process, and indicate error to waiting thread */

--- a/drivers/soft_onewire/soft_onewire.c
+++ b/drivers/soft_onewire/soft_onewire.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Prime Controls
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/soft_onewire/soft_onewire.c
+++ b/drivers/soft_onewire/soft_onewire.c
@@ -1,0 +1,395 @@
+/*
+ * Copyright (C) 2023 Prime Controls
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       Soft 1-Wire bus driver implementation
+ *
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ *
+ * @}
+ */
+
+#include "soft_onewire.h"
+
+#include <assert.h>
+#include <errno.h>
+
+#include "irq.h"
+#include "macros/units.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#if MODULE_ONEWIRE_MULTIDRIVER
+#  define MAYBE_STATIC              static
+#else
+#  define MAYBE_STATIC
+#endif
+
+/* bus timings as given in
+ * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
+ * all in microseconds
+ */
+#define T_RESET_HOLD_US     (480U)
+#define T_RESET_SAMPLE_US   (70U)
+#define T_RESET_RECOVERY_US (410U)
+#define T_RW_START_US       (6U)
+#define T_W_0_HOLD_US       (60U)
+#define T_W_0_END_US        (10U)
+#define T_W_1_DELAY_US      (64U)
+#define T_R_WAIT_US         (9U)
+#define T_R_END_US          (55U)
+
+static void _reset_release_cb(soft_onewire_t *bus);
+static void _reset_sample_cb(soft_onewire_t *bus);
+static void _reset_finished_cb(soft_onewire_t *bus);
+static void _read_pull_cb(soft_onewire_t *bus);
+static void _read_release_cb(soft_onewire_t *bus);
+static void _read_sample_cb(soft_onewire_t *bus);
+static void _write_pull_cb(soft_onewire_t *bus);
+static void _write_0_release_cb(soft_onewire_t *bus);
+static void _write_1_release_cb(soft_onewire_t *bus);
+
+/* get pointer to driver instance */
+static soft_onewire_t* _bus(onewire_t *super)
+{
+    return container_of(super, soft_onewire_t, super);
+}
+
+/* get pointer to driver params */
+static soft_onewire_params_t* _params(soft_onewire_t *bus)
+{
+    return container_of(bus->super.params, soft_onewire_params_t, super);
+}
+
+/* drive the bus high to power any bus powered devices */
+static void _bus_power(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->tx_pin;
+    gpio_clear(pin);
+#else
+    gpio_t pin = _params(bus)->pin;
+
+    /* Re-initializing a GPIO pin is supposed to leave it's set/clear state
+       untouched, but not all platforms can guarantee this. So we set the pin
+       before and after re-initializing it. This is to avoid momentarily pulling
+       the bus low. */
+    gpio_set(pin);
+    gpio_init(pin, GPIO_OUT);
+    gpio_set(pin);
+#endif
+}
+
+/* pull the bus low */
+static void _bus_pull(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->tx_pin;
+    gpio_set(pin);
+#else
+    gpio_t pin = _params(bus)->pin;
+
+    gpio_init(pin, GPIO_OUT);
+    gpio_clear(pin);
+#endif
+}
+
+/* release the bus low, allow it to idle high unless another device is holding
+   it low */
+static void _bus_release(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->tx_pin;
+    gpio_clear(pin);
+#else
+    gpio_t pin      = _params(bus)->pin;
+    gpio_t pin_mode = _params(bus)->pin_imode;
+
+    gpio_init(pin, pin_mode);
+#endif
+}
+
+/* sample the bus - returns true if the line is high */
+static bool _bus_sample(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->rx_pin;
+#else
+    gpio_t pin = _params(bus)->pin;
+#endif
+
+    return gpio_read(pin);
+}
+
+/* schedule the next timer callback */
+static void _schedule(soft_onewire_t *bus, soft_onewire_timer_cb_t cb,
+    unsigned usec)
+{
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+    bus->timer_cb = cb;
+
+    tim_t timer = _params(bus)->timer;
+    const int res = timer_set(timer, 0, usec);
+    if (res < 0)
+    {
+        /* release bus, but don't power it in-case a slave deice is trying to
+           hold it low*/
+        _bus_release(bus);
+
+        /* stop ongoing process, and indicate error to waiting thread */
+        bus->err = -EIO;
+        mutex_unlock(&bus->sync);
+    }
+#else
+    ztimer_t *timer = &bus->timer;
+
+    timer->callback = (ztimer_callback_t)cb;
+    ztimer_set(ZTIMER_USEC, timer, usec);
+#endif
+}
+
+static void _reset_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_reset_sample_cb, T_RESET_SAMPLE_US);
+}
+
+static void _reset_sample_cb(soft_onewire_t *bus)
+{
+    /* if the bus isn't being held low, no device is present */
+    bus->err = (_bus_sample(bus)) ? -ENXIO : 0;
+
+    _schedule(bus, &_reset_finished_cb, T_RESET_RECOVERY_US);
+}
+
+static void _reset_finished_cb(soft_onewire_t *bus)
+{
+    if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+        _bus_power(bus);
+    }
+    mutex_unlock(&bus->sync);
+}
+
+MAYBE_STATIC
+int _onewire_reset(onewire_t *super)
+{
+    soft_onewire_t *bus = _bus(super);
+
+    DEBUG("soft_onewire: resetting bus\n");
+
+    /* begin the bus reset */
+    const int irq_state = irq_disable();
+    _bus_pull(bus);
+    _schedule(bus, &_reset_release_cb, T_RESET_HOLD_US);
+    irq_restore(irq_state);
+
+    DEBUG("soft_onewire: waiting for reset\n");
+
+    mutex_lock(&bus->sync);
+
+    DEBUG("soft_onewire: reset done (res = %i)\n", bus->err);
+
+    return bus->err;
+}
+
+static void _read_pull_cb(soft_onewire_t *bus)
+{
+    bus->buf_size--;
+
+    /* if all bits have been read */
+    if (bus->buf_size == 0) {
+        if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+            _bus_power(bus);
+        }
+        bus->err = 0;
+        mutex_unlock(&bus->sync);
+        return;
+    }
+
+    bus->mask <<= 1;
+
+    if (bus->mask == 0) {
+        bus->mask = 1;
+        bus->rx_buf++;
+        *bus->rx_buf = 0;
+    }
+
+    _bus_pull(bus);
+    _schedule(bus, &_read_release_cb, T_RW_START_US);
+}
+
+static void _read_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_read_sample_cb, T_R_WAIT_US);
+}
+
+static void _read_sample_cb(soft_onewire_t *bus)
+{
+    const bool rx_bit = _bus_sample(bus);
+    _schedule(bus, &_read_pull_cb, T_R_END_US);
+    *bus->rx_buf |= (rx_bit) ? bus->mask : 0;
+}
+
+MAYBE_STATIC
+int _onewire_read_bits(onewire_t *super, void *buf, size_t len)
+{
+    soft_onewire_t *bus = _bus(super);
+
+    DEBUG("soft_onewire: begin read bits\n");
+
+    bus->rx_buf = buf;
+    bus->buf_size = len;
+    bus->mask = 1;
+
+    /* Clear first byte of the buffer, because sampling only sets bits. */
+    *bus->rx_buf = 0;
+
+    /* start the transfer */
+    const int irq_state = irq_disable();
+    _bus_pull(bus);
+    _schedule(bus, _read_release_cb, T_RW_START_US);
+    irq_restore(irq_state);
+
+    DEBUG("soft_onewire: waiting for data\n");
+
+    /* wait for transfer to finish */
+    mutex_lock(&bus->sync);
+
+    DEBUG("soft_onewire: got data (res = %i)\n", bus->err);
+
+    return bus->err;
+}
+
+static void _write_pull_cb(soft_onewire_t *bus)
+{
+    bus->buf_size--;
+
+    /* if all bits have been written */
+    if (bus->buf_size == 0) {
+        if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+            _bus_power(bus);
+        }
+        bus->err = 0;
+        mutex_unlock(&bus->sync);
+        return;
+    }
+
+    bus->mask <<= 1;
+
+    if (bus->mask == 0) {
+        bus->mask = 1;
+        bus->tx_buf++;
+    }
+
+    const bool tx_bit = *bus->tx_buf & bus->mask;
+    const unsigned release_time = (tx_bit) ? T_RW_START_US : T_W_0_HOLD_US;
+    const soft_onewire_timer_cb_t release_cb = (tx_bit) ?
+        _write_1_release_cb : _write_0_release_cb;
+
+    _bus_pull(bus);
+    _schedule(bus, release_cb, release_time);
+}
+
+static void _write_0_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_write_pull_cb, T_W_0_END_US);
+}
+
+static void _write_1_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_write_pull_cb, T_W_1_DELAY_US);
+}
+
+MAYBE_STATIC
+int _onewire_write_bits(onewire_t *super, const void *buf, size_t len)
+{
+    soft_onewire_t *bus = _bus(super);
+
+    DEBUG("soft_onewire: begin write bits\n");
+
+    bus->tx_buf = buf;
+    bus->buf_size = len;
+    bus->mask = 1;
+
+    const bool tx_bit = *bus->tx_buf & 0x01;
+    const unsigned release_time = (tx_bit) ? T_RW_START_US : T_W_0_HOLD_US;
+    const soft_onewire_timer_cb_t release_cb =
+        (tx_bit) ? _write_1_release_cb : _write_0_release_cb;
+
+    /* start the transfer */
+    const int irq_state = irq_disable();
+    _bus_pull(bus);
+    _schedule(bus, release_cb, release_time);
+    irq_restore(irq_state);
+
+    DEBUG("soft_onewire: sending data\n");
+
+    /* wait for transfer to finish */
+    mutex_lock(&bus->sync);
+
+    DEBUG("soft_onewire: data sent (res = %i)\n", bus->err);
+
+    return bus->err;
+}
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+static void _timer_cb(void *arg, int channel)
+{
+    (void)channel;
+
+    soft_onewire_t *bus = arg;
+
+    bus->timer_cb(arg);
+}
+#endif
+
+#if MODULE_ONEWIRE_MULTIDRIVER
+const onewire_driver_t soft_onewire_driver = {
+    .reset = &_onewire_reset,
+    .read_bits = &_onewire_read_bits,
+    .write_bits = &_onewire_write_bits,
+};
+#endif
+
+void soft_onewire_init(soft_onewire_t *bus, const soft_onewire_params_t *params)
+{
+    assert(bus);
+    assert(params);
+
+    _onewire_init(&bus->super, &params->super);
+
+    bus->sync = (mutex_t)MUTEX_INIT_LOCKED;
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+    tim_t timer = params->timer;
+    const int res = timer_init(timer, MHZ(1), &_timer_cb, bus);
+    assert(res == 0);
+#else
+    bus->timer.arg = bus;
+#endif
+
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_init(params->rx_pin, GPIO_IN);
+    gpio_init(params->tx_pin, GPIO_OUT);
+#endif
+
+    if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+        _bus_power(bus);
+    }
+    else {
+        _bus_release(bus);
+    }
+}

--- a/drivers/soft_onewire/soft_onewire.c
+++ b/drivers/soft_onewire/soft_onewire.c
@@ -1,0 +1,391 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Prime Controls
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       Soft 1-Wire bus driver implementation
+ *
+ * @author      Joshua DeWeese <jdeweese@primecontrols.com>
+ *
+ * @}
+ */
+
+#include "soft_onewire.h"
+
+#include <assert.h>
+#include <errno.h>
+
+#include "irq.h"
+#include "macros/units.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#if MODULE_ONEWIRE_MULTIDRIVER
+#  define MAYBE_STATIC              static
+#else
+#  define MAYBE_STATIC
+#endif
+
+/* All bus timing values are given in microseconds, based on this article:
+ * https://www.analog.com/en/resources/technical-articles/1wire-communication-through-software.html
+ */
+#define T_RESET_HOLD_US     (480U)
+#define T_RESET_SAMPLE_US   (70U)
+#define T_RESET_RECOVERY_US (410U)
+#define T_RW_START_US       (6U)
+#define T_W_0_HOLD_US       (60U)
+#define T_W_0_END_US        (10U)
+#define T_W_1_DELAY_US      (64U)
+#define T_R_WAIT_US         (9U)
+#define T_R_END_US          (55U)
+
+static void _reset_release_cb(soft_onewire_t *bus);
+static void _reset_sample_cb(soft_onewire_t *bus);
+static void _reset_finished_cb(soft_onewire_t *bus);
+static void _read_pull_cb(soft_onewire_t *bus);
+static void _read_release_cb(soft_onewire_t *bus);
+static void _read_sample_cb(soft_onewire_t *bus);
+static void _write_pull_cb(soft_onewire_t *bus);
+static void _write_0_release_cb(soft_onewire_t *bus);
+static void _write_1_release_cb(soft_onewire_t *bus);
+
+/* get pointer to driver instance */
+static soft_onewire_t* _bus(onewire_t *super)
+{
+    return container_of(super, soft_onewire_t, super);
+}
+
+/* get pointer to driver params */
+static soft_onewire_params_t* _params(soft_onewire_t *bus)
+{
+    return container_of(bus->super.params, soft_onewire_params_t, super);
+}
+
+/* drive the bus high to power any bus powered devices */
+static void _bus_power(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->tx_pin;
+    gpio_clear(pin);
+#else
+    gpio_t pin = _params(bus)->pin;
+
+    /* Re-initializing a GPIO pin is supposed to leave it's set/clear state
+     * untouched, but not all platforms can guarantee this. So we set the pin
+     * before and after re-initializing it. This is to avoid momentarily pulling
+     * the bus low. */
+    gpio_set(pin);
+    gpio_init(pin, GPIO_OUT);
+    gpio_set(pin);
+#endif
+}
+
+/* pull the bus low */
+static void _bus_pull(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->tx_pin;
+    gpio_set(pin);
+#else
+    gpio_t pin = _params(bus)->pin;
+
+    gpio_init(pin, GPIO_OUT);
+    gpio_clear(pin);
+#endif
+}
+
+/* release the bus low, allow it to idle high unless another device is holding
+ * it low */
+static void _bus_release(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->tx_pin;
+    gpio_clear(pin);
+#else
+    gpio_t pin      = _params(bus)->pin;
+    gpio_t pin_mode = _params(bus)->pin_imode;
+
+    gpio_init(pin, pin_mode);
+#endif
+}
+
+/* sample the bus - returns true if the line is high */
+static bool _bus_sample(soft_onewire_t *bus)
+{
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_t pin = _params(bus)->rx_pin;
+#else
+    gpio_t pin = _params(bus)->pin;
+#endif
+
+    return gpio_read(pin);
+}
+
+/* schedule the next timer callback */
+static void _schedule(soft_onewire_t *bus, soft_onewire_timer_cb_t cb,
+    unsigned usec)
+{
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+    bus->timer_cb = cb;
+
+    tim_t timer = _params(bus)->timer;
+    const int res = timer_set(timer, 0, usec);
+    if (res < 0)
+    {
+        /* release bus, but don't power it in case a slave deice is trying to
+         * hold it low*/
+        _bus_release(bus);
+
+        /* stop ongoing process, and indicate error to waiting thread */
+        bus->err = -EIO;
+        mutex_unlock(&bus->sync);
+    }
+#else
+    ztimer_t *timer = &bus->timer;
+
+    timer->callback = (ztimer_callback_t)cb;
+    ztimer_set(ZTIMER_USEC, timer, usec);
+#endif
+}
+
+static void _reset_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_reset_sample_cb, T_RESET_SAMPLE_US);
+}
+
+static void _reset_sample_cb(soft_onewire_t *bus)
+{
+    /* if the bus isn't being held low, no device is present */
+    bus->err = (_bus_sample(bus)) ? -ENXIO : 0;
+
+    _schedule(bus, &_reset_finished_cb, T_RESET_RECOVERY_US);
+}
+
+static void _reset_finished_cb(soft_onewire_t *bus)
+{
+    if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+        _bus_power(bus);
+    }
+    mutex_unlock(&bus->sync);
+}
+
+MAYBE_STATIC
+int _onewire_reset(onewire_t *super)
+{
+    soft_onewire_t *bus = _bus(super);
+
+    DEBUG("soft_onewire: resetting bus\n");
+
+    /* begin the bus reset */
+    const int irq_state = irq_disable();
+    _bus_pull(bus);
+    _schedule(bus, &_reset_release_cb, T_RESET_HOLD_US);
+    irq_restore(irq_state);
+
+    DEBUG("soft_onewire: waiting for reset\n");
+
+    mutex_lock(&bus->sync);
+
+    DEBUG("soft_onewire: reset done (res = %i)\n", bus->err);
+
+    return bus->err;
+}
+
+static void _read_pull_cb(soft_onewire_t *bus)
+{
+    bus->buf_size--;
+
+    /* if all bits have been read */
+    if (bus->buf_size == 0) {
+        if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+            _bus_power(bus);
+        }
+        bus->err = 0;
+        mutex_unlock(&bus->sync);
+        return;
+    }
+
+    bus->mask <<= 1;
+
+    if (bus->mask == 0) {
+        bus->mask = 1;
+        bus->rx_buf++;
+        *bus->rx_buf = 0;
+    }
+
+    _bus_pull(bus);
+    _schedule(bus, &_read_release_cb, T_RW_START_US);
+}
+
+static void _read_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_read_sample_cb, T_R_WAIT_US);
+}
+
+static void _read_sample_cb(soft_onewire_t *bus)
+{
+    const bool rx_bit = _bus_sample(bus);
+    _schedule(bus, &_read_pull_cb, T_R_END_US);
+    *bus->rx_buf |= (rx_bit) ? bus->mask : 0;
+}
+
+MAYBE_STATIC
+int _onewire_read_bits(onewire_t *super, void *buf, size_t len)
+{
+    soft_onewire_t *bus = _bus(super);
+
+    DEBUG("soft_onewire: begin read bits\n");
+
+    bus->rx_buf = buf;
+    bus->buf_size = len;
+    bus->mask = 1;
+
+    /* Clear first byte of the buffer, because sampling only sets bits. */
+    *bus->rx_buf = 0;
+
+    /* start the transfer */
+    const int irq_state = irq_disable();
+    _bus_pull(bus);
+    _schedule(bus, _read_release_cb, T_RW_START_US);
+    irq_restore(irq_state);
+
+    DEBUG("soft_onewire: waiting for data\n");
+
+    /* wait for transfer to finish */
+    mutex_lock(&bus->sync);
+
+    DEBUG("soft_onewire: got data (res = %i)\n", bus->err);
+
+    return bus->err;
+}
+
+static void _write_pull_cb(soft_onewire_t *bus)
+{
+    bus->buf_size--;
+
+    /* if all bits have been written */
+    if (bus->buf_size == 0) {
+        if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+            _bus_power(bus);
+        }
+        bus->err = 0;
+        mutex_unlock(&bus->sync);
+        return;
+    }
+
+    bus->mask <<= 1;
+
+    if (bus->mask == 0) {
+        bus->mask = 1;
+        bus->tx_buf++;
+    }
+
+    const bool tx_bit = *bus->tx_buf & bus->mask;
+    const unsigned release_time = (tx_bit) ? T_RW_START_US : T_W_0_HOLD_US;
+    const soft_onewire_timer_cb_t release_cb = (tx_bit) ?
+        _write_1_release_cb : _write_0_release_cb;
+
+    _bus_pull(bus);
+    _schedule(bus, release_cb, release_time);
+}
+
+static void _write_0_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_write_pull_cb, T_W_0_END_US);
+}
+
+static void _write_1_release_cb(soft_onewire_t *bus)
+{
+    _bus_release(bus);
+    _schedule(bus, &_write_pull_cb, T_W_1_DELAY_US);
+}
+
+MAYBE_STATIC
+int _onewire_write_bits(onewire_t *super, const void *buf, size_t len)
+{
+    soft_onewire_t *bus = _bus(super);
+
+    DEBUG("soft_onewire: begin write bits\n");
+
+    bus->tx_buf = buf;
+    bus->buf_size = len;
+    bus->mask = 1;
+
+    const bool tx_bit = *bus->tx_buf & 0x01;
+    const unsigned release_time = (tx_bit) ? T_RW_START_US : T_W_0_HOLD_US;
+    const soft_onewire_timer_cb_t release_cb =
+        (tx_bit) ? _write_1_release_cb : _write_0_release_cb;
+
+    /* start the transfer */
+    const int irq_state = irq_disable();
+    _bus_pull(bus);
+    _schedule(bus, release_cb, release_time);
+    irq_restore(irq_state);
+
+    DEBUG("soft_onewire: sending data\n");
+
+    /* wait for transfer to finish */
+    mutex_lock(&bus->sync);
+
+    DEBUG("soft_onewire: data sent (res = %i)\n", bus->err);
+
+    return bus->err;
+}
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+static void _timer_cb(void *arg, int channel)
+{
+    (void)channel;
+
+    soft_onewire_t *bus = arg;
+
+    bus->timer_cb(arg);
+}
+#endif
+
+#if MODULE_ONEWIRE_MULTIDRIVER
+const onewire_driver_t soft_onewire_driver = {
+    .reset = &_onewire_reset,
+    .read_bits = &_onewire_read_bits,
+    .write_bits = &_onewire_write_bits,
+};
+#endif
+
+void soft_onewire_init(soft_onewire_t *bus, const soft_onewire_params_t *params)
+{
+    assert(bus);
+    assert(params);
+
+    _onewire_init(&bus->super, &params->super);
+
+    bus->sync = (mutex_t)MUTEX_INIT_LOCKED;
+
+#if MODULE_SOFT_ONEWIRE_HWTIMER
+    tim_t timer = params->timer;
+    const int res = timer_init(timer, MHZ(1), &_timer_cb, bus);
+    assert(res == 0);
+#else
+    bus->timer.arg = bus;
+#endif
+
+#if MODULE_SOFT_ONEWIRE_2PINS
+    gpio_init(params->rx_pin, GPIO_IN);
+    gpio_init(params->tx_pin, GPIO_OUT);
+#endif
+
+    if (IS_ACTIVE(MODULE_SOFT_ONEWIRE_PWR)) {
+        _bus_power(bus);
+    }
+    else {
+        _bus_release(bus);
+    }
+}

--- a/tests/drivers/soft_onewire/Makefile
+++ b/tests/drivers/soft_onewire/Makefile
@@ -1,0 +1,20 @@
+include ../Makefile.drivers_common
+
+# uncomment and adjust the driver's params as needed below if the board does not
+# already define a 1-wire bus and its params
+#CFLAGS += -DSOFT_ONEWIRE_PARAMS_PIN="GPIO_PIN(PORT_C, 0)"
+#CFLAGS += -DSOFT_ONEWIRE_PARAMS_TX_PIN="GPIO_PIN(PORT_C, 0)"
+#CFLAGS += -DSOFT_ONEWIRE_PARAMS_RX_PIN="GPIO_PIN(PORT_C, 1)"
+
+# uncomment to use a dedicated hardware timer for the 1-wire bus
+# Note that TIMER_DEV(0) is often used by ztimer. This test does not need
+# ztimer, when soft_onewire_hwtimer is used. So this is not a problem unless
+# ztimer gets enabled for some other reason (such as it being depended upon by
+# the board)
+#USEMODULE += soft_onewire_hwtimer
+#CFLAGS += -DSOFT_ONEWIRE_PARAMS_HWTIMER="TIMER_DEV(0)"
+
+USEMODULE += soft_onewire
+USEMODULE += tiny_strerror
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/drivers/soft_onewire/Makefile
+++ b/tests/drivers/soft_onewire/Makefile
@@ -1,0 +1,20 @@
+include ../Makefile.drivers_common
+
+# uncomment and adjust the driver's params as needed below if the board does not
+# already define a 1-wire bus and its params
+#CFLAGS += -DSOFT_ONEWIRE_PARAM_PIN="GPIO_PIN(PORT_C, 0)"
+#CFLAGS += -DSOFT_ONEWIRE_PARAM_TX_PIN="GPIO_PIN(PORT_C, 0)"
+#CFLAGS += -DSOFT_ONEWIRE_PARAM_RX_PIN="GPIO_PIN(PORT_C, 1)"
+
+# uncomment to use a dedicated hardware timer for the 1-wire bus
+# Note that TIMER_DEV(0) is often used by ztimer. This test does not need
+# ztimer, when soft_onewire_hwtimer is used. So this is not a problem unless
+# ztimer gets enabled for some other reason (such as it being depended upon by
+# the board)
+#USEMODULE += soft_onewire_hwtimer
+#CFLAGS += -DSOFT_ONEWIRE_PARAM_HWTIMER="TIMER_DEV(0)"
+
+USEMODULE += soft_onewire
+USEMODULE += tiny_strerror
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/drivers/soft_onewire/README.md
+++ b/tests/drivers/soft_onewire/README.md
@@ -1,0 +1,8 @@
+# About
+This is a test application for the soft 1-Wire driver. It will scan each soft
+1-Wire bus for attached devices, and then print their IDs to the console.
+
+# Configuring The Bus
+If your board already defines one or more 1-Wire buses, those will be used, and
+no configuration should be necessary. Otherwise, edit `./Makefile` to define the
+pin to use as a 1-Wire bus and override any of the driver defaults as necessary.

--- a/tests/drivers/soft_onewire/main.c
+++ b/tests/drivers/soft_onewire/main.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Joshua DeWeese
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the 1-Wire (onewire) bus driver
+ *
+ * @author      Joshua DeWeese <josh.deweese@gmail.com>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "onewire.h"
+#include "soft_onewire.h"
+#include "soft_onewire_params.h"
+#include "tiny_strerror.h"
+
+static void _enumerate_bus(onewire_t *bus)
+{
+    onewire_rom_t id;
+    int res = ONEWIRE_SEARCH_FIRST;
+
+    onewire_aquire(bus);
+
+    do {
+        res = onewire_search(bus, &id, res);
+        if (res < 0) {
+            printf("failure to enumerate device: %s\n", tiny_strerror(-res));
+            break;
+        }
+
+        printf("found device: ");
+        onewire_rom_print(&id);
+        puts("");
+
+    } while (res > 0);
+
+    onewire_release(bus);
+}
+
+int main(void)
+{
+    soft_onewire_t buses[SOFT_ONEWIRE_NUMOF];
+
+    for (unsigned i = 0; i < SOFT_ONEWIRE_NUMOF; i++) {
+        soft_onewire_init(&buses[i], &soft_onewire_params[i]);
+        printf("searching for 1-wire devices on bus %i...\n", i);
+        _enumerate_bus(&buses[i].super);
+    }
+
+    return 0;
+}

--- a/tests/drivers/soft_onewire/main.c
+++ b/tests/drivers/soft_onewire/main.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Joshua DeWeese
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Joshua DeWeese
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/tests/drivers/soft_onewire/main.c
+++ b/tests/drivers/soft_onewire/main.c
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Joshua DeWeese
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the 1-Wire (onewire) bus driver
+ *
+ * @author      Joshua DeWeese <josh.deweese@gmail.com>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "onewire.h"
+#include "soft_onewire.h"
+#include "soft_onewire_params.h"
+#include "tiny_strerror.h"
+
+static void _enumerate_bus(onewire_t *bus)
+{
+    onewire_rom_t id;
+    int res = ONEWIRE_SEARCH_FIRST;
+
+    onewire_acquire(bus);
+
+    do {
+        res = onewire_search(bus, &id, res);
+        if (res < 0) {
+            printf("failure to enumerate device: %s\n", tiny_strerror(-res));
+            break;
+        }
+
+        printf("found device: ");
+        onewire_rom_print(&id);
+        puts("");
+
+    } while (res > 0);
+
+    onewire_release(bus);
+}
+
+int main(void)
+{
+    soft_onewire_t buses[SOFT_ONEWIRE_NUMOF];
+
+    for (unsigned i = 0; i < SOFT_ONEWIRE_NUMOF; i++) {
+        soft_onewire_init(&buses[i], &soft_onewire_params[i]);
+        printf("searching for 1-wire devices on bus %i...\n", i);
+        _enumerate_bus(&buses[i].super);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This patch adds a 1-Wire driver which can handle multiple driver implementations. Included in the patch is a soft 1-Wire driver implementation.

### Testing procedure

Attach one or more 1-wire devices to pin C0 of an stm32f429i-disc1 eval board.

Apply the following patch:

``` patch
diff --git a/tests/drivers/soft_onewire/Makefile b/tests/drivers/soft_onewire/Makefile
index 070eed4df7..d18579e55d 100644
--- a/tests/drivers/soft_onewire/Makefile
+++ b/tests/drivers/soft_onewire/Makefile
@@ -1,5 +1,8 @@
 include ../Makefile.drivers_common
 
+BOARD = stm32f429i-disc1
+CFLAGS += -DSOFT_ONEWIRE_PARAMS_PIN="GPIO_PIN(PORT_C, 0)"
+
 # uncomment and adjust the driver's params as needed below if the board does not
 # already define a 1-wire bus and its params
 #CFLAGS += -DSOFT_ONEWIRE_PARAMS_PIN="GPIO_PIN(PORT_C, 0)"
```

Run `make -C tests/drivers/soft_onewire flash`

Observe the something like the following on the board's console:

```
2026-07-04 12:10:28,935 # main(): This is RIOT! (Version: 2025.10-devel-203-ge638c2-add-driver-onewire)
2026-07-04 12:10:28,939 # searching for 1-wire devices on bus 0...
2026-07-04 12:10:28,961 # found device: 28083C49F62E3C35
2026-07-04 12:10:28,982 # found device: 281AA049F6DB3CF0
2026-07-04 12:10:29,003 # found device: 28E3FB49F6E93C4D
```

### Issues/PRs references

- PR #18051 was an earlier attempt of mine.
- PR #14897 was an attempt that predated my first attempt. I used it as a starting point this time. Although, not much of it actually remains.
- PR #22457 is a PR to make the `ds18` driver (which is a 1-Wire device) more esp32 friendly.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
