### PR TITLE
boards: fix documentation for GD32V boards and doxygen 1.9.4

### DIFF
--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -7,8 +7,7 @@
 
 ## Overview
 
-The [Seedstudio GD32 RISC-V Dev Board]
-(https://wiki.seeedstudio.com/SeeedStudio-GD32-RISC-V-Dev-Board/) is a
+The [Seedstudio GD32 RISC-V Dev Board](https://wiki.seeedstudio.com/SeeedStudio-GD32-RISC-V-Dev-Board/) is a
 development board for the GigaDevice GD32VF103VBT6 MCU with the following
 on-board components:
 
@@ -147,11 +146,10 @@ All other pins are either not broken out or have no special usage.
 
 ## Flashing the Device
 
-The board is flashed via a JTAG interface with OpenOCD (at least [release version 0.12.0]
-(https://github.com/openocd-org/openocd/tree/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c)).
+The board is flashed via a JTAG interface with OpenOCD (at least
+[release version 0.12.0](https://github.com/openocd-org/openocd/tree/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c)).
 By default, an FTDI adapter according to the configuration defined in
-[`interface/openocd-usb.cfg`]
-(https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
+[`interface/openocd-usb.cfg`](https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
 is assumed.
 ```
 BOARD=seeedstudio-gd32 make -C examples/hello-world flash

--- a/boards/sipeed-longan-nano-tft/doc.txt
+++ b/boards/sipeed-longan-nano-tft/doc.txt
@@ -12,7 +12,7 @@ that is equipped with a TFT display with the following on-board components:
 - USB Type C
 - TF card slot
 - 3 user LEDs
-- 0.96" TFT display 160 x 80 pixel
+- 0.96 inches TFT display 160 x 80 pixel
 
 @image html "https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/1/114992425_1.jpg" "Sipeed Longan Nano" width=600
 

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -16,11 +16,11 @@ on-board components:
 - USB Type C
 - TF card slot
 - 3 user LEDs
-- 0.96" TFT display 160 x 80 pixel (optional)
+- 0.96 inches TFT display 160 x 80 pixel (optional)
 
-@image html "https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/1/114992425_1.jpg" "Sipeed Longan Nano" width=600
+@image html "https://wiki.sipeed.com/hardware/assets/Longan/nano/Longan_nano.124.jpg" "Sipeed Longan Nano" width=600
 
-## Hardware:
+## Hardware
 
 | MCU         | GD32VF103CBT6                          | Supported |
 |:----------- |:-------------------------------------- | --------- |
@@ -173,11 +173,10 @@ BOARD=sipeed-longan-nano-tft make -C examples/hello-world flash
 
 ### Using an external debug adapter
 
-The board can also be flashed via a JTAG interface with OpenOCD (at least [release version 0.12.0]
-(https://github.com/openocd-org/openocd/tree/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c)).
+The board can also be flashed via a JTAG interface with OpenOCD (at least
+[release version 0.12.0](https://github.com/openocd-org/openocd/tree/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c)).
 By default, an FTDI adapter according to the configuration defined in
-[`interface/openocd-usb.cfg`]
-(https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
+[`interface/openocd-usb.cfg`](https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
 is assumed.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PROGRAMMER=openocd BOARD=sipeed-longan-nano make -C examples/hello-world flash


### PR DESCRIPTION
### Contribution description

This PR fixes some small problems in documentation of `sipeed-longan-nano`, `sipeed-longan-nano-tft` and `seeedstudio-gd32` for doxygen 1.9.4 that is used on `doc.riot-os.org`.

Doxygen version 1.9.4 doesn't like anymore
- single double quotes as symbol for the inches unit in the text
- line breaks in `[]()` to avoid exhausting the 100 characters per line.

See https://doc.riot-os.org/group__boards__sipeed__longan__nano.html for example.

Doxygen 1.9.1 which is part of `riot-docker` container didn't have theses problems :worried:

### Testing procedure

Documentation should be fixed.

### Issues/PRs references
