### PR TITLE
drivers/mtd_spi_nor: fix init when only ztimer_msec is used

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -27,12 +27,14 @@
 
 #include "byteorder.h"
 #include "kernel_defines.h"
+#include "macros/math.h"
 #include "macros/utils.h"
 #include "mtd.h"
 #include "mtd_spi_nor.h"
+#include "time_units.h"
 #include "thread.h"
 
-#if IS_USED(MODULE_ZTIMER_USEC)
+#if IS_USED(MODULE_ZTIMER)
 #include "ztimer.h"
 #elif IS_USED(MODULE_XTIMER)
 #include "xtimer.h"
@@ -451,6 +453,9 @@ static int mtd_spi_nor_power(mtd_dev_t *mtd, enum mtd_power_state power)
             do {
 #if IS_USED(MODULE_ZTIMER_USEC)
                 ztimer_sleep(ZTIMER_USEC, dev->params->wait_chip_wake_up);
+#elif IS_USED(MODULE_ZTIMER_MSEC)
+                ztimer_sleep(ZTIMER_MSEC,
+                             DIV_ROUND_UP(dev->params->wait_chip_wake_up, US_PER_MS));
 #elif IS_USED(MODULE_XTIMER)
                 xtimer_usleep(dev->params->wait_chip_wake_up);
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If only `ztimer_msec` (and not `ztimer_usec`) is used, the `mtd_spi_nor_power()` function will not execute the `wait_chip_wake_up` delay.

This causes `mtd_init()` to fail (and in a very annoying way: adding debug prints can cause enough of a delay that the init then works again).


### Testing procedure

`tests/drivers/mtd_raw`  should work with only `ztimer_msec`  instead of `ztimer_usec`.


### Issues/PRs references

wouldn't have happened if we had #19719
