### PR TITLE
make: COMPILE_COMMANDS_PATH adapt for external apps

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -730,7 +730,7 @@ else
   _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $$(find $(BASELIBS:%.module=$(BINDIR)/%/) -name "*.o" 2> /dev/null | sort) $(ARCHIVES_GROUP) $(LINKFLAGS) $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map
 endif # BUILDOSXNATIVE
 
-COMPILE_COMMANDS_PATH ?= $(RIOTBASE)/compile_commands.json
+COMPILE_COMMANDS_PATH ?= $(if $(findstring $(RIOTBASE),$(APPDIR)),$(RIOTBASE)/compile_commands.json, $(APPDIR)/compile_commands.json)
 COMPILE_COMMANDS_FLAGS ?= --clangd
 .PHONY: compile-commands
 compile-commands: $(BUILDDEPS)


### PR DESCRIPTION
### Contribution description

`COMPILE_COMMANDS_PATH` currently defaults to `RIOTBASE` which may not be an parent path for external applications -> set to `APPDIR` in case

### Testing procedure
- current good will stay good 
test with riot examples and or testes `$make compile-commands` should create a `compile_command.json` in `<RIOT>`

- test with external app  Makefile including
`include $(RIOTBASE)/Makefile.include`
should create `compile_command.json` in `APPDIR`


### Issues/PRs references
