### PR TITLE
core: Express -1 as ~0 in thread_status_t cast

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -184,7 +184,7 @@ typedef enum {
  */
 #define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
                                                    `st >= STATUS_ON_RUNQUEUE`   */
-#define STATUS_NOT_FOUND ((thread_status_t)-1)  /**< Describes an illegal thread status */
+#define STATUS_NOT_FOUND ((thread_status_t)~0)  /**< Describes an illegal thread status */
 /** @} */
 /**
  * @def SCHED_PRIO_LEVELS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

When compiling _rust-hello-world_ for the _nrf52840dongle_, c2rust seem to generate code which casts -1 to u8 which fails because it's unsigned. Changing to ~0 fixes this.

```
error[E0600]: cannot apply unary operator `-` to type `u8`
    --> RIOT/examples/rust-hello-world/bin/nrf52840dongle/target/thumbv7em-none-eabihf/release/build/riot-sys-a758a33386ee540f/out/riot_c2rust_replaced.rs:6813:39
     |
6813 |     let mut result: thread_status_t = -1 as thread_status_t;
     |                                       ^^
     |                                       |
     |                                       cannot apply unary operator `-`
     |                                       help: you may have meant the maximum value of `u8`: `u8::MAX`
     |
     = note: unsigned values cannot be negated

For more information about this error, try `rustc --explain E0600`.
error: could not compile `riot-sys` (lib) due to previous error
```

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Change `-1` to `~0` for casting to `u8`


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

`make BOARD=nrf52840dongle`in _rust-hello-world_
