### PR TITLE
gnrc_ipv6_nib: fix for border router with non-6lo interfaces

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -794,6 +794,8 @@ _nib_offl_entry_t *_nib_abr_iter_pfx(const _nib_abr_entry_t *abr,
  * @return  NULL, if @p last is the last ABR in the NIB.
  */
 _nib_abr_entry_t *_nib_abr_iter(const _nib_abr_entry_t *last);
+#else
+#define _nib_abr_iter(abr) NULL
 #endif
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -86,18 +86,18 @@ void _handle_snd_mc_ra(gnrc_netif_t *netif)
 
 void _snd_rtr_advs(gnrc_netif_t *netif, const ipv6_addr_t *dst, bool final)
 {
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
-    _nib_abr_entry_t *abr = NULL;
+    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C) && gnrc_netif_is_6lr(netif)) {
+        _nib_abr_entry_t *abr = NULL;
 
-    DEBUG("nib: Send router advertisements for each border router:\n");
-    while ((abr = _nib_abr_iter(abr))) {
-        DEBUG("    - %s\n", ipv6_addr_to_str(addr_str, &abr->addr,
-                                             sizeof(addr_str)));
-        _snd_ra(netif, dst, final, abr);
+        DEBUG("nib: Send router advertisements for each border router:\n");
+        while ((abr = _nib_abr_iter(abr))) {
+            DEBUG("    - %s\n", ipv6_addr_to_str(addr_str, &abr->addr,
+                                                 sizeof(addr_str)));
+            _snd_ra(netif, dst, final, abr);
+        }
+    } else {
+        _snd_ra(netif, dst, final, NULL);
     }
-#else   /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
-    _snd_ra(netif, dst, final, NULL);
-#endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
 }
 
 static gnrc_pktsnip_t *_offl_to_pio(_nib_offl_entry_t *offl,


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A border router should not send router advertisements on it's 6LoWPAN interfaces, but if it also has classic IPv6 downstream interfaces it should very much do so.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
