### PR TITLE
cpu/esp_common: esp-wifi: drop assert(val)

### DIFF
--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -742,7 +742,6 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
     ESP_WIFI_DEBUG("%s %p %p %u", netopt2str(opt), netdev, val, max_len);
 
     assert(netdev != NULL);
-    assert(val != NULL);
 
 #ifndef MODULE_ESP_WIFI_AP
     esp_wifi_netdev_t* dev = container_of(netdev, esp_wifi_netdev_t, netdev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `assert()` in `_esp_wifi_get` is excessive and wrong for `NETOPT_IS_WIRED` where `val == NULL` is valid.


### Testing procedure

Running applications that query the `NETOPT_IS_WIRED` option (e.g. `gnrc_ipv6_static_addr`) should now work without triggering the assertion.

### Issues/PRs references

https://forum.riot-os.org/t/border-router-ota-using-wifi/3895/24