### PR TITLE
sys/event: add event_is_queued()

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -22,7 +22,7 @@
  */
 
 #include <assert.h>
-
+#include <stdbool.h>
 #include <string.h>
 
 #include "event.h"
@@ -58,6 +58,17 @@ void event_cancel(event_queue_t *queue, event_t *event)
     clist_remove(&queue->event_list, &event->list_node);
     event->list_node.next = NULL;
     irq_restore(state);
+}
+
+bool event_is_queued(const event_queue_t *queue, const event_t *event)
+{
+    assert(queue);
+    assert(event);
+
+    unsigned state = irq_disable();
+    bool result = clist_find(&queue->event_list, &event->list_node);
+    irq_restore(state);
+    return result;
 }
 
 event_t *event_get(event_queue_t *queue)

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -97,6 +97,7 @@
 #define EVENT_H
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "assert.h"
@@ -275,6 +276,17 @@ void event_post(event_queue_t *queue, event_t *event);
  * @param[in]   event   event to remove from queue
  */
 void event_cancel(event_queue_t *queue, event_t *event);
+
+/**
+ * @brief   Check if an event is already queued
+ *
+ * @param[in]   queue   event queue to check
+ * @param[in]   event   event to check
+ *
+ * @returns true if @p event is in @p queue
+ * @returns false otherwise
+ */
+bool event_is_queued(const event_queue_t *queue, const event_t *event);
 
 /**
  * @brief   Get next event from event queue, non-blocking


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

It can be useful to know if an event is already queued. I was looking for such an API.
I tried `event_timeout_is_set()` but this only checks if the timer is scheduled which would put the event in the event list, which is fine IMO.
This checks if the event is in the event queue.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Given the other  `event_*` functions, implementation is straight forward, I would say.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#19963