### PR TITLE
dist/tools/pyterm: set exclusive access on port

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -654,7 +654,7 @@ class SerCmd(cmd.Cmd):
                 self.process_line(line)
 
     def serial_connect(self):
-        self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0)
+        self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0, exclusive=1)
         self.ser.baudrate = self.baudrate
 
         if self.toggle:


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A common source of error is that a user connects to a serial port that has already been opened in another terminal.
This may lead to garbled output or no output at all.

To avoid this, claim exclusive access on the serial port so we get a proper error instead of corrupted output.


### Testing procedure

Connect to a serial port

```
$ ./dist/tools/pyterm/pyterm
2023-09-13 12:07:44,770 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
```

Now try to open the same port again in a different terminal

```
$ ./dist/tools/pyterm/pyterm
2023-09-13 12:08:07,907 # Connect to serial port /dev/ttyUSB0
2023-09-13 12:08:07,908 # Could not exclusively lock port /dev/ttyUSB0: [Errno 11] Resource temporarily unavailable
2023-09-13 12:08:07,908 # Trying to reconnect to /dev/ttyUSB0 in 10 sec
2023-09-13 12:08:17,909 # Could not exclusively lock port /dev/ttyUSB0: [Errno 11] Resource temporarily unavailable
```




### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
