### PR TITLE
boards/nucleo64: fix SPI Arduino mapping for most boards

### DIFF
--- a/boards/common/nucleo64/include/arduino_iomap.h
+++ b/boards/common/nucleo64/include/arduino_iomap.h
@@ -24,6 +24,7 @@
 
 #include "periph/gpio.h"
 #include "periph/adc.h"
+#include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,7 +44,9 @@ extern "C" {
 /**
  * @brief   SPI_DEV(1) is connected to D11/D12/D13
  */
-#define ARDUINO_SPI_D11D12D13   SPI_DEV(1)
+#if !defined(ARDUINO_SPI_D11D12D13) && defined(SPI_NUMOF)
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(0)
+#endif
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Before, the Arduino SPI mapping for all Nucleo-64 boards was incorrect. With this, the situation improves to the following:

- [x] nucleo-f030r8
- [ ] nucleo-f070rb
    - No SPI buses provided.
- [x] nucleo-f072rb
- [x] nucleo-f091rc
- [x] nucleo-f103rb
- [ ] nucleo-f302r8
    - No SPI bus at D11, D12, D13 provided
- [x] nucleo-f303re
- [x] nucleo-f334r8
- [x] nucleo-f401re
- [x] nucleo-f410rb
- [x] nucleo-f411re
- [x] nucleo-f446re
- [x] nucleo-g070rb
- [x] nucleo-g071rb
- [x] nucleo-g431rb
- [x] nucleo-g474re
- [x] nucleo-l053r8
- [x] nucleo-l073rz
- [x] nucleo-l152re
    - No SPI bus at D11, D12, D13 provided
- [x] nucleo-l452re
- [x] nucleo-l476rg
- [x] nucleo-wl55jc

The remaining offenders still need to be fixed, but that is better done one PR at a time.

### Testing procedure

- Check if the SPI device provided in the given `boards/<BOARD_NAME>/incude/periph_conf.h` is indeed `SPI_DEV(0)`, or in `periph_conf.h` the correct SPI dev is found
    - this should be fine for all boards above, except for the unchecked ones

or:

- run https://github.com/RIOT-OS/RIOT/pull/19932: The SPI test should pass now

### Issues/PRs references

Bug found in https://github.com/RIOT-OS/RIOT/pull/19932#issuecomment-1726305437