### PR TITLE
sock/udp: work around gnrc_sock_recv() returning early timeout

### DIFF
--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -25,6 +25,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     olimex-msp430-h1611 \
     olimex-msp430-h2618 \
     samd10-xmini \
+    saml10-xpro \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -237,6 +237,16 @@ static bool _accept_remote(const sock_udp_t *sock, const udp_hdr_t *hdr,
     return true;
 }
 
+static uint32_t _now_us(void)
+{
+#ifdef MODULE_ZTIMER_USEC
+    return ztimer_now(ZTIMER_USEC);
+#endif
+#ifdef MODULE_ZTIMER_MSEC
+    return ztimer_now(ZTIMER_MSEC) * US_PER_MS;
+#endif
+}
+
 ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
                               uint32_t timeout, sock_udp_ep_t *remote,
                               sock_udp_aux_rx_t *aux)
@@ -274,7 +284,26 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
         _aux.rssi = &aux->rssi;
     }
 #endif
-    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp, &_aux);
+    unsigned now = _now_us();
+    while (1) {
+        res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp, &_aux);
+
+        if (res != -ETIMEDOUT) {
+            break;
+        }
+
+        /* HACK: gnrc_sock_recv() sometimes returns -ETIMEDOUT too early */
+        uint32_t time_elapsed = _now_us() - now;
+        if (time_elapsed < (timeout - timeout/10))  {
+            DEBUG("gnrc_sock_udp: timeout happened  %"PRIu32" µs early\n",
+                  timeout - time_elapsed);
+            timeout -= time_elapsed;
+            now = _now_us();
+            continue;
+        }
+        break;
+    }
+
     if (res < 0) {
         return res;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
`sock_udp_recv_buf_aux()` sometimes will return `-ETIMEDOUT` before the given timeout has expired (e.g. after 28798µs instead of 160000µs).

This messes with many assumptions and breaks protocols that rely on the timeout.

Until we have a proper fix, add this workaround.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/net/gcoap_fileserver` should now be more reliable even without the increased retries. 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
