### PR TITLE
cpu/stm32/periph/eth: Disable hardware checksums

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -569,8 +569,7 @@ static int stm32_eth_send(netdev_t *netdev, const struct iolist *iolist)
     for (unsigned i = 0; iolist; iolist = iolist->iol_next, i++) {
         dma_iter->control = iolist->iol_len;
         dma_iter->buffer_addr = iolist->iol_base;
-        uint32_t status = TX_DESC_STAT_IC | TX_DESC_STAT_TCH | TX_DESC_STAT_CIC
-                          | TX_DESC_STAT_OWN;
+        uint32_t status = TX_DESC_STAT_IC | TX_DESC_STAT_TCH | TX_DESC_STAT_OWN;
         if (!i) {
             /* fist chunk */
             status |= TX_DESC_STAT_FS;


### PR DESCRIPTION
lwIP will fill them in already.

Having this enabled causes empty checksums to be sent: #19853

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Test pinging the stm32 board using both GNRC and lwIP running.

For lwip:

`$ LWIP_IPV4=1 make -C tests/pkg/lwip flash`

Not tested yet since I don't have the hardware.

### Issues/PRs references

Tries to fix underlying issue in #19853
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
