### PR TITLE
drivers/lcd: add CMD sequence feature

### DIFF
--- a/drivers/ili9341/include/ili9341_params.h
+++ b/drivers/ili9341/include/ili9341_params.h
@@ -121,6 +121,20 @@ extern "C" {
 #define ILI9341_PARAM_IF_MODE
 #endif
 
+#if MODULE_LCD_INIT_SEQUENCE || DOXYGEN
+#ifndef ILI9341_PARAM_INIT_SEQ
+#define ILI9341_PARAM_INIT_SEQ      (NULL)  /**< Init sequence not used by default */
+#endif
+#ifndef ILI9341_PARAM_INIT_SEQ_LEN
+#define ILI9341_PARAM_INIT_SEQ_LEN  0       /**< Init sequence length is 0 by default */
+#endif
+/** Additional default parameters if init sequence is enabled */
+#define ILI9341_PARAMS_INIT         .init_seq = ILI9341_PARAM_INIT_SEQ, \
+                                    .init_seq_len = ILI9341_PARAM_INIT_SEQ_LEN,
+#else /* MODULE_LCD_INIT_SEQUENCE */
+#define ILI9341_PARAMS_INIT
+#endif /* MODULE_LCD_INIT_SEQUENCE */
+
 /**
  * @brief   Default params
  *
@@ -147,6 +161,7 @@ extern "C" {
                                       .rotation = ILI9341_PARAM_ROTATION, \
                                       .offset_x = ILI9341_PARAM_OFFSET_X, \
                                       .offset_y = ILI9341_PARAM_OFFSET_Y, \
+                                      ILI9341_PARAMS_INIT \
 }
 #endif
 /** @} */

--- a/drivers/include/lcd.h
+++ b/drivers/include/lcd.h
@@ -389,17 +389,17 @@ void lcd_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
  * - n bytes the parameters of the command.
  *
  * If @ref LCD_DELAY is used as the command index, the command is not sent
- * to the display controller, but a delay is inserted, where the length
- * in the CLP tuple then defines the delay in milliseconds.
+ * to the display controller, but a delay is inserted, where the length in the
+ * CLP tuple must be 1 and the value then defines the delay in milliseconds.
  *
  * The following example shows the initialization sequence for a display
  * with a ST7789:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
  * static const uint8_t st7789_default_init[] =  {
  *     LCD_CMD_SWRESET, 0,              // Soft Reset
- *     LCD_DELAY, 120,                  // Soft Reset needs 120 ms if in Sleep In mode
+ *     LCD_DELAY, 1, 120,               // Soft Reset needs 120 ms if in Sleep In mode
  *     LCD_CMD_SLPOUT, 0,               // Sleep Out leave Sleep In state after reset
- *     LCD_DELAY, 120,                  // Sleep Out needs 120 ms
+ *     LCD_DELAY, 1, 120,               // Sleep Out needs 120 ms
  *     LCD_CMD_VCOMS, 1, 0x20,          // VCOM=0.9V
  *     LCD_CMD_VRHS, 1, 0x0b,           // VRH=4.1V
  *     LCD_CMD_VDVS, 1, 0x20,           // VDV=0V
@@ -416,7 +416,7 @@ void lcd_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
  *     LCD_CMD_DINVON, 0,               // enable Inversion, reset default is off
  *     LCD_CMD_SLPOUT, 0,               // Sleep out (turn off sleep mode)
  *     LCD_CMD_NORON, 0,                // Normal display mode on
- *     LCD_DELAY, 1,
+ *     LCD_DELAY, 1, 1,
  *     LCD_CMD_DISPON, 0,               // Display on
  * };
  *

--- a/drivers/include/lcd.h
+++ b/drivers/include/lcd.h
@@ -427,7 +427,7 @@ void lcd_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
  * @param[in]   seq     command sequence of CLP tuples as a sequence of bytes
  * @param[in]   seq_len length of the command sequence
  */
-void lcd_write_cmd_sequence(const lcd_t *dev, const uint8_t *seq, size_t seq_len);
+void lcd_write_cmd_sequence(lcd_t *dev, const uint8_t *seq, size_t seq_len);
 
 /**
  * @brief   Raw read command

--- a/drivers/include/lcd.h
+++ b/drivers/include/lcd.h
@@ -150,7 +150,7 @@ typedef  struct {
                                      False when display is connected in BGR mode */
     bool inverted;              /**< Display works in inverted color mode */
     uint16_t lines;             /**< Number of lines, from 16 to the number of
-                                     lines supported by the driver IC in 8 line
+                                     lines supported by the controller in 8 line
                                      steps */
     uint16_t rgb_channels;      /**< Display rgb channels */
     uint8_t rotation;           /**< Display rotation mode */
@@ -161,6 +161,13 @@ typedef  struct {
                                      specific driver supports multiple
                                      controller variants */
 #endif
+#if MODULE_LCD_INIT_SEQUENCE || DOXYGEN
+    const uint8_t *init_seq;    /**< Init command sequence that is executed if
+                                     not NULL in @ref lcd_init instead of the
+                                     controller-specific driver init function
+                                     @ref lcd_driver_t::init */
+    size_t init_seq_len;        /**< Init sequence length */
+#endif /* MODULE_LCD_INIT_SEQUENCE */
 } lcd_params_t;
 
 /**
@@ -303,6 +310,12 @@ void lcd_ll_set_area(lcd_t *dev, uint16_t x1, uint16_t x2, uint16_t y1, uint16_t
  */
 /**
  * @brief   Setup an LCD display device
+ *
+ * Initializes the controller interface and performs the initialization
+ * of the controller. For the latter either the controller-specific @ref
+ * lcd_driver_t::init function is called or the @ref lcd_params_t::init_seq
+ * is used if defined. For details about the format of the command sequence
+ * in @ref lcd_params_t::init_seq, see @ref lcd_write_cmd_sequence.
  *
  * @param[in]   dev     device descriptor
  * @param[in]   params  parameters for device initialization

--- a/drivers/lcd/Makefile.include
+++ b/drivers/lcd/Makefile.include
@@ -4,6 +4,7 @@ PSEUDOMODULES += lcd_spi
 PSEUDOMODULES += lcd_parallel
 PSEUDOMODULES += lcd_parallel_16bit
 PSEUDOMODULES += lcd_parallel_ll_mcu
+PSEUDOMODULES += lcd_init_sequence
 
 USEMODULE_INCLUDES_lcd := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_lcd)

--- a/drivers/lcd/include/lcd_internal.h
+++ b/drivers/lcd/include/lcd_internal.h
@@ -77,6 +77,8 @@ extern "C" {
 #define LCD_PIXSET_16BIT        0x55    /**< MCU and RGB 16 bit interface */
 #define LCD_PIXSET_18BIT        0x66    /**< MCU and RGB 18 bit interface (not implemented) */
 
+#define LCD_DELAY               0x80    /**< Driver delay command */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -394,7 +394,7 @@ void lcd_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
     lcd_ll_release(dev);
 }
 
-void lcd_write_cmd_sequence(const lcd_t *dev, const uint8_t *seq, size_t seq_len)
+void lcd_write_cmd_sequence(lcd_t *dev, const uint8_t *seq, size_t seq_len)
 {
     assert(seq_len > 0);
     assert(seq);
@@ -428,7 +428,7 @@ void lcd_write_cmd_sequence(const lcd_t *dev, const uint8_t *seq, size_t seq_len
     lcd_ll_release(dev);
 }
 
-void lcd_read_cmd(const lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
+void lcd_read_cmd(lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
 {
     lcd_ll_acquire(dev);
     lcd_ll_read_cmd(dev, cmd, data, len);

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -372,6 +372,15 @@ int lcd_init(lcd_t *dev, const lcd_params_t *params)
     }
     ztimer_sleep(ZTIMER_MSEC, 120);
 
+#if IS_USED(MODULE_LCD_INIT_SEQUENCE)
+    if (dev->params->init_seq && dev->params->init_seq_len) {
+        lcd_write_cmd_sequence(dev,
+                               dev->params->init_seq,
+                               dev->params->init_seq_len);
+        return 0;
+    }
+#endif
+
     /* controller-specific init function has to be defined */
     assert(dev->driver->init);
     return dev->driver->init(dev, params);

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -409,9 +409,9 @@ void lcd_write_cmd_sequence(const lcd_t *dev, const uint8_t *seq, size_t seq_len
         uint8_t num = seq[idx++];
 
         if (cmd == LCD_DELAY) {
-            /* in case of delay command, the number of parameters represents the
-             * delay in ms */
-            ztimer_sleep(ZTIMER_MSEC, num);
+            /* in case of delay command, the number of parameters is 1 */
+            assert(1);
+            ztimer_sleep(ZTIMER_MSEC, seq[idx++]);
             continue;
         }
 

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -399,7 +399,7 @@ void lcd_write_cmd_sequence(lcd_t *dev, const uint8_t *seq, size_t seq_len)
     assert(seq_len > 0);
     assert(seq);
 
-    DEBUG("[%s] %p %u\n", __func__, (void *)seq, seq_len);
+    DEBUG("[%s] %p %zu\n", __func__, (void *)seq, seq_len);
 
     lcd_ll_acquire(dev);
 

--- a/drivers/st77xx/include/st77xx_params.h
+++ b/drivers/st77xx/include/st77xx_params.h
@@ -187,6 +187,20 @@ extern "C" {
 #define ST77XX_PARAM_IF_MODE
 #endif
 
+#if MODULE_LCD_INIT_SEQUENCE || DOXYGEN
+#ifndef ST77XX_PARAM_INIT_SEQ
+#define ST77XX_PARAM_INIT_SEQ       (NULL)  /**< Init sequence not used by default */
+#endif
+#ifndef ST77XX_PARAM_INIT_SEQ_LEN
+#define ST77XX_PARAM_INIT_SEQ_LEN   0       /**< Init sequence length is 0 by default */
+#endif
+/** Additional default parameters if init sequence is enabled */
+#define ST77XX_PARAMS_INIT          .init_seq = ST77XX_PARAM_INIT_SEQ, \
+                                    .init_seq_len = ST77XX_PARAM_INIT_SEQ_LEN,
+#else /* MODULE_LCD_INIT_SEQUENCE */
+#define ST77XX_PARAMS_INIT
+#endif /* MODULE_LCD_INIT_SEQUENCE */
+
 /**
  * @brief   Default params
  *
@@ -214,6 +228,7 @@ extern "C" {
                                       .rotation = ST77XX_PARAM_ROTATION, \
                                       .offset_x = ST77XX_PARAM_OFFSET_X, \
                                       .offset_y = ST77XX_PARAM_OFFSET_Y, \
+                                      ST77XX_PARAMS_INIT \
                                     }
 #endif /* ST77XX_PARAMS */
 /** @} */

--- a/tests/drivers/st77xx/main.c
+++ b/tests/drivers/st77xx/main.c
@@ -41,9 +41,9 @@
 
 static const uint8_t st7735_default_init[] =  {
     LCD_CMD_SWRESET, 0,              /* Soft Reset */
-    LCD_DELAY, 120,                  /* Soft Reset needs 120 ms if in Sleep In mode */
+    LCD_DELAY, 1, 120,               /* Soft Reset needs 120 ms if in Sleep In mode */
     LCD_CMD_SLPOUT, 0,               /* Sleep Out leave Sleep In state after reset */
-    LCD_DELAY, 120,                  /* Sleep Out needs 120 ms */
+    LCD_DELAY, 1, 120,               /* Sleep Out needs 120 ms */
     LCD_CMD_PWCTRL1, 3,              /* Power Control 1 */
         0x82, 0x02, 0x84,            /* AVDD=4.9V, GVDD=4.6V, GVCL=-4.6V, AUTO mode */
     LCD_CMD_PWCTRL2, 1, 0xc5,        /* VGH=3*AVDD, VGL=-10V */
@@ -74,7 +74,7 @@ static const uint8_t st7735_default_init[] =  {
 #endif
     LCD_CMD_SLPOUT, 0,               /* Sleep out (turn off sleep mode) */
     LCD_CMD_NORON, 0,                /* Normal display mode on */
-    LCD_DELAY, 1,
+    LCD_DELAY, 1, 1,
     LCD_CMD_DISPON, 0,               /* Display on */
 };
 
@@ -87,9 +87,9 @@ size_t seq_len = ARRAY_SIZE(st7735_default_init);
 
 static const uint8_t st7789_default_init[] =  {
     LCD_CMD_SWRESET, 0,              /* Soft Reset */
-    LCD_DELAY, 120,                  /* Soft Reset needs 120 ms if in Sleep In mode */
+    LCD_DELAY, 1, 120,               /* Soft Reset needs 120 ms if in Sleep In mode */
     LCD_CMD_SLPOUT, 0,               /* Sleep Out leave Sleep In state after reset */
-    LCD_DELAY, 120,                  /* Sleep Out needs 120 ms */
+    LCD_DELAY, 1, 120,               /* Sleep Out needs 120 ms */
     LCD_CMD_VCOMS, 1, 0x20,          /* VCOM=0.9V */
     LCD_CMD_VRHS, 1, 0x0b,           /* VRH=4.1V */
     LCD_CMD_VDVS, 1, 0x20,           /* VDV=0V */
@@ -108,7 +108,7 @@ static const uint8_t st7789_default_init[] =  {
 #endif
     LCD_CMD_SLPOUT, 0,               /* Sleep out (turn off sleep mode) */
     LCD_CMD_NORON, 0,                /* Normal display mode on */
-    LCD_DELAY, 1,
+    LCD_DELAY, 1, 1,
     LCD_CMD_DISPON, 0,               /* Display on */
 };
 

--- a/tests/drivers/st77xx/main.c
+++ b/tests/drivers/st77xx/main.c
@@ -33,6 +33,94 @@
 #include "st77xx.h"
 #include "st77xx_params.h"
 
+#if MODULE_LCD_INIT_SEQUENCE
+
+#if MODULE_ST7735
+
+#include "st7735_internal.h"
+
+static const uint8_t st7735_default_init[] =  {
+    LCD_CMD_SWRESET, 0,              /* Soft Reset */
+    LCD_DELAY, 120,                  /* Soft Reset needs 120 ms if in Sleep In mode */
+    LCD_CMD_SLPOUT, 0,               /* Sleep Out leave Sleep In state after reset */
+    LCD_DELAY, 120,                  /* Sleep Out needs 120 ms */
+    LCD_CMD_PWCTRL1, 3,              /* Power Control 1 */
+        0x82, 0x02, 0x84,            /* AVDD=4.9V, GVDD=4.6V, GVCL=-4.6V, AUTO mode */
+    LCD_CMD_PWCTRL2, 1, 0xc5,        /* VGH=3*AVDD, VGL=-10V */
+    LCD_CMD_VMCTRL1, 1, 0x04,        /* VCOM=-0.525V */
+    LCD_CMD_PWCTRL3, 2,              /* Power Control Normal Mode */
+        0x0a, 0x00,                  /* AP=Medium Low, SAP=Small */
+    LCD_CMD_PWCTRL4, 2,              /* Power Control Idle Mode */
+        0x8a, 0x2e,                  /* AP=Medium Low, SAP=Small */
+    LCD_CMD_PWCTRL5, 2,              /* Power Control Partial Mode */
+        0x8a, 0xaa,                  /* AP=Medium Low, SAP=Small */
+    LCD_CMD_FRAMECTL1, 3,            /* Frame Control in Normal mode */
+        0x01, 0x2c, 0x2d,            /* RNTA=1, FPA=44 lines, BPA=45 lines */
+    LCD_CMD_FRAMECTL2, 3,            /* Frame Control in Idle mode */
+        0x01, 0x2c, 0x2d,            /* RNTB=1, FPA=44 lines, BPA=45 lines */
+    LCD_CMD_FRAMECTL3, 6,            /* Frame Control in partial mode */
+        0x01, 0x2c, 0x2d,            /* RNTC=1, FPA=44 lines, BPA=45 lines */
+        0x01, 0x2c, 0x2d,            /* RNTD=1, FPA=44 lines, BPA=45 lines */
+    LCD_CMD_PGAMCTRL, 16,            /* Positive Voltage Gamma Control */
+        0x02, 0x1c, 0x07, 0x12, 0x37, 0x32, 0x29, 0x2d,
+        0x29, 0x25, 0x2B, 0x39, 0x00, 0x01, 0x03, 0x10,
+    LCD_CMD_NGAMCTRL, 16,            /* Negative Voltage Gamma Control */
+        0x03, 0x1d, 0x07, 0x06, 0x2E, 0x2C, 0x29, 0x2D,
+        0x2E, 0x2E, 0x37, 0x3F, 0x00, 0x00, 0x02, 0x10,
+    LCD_CMD_COLMOD, 1, 0x055,        /* 16 bit mode RGB & Control interface pixel format */
+    LCD_CMD_MADCTL, 1, ST77XX_PARAM_ROTATION | (ST77XX_PARAM_RGB ? 0 : LCD_MADCTL_BGR),
+#if ST77XX_PARAM_INVERTED
+    LCD_CMD_DINVON, 0,               /* enable Inversion, reset default is off */
+#endif
+    LCD_CMD_SLPOUT, 0,               /* Sleep out (turn off sleep mode) */
+    LCD_CMD_NORON, 0,                /* Normal display mode on */
+    LCD_DELAY, 1,
+    LCD_CMD_DISPON, 0,               /* Display on */
+};
+
+const uint8_t *seq = st7735_default_init;
+size_t seq_len = ARRAY_SIZE(st7735_default_init);
+
+#elif MODULE_ST7789
+
+#include "st7789_internal.h"
+
+static const uint8_t st7789_default_init[] =  {
+    LCD_CMD_SWRESET, 0,              /* Soft Reset */
+    LCD_DELAY, 120,                  /* Soft Reset needs 120 ms if in Sleep In mode */
+    LCD_CMD_SLPOUT, 0,               /* Sleep Out leave Sleep In state after reset */
+    LCD_DELAY, 120,                  /* Sleep Out needs 120 ms */
+    LCD_CMD_VCOMS, 1, 0x20,          /* VCOM=0.9V */
+    LCD_CMD_VRHS, 1, 0x0b,           /* VRH=4.1V */
+    LCD_CMD_VDVS, 1, 0x20,           /* VDV=0V */
+    LCD_CMD_VCMOFSET, 1, 0x20,       /* VCOMFS=0V */
+    LCD_CMD_PWCTRL1X, 2, 0xa4, 0xa1, /* AVDD=6.8V, AVCL=4.8V, VDS=2.3 */
+    LCD_CMD_PGAMCTRL, 14,            /* Positive Voltage Gamma Control */
+        0xd0, 0x08, 0x11, 0x08, 0x0c, 0x15, 0x39,
+        0x33, 0x50, 0x36, 0x13, 0x14, 0x29, 0x2d,
+    LCD_CMD_NGAMCTRL, 14,            /* Negative Voltage Gamma Control */
+        0xd0, 0x08, 0x10, 0x08, 0x06, 0x06, 0x39,
+        0x44, 0x51, 0x0b, 0x16, 0x14, 0x2f, 0x32,
+    LCD_CMD_COLMOD, 1, 0x055,        /* 16 bit mode RGB & Control interface pixel format */
+    LCD_CMD_MADCTL, 1, ST77XX_PARAM_ROTATION | (ST77XX_PARAM_RGB ? 0 : LCD_MADCTL_BGR),
+#if ST77XX_PARAM_INVERTED
+    LCD_CMD_DINVON, 0,               /* enable Inversion, reset default is off */
+#endif
+    LCD_CMD_SLPOUT, 0,               /* Sleep out (turn off sleep mode) */
+    LCD_CMD_NORON, 0,                /* Normal display mode on */
+    LCD_DELAY, 1,
+    LCD_CMD_DISPON, 0,               /* Display on */
+};
+
+const uint8_t *seq = st7789_default_init;
+size_t seq_len = ARRAY_SIZE(st7789_default_init);
+
+#else
+#error "No init sequence defined for the ST77xx variant"
+#endif
+
+#endif /* MODULE_LCD_INIT_SEQUENCE */
+
 int main(void)
 {
     lcd_t dev;
@@ -55,6 +143,10 @@ int main(void)
         puts("[Failed]");
         return 1;
     }
+
+#if MODULE_LCD_INIT_SEQUENCE
+    lcd_write_cmd_sequence(&dev, seq, seq_len);
+#endif
 
 #if MODULE_LCD_PARALLEL
     if (gpio_is_valid(st77xx_params[0].rdx_pin)) {


### PR DESCRIPTION
### Contribution description

The PR provides the capability to execute a sequence of LCD controller commands defined in a byte array as CLP tuples (command, length, parameter). This can be used for example
- to send an initialization sequence to a controller that is not supported by a controller-specific driver or
- to write specific configuration parameters that are not covered by the controller-specific driver.

The PR introduces the pseudomodule `lcd_init_sequence` to use the initialization command sequence defined in the driver parameter set instead of the the controller-specific initialization function.

The format of a CLP tuple is:
- one byte the command index
- one byte the length of the following parameters, i.e. the number of bytes representing the parameters for the command. If the command has no parameters, the length is 0.
- n bytes the parameters of the command.

For testing, `tests/drivers/st77xx` has been extended to use initialize the LCD controller by a intialization command sequence if module `lcd_init_sequence` is enabled.

### Testing procedure

`tests/drivers/st77xx` should work with enabled `lcd_init_sequence`:
```
USEMODULE=lcd_init_sequence BOARD=adafruit-pybadge make -C tests/drivers/st77xx flash
```
```
USEMODULE=lcd_init_sequence BOARD=esp32s3-usb-otg make -j8 -C tests/drivers/st77xx flash
```

### Issues/PRs references