### PR TITLE
gnrc_ipv6_ext_frag: _completed: Add comment why list head is not checked for NULL pointer dereference

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
@@ -711,6 +711,7 @@ static gnrc_pktsnip_t *_completed(gnrc_ipv6_ext_frag_rbuf_t *rbuf)
     /* clist: first element is second element ;-) (from next of head) */
     gnrc_ipv6_ext_frag_limits_t *ptr =
             (gnrc_ipv6_ext_frag_limits_t *)rbuf->limits.next->next;
+    /* ptr should not be NULL at this point so it is safe to dereference with ptr->start here */
     if (rbuf->last && (ptr->start == 0)) {
         gnrc_pktsnip_t *res = NULL;
 


### PR DESCRIPTION
 
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Should avoid some confusion in security reviews.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
