### PR TITLE
boards/stm32f723e-disco: enable ST7789 display

### DIFF
--- a/boards/stm32f723e-disco/Kconfig
+++ b/boards/stm32f723e-disco/Kconfig
@@ -37,6 +37,9 @@ config BOARD_STM32F723E_DISCO
 
     select HAVE_SAUL_GPIO
     select HAVE_FT5X06
+    select HAVE_ST7789
+    select HAVE_LCD_PARALLEL_16BIT if MODULE_ST7789
+
     select MODULE_PERIPH_UART_HW_FC if HAS_PERIPH_UART_HW_FC && MODULE_PERIPH_UART
     # Workaround due to stdout only working with stdin enabled
     select MODULE_STDIN if TEST_KCONFIG

--- a/boards/stm32f723e-disco/Makefile.dep
+++ b/boards/stm32f723e-disco/Makefile.dep
@@ -19,5 +19,13 @@ ifneq (,$(filter periph_spi,$(USEMODULE)))
   DISABLE_MODULE += periph_init_led0
 endif
 
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += st7789
+endif
+
+ifneq (,$(filter st7789,$(USEMODULE)))
+  USEMODULE += lcd_parallel_16bit
+endif
+
 # TODO: remove the stdin dependency
 USEMODULE += stdin

--- a/boards/stm32f723e-disco/board.c
+++ b/boards/stm32f723e-disco/board.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f723e-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific initializations for the STM32F723E-DISCO board
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+
+void board_init(void)
+{
+#if MODULE_ST77XX
+    /* initialize the pin for the HIGH active LCD_BL signal */
+    gpio_init(BACKLIGHT_PIN, GPIO_OUT);
+#endif
+}

--- a/boards/stm32f723e-disco/include/board.h
+++ b/boards/stm32f723e-disco/include/board.h
@@ -27,6 +27,92 @@ extern "C" {
 #endif
 
 /**
+ * @name    LCD Backlight control defines
+ * @{
+ */
+#define BACKLIGHT_PIN       GPIO_PIN(PORT_H, 11)    /**< Backlight pin (HIGH active LD_BL) */
+#define BACKLIGHT_MASK      (1 << 11)               /**< Backlight pin mask */
+
+/** Set the backlight pin */
+#define BACKLIGHT_ON        (GPIOH->BSRR = BACKLIGHT_MASK)
+/** Clear the backlight pin */
+#define BACKLIGHT_OFF       (GPIOH->BSRR = (BACKLIGHT_MASK << 16))
+/** Toggle the backlight pin */
+#define BACKLIGHT_TOGGLE    (GPIOH->ODR  ^= BACKLIGHT_MASK)
+/** @} */
+
+/**
+ * @name    LCD display definitions
+ *
+ * The STM32F723G-DISCO board has a 240 x 240 pixel TFT color LCD display with
+ * ST7789H2 driver IC using the MCU 8080 16-bit parallel interface (default with
+ * SB15=ON and SB16=OFF). SB15 and SB16 control the ST7789H2 `IM0` signal.
+ * With SB15=OFF and SB16=ON, the MCU 8080 8-bit parallel interface is enabled.
+ *
+ * For the `LCD_*` pins, please refer to the
+ * [schematic](https://www.st.com/resource/en/schematic_pack/mb1260-f723e-d03_schematic.pdf).
+ *
+ * @{
+ */
+#define LCD_SCREEN_WIDTH    240                     /**< LCD width */
+#define LCD_SCREEN_HEIGHT   240                     /**< LCD height */
+
+#define LCD_D0              GPIO_PIN(PORT_D, 14)    /**< LCD_D0 pin */
+#define LCD_D1              GPIO_PIN(PORT_D, 15)    /**< LCD_D1 pin */
+#define LCD_D2              GPIO_PIN(PORT_D, 0)     /**< LCD_D2 pin */
+#define LCD_D3              GPIO_PIN(PORT_D, 1)     /**< LCD_D3 pin */
+#define LCD_D4              GPIO_PIN(PORT_E, 7)     /**< LCD_D4 pin */
+#define LCD_D5              GPIO_PIN(PORT_E, 8)     /**< LCD_D5 pin */
+#define LCD_D6              GPIO_PIN(PORT_E, 9)     /**< LCD_D6 pin */
+#define LCD_D7              GPIO_PIN(PORT_E, 10)    /**< LCD_D7 pin */
+#define LCD_D8              GPIO_PIN(PORT_E, 11)    /**< LCD_D8 pin */
+#define LCD_D9              GPIO_PIN(PORT_E, 12)    /**< LCD_D9 pin */
+#define LCD_D10             GPIO_PIN(PORT_E, 13)    /**< LCD_D10 pin */
+#define LCD_D11             GPIO_PIN(PORT_E, 14)    /**< LCD_D11 pin */
+#define LCD_D12             GPIO_PIN(PORT_E, 15)    /**< LCD_D12 pin */
+#define LCD_D13             GPIO_PIN(PORT_D, 8)     /**< LCD_D13 pin */
+#define LCD_D14             GPIO_PIN(PORT_D, 9)     /**< LCD_D14 pin */
+#define LCD_D15             GPIO_PIN(PORT_D, 10)    /**< LCD_D15 pin */
+#define LCD_TE              GPIO_PIN(PORT_C, 8)     /**< LCD_TE pin */
+#define LCD_WE              GPIO_PIN(PORT_D, 5)     /**< LCD_WE pin */
+#define LCD_OE              GPIO_PIN(PORT_D, 4)     /**< LCD_OE pin */
+#define LCD_RS              GPIO_PIN(PORT_F, 0)     /**< LCD_RS pin */
+#define LCD_NE              GPIO_PIN(PORT_G, 9)     /**< LCD_NE pin */
+#define LCD_RST             GPIO_PIN(PORT_H, 7)     /**< LCD_RST pin */
+#define LCD_BACKLIGHT       BACKLIGHT_PIN           /**< LCD_BL pin */
+
+#define ST77XX_PARAM_CNTRL         ST77XX_CNTRL_ST7789  /**< ST77xx controller variant */
+#define ST77XX_PARAM_SPI           SPI_UNDEF        /**< parallel interface is used */
+#define ST77XX_PARAM_D0            LCD_D0           /**< ST77xx D0 signal */
+#define ST77XX_PARAM_D1            LCD_D1           /**< ST77xx D1 signal */
+#define ST77XX_PARAM_D2            LCD_D2           /**< ST77xx D2 signal */
+#define ST77XX_PARAM_D3            LCD_D3           /**< ST77xx D3 signal */
+#define ST77XX_PARAM_D4            LCD_D4           /**< ST77xx D4 signal */
+#define ST77XX_PARAM_D5            LCD_D5           /**< ST77xx D5 signal */
+#define ST77XX_PARAM_D6            LCD_D6           /**< ST77xx D6 signal */
+#define ST77XX_PARAM_D7            LCD_D7           /**< ST77xx D7 signal */
+#define ST77XX_PARAM_D8            LCD_D8           /**< ST77xx D8 signal */
+#define ST77XX_PARAM_D9            LCD_D9           /**< ST77xx D9 signal */
+#define ST77XX_PARAM_D10           LCD_D10          /**< ST77xx D10 signal */
+#define ST77XX_PARAM_D11           LCD_D11          /**< ST77xx D11 signal */
+#define ST77XX_PARAM_D12           LCD_D12          /**< ST77xx D12 signal */
+#define ST77XX_PARAM_D13           LCD_D13          /**< ST77xx D13 signal */
+#define ST77XX_PARAM_D14           LCD_D14          /**< ST77xx D14 signal */
+#define ST77XX_PARAM_D15           LCD_D15          /**< ST77xx D15 signal */
+#define ST77XX_PARAM_WRX           LCD_WE           /**< ST77xx WR signal */
+#define ST77XX_PARAM_RDX           LCD_OE           /**< ST77xx RD signal */
+#define ST77XX_PARAM_DCX           LCD_RS           /**< ST77xx RS signal */
+#define ST77XX_PARAM_RST           LCD_RST          /**< ST77xx RST signal */
+#define ST77XX_PARAM_CS            LCD_NE           /**< ST77xx CS signal */
+#define ST77XX_PARAM_RGB           1                /**< ST77xx RGB mode */
+#define ST77XX_PARAM_INVERTED      1                /**< ST77xx inverted colors */
+#define ST77XX_PARAM_ROTATION      ST77XX_ROTATION_90  /**< ST77xx rotation */
+#define ST77XX_PARAM_OFFSET_X      80                  /**< ST77xx offset because of rotation */
+#define ST77XX_PARAM_NUM_LINES     LCD_SCREEN_HEIGHT   /**< ST77xx number of lines */
+#define ST77XX_PARAM_RGB_CHANNELS  LCD_SCREEN_WIDTH    /**< ST77xx number of channels */
+/** @} */
+
+/**
  * @name Macros for controlling the on-board LEDs.
  * @{
  */

--- a/boards/stm32l496g-disco/include/board.h
+++ b/boards/stm32l496g-disco/include/board.h
@@ -55,7 +55,7 @@ extern "C" {
  * For the `LCD_*` pins the identifiers are used as given in the [schematic]
  * (https://www.st.com/resource/en/schematic_pack/mb1261-l496g-b06-schematic.pdf).
  *
- * The LCD display has to switched on explicitly by activating VDD_LCD using
+ * The LCD display has to be switched on explicitly by activating VDD_LCD using
  * the LOW active `LD_PWR_ON` signal.
  *
  * @note The `LCD_RESET` signal is provided by the MFX GPIO2 pin. Since the MFX

--- a/tests/drivers/st77xx/Makefile
+++ b/tests/drivers/st77xx/Makefile
@@ -5,6 +5,7 @@ include ../Makefile.drivers_common
 ST7789_BOARDS = \
   esp32s2-lilygo-ttgo-t8 \
   esp32s3-usb-otg \
+  stm32f723e-disco \
   stm32l496g-disco \
   #
 


### PR DESCRIPTION
### Contribution description

This PR enables the ST7789 display and the touch panel for the `stm32f723e-disco`.

The PR requires PR #19937.

### Testing procedure

```
BOARD=sstm32f723e-disco make -j8 -C tests/drivers/st77xx
```
should work.

### Issues/PRs references

Depends on PR #19937