### PR TITLE
pkg/driver_cryptocell_310: Fix Makefile

### DIFF
--- a/pkg/c25519/Makefile
+++ b/pkg/c25519/Makefile
@@ -7,6 +7,7 @@ PKG_SHA512  = dbfb4285837ab2ea3d99c448b22877cc7a139ccbaebb1de367e2bec1fd562fe629
 
 PKG_SOURCE_DIR ?= $(PKGDIRBASE)/$(PKG_NAME)
 PKG_ZIPFILE = $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+PKG_ZIP_URL = $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
 
 ifneq ($(RIOTBASE),)
 include $(RIOTBASE)/Makefile.base
@@ -19,17 +20,17 @@ prepare: $(PKG_SOURCE_DIR)/
 all: $(PKG_SOURCE_DIR)/
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
 
-$(PKG_SOURCE_DIR)/: $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
-	$(QQ)test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "${PKG_ZIPFILE}")"
+$(PKG_SOURCE_DIR)/: $(PKG_ZIPFILE)
+	$(QQ)test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "$(PKG_ZIPFILE)")"
 	$(Q)$(UNZIP_HERE) -D -d $(PKGDIRBASE) $<
 
 $(PKG_ZIPFILE):
 	$(QQ)mkdir -p $(PKGDIRBASE)
-	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_ZIP_URL)
 
 clean::
 	# Reset package to checkout state.
 	rm -rf $(PKG_SOURCE_DIR)
 
 distclean::
-	rm -rf $(PKG_SOURCE_DIR) $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+	rm -rf $(PKG_SOURCE_DIR) $(PKG_ZIPFILE)

--- a/pkg/driver_cryptocell_310/Makefile
+++ b/pkg/driver_cryptocell_310/Makefile
@@ -1,36 +1,42 @@
-PKG_NAME=driver_cryptocell_310
-PKG_URL=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5/Binaries
-PKG_VERSION=17.1.0
-PKG_EXT=zip
-PKG_DIR_NAME=nRF5_SDK_17.1.0_ddde560
-PKG_LICENSE=ARM Object Code and Header Files License
+PKG_NAME      = driver_cryptocell_310
+PKG_URL       = https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5/Binaries
+PKG_VERSION   = 17.1.0_ddde560
+PKG_DIR_NAME  = nRF5_SDK
+PKG_EXT       = zip
+PKG_LICENSE   = ARM Object Code and Header Files License
+PKG_SHA512  	= cb610d724d27ef79c792511d8b889cbf2d411a3a391f5c740ea10b86139201b97eedf0c1edcf4d199c3fbd51e4cc5a4bd922c0c40d01e2f5359acd16a2b163e4
 
 PKG_SOURCE_DIR ?= $(PKGDIRBASE)/$(PKG_NAME)
-NRF_CC310_PATH = $(PKG_DIR_NAME)/external/nrf_cc310
-PKG_ZIPFILE = $(PKG_DIR_NAME).$(PKG_EXT)
+PKG_ZIP_DIR = $(PKGDIRBASE)/$(PKG_DIR_NAME)_$(PKG_VERSION)
+PKG_ZIPFILE = $(PKGDIRBASE)/$(PKG_DIR_NAME)_$(PKG_VERSION).$(PKG_EXT)
+PKG_ZIP_URL = $(PKG_URL)/$(PKG_DIR_NAME)_$(PKG_VERSION).$(PKG_EXT)
+
+NRF_CC310_PATH = external/nrf_cc310
 
 ifneq ($(RIOTBASE),)
 include $(RIOTBASE)/Makefile.base
 endif
 
-.PHONY: all clean distclean prepare
+.PHONY: all clean distcleanq
 
-prepare: $(PKG_PREPARED)
-	@:
+prepare: $(PKG_SOURCE_DIR)/
 
-all: $(PKGDIRBASE)/$(PKG_ZIPFILE)
-	$(Q)$(UNZIP_HERE) -D -n -d $(PKGDIRBASE) $(PKGDIRBASE)/$(PKG_ZIPFILE)
-	$(Q) mkdir -p $(PKG_SOURCE_DIR)/include
-	$(Q)cp $(PKGDIRBASE)/$(NRF_CC310_PATH)/include/* $(PKG_SOURCE_DIR)/include
-	$(Q)cp $(PKGDIRBASE)/$(NRF_CC310_PATH)/lib/cortex-m4/hard-float/libnrf_cc310_0.9.13.a $(PKG_SOURCE_DIR)
-	$(Q)rm -rf $(PKGDIRBASE)/$(PKG_DIR_NAME)
+all: $(PKG_SOURCE_DIR)/
 
-$(PKGDIRBASE)/$(PKG_ZIPFILE):
+$(PKG_SOURCE_DIR)/: $(PKG_ZIPFILE)
+	$(QQ)test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "$(PKG_ZIPFILE)")"
+	$(Q)$(UNZIP_HERE) -D -d $(PKGDIRBASE) $<
+	$(Q)mkdir -p $(PKG_SOURCE_DIR)/include
+	$(Q)cp $(PKG_ZIP_DIR)/$(NRF_CC310_PATH)/include/* $(PKG_SOURCE_DIR)/include
+	$(Q)cp $(PKG_ZIP_DIR)/$(NRF_CC310_PATH)/lib/cortex-m4/hard-float/libnrf_cc310_0.9.13.a $(PKG_SOURCE_DIR)
+	$(Q)rm -rf $(PKG_ZIP_DIR)
+
+$(PKG_ZIPFILE):
 	$(QQ)mkdir -p $(PKGDIRBASE)
-	$(Q)$(DOWNLOAD_TO_FILE) $(PKGDIRBASE)/$(PKG_ZIPFILE) $(PKG_URL)/$(PKG_ZIPFILE)
+	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_ZIP_URL)
 
 clean::
 	rm -rf $(PKG_SOURCE_DIR)
 
 distclean::
-	rm -rf $(PKG_SOURCE_DIR) $(PKGDIRBASE)/$(PKG_ZIPFILE)
+	rm -rf $(PKG_SOURCE_DIR) $(PKG_ZIPFILE)


### PR DESCRIPTION

### Contribution description

- make sure to download/extract during prepare, instead of build
- this fixes the issue of missing include dependencies for other pkgs at build time

### Testing procedure

- for an app Makefile, include both `c25519` and `driver_cryptocell_310`
- on `master`, `make all` fails with a missing include path from the `driver_cryptocell_310` package
- with this change, it works


### Issues/PRs references

- isolated from #19954 as suggested by @miri64 