### PR TITLE
RFC: Support enabling/disabling lwIP netifs from gnrc_netif shell

### DIFF
--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -42,6 +42,17 @@ int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
     struct netdev *dev = netif->state;
     int res = -ENOTSUP;
     switch (opt) {
+    case NETOPT_ACTIVE: {
+            assert(max_len >= sizeof(netopt_enable_t));
+            netopt_enable_t *tgt = value;
+            if (netif_is_up(netif)) {
+                *tgt = NETOPT_ENABLE;
+            } else {
+                *tgt = NETOPT_DISABLE;
+            }
+            res = 0;
+        }
+        break;
 #ifdef MODULE_LWIP_IPV6
     case NETOPT_IPV6_ADDR: {
             assert(max_len >= sizeof(ipv6_addr_t));

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -300,6 +300,16 @@ typedef enum {
     NETOPT_LINK,
 
     /**
+     * @brief (@ref netopt_enable_t) network interface status.
+     *
+     * This option is used check state or to enable/disable the interface,
+     * regardless of link status.
+     *
+     * @note On error this option should return a negative number.
+     */
+    NETOPT_ACTIVE,
+
+    /**
      * @brief   (@ref netopt_enable_t) CSMA/CA support
      *
      * If the device supports CSMA in hardware, this option enables it with

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -63,6 +63,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_MAC_NO_SLEEP]          = "NETOPT_MAC_NO_SLEEP",
     [NETOPT_IS_WIRED]              = "NETOPT_IS_WIRED",
     [NETOPT_LINK]                  = "NETOPT_LINK",
+    [NETOPT_ACTIVE]                = "NETOPT_ACTIVE",
     [NETOPT_DEVICE_TYPE]           = "NETOPT_DEVICE_TYPE",
     [NETOPT_CHANNEL_PAGE]          = "NETOPT_CHANNEL_PAGE",
     [NETOPT_CCA_THRESHOLD]         = "NETOPT_CCA_THRESHOLD",

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -1684,10 +1684,17 @@ static uint8_t _get_prefix_len(char *addr)
 
 static int _netif_link(netif_t *iface, netopt_enable_t en)
 {
+#if IS_USED(MODULE_LWIP_NETIF) /* lwIP sets netif state, not link state */
+    if (netif_set_opt(iface, NETOPT_ACTIVE, 0, &en, sizeof(en)) < 0) {
+        printf("error: unable to set state %s\n", en == NETOPT_ENABLE ? "up" : "down");
+        return 1;
+    }
+#else
     if (netif_set_opt(iface, NETOPT_LINK, 0, &en, sizeof(en)) < 0) {
         printf("error: unable to set link %s\n", en == NETOPT_ENABLE ? "up" : "down");
         return 1;
     }
+#endif
     return 0;
 }
 

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -776,11 +776,17 @@ static void _netif_list(netif_t *iface)
         }
     }
 #endif /* MODULE_NETDEV_IEEE802154 */
-    netopt_enable_t link;
-    res = netif_get_opt(iface, NETOPT_LINK, 0, &link, sizeof(netopt_enable_t));
+    netopt_enable_t enabled;
+    res = netif_get_opt(iface, NETOPT_LINK, 0, &enabled, sizeof(enabled));
     if (res >= 0) {
-        printf(" Link: %s ", (link == NETOPT_ENABLE) ? "up" : "down" );
+        printf(" Link: %s ", (enabled == NETOPT_ENABLE) ? "up" : "down" );
     }
+#if IS_USED(MODULE_LWIP_NETIF) /* only supported on lwIP for now */
+    res = netif_get_opt(iface, NETOPT_ACTIVE, 0, &enabled, sizeof(enabled));
+    if (res >= 0) {
+        printf(" State: %s ", (enabled == NETOPT_ENABLE) ? "up" : "down" );
+    }
+#endif /* MODULE_LWIP_NETIF */
     line_thresh = _newline(0U, line_thresh);
     res = netif_get_opt(iface, NETOPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));
     if (res >= 0) {
@@ -806,9 +812,9 @@ static void _netif_list(netif_t *iface)
     }
     res = netif_get_opt(iface, NETOPT_CSMA_RETRIES, 0, &u8, sizeof(u8));
     if (res >= 0) {
-        netopt_enable_t enable = NETOPT_DISABLE;
-        res = netif_get_opt(iface, NETOPT_CSMA, 0, &enable, sizeof(enable));
-        if ((res >= 0) && (enable == NETOPT_ENABLE)) {
+        enabled = NETOPT_DISABLE;
+        res = netif_get_opt(iface, NETOPT_CSMA, 0, &enabled, sizeof(enabled));
+        if ((res >= 0) && (enabled == NETOPT_ENABLE)) {
             printf(" CSMA Retries: %u ", (unsigned)u8);
         }
         line_thresh++;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Similar to Linux, lwIP has separate link and interface statuses. 
This change expose this in a netopt and updates gnrc ifconfig to show and set it.

I am not really happy with the `NETOPT_ACTIVE` name. Maybe `NETOPT_STATE` could be renamed to `NETOPT_RF_STATE`?

The code for setting up/down is not very nice. Not sure if link state will be controllable in lwIP - maybe for 6lowpan radios.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Flash `tests/pkg/lwip` . Any traffic received while the interface is down is dropped.

```
> ifconfig
Iface  ET0  HWaddr: 24:0A:C4:E6:0E:9F  Link: up  State: up 
          L2-PDU:1500  Source address length: 6
          Link type: wired
          inet6 addr: fe80::260a:c4ff:fee6:e9f  scope: link
          
> ifconfig ET0 down
> ifconfig
Iface  ET0  HWaddr: 24:0A:C4:E6:0E:9F  Link: up  State: down 
          L2-PDU:1500  Source address length: 6
          Link type: wired
          inet6 addr: fe80::260a:c4ff:fee6:e9f  scope: link
          
> ifconfig ET0 up
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

This only makes a difference when gnrc_netif ifconfig command is used. For that it depends on #19971 and an extra change like 7160ed925813334f89875d0245980af1d25c6a5b to replace lwip netif with the gnrc version.
