### PR TITLE
drivers/pcf857x: Move compile time check to compilation unit

### DIFF
--- a/drivers/include/pcf857x.h
+++ b/drivers/include/pcf857x.h
@@ -260,10 +260,6 @@ extern "C"
 #include "event.h"
 #endif /* MODULE_PCF857X_IRQ */
 
-#if !IS_USED(MODULE_PCF8574) && !IS_USED(MODULE_PCF8574A) && !IS_USED(MODULE_PCF8575)
-#error "Please provide a list of pcf857x variants used by the application (pcf8574, pcf8574a or pcf8575)"
-#endif
-
 /**
  * @name    PCF857X I2C slave addresses
  *

--- a/drivers/pcf857x/pcf857x.c
+++ b/drivers/pcf857x/pcf857x.c
@@ -42,6 +42,10 @@
 
 #endif /* ENABLE_DEBUG */
 
+#if !IS_USED(MODULE_PCF8574) && !IS_USED(MODULE_PCF8574A) && !IS_USED(MODULE_PCF8575)
+#error "Please provide a list of pcf857x variants used by the application (pcf8574, pcf8574a or pcf8575)"
+#endif
+
 #if IS_USED(MODULE_PCF857X_IRQ_LOW)
 #define PCF857X_EVENT_PRIO EVENT_PRIO_LOWEST
 #elif IS_USED(MODULE_PCF857X_IRQ_MEDIUM)


### PR DESCRIPTION
### Contribution description

This allows including the header without using the module. Obviously, calls to the functions provided by the header won't like without using the module. But including the header can still be useful for e.g.:

    if (IS_USED(MODULE_PCF857x)) {
        /* make use of the module */
    }

In the above example all calls to pcf857x functions would be optimized out when the module is not used, full compile checks happen in either case.

### Testing procedure

- binaries should not change
- including the pcf857x header should work without having selected one of the pcf857x variants, if the driver is not actually used
    - when calling any of the functions provided, linking should fail
    - when using the `pcf857x` module without any variant, compiling should still fail with a message indicating that (at least) one of the pcf857x needs to be selected

### Issues/PRs references

None