### PR TITLE
checkout before kconfig external modules

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -822,7 +822,7 @@ all $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
 .PHONY: pkg-prepare pkg-build
 pkg-prepare:
 	-@$(foreach dir,$(PKG_PATHS),"$(MAKE)" -C $(dir) prepare $(NEWLINE))
-
+export pkg-prepare
 pkg-build: $(BUILDDEPS)
 	$(foreach dir,$(PKG_PATHS),$(QQ)"$(MAKE)" -C $(dir) $(NEWLINE))
 

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -193,7 +193,7 @@ EXTERNAL_MODULE_KCONFIGS ?= $(sort $(foreach dir,$(EXTERNAL_MODULE_DIRS),\
 # Build a Kconfig file that source all external modules configuration
 # files. Every EXTERNAL_MODULE_DIRS with a Kconfig file is written to
 # KCONFIG_EXTERNAL_MODULE_CONFIGS as 'osource dir/Kconfig'
-$(KCONFIG_EXTERNAL_MODULE_CONFIGS): FORCE | $(GENERATED_DIR)
+$(KCONFIG_EXTERNAL_MODULE_CONFIGS): pkg-prepare FORCE | $(GENERATED_DIR)
 	$(Q)\
 	if [ -n "$(EXTERNAL_MODULE_KCONFIGS)" ] ; then  \
 		printf "%s\n" $(EXTERNAL_MODULE_KCONFIGS) \


### PR DESCRIPTION


### Contribution description

Moves checkout of external modules ahead of GENCONFIG calls in order to allow for external kconfig options to be visible. This specifically allows for individual RIOT applications to have a saved app.config file that can Kconfig options that may exist only in external packages (such as LVGL). On a fresh clone of RIOT, where the build directory (and subsequently external modules/pkgs) may not exist, this app.config file would throw an error regarding undefined Kconfig options.

This moves checkout of external modules/packages ahead of Kconfig calls which allows for packages to be checked out prior, and thus allowing RIOTs genconfig call visibility to options that would otherwise not exist.


### Testing procedure

Have an application and external pkg with a Kconfig menu. Set some subset of keys that only exist within that Kconfig and save.
Create a fresh clone, or empty the build directory in RIOT and build

RIOTs LVGL package is a prime example of this, where LVGL has a set of kconfig menu options that only exist within LVGLs repo, but can be saved on an individual application - on a fresh build directory, such as in a build pipeline, the saved config options from LVGL will be seen as undefined Kconfig options until after LVGL has been checked out into RIOT/build/pkg. This fix allows RIOTs genconfig/kconfig menu to have visibility to config options such as these by checkout out external packages before collection of external modules/pkgs


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/issues/19913
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
