### PR TITLE
sys/shell/gnrc_netif: Fix a few blockers for sharing ifconfig shell

### DIFF
--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -3,6 +3,9 @@ USEMODULE += stdin
 ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   USEMODULE += shell_cmd_sys
 
+  ifneq (,$(filter netif,$(USEMODULE)))
+    USEMODULE += l2util
+  endif
   ifneq (,$(filter app_metadata,$(USEMODULE)))
     USEMODULE += shell_cmd_app_metadata
   endif

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -29,6 +29,7 @@
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/ipv6/addr.h"
+#include "net/l2util.h"
 #include "net/lora.h"
 #include "net/loramac.h"
 #include "net/netif.h"
@@ -660,7 +661,7 @@ static void _netif_list(netif_t *iface)
     if (res >= 0) {
         char hwaddr_str[res * 3];
         printf(" HWaddr: %s ",
-               gnrc_netif_addr_to_str(hwaddr, res, hwaddr_str));
+               l2util_addr_to_str(hwaddr, res, hwaddr_str));
     }
     res = netif_get_opt(iface, NETOPT_CHANNEL, 0, &u16, sizeof(u16));
     if (res >= 0) {
@@ -788,7 +789,7 @@ static void _netif_list(netif_t *iface)
     if (res >= 0) {
         char hwaddr_str[res * 3];
         printf("Long HWaddr: ");
-        printf("%s ", gnrc_netif_addr_to_str(hwaddr, res, hwaddr_str));
+        printf("%s ", l2util_addr_to_str(hwaddr, res, hwaddr_str));
         line_thresh++;
     }
     line_thresh = _newline(0U, line_thresh);
@@ -935,8 +936,8 @@ static void _netif_list(netif_t *iface)
         for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
             if (filter[i].addr_len > 0) {
                 char hwaddr_str[filter[i].addr_len * 3];
-                gnrc_netif_addr_to_str(filter[i].addr, filter[i].addr_len,
-                                       hwaddr_str);
+                l2util_addr_to_str(filter[i].addr, filter[i].addr_len,
+                                   hwaddr_str);
                 printf("            %2i: %s\n", count++, hwaddr_str);
             }
         }
@@ -1300,7 +1301,7 @@ static int _netif_set_lw_key(netif_t *iface, netopt_t opt, char *key_str)
 static int _netif_set_addr(netif_t *iface, netopt_t opt, char *addr_str)
 {
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
-    size_t addr_len = gnrc_netif_addr_from_str(addr_str, addr);
+    size_t addr_len = l2util_addr_from_str(addr_str, addr);
 
     if (addr_len == 0) {
         printf("error: unable to parse address.\n"
@@ -1449,7 +1450,7 @@ static int _netif_set_encrypt_key(netif_t *iface, netopt_t opt, char *key_str)
 static int _netif_addrm_l2filter(netif_t *iface, char *val, bool add)
 {
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
-    size_t addr_len = gnrc_netif_addr_from_str(val, addr);
+    size_t addr_len = l2util_addr_from_str(val, addr);
 
     if ((addr_len == 0) || (addr_len > CONFIG_L2FILTER_ADDR_MAXLEN)) {
         printf("error: given address is invalid\n");

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -580,7 +580,7 @@ static unsigned _netif_list_flag(netif_t *iface, netopt_t opt, char *str,
     return line_thresh;
 }
 
-#ifdef MODULE_GNRC_IPV6
+#ifdef MODULE_IPV6
 static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
@@ -600,6 +600,7 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
     else {
         printf("unknown");
     }
+#if MODULE_GNRC_IPV6
     if (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST) {
         printf(" [anycast]");
     }
@@ -620,6 +621,7 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
             break;
         }
     }
+#endif
     _newline(0U, _LINE_THRESHOLD);
 }
 
@@ -636,7 +638,7 @@ static void _netif_list_groups(ipv6_addr_t *addr)
 
 static void _netif_list(netif_t *iface)
 {
-#ifdef MODULE_GNRC_IPV6
+#ifdef MODULE_IPV6
     ipv6_addr_t ipv6_addrs[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
     ipv6_addr_t ipv6_groups[GNRC_NETIF_IPV6_GROUPS_NUMOF];
 #endif
@@ -892,11 +894,11 @@ static void _netif_list(netif_t *iface)
         line_thresh++;
     }
     line_thresh = _newline(0U, line_thresh);
-#ifdef MODULE_GNRC_IPV6
     printf("Link type: %s",
            (netif_get_opt(iface, NETOPT_IS_WIRED, 0, &u16, sizeof(u16)) > 0) ?
            "wired" : "wireless");
     _newline(0U, ++line_thresh);
+#ifdef MODULE_IPV6
     res = netif_get_opt(iface, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
                         sizeof(ipv6_addrs));
     if (res >= 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When using general IPv6 functions, require only shared IPV6 module instead of gnrc version.

Print addresses using l2util functions in gnrc_netif instead of with gnrc wrappers.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

* ifconfig with gnrc_networking example still works

```
> ifconfig
Iface  8  HWaddr: 24:0A:C4:E6:0E:9F  Link: up
          L2-PDU:1500  MTU:1500  HL:64  RTR
          RTR_ADV
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::260a:c4ff:fee6:e9f  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffe6:e9f
          inet6 group: ff02::1a
```

* tests/pkg/lwip ifconfig prints v6 info when 7160ed925813334f89875d0245980af1d25c6a5b applied

```
> ifconfig
Iface  ET0  HWaddr: 24:0A:C4:E6:0E:9F  Link: up
          L2-PDU:1500  Source address length: 6
          Link type: wired
          inet6 addr: fe80::260a:c4ff:fee6:e9f  scope: link
          inet6 addr: 2001:db8::260a:c4ff:fee6:e9f  scope: global
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
