### PR TITLE
tests/gcoap_fileserver: only enable test with GCC

### DIFF
--- a/tests/net/gcoap_fileserver/Makefile
+++ b/tests/net/gcoap_fileserver/Makefile
@@ -23,6 +23,8 @@ USEMODULE += shell_cmd_md5sum
 
 # automated test only works on native
 TEST_ON_CI_WHITELIST += native
+# FIXME: for some reason the test fails very often when built with clang
+TOOLCHAINS_BLACKLIST += llvm
 
 # use small blocksize for test to increase chance for errors
 CFLAGS += -DCONFIG_NANOCOAP_BLOCKSIZE_DEFAULT=COAP_BLOCKSIZE_16


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
We see a lot of failures on this on CI with LLVM.
Blacklist the LLVM build until someone manages to find out what the problem is.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
