### PR TITLE
examples/gcoap: add saml11-xpro to CI boards with insufficient memory

### DIFF
--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     olimex-msp430-h1611 \
     olimex-msp430-h2618 \
     samd10-xmini \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \


### PR DESCRIPTION
### Contribution description

Bors run for PR #19927 reveals that ```examples\gcoap``` do not fit in saml11-xpro board. 
I checked and this same linker error also appears on current master branch. 

This PR add sampl11-xpro board to the Makefile.ci BOARD_INSUFFICIENT_MEMORY list.

### Testing procedure

See logs from bors https://ci.riot-os.org/details/073c5dadc6ba4bc8a613edb78a1a4a2d

### Issues/PRs references

PR #19927 
