### PR TITLE
drivers/ft5x06: use a pointer to config parameters instead of copying them

### DIFF
--- a/drivers/ft5x06/ft5x06_internal.c
+++ b/drivers/ft5x06/ft5x06_internal.c
@@ -20,7 +20,7 @@
 #include "ft5x06_internal.h"
 
 uint8_t ft5x06_get_touches_count_max(const ft5x06_t *dev) {
-    if (dev->params.type == FT5X06_TYPE_FT6X06 || dev->params.type == FT5X06_TYPE_FT6X36) {
+    if (dev->params->type == FT5X06_TYPE_FT6X06 || dev->params->type == FT5X06_TYPE_FT6X36) {
         return FT6XX6_TOUCHES_COUNT_MAX;
     }
     else {

--- a/drivers/ft5x06/ft5x06_touch_dev.c
+++ b/drivers/ft5x06/ft5x06_touch_dev.c
@@ -37,7 +37,7 @@ uint16_t _ft5x06_height(const touch_dev_t *touch_dev)
     const ft5x06_t *dev = (const ft5x06_t *)touch_dev;
     assert(dev);
 
-    return dev->params.ymax;
+    return dev->params->ymax;
 }
 
 uint16_t _ft5x06_width(const touch_dev_t *touch_dev)
@@ -45,7 +45,7 @@ uint16_t _ft5x06_width(const touch_dev_t *touch_dev)
     const ft5x06_t *dev = (const ft5x06_t *)touch_dev;
     assert(dev);
 
-    return dev->params.xmax;
+    return dev->params->xmax;
 }
 
 uint8_t _ft5x06_touches(const touch_dev_t *touch_dev, touch_t *touches, size_t len)
@@ -69,8 +69,8 @@ void _ft5x06_set_event_callback(const touch_dev_t *touch_dev, touch_event_cb_t c
     ft5x06_t *dev = (ft5x06_t *)touch_dev;
     assert(dev);
 
-    if (gpio_is_valid(dev->params.int_pin)) {
-        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, cb, arg);
+    if (gpio_is_valid(dev->params->int_pin)) {
+        gpio_init_int(dev->params->int_pin, GPIO_IN, GPIO_RISING, cb, arg);
     }
 }
 

--- a/drivers/include/ft5x06.h
+++ b/drivers/include/ft5x06.h
@@ -101,9 +101,9 @@ typedef struct {
  */
 typedef struct {
 #ifdef MODULE_TOUCH_DEV
-    touch_dev_t *dev;       /**< Pointer to the generic touch device */
+    touch_dev_t *dev;               /**< Pointer to the generic touch device */
 #endif
-    ft5x06_params_t params; /**< Initialization parameters */
+    const ft5x06_params_t *params;  /**< Initialization parameters */
 } ft5x06_t;
 
 /**


### PR DESCRIPTION
### Contribution description

There is no need to copy the configuration parameter set to the device descriptor. A const pointer to the configuration parameter set in ROM is sufficient. It saves 16 byte of RAM.

Includes PR #19860 for the moment to be compilable.

### Testing procedure

Use 
```
CFLAGS='-DNDEBUG' BOARD=stm32f723e-disco make -j8 -C tests/drivers/touch_dev/
```
with and w/o this PR and compare the sizes.

Without the PR the sizes are:
```
  text	   data	    bss	    dec
  14652	    136	   2704	  17492
```
With the PR the sizes are:
```
  text	   data	    bss	    dec
  14676	    136	   2688	  17500
```

### Issues/PRs references

~Depends on PR #19860~
