### PR TITLE
sys/event/timeout: add event_timeout_is_pending()

### DIFF
--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -107,6 +107,18 @@ void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout);
  */
 void event_timeout_clear(event_timeout_t *event_timeout);
 
+/**
+ * @brief   Check if a timeout event is scheduled to be executed in the future
+ *
+ * @param[in]   event_timeout   event_timout context object to use
+ * @return      true if the event is scheduled, false otherwise
+ */
+static inline bool event_timeout_is_pending(const event_timeout_t *event_timeout)
+{
+    return ztimer_is_set(event_timeout->clock, &event_timeout->timer)
+        || event_is_queued(event_timeout->queue, event_timeout->event);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/sys/events/main.c
+++ b/tests/sys/events/main.c
@@ -197,6 +197,7 @@ int main(void)
     before = xtimer_now_usec();
 #endif
     event_timeout_set(&event_timeout, (1 * US_PER_SEC));
+    expect(event_timeout_is_pending(&event_timeout));
 
     event_timeout_t event_timeout_canceled;
 
@@ -205,6 +206,7 @@ int main(void)
                        (event_t *)&noevent_callback);
     event_timeout_set(&event_timeout_canceled, 500 * US_PER_MS);
     event_timeout_clear(&event_timeout_canceled);
+    expect(!event_timeout_is_pending(&event_timeout_canceled));
 
     puts("launching event queue");
     event_loop(&queue);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a small convenience function to check if an event is scheduled.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/sys/events` includes a test for the new function.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
