### PR TITLE
cpu/riscv_common: remove picolibc from blacklisting in CI

### DIFF
--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -11,7 +11,7 @@ config CPU_ARCH_RISCV
     select HAS_LIBSTDCPP
     select HAS_NEWLIB
     select HAS_PERIPH_CORETIMER
-    select HAS_PICOLIBC if '$(RIOT_CI_BUILD)' != '1'
+    select HAS_PICOLIBC
     select HAS_PUF_SRAM
     select HAS_RUST_TARGET
     select HAS_SSP

--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -13,6 +13,4 @@ FEATURES_PROVIDED += rust_target
 FEATURES_PROVIDED += ssp
 
 # RISC-V toolchain on CI does not work properly with picolibc yet
-ifeq (,$(RIOT_CI_BUILD))
-  FEATURES_PROVIDED += picolibc
-endif
+FEATURES_PROVIDED += picolibc


### PR DESCRIPTION
### Contribution description

`picolibc` is now supported by the RISC-V toolchain in `riotdocker`. It is not necessary to blacklist it in CI any longer.

Reference: `picolib` was blacklisted by commit 45270dada0af1269f8499f04e4f82329230e6944 in PR #15011.

### Testing procedure

1. Green CI
2. Check feature list for CI compilation:
   ```
   BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 FEATURES_OPTIONAL=picolibc \
   BOARD=sipeed-longan-nano make -j8 -C tests/sys/shell info-modules | grep picolib
   picolibc
   picolibc_stdout_buffered
   picolibc_syscalls_default
   ```

### Issues/PRs references

