### PR TITLE
sys,drivers/can: extend can filter struct

### DIFF
--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -4226,6 +4226,8 @@ warning: Member MCP2515_RXM1EID8 (macro definition) of file mcp2515_defines.h is
 warning: Member MCP2515_RXM1SIDH (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXM1SIDL (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RX_MAILBOXES (macro definition) of group drivers_mcp2515 is not documented.
+warning: Member MCP2515_RX_MAILBOX_0 (macro definition) of group drivers_mcp2515 is not documented.
+warning: Member MCP2515_RX_MAILBOX_1 (macro definition) of group drivers_mcp2515 is not documented.
 warning: Member MCP2515_SPI_BITMOD (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_SPI_LOAD_TXBUF (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_SPI_READ (macro definition) of file mcp2515_defines.h is not documented.

--- a/drivers/include/can/candev.h
+++ b/drivers/include/can/candev.h
@@ -161,6 +161,19 @@ typedef struct candev_driver {
      */
     int (*set_filter)(candev_t *dev, const struct can_filter *filter);
 
+#if defined(MODULE_CAN_FILTER_TYPE_SPECIFIC)
+    /**
+     * @brief   Set and configure a reception filter
+     *
+     * @param[in] dev           CAN device descriptor
+     * @param[in] filter_mode   The mode in which the filter will be applied
+     *
+     * @return              a positive filter number
+     * @return              <0 on error
+     */
+    int (*set_filter_type_spec)(candev_t *dev, const struct can_filter_mode *filter_mode);
+#endif
+
     /**
      * @brief  Remove a @p filter
      *

--- a/drivers/include/candev_mcp2515.h
+++ b/drivers/include/candev_mcp2515.h
@@ -80,6 +80,8 @@ extern "C" {
 #define MCP2515_FILTERS_MB0 2
 #define MCP2515_FILTERS_MB1 4
 #define MCP2515_FILTERS (MCP2515_FILTERS_MB0 + MCP2515_FILTERS_MB1)
+#define MCP2515_RX_MAILBOX_0 0
+#define MCP2515_RX_MAILBOX_1 1
 /** @} */
 
 /** MCP2515 candev descriptor */

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -34,7 +34,7 @@
 #include "sched.h"
 #include "ztimer.h"
 
-#define ENABLE_DEBUG 1
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 static mutex_t _mcp_mutex;

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -34,7 +34,7 @@
 #include "sched.h"
 #include "ztimer.h"
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 #include "debug.h"
 
 static mutex_t _mcp_mutex;
@@ -535,11 +535,11 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
 #if defined(MODULE_CAN_FILTER_TYPE_SPECIFIC)
 static int _set_filter_type_spec(candev_t *dev, const struct can_filter_mode *filter_mode)
 {
-    DEBUG("inside _set_filter of MCP2515\n");
+    DEBUG("inside _set_filter_type_spec of MCP2515\n");
     /* Filter type supported is classic mode (Mask and Identifier) */
     assert(filter_mode->can_filter_type == CAN_FILTER_TYPE_CLASSIC);
-    /* Filter configuration applied to reception mailbox Rx_0 or Rx_1 */
-    assert(filter_mode->can_filter_conf == CAN_FILTER_RX_0 || filter_mode->can_filter_conf == CAN_FILTER_RX_1);
+    /* Filter applied to reception mailbox Rx_0 or Rx_1 */
+    assert(filter_mode->rx_mailbox == MCP2515_RX_MAILBOX_0 || filter_mode->rx_mailbox == MCP2515_RX_MAILBOX_1);
 
     struct can_filter_classic *classic_filter = container_of(filter_mode, struct can_filter_classic, mode);
 
@@ -571,12 +571,12 @@ static int _set_filter_type_spec(candev_t *dev, const struct can_filter_mode *fi
     }
 
     uint8_t rx_mailbox = 0;
-    switch (classic_filter->mode.can_filter_conf) {
-        case CAN_FILTER_RX_0:
+    switch (classic_filter->mode.rx_mailbox) {
+        case MCP2515_RX_MAILBOX_0:
             DEBUG_PUTS("Filter to apply to reception mailbox Rx_0");
             rx_mailbox = 0;
             break;
-        case CAN_FILTER_RX_1:
+        case MCP2515_RX_MAILBOX_1:
             DEBUG_PUTS("Filter to apply to reception mailbox Rx_1");
             rx_mailbox = 1;
             break;

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -38,6 +38,7 @@ PSEUDOMODULES += arduino_serial_stdio
 PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw
+PSEUDOMODULES += can_filter_type_specific
 PSEUDOMODULES += ccn-lite-utils
 PSEUDOMODULES += cc2538_rf_obs_sig
 PSEUDOMODULES += conn_can_isotp_multi

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -95,15 +95,134 @@ struct can_frame {
     uint8_t data[CAN_MAX_DLEN] __attribute__((aligned(8)));
 };
 
+#if defined(MODULE_CAN_FILTER_TYPE_SPECIFIC)
+/**
+ * @brief Controller Area Network filter type
+ *
+ * The different CAN controllers provide different CAN filter
+ * types. These types are provided by the SAMD5x family (please check
+ * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
+ *
+ * The current CAN filter types list is from the SAMD5x/SAME5x family.
+ *
+ * Can be extended by other filter types if provided
+ */
+typedef enum {
+    CAN_FILTER_TYPE_CLASSIC = 0x00,     /**< Classic Filter: Filter ID and Mask */
+    CAN_FILTER_TYPE_RANGE,              /**< Range filter from Filter 1 to Filter 2 (Filter 2 > Filter 1) */
+    CAN_FILTER_TYPE_DUAL,               /**< Dual ID Filter (Filter 2 or Filter 1) */
+    CAN_FILTER_TYPE_EXT_RANGE           /**< For extended filters, Range filter from Filter 1 to Filter 2 (Filter 2 > Filter 1) */
+} can_filter_type_t;
+
+/**
+ * @brief Controller Area Network filter configuration
+ *
+ * The different CAN controllers provide different CAN filter
+ * configurations. These types are provided by the SAMD5x family (please check
+ * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
+ *
+ * The current CAN filter configuration list is from the SAMD5x/SAME5x family.
+ *
+ * Can be extended by other filter configurations if provided
+ */
+typedef enum {
+    CAN_FILTER_DISABLE = 0x00,      /**< Disable Filter element */
+    CAN_FILTER_RX_0,                /**< Store message in reception mailbox Rx_0 if filter matches */
+    CAN_FILTER_RX_1,                /**< Store message in reception mailbox Rx_1 if filter matches */
+    CAN_FILTER_RX_REJECT,           /**< Reject message if filter matches */
+    CAN_FILTER_RX_PRIO,             /**< Set priority if filter matches */
+    CAN_FILTER_RX_PRIO_0,           /**< Set priority and store message in reception mailbox Rx_0 if filter matches */
+    CAN_FILTER_RX_PRIO_1,           /**< Set priority and store message in reception mailbox Rx_1 if filter matches */
+    CAN_FILTER_RX_STRXBUF           /**< Store message in the RX buffer or as debug message */
+} can_filter_conf_t;
+
+/**
+ * @brief Controller Area Network filter mode
+ */
+struct can_filter_mode {
+    can_filter_conf_t can_filter_conf;      /**< CAN filter configuration */
+    can_filter_type_t can_filter_type;      /**< CAN filter type */
+};
+
+/**
+ * @brief Controller Area Network classic filter (Mask and Identifier)
+ */
+struct can_filter_classic {
+    struct can_filter_mode mode;    /**< CAN filter mode */
+    canid_t can_id;                 /**< Filter identifier */
+    canid_t can_mask;               /**< Filter mask */
+};
+
+/**
+ * @brief Controller Area Network range filter
+ *
+ * This filter accepts CAN frames from start ID to end ID.
+ */
+struct can_filter_range {
+    struct can_filter_mode mode;    /**< Can filter mode */
+    canid_t start_id;               /**< Filter start ID */
+    canid_t end_id;                 /**< Filter end ID */
+};
+
+/**
+ * @brief Controller Area Network dual filter
+ *
+ * This filter accepts CAN frames with one of the two CAN IDs
+ */
+struct can_filter_dual {
+    struct can_filter_mode mode;    /**< Can filter mode */
+    canid_t can_id[2];              /**< Filter IDs to accept */
+};
+#endif
+
+/**
+ * @brief Controller Area Network filter type
+ *
+ * The different CAN controllers provide different CAN filter
+ * types. These types are provided by the SAMD5x family (please check
+ * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
+ *
+ * The current CAN filter types list is from the SAMD5x/SAME5x family.
+ *
+ * Can be extended by other filter types if provided
+ */
+typedef enum {
+    CAN_FILTER_TYPE_RANGE = 0x00,   /**< Range filter from Filter 1 to Filter 2 (Filter 2 > Filter 1) */
+    CAN_FILTER_TYPE_DUAL,           /**< Dual ID Filter (Filter 2 or Filter 1) */
+    CAN_FILTER_TYPE_CLASSIC,        /**< Classic Filter: Filter ID and Mask */
+    CAN_FILTER_TYPE_EXT_RANGE       /**< For extended filters, Range filter from Filter 1 to Filter 2 (Filter 2 > Filter 1) */
+} can_filter_type_t;
+
+/**
+ * @brief Controller Area Network filter configuration
+ *
+ * The different CAN controllers provide different CAN filter
+ * configurations. These types are provided by the SAMD5x family (please check
+ * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
+ *
+ * The current CAN filter configuration list is from the SAMD5x/SAME5x family.
+ *
+ * Can be extended by other filter configurations if provided
+ */
+typedef enum {
+    CAN_FILTER_DISABLE = 0x00,      /**< Disable Filter element */
+    CAN_FILTER_RX_0,                /**< Store message in reception mailbox Rx_0 if filter matches */
+    CAN_FILTER_RX_1,                /**< Store message in reception mailbox Rx_1 if filter matches */
+    CAN_FILTER_RX_REJECT,           /**< Reject message if filter matches */
+    CAN_FILTER_RX_PRIO,             /**< Set priority if filter matches */
+    CAN_FILTER_RX_PRIO_0,           /**< Set priority and store message in reception mailbox Rx_0 if filter matches */
+    CAN_FILTER_RX_PRIO_1,           /**< Set priority and store message in reception mailbox Rx_1 if filter matches */
+    CAN_FILTER_RX_STRXBUF           /**< Store message in the RX buffer or as debug message */
+} can_filter_conf_t;
+
 /**
  * @brief Controller Area Network filter
  */
 struct can_filter {
     canid_t can_id;    /**< CAN ID */
     canid_t can_mask;  /**< Mask */
-#if defined(MODULE_MCP2515)
-    uint8_t target_mailbox; /**< The mailbox to apply the filter to */
-#endif
+    can_filter_conf_t can_filter_conf;      /**< CAN filter configuration */
+    can_filter_type_t can_filter_type;      /**< CAN filter type */
 };
 
 /**

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -31,6 +31,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #if defined(__linux__)
 
@@ -115,32 +116,13 @@ typedef enum {
 } can_filter_type_t;
 
 /**
- * @brief Controller Area Network filter configuration
- *
- * The different CAN controllers provide different CAN filter
- * configurations. These types are provided by the SAMD5x family (please check
- * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
- *
- * The current CAN filter configuration list is from the SAMD5x/SAME5x family.
- *
- * Can be extended by other filter configurations if provided
- */
-typedef enum {
-    CAN_FILTER_DISABLE = 0x00,      /**< Disable Filter element */
-    CAN_FILTER_RX_0,                /**< Store message in reception mailbox Rx_0 if filter matches */
-    CAN_FILTER_RX_1,                /**< Store message in reception mailbox Rx_1 if filter matches */
-    CAN_FILTER_RX_REJECT,           /**< Reject message if filter matches */
-    CAN_FILTER_RX_PRIO,             /**< Set priority if filter matches */
-    CAN_FILTER_RX_PRIO_0,           /**< Set priority and store message in reception mailbox Rx_0 if filter matches */
-    CAN_FILTER_RX_PRIO_1,           /**< Set priority and store message in reception mailbox Rx_1 if filter matches */
-    CAN_FILTER_RX_STRXBUF           /**< Store message in the RX buffer or as debug message */
-} can_filter_conf_t;
-
-/**
  * @brief Controller Area Network filter mode
  */
 struct can_filter_mode {
-    can_filter_conf_t can_filter_conf;      /**< CAN filter configuration */
+    bool reject;                            /**< Defines whether to use the CAN filter as a whitelist or blacklist.
+                                                 Set to TRUE: Messages with matching filter will be REJECTED
+                                                 Set to FALSE: Messages with matching filter will be ACCEPTED */
+    uint8_t rx_mailbox;                     /**< The reception mailbox to which the CAN filter will be applied */
     can_filter_type_t can_filter_type;      /**< CAN filter type */
 };
 

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -176,53 +176,14 @@ struct can_filter_dual {
 #endif
 
 /**
- * @brief Controller Area Network filter type
- *
- * The different CAN controllers provide different CAN filter
- * types. These types are provided by the SAMD5x family (please check
- * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
- *
- * The current CAN filter types list is from the SAMD5x/SAME5x family.
- *
- * Can be extended by other filter types if provided
- */
-typedef enum {
-    CAN_FILTER_TYPE_RANGE = 0x00,   /**< Range filter from Filter 1 to Filter 2 (Filter 2 > Filter 1) */
-    CAN_FILTER_TYPE_DUAL,           /**< Dual ID Filter (Filter 2 or Filter 1) */
-    CAN_FILTER_TYPE_CLASSIC,        /**< Classic Filter: Filter ID and Mask */
-    CAN_FILTER_TYPE_EXT_RANGE       /**< For extended filters, Range filter from Filter 1 to Filter 2 (Filter 2 > Filter 1) */
-} can_filter_type_t;
-
-/**
- * @brief Controller Area Network filter configuration
- *
- * The different CAN controllers provide different CAN filter
- * configurations. These types are provided by the SAMD5x family (please check
- * chapter 39.9.5 and 39.9.6 of the SAMD5x/SAME5x family Datasheet).
- *
- * The current CAN filter configuration list is from the SAMD5x/SAME5x family.
- *
- * Can be extended by other filter configurations if provided
- */
-typedef enum {
-    CAN_FILTER_DISABLE = 0x00,      /**< Disable Filter element */
-    CAN_FILTER_RX_0,                /**< Store message in reception mailbox Rx_0 if filter matches */
-    CAN_FILTER_RX_1,                /**< Store message in reception mailbox Rx_1 if filter matches */
-    CAN_FILTER_RX_REJECT,           /**< Reject message if filter matches */
-    CAN_FILTER_RX_PRIO,             /**< Set priority if filter matches */
-    CAN_FILTER_RX_PRIO_0,           /**< Set priority and store message in reception mailbox Rx_0 if filter matches */
-    CAN_FILTER_RX_PRIO_1,           /**< Set priority and store message in reception mailbox Rx_1 if filter matches */
-    CAN_FILTER_RX_STRXBUF           /**< Store message in the RX buffer or as debug message */
-} can_filter_conf_t;
-
-/**
  * @brief Controller Area Network filter
  */
 struct can_filter {
     canid_t can_id;    /**< CAN ID */
     canid_t can_mask;  /**< Mask */
-    can_filter_conf_t can_filter_conf;      /**< CAN filter configuration */
-    can_filter_type_t can_filter_type;      /**< CAN filter type */
+#if defined(MODULE_MCP2515)
+    uint8_t target_mailbox; /**< The mailbox to apply the filter to */
+#endif
 };
 
 /**

--- a/tests/drivers/candev/Makefile.board.dep
+++ b/tests/drivers/candev/Makefile.board.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter native,$(BOARD)))
   CAN_DRIVER ?= PERIPH_CAN
+  DISABLE_MODULE += can_filter_type_specific
 endif
 
 # define the CAN driver you want to use here
@@ -11,6 +12,8 @@ else ifeq ($(CAN_DRIVER), MCP2515)
   USEMODULE += mcp2515
   # Uncomment to enable MCP2515 reception filtering
   # CFLAGS += "-DMCP2515_RECV_FILTER_EN=1"
+  # Uncomment to apply type specific filters
+  # USEMODULE += can_filter_type_specific
 else ifeq ($(CAN_DRIVER), CAN_ALT)
   # other can modules can be defined here
 endif

--- a/tests/drivers/candev/main.c
+++ b/tests/drivers/candev/main.c
@@ -251,7 +251,8 @@ if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
 #else
         struct can_filter_classic filter_classic_test_1 = {
             .mode = {
-                CAN_FILTER_RX_0,
+                false,
+                MCP2515_RX_MAILBOX_0,
                 CAN_FILTER_TYPE_CLASSIC
             },
             .can_id = 0x111,
@@ -260,7 +261,8 @@ if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
         candev->driver->set_filter_type_spec(candev, &filter_classic_test_1.mode);
         struct can_filter_classic filter_classic_test_2 = {
             .mode = {
-                CAN_FILTER_RX_1,
+                false,
+                MCP2515_RX_MAILBOX_1,
                 CAN_FILTER_TYPE_CLASSIC
             },
             .can_id = 0x222,

--- a/tests/drivers/candev/main.c
+++ b/tests/drivers/candev/main.c
@@ -222,6 +222,7 @@ if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
 }
 
     if (IS_ACTIVE(MCP2515_RECV_FILTER_EN)) {
+#if !defined(MODULE_CAN_FILTER_TYPE_SPECIFIC)
         /* CAN filters examples */
         struct can_filter filter[4];
         filter[0].can_mask = 0x7FF;
@@ -247,6 +248,26 @@ if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
         for (uint8_t i = 0; i < 4; i++) {
             candev->driver->set_filter(candev, &filter[i]);
         }
+#else
+        struct can_filter_classic filter_classic_test_1 = {
+            .mode = {
+                CAN_FILTER_RX_0,
+                CAN_FILTER_TYPE_CLASSIC
+            },
+            .can_id = 0x111,
+            .can_mask = 0x7FF
+        };
+        candev->driver->set_filter_type_spec(candev, &filter_classic_test_1.mode);
+        struct can_filter_classic filter_classic_test_2 = {
+            .mode = {
+                CAN_FILTER_RX_1,
+                CAN_FILTER_TYPE_CLASSIC
+            },
+            .can_id = 0x222,
+            .can_mask = 0x7FF
+        };
+        candev->driver->set_filter_type_spec(candev, &filter_classic_test_2.mode);
+#endif
         /* All other messages won't be received */
     }
 


### PR DESCRIPTION
### Contribution description

This PR extends the CAN filter structure by adding the possibility to the user to use different filter types and configurations.
The CAN controllers provide different filter modes that can be used, e.g STM32 family provides mask-ID mode and list mode, SAMD5/E5 provide range mode, dual mode and the mask-ID mode. These modes are added in an enum to the current can_filter struct, and ca be extended in case other controllers provide other features.


### Testing procedure

Details steps to test your contribution:
- This PR was tested using `tests/drivers/candev`application, on native as well as using the MCP2515 with SAME54-XPRO board.
- For native, create a virtual can interface (must be named `vcan0`) and use the `candump vcan0`command to monitor the bus. For the MCP2515, connect a PCAN-USB adapter and send using it some CAN frames. The CAN frames must have the correct CAN filters in order to be received by the MCP2515 CAN controller.
