### PR TITLE
clang floating point handling fix

### DIFF
--- a/tests/pkg/cayenne-lpp/main.c
+++ b/tests/pkg/cayenne-lpp/main.c
@@ -24,9 +24,7 @@
 #include "cayenne_lpp.h"
 
 #define TEST_BUFFER1 { 0x03, 0x67, 0x01, 0x10, 0x05, 0x67, 0x00, 0xff }
-#if defined(BOARD_NATIVE) && !defined(__clang__)    /* clang uses same floating
-                                                     * point handling as GCC
-                                                     * with cross compiling */
+#if defined(BOARD_NATIVE)
 #define TEST_BUFFER2 { 0x01, 0x67, 0xFF, 0xD8, \
                        0x06, 0x71, 0x04, 0xD1, 0xFB, 0x2F, 0x00, 0x00 }
 #else

--- a/tests/pkg/lora-serialization/main.c
+++ b/tests/pkg/lora-serialization/main.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include "lora_serialization.h"
 
-#if defined(BOARD_NATIVE) && !defined(__clang__)
+#if defined(BOARD_NATIVE)
 #define TEST_01_EXPECTED    { 0x1f, 0x4c, 0x0e, 0x27 }
 #define TEST_02_EXPECTED    { 0x65, 0xa6, 0xfa, 0xfd, \
                               0x6a, 0x24, 0x04, 0x09, \


### PR DESCRIPTION

### Contribution description

As promised (with a delay for vacation), here is the nightlies fix.  It is very easy...

I guess previously native had different handling of floating points (similar to cross-compiled gcc) when using clang.  thanks to @maribu great work on fixing the llvm toolchain issues, that seems to not be an issue anymore (though I don't know the commit that fixed it).

Thus we remove clang conditions and enjoy a green CI.

### Testing procedure

It seems like this wasn't tested or doesn't get tested in the normal murdock/bors procedure (still don't know why) but can be easily verified with a/b testing (master vs this PR)

```
TOOLCHAIN=llvm make all test -C tests/pkg/cayenne-lpp/
```

and
```
TOOLCHAIN=llvm make all test -C tests/pkg/lora-serialization/
```

I also tested with cross compiling on  the samr21 and they all work...

### Issues/PRs references

Look at nightlies...