### PR TITLE
nanocoap: Add functions to handle etag options

### DIFF
--- a/examples/gcoap_block_server/gcoap_block.c
+++ b/examples/gcoap_block_server/gcoap_block.c
@@ -46,6 +46,7 @@ static gcoap_listener_t _listener = {
 static const uint8_t block2_intro[] = "This is RIOT (Version: ";
 static const uint8_t block2_board[] = " running on a ";
 static const uint8_t block2_mcu[] = " board with a ";
+static const uint8_t test_etag[4] = { 0xAA, 0xBB, 0xCC, 0xDD };
 
 static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
@@ -54,6 +55,7 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, c
     coap_block2_init(pdu, &slicer);
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    coap_opt_add_etag_dummy(pdu, 4);
     coap_opt_add_format(pdu, COAP_FORMAT_TEXT);
     coap_opt_add_block2(pdu, &slicer, 1);
     ssize_t plen = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
@@ -72,6 +74,8 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, c
     plen += coap_blockwise_put_char(&slicer, buf+plen, 'C');
     plen += coap_blockwise_put_char(&slicer, buf+plen, 'U');
     plen += coap_blockwise_put_char(&slicer, buf+plen, '.');
+
+    coap_opt_replace_etag(pdu, test_etag, 4);
 
     coap_block2_finish(&slicer);
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1501,6 +1501,61 @@ static inline ssize_t coap_opt_add_uri_path_buffer(coap_pkt_t *pkt,
 }
 
 /**
+ * @brief   Adds an entity-tag (etag) value to the coap pkt.
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     etag        Etag value of the packet
+ * @param[in]     len         Length of @p etag in bytes
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        -EINVAL if invalid etag size is used for @p len
+ * @return        -ENOSPC if no available options or pkt full
+ */
+static inline ssize_t coap_opt_add_etag(coap_pkt_t *pkt, const uint8_t *etag, size_t len)
+{
+    if (len == 0 || len > 8) {
+        return -EINVAL;
+    }
+    return coap_opt_add_opaque(pkt, COAP_OPT_ETAG, etag, len);
+}
+
+/**
+ * @brief   Adds an empty dummy entity-tag (etag) value to the coap pkt.
+ *
+ * This function adds an all-zero etag value to the packet as placeholder for later updating
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     len         Length of etag space to reserve in bytes
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        -EINVAL if invalid etag size is used for @p len
+ * @return        -ENOSPC if no available options or pkt full
+ */
+static inline ssize_t coap_opt_add_etag_dummy(coap_pkt_t *pkt, size_t len)
+{
+    const uint8_t zeros[8] = { 0 };
+    return coap_opt_add_etag(pkt, zeros, len);
+}
+
+
+/**
+ * @brief   replaces an entity-tag (etag) value with a new one in a coap pkt.
+ *
+ * @note    The etag option must have been added first via @ref coap_opt_add_etag or
+ *          @ref coap_opt_add_etag_dummy
+ * @note    The @p len supplied to this call must match the length supplied to the call to add the
+ *          etag option
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     etag        New etag value of the packet
+ * @param[in]     len         Length of etag space to reserve in bytes
+ *
+ * @return        number of bytes replaced in the packet
+ * @return        -ENOENT if no existing etag value is found
+ */
+ssize_t coap_opt_replace_etag(coap_pkt_t *pkt, const uint8_t *etag, size_t len);
+
+/**
  * @brief   Finalizes options as required and prepares for payload
  *
  * @post pkt.payload advanced to first available byte after options

--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -204,7 +204,7 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     if (request->options.exists.etag &&
         !memcmp(&etag, &request->options.etag, sizeof(etag))) {
         gcoap_resp_init(pdu, buf, len, COAP_CODE_VALID);
-        coap_opt_add_opaque(pdu, COAP_OPT_ETAG, &etag, sizeof(etag));
+        coap_opt_add_etag(pdu, &etag, sizeof(etag));
         return coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
     }
 
@@ -214,7 +214,7 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     }
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
-    coap_opt_add_opaque(pdu, COAP_OPT_ETAG, &etag, sizeof(etag));
+    coap_opt_add_etag(pdu, &etag, sizeof(etag));
     coap_block_slicer_t slicer;
     _calc_szx2(pdu,
                5 + 1 + 1 /* reserve BLOCK2 size + payload marker + more */,
@@ -366,7 +366,7 @@ static ssize_t _put_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 
         stat_etag(&stat, &etag); /* Etag after write */
         gcoap_resp_init(pdu, buf, len, create ? COAP_CODE_CREATED : COAP_CODE_CHANGED);
-        coap_opt_add_opaque(pdu, COAP_OPT_ETAG, &etag, sizeof(etag));
+        coap_opt_add_etag(pdu, &etag, sizeof(etag));
     }
     else {
         gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTINUE);

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -272,7 +272,7 @@ static void _forward_resp_handler(const gcoap_request_memo_t *memo,
                     max_age = 60U;
                 }
                 gcoap_resp_init(pdu, (uint8_t *)pdu->hdr, buf_len, COAP_CODE_VALID);
-                coap_opt_add_opaque(pdu, COAP_OPT_ETAG, cep->req_etag, req_etag_len);
+                coap_opt_add_etag(pdu, cep->req_etag, req_etag_len);
                 if (max_age != 60U) {
                     /* only include Max-Age option if it is not the default value */
                     coap_opt_add_uint(pdu, COAP_OPT_MAX_AGE, max_age);
@@ -339,7 +339,7 @@ static int _gcoap_forward_proxy_copy_options(coap_pkt_t *pkt,
                 static const uint8_t tmp[COAP_ETAG_LENGTH_MAX] = { 0 };
                 /* add slack to maybe add an ETag on stale cache hit later, as is done in
                  * gcoap_req_send() (which we circumvented in _gcoap_forward_proxy_via_coap()) */
-                if (coap_opt_add_opaque(pkt, COAP_OPT_ETAG, tmp, sizeof(tmp))) {
+                if (coap_opt_add_etag(pkt, COAP_OPT_ETAG, tmp, sizeof(tmp))) {
                     etag_added = true;
                 }
             }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1462,7 +1462,7 @@ int gcoap_req_init_path_buffer(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     if (IS_USED(MODULE_NANOCOAP_CACHE)) {
         static const uint8_t tmp[COAP_ETAG_LENGTH_MAX] = { 0 };
         /* add slack to maybe add an ETag on stale cache hit later */
-        res = coap_opt_add_opaque(pdu, COAP_OPT_ETAG, tmp, sizeof(tmp));
+        res = coap_opt_add_etag(pdu, tmp, sizeof(tmp));
     }
     if ((res > 0) && (path != NULL) && (path_len > 0)) {
         res = coap_opt_add_uri_path_buffer(pdu, path, path_len);

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1059,6 +1059,24 @@ ssize_t coap_opt_add_proxy_uri(coap_pkt_t *pkt, const char *uri)
     return _add_opt_pkt(pkt, COAP_OPT_PROXY_URI, (uint8_t *)uri, strlen(uri));
 }
 
+ssize_t coap_opt_replace_etag(coap_pkt_t *pkt, const uint8_t *etag, size_t len)
+{
+    coap_optpos_t optpos = { 0 };
+    uint8_t *val = NULL;
+    ssize_t res = coap_opt_get_next(pkt, &optpos, &val, true);
+    while (optpos.opt_num != COAP_OPT_ETAG) {
+        res = coap_opt_get_next(pkt, &optpos, &val, false);
+        if (res < 0) {
+            return res;
+        }
+    }
+    /* Supplied etag size and reserved etag space do not match */
+    assert(len == (size_t)res);
+
+    memcpy(val, etag, len);
+    return res;
+}
+
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
 {
     if (flags & COAP_OPT_FINISH_PAYLOAD) {


### PR DESCRIPTION
### Contribution description

This adds 3 functions for adding entity-tags to coap packets. The first
simply adds the option to the coap packet with the supplied etag value.
The second functionallow for adding a dummy etag value which is to be
replaced later by the last function. This allows for allocating space
for the option up front when the etag value itself is generated based on
the payload.

I also did a quick replace of `coap_opt_add_opaque(pdu, COAP_OPT_ETAG…)` in other sources.

### Testing procedure

Added the option to one of the handlers of the `gcoap_block_server` example to test this.

The response result should look like this in wireshark:

![image](https://github.com/RIOT-OS/RIOT/assets/5160052/e7c85da0-6fc4-486c-b8c2-8a29ed7eb69d)


### Issues/PRs references

None