### PR TITLE
tests/pkg/lvgl*: fix the main thread stack size for ESPs

### DIFF
--- a/tests/pkg/lvgl/Makefile
+++ b/tests/pkg/lvgl/Makefile
@@ -12,12 +12,13 @@ USEMODULE += lvgl_extra_layout_flex
 USEMODULE += lvgl_extra_theme_default
 USEMODULE += lvgl_extra_theme_default_dark
 
+include $(RIOTBASE)/Makefile.include
+
 # SDL requires more stack
 ifeq (native,$(BOARD))
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=64*1024
+else ifneq (,$(filter esp%,$(CPU_FAM)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=4*1024
 else
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=2*1024
 endif
-
-
-include $(RIOTBASE)/Makefile.include

--- a/tests/pkg/lvgl_touch/Makefile
+++ b/tests/pkg/lvgl_touch/Makefile
@@ -17,11 +17,13 @@ USEMODULE += lvgl_extra_theme_default
 
 USEMODULE += random
 
+include $(RIOTBASE)/Makefile.include
+
 # SDL requires more stack
 ifeq (native,$(BOARD))
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=64*1024
+else ifneq (,$(filter esp%,$(CPU_FAM)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=4*1024
 else
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=2*1024
 endif
-
-include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

ESPx SoC need more stack size for the main thread to avoid stack overflows.

### Testing procedure

Use any ESP32 board or any ESP32-S2 board and flash `tests/pkg/lvgl` for the `esp32-wrover-kit` respective the `esp32s2-lilygo-ttgo-t8`, for example:
```
BOARD=esp32-wrover-kit make -j8 -C tests/pkg/lvgl flash
```
Without this PR the application crashes
```
main(): This is RIOT! (Version: 2023.10-devel-106-gd512f-tests/pkg/lvgl_fix_main_stack_size)
EXCEPTION!! exccause=29 (StoreProhibitedCause) @4008274a excvaddr=fefffffb
heap: 310368 (used 4176, free 306192) [bytes]

register set
pc      : 40082f74	ps      : 00050033	exccause: 0000001d	excvaddr: fefffffb
epc1    : 40082f74	
a0      : 4008274a	a1      : 3ffb1bd0	a2      : fefffff7	a3      : 00000000
a4      : 3ff000dc	a5      : 400826e0	a6      : 00000000	a7      : 3ffb1e08
a8      : 0000000b	a9      : 3ffb1df8	a10     : 3ffb1e7c	a11     : 00000001
a12     : 00000000	a13     : 00000000	a14     : 00000000	a15     : 000000a3
```
with this PR the application works as expected.

### Issues/PRs references