### PR TITLE
drivers/lcd: support MCU 8080 8-bit parallel mode

### DIFF
--- a/drivers/ili9341/include/ili9341_params.h
+++ b/drivers/ili9341/include/ili9341_params.h
@@ -71,13 +71,45 @@ extern "C" {
 #define ILI9341_PARAM_OFFSET_Y          0               /**< Vertival offset */
 #endif
 
+#if MODULE_LCD_SPI || DOXYGEN
+/** Default interface params if SPI serial interface is enabled */
+#define ILI9341_PARAM_IF_SPI        .spi = ILI9341_PARAM_SPI, \
+                                    .spi_clk = ILI9341_PARAM_SPI_CLK, \
+                                    .spi_mode = ILI9341_PARAM_SPI_MODE,
+#else
+#define ILI9341_PARAM_IF_SPI
+#endif
+
+#if MODULE_LCD_PARALLEL || DOXYGEN
+/** Default interface params if MCU 8080 8-bit parallel interface is enabled */
+#define ILI9341_PARAM_IF_PAR        .d0_pin = ILI9341_PARAM_D0, \
+                                    .d1_pin = ILI9341_PARAM_D1, \
+                                    .d2_pin = ILI9341_PARAM_D2, \
+                                    .d3_pin = ILI9341_PARAM_D3, \
+                                    .d4_pin = ILI9341_PARAM_D4, \
+                                    .d5_pin = ILI9341_PARAM_D5, \
+                                    .d6_pin = ILI9341_PARAM_D6, \
+                                    .d7_pin = ILI9341_PARAM_D7, \
+                                    .wrx_pin = ILI9341_PARAM_WRX, \
+                                    .rdx_pin = ILI9341_PARAM_RDX,
+#else
+#define ILI9341_PARAM_IF_PAR
+#endif
+
 /**
  * @brief   Default params
+ *
+ * @note The default parameter set defined here can only be used if a single
+ *       ILI9341 display and only one interface mode is used. If multiple
+ *       ILI9341 displays are used or if multiple interface modes are enabled
+ *       by the modules `lcd_spi`, lcd_parallel and `lcd_parallel_16bit`, a user
+ *       defined parameter set @ref ILI9341_PARAMS has to be defined. In the
+ *       latter case @ref lcd_params_t::spi must then be set to @ref SPI_UNDEF
+ *       for displays with MCU 8080 8-/16-bit parallel interfaces.
  */
 #ifndef ILI9341_PARAMS
-#define ILI9341_PARAMS              { .spi = ILI9341_PARAM_SPI, \
-                                      .spi_clk = ILI9341_PARAM_SPI_CLK, \
-                                      .spi_mode = ILI9341_PARAM_SPI_MODE, \
+#define ILI9341_PARAMS              { ILI9341_PARAM_IF_SPI \
+                                      ILI9341_PARAM_IF_PAR \
                                       .cs_pin = ILI9341_PARAM_CS, \
                                       .dcx_pin = ILI9341_PARAM_DCX, \
                                       .rst_pin = ILI9341_PARAM_RST, \
@@ -123,7 +155,6 @@ static const uint8_t ili9341_screen_ids[] =
  * @brief   Define the number screens this display driver is attached to
  */
 #define ILI9341_SCREEN_NUMOF    ARRAY_SIZE(ili9341_screen_ids)
-
 
 #ifdef __cplusplus
 }

--- a/drivers/include/st77xx.h
+++ b/drivers/include/st77xx.h
@@ -22,8 +22,18 @@
  * @ref lcd_params_t::cntrl or as macro @ref ST77XX_PARAM_CNTRL if the
  * default parameter set @ref ST77XX_PARAMS is used.
  *
- * The driver uses the SPI serial interface to communicate with the display
- * controller.
+ * The driver communicates with the device either via an
+ *
+ * - SPI serial interface (if module `lcd_spi` enabled) or an
+ * - MCU 8080 8-/16-bit parallel interface (if module `lcd_parallel` or
+ *   module `lcd_parallel_16` is enabled).
+ *
+ * Usually the device driver is used either for a single display with SPI serial
+ * interface or for a display with parallel MCU 8080 8-/16-bit parallel
+ * interface. However, the device driver can also be used simultaneously for
+ * multiple displays with different interfaces if several of the `lcd_spi`,
+ * `lcd_parallel` and `lcd_parallel_16bit` modules are enabled at the same time.
+ * In this case, please refer to the notes in @ref lcd_params_t.
  *
  * The device requires colors to be send in big endian RGB-565 format. The
  * @ref CONFIG_LCD_LE_MODE compile time option can switch this, but only use this

--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -7,16 +7,56 @@
 
 config MODULE_LCD
     bool "LCD display driver"
-    depends on HAS_PERIPH_SPI
     depends on HAS_PERIPH_GPIO
     depends on TEST_KCONFIG
-    select MODULE_PERIPH_SPI
     select MODULE_PERIPH_GPIO
 
 config MODULE_LCD_MULTI_CNTRL
     bool
     help
         The controller-specific driver supports multiple controller variants.
+
+config MODULE_LCD_SPI
+    bool
+    default y if !MODULE_LCD_PARALLEL && !MODULE_LCD_PARALLEL_16BIT
+    default y if HAVE_LCD_SPI
+    depends on HAS_PERIPH_SPI
+    depends on MODULE_LCD
+    select MODULE_PERIPH_SPI
+    help
+        SPI serial interface is used
+
+config MODULE_LCD_PARALLEL
+    bool
+    default y if HAVE_LCD_PARALLEL || HAVE_LCD_PARALLEL_16BIT
+    depends on MODULE_LCD
+    help
+        MCU 8080 8-/16-bit parallel interface is used
+
+config MODULE_LCD_PARALLEL_16BIT
+    bool
+    default y if HAVE_LCD_PARALLEL_16BIT
+    depends on MODULE_LCD
+    help
+        MCU 8080 16-bit paralell interface is used
+
+config HAVE_LCD_SPI
+    bool
+    help
+        Indicates that a display with MCU 8080 8-/16-bit parallel interface
+        is present
+
+config HAVE_LCD_PARALLEL
+    bool
+    help
+        Indicates that a display with MCU 8080 8-/16-bit parallel interface
+        is present
+
+config HAVE_LCD_PARALLEL_16BIT
+    bool
+    help
+        Indicates that a display with MCU 8080 16-bit parallel interface
+        is present
 
 menuconfig KCONFIG_USEMODULE_LCD
     bool "Configure LCD driver"

--- a/drivers/lcd/Makefile.dep
+++ b/drivers/lcd/Makefile.dep
@@ -1,2 +1,14 @@
-FEATURES_REQUIRED += periph_spi
 FEATURES_REQUIRED += periph_gpio
+
+ifneq (,$(filter lcd_parallel_16bit,$(USEMODULE)))
+  USEMODULE += lcd_parallel
+endif
+
+ifeq (,$(filter lcd_parallel%,$(USEMODULE)))
+  # default to SPI serial interface if no MCU 8080 parallel interface is enabled
+  USEMODULE += lcd_spi
+endif
+
+ifneq (,$(filter lcd_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
+endif

--- a/drivers/lcd/Makefile.include
+++ b/drivers/lcd/Makefile.include
@@ -1,4 +1,8 @@
 PSEUDOMODULES += lcd_multi_cntrl
 
+PSEUDOMODULES += lcd_spi
+PSEUDOMODULES += lcd_parallel
+PSEUDOMODULES += lcd_parallel_16bit
+
 USEMODULE_INCLUDES_lcd := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_lcd)

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -25,9 +25,12 @@
 #include <assert.h>
 #include <string.h>
 #include "byteorder.h"
-#include "periph/spi.h"
 #include "kernel_defines.h"
 #include "ztimer.h"
+
+#if IS_USED(MODULE_LCD_SPI)
+#include "periph/spi.h"
+#endif
 
 #include "lcd.h"
 #include "lcd_internal.h"
@@ -35,33 +38,136 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-static inline void lcd_ll_write_byte(const lcd_t *dev, bool cont, uint8_t data)
+#if IS_USED(MODULE_LCD_PARALLEL)
+
+#if MODULE_LCD_PARALLEL_16BIT
+#error "MCU 8080 16-bit parallel interface is not supported yet"
+#endif
+
+static void lcd_ll_par_write_byte(lcd_t *dev, bool cont, uint8_t out)
 {
+    if (gpio_is_valid(dev->params->cs_pin)) {
+        gpio_clear(dev->params->cs_pin);
+    }
+
+    gpio_clear(dev->params->wrx_pin);
+
+    gpio_write(dev->params->d0_pin, out & 0x01);
+    gpio_write(dev->params->d1_pin, out & 0x02);
+    gpio_write(dev->params->d2_pin, out & 0x04);
+    gpio_write(dev->params->d3_pin, out & 0x08);
+    gpio_write(dev->params->d4_pin, out & 0x10);
+    gpio_write(dev->params->d5_pin, out & 0x20);
+    gpio_write(dev->params->d6_pin, out & 0x40);
+    gpio_write(dev->params->d7_pin, out & 0x80);
+
+    gpio_set(dev->params->wrx_pin);
+
+    if (gpio_is_valid(dev->params->cs_pin) && !cont) {
+        gpio_set(dev->params->cs_pin);
+    };
+}
+
+static uint8_t lcd_ll_par_read_byte(lcd_t *dev, bool cont)
+{
+    uint8_t in = 0;
+
+    if (gpio_is_valid(dev->params->cs_pin)) {
+        gpio_clear(dev->params->cs_pin);
+    }
+
+    gpio_clear(dev->params->rdx_pin);
+
+    in |= gpio_read(dev->params->d0_pin) ? 0x01 : 0;
+    in |= gpio_read(dev->params->d1_pin) ? 0x02 : 0;
+    in |= gpio_read(dev->params->d2_pin) ? 0x04 : 0;
+    in |= gpio_read(dev->params->d3_pin) ? 0x08 : 0;
+    in |= gpio_read(dev->params->d4_pin) ? 0x10 : 0;
+    in |= gpio_read(dev->params->d5_pin) ? 0x20 : 0;
+    in |= gpio_read(dev->params->d6_pin) ? 0x40 : 0;
+    in |= gpio_read(dev->params->d7_pin) ? 0x80 : 0;
+
+    gpio_set(dev->params->rdx_pin);
+
+    if (gpio_is_valid(dev->params->cs_pin) && !cont) {
+        gpio_set(dev->params->cs_pin);
+    };
+
+    return in;
+}
+
+static void lcd_ll_par_read_bytes(lcd_t *dev, bool cont,
+                                  void *data, size_t len)
+{
+    assert(len);
+
+    uint8_t *data_in = data;
+
+    for (size_t i = 0; i < len; i++) {
+        data_in[i] = lcd_ll_par_read_byte(dev, i == (len - 1) ? cont : true);
+    }
+}
+
+static void lcd_ll_par_write_bytes(lcd_t *dev, bool cont,
+                                   const void *data, size_t len)
+{
+    assert(len);
+
+    const uint8_t *data_out = data;
+
+    for (size_t i = 0; i < len; i++) {
+        lcd_ll_par_write_byte(dev, i == (len - 1) ? cont : true, data_out[i]);
+    }
+}
+
+#endif /* IS_USED(MODULE_LCD_PARALLEL) */
+
+static inline void lcd_ll_write_byte(lcd_t *dev, bool cont, uint8_t data)
+{
+#if IS_USED(MODULE_LCD_SPI)
     if (dev->params->spi != SPI_UNDEF) {
         /* SPI serial interface is used */
         spi_transfer_byte(dev->params->spi, dev->params->cs_pin, cont, data);
     }
     else {
+#endif
+#if IS_USED(MODULE_LCD_PARALLEL)
+        /* MCU 8080 8-/16-bit parallel interface is used */
+        lcd_ll_par_write_byte(dev, cont, data);
+#else
         assert(false);
+#endif
+#if IS_USED(MODULE_LCD_SPI)
     }
+#endif
 }
 
-static inline void lcd_ll_write_bytes(const lcd_t *dev, bool cont,
+static inline void lcd_ll_write_bytes(lcd_t *dev, bool cont,
                                       const void *data, size_t len)
 {
+#if IS_USED(MODULE_LCD_SPI)
     if (dev->params->spi != SPI_UNDEF) {
         /* SPI serial interface is used */
         spi_transfer_bytes(dev->params->spi,
                            dev->params->cs_pin, cont, data, NULL, len);
     }
     else {
+#endif
+#if IS_USED(MODULE_LCD_PARALLEL)
+        /* MCU 8080 8-/16-bit parallel interface is used */
+        lcd_ll_par_write_bytes(dev, cont, data, len);
+#else
         assert(false);
+#endif
+#if IS_USED(MODULE_LCD_SPI)
     }
+#endif
 }
 
-static inline void lcd_ll_read_bytes(const lcd_t *dev, bool cont,
+static inline void lcd_ll_read_bytes(lcd_t *dev, bool cont,
                                      void *data, size_t len)
 {
+#if IS_USED(MODULE_LCD_SPI)
     if (dev->params->spi != SPI_UNDEF) {
         /* SPI serial interface is used */
         /* Dummy read */
@@ -71,18 +177,49 @@ static inline void lcd_ll_read_bytes(const lcd_t *dev, bool cont,
                            dev->params->cs_pin, cont, NULL, data, len);
     }
     else {
+#endif
+#if IS_USED(MODULE_LCD_PARALLEL)
+        /* MCU 8080 8-/16-bit parallel interface is used */
+
+        /* switch GPIO mode to input */
+        gpio_init(dev->params->d0_pin, GPIO_IN);
+        gpio_init(dev->params->d1_pin, GPIO_IN);
+        gpio_init(dev->params->d2_pin, GPIO_IN);
+        gpio_init(dev->params->d3_pin, GPIO_IN);
+        gpio_init(dev->params->d4_pin, GPIO_IN);
+        gpio_init(dev->params->d5_pin, GPIO_IN);
+        gpio_init(dev->params->d6_pin, GPIO_IN);
+        gpio_init(dev->params->d7_pin, GPIO_IN);
+
+        /* Dummy read */
+        lcd_ll_par_read_byte(dev, true);
+        lcd_ll_par_read_bytes(dev, cont, data, len);
+
+        /* switch GPIO mode back to output */
+        gpio_init(dev->params->d0_pin, GPIO_OUT);
+        gpio_init(dev->params->d1_pin, GPIO_OUT);
+        gpio_init(dev->params->d2_pin, GPIO_OUT);
+        gpio_init(dev->params->d3_pin, GPIO_OUT);
+        gpio_init(dev->params->d4_pin, GPIO_OUT);
+        gpio_init(dev->params->d5_pin, GPIO_OUT);
+        gpio_init(dev->params->d6_pin, GPIO_OUT);
+        gpio_init(dev->params->d7_pin, GPIO_OUT);
+#else
         assert(false);
+#endif
+#if IS_USED(MODULE_LCD_SPI)
     }
+#endif
 }
 
-static void lcd_ll_cmd_start(const lcd_t *dev, uint8_t cmd, bool cont)
+static void lcd_ll_cmd_start(lcd_t *dev, uint8_t cmd, bool cont)
 {
     gpio_clear(dev->params->dcx_pin);
     lcd_ll_write_byte(dev, cont, cmd);
     gpio_set(dev->params->dcx_pin);
 }
 
-static void lcd_ll_set_area_default(const lcd_t *dev, uint16_t x1, uint16_t x2,
+static void lcd_ll_set_area_default(lcd_t *dev, uint16_t x1, uint16_t x2,
                                     uint16_t y1, uint16_t y2)
 {
     be_uint16_t params[2];
@@ -106,7 +243,7 @@ static void lcd_ll_set_area_default(const lcd_t *dev, uint16_t x1, uint16_t x2,
                      sizeof(params));
 }
 
-static void lcd_ll_set_area(const lcd_t *dev, uint16_t x1, uint16_t x2,
+static void lcd_ll_set_area(lcd_t *dev, uint16_t x1, uint16_t x2,
                             uint16_t y1, uint16_t y2)
 {
     if (dev->driver->set_area) {
@@ -117,30 +254,48 @@ static void lcd_ll_set_area(const lcd_t *dev, uint16_t x1, uint16_t x2,
     }
 }
 
-void lcd_ll_acquire(const lcd_t *dev)
+void lcd_ll_acquire(lcd_t *dev)
 {
+#if IS_USED(MODULE_LCD_SPI)
     if (dev->params->spi != SPI_UNDEF) {
         /* SPI serial interface is used */
         spi_acquire(dev->params->spi, dev->params->cs_pin,
                     dev->params->spi_mode, dev->params->spi_clk);
     }
     else {
+#endif
+#if IS_USED(MODULE_LCD_PARALLEL)
+        /* MCU 8080 8-/16-bit parallel interface is used */
+        mutex_lock(&dev->lock);
+#else
         assert(false);
+#endif
+#if IS_USED(MODULE_LCD_SPI)
     }
+#endif
 }
 
-void lcd_ll_release(const lcd_t *dev)
+void lcd_ll_release(lcd_t *dev)
 {
+#if IS_USED(MODULE_LCD_SPI)
     if (dev->params->spi != SPI_UNDEF) {
         /* SPI serial interface is used */
         spi_release(dev->params->spi);
     }
     else {
+#endif
+#if IS_USED(MODULE_LCD_PARALLEL)
+        /* MCU 8080 8-/16-bit parallel interface is used */
+        mutex_unlock(&dev->lock);
+#else
         assert(false);
+#endif
+#if IS_USED(MODULE_LCD_SPI)
     }
+#endif
 }
 
-void lcd_ll_write_cmd(const lcd_t *dev, uint8_t cmd, const uint8_t *data,
+void lcd_ll_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
                       size_t len)
 {
     lcd_ll_cmd_start(dev, cmd, len ? true : false);
@@ -149,7 +304,7 @@ void lcd_ll_write_cmd(const lcd_t *dev, uint8_t cmd, const uint8_t *data,
     }
 }
 
-void lcd_ll_read_cmd(const lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
+void lcd_ll_read_cmd(lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
 {
     assert(len);
     lcd_ll_cmd_start(dev, cmd, len ? true : false);
@@ -163,6 +318,7 @@ int lcd_init(lcd_t *dev, const lcd_params_t *params)
     assert(gpio_is_valid(dev->params->dcx_pin));
     gpio_init(dev->params->dcx_pin, GPIO_OUT);
 
+#if IS_USED(MODULE_LCD_SPI)
     if (dev->params->spi != SPI_UNDEF) {
         /* SPI serial interface is used */
         int res = spi_init_cs(dev->params->spi, dev->params->cs_pin);
@@ -173,8 +329,50 @@ int lcd_init(lcd_t *dev, const lcd_params_t *params)
         }
     }
     else {
-       assert(false);
+#endif
+#if IS_USED(MODULE_LCD_PARALLEL)
+        /* MCU 8080 8-/16-bit parallel interface is used */
+        if (gpio_is_valid(dev->params->cs_pin)) {
+            gpio_init(dev->params->cs_pin, GPIO_OUT);
+            gpio_set(dev->params->cs_pin);
+        }
+
+        assert(gpio_is_valid(dev->params->wrx_pin));
+        gpio_init(dev->params->wrx_pin, GPIO_OUT);
+        gpio_set(dev->params->wrx_pin);
+
+        if (gpio_is_valid(dev->params->wrx_pin)) {
+            gpio_init(dev->params->wrx_pin, GPIO_OUT);
+            gpio_set(dev->params->wrx_pin);
+        }
+
+        if (gpio_is_valid(dev->params->rdx_pin)) {
+            gpio_init(dev->params->rdx_pin, GPIO_OUT);
+            gpio_set(dev->params->rdx_pin);
+        }
+
+        assert(gpio_is_valid(dev->params->d0_pin));
+        assert(gpio_is_valid(dev->params->d1_pin));
+        assert(gpio_is_valid(dev->params->d2_pin));
+        assert(gpio_is_valid(dev->params->d3_pin));
+        assert(gpio_is_valid(dev->params->d4_pin));
+        assert(gpio_is_valid(dev->params->d5_pin));
+        assert(gpio_is_valid(dev->params->d6_pin));
+        assert(gpio_is_valid(dev->params->d7_pin));
+        gpio_init(dev->params->d0_pin, GPIO_OUT);
+        gpio_init(dev->params->d1_pin, GPIO_OUT);
+        gpio_init(dev->params->d2_pin, GPIO_OUT);
+        gpio_init(dev->params->d3_pin, GPIO_OUT);
+        gpio_init(dev->params->d4_pin, GPIO_OUT);
+        gpio_init(dev->params->d5_pin, GPIO_OUT);
+        gpio_init(dev->params->d6_pin, GPIO_OUT);
+        gpio_init(dev->params->d7_pin, GPIO_OUT);
+#else
+        assert(false);
+#endif
+#if IS_USED(MODULE_LCD_SPI)
     }
+#endif
 
     if (gpio_is_valid(dev->params->rst_pin)) {
         gpio_init(dev->params->rst_pin, GPIO_OUT);
@@ -184,12 +382,16 @@ int lcd_init(lcd_t *dev, const lcd_params_t *params)
     }
     ztimer_sleep(ZTIMER_MSEC, 120);
 
+#if IS_USED(MODULE_LCD_PARALLEL)
+    mutex_init(&dev->lock);
+#endif
+
     /* controller-specific init function has to be defined */
     assert(dev->driver->init);
     return dev->driver->init(dev, params);
 }
 
-void lcd_write_cmd(const lcd_t *dev, uint8_t cmd, const uint8_t *data,
+void lcd_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
                    size_t len)
 {
     lcd_ll_acquire(dev);
@@ -197,14 +399,14 @@ void lcd_write_cmd(const lcd_t *dev, uint8_t cmd, const uint8_t *data,
     lcd_ll_release(dev);
 }
 
-void lcd_read_cmd(const lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
+void lcd_read_cmd(lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
 {
     lcd_ll_acquire(dev);
     lcd_ll_read_cmd(dev, cmd, data, len);
     lcd_ll_release(dev);
 }
 
-void lcd_fill(const lcd_t *dev, uint16_t x1, uint16_t x2, uint16_t y1,
+void lcd_fill(lcd_t *dev, uint16_t x1, uint16_t x2, uint16_t y1,
               uint16_t y2, uint16_t color)
 {
     /* Send fill area to the display */
@@ -234,7 +436,7 @@ void lcd_fill(const lcd_t *dev, uint16_t x1, uint16_t x2, uint16_t y1,
     lcd_ll_release(dev);
 }
 
-void lcd_pixmap(const lcd_t *dev, uint16_t x1, uint16_t x2,
+void lcd_pixmap(lcd_t *dev, uint16_t x1, uint16_t x2,
                 uint16_t y1, uint16_t y2, const uint16_t *color)
 {
     size_t num_pix = (x2 - x1 + 1) * (y2 - y1 + 1);
@@ -266,7 +468,7 @@ void lcd_pixmap(const lcd_t *dev, uint16_t x1, uint16_t x2,
     lcd_ll_release(dev);
 }
 
-void lcd_invert_on(const lcd_t *dev)
+void lcd_invert_on(lcd_t *dev)
 {
     uint8_t command = (dev->params->inverted) ? LCD_CMD_DINVOFF
                                               : LCD_CMD_DINVON;
@@ -274,7 +476,7 @@ void lcd_invert_on(const lcd_t *dev)
     lcd_write_cmd(dev, command, NULL, 0);
 }
 
-void lcd_invert_off(const lcd_t *dev)
+void lcd_invert_off(lcd_t *dev)
 {
     uint8_t command = (dev->params->inverted) ? LCD_CMD_DINVON
                                               : LCD_CMD_DINVOFF;
@@ -282,7 +484,7 @@ void lcd_invert_off(const lcd_t *dev)
     lcd_write_cmd(dev, command, NULL, 0);
 }
 
-void lcd_set_brightness(const lcd_t *dev, uint8_t brightness)
+void lcd_set_brightness(lcd_t *dev, uint8_t brightness)
 {
     lcd_write_cmd(dev, LCD_CMD_WRDISBV, &brightness, 1);
     uint8_t param = 0x26;

--- a/drivers/lcd/lcd_disp_dev.c
+++ b/drivers/lcd/lcd_disp_dev.c
@@ -57,7 +57,7 @@ static uint8_t _lcd_color_depth(const disp_dev_t *disp_dev)
 
 static void _lcd_set_invert(const disp_dev_t *disp_dev, bool invert)
 {
-    const lcd_t *dev = (lcd_t *)disp_dev;
+    lcd_t *dev = (lcd_t *)disp_dev;
 
     assert(dev);
 

--- a/drivers/st77xx/include/st77xx_params.h
+++ b/drivers/st77xx/include/st77xx_params.h
@@ -137,14 +137,46 @@ extern "C" {
 #define ST77XX_PARAM_OFFSET_Y       0               /**< Vertival offset */
 #endif
 
+#if MODULE_LCD_SPI || DOXYGEN
+/** Default interface params if SPI serial interface is enabled */
+#define ST77XX_PARAM_IF_SPI         .spi = ST77XX_PARAM_SPI, \
+                                    .spi_clk = ST77XX_PARAM_SPI_CLK, \
+                                    .spi_mode = ST77XX_PARAM_SPI_MODE,
+#else
+#define ST77XX_PARAM_IF_SPI
+#endif
+
+#if MODULE_LCD_PARALLEL || DOXYGEN
+/** Default interface params if MCU 8080 8-bit parallel interface is enabled */
+#define ST77XX_PARAM_IF_PAR         .d0_pin = ST77XX_PARAM_D0, \
+                                    .d1_pin = ST77XX_PARAM_D1, \
+                                    .d2_pin = ST77XX_PARAM_D2, \
+                                    .d3_pin = ST77XX_PARAM_D3, \
+                                    .d4_pin = ST77XX_PARAM_D4, \
+                                    .d5_pin = ST77XX_PARAM_D5, \
+                                    .d6_pin = ST77XX_PARAM_D6, \
+                                    .d7_pin = ST77XX_PARAM_D7, \
+                                    .wrx_pin = ST77XX_PARAM_WRX, \
+                                    .rdx_pin = ST77XX_PARAM_RDX,
+#else
+#define ST77XX_PARAM_IF_PAR
+#endif
+
 /**
  * @brief   Default params
+ *
+ * @note The default parameter set defined here can only be used if a single
+ *       ST77xx display and only one interface mode is used. If multiple
+ *       ST77xx displays are used or if multiple interface modes are enabled
+ *       by the modules `lcd_spi`, lcd_parallel and `lcd_parallel_16bit`, a user
+ *       defined parameter set @ref ST77XX_PARAMS has to be defined. In the
+ *       latter case @ref lcd_params_t::spi must then be set to @ref SPI_UNDEF
+ *       for displays with MCU 8080 8-/16-bit parallel interfaces.
  */
 #ifndef ST77XX_PARAMS
 #define ST77XX_PARAMS              {  .cntrl = ST77XX_PARAM_CNTRL, \
-                                      .spi = ST77XX_PARAM_SPI, \
-                                      .spi_clk = ST77XX_PARAM_SPI_CLK, \
-                                      .spi_mode = ST77XX_PARAM_SPI_MODE, \
+                                      ST77XX_PARAM_IF_SPI \
+                                      ST77XX_PARAM_IF_PAR \
                                       .cs_pin = ST77XX_PARAM_CS, \
                                       .dcx_pin = ST77XX_PARAM_DCX, \
                                       .rst_pin = ST77XX_PARAM_RST, \
@@ -156,7 +188,7 @@ extern "C" {
                                       .offset_x = ST77XX_PARAM_OFFSET_X, \
                                       .offset_y = ST77XX_PARAM_OFFSET_Y, \
                                     }
-#endif
+#endif /* ST77XX_PARAMS */
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

LCD driver ICs usually support
- SPI serial mode,
- MCU 8080 8-bit parallel mode and
- MCU 8080 16-bit parallel mode.

This PR extends the LCD display driver API to support the MCU 8080 8-/16-bit parallel modes and implements a GPIO-driven MCU 8080 8-bit parallel mode.

The following features are already working locally and will be provided as follow-on PRs for which this PR is a prerequisite.

- GPIO-driven bit-banging implementation of the 16-bit mode of the MCU 8080 parallel interface
- Enabling the display on `stm32f723e-disco` and `stm32l496g-disco` using the feature above
- Definition of a low-level API for the parallel modes using the LCD controller of the MCU
- Using FMC for the display on `stm32f723e-disco` and `stm32l496g-disco`
- Using LCD controller for the display of `esp32-wt32-sc01-plus` (PR #19917)

### Testing procedure

The PR can be tested with PR #19917 on top of this PR.
```
BOARD=esp32s3-wt32-sc01-plus make -j8 -C tests/drivers/st77xx flash
```
The following video shows the test.

**Please note** The test is pretty slow because the display has 480 x 320 pixels and the MCU 8080 8-bit parallel interface is realized by a GPIO-driven bit-banging implementation where each GPIO of the data bus is set separately. A follow-up PR will use the ESP32-S3 LCD controller and DMA for this board. This PR just defines the extension of the driver by the parallel interface and provides the bit-banging implementation for MCUs that don't have a LCD controller on chip.

https://github.com/RIOT-OS/RIOT/assets/31932013/c1e3e3d7-05d9-4ca5-8fff-9a5eaca50fba

### Issues/PRs references