### PR TITLE
pkg/tinyusb: add missing include

### DIFF
--- a/pkg/tinyusb/contrib/tinyusb.c
+++ b/pkg/tinyusb/contrib/tinyusb.c
@@ -19,6 +19,7 @@
 
 #if IS_USED(MODULE_AUTO_INIT)
 #include "auto_init_utils.h"
+#include "auto_init_priorities.h"
 #endif
 
 #define ENABLE_DEBUG    0


### PR DESCRIPTION
### Contribution description

The macro `AUTO_INIT_PRIO_MOD_TINYUSB` was being used, but not defined. This patch includes the header where `AUTO_INIT_PRIO_MOD_TINYUSB` is defined to fix the compiler error.


### Testing procedure

Run any build with `auto_init` and `stdio_tinyusb_cdc_acm` modules active and see that build fails without patch and succeeds with the patch.


### Issues/PRs references

- none known
