### PR TITLE
cpu/efm32: fix DAC configuration

### DIFF
--- a/boards/slwstk6220a/include/periph_conf.h
+++ b/boards/slwstk6220a/include/periph_conf.h
@@ -83,6 +83,7 @@ static const adc_chan_conf_t adc_channel_config[] = {
 static const dac_conf_t dac_config[] = {
     {
         .dev = DAC0,
+        .ref = dacRefVDD,
         .cmu = cmuClock_DAC0,
     }
 };
@@ -91,7 +92,6 @@ static const dac_chan_conf_t dac_channel_config[] = {
     {
         .dev = 0,
         .index = 1,
-        .ref = dacRefVDD,
     }
 };
 

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -84,6 +84,7 @@ static const adc_chan_conf_t adc_channel_config[] = {
 static const dac_conf_t dac_config[] = {
     {
         .dev = DAC0,
+        .ref = dacRefVDD,
         .cmu = cmuClock_DAC0,
     }
 };
@@ -92,7 +93,6 @@ static const dac_chan_conf_t dac_channel_config[] = {
     {
         .dev = 0,
         .index = 1,
-        .ref = dacRefVDD,
     }
 };
 

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -84,6 +84,7 @@ static const adc_chan_conf_t adc_channel_config[] = {
 static const dac_conf_t dac_config[] = {
     {
         .dev = DAC0,
+        .ref = dacRefVDD,
         .cmu = cmuClock_DAC0,
     }
 };
@@ -92,7 +93,6 @@ static const dac_chan_conf_t dac_channel_config[] = {
     {
         .dev = 0,
         .index = 1,
-        .ref = dacRefVDD,
     }
 };
 

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -79,6 +79,7 @@ typedef struct {
  */
 typedef struct {
     DAC_TypeDef *dev;       /**< DAC device used */
+    DAC_Ref_TypeDef ref;    /**< DAC voltage reference */
     CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
 } dac_conf_t;
 
@@ -88,7 +89,6 @@ typedef struct {
 typedef struct {
     uint8_t dev;            /**< device index */
     uint8_t index;          /**< channel index */
-    DAC_Ref_TypeDef ref;    /**< channel voltage reference */
 } dac_chan_conf_t;
 #endif
 

--- a/cpu/efm32/periph/dac.c
+++ b/cpu/efm32/periph/dac.c
@@ -45,6 +45,7 @@ int8_t dac_init(dac_t line)
     /* reset and initialize peripheral */
     DAC_Init_TypeDef init = DAC_INIT_DEFAULT;
 
+    init.reference = dac_config[dev].ref;
     DAC_Reset(dac_config[dev].dev);
     DAC_Init(dac_config[dev].dev, &init);
 


### PR DESCRIPTION
### Contribution description

The EFM32 MCU allows the reference voltage to be configured per DAC device, not per DAC channel. Also, the DAC reference voltage was defined in the configuration but not used anywhere.

At the moment we have only defined one board (`stwstk6220a`) that uses the DAC, so changing the configuration interface shouldn't be critical.

### Testing procedure

`tests/periph/dac` should still work for the `stwstk6220a`
```
BOARD=slwstk6220a make -j8 -C tests/periph/dac flash
```
I don't have a `stwstk6220a` board (EFM32 Series 0) so that I can't test it. I could only test it for the `sltb009a` board (EFM32 Series 1) with the change for VDAC in PR #19887.

### Issues/PRs references
