### PR TITLE
gnrc_ipv6_nib: disable router advertisements on interface startup

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -130,17 +130,10 @@ extern "C" {
 #endif
 
 /**
- * @brief    (de-)activate router advertising at interface start-up
+ * @brief    activate router advertising at interface start-up
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_ADV_ROUTER
-#if CONFIG_GNRC_IPV6_NIB_ROUTER && \
-    (!CONFIG_GNRC_IPV6_NIB_6LR || CONFIG_GNRC_IPV6_NIB_6LBR) && \
-    !(IS_USED(MODULE_DHCPV6_CLIENT_IA_PD) || IS_USED(MODULE_GNRC_UHCPC) || \
-      IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS) || IS_USED(MODULE_GNRC_IPV6_STATIC_ADDR))
-#define CONFIG_GNRC_IPV6_NIB_ADV_ROUTER               1
-#else
 #define CONFIG_GNRC_IPV6_NIB_ADV_ROUTER               0
-#endif
 #endif
 
 /**

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -122,10 +122,15 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
     }
 
     /* register all_RPL_nodes multicast address */
-    gnrc_netif_ipv6_group_join_internal(gnrc_netif_get_by_pid(if_pid),
-                                        &ipv6_addr_all_rpl_nodes);
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(if_pid);
+    gnrc_netif_ipv6_group_join_internal(netif, &ipv6_addr_all_rpl_nodes);
 
+    /* send DODAG Information Solicitation */
     gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes, NULL, 0);
+
+    /* RPL enables routing, start advertising ourself as a router */
+    gnrc_ipv6_nib_change_rtr_adv_iface(netif, true);
+
     return gnrc_rpl_pid;
 }
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Router Advertisements are enabled automatically for routing nodes as soon as they obtain a prefix (e.g. via DHCPv6, UHCP, …).

Enabling router advertisements without a prefix to advertise is wrong and causes no router solicitations to be send on an upstream interface.

Also from https://www.rfc-editor.org/rfc/rfc4861#section-6.2.1

	Note that AdvSendAdvertisements MUST be FALSE by
	default so that a node will not accidentally start
	acting as a router unless it is explicitly
	configured by system management to send Router
	Advertisements.


### Testing procedure

`examples/gnrc_networking` does now instantly obtain an address on a network with an upstream router.

`examples/gnrc_border_router` had this disabled already because an automatic prefix configuration method was used. 

`tests/net/gnrc_rpl` shows that RPL operation is not affected. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
