### PR TITLE
sys/shell/gnrc_netif: fix ifconfig set language issue

### DIFF
--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -196,7 +196,7 @@ static void _link_usage(char *cmd_name)
 static void _set_usage(char *cmd_name)
 {
     printf("usage: %s <if_id> set <key> <value>\n", cmd_name);
-    printf("      Sets an hardware specific specific value\n"
+    printf("      Sets a hardware specific value\n"
          "      <key> may be one of the following\n"
          "       * \"addr\" - sets (short) address\n"
          "       * \"addr_long\" - sets long address\n"


### PR DESCRIPTION
### Contribution description

This PR fix some language issues in the output of `ifconfig set`.

### Testing procedure

Compile any program with `gnrc_netif` module, for example `examples/gcoap`. 
Compare last line of presented outputs.

Output of `ifconfig help` without this PR.

```
All up, running the shell now
> ifconfig help
ifconfig help
usage: ifconfig help
usage: ifconfig <if_id> [up|down]
usage: ifconfig <if_id> set <key> <value>
      Sets an hardware specific specific value
```

Output of `ifconfig help` with this PR.

```
All up, running the shell now
> ifconfig help
ifconfig help
usage: ifconfig
usage: ifconfig help
usage: ifconfig <if_id> [up|down]
usage: ifconfig <if_id> set <key> <value>
      Sets a hardware specific value
```

### Issues/PRs references
None