### PR TITLE
doc: fix references and inches unit

### DIFF
--- a/boards/adafruit-grand-central-m4-express/doc.txt
+++ b/boards/adafruit-grand-central-m4-express/doc.txt
@@ -5,8 +5,7 @@
 
 ### General information
 
-![Adafruit Grand Central M4 Expressboard]
-(https://cdn-learn.adafruit.com/assets/assets/000/068/748/medium800/adafruit_products_grand_central_top_angle.jpg?1546734839)
+![Adafruit Grand Central M4 Expressboard](https://cdn-learn.adafruit.com/assets/assets/000/068/748/medium800/adafruit_products_grand_central_top_angle.jpg?1546734839)
 
 The main features of the board are:
 - ATSAMD51 Cortex M4 running at 120 MHz

--- a/boards/adafruit-itsybitsy-m4/doc.txt
+++ b/boards/adafruit-itsybitsy-m4/doc.txt
@@ -7,7 +7,7 @@
 
 ![Adafruit-Itsybitsy-M4 compared to a quarter dollar](https://cdn-learn.adafruit.com/assets/assets/000/055/465/large1024/adafruit_products_3800_quarter_ORIG_2018_06.jpg?1529192175)
 
-This is a small formfactor (only 1.4" long by 0.7" wide) SAM D51 board made by Adafruit.
+This is a small formfactor (only 1.4\" long by 0.7\" wide) SAM D51 board made by Adafruit.
 
 The board features one red LED (LD1), one DotStar / APA102 RGB LED, a reset button as well as
 21 configurable external pins(6 of which can be analog in).

--- a/boards/adafruit-itsybitsy-nrf52/doc.txt
+++ b/boards/adafruit-itsybitsy-nrf52/doc.txt
@@ -5,7 +5,7 @@
 
 ### General information
 
-This is a small formfactor (only 1.4" long by 0.7" wide) nRF52840 board made by Adafruit.
+This is a small formfactor (only 1.4\" long by 0.7\" wide) nRF52840 board made by Adafruit.
 
 The board features one red LED (LD1), one DotStar / APA102 RGB LED, a user (SW1), a
 reset button as well as 21 configurable external pins(6 of which can be analog in).

--- a/boards/airfy-beacon/doc.txt
+++ b/boards/airfy-beacon/doc.txt
@@ -11,13 +11,11 @@ usual micro-controller peripherals with a 2.4GHz radio that supports both
 Nordics proprietary ShockBurst as well as Bluetooth Low Energy (BLE).
 
 The board was available via
-[Indiegogo]
-(https://www.indiegogo.com/projects/airfy-beacon-make-your-smart-home-even-smarter).
+[Indiegogo](https://www.indiegogo.com/projects/airfy-beacon-make-your-smart-home-even-smarter).
 
 ## Hardware
 
-![airfy-beacon]
-(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/airfy-beacon.jpg)
+![airfy-beacon](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/airfy-beacon.jpg)
 
 | MCU                   | NRF51822QFAA                      |
 |:--------------------- |:--------------------------------- |
@@ -114,8 +112,7 @@ SWD data I/O:      SWDIO <-----------> SWDIO (CN3, pin4)
 
 The following image shows the wiring for an SWD flasher board:
 
-![airfy-beacon-flash-connect]
-(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/airfy-beacon-flash-connect.jpg)
+![airfy-beacon-flash-connect](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/airfy-beacon-flash-connect.jpg)
 
 ### Software
 Debugging and programming this module works well with

--- a/boards/arduino-mega2560/doc.txt
+++ b/boards/arduino-mega2560/doc.txt
@@ -72,8 +72,7 @@ to overwrite the bootloader on the MCU. Because of that it is a necessity to use
 an ISP (in system programmer) to do the debugging. This isn't an issue because
 all of the afore mentioned devices have ISP capabilities, but it requires some
 additional steps to get back normal operation after debugging:
- * flash a new arduino bootloader on the device, e.g. [this one]
-(https://raw.githubusercontent.com/arduino/Arduino-stk500v2-bootloader/master/goodHexFiles/stk500boot_v2_mega2560.hex)
+ * flash a new arduino bootloader on the device, e.g. [this one](https://raw.githubusercontent.com/arduino/Arduino-stk500v2-bootloader/master/goodHexFiles/stk500boot_v2_mega2560.hex)
  * restore the fuses to the default state.
 
 

--- a/boards/cc2538dk/doc.txt
+++ b/boards/cc2538dk/doc.txt
@@ -42,8 +42,7 @@ internal bootloader, then run:
 
 Activating this bootloader is NOT enabled if the flash content is in factory
 default state (e.g. after unboxing). To set the bits in the CCA accordingly you
-have to follow the guidelines found [here]
-(https://web.archive.org/web/20170610111337/http://processors.wiki.ti.com/index.php/CC2538_Bootloader_Backdoor).
+have to follow the guidelines found [here](https://web.archive.org/web/20170610111337/http://processors.wiki.ti.com/index.php/CC2538_Bootloader_Backdoor).
 To manage this first time access you have to download the
 ["Uniflash"](http://processors.wiki.ti.com/index.php/Category:CCS_UniFlash) tool
 at TI's website.
@@ -58,8 +57,7 @@ FTDI driver manually:
 If the path `/sys/bus/usb-serial/drivers/ftdi_sio/` doesn't exist, you also
 have to load the module `ftdi_sio` by hand.  Alternatively, you can install a
 `udev` rule that configures this on device connection, see [this post on TI's
-E2E site]
-(https://e2e.ti.com/support/microcontrollers/c2000/f/171/p/359074/1843485#1843485)
+E2E site](https://e2e.ti.com/support/microcontrollers/c2000/f/171/p/359074/1843485#1843485)
 for details.
 
 RIOT will use /dev/ttyUSB1 by default, but if the UART is given a different
@@ -114,8 +112,8 @@ $ csrutil status
 System Integrity Protection status: disabled.
 ```
 
-Afterwards you'll be able to install this [driver]
-(https://cdn.sparkfun.com/assets/learn_tutorials/7/4/FTDIUSBSerialDriver_v2_3.dmg).
+Afterwards you'll be able to install this
+[driver](https://cdn.sparkfun.com/assets/learn_tutorials/7/4/FTDIUSBSerialDriver_v2_3.dmg).
 
 If everything goes OK reboot your Mac and then edit
 `/System/Library/Extensions/FTDIUSBSerialDriver.kext/Contents/Info.plist` with a

--- a/boards/cc2650stk/doc.txt
+++ b/boards/cc2650stk/doc.txt
@@ -54,8 +54,7 @@ The arm-none-eabi toolchain works fine. You can get it
 
 ## Programming and Debugging
 
-You'll need [debugging hardware]
-(https://processors.wiki.ti.com/index.php?title=CC13xx_CC26xx_Tools_Overview#Debuggers).
+You'll need [debugging hardware](https://processors.wiki.ti.com/index.php?title=CC13xx_CC26xx_Tools_Overview#Debuggers).
 So far, the [XDS110 debug probe](https://www.ti.com/tool/CC-DEVPACK-DEBUG) has
 been tested. That bugger requires you to load a firmware onto it each time it
 powers up. The tool is contained in the Uniflash utility or the `CodeComposer

--- a/boards/common/slwstk6000b/doc.txt
+++ b/boards/common/slwstk6000b/doc.txt
@@ -90,8 +90,8 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.1]
-(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
+peripherals. You are advised to read
+[AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/derfmega128/doc.txt
+++ b/boards/derfmega128/doc.txt
@@ -9,32 +9,23 @@ deRFmega128 modules are based on [ATmega128rfa1](http://ww1.microchip.com/downlo
 MCUs. It include 16MHz main and 32K RTC crystalls and (depending on module type) integrated or not integrated 2.4GHz antenna.
 
 These modules are available in different variants:
-- [deRFmega128-22M00]
-  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m00.html)
+- [deRFmega128-22M00](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m00.html)
   with integrated antenna,
-- [deRFmega128-22M10]
-  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m10.html)
+- [deRFmega128-22M10](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22m10.html)
   without integrated antenna.
-- [deRFmega128-22A00]
-  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22a00.html)
+- [deRFmega128-22A00](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22a00.html)
   with connectors and integrated antenna,
-- [deRFmega128-22A02]
-  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22a02.html)
+- [deRFmega128-22A02](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22a02.html)
   with connectors, but without integrated antenna.
-- [deRFmega128-22C00]
-  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22c00.html)
+- [deRFmega128-22C00](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22c00.html)
   solderable with integrated antenna,
-- [deRFmega128-22C02]
-  (https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22c02.html)
+- [deRFmega128-22C02](https://www.dresden-elektronik.de/produkt/24-ghz-avr-derfmega128-22c02.html)
   solderable without integrated antenna.
 
 # Hardware
 
 For details see the according data sheets:
-- [deRFmega128-22M00 and deRFmega128-22M10]
-  (https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22M00-22M10-DBT-de.pdf)
-- [deRFmega128-22A00 and deRFmega128-22C00]
-  (https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22A00-C00-DBT-de.pdf)
-- [deRFmega128-22A02 and deRFmega128-22C02]
-  (https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22A02-C02-DBT-de.pdf)
+- [deRFmega128-22M00 and deRFmega128-22M10](https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22M00-22M10-DBT-de.pdf)
+- [deRFmega128-22A00 and deRFmega128-22C00](https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22A00-C00-DBT-de.pdf)
+- [deRFmega128-22A02 and deRFmega128-22C02](https://www.dresden-elektronik.de/files/dresden-elektronik/content/downloads/datenblaetter/_outdated/deRFmega128-22A02-C02-DBT-de.pdf)
  */

--- a/boards/esp32-heltec-lora32-v2/doc.txt
+++ b/boards/esp32-heltec-lora32-v2/doc.txt
@@ -22,8 +22,7 @@
     2. [Board Configuration](#esp32_heltec_lora32_v2_board_configuration)
     3. [Board Pinout](#esp32_heltec_lora32_v2_pinout)
     4. [Using the OLED Display](#esp32_heltec_lora32_v2_oled_display)
-    5. [Optional Hardware Configurations]
-       (#esp32_heltec_lora32_v2_optional_hardware)
+    5. [Optional Hardware Configurations](#esp32_heltec_lora32_v2_optional_hardware)
 3. [Flashing the Device](#esp32_heltec_lora32_v2_flashing)
 
 ## Overview {#esp32_heltec_lora32_v2_overview}
@@ -217,10 +216,8 @@ purpose. However, if optional off-board hardware modules are used,
 these GPIOs may also be occupied,
 see section \ref esp32_heltec_lora32_v2_board_configuration for more information.
 
-The corresponding board schematics can be found [here for SX1276 version]
-(https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/blob/master/SchematicDiagram/WiFi_LoRa_32(V2)/WIFI_LoRa_32_V2(868-915).PDF)
-and [here for SX1278 version]
-(https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/blob/master/SchematicDiagram/WiFi_LoRa_32(V2)/WiFi_LoRa_32_V2(433%2C470-510).PDF).
+The corresponding board schematics can be found [here for SX1276 version](https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/blob/master/SchematicDiagram/WiFi_LoRa_32(V2)/WIFI_LoRa_32_V2(868-915).PDF)
+and [here for SX1278 version](https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/blob/master/SchematicDiagram/WiFi_LoRa_32(V2)/WiFi_LoRa_32_V2(433%2C470-510).PDF).
 
 \anchor esp32_heltec_lora_32_v2_pinout_img
 @image html "https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/Heltec_WiFi_LoRa_32_V2_pinout.png" "WiFi LoRa 32 V2 Pintout Diagram"

--- a/boards/esp32-mh-et-live-minikit/doc.txt
+++ b/boards/esp32-mh-et-live-minikit/doc.txt
@@ -21,17 +21,15 @@
     1. [MCU](#esp32_mh_et_live_minikit_mcu)
     2. [Board Configuration](#esp32_mh_et_live_minikit_board_configuration)
     3. [Board Pinout](#esp32_mh_et_live_minikit_pinout)
-    4. [Optional Hardware Configurations]
-       (#esp32_mh_et_live_minikit_optional_hardware)
+    4. [Optional Hardware Configurations](#esp32_mh_et_live_minikit_optional_hardware)
 3. [Flashing the Device](#esp32_mh_et_live_minikit_flashing)
 
 ## Overview {#esp32_mh_et_live_minikit_overview}
 
 The MH-ET LIVE MiniKit for ESP32 uses the ESP32-WROOM-32 module. It is a very
 interesting development kit as it uses in the stackable Wemos D1 Mini format.
-Thus, all [shields for Wemos D1 mini]
-(https://docs.wemos.cc/en/latest/d1_mini_shield/index.html) for ESP8266
-can also be used with ESP32. Examples for such shields are:
+Thus, all [shields for Wemos D1 mini](https://docs.wemos.cc/en/latest/d1_mini_shield/index.html)
+for ESP8266 can also be used with ESP32. Examples for such shields are:
 
 - Micro SD-Card Shield
 - MRF24J40 IEEE 802.15.4 radio Shield

--- a/boards/esp32-wemos-lolin-d32-pro/doc.txt
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.txt
@@ -21,8 +21,7 @@
     1. [MCU](#esp32_wemos_lolin_d32_pro_mcu)
     2. [Board Configuration](#esp32_wemos_lolin_d32_pro_board_configuration)
     3. [Board Pinout](#esp32_wemos_lolin_d32_pro_pinout)
-    4. [Optional Hardware Configurations]
-       (#esp32_wemos_lolin_d32_pro_optional_hardware)
+    4. [Optional Hardware Configurations](#esp32_wemos_lolin_d32_pro_optional_hardware)
 3. [Flashing the Device](#esp32_wemos_lolin_d32_pro_flashing)
 
 ## Overview {#esp32_wemos_lolin_d32_pro_overview}
@@ -164,8 +163,8 @@ any purpose. However, if optional off-board hardware modules are used,
 these GPIOs may also be occupied, see section
 \ref esp32_wemos_lolin_d32_pro_board_configuration for more information.
 
-The corresponding board schematic can be found [here]
-(https://docs.wemos.cc/en/latest/_static/files/sch_d32_pro_v2.0.0.pdf).
+The corresponding board schematic can be found
+[here](https://docs.wemos.cc/en/latest/_static/files/sch_d32_pro_v2.0.0.pdf).
 
 \anchor esp32_wemos_lolin_d32_pro_pinout_img
 @image html "https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/Wemos_LOLIN_D32_PRO_pinout.png" "Wemos LOLIN D32 PRO pinout"

--- a/boards/esp32-wroom-32/doc.txt
+++ b/boards/esp32-wroom-32/doc.txt
@@ -170,8 +170,8 @@ and can be used for any purpose. However, if optional off-board hardware
 modules are used, these GPIOs may also be occupied, see
 section \ref esp32_wroom_32_board_configuration for more information.
 
-The corresponding board schematics can be found her [here]
-(https://dl.espressif.com/dl/schematics/esp32_devkitc_v4-sch-20180607a.pdf)
+The corresponding board schematics can be found
+[here](https://dl.espressif.com/dl/schematics/esp32_devkitc_v4-sch-20180607a.pdf)
 
 @image html "https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/ESP32-WROOM-32_pinouts.png" "EPS32-DevKitC V4 Pinout"
 

--- a/boards/esp32-wrover-kit/doc.txt
+++ b/boards/esp32-wrover-kit/doc.txt
@@ -286,8 +286,7 @@ for ESP32 boards, see \ref esp32_riot.
 Since the USB bridge based on FDI FT2232HL provides a JTAG interface for
 debugging through an USB interface, using ESP-WROVER-Kit V3 is the easiest
 and most convenient way for On-Chip debugging. Please refer the
-[ESP-IDF Programming Guide]
-(https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html)
+[ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html)
 for details on how to setup and how to use ESP-WROVER-Kit V3 and OpenOCD.
 
 To use the JTAG interface, the `esp_jtag` module has to be enabled for
@@ -298,8 +297,8 @@ USEMODULE=esp_jtag make flash BOARD=esp32-wrover-kit ...
 
 To flash and debug using OpenOCD, the precompiled version of OpenOCD for
 ESP32 has to be installed using the install script while being in RIOT's
-root directory, see also section [Using Local Toolchain Installation]
-(#esp32_local_toolchain_installation).
+root directory, see also section
+[Using Local Toolchain Installation](#esp32_local_toolchain_installation).
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 dist/tools/esptool/install.sh openocd
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -333,7 +332,6 @@ method for flashing with `esptool.py` can still be used. In that case, the
 ## Other Documentation Resources  {#esp32_wrover_kit_other-resources}
 
 There is a comprehensive
-[Getting Started Guide]
-(https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-wrover-kit-v3.html)
+[Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-wrover-kit-v3.html)
 for the ESP-WROVER-KIT with a lot information about hardware configuration.
  */

--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -17,7 +17,7 @@
  *
  * - Micro-SD card interface
  * - OV7670 camera interface
- * - 3.2" SPI LCD panel
+ * - 3.2\" SPI LCD panel
  * - RGB LED
  *
  * Furthermore, many GPIOs are broken out for extension. The USB bridge

--- a/boards/esp32-wrover-kit/include/periph_conf.h
+++ b/boards/esp32-wrover-kit/include/periph_conf.h
@@ -17,7 +17,7 @@
  *
  * - Micro-SD card interface
  * - OV7670 camera interface
- * - 3.2" SPI LCD panel
+ * - 3.2\" SPI LCD panel
  * - RGB LED
  *
  * Furthermore, many GPIOs are broken out for extension. The USB bridge

--- a/boards/esp32c3-wemos-mini/doc.txt
+++ b/boards/esp32c3-wemos-mini/doc.txt
@@ -26,9 +26,9 @@
 ## Overview {#esp32c3_wemos_mini_overview}
 
 The Wemos ESP32-C3 mini board is an interesting development kit as it uses
-in the stackable Wemos LOLIN D1 Mini format. Thus, all [shields for Wemos D1 mini]
-(https://docs.wemos.cc/en/latest/d1_mini_shield/index.html) for ESP8266
-can also be used with ESP32-C3. Examples for such shields are:
+in the stackable Wemos LOLIN D1 Mini format. Thus, all
+[shields for Wemos D1 mini](https://docs.wemos.cc/en/latest/d1_mini_shield/index.html)
+for ESP8266 can also be used with ESP32-C3. Examples for such shields are:
 
 - Micro SD-Card Shield
 - MRF24J40 IEEE 802.15.4 radio Shield
@@ -45,7 +45,7 @@ the need for a soldering iron or a breadboard.
 This stackable platform was tested in an RIOT application with:
 
 - MRF24J40 IEEE 802.15.4 radio Shield (contact gunar@schorcht.net for more information)
-- [BMP180 Pressure Sensor Shield]
+- [BMP180 Pressure Sensor Shield](http://www.esp8266learning.com/wemos-mini-bmp180-shield.php)
 
 This application is a good example how easy it is with this board to create
 different hardware applications.

--- a/boards/esp32s2-lilygo-ttgo-t8/doc.txt
+++ b/boards/esp32s2-lilygo-ttgo-t8/doc.txt
@@ -125,8 +125,7 @@ definition.
 
 @image html https://ae01.alicdn.com/kf/H4a77f8684c144384a165d7a89476c602q.jpg "LILYGO TTGO T8 ESP32-S2 Pinout" width=900px
 
-The corresponding board schematics can be found [here]
-(https://github.com/Xinyuan-LilyGO/LilyGo-T-Display-S2/raw/master/schematic/ESP32_S2-Display.pdf)
+The corresponding board schematics can be found [here](https://github.com/Xinyuan-LilyGO/LilyGo-T-Display-S2/raw/master/schematic/ESP32_S2-Display.pdf)
 
 [Back to table of contents](#esp32s2_lilygo_ttgo_t8_toc)
 

--- a/boards/esp32s3-box/doc.txt
+++ b/boards/esp32s3-box/doc.txt
@@ -38,7 +38,7 @@ The ESP32-S3-Box has following main features:
 | ESP32-S3 SoC                                | yes     |
 | 16 MB Flash                                 | yes     |
 | 8 MB QSPI RAM                               | yes     |
-| 2.4" LCD Display 320 x 240 with ILI9342C    | yes     |
+| 2.4\" LCD Display 320 x 240 with ILI9342C   | yes     |
 | Capacitive Touch Panel                      | no      |
 | Dual Microphone ES7210                      | no      |
 | Speaker Codec ES8311                        | no      |

--- a/boards/esp32s3-pros3/doc.txt
+++ b/boards/esp32s3-pros3/doc.txt
@@ -128,8 +128,8 @@ The following figure shows the pinout as configured by board definition.
 
 @image html https://esp32s3.com/images/pins_pros3.jpg "ESP32 ProS3C-1 Pinout" width=900px
 
-The corresponding board schematic can be found [here]
-(https://github.com/UnexpectedMaker/esp32s3/raw/main/schematics/schematic-pros3.pdf)
+The corresponding board schematic can be found
+[here](https://github.com/UnexpectedMaker/esp32s3/raw/main/schematics/schematic-pros3.pdf)
 
 [Back to table of contents](#esp32s3_pros3_toc)
 

--- a/boards/esp32s3-usb-otg/doc.txt
+++ b/boards/esp32s3-usb-otg/doc.txt
@@ -73,7 +73,7 @@ The Espressif ESP32-S3-USB-OTG is a development board that uses the
 ESP32-S3-MINI-1 module. Most important features of the board are
 
 - Micro-SD Card interface
-- 1.3" Color LCD display with ST7789 display controller
+- 1.3\" Color LCD display with ST7789 display controller
 - USB-to-UART bridge
 - `USB_DEV` Type-A male port
 - `USB_HOST` Type-A female port

--- a/boards/esp32s3-wt32-sc01-plus/doc.txt
+++ b/boards/esp32s3-wt32-sc01-plus/doc.txt
@@ -31,8 +31,8 @@ is a smart panel development platform with the ESP32-S3 SoC.
 
 \image html https://raw.githubusercontent.com/sukesh-ak/ESP32-TUX/master/datasheet/WT32-SC01-Plus.png "ESP32-S3 WT32-SC01 Plus" width=400px
 
-It also available on the market as [Smart Panlee SC01 Plus]
-(http://en.smartpanle.com/product-item-15.html).
+It also available on the market as
+[Smart Panlee SC01 Plus](http://en.smartpanle.com/product-item-15.html).
 
 The ESP32-S3 WT32-SC01 Plus has following main features:
 <center>

--- a/boards/esp32s3-wt32-sc01-plus/doc.txt
+++ b/boards/esp32s3-wt32-sc01-plus/doc.txt
@@ -41,7 +41,7 @@ The ESP32-S3 WT32-SC01 Plus has following main features:
 | ESP32-S3 SoC                                | yes     |
 | 16 MB Flash                                 | yes     |
 | 2 MB QSPI RAM                               | yes     |
-| 3.5" LCD Display 480 x 320 with ST7796UI    | yes     |
+| 3.5\" LCD Display 480 x 320 with ST7796UI   | yes     |
 | Capacitive Touch Panel with FT6336U         | yes     |
 | SD Card SPI mode                            | yes     |
 | USB Type-C                                  | yes     |

--- a/boards/esp32s3-wt32-sc01-plus/include/board.h
+++ b/boards/esp32s3-wt32-sc01-plus/include/board.h
@@ -63,7 +63,7 @@
 /**
  * @name    LCD display configuration
  *
- * ESP32-S3 WT32-SC01 Plus uses a 3.5" LCD 480 x 320 pixel display with
+ * ESP32-S3 WT32-SC01 Plus uses a 3.5\" LCD 480 x 320 pixel display with
  * an ST7796UI as driver chip and MCU8080 8-bit parallel interface.
  *
  * This configuration cannot be changed.

--- a/boards/esp8266-esp-12x/doc.txt
+++ b/boards/esp8266-esp-12x/doc.txt
@@ -63,13 +63,12 @@ RIOT for ESP8266 boards, see \ref esp8266_riot.
 
 ## WEMOS LOLIN D1 mini {#esp8266_wemos_lolin_d1_mini}
 
-[WEMOS LOLIN D1 mini]
-(https://www.wemos.cc/en/latest/d1/d1_mini.html)
+[WEMOS LOLIN D1 mini](https://www.wemos.cc/en/latest/d1/d1_mini.html)
 is a very interesting board series as it offers a stackable ESP8266 platform.
 This board can be easily extended with a large number of compatible peripheral
 shields, e.g. a micro SD card shield, an IR controller shield, a battery
-shield, and various sensor and actuator shields, see [D1 mini shields]
-(https://docs.wemos.cc/en/latest/d1_mini_shield/index.html) for more
+shield, and various sensor and actuator shields, see
+[D1 mini shields](https://docs.wemos.cc/en/latest/d1_mini_shield/index.html) for more
 information. This makes it possible to create different hardware configurations
 without the need for a soldering iron or a breadboard.
 
@@ -88,8 +87,7 @@ microUSB port with flash / boot / reset logic that makes flashing much
 easier. Their peripherals are equal and work with the default ESP8266 ESP-12x
 board definition.
 
-For more information, see [D1 Boards]
-(https://docs.wemos.cc/en/latest/d1/d1_mini.html).
+For more information, see [D1 Boards](https://docs.wemos.cc/en/latest/d1/d1_mini.html).
 
 <center>
 Board        | MCU       | Flash    | Antenna | Remark

--- a/boards/esp8266-sparkfun-thing/doc.txt
+++ b/boards/esp8266-sparkfun-thing/doc.txt
@@ -93,8 +93,8 @@ Since the SparkFun Thing Dev board has an USB to Serial adapter on board,
 this can done directly using the Micro USB. SparkFun Thin board has to be
 connected to the host computer using the FTDI interface and a FTDI USB to
 Serial adapter/cable. For more information on how to program the
-SparkFun Thing board, please refer the [ESP8266 Thing Hookup Guide]
-(https://learn.sparkfun.com/tutorials/esp8266-thing-hookup-guide/programming-the-thing).
+SparkFun Thing board, please refer the
+[ESP8266 Thing Hookup Guide](https://learn.sparkfun.com/tutorials/esp8266-thing-hookup-guide/programming-the-thing).
 
 @note Please make sure the FTDI USB to Serial adapter/cable uses 3.3 V.
 

--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -103,8 +103,8 @@ with `EFM32_USE_LEUART=1`.
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.1]
-(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
+peripherals. You are advised to read
+[AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -18,13 +18,11 @@
 
 ## Board HW overview
 
-![IoT-LAB M3 Layout]
-(https://www.iot-lab.info/wp-content/uploads/2013/10/m3opennode.png)
+![IoT-LAB M3 Layout](https://www.iot-lab.info/wp-content/uploads/2013/10/m3opennode.png)
 
 ### Board Architecture
 
-![IoT-LAB M3 Architecture]
-(https://github.com/iot-lab/iot-lab/wiki/Images/archiopenm3.png)
+![IoT-LAB M3 Architecture](https://github.com/iot-lab/iot-lab/wiki/Images/archiopenm3.png)
 
 ### [Board schematics](http://github.com/iot-lab/iot-lab/wiki/Docs/openm3-schematics.pdf)
 , wiring, pinouts, etc...

--- a/boards/mulle/doc.txt
+++ b/boards/mulle/doc.txt
@@ -3,8 +3,7 @@
 @ingroup     boards
 @brief       Support for Eistec Mulle IoT boards
 
-![Mulle]
-(https://web.archive.org/web/20161213064400im_/http://eistec.github.io/images/mulle-small.jpg)
+![Mulle](https://web.archive.org/web/20161213064400im_/http://eistec.github.io/images/mulle-small.jpg)
 
 The Mulle is a miniature wireless Embedded Internet System suitable for
 wireless sensors connected to the Internet of Things, and designed for rapid

--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -6,8 +6,7 @@
 [Family: native](https://github.com/RIOT-OS/RIOT/wiki/Family:-native)
 
 # Overview
-![Terminal running RIOT native]
-(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/Native.jpg)
+![Terminal running RIOT native](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/Native.jpg)
 
 # Hardware
 - CPU: Host CPU

--- a/boards/nrf51dongle/doc.txt
+++ b/boards/nrf51dongle/doc.txt
@@ -18,8 +18,7 @@ While the pca10000 contains an on-board J-Link debugger, the pca10005 boards
 have to be flashed/debugged using the (included) external J-Link device.
 
 ## Hardware:
-![Nordic Semiconductor nrF51822 Development Kit]
-(https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF51-Series/nRF51-Dongle-promo.png)
+![Nordic Semiconductor nrF51822 Development Kit](https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF51-Series/nRF51-Dongle-promo.png)
 
 | MCU               | NRF51822QFAA                                                                  |
 |:----------------- |:----------------------------------------------------------------------------- |

--- a/boards/nucleo-f030r8/doc.txt
+++ b/boards/nucleo-f030r8/doc.txt
@@ -10,8 +10,7 @@ STM32F030R8 microcontroller with 8KiB of RAM and 64KiB of Flash.
 
 ## Hardware
 
-![Nucleo64 F030R8]
-(http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F030R8](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ## Pinout
 

--- a/boards/nucleo-f070rb/doc.txt
+++ b/boards/nucleo-f070rb/doc.txt
@@ -10,8 +10,7 @@ STM32F070RB microcontroller with 16KiB of RAM and 128KiB of Flash.
 
 ## Hardware
 
-![Nucleo64 F070RB]
-(http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F070RB](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ## Pinout
 

--- a/boards/nucleo-f446re/doc.txt
+++ b/boards/nucleo-f446re/doc.txt
@@ -10,8 +10,7 @@ STM32F446RE microcontroller with 128KiB of RAM and 512KiB of Flash.
 
 ## Hardware
 
-![Nucleo64 F446RE]
-(http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
+![Nucleo64 F446RE](http://www.open-electronics.org/wp-content/uploads/2015/08/Figura2-500x467.png)
 
 ## Pinout
 

--- a/boards/openmote-cc2538/doc.txt
+++ b/boards/openmote-cc2538/doc.txt
@@ -10,8 +10,7 @@ SoC combining an ARM Cortex-M3 microcontroller with an IEEE802.15.4 radio.
 
 ## Hardware
 
-![openmote]
-(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/openmote.jpg)
+![openmote](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/openmote.jpg)
 
 | MCU        | CC2538SF53        |
 |:------------- |:--------------------- |

--- a/boards/sipeed-longan-nano-tft/doc.txt
+++ b/boards/sipeed-longan-nano-tft/doc.txt
@@ -12,7 +12,7 @@ that is equipped with a TFT display with the following on-board components:
 - USB Type C
 - TF card slot
 - 3 user LEDs
-- 0.96 inches TFT display 160 x 80 pixel
+- 0.96\" TFT display 160 x 80 pixel
 
 @image html "https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/1/114992425_1.jpg" "Sipeed Longan Nano" width=600
 

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -16,7 +16,7 @@ on-board components:
 - USB Type C
 - TF card slot
 - 3 user LEDs
-- 0.96 inches TFT display 160 x 80 pixel (optional)
+- 0.96\" TFT display 160 x 80 pixel (optional)
 
 @image html "https://wiki.sipeed.com/hardware/assets/Longan/nano/Longan_nano.124.jpg" "Sipeed Longan Nano" width=600
 

--- a/boards/slstk3701a/doc.txt
+++ b/boards/slstk3701a/doc.txt
@@ -159,8 +159,8 @@ symbols (`-gdwarf-2` for GCC).
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0]
-(https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read
+[AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/sltb009a/doc.txt
+++ b/boards/sltb009a/doc.txt
@@ -130,8 +130,8 @@ expects data from the MCU with the same settings.
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0]
-(https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read
+[AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |
@@ -249,8 +249,8 @@ make emulate
 ## Supported Toolchains
 
 For using the Silicon Labs SLTB009A starter kit we strongly recommend
-the usage of the [GNU Tools for ARM Embedded Processors]
-(https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+the usage of the
+[GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information

--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -12,8 +12,7 @@ when you're ready to integrate the Core into your product, you can.
 
 ## Hardware
 
-![Spark-Core image]
-(https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/spark-core.jpg)
+![Spark-Core image](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/spark-core.jpg)
 
 Link to [product website](http://docs.spark.io/hardware/).
 

--- a/boards/stm32f3discovery/doc.txt
+++ b/boards/stm32f3discovery/doc.txt
@@ -15,8 +15,7 @@ and 3-axis magnetometer).
 The board does however not provide any radio capabilities, radio devices have
 to be connected externally via I2C, SPI, UART or similar.
 
-See [this page]
-(https://github.com/RIOT-OS/RIOT/wiki/Getting-started-with-STM32F%5B0%7C3%7C4%5Ddiscovery-boards)
+See [this page](https://github.com/RIOT-OS/RIOT/wiki/Getting-started-with-STM32F%5B0%7C3%7C4%5Ddiscovery-boards)
 for a quick getting started guide.
 
 ## Hardware

--- a/boards/stm32f746g-disco/doc.txt
+++ b/boards/stm32f746g-disco/doc.txt
@@ -10,7 +10,7 @@ is an evaluation board supporting a ARM Cortex-M7 STM32F746NG microcontroller
 with 340KB of RAM and 1MB of ROM Flash.
 
 As main features, this board provides:
-- a 4"3 RGB 480×272 color LCD-TFT with capacitive touch screen,
+- a 4.3\" RGB 480×272 color LCD-TFT with capacitive touch screen,
 - an ethernet port
 - 2 user USB ports (FS and HS)
 - 2 user digital microphones

--- a/boards/stm32f7508-dk/doc.txt
+++ b/boards/stm32f7508-dk/doc.txt
@@ -13,7 +13,7 @@ is identical.
 
 As a result, the main features available on this board are shared with the ones
 provided by the STM32F746G-DISCO:
-- a 4"3 RGB 480×272 color LCD-TFT with capacitive touch screen,
+- a 4.3\" RGB 480×272 color LCD-TFT with capacitive touch screen,
 - an ethernet port
 - 2 user USB ports (FS and HS)
 - 2 user digital microphones

--- a/boards/stm32l0538-disco/doc.txt
+++ b/boards/stm32l0538-disco/doc.txt
@@ -9,7 +9,7 @@ The
 [STM32L0538-DISCO](https://www.st.com/en/evaluation-tools/32l0538discovery.html)
 discovery kit features an ultra low-power stm32l053c8t6 microcontroller with
 64KB of FLASH and 8KB of RAM.
-The board also provides an on-board 2.04" E-paper display (not supported yet).
+The board also provides an on-board 2.04\" E-paper display (not supported yet).
 
 ![STM32L0538-DISCO](https://www.st.com/content/ccc/fragment/product_related/rpn_information/board_photo/group0/67/a2/3f/98/6b/24/4a/27/stm32l0538-discovery.jpg/files/stm32l0538-disco.jpg/_jcr_content/translations/en.stm32l0538-disco.jpg)
 

--- a/boards/stm32mp157c-dk2/doc.txt
+++ b/boards/stm32mp157c-dk2/doc.txt
@@ -11,8 +11,7 @@ and no ROM Flash.
 
 ## Hardware
 
-![STM32MP157C-DK2]
-(https://www.st.com/bin/ecommerce/api/image.PF267415.en.feature-description-include-personalized-no-cpn-medium.jpg)
+![STM32MP157C-DK2](https://www.st.com/bin/ecommerce/api/image.PF267415.en.feature-description-include-personalized-no-cpn-medium.jpg)
 
 ### MCU
 

--- a/boards/waveshare-nrf52840-eval-kit/doc.txt
+++ b/boards/waveshare-nrf52840-eval-kit/doc.txt
@@ -6,9 +6,8 @@
 
 ## Overview
 
-The [Waveshare nRF52840 Eval Kit]
-(https://www.waveshare.com/NRF52840-Eval-Kit.htm) is an evaluation board
-for the nRF52840 SoC with the following on-board components:
+The [Waveshare nRF52840 Eval Kit](https://www.waveshare.com/NRF52840-Eval-Kit.htm)
+is an evaluation board for the nRF52840 SoC with the following on-board components:
 
 1. Arduino headers for connecting Arduino shields
 2. Raspberry Pi GPIO header for connecting Raspberry Pi HATs
@@ -29,8 +28,7 @@ for the nRF52840 SoC with the following on-board components:
 16. TF card slot
 17. CR2032 battery holder
 
-![Waveshare nRF52840 Eval Kit]
-(https://www.waveshare.com/img/devkit/accBoard/NRF52840-Eval-Kit/NRF52840-Eval-Kit-intro.jpg)
+![Waveshare nRF52840 Eval Kit](https://www.waveshare.com/img/devkit/accBoard/NRF52840-Eval-Kit/NRF52840-Eval-Kit-intro.jpg)
 
 Using the onboard Arduino and Raspberry Pi compatible headers, both Arduino
 shields and Raspberry Pi HATs can be used at the same time.

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -444,8 +444,7 @@ $ BUILD_IN_DOCKER=1 DOCKER="sudo docker" \
 During the migration phase from the ESP32 toolchain with GCC 5.2.0, which was
 specially compiled for RIOT, to Espressif's precompiled ESP32 vendor toolchain
 with GCC 8.4.0, the RIOT Docker build image
-[schorcht/riotbuild_esp32_espressif_gcc_8.4.0]
-(https://hub.docker.com/repository/docker/schorcht/riotbuild_esp32_espressif_gcc_8.4.0)
+[schorcht/riotbuild_esp32_espressif_gcc_8.4.0](https://hub.docker.com/repository/docker/schorcht/riotbuild_esp32_espressif_gcc_8.4.0)
 has to be used instead of `riot/riotbuild` as this already contains the
 precompiled ESP32 vendor toolchain from Espressif while `riot/riotbuild`
 does not.
@@ -509,8 +508,8 @@ by the environment variable `$IDF_TOOLS_PATH`. If the environment variable
 
 Using the variable `IDF_TOOLS_PATH` and its default value `$HOME/.espressif` for
 the toolchain installation in RIOT allows to reuse the tools that have already
-been installed according to the section ["Get Started, Step 3. Set up the tools"]
-(https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html#get-started-set-up-tools).
+been installed according to the section
+["Get Started, Step 3. Set up the tools"](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html#get-started-set-up-tools).
 if you have already used ESP-IDF directly.
 
 ### Using the toolchain
@@ -777,8 +776,8 @@ list of GPIOs that can be used as ADC channels on the board, for example:
 Thereby the order of the listed GPIOs determines the mapping between the
 ADC lines of the RIOT and the GPIOs. The maximum number of GPIOs in the
 list is #ADC_NUMOF_MAX. The board specific configuration of #ADC_GPIOS
-can be overridden by [Application specific configurations]
-(#esp32_application_specific_configurations).
+can be overridden by
+[Application specific configurations](#esp32_application_specific_configurations).
 
 The number of defined ADC channels #ADC_NUMOF is determined automatically
 from the #ADC_GPIOS definition.
@@ -849,8 +848,8 @@ used as DAC channels on the respective ESP32x SoC.
 #define DAC_GPIOS   { GPIO25, GPIO26 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This configuration can be changed by [application-specific configurations]
-(#esp32_application_specific_configurations).
+This configuration can be changed by
+[application-specific configurations](#esp32_application_specific_configurations).
 
 The order of the listed GPIOs determines the mapping between the RIOT's
 DAC lines and the GPIOs. The maximum number of GPIOs in the list is
@@ -972,8 +971,8 @@ virtual PWM devices PWM_DEV(0) ... PWM_DEV(3) in RIOT, for example:
 #define PWM1_GPIOS  { GPIO27, GPIO32, GPIO33 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This configuration can be changed by [application-specific configurations]
-(#esp32_application_specific_configurations).
+This configuration can be changed by
+[application-specific configurations](#esp32_application_specific_configurations).
 
 The mapping of the GPIOs as channels of the available channel groups and
 channel group timers is organized by the driver automatically as follows:
@@ -1432,8 +1431,8 @@ The RIOT port for ESP32x SoCs also supports:
 
 Dependent on the ESP32x SoC variant (family), external SPI RAM can be
 connected to the SPI interface that is driven by the SPI1 controller
-(`SPI1_HOST`). For example, all boards that use the [ESP32-WROVER modules]
-(https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf)
+(`SPI1_HOST`). For example, all boards that use the
+[ESP32-WROVER modules](https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf)
 have already integrated such SPI RAM. The connected SPI RAM is treated
 as PSRAM (pseudo-static RAM) and is integrated into the heap.
 
@@ -1736,8 +1735,8 @@ is the concatenation of the prefix `RIOT_ESP_` with the MAC address of its
 SoftAP WiFi interface. The driver periodically scans all visible ESP32x nodes.
 
 The following parameters are defined for ESP-NOW nodes. These parameters can
-be overridden by [application-specific board configurations]
-(#esp32_application_specific_board_configuration).
+be overridden by
+[application-specific board configurations](#esp32_application_specific_board_configuration).
 
 <center>
 

--- a/cpu/stm32/include/periph/cpu_fmc.h
+++ b/cpu/stm32/include/periph/cpu_fmc.h
@@ -257,8 +257,7 @@ typedef struct {
  *
  * The GPIOs are defined depending on used memory type according to the
  * FMC pin definition in Table 12 of section 4 in the
- * [Datasheet for STM32F765xx, STM32F767xx, STM32F768Ax, STM32F769xx]
- * (https://www.st.com/resource/en/datasheet/stm32f767zi.pdf).
+ * [Datasheet for STM32F765xx, STM32F767xx, STM32F768Ax, STM32F769xx](https://www.st.com/resource/en/datasheet/stm32f767zi.pdf).
  * Which memory types are used is defined by the pseudomodules
  * `periph_fmc_nor_sram`, `periph_fmc_nand` and `periph_fmc_sdram`
  *

--- a/drivers/sht3x/doc.txt
+++ b/drivers/sht3x/doc.txt
@@ -94,8 +94,7 @@ high). The stated repeatability is 3 times the standard deviation of multiple
 consecutive measurements at the stated repeatability and at constant ambient
 conditions. It is a measure for the noise on the physical sensor output.
 Different measurement modes allow for high/medium/low repeatability.
-[Datasheet SHT3x-DIS]
-(https://developer.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf)
+[Datasheet SHT3x-DIS](https://developer.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf)
 
 The repeatability settings influences the measurement duration as well as the power consumption of the sensor. The measurement takes typically 2.5 ms with low repeatability, 4.5 ms with medium repeatability and 12.5 ms with high repeatability. That is, the measurement produces a noticeable delay in execution.
 


### PR DESCRIPTION
### Contribution description

This PR fixes the references and inches unit symbols in documentation of `{boards,cpu,drivers}.

Doxygen version 1.9.4 that is used on https://doc.riot-os.org doesn't support the following any longer:
- References with line breaks between `[...]` and `(...)` which lead either to
  - missing images (e.g. in https://doc.riot-os.org/group__boards__nucleo-f030r8.html) or to
  - source code instead of references (e.g. in https://doc.riot-os.org/group__boards__deRFmega128.html)
- Using `"` as inch unit wihtout `\` which lead to complete messed up documentatoin
  (e.g. in https://doc.riot-os.org/group__boards__stm32f746g-disco.html)

### Testing procedure

Use doxygen 1.9.4 and `make doc` to generate the documentation and check the examples for correctness.

### Issues/PRs references
