### PR TITLE
tests/unittests: blacklist LLVM on native

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -13,6 +13,12 @@ ifeq (, $(UNIT_TESTS))
   endif
 endif
 
+ifeq (llvm,$(TOOLCHAIN))
+  # the floating point exception bug is more likely to trigger when build
+  # with LLVM, so we just disable LLVM on native as a work around
+  TEST_ON_CI_BLACKLIST += native
+endif
+
 DISABLE_MODULE += auto_init auto_init_%
 
 # boards using stdio via CDC ACM require auto_init to automatically


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This test is randomly failing CI, so disable it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Hopefully less [sporadic](https://ci.riot-os.org/details/eb28f35184364283979f048387078f3b) [CI](https://ci.riot-os.org/details/ba8dc586773848169e824fef3040ba9e) [failures](https://ci.riot-os.org/details/8758555a2c3b49938a64bfecf958e44b).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

same as #19634
708e5eadb4e
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
