### PR TITLE
cpu/esp32: fix RISC-V ISA for ESP32-C3 with GCC 12.2

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -241,7 +241,8 @@ CFLAGS += -D_CONST=const
 
 # TODO no relaxation yet
 ifneq (,$(filter riscv%,$(TARGET_ARCH)))
-  CFLAGS += -mno-relax -march=rv32imc -mabi=ilp32 -DRISCV_NO_RELAX
+  CFLAGS += -mno-relax -march=rv32imc_zicsr_zifencei -mabi=ilp32 -DRISCV_NO_RELAX
+  LINKFLAGS += -mno-relax -march=rv32imc_zicsr_zifencei -mabi=ilp32
   GCC_NEW_RISCV_ISA ?= $(shell echo "typedef int dont_be_pedantic;" | \
                                $(TARGET_ARCH)-gcc -march=rv32imac -mabi=ilp32 \
                                                   -misa-spec=2.2 -E - > /dev/null 2>&1 && \


### PR DESCRIPTION
### Contribution description

This PR fixes the RISC-V ISA spec in compiler and linker flags for ESP32-C3 and GCC 12.2.

Earlier versions of the specs and tools subsumed `zicsr` and `zifencei` into the `I` extension which is no longer the case. Therefore, the RISC-V ISA spec in compiler and linker flags had to be changed from `-march=rv32imc` to `-march=rv32imc_zicsr_zifencei`.

As a consequence floating-point arithmetics and I/O were no longer working with `-march=rv32imc` with GCC 12.2 since `riscv32-esp-elf/lib/libm_nano.a` was linked instead of `riscv32-esp-elf/lib/rv32imc_zicsr_zifencei/ilp32/libm_nano.a` because `riscv32-esp-elf/lib/rv32imc/ilp32/libm_nano.a` is not existing in the toolchain.

### Testing procedure

Add a
```c
#include <math.h>
...
printf("sin(x): %f\n", sin(1.0f));
``` 
in the `main` function of any application. Without this PR the application should crash while it should work with this PR.

### Issues/PRs references
