### PR TITLE
gnrc_static: fix static PID assignment

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
+++ b/sys/net/gnrc/network_layer/ipv6/static_addr/gnrc_ipv6_static_addr.c
@@ -119,16 +119,16 @@ void auto_init_gnrc_ipv6_static_addr(void)
     if (gnrc_netif_highlander() || gnrc_netif_numof() == 1) {
         upstream = gnrc_netif_iter(NULL);
 
-        if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM)) {
+        if (CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM) {
             assert(upstream->pid == CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM);
         }
     } else {
 
-        if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM)) {
+        if (CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM) {
             upstream = gnrc_netif_get_by_pid(CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM);
         }
 
-        if (IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM)) {
+        if (CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM) {
             downstream = gnrc_netif_get_by_pid(CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM);
         }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Both `CONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM` and `CONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM` get set to 0 if they are not defined, so we don't need the `IS_ACTIVE()` - in fact, using `IS_ACTIVE()` leads to wrong results here.


### Testing procedure

Build an application with

```
CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM=8       # netif-esp-wifi
CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_ADDR_DOWNSTREAM=9     # slipdev
```

Turns out the `IS_ACTIVE(DCONFIG_GNRC_IPV6_STATIC_ADDR_UPSTREAM)` would evaluate to `false`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
https://forum.riot-os.org/t/border-router-ota-using-wifi/3895/24