### PR TITLE
.github/test-on-iotlab: prefer Toulouse site for dwm1001 board

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -36,7 +36,7 @@ jobs:
           - riot: dwm1001
             iotlab:
               archi: dwm1001:dw1000
-              site: lille
+              site: toulouse
           - riot: iotlab-m3
             iotlab:
               archi: m3:at86rf231


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It seems all dwm1001 boards on the IoT-LAB Lille site are down and the Toulouse site should now be considered as the preferred site anyway.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Not sure how this can be tested.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
