### PR TITLE
tests/gcoap_fileserver: add zep_dispatcher to TEST_DEPS

### DIFF
--- a/tests/net/gcoap_fileserver/Makefile
+++ b/tests/net/gcoap_fileserver/Makefile
@@ -46,6 +46,6 @@ endif
 host-tools:
 	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)
 
-TERMDEPS += host-tools
+TEST_DEPS += host-tools
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/net/gcoap_fileserver/tests/01-run.py
+++ b/tests/net/gcoap_fileserver/tests/01-run.py
@@ -110,11 +110,6 @@ def test_linear_topology(factory, zep_dispatch):
     # upload the file to node B (only one node should write MEMORY.bin)
     A.cmd("ncput /const/song.txt coap://[" + global_addr(B.cmd("ifconfig 7"))[1] + "]/vfs/song2.txt", timeout=60)
 
-    # It seems like failures may occur due to the `ncput` command finishing but
-    # the data not being written to the file yet. Therefore, we wait a bit...
-    # This is just a guess though.
-    time.sleep(0.5)
-
     # make sure the content matches
     assert B.cmd("md5sum /nvm0/song.txt").split()[2] == B.cmd("md5sum /nvm0/song2.txt").split()[2]
 

--- a/tests/net/gnrc_rpl/Makefile
+++ b/tests/net/gnrc_rpl/Makefile
@@ -25,7 +25,7 @@ endif
 host-tools:
 	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)
 
-TERMDEPS += host-tools
+TEST_DEPS += host-tools
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
@@ -54,7 +54,7 @@ endif
 zep_dispatch:
 	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS) $@
 
-TERMDEPS += zep_dispatch
+TEST_DEPS += zep_dispatch
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The test needs `zep_dispatch` to run.
Without it the nodes can't communicate.


### Testing procedure

CI should no longer fail because test is started while `TERMDEPS` are still being built. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
