### PR TITLE
drivers/at86rf215: switch example config to use EXT3 on same54-xpro 

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -333,6 +333,10 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         return -1;
     }
 
+    if (gpio_config[exti].cb) {
+        DEBUG("gpio: Warning - interrupt line %u already in use\n", exti);
+    }
+
     /* save callback */
     gpio_config[exti].cb = cb;
     gpio_config[exti].arg = arg;

--- a/drivers/at86rf215/include/at86rf215_params.h
+++ b/drivers/at86rf215/include/at86rf215_params.h
@@ -28,23 +28,23 @@ extern "C" {
 
 /**
  * @name    Set default configuration parameters for the AT86RF215 driver
- *          Example config for EXT1 on same54-xpro
+ *          Example config for EXT3 on same54-xpro
  * @{
  */
 #ifndef AT86RF215_PARAM_SPI
-#define AT86RF215_PARAM_SPI         (SPI_DEV(0))
+#define AT86RF215_PARAM_SPI         (SPI_DEV(1))
 #endif
 #ifndef AT86RF215_PARAM_SPI_CLK
 #define AT86RF215_PARAM_SPI_CLK     (SPI_CLK_5MHZ)
 #endif
 #ifndef AT86RF215_PARAM_CS
-#define AT86RF215_PARAM_CS          (GPIO_PIN(1, 28))
+#define AT86RF215_PARAM_CS          (GPIO_PIN(2, 14))
 #endif
 #ifndef AT86RF215_PARAM_INT
-#define AT86RF215_PARAM_INT         (GPIO_PIN(1, 7))
+#define AT86RF215_PARAM_INT         (GPIO_PIN(2, 30))
 #endif
 #ifndef AT86RF215_PARAM_RESET
-#define AT86RF215_PARAM_RESET       (GPIO_PIN(1, 8))
+#define AT86RF215_PARAM_RESET       (GPIO_PIN(3, 10))
 #endif
 
 #ifndef AT86RF215_PARAMS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Attaching the `at86rf215` reference module to a `same54-xpro` (via EXT1) stops working after 2a255ff3e80111682aac9df0e2a49974e770ba16 configured the PHY IRQ pin to produce interrupts.

This is because both the PHY IRQ (PD12) as well as the `at86rf215` IRQ (PB07) map to EXI7.
Whatever of the two pins gets configured last wins.


### Testing procedure

Attach the REB215-XPRO module to EXT3 on `same54-xpro`.
Frame reception should now work again even if `sam0_eth` is in use.


### Issues/PRs references

fixes #19911