### PR TITLE
dist/tools/jlink: fix DBG_PID assignment

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -250,7 +250,7 @@ do_debug() {
                            -port '${GDB_PORT}' \
                            -telnetport '${TELNET_PORT}'" &
     # save PID for terminating the server afterwards
-    DBG_PID=$?
+    DBG_PID=$!
     # connect to the GDB server
     ${DBG} -q ${TUI} -ex "tar ext :${GDB_PORT}" ${ELFFILE}
     # clean up


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I have noticed that when debugging the "hifive1b" board, JLinkGDBServer is still running after exiting GDB. 
After investigating the issue, it appears to be just a minor confusion of `$?` and `$!`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

```
$ BOARD=hifive1b make -C examples/hello-world all flash debug
$ ps aux | grep JLink
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
