### PR TITLE
tests/net/gcoap_fileserver: Fix failing nightlies

### DIFF
--- a/tests/net/gcoap_fileserver/tests/01-run.py
+++ b/tests/net/gcoap_fileserver/tests/01-run.py
@@ -110,6 +110,11 @@ def test_linear_topology(factory, zep_dispatch):
     # upload the file to node B (only one node should write MEMORY.bin)
     A.cmd("ncput /const/song.txt coap://[" + global_addr(B.cmd("ifconfig 7"))[1] + "]/vfs/song2.txt", timeout=60)
 
+    # It seems like failures may occur due to the `ncput` command finishing but
+    # the data not being written to the file yet. Therefore, we wait a bit...
+    # This is just a guess though.
+    time.sleep(0.5)
+
     # make sure the content matches
     assert B.cmd("md5sum /nvm0/song.txt").split()[2] == B.cmd("md5sum /nvm0/song2.txt").split()[2]
 


### PR DESCRIPTION

### Contribution description

This test has been failing inconsistently in the nightlies and sometimes on unrelated PRs. I was able to reproduce it with murdock and as soon as I added some print statements to the test it went away.  Since the issue is something to do with a failure when comparing 2 files after a node sends a file I am guessing that the comparison comes occasionally too fast and the file is not ready.

Maybe there is some more synchronization needed after a `ncput` but for now just adding a small sleep should prevent this issue.


### Testing procedure

Run murdock multiple times or try to get it failing on a local setup then apply the PR...


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
