### PR TITLE
drivers/mtd_default: fix for boards that define MTD_NUMOF

### DIFF
--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -55,6 +55,8 @@ extern "C" {
  */
 #define MTD_NUMOF           (MTD_BOARD_NUMOF + MTD_SDCARD_NUMOF + MTD_EMULATED_NUMOF)
 
+#else
+#define MTD_BOARD_NUMOF     MTD_NUMOF
 #endif /*  !defined(MTD_NUMOF) && !DOXYGEN */
 
 #if !DOXYGEN


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/drivers/mtd_raw` should work again for boards that define `MTD_NUMOF`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
