### PR TITLE
pkg/littlefs2: bump to v2.8

### DIFF
--- a/pkg/littlefs2/Makefile
+++ b/pkg/littlefs2/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=littlefs2
 PKG_URL=https://github.com/littlefs-project/littlefs.git
-# v2.7
-PKG_VERSION=611c9b20db2b99faee261daa7cc9bbe175d3eaca
+# v2.8
+PKG_VERSION=f77214d1f0a8ccd7ddc7e1204fedd25ee5a41534
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

New [upstream release](https://github.com/littlefs-project/littlefs/releases/tag/v2.8.0
), what's new:

 -  littlefs no longer needs the block_count when mounting an existing filesystem (https://github.com/littlefs-project/littlefs/pull/866)

    Simply set block_count=0 in your configuration, and littlefs will automatically determine the block_count based on what's on disk. This allows you to mount a filesystem of unknown size.

 - Added `lfs_fs_grow` which allows you to change the size of an existing filesystem (https://github.com/littlefs-project/littlefs/pull/872)



 - Added `lfs_fs_gc` which allows you to manually run the block allocator (https://github.com/littlefs-project/littlefs/pull/875)


### Testing procedure

`tests/pkg/littlefs2` still works
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
