### PR TITLE
boards/stm32f769i-disco: enable FMC with SDRAM support

### DIFF
--- a/boards/stm32f746g-disco/Makefile.include
+++ b/boards/stm32f746g-disco/Makefile.include
@@ -14,5 +14,6 @@ PROGRAMMERS_SUPPORTED += openocd
 # use connect_assert_srst to always be able to flash or reset the board.
 OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
+# heap configuration
 FMC_RAM_ADDR=0xc0000000
 FMC_RAM_LEN=8192K

--- a/boards/stm32f746g-disco/doc.txt
+++ b/boards/stm32f746g-disco/doc.txt
@@ -31,7 +31,7 @@ Current hardware support:
 | Capacitive touch screen | X | |
 | User microphones | - | |
 | External Quad-SPI Flash | - | |
-| External SDRAM | - | |
+| External SDRAM | X | |
 
 ## Flashing the device
 

--- a/boards/stm32f746g-disco/include/periph_conf.h
+++ b/boards/stm32f746g-disco/include/periph_conf.h
@@ -396,7 +396,7 @@ static const fmc_bank_conf_t fmc_bank_config[] = {
         .bank = FMC_BANK_5,
         .mem_type = FMC_SDRAM,
         .data_width = FMC_BUS_WIDTH_16BIT,
-        .address = 0xc0000000,               /* Bank 6 is mapped to 0xd0000000 */
+        .address = 0xc0000000,               /* Bank 5 is mapped to 0xc0000000 */
         .size = MiB(8),                      /* Size in MByte, 4M x 16 Bit */
         .sdram = {
             .clk_period = 2,                 /* SDCLK = 2 x HCLK */

--- a/boards/stm32f769i-disco/Kconfig
+++ b/boards/stm32f769i-disco/Kconfig
@@ -14,6 +14,9 @@ config BOARD_STM32F769I_DISCO
     select CPU_MODEL_STM32F769NI
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_FMC
+    select HAS_PERIPH_FMC_SDRAM
+    select HAS_PERIPH_FMC_32BIT
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_TIMER

--- a/boards/stm32f769i-disco/Makefile.dep
+++ b/boards/stm32f769i-disco/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+ifneq (,$(filter periph_fmc,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_fmc_32bit
+endif

--- a/boards/stm32f769i-disco/Makefile.features
+++ b/boards/stm32f769i-disco/Makefile.features
@@ -2,6 +2,9 @@ CPU = stm32
 CPU_MODEL = stm32f769ni
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_fmc
+FEATURES_PROVIDED += periph_fmc_32bit
+FEATURES_PROVIDED += periph_fmc_sdram
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer

--- a/boards/stm32f769i-disco/Makefile.include
+++ b/boards/stm32f769i-disco/Makefile.include
@@ -9,3 +9,7 @@ OPENOCD_DEBUG_ADAPTER ?= stlink
 
 # openocd programmer is supported
 PROGRAMMERS_SUPPORTED += openocd
+
+# heap configuration
+FMC_RAM_ADDR=0xc0000000
+FMC_RAM_LEN=16384K

--- a/boards/stm32f769i-disco/include/periph_conf.h
+++ b/boards/stm32f769i-disco/include/periph_conf.h
@@ -66,6 +66,129 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name    FMC configuration
+ * @{
+ */
+/**
+ * @brief   FMC controller configuration
+ */
+static const fmc_conf_t fmc_config = {
+    .bus = AHB3,
+    .rcc_mask = RCC_AHB3ENR_FMCEN,
+#if MODULE_PERIPH_FMC_SDRAM
+    .ba0_pin = { .pin = GPIO_PIN(PORT_G, 4), .af = GPIO_AF12, },     /* FMC_BA0 signal */
+    .ba1_pin = { .pin = GPIO_PIN(PORT_G, 5), .af = GPIO_AF12, },     /* FMC_BA1 signal */
+    .sdclk_pin = { .pin = GPIO_PIN(PORT_G, 8), .af = GPIO_AF12, },   /* FMC_SDCLK signal */
+    .sdnwe_pin = { .pin = GPIO_PIN(PORT_H, 5), .af = GPIO_AF12, },   /* FMC_SDNWE signal */
+    .sdnras_pin = { .pin = GPIO_PIN(PORT_F, 11), .af = GPIO_AF12, }, /* FMC_SDNRAS signal */
+    .sdncas_pin = { .pin = GPIO_PIN(PORT_G, 15), .af = GPIO_AF12, }, /* FMC_SDNCAS signal */
+    .sdcke0_pin = { .pin = GPIO_PIN(PORT_H, 2), .af = GPIO_AF12, },  /* FMC_SDCKE0 signal */
+    .sdne0_pin = { .pin = GPIO_PIN(PORT_H, 3), .af = GPIO_AF12, },   /* FMC_SDNE0 signal */
+    .addr = {
+        { .pin = GPIO_PIN(PORT_F, 0), .af = GPIO_AF12, },  /* FMC_A0 signal */
+        { .pin = GPIO_PIN(PORT_F, 1), .af = GPIO_AF12, },  /* FMC_A1 signal */
+        { .pin = GPIO_PIN(PORT_F, 2), .af = GPIO_AF12, },  /* FMC_A2 signal */
+        { .pin = GPIO_PIN(PORT_F, 3), .af = GPIO_AF12, },  /* FMC_A3 signal */
+        { .pin = GPIO_PIN(PORT_F, 4), .af = GPIO_AF12, },  /* FMC_A4 signal */
+        { .pin = GPIO_PIN(PORT_F, 5), .af = GPIO_AF12, },  /* FMC_A5 signal */
+        { .pin = GPIO_PIN(PORT_F, 12), .af = GPIO_AF12, }, /* FMC_A6 signal */
+        { .pin = GPIO_PIN(PORT_F, 13), .af = GPIO_AF12, }, /* FMC_A7 signal */
+        { .pin = GPIO_PIN(PORT_F, 14), .af = GPIO_AF12, }, /* FMC_A8 signal */
+        { .pin = GPIO_PIN(PORT_F, 15), .af = GPIO_AF12, }, /* FMC_A9 signal */
+        { .pin = GPIO_PIN(PORT_G, 0), .af = GPIO_AF12, },  /* FMC_A10 signal */
+        { .pin = GPIO_PIN(PORT_G, 1), .af = GPIO_AF12, },  /* FMC_A11 signal */
+    },
+#endif
+    .data = {
+        { .pin = GPIO_PIN(PORT_D, 14), .af = GPIO_AF12, }, /* FMC_D0 signal */
+        { .pin = GPIO_PIN(PORT_D, 15), .af = GPIO_AF12, }, /* FMC_D1 signal */
+        { .pin = GPIO_PIN(PORT_D, 0), .af = GPIO_AF12, },  /* FMC_D2 signal */
+        { .pin = GPIO_PIN(PORT_D, 1), .af = GPIO_AF12, },  /* FMC_D3 signal */
+        { .pin = GPIO_PIN(PORT_E, 7), .af = GPIO_AF12, },  /* FMC_D4 signal */
+        { .pin = GPIO_PIN(PORT_E, 8), .af = GPIO_AF12, },  /* FMC_D5 signal */
+        { .pin = GPIO_PIN(PORT_E, 9), .af = GPIO_AF12, },  /* FMC_D6 signal */
+        { .pin = GPIO_PIN(PORT_E, 10), .af = GPIO_AF12, }, /* FMC_D7 signal */
+#if MODULE_PERIPH_FMC_32BIT
+        { .pin = GPIO_PIN(PORT_E, 11), .af = GPIO_AF12, }, /* FMC_D8 signal */
+        { .pin = GPIO_PIN(PORT_E, 12), .af = GPIO_AF12, }, /* FMC_D9 signal */
+        { .pin = GPIO_PIN(PORT_E, 13), .af = GPIO_AF12, }, /* FMC_D10 signal */
+        { .pin = GPIO_PIN(PORT_E, 14), .af = GPIO_AF12, }, /* FMC_D11 signal */
+        { .pin = GPIO_PIN(PORT_E, 15), .af = GPIO_AF12, }, /* FMC_D12 signal */
+        { .pin = GPIO_PIN(PORT_D, 8), .af = GPIO_AF12, },  /* FMC_D13 signal */
+        { .pin = GPIO_PIN(PORT_D, 9), .af = GPIO_AF12, },  /* FMC_D14 signal */
+        { .pin = GPIO_PIN(PORT_D, 10), .af = GPIO_AF12, }, /* FMC_D15 signal */
+        { .pin = GPIO_PIN(PORT_H, 8), .af = GPIO_AF12, },  /* FMC_D16 signal */
+        { .pin = GPIO_PIN(PORT_H, 9), .af = GPIO_AF12, },  /* FMC_D17 signal */
+        { .pin = GPIO_PIN(PORT_H, 10), .af = GPIO_AF12, }, /* FMC_D18 signal */
+        { .pin = GPIO_PIN(PORT_H, 11), .af = GPIO_AF12, }, /* FMC_D19 signal */
+        { .pin = GPIO_PIN(PORT_H, 12), .af = GPIO_AF12, }, /* FMC_D20 signal */
+        { .pin = GPIO_PIN(PORT_H, 13), .af = GPIO_AF12, }, /* FMC_D21 signal */
+        { .pin = GPIO_PIN(PORT_H, 14), .af = GPIO_AF12, }, /* FMC_D22 signal */
+        { .pin = GPIO_PIN(PORT_H, 15), .af = GPIO_AF12, }, /* FMC_D23 signal */
+        { .pin = GPIO_PIN(PORT_I, 0), .af = GPIO_AF12, },  /* FMC_D24 signal */
+        { .pin = GPIO_PIN(PORT_I, 1), .af = GPIO_AF12, },  /* FMC_D25 signal */
+        { .pin = GPIO_PIN(PORT_I, 2), .af = GPIO_AF12, },  /* FMC_D26 signal */
+        { .pin = GPIO_PIN(PORT_I, 3), .af = GPIO_AF12, },  /* FMC_D27 signal */
+        { .pin = GPIO_PIN(PORT_I, 6), .af = GPIO_AF12, },  /* FMC_D28 signal */
+        { .pin = GPIO_PIN(PORT_I, 7), .af = GPIO_AF12, },  /* FMC_D29 signal */
+        { .pin = GPIO_PIN(PORT_I, 9), .af = GPIO_AF12, },  /* FMC_D30 signal */
+        { .pin = GPIO_PIN(PORT_I, 10), .af = GPIO_AF12, }, /* FMC_D31 signal */
+#endif
+    },
+    .nbl0_pin = { .pin = GPIO_PIN(PORT_E, 0), .af = GPIO_AF12, },   /* FMC_NBL0 signal (DQM0) */
+    .nbl1_pin = { .pin = GPIO_PIN(PORT_E, 1), .af = GPIO_AF12, },   /* FMC_NBL1 signal (DQM1) */
+    .nbl2_pin = { .pin = GPIO_PIN(PORT_I, 4), .af = GPIO_AF12, },   /* FMC_NBL2 signal (DQM2) */
+    .nbl3_pin = { .pin = GPIO_PIN(PORT_I, 5), .af = GPIO_AF12, },   /* FMC_NBL3 signal (DQM3) */
+};
+
+/**
+ * @brief   FMC Bank configuration
+ *
+ * The board has a SDRAM MT48LC4M32B2B5-6A with 128 MBit on-board.
+ * It is organized in 4 banks of 1M x 32 bits each and connected to bank 5
+ * at address 0xc0000000.
+ */
+static const fmc_bank_conf_t fmc_bank_config[] = {
+    /* bank 5 is used for SDRAM */
+    {
+        .bank = FMC_BANK_5,
+        .mem_type = FMC_SDRAM,
+        .data_width = FMC_BUS_WIDTH_32BIT,
+        .address = 0xc0000000,               /* Bank 6 is mapped to 0xc0000000 */
+        .size = MiB(16),                      /* Size in MByte, 4M x 32 Bit */
+        .sdram = {
+            .clk_period = 2,                 /* SDCLK = 2 x HCLK */
+            .row_bits = 12,                  /* A11..A0 used for row address */
+            .col_bits = 8,                   /* A7..A0 used for column address */
+            .cas_latency = 2,                /* CAS latency is 2 clock cycles */
+            .read_delay = 0,                 /* No read delay after CAS */
+            .burst_read = true,              /* Burst read mode enabled */
+            .burst_write = false,            /* Burst write mode disabled */
+            .burst_len = FMC_BURST_LENGTH_1, /* Burst length is 1 */
+            .burst_interleaved = false,      /* Burst mode interleaved */
+            .write_protect = false,          /* No write protection */
+            .four_banks = true,              /* SDRAM has four internal banks */
+            .timing = {                      /* SDRAM Timing parameters */
+                .row_to_col_delay = 2,       /* Row to column delay (2 clock cycles) */
+                .row_precharge = 2,          /* Row precharge delay (2 clock cycles) */
+                .recovery_delay = 2,         /* Recovery delay is (2 clock cycles) */
+                .row_cylce = 7,              /* Row cycle delay is (7 clock cycles) */
+                .self_refresh = 4,           /* Self refresh time is (4 clock cycles) */
+                .exit_self_refresh = 7,      /* Exit self-refresh delay (7 clock cycles) */
+                .load_mode_register = 2,     /* Load Mode Register to Activate delay */
+                .refresh_period = 64,        /* Refresh period in ms */
+            },
+        },
+    },
+};
+
+/**
+ * @brief   Number of configured FMC banks
+ */
+#define FMC_BANK_NUMOF  ARRAY_SIZE(fmc_bank_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/periph/fmc/main.c
+++ b/tests/periph/fmc/main.c
@@ -94,7 +94,6 @@ int main(void)
     }
     puts("------------------------------------------------------------------------");
 
-
     printf("fill complete memory of %lu kByte, a . represents a 16 kByte block\n",
            fmc_bank_config[FMC_BANK].size >> 10);
 


### PR DESCRIPTION
### Contribution description

This PR enables the FMC support on the `stm32f769i-disco` board and the on-board SDRAM MT48LC4M32B2B5-6A with 16 MByte.

The PR also includes a very small documentation fix for the `stm32f746g-disco` board (commit
f761e2d616c861e4857563bae26152bc1f1699d7) and removes double empy line in the test app `tests/periph/fmc`.

### Testing procedure

1. `tests/periph/fmc` should succeed, just compile and flash the app with
   
   ```
   BOARD=stm32f769i-disco make -C tests/periph/fmc flash term
   ```
2. `tests/sys/malloc` should also use the SDRAM. Use
   
   ```
   USEMODULE=periph_fmc_sdram CFLAGS='-DCHUNK_SIZE=131072' \
   BOARD=stm32f769i-disco make -C tests/sys/malloc flash term
   ```
   and check that the heap also uses the memory in the range from `0xc0000000` to `0xc0fffffff`.

**UPDATE:** Tested with a `stm32f769i-disco` board.

<details>
<summary>Output from <b>tests/periph/fmc</b></summary>

```
Help: Press s to start test, r to print it is ready
START
main(): This is RIOT! (Version: 2023.10-devel-88-gdcecc-boards/stm32f769i_disco_fmc)
FMC HCLK freq 216 MHz
8-bit data @0xc0000000, 16-bit data @0xc0000100, 32-bit data @0xc0ffff00
------------------------------------------------------------------------
C0000000  00  01  02  03  04  05  06  07  08  09  0A  0B  0C  0D  0E  0F
C0000010  10  11  12  13  14  15  16  17  18  19  1A  1B  1C  1D  1E  1F
C0000020  20  21  22  23  24  25  26  27  28  29  2A  2B  2C  2D  2E  2F
C0000030  30  31  32  33  34  35  36  37  38  39  3A  3B  3C  3D  3E  3F
C0000040  40  41  42  43  44  45  46  47  48  49  4A  4B  4C  4D  4E  4F
C0000050  50  51  52  53  54  55  56  57  58  59  5A  5B  5C  5D  5E  5F
C0000060  60  61  62  63  64  65  66  67  68  69  6A  6B  6C  6D  6E  6F
C0000070  70  71  72  73  74  75  76  77  78  79  7A  7B  7C  7D  7E  7F
C0000080  80  81  82  83  84  85  86  87  88  89  8A  8B  8C  8D  8E  8F
C0000090  90  91  92  93  94  95  96  97  98  99  9A  9B  9C  9D  9E  9F
C00000A0  A0  A1  A2  A3  A4  A5  A6  A7  A8  A9  AA  AB  AC  AD  AE  AF
C00000B0  B0  B1  B2  B3  B4  B5  B6  B7  B8  B9  BA  BB  BC  BD  BE  BF
C00000C0  C0  C1  C2  C3  C4  C5  C6  C7  C8  C9  CA  CB  CC  CD  CE  CF
C00000D0  D0  D1  D2  D3  D4  D5  D6  D7  D8  D9  DA  DB  DC  DD  DE  DF
C00000E0  E0  E1  E2  E3  E4  E5  E6  E7  E8  E9  EA  EB  EC  ED  EE  EF
C00000F0  F0  F1  F2  F3  F4  F5  F6  F7  F8  F9  FA  FB  FC  FD  FE  FF
------------------------------------------------------------------------
C0000100  00  80  01  81  02  82  03  83  04  84  05  85  06  86  07  87
C0000110  08  88  09  89  0A  8A  0B  8B  0C  8C  0D  8D  0E  8E  0F  8F
C0000120  10  90  11  91  12  92  13  93  14  94  15  95  16  96  17  97
C0000130  18  98  19  99  1A  9A  1B  9B  1C  9C  1D  9D  1E  9E  1F  9F
C0000140  20  A0  21  A1  22  A2  23  A3  24  A4  25  A5  26  A6  27  A7
C0000150  28  A8  29  A9  2A  AA  2B  AB  2C  AC  2D  AD  2E  AE  2F  AF
C0000160  30  B0  31  B1  32  B2  33  B3  34  B4  35  B5  36  B6  37  B7
C0000170  38  B8  39  B9  3A  BA  3B  BB  3C  BC  3D  BD  3E  BE  3F  BF
C0000180  40  C0  41  C1  42  C2  43  C3  44  C4  45  C5  46  C6  47  C7
C0000190  48  C8  49  C9  4A  CA  4B  CB  4C  CC  4D  CD  4E  CE  4F  CF
C00001A0  50  D0  51  D1  52  D2  53  D3  54  D4  55  D5  56  D6  57  D7
C00001B0  58  D8  59  D9  5A  DA  5B  DB  5C  DC  5D  DD  5E  DE  5F  DF
C00001C0  60  E0  61  E1  62  E2  63  E3  64  E4  65  E5  66  E6  67  E7
C00001D0  68  E8  69  E9  6A  EA  6B  EB  6C  EC  6D  ED  6E  EE  6F  EF
C00001E0  70  F0  71  F1  72  F2  73  F3  74  F4  75  F5  76  F6  77  F7
C00001F0  78  F8  79  F9  7A  FA  7B  FB  7C  FC  7D  FD  7E  FE  7F  FF
------------------------------------------------------------------------
C0FFFF00  00  40  80  C0  01  41  81  C1  02  42  82  C2  03  43  83  C3
C0FFFF10  04  44  84  C4  05  45  85  C5  06  46  86  C6  07  47  87  C7
C0FFFF20  08  48  88  C8  09  49  89  C9  0A  4A  8A  CA  0B  4B  8B  CB
C0FFFF30  0C  4C  8C  CC  0D  4D  8D  CD  0E  4E  8E  CE  0F  4F  8F  CF
C0FFFF40  10  50  90  D0  11  51  91  D1  12  52  92  D2  13  53  93  D3
C0FFFF50  14  54  94  D4  15  55  95  D5  16  56  96  D6  17  57  97  D7
C0FFFF60  18  58  98  D8  19  59  99  D9  1A  5A  9A  DA  1B  5B  9B  DB
C0FFFF70  1C  5C  9C  DC  1D  5D  9D  DD  1E  5E  9E  DE  1F  5F  9F  DF
C0FFFF80  20  60  A0  E0  21  61  A1  E1  22  62  A2  E2  23  63  A3  E3
C0FFFF90  24  64  A4  E4  25  65  A5  E5  26  66  A6  E6  27  67  A7  E7
C0FFFFA0  28  68  A8  E8  29  69  A9  E9  2A  6A  AA  EA  2B  6B  AB  EB
C0FFFFB0  2C  6C  AC  EC  2D  6D  AD  ED  2E  6E  AE  EE  2F  6F  AF  EF
C0FFFFC0  30  70  B0  F0  31  71  B1  F1  32  72  B2  F2  33  73  B3  F3
C0FFFFD0  34  74  B4  F4  35  75  B5  F5  36  76  B6  F6  37  77  B7  F7
C0FFFFE0  38  78  B8  F8  39  79  B9  F9  3A  7A  BA  FA  3B  7B  BB  FB
C0FFFFF0  3C  7C  BC  FC  3D  7D  BD  FD  3E  7E  BE  FE  3F  7F  BF  FF
------------------------------------------------------------------------
fill complete memory of 16384 kByte, a . represents a 16 kByte block
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
ready
check memory content, a + represents one 16 kByte block of matching data
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
ready
------------------------------------------------------------------------
Doing some benchmarks

              write 8 bit:    233018us  ---   0.013us per call  ---   71999656 calls per sec
             write 16 bit:    116510us  ---   0.013us per call  ---   71999038 calls per sec
             write 32 bit:    563125us  ---   0.134us per call  ---    7448264 calls per sec
               read 8 bit:    900066us  ---   0.053us per call  ---   18639984 calls per sec
              read 16 bit:   1165181us  ---   0.138us per call  ---    7199403 calls per sec
              read 32 bit:    225729us  ---   0.053us per call  ---   18581148 calls per sec

ready
------------------------------------------------------------------------
print first and last memory block after benchmark, should be 0xaa

C0000000  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000010  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000020  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000030  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000040  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000050  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000060  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000070  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000080  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0000090  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C00000A0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C00000B0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C00000C0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C00000D0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C00000E0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C00000F0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA

C0FFFF00  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF10  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF20  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF30  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF40  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF50  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF60  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF70  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF80  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFF90  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFFA0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFFB0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFFC0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFFD0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFFE0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
C0FFFFF0  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA  AA
------------------------------------------------------------------------

[SUCCESS]

{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 412}]}
```

</details>

<details>
<summary>Output from <b>tests/sys/malloc</b></summary>

```
Help: Press s to start test, r to print it is ready
START
main(): This is RIOT! (Version: 2023.10-devel-88-gdcecc-boards/stm32f769i_disco_fmc)
calloc(zu, zu) = 0x10000000
CHUNK_SIZE: 131072
NUMBER_OF_TESTS: 3
Allocated 131072 Bytes at 0x200013a8, total 131072
Allocated 131072 Bytes at 0x200213c0, total 262152
Allocated 131072 Bytes at 0x200413d8, total 393232
Allocated 131072 Bytes at 0xc0000008, total 524312
Allocated 131072 Bytes at 0xc0020010, total 655392
Allocated 131072 Bytes at 0xc0040018, total 786472
Allocated 131072 Bytes at 0xc0060020, total 917552
Allocated 131072 Bytes at 0xc0080028, total 1048632
Allocated 131072 Bytes at 0xc00a0030, total 1179712
Allocated 131072 Bytes at 0xc00c0038, total 1310792
Allocated 131072 Bytes at 0xc00e0040, total 1441872
Allocated 131072 Bytes at 0xc0100048, total 1572952
Allocated 131072 Bytes at 0xc0120050, total 1704032
Allocated 131072 Bytes at 0xc0140058, total 1835112
Allocated 131072 Bytes at 0xc0160060, total 1966192
Allocated 131072 Bytes at 0xc0180068, total 2097272
Allocated 131072 Bytes at 0xc01a0070, total 2228352
Allocated 131072 Bytes at 0xc01c0078, total 2359432
Allocated 131072 Bytes at 0xc01e0080, total 2490512
Allocated 131072 Bytes at 0xc0200088, total 2621592
Allocated 131072 Bytes at 0xc0220090, total 2752672
Allocated 131072 Bytes at 0xc0240098, total 2883752
Allocated 131072 Bytes at 0xc02600a0, total 3014832
Allocated 131072 Bytes at 0xc02800a8, total 3145912
Allocated 131072 Bytes at 0xc02a00b0, total 3276992
Allocated 131072 Bytes at 0xc02c00b8, total 3408072
Allocated 131072 Bytes at 0xc02e00c0, total 3539152
Allocated 131072 Bytes at 0xc03000c8, total 3670232
Allocated 131072 Bytes at 0xc03200d0, total 3801312
Allocated 131072 Bytes at 0xc03400d8, total 3932392
Allocated 131072 Bytes at 0xc03600e0, total 4063472
Allocated 131072 Bytes at 0xc03800e8, total 4194552
Allocated 131072 Bytes at 0xc03a00f0, total 4325632
Allocated 131072 Bytes at 0xc03c00f8, total 4456712
Allocated 131072 Bytes at 0xc03e0100, total 4587792
Allocated 131072 Bytes at 0xc0400108, total 4718872
Allocated 131072 Bytes at 0xc0420110, total 4849952
Allocated 131072 Bytes at 0xc0440118, total 4981032
Allocated 131072 Bytes at 0xc0460120, total 5112112
Allocated 131072 Bytes at 0xc0480128, total 5243192
Allocated 131072 Bytes at 0xc04a0130, total 5374272
Allocated 131072 Bytes at 0xc04c0138, total 5505352
Allocated 131072 Bytes at 0xc04e0140, total 5636432
Allocated 131072 Bytes at 0xc0500148, total 5767512
Allocated 131072 Bytes at 0xc0520150, total 5898592
Allocated 131072 Bytes at 0xc0540158, total 6029672
Allocated 131072 Bytes at 0xc0560160, total 6160752
Allocated 131072 Bytes at 0xc0580168, total 6291832
Allocated 131072 Bytes at 0xc05a0170, total 6422912
Allocated 131072 Bytes at 0xc05c0178, total 6553992
Allocated 131072 Bytes at 0xc05e0180, total 6685072
Allocated 131072 Bytes at 0xc0600188, total 6816152
Allocated 131072 Bytes at 0xc0620190, total 6947232
Allocated 131072 Bytes at 0xc0640198, total 7078312
Allocated 131072 Bytes at 0xc06601a0, total 7209392
Allocated 131072 Bytes at 0xc06801a8, total 7340472
Allocated 131072 Bytes at 0xc06a01b0, total 7471552
Allocated 131072 Bytes at 0xc06c01b8, total 7602632
Allocated 131072 Bytes at 0xc06e01c0, total 7733712
Allocated 131072 Bytes at 0xc07001c8, total 7864792
Allocated 131072 Bytes at 0xc07201d0, total 7995872
Allocated 131072 Bytes at 0xc07401d8, total 8126952
Allocated 131072 Bytes at 0xc07601e0, total 8258032
Allocated 131072 Bytes at 0xc07801e8, total 8389112
Allocated 131072 Bytes at 0xc07a01f0, total 8520192
Allocated 131072 Bytes at 0xc07c01f8, total 8651272
Allocated 131072 Bytes at 0xc07e0200, total 8782352
Allocated 131072 Bytes at 0xc0800208, total 8913432
Allocated 131072 Bytes at 0xc0820210, total 9044512
Allocated 131072 Bytes at 0xc0840218, total 9175592
Allocated 131072 Bytes at 0xc0860220, total 9306672
Allocated 131072 Bytes at 0xc0880228, total 9437752
Allocated 131072 Bytes at 0xc08a0230, total 9568832
Allocated 131072 Bytes at 0xc08c0238, total 9699912
Allocated 131072 Bytes at 0xc08e0240, total 9830992
Allocated 131072 Bytes at 0xc0900248, total 9962072
Allocated 131072 Bytes at 0xc0920250, total 10093152
Allocated 131072 Bytes at 0xc0940258, total 10224232
Allocated 131072 Bytes at 0xc0960260, total 10355312
Allocated 131072 Bytes at 0xc0980268, total 10486392
Allocated 131072 Bytes at 0xc09a0270, total 10617472
Allocated 131072 Bytes at 0xc09c0278, total 10748552
Allocated 131072 Bytes at 0xc09e0280, total 10879632
Allocated 131072 Bytes at 0xc0a00288, total 11010712
Allocated 131072 Bytes at 0xc0a20290, total 11141792
Allocated 131072 Bytes at 0xc0a40298, total 11272872
Allocated 131072 Bytes at 0xc0a602a0, total 11403952
Allocated 131072 Bytes at 0xc0a802a8, total 11535032
Allocated 131072 Bytes at 0xc0aa02b0, total 11666112
Allocated 131072 Bytes at 0xc0ac02b8, total 11797192
Allocated 131072 Bytes at 0xc0ae02c0, total 11928272
Allocated 131072 Bytes at 0xc0b002c8, total 12059352
Allocated 131072 Bytes at 0xc0b202d0, total 12190432
Allocated 131072 Bytes at 0xc0b402d8, total 12321512
Allocated 131072 Bytes at 0xc0b602e0, total 12452592
Allocated 131072 Bytes at 0xc0b802e8, total 12583672
Allocated 131072 Bytes at 0xc0ba02f0, total 12714752
Allocated 131072 Bytes at 0xc0bc02f8, total 12845832
Allocated 131072 Bytes at 0xc0be0300, total 12976912
Allocated 131072 Bytes at 0xc0c00308, total 13107992
Allocated 131072 Bytes at 0xc0c20310, total 13239072
Allocated 131072 Bytes at 0xc0c40318, total 13370152
Allocated 131072 Bytes at 0xc0c60320, total 13501232
Allocated 131072 Bytes at 0xc0c80328, total 13632312
Allocated 131072 Bytes at 0xc0ca0330, total 13763392
Allocated 131072 Bytes at 0xc0cc0338, total 13894472
Allocated 131072 Bytes at 0xc0ce0340, total 14025552
Allocated 131072 Bytes at 0xc0d00348, total 14156632
Allocated 131072 Bytes at 0xc0d20350, total 14287712
Allocated 131072 Bytes at 0xc0d40358, total 14418792
Allocated 131072 Bytes at 0xc0d60360, total 14549872
Allocated 131072 Bytes at 0xc0d80368, total 14680952
Allocated 131072 Bytes at 0xc0da0370, total 14812032
Allocated 131072 Bytes at 0xc0dc0378, total 14943112
Allocated 131072 Bytes at 0xc0de0380, total 15074192
Allocated 131072 Bytes at 0xc0e00388, total 15205272
Allocated 131072 Bytes at 0xc0e20390, total 15336352
Allocated 131072 Bytes at 0xc0e40398, total 15467432
Allocated 131072 Bytes at 0xc0e603a0, total 15598512
Allocated 131072 Bytes at 0xc0e803a8, total 15729592
Allocated 131072 Bytes at 0xc0ea03b0, total 15860672
Allocated 131072 Bytes at 0xc0ec03b8, total 15991752
Allocated 131072 Bytes at 0xc0ee03c0, total 16122832
Allocated 131072 Bytes at 0xc0f003c8, total 16253912
Allocated 131072 Bytes at 0xc0f203d0, total 16384992
Allocated 131072 Bytes at 0xc0f403d8, total 16516072
Allocated 131072 Bytes at 0xc0f603e0, total 16647152
Allocated 131072 Bytes at 0xc0f803e8, total 16778232
Allocated 131072 Bytes at 0xc0fa03f0, total 16909312
Allocated 131072 Bytes at 0xc0fc03f8, total 17040392
Allocations count: 130
Free 131072 Bytes at 0x200013a8, total 16909328
Free 131072 Bytes at 0x200213c0, total 16778248
Free 131072 Bytes at 0x200413d8, total 16647168
Free 131072 Bytes at 0xc0000008, total 16516088
Free 131072 Bytes at 0xc0020010, total 16385008
Free 131072 Bytes at 0xc0040018, total 16253928
Free 131072 Bytes at 0xc0060020, total 16122848
Free 131072 Bytes at 0xc0080028, total 15991768
Free 131072 Bytes at 0xc00a0030, total 15860688
Free 131072 Bytes at 0xc00c0038, total 15729608
Free 131072 Bytes at 0xc00e0040, total 15598528
Free 131072 Bytes at 0xc0100048, total 15467448
Free 131072 Bytes at 0xc0120050, total 15336368
Free 131072 Bytes at 0xc0140058, total 15205288
Free 131072 Bytes at 0xc0160060, total 15074208
Free 131072 Bytes at 0xc0180068, total 14943128
Free 131072 Bytes at 0xc01a0070, total 14812048
Free 131072 Bytes at 0xc01c0078, total 14680968
Free 131072 Bytes at 0xc01e0080, total 14549888
Free 131072 Bytes at 0xc0200088, total 14418808
Free 131072 Bytes at 0xc0220090, total 14287728
Free 131072 Bytes at 0xc0240098, total 14156648
Free 131072 Bytes at 0xc02600a0, total 14025568
Free 131072 Bytes at 0xc02800a8, total 13894488
Free 131072 Bytes at 0xc02a00b0, total 13763408
Free 131072 Bytes at 0xc02c00b8, total 13632328
Free 131072 Bytes at 0xc02e00c0, total 13501248
Free 131072 Bytes at 0xc03000c8, total 13370168
Free 131072 Bytes at 0xc03200d0, total 13239088
Free 131072 Bytes at 0xc03400d8, total 13108008
Free 131072 Bytes at 0xc03600e0, total 12976928
Free 131072 Bytes at 0xc03800e8, total 12845848
Free 131072 Bytes at 0xc03a00f0, total 12714768
Free 131072 Bytes at 0xc03c00f8, total 12583688
Free 131072 Bytes at 0xc03e0100, total 12452608
Free 131072 Bytes at 0xc0400108, total 12321528
Free 131072 Bytes at 0xc0420110, total 12190448
Free 131072 Bytes at 0xc0440118, total 12059368
Free 131072 Bytes at 0xc0460120, total 11928288
Free 131072 Bytes at 0xc0480128, total 11797208
Free 131072 Bytes at 0xc04a0130, total 11666128
Free 131072 Bytes at 0xc04c0138, total 11535048
Free 131072 Bytes at 0xc04e0140, total 11403968
Free 131072 Bytes at 0xc0500148, total 11272888
Free 131072 Bytes at 0xc0520150, total 11141808
Free 131072 Bytes at 0xc0540158, total 11010728
Free 131072 Bytes at 0xc0560160, total 10879648
Free 131072 Bytes at 0xc0580168, total 10748568
Free 131072 Bytes at 0xc05a0170, total 10617488
Free 131072 Bytes at 0xc05c0178, total 10486408
Free 131072 Bytes at 0xc05e0180, total 10355328
Free 131072 Bytes at 0xc0600188, total 10224248
Free 131072 Bytes at 0xc0620190, total 10093168
Free 131072 Bytes at 0xc0640198, total 9962088
Free 131072 Bytes at 0xc06601a0, total 9831008
Free 131072 Bytes at 0xc06801a8, total 9699928
Free 131072 Bytes at 0xc06a01b0, total 9568848
Free 131072 Bytes at 0xc06c01b8, total 9437768
Free 131072 Bytes at 0xc06e01c0, total 9306688
Free 131072 Bytes at 0xc07001c8, total 9175608
Free 131072 Bytes at 0xc07201d0, total 9044528
Free 131072 Bytes at 0xc07401d8, total 8913448
Free 131072 Bytes at 0xc07601e0, total 8782368
Free 131072 Bytes at 0xc07801e8, total 8651288
Free 131072 Bytes at 0xc07a01f0, total 8520208
Free 131072 Bytes at 0xc07c01f8, total 8389128
Free 131072 Bytes at 0xc07e0200, total 8258048
Free 131072 Bytes at 0xc0800208, total 8126968
Free 131072 Bytes at 0xc0820210, total 7995888
Free 131072 Bytes at 0xc0840218, total 7864808
Free 131072 Bytes at 0xc0860220, total 7733728
Free 131072 Bytes at 0xc0880228, total 7602648
Free 131072 Bytes at 0xc08a0230, total 7471568
Free 131072 Bytes at 0xc08c0238, total 7340488
Free 131072 Bytes at 0xc08e0240, total 7209408
Free 131072 Bytes at 0xc0900248, total 7078328
Free 131072 Bytes at 0xc0920250, total 6947248
Free 131072 Bytes at 0xc0940258, total 6816168
Free 131072 Bytes at 0xc0960260, total 6685088
Free 131072 Bytes at 0xc0980268, total 6554008
Free 131072 Bytes at 0xc09a0270, total 6422928
Free 131072 Bytes at 0xc09c0278, total 6291848
Free 131072 Bytes at 0xc09e0280, total 6160768
Free 131072 Bytes at 0xc0a00288, total 6029688
Free 131072 Bytes at 0xc0a20290, total 5898608
Free 131072 Bytes at 0xc0a40298, total 5767528
Free 131072 Bytes at 0xc0a602a0, total 5636448
Free 131072 Bytes at 0xc0a802a8, total 5505368
Free 131072 Bytes at 0xc0aa02b0, total 5374288
Free 131072 Bytes at 0xc0ac02b8, total 5243208
Free 131072 Bytes at 0xc0ae02c0, total 5112128
Free 131072 Bytes at 0xc0b002c8, total 4981048
Free 131072 Bytes at 0xc0b202d0, total 4849968
Free 131072 Bytes at 0xc0b402d8, total 4718888
Free 131072 Bytes at 0xc0b602e0, total 4587808
Free 131072 Bytes at 0xc0b802e8, total 4456728
Free 131072 Bytes at 0xc0ba02f0, total 4325648
Free 131072 Bytes at 0xc0bc02f8, total 4194568
Free 131072 Bytes at 0xc0be0300, total 4063488
Free 131072 Bytes at 0xc0c00308, total 3932408
Free 131072 Bytes at 0xc0c20310, total 3801328
Free 131072 Bytes at 0xc0c40318, total 3670248
Free 131072 Bytes at 0xc0c60320, total 3539168
Free 131072 Bytes at 0xc0c80328, total 3408088
Free 131072 Bytes at 0xc0ca0330, total 3277008
Free 131072 Bytes at 0xc0cc0338, total 3145928
Free 131072 Bytes at 0xc0ce0340, total 3014848
Free 131072 Bytes at 0xc0d00348, total 2883768
Free 131072 Bytes at 0xc0d20350, total 2752688
Free 131072 Bytes at 0xc0d40358, total 2621608
Free 131072 Bytes at 0xc0d60360, total 2490528
Free 131072 Bytes at 0xc0d80368, total 2359448
Free 131072 Bytes at 0xc0da0370, total 2228368
Free 131072 Bytes at 0xc0dc0378, total 2097288
Free 131072 Bytes at 0xc0de0380, total 1966208
Free 131072 Bytes at 0xc0e00388, total 1835128
Free 131072 Bytes at 0xc0e20390, total 1704048
Free 131072 Bytes at 0xc0e40398, total 1572968
Free 131072 Bytes at 0xc0e603a0, total 1441888
Free 131072 Bytes at 0xc0e803a8, total 1310808
Free 131072 Bytes at 0xc0ea03b0, total 1179728
Free 131072 Bytes at 0xc0ec03b8, total 1048648
Free 131072 Bytes at 0xc0ee03c0, total 917568
Free 131072 Bytes at 0xc0f003c8, total 786488
Free 131072 Bytes at 0xc0f203d0, total 655408
Free 131072 Bytes at 0xc0f403d8, total 524328
Free 131072 Bytes at 0xc0f603e0, total 393248
Free 131072 Bytes at 0xc0f803e8, total 262168
Free 131072 Bytes at 0xc0fa03f0, total 131088
Free 131072 Bytes at 0xc0fc03f8, total 8
Free count: 130
...
Free 131072 Bytes at 0xc0fc03f8, total 8
Free count: 130
[SUCCESS]
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 396 }]}
```

</details>

### Issues/PRs references