### PR TITLE
cpu/esp32: fix Octal SPI RAM for ESP32-S3

### DIFF
--- a/boards/esp32s3-box/doc.txt
+++ b/boards/esp32s3-box/doc.txt
@@ -37,7 +37,7 @@ The ESP32-S3-Box has following main features:
 |:--------------------------------------------|:-------:|
 | ESP32-S3 SoC                                | yes     |
 | 16 MB Flash                                 | yes     |
-| 8 MB QSPI RAM                               | yes     |
+| 8 MB Octal SPI RAM                          | yes     |
 | 2.4\" LCD Display 320 x 240 with ILI9342C   | yes     |
 | Capacitive Touch Panel                      | no      |
 | Dual Microphone ES7210                      | no      |
@@ -104,7 +104,7 @@ UART_DEV(0) RxD | GPIO44 | PMOD2 | \ref esp32_uart_interfaces "UART interfaces"
 The following figures show the pinouts as configured by default board
 definition.
 
-@image html https://raw.githubusercontent.com/espressif/esp-box/master/docs/_static/_get_started_static/hardware_pmod.png "ESP32-S3-BoxC-1 Pinout" width=900px
+@image html https://raw.githubusercontent.com/espressif/esp-box/master/docs/_static/previous_get_started_fig/hardware_pmod.png "ESP32-S3-BoxC-1 Pinout" width=900px
 
 The corresponding schematics can be found:
 

--- a/boards/esp32s3-pros3/doc.txt
+++ b/boards/esp32s3-pros3/doc.txt
@@ -33,7 +33,7 @@ The main features of the board are:
 
 - ESP32-S3 SoC with 2.4 GHz WiFi 802.11b/g/n and Bluetooth5, BLE
 - 16 MByte Flash
-- 4 MByte SPI RAM
+- 8 MByte QSPI RAM
 - RGB LED WS2812B
 - Native USB and USB Serial JTAG
 - LiPo Battery Charging and PicoBlade connector

--- a/cpu/esp32/ld/esp32s3/sections.ld.in
+++ b/cpu/esp32/ld/esp32s3/sections.ld.in
@@ -213,6 +213,8 @@ SECTIONS
     *components/esp_hw_support/*/rtc_sleep.*(.literal .literal.* .text .text.*)
     *components/esp_hw_support/*/rtc_time.*(.literal .literal.* .text .text.*)
     *components/esp_hw_support/*/rtc_wdt.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/*/spiram_psram.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/*/opiram_psram.*(.literal .literal.* .text .text.*)
     *components/esp_ringbuf/*(.literal .literal.* .text .text.*)
     *components/esp_rom/esp_rom_spiflash.*(.literal .literal.* .text .text.*)
     *components/esp_system/esp_err.*(.literal .literal.* .text .text.*)


### PR DESCRIPTION
### Contribution description

This PR fixes Octal SPI RAM handling for ESP32-S3.

Functions that are used during the initialization of the Octal SPI RAM must reside in IRAM instead of Flash. Otherwise, the system stucks during boot once the Octal SPI RAM is enabled. The reason is that the Flash is not available during the initialization of the Octal SPI RAM and the functions that are called during that initialization can't be accessed in Flash. As a result the call of such a function leads to code that is messed up and the system crashes.

The PR also includes the documentation fixe for the `esp32s3-box`. It also includes a small documentation fix regarding the SPI RAM for the `esp32s3-pros3` board.

### Testing procedure

Use a board that has Octal SPI RAM and flash `tests/sys/malloc`, e.g.:
```
CFLAGS='-DCHUNK_SIZE=16384' USEMODULE='stdio_uart esp_spi_ram esp_log_startup' \
BOARD=esp32s3-box make -C tests/sys/malloc
```
Without the PR, the system stuck during boot once the information for the Octal SPI RAM is print
```
ESP-ROM:esp32s3-20210327
...
I (133) boot: Loaded app from partition at offset 0x10000
I (134) boot: Disabling RNG early entropy source...
vendor id : 0x0d (AP)
dev id    : 0x02 (generation 3)
density   : 0x03 (64 Mbit)
good-die  : 0x01 (Pass)
Latency   : 0x01 (Fixed)
VCC       : 0x01 (3V)
SRF       : 0x01 (Fast Refresh)
BurstType : 0x01 (Hybrid Wrap)
BurstLen  : 0x01 (32 Byte)
Readlatency  : 0x02 (10 cycles@Fixed)
DriveStrength: 0x00 (1/1)
```
and the board restarts when the watchdog timer expires.

With this PR, the system starts as expected.
```
ESP-ROM:esp32s3-20210327
...
I (132) boot: Loaded app from partition at offset 0x10000
I (133) boot: Disabling RNG early entropy source...
vendor id : 0x0d (AP)
dev id    : 0x02 (generation 3)
density   : 0x03 (64 Mbit)
good-die  : 0x01 (Pass)
Latency   : 0x01 (Fixed)
VCC       : 0x01 (3V)
SRF       : 0x01 (Fast Refresh)
BurstType : 0x01 (Hybrid Wrap)
BurstLen  : 0x01 (32 Byte)
Readlatency  : 0x02 (10 cycles@Fixed)
DriveStrength: 0x00 (1/1)
Found 64MBit SPI RAM device
SPI RAM mode: sram 40m
PSRAM initialized, cache is in normal (1-core) mode.
Pro cpu up.
Single core mode
SPI SRAM memory test OK
Initializing. RAM available for dynamic allocation:
At 3FC8C150 len 00053EB0 (335 KiB): D/IRAM
At 3FCE0000 len 0000EE34 (59 KiB): STACK/DRAM
At 3FCF0000 len 00008000 (32 KiB): DRAM

Starting ESP32x with ID: f412fafd0f8c
ESP-IDF SDK Version v4.4.1

Current clocks in Hz: CPU=80000000 APB=80000000 XTAL=40000000 SLOW=150000
PRO cpu is up (single core mode, only PRO cpu is used)
PRO cpu starts user code
Adding pool of 8192K of external SPI memory to heap allocator
Used clocks in Hz: CPU=80000000 APB=80000000 XTAL=40000000 FAST=8000000 SLOW=150000
XTAL calibration value: 3643448
Heap free: 8754851 bytes

Board configuration:
	UART_DEV(0)	txd=43 rxd=44
	LED		pins=[ ]
	BUTTONS		pins=[ 0 ]

Starting RIOT kernel on PRO cpu
Help: Press s to start test, r to print it is ready
```

### Issues/PRs references
