### PR TITLE
gh-actions: remove reporting release tests to Matrix

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -123,7 +123,6 @@ jobs:
         sudo apt-get install lib32asan6
     - name: Run release tests
       timeout-minutes: 350
-      id: tests
       run: |
         RIOTBASE="$GITHUB_WORKSPACE/RIOT"
         TOX_ARGS=""
@@ -174,27 +173,6 @@ jobs:
         mkdir test-reports/
         junit2html ${REPORT_XML} ${REPORT_NAME}.html
         cp ${REPORT_XML} ${REPORT_NAME}.xml
-    - name: Generate result message
-      if: always()
-      id: generate_results
-      run: |
-        if [ "${{ steps.tests.conclusion }}" == "success" ]; then
-          nice_str="&#x2705; **PASSED**"
-        elif [ "${{ steps.tests.conclusion }}" == "failure" ]; then
-          nice_str="&#x274C; **FAILED**"
-        fi
-        echo "nice_str=${nice_str}" >> ${GITHUB_OUTPUT}
-    - name: Report to Matrix channel
-      if: ${{ always() && steps.generate_results.outputs.nice_str != '' }}
-      uses: fadenb/matrix-chat-message@v0.0.6
-      with:
-        homeserver: matrix.org
-        token: ${{ secrets.RIOT_CI_MATRIX_TOKEN }}
-        channel: '!UXNJuMzHTSAnwntbbN:utwente.io'
-        message: |
-          ${{ steps.generate_results.outputs.nice_str}}: Release tests
-          [${{ matrix.pytest_mark }}, ${{ matrix.sudo }}] on "*${{ github.event_name }}*":
-          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     - uses: actions/upload-artifact@v2
       if: always()
       with:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Reporting the release tests to Matrix never really worked and currently it makes the release tests look like failing. So lets just remove this action.

This effectively reverts commits 98100704ab74 and 764f7f0bf4cf.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Release tests should still work... we can start a run, but since this just reverts the to commits that added this which are the two last changes in the log to tha workflow file, I am pretty confident that this does not break anything:

```console
$ git log upstream/master -- .github/workflows/release-test.yml
commit 98100704ab74a7163bb2a32c4d1d4c25a6ad588a
Author: Martine Lenders <m.lenders@fu-berlin.de>
Date:   Sat Jan 14 09:49:52 2023 +0100

    release-tests: fix PASSED chat message

commit 764f7f0bf4cff93676f830e5bad441e534a20b1e
Author: Martine Lenders <m.lenders@fu-berlin.de>
Date:   Fri Jan 6 14:24:17 2023 +0100

    gh-actions: report release-tests result to Matrix

commit 37be7b9420c5735968139e6261e1e7b1b990629c
Author: Martine Lenders <m.lenders@fu-berlin.de>
Date:   Thu Oct 13 18:05:07 2022 +0200

    Revert "release-tests: add capability to run on PR comment"

[...]
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Reverts https://github.com/RIOT-OS/RIOT/pull/19102 and https://github.com/RIOT-OS/RIOT/pull/19145.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
