### PR TITLE
cpu/esp32: fix heap definition for ESP32-S2 and ESP32-S3

### DIFF
--- a/cpu/esp32/ld/esp32s2/sections.ld.in
+++ b/cpu/esp32/ld/esp32s2/sections.ld.in
@@ -590,8 +590,10 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } > dram0_0_seg
 
-  . = _heap_end;
+  . = ORIGIN(dram0_0_seg) + LENGTH(dram0_0_seg);
   _eheap = ABSOLUTE(.);
+
+  . = _heap_end;
 
 #ifdef MODULE_PERIPH_FLASHPAGE
   .flash_writable (NOLOAD) : ALIGN(65536)

--- a/cpu/esp32/ld/esp32s3/sections.ld.in
+++ b/cpu/esp32/ld/esp32s3/sections.ld.in
@@ -617,8 +617,10 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } > dram0_0_seg
 
-  . = _heap_end;
+  . = ORIGIN(dram0_0_seg) + LENGTH(dram0_0_seg);
   _eheap = ABSOLUTE(.);
+
+  . = _heap_end;
 
 #ifdef MODULE_PERIPH_FLASHPAGE
   .flash_writable (NOLOAD) : ALIGN(65536)


### PR DESCRIPTION
### Contribution description

For ESP32-S2 and ESP32-S3 the symbol `_heap_end` must not be used as `_eheap` for the newlibc `malloc` and function `sbrk`.

`_heap_end` is used by the ESP-IDF heap implementation `esp-idf-heap` and points to the highest possible address (0x40000000) that could be used for the heap in ESP-IDF. It doesn't point to the top address of the unused SRAM area that can be used in newlibc `malloc` and function `sbrk`. Instead, the origin and the length of `dram0_0_seg` must be used to calculate the end of the heap `_eheap`.

The problem only occurs for the newlibc `malloc` when the `sbrk` function is used but not for the ESP-IDF heap implementation `esp_idf_heap`.

### Testing procedure

Use any ESP32-S2 or ESP32-S3 board and flash `tests/sys/malloc`, e.g.
```
CFLAGS='-DCHUNK_SIZE=16384' USEMODULE='stdio_uart' BOARD=esp32s3-pros3 make -j8 -C tests/sys/malloc flash
```
Without the PR the `nm` command will give the wrong address 
```
nm -s tests/sys/malloc/bin/esp32s3-pros3/tests_malloc.elf | grep _eheap
40000000 A _eheap
```
The test will stuck, i.e. the allocation of memory stops when the top of unused SRAM is reached and the board restarts when the watchdog timer expires. With the PR it should work as expected
```
Help: Press s to start test, r to print it is ready
START
main(): This is RIOT! (Version: 2023.10-devel-309-g4669e)
calloc(zu, zu) = 0x10000000
CHUNK_SIZE: 16384
NUMBER_OF_TESTS: 3
Allocated 16384 Bytes at 0x3fc8c4b0, total 16384
...
Allocated 16384 Bytes at 0x3fcec6f0, total 409792
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x7 (TG0WDT_SYS_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)
Saved PC:0x403763e3
```

With this PR the `nm` command should give a address in unused SRAM address space
```
nm -s tests/sys/malloc/bin/esp32s3-pros3/tests_malloc.elf | grep _eheap
3fcca000 A _eheap
```
and the test should pass.

### Issues/PRs references
