### PR TITLE
makefiles/usb_board_reset.mk: declare term-delay target with test target

### DIFF
--- a/makefiles/tools/usb_board_reset.mk
+++ b/makefiles/tools/usb_board_reset.mk
@@ -33,7 +33,7 @@ preflash-delay: preflash
 	sleep $(PREFLASH_DELAY)
 endif
 
-ifneq (,$(filter term,$(MAKECMDGOALS)))
+ifneq (,$(filter test term,$(MAKECMDGOALS)))
 term-delay: $(TERMDELAYDEPS)
 	sleep $(TERM_DELAY)
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

While testing #19726 on adafruit-clue I noticed that the `test` target was broken because on this kind of board (with an integrated bootloader and stdio over usb) it expects the `term-delay` to be defined and without this PR it fails.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make test` works on adafruit-clue and similar boards.

<details><summary>master:</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 BOARD=adafruit-clue make -C tests/periph/cpuid/ flash test --no-print-directory 
Launching build container using image "docker.io/riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/aabadie/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/aabadie/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=adafruit-clue' -e 'RIOT_CI_BUILD=1' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=periph_cpuid' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/tests/periph/cpuid/' 'docker.io/riot/riotbuild:latest' make     
Building application "tests_cpuid" for "adafruit-clue" with MCU "nrf52".

   text	   data	    bss	    dec	    hex	filename
  17300	    128	   4580	  22008	   55f8	/data/riotbuild/riotbase/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip
Zip created at /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip
adafruit-nrfutil dfu serial --port=/dev/ttyACM0 --baudrate=115200 --touch=1200 --package=/work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip --singlebank
Upgrading target on /dev/ttyACM0 with DFU package /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip. Flow control is disabled, Single bank, Touch 1200
###################################
Activating new firmware
Device programmed.
make: *** No rule to make target 'term-delay', needed by 'test'.  Stop.
```

</details>

<details><summary>this PR:</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 BOARD=adafruit-clue make -C tests/periph/cpuid/ flash test --no-print-directory 
Launching build container using image "docker.io/riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/aabadie/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/aabadie/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=adafruit-clue' -e 'RIOT_CI_BUILD=1' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=periph_cpuid' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/tests/periph/cpuid/' 'docker.io/riot/riotbuild:latest' make     
Building application "tests_cpuid" for "adafruit-clue" with MCU "nrf52".

   text	   data	    bss	    dec	    hex	filename
  17300	    128	   4580	  22008	   55f8	/data/riotbuild/riotbase/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip
Zip created at /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip
adafruit-nrfutil dfu serial --port=/dev/ttyACM0 --baudrate=115200 --touch=1200 --package=/work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip --singlebank
Upgrading target on /dev/ttyACM0 with DFU package /work/riot/RIOT/tests/periph/cpuid/bin/adafruit-clue/tests_cpuid.hex.zip. Flow control is disabled, Single bank, Touch 1200
###################################
Activating new firmware
Device programmed.
sleep 2
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: buildtest)
Test for the CPUID driver
This test is reading out the CPUID of the platforms CPU

CPUID_LEN: 8
CPUID: 0x1b 0xb1 0xc6 0x92 0xf2 0xcb 0xad 0x3c

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while testing #19726 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
