### PR TITLE
pkg/lwip: fix wrong icmp chksum in IPv4

### DIFF
--- a/pkg/lwip/Makefile.include
+++ b/pkg/lwip/Makefile.include
@@ -20,8 +20,13 @@ PSEUDOMODULES += lwip_sock_async
 #These flags enable calculating ICMP chksum in LWIP software.
 #Without these flags RIOT device respond with ICMP chsum equal to 0, and
 #cannot be successfully "pinged" from Windows hosts.
-CFLAGS +=-DCHECKSUM_GEN_ICMP=0
-CFLAGS +=-DLWIP_CHECKSUM_CTRL_PER_NETIF=1
+ifeq ($(BOARD),nucleo-f207zg)
+ CFLAGS +=-DCHECKSUM_GEN_ICMP=0
+endif
+
+ifeq ($(BOARD),nucleo-f429zi)
+ CFLAGS +=-DCHECKSUM_GEN_ICMP=0
+endif
 
 ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/lwip/contrib

--- a/pkg/lwip/Makefile.include
+++ b/pkg/lwip/Makefile.include
@@ -17,6 +17,12 @@ PSEUDOMODULES += lwip_udp
 PSEUDOMODULES += lwip_udplite
 PSEUDOMODULES += lwip_sock_async
 
+#These flags enable calculating ICMP chksum in LWIP software.
+#Without these flags RIOT device respond with ICMP chsum equal to 0, and
+#cannot be successfully "pinged" from Windows hosts.
+CFLAGS +=-DCHECKSUM_GEN_ICMP=0
+CFLAGS +=-DLWIP_CHECKSUM_CTRL_PER_NETIF=1
+
 ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/lwip/contrib
 endif


### PR DESCRIPTION
### Contribution description

Device with RIOT OS and LWIP IPv4 stack did not respond to ping from Windows hosts. Linux hosts could
ping device without problems. In the network trace icmp responses with chksum set to 0 could be observed. 
Additionally Wireshark flag icmp requests as "no response found!". The cause of such behavior is icmp chksum
set to 0.

This PR enables calculation of icmp chksum in the LWIP stack.

I tested this behavior and PR using LWIP 2.2.0 provided by PR #19780 - the stack behaves in this same manner and
this PR fix problem.

### Testing procedure

Run any LWIP code, for e.g. `examples/coap` with enabled IPv4 stack. To do this:

1) in Makefile, line 17 change:

```
LWIP_IPV4 ?= 0
```
to 

```
LWIP_IPV4 ?= 1
```

2) add to `main.c` code which configure IPv4 address

```
include "lwip/netif.h"
```

and in main function:
```
#define _TEST_ADDR4_LOCAL  (0x964fa8c0U)   /* 192.168.79.150 */
#define _TEST_ADDR4_MASK   (0x00ffffffU)   /* 255.255.255.0 */
sys_lock_tcpip_core();
struct netif *iface = netif_find("ET0");

ip4_addr_t ip, subnet;
ip.addr = _TEST_ADDR4_LOCAL;
subnet.addr = _TEST_ADDR4_MASK;
netif_set_addr(iface, &ip, &subnet, NULL);
sys_unlock_tcpip_core();
```

Ping 192.168.79.150 from Windows machine - without this PR ping should fail.
I tested this PR code in hardware - `nucleo-f207zg`.

### Issues/PRs references

Tested with  PR #19780 .