### PR TITLE
boards: complete SD Card MTD definition for several bords

### DIFF
--- a/boards/common/esp32x/include/board_common.h
+++ b/boards/common/esp32x/include/board_common.h
@@ -103,11 +103,15 @@ extern "C" {
 #define SPI_FLASH_DRIVE_START  0
 #endif
 
-/** Default MTD drive definition */
-#define MTD_0 mtd0
+#define MTD_0 mtd0          /**< Flash MTD device */
+extern mtd_dev_t *mtd0;     /**< Flash MTD device pointer */
 
-/** Pointer to the default MTD drive structure */
-extern mtd_dev_t *mtd0;
+#if MODULE_MTD_SDCARD_DEFAULT || DOXYGEN
+
+#define MTD_1 mtd1          /**< SD Card MTD device */
+extern mtd_dev_t *mtd1;     /**< SD Card MTD device pointer */
+
+#endif /* MODULE_MTD_SDCARD_DEFAULT || DOXYGEN */
 
 /**
  * @brief   MTD offset for SD Card interfaces

--- a/boards/seeedstudio-gd32/include/board.h
+++ b/boards/seeedstudio-gd32/include/board.h
@@ -22,6 +22,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +66,25 @@ extern "C" {
 #define LED_RED_PIN         LED0_PIN    /**< LED0 is red */
 #define LED_GREEN_PIN       LED1_PIN    /**< LED1 is green */
 #define LED_BLUE_PIN        LED2_PIN    /**< LED2 is blue */
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+#define MTD_0 mtd0          /**< MTD device for SD Card */
+extern mtd_dev_t *mtd0;     /**< MTD device pointer for SD Card */
+/** @} */
+
+/**
+ * @name   SD-Card interface configuration
+ * @{
+ */
+#define SDCARD_SPI_PARAM_SPI         SPI_DEV(0)
+#define SDCARD_SPI_PARAM_CS          GPIO_PIN(PORT_B, 12)
+#define SDCARD_SPI_PARAM_CLK         GPIO_PIN(PORT_B, 13)
+#define SDCARD_SPI_PARAM_MISO        GPIO_PIN(PORT_B, 14)
+#define SDCARD_SPI_PARAM_MOSI        GPIO_PIN(PORT_B, 15)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/sipeed-longan-nano/include/board.h
+++ b/boards/sipeed-longan-nano/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,13 +63,24 @@ extern "C" {
 #define LED_BLUE_PIN        LED2_PIN    /**< LED2 is blue */
 /** @} */
 
-#if defined(MODULE_SDCARD_SPI)
+/**
+ * @name MTD configuration
+ * @{
+ */
+#define MTD_0 mtd0          /**< MTD device for SD Card */
+extern mtd_dev_t *mtd0;     /**< MTD device pointer for SD Card */
+/** @} */
+
+/**
+ * @name   SD-Card interface configuration
+ * @{
+ */
 #define SDCARD_SPI_PARAM_SPI         SPI_DEV(0)
 #define SDCARD_SPI_PARAM_CS          GPIO_PIN(PORT_B, 12)
 #define SDCARD_SPI_PARAM_CLK         GPIO_PIN(PORT_B, 13)
 #define SDCARD_SPI_PARAM_MISO        GPIO_PIN(PORT_B, 14)
 #define SDCARD_SPI_PARAM_MOSI        GPIO_PIN(PORT_B, 15)
-#endif
+/** @} */
 
 #if defined(MODULE_ST7735) && defined(BOARD_SIPEED_LONGAN_NANO_TFT)
 #define ST7735_PARAM_SPI          SPI_DEV(1)            /**< SPI device */

--- a/boards/waveshare-nrf52840-eval-kit/include/board.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,6 +81,14 @@ extern "C" {
 #define SDCARD_SPI_PARAM_CLK         GPIO_PIN(0, 17)
 #define SDCARD_SPI_PARAM_MOSI        GPIO_PIN(0, 24)
 #define SDCARD_SPI_PARAM_MISO        GPIO_PIN(0, 20)
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+#define MTD_0 mtd0          /**< MTD device for SD Card */
+extern mtd_dev_t *mtd0;     /**< MTD device pointer for SD Card */
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

This PR completes the MTD definition for the following boards:
- `seeedstudio-gd32`
- `sipeed-longan-nano` including `sipeed-longan-nano-tft`
- `waveshare-nrf52840-eval-kit`
- ESP32x boards that have an SPI SD Card interface and use `mtd_sdcard_default`

### Testing procedure

Green CI

### Issues/PRs references#19465 

Prerequisite for PR #19465 