### PR TITLE
boards/esp32-wt32-sc01-plus: fix I2C driver selection in Kconfig

### DIFF
--- a/boards/esp32s3-wt32-sc01-plus/Kconfig
+++ b/boards/esp32s3-wt32-sc01-plus/Kconfig
@@ -37,4 +37,8 @@ choice STDIO_IMPLEMENTATION
     default MODULE_STDIO_USB_SERIAL_JTAG
 endchoice
 
+choice ESP32_I2C_IMPLEMENTATION
+     default MODULE_ESP_I2C_HW
+endchoice
+
 source "$(RIOTBOARD)/common/esp32s3/Kconfig"


### PR DESCRIPTION
### Contribution description

This PR fixes the `Kconfig` mismatch for the I2C peripheral driver selection for the `esp32s3-wt32-sc01-plus` board.

### Testing procedure

```
python3 dist/tools/compile_test/compile_like_murdock.py -a tests/periph/i2c -b esp32s3-wt32-sc01-plus
```
fails w/o this PR
```
tests/periph/i2c               esp32s3-wt32-sc01-plus         FAIL: Kconfig module or pkg mismatch
```
and should succeed with this PR
```
tests/periph/i2c               esp32s3-wt32-sc01-plus         PASS
```

### Issues/PRs references
