### PR TITLE
boards/msb-430: Fix periph config & improve doc

### DIFF
--- a/boards/msb-430/Kconfig
+++ b/boards/msb-430/Kconfig
@@ -20,4 +20,8 @@ config BOARD_MSB_430
 
     select HAVE_SHT11
 
+config ERROR_MODULES_CONFLICT
+    default "The msb-430 uses the same USART for UART and SPI" if MODULE_PERIPH_SPI && MODULE_PERIPH_UART
+    depends on BOARD_MSB_430
+
 source "$(RIOTBOARD)/common/msb-430/Kconfig"

--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -4,6 +4,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+FEATURES_CONFLICT += periph_spi:periph_uart
+FEATURES_CONFLICT_MSG += "Both SPI and UART are provided by the same USART peripheral"
+
 # Various other features (if any)
 
 include $(RIOTBOARD)/common/msb-430/Makefile.features

--- a/boards/msb-430/doc.txt
+++ b/boards/msb-430/doc.txt
@@ -18,9 +18,9 @@
 | FPU               | no                                                            |
 | Timers            | 2 (2x 16bit)                                                  |
 | ADCs              | 1x 8 channel 12-bit                                           |
-| UARTs             | 2                                                             |
-| SPIs              | 2                                                             |
-| I2Cs              | 1                                                             |
+| UARTs             | 2 (*)                                                         |
+| SPIs              | 2 (*)                                                         |
+| I2Cs              | 1 (*)                                                         |
 | Vcc               | 1.8 V - 3.6 V (battery holder board provides 3.0 V)           |
 | Datasheet MCU     | [Datasheet](https://www.ti.com/lit/ds/symlink/msp430f1612.pdf)|
 | User Guide MCU    | [User Guide](https://www.ti.com/lit/ug/slau049f/slau049f.pdf) |
@@ -32,12 +32,47 @@
             is used, the supply voltage must initially be at least 2.0 V due to
             the hysteresis of the SVS circuitry. Afterwards the MCU remains
             operational with VCC >= 1.8 V.
+@warning    The MSP430F1612 has two USARTS, which can be configured as UART,
+            SPI, or (only in case of USART0) as I2C bus. Each USART can only
+            provide one serial interface at a time; time sharing is
+            theoretically possible but not yet implemented.
 
 ## Schematics
 
 <img src="https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/pic/blueprints/MSB430_s1.png" alt="Schematics of the MSB-430 (Part 1 / 2)" style="width: 978px; max-width: 100%;">
 
 <img src="https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/pic/blueprints/MSB430_s2.png" alt="Schematics of the MSB-430 (Part 2 / 2)" style="width: 1368px; max-width: 100%;">
+
+### Hardware Limitations
+
+The GPIOs on the MSP430F1612 only have two MUX settings: Being used as digital
+input/output or routed to a peripheral. The MCU has two universal serial
+synchronous/asynchronous communication interfaces (USARTs), which can be
+used to provide either an UART, an SPI, or (only in case of USART0) an I2C bus.
+Every USART signal is available at exactly one GPIO pin.
+
+The UART exposed via the battery holder board (P3.6 and P3.7) can only be
+provided via USART1. In order to support asynchronous reception (e.g. to allow
+interaction via the shell), USART1 needs to be continuously configured as UART
+and cannot be used to provide an SPI bus.
+
+The SPI bus connected to the SD card socket (P5.1, P5.2, and P5.3) can only
+be provided via USART1. Hence, it is not possible to use SPI bus connected to
+the SD card socket while the UART used for `stdio` is in use, as they use the
+same USART. They could be used at the same time, if module `stdin` is not used
+(the UART is output only). However, sharing USARTs is not yet implemented.
+
+The SPI bus of the CC1020 transceiver (used for configuration only) is connected
+to pins P2.0, P2.1, and P2.3. Those pins are not connected to either USART, so
+no hardware SPI can be used to interact with the transceiver. However, the SPI
+is only used for configuration and control of the transceiver, so using a slow
+bit-banging SPI bus won't affect the performance of the transceiver, other than
+for quick power down after transmission or channel hopping. A second two
+wire serial interface (not I2C or compatible) is used to feed data into
+the CC1020 or read data from the CC1020. The serial clock is driven by the
+transceiver and the MCU needs to keep up with providing the frames to send
+bit by bit. Unlike modern transceivers, the CC1020 has no frame buffer and the
+MCU needs to control the transmission and reception on the bit level.
 
 ## Pinout
 

--- a/boards/msb-430/include/periph_conf.h
+++ b/boards/msb-430/include/periph_conf.h
@@ -80,8 +80,8 @@ static const msp430_clock_params_t clock_params = {
 #define SPI_NUMOF           (1U)
 
 /* SPI configuration */
-#define SPI_BASE            (&USART_0)
-#define SPI_SFR             (&USART_0_SFR)
+#define SPI_BASE            (&USART_1)
+#define SPI_SFR             (&USART_1_SFR)
 #define SPI_IE_RX_BIT       (1 << 6)
 #define SPI_IE_TX_BIT       (1 << 7)
 #define SPI_ME_BIT          (1 << 6)


### PR DESCRIPTION
### Contribution description

tl;dr: This fixes the periph config of the MSB-430 board and improves the documentation.

The pins P5.2, P5.1, P5.3 configured as SPI pins are only routed to USART1 and not to USART0, but previously USART0 was configured as peripheral backing the bus. This fixes the peripheral configuration by changing it to USART1.

This is quite unfortunate as USART1 is also used to provide the UART interface used for `stdio`. Hence, one can either use `stdio` or SPI. A feature conflict between UART and SPI has therefore been added.

Note that while it would be possible to use P3.2, P3.1, P3.3 to provide SPI with USART0, this would not work in practise: P3.1 and P3.3 are connected to the CC1020 transceiver.

Switching to P3.4/P3.5 for UART to provide it using USART 0 would also resolve the resource conflict. However, these pins are not available via any of the header and would require soldering the UART<->USB adapter directly to the pins of the MCU chip on the PCB. It is therefore much more user friendly to keep the UART bus backed by USART1 to use pins P3.6 and P3.7 that are easily accessible via the pin header.

### Testing procedure

![20230914_14h59m43s_grim](https://github.com/RIOT-OS/RIOT/assets/2041729/f8220a56-6093-4924-8539-9fcb499c6fa6)

Check in above screenshot of the datasheet that P5.2, P5.1, and P5.3 indeed can only provide SPI via USART 1, as indicated by the names SOMI1 (SOMI = slave out, master in ≈ master in, slave out = MISO; 1 for USART 1), SIMO1, and UCLK1 (UCLK = USART clock, used as SCK in SPI mode or SCL in I2C mode).

### Issues/PRs references

None
