### PR TITLE
drivers/ft5x06: fix vendor ID for FT6xx6 and FTxxxx register addresses

### DIFF
--- a/drivers/ft5x06/ft5x06.c
+++ b/drivers/ft5x06/ft5x06.c
@@ -54,17 +54,17 @@ int ft5x06_init(ft5x06_t *dev, const ft5x06_params_t *params, ft5x06_event_cb_t 
         return -EPROTO;
     }
 
-    uint8_t expected_id;
     if (dev->params.type == FT5X06_TYPE_FT6X06 || dev->params.type == FT5X06_TYPE_FT6X36) {
-        expected_id = FT6XX6_VENDOR_ID;
+        if ((vendor_id != FT5X06_VENDOR_ID_2) && (vendor_id != FT5X06_VENDOR_ID_3)) {
+            DEBUG("[ft5x06] init: invalid vendor ID: '0x%02x' (expected: 0x%02x or 0x%02x)\n",
+                  vendor_id, FT5X06_VENDOR_ID_2, FT5X06_VENDOR_ID_3);
+            i2c_release(FT5X06_BUS);
+            return -ENODEV;
+        }
     }
-    else {
-        expected_id = FT5X06_VENDOR_ID;
-    }
-
-    if (expected_id != vendor_id) {
+    else if (vendor_id != FT5X06_VENDOR_ID_1) {
         DEBUG("[ft5x06] init: invalid vendor ID: '0x%02x' (expected: 0x%02x)\n",
-                vendor_id, expected_id);
+                vendor_id, FT5X06_VENDOR_ID_1);
         i2c_release(FT5X06_BUS);
         return -ENODEV;
     }

--- a/drivers/ft5x06/include/ft5x06_constants.h
+++ b/drivers/ft5x06/include/ft5x06_constants.h
@@ -32,14 +32,19 @@ extern "C" {
 #define FT5X06_I2C_DEFAULT_ADDRESS                  (0x38)
 
 /**
- * @brief Vendor ID for FT6X06 and FT6X36 models.
- */
-#define FT6XX6_VENDOR_ID                            (0x11)
-
-/**
  * @brief Vendor ID for FT5606, FT5X16, FT5X06I, FT5336, FT3316, FT5436I, FT5336I, FT5X46 models.
  */
-#define FT5X06_VENDOR_ID                            (0x51)
+#define FT5X06_VENDOR_ID_1                          (0x51)
+
+/**
+ * @brief Vendor ID used for most FT6X06 and FT6X36 as well as FT3X67 models.
+ */
+#define FT5X06_VENDOR_ID_2                          (0x11)
+
+/**
+ * @brief Vendor ID used for some FT6X06 and FT6X36 models.
+ */
+#define FT5X06_VENDOR_ID_3                          (0xcd)
 
 /**
  * @brief Maximum touches count for FT6X06 and FT6X36 models.
@@ -81,9 +86,9 @@ extern "C" {
 #define FT5X06_TOUCH5_YH_REG                        (0x1D)
 #define FT5X06_TOUCH5_YL_REG                        (0x1E)
 #define FT5X06_G_AUTO_CLB_MODE_REG                  (0xA0)
-#define FT5X06_G_CIPHER_REG                         (0xA1)
-#define FT5X06_G_LIB_VERSION_H_REG                  (0xA2)
-#define FT5X06_G_LIB_VERSION_L_REG                  (0xA3)
+#define FT5X06_G_LIB_VERSION_H_REG                  (0xA1)
+#define FT5X06_G_LIB_VERSION_L_REG                  (0xA2)
+#define FT5X06_G_CIPHER_REG                         (0xA3)
 #define FT5X06_G_MODE_REG                           (0xA4)
 #define FT5X06_G_PMODE_REG                          (0xA5)
 #define FT5X06_G_FIRMID_REG                         (0xA6)

--- a/drivers/ft5x06/include/ft5x06_constants.h
+++ b/drivers/ft5x06/include/ft5x06_constants.h
@@ -34,7 +34,7 @@ extern "C" {
 /**
  * @brief Vendor ID for FT6X06 and FT6X36 models.
  */
-#define FT6XX6_VENDOR_ID                            (0xcd)
+#define FT6XX6_VENDOR_ID                            (0x11)
 
 /**
  * @brief Vendor ID for FT5606, FT5X16, FT5X06I, FT5336, FT3316, FT5436I, FT5336I, FT5X46 models.


### PR DESCRIPTION
### Contribution description

This PR provides a fix of the vendor ID for FT6xx6 touch panel driver ICs and a fix of register addresses for FTxxxx.

According to the [Application Note for FT6x06 CTPM](https://cdn-shop.adafruit.com/datasheets/FT6x06_AN_public_ver0.1.3.pdf), the vendor ID of FT6x06 touch panel driver ICs is `0x11` instead of `0xcd`. Although there are no information found in the Web about the FT6x36, the FT6336U touch panel of a ESP32-S3 WT32 SC01 Plus is also working with `0x11` as vendor ID so that it seems that FT6x36 is also using `0x11` as vendor ID.

Figured out with a `stm32f723e-disco` board (revision D03). Without this PR, `tests/drivers/ft5x06` gives:
```
+------------Initializing------------+
[ft5x06] init: invalid vendor ID: '0x11' (expected: 0xcd)
[Error] Initialization failed
```
With this PR it works as expected.
```
+------------Initializing------------+
Initialization successful
main(): This is RIOT! (Version: 2023.10-devel-96-gbb9011-drivers/ft5x06_fix_vendor_id)
FT5x06 test application

+------------Initializing------------+
[ft5x06] init: configuring touchscreen interrupt
Initialization successful
1 touch detected
[ft5x06] read gesture_id '0x00'
Touch 1 - X: 151, Y:138
[ft5x06] read gesture_id '0x00'
```

Some background information found in the Web:

- According to the [STM32CubeF7](https://github.com/STMicroelectronics/STM32CubeF7/blob/c20e6dd15bd2a90e19f28cadc703aeb26825d211/Drivers/BSP/STM32F723E-Discovery/stm32f723e_discovery_ts.c#L24-L27) the FRIDA LCD panel mounted on the `stm32f723e-disco` board either uses FT6x36 (prior revision D) or FT3x67 (revision D). However, the FT5x06 driver type for the card is defined as FT6x06, which does not seem correct: https://github.com/RIOT-OS/RIOT/blob/bb9011c3fbfe7c20bde99ce2462ef564d555ea08/boards/stm32f723e-disco/include/board.h#L59
- According to the [STM32CubeF7](https://github.com/STMicroelectronics/STM32CubeF7/blob/c20e6dd15bd2a90e19f28cadc703aeb26825d211/Drivers/BSP/Components/ft6x06/ft6x06.h#L269-L270), the vendor ID for FT6x36 should be `0xcd`. However, the FT6336U on ESP32-S3 WT32 SC01 Plus works with vendor ID `0x11`.
- The [Adafruit FT6206 library](https://github.com/adafruit/Adafruit_FT6206_Library/blob/95118cd9831890616a1afb55d323b6261dee15af/Adafruit_FT6206.h#L28) uses `0x11` as vendor id.
- The `stm32l496g-disco` board uses a FT6236 which has vendor ID `0xcd`.

So the information available on the web is confusing. Maybe, a better solution would be to accept `0x11` as well as `0xcd` as vendor ID for FT6xxx touch panels. Unfortunately, there are no documents available on the registers directly from FocalTech :worried: so it seems to be more speculation than knowledge.

### Testing procedure


### Issues/PRs references

