### PR TITLE
netdev/ieee802154_submac: support setting promiscuous mode option

### DIFF
--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -115,6 +115,10 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
         return res;
     case NETOPT_STATE:
         return _set_submac_state(submac, *((netopt_state_t*) value));
+    case NETOPT_PROMISCUOUSMODE:
+        return ieee802154_radio_set_frame_filter_mode(&submac->dev,
+                                                      *((bool *)value) ? IEEE802154_FILTER_PROMISC
+                                                                       : IEEE802154_FILTER_ACCEPT);
     default:
         break;
     }


### PR DESCRIPTION


### Contribution description

Found this was missing when trying to use `examples/sniffer` with the `nrf52840dk`. The solution was actually provided by @benpicco on the matrix channel.


### Testing procedure

Use the `examples/sniffer` following its README.


### Issues/PRs references

N/A.