### PR TITLE
Fletcher32: Add incremental API

### DIFF
--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -43,8 +43,7 @@ typedef struct {
  * http://en.wikipedia.org/w/index.php?title=Fletcher%27s_checksum&oldid=661273016#Optimizations
  *
  * @note the returned sum is never 0
- * @note pay attention to alignment issues since this operates on an input
- *       buffer containing 16 bit words, not bytes.
+ * @note pay attention to the @p words parameter buffer containing 16 bit words, not bytes.
  *
  * @param buf input buffer to hash
  * @param words length of buffer, in 16 bit words

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -15,6 +15,7 @@
  *
  * @file
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Koen Zandberg <koen@bergzand.net>
  */
 
 #ifndef CHECKSUM_FLETCHER32_H
@@ -26,6 +27,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Fletcher's 32 bit checksum context struct
+ */
+typedef struct {
+    uint32_t sum1;  /**< First sum of the checksum */
+    uint32_t sum2;  /**< Second sum of the checksum */
+} fletcher32_ctx_t;
 
 /**
  * @brief Fletcher's 32 bit checksum
@@ -42,6 +51,37 @@ extern "C" {
  * @return 32 bit sized hash in the interval [1..2^32]
  */
 uint32_t fletcher32(const uint16_t *buf, size_t words);
+
+/**
+ * @brief Initialize a fletcher32 context
+ *
+ * Multi-part version of @ref fletcher32.
+ *
+ * @param[in]   ctx     fletcher32 context to initialize
+ */
+void fletcher32_init(fletcher32_ctx_t *ctx);
+
+/**
+ * @brief Incrementally update the fletcher32 context with new data. Can be an arbitrary amount of
+ * times with new data to checksum.
+ *
+ * @note @p words is the number of 16 bit words in the buffer
+ * @note @p data should contain an integer number of 16 bit words
+ *
+ * @param[in]   ctx     fletcher32 context
+ * @param[in]   data    Data to add to the context
+ * @param[in]   words   Length of the data in 16 bit words
+ */
+void fletcher32_update(fletcher32_ctx_t *ctx, const void *data, size_t words);
+
+/**
+ * @brief Finalize the checksum operation and return the checksum
+ *
+ * @param[in]   ctx     fletcher32 context
+ *
+ * @return 32 bit sized hash in the interval [1..2^32]
+ */
+uint32_t fletcher32_finish(fletcher32_ctx_t *ctx);
 
 #ifdef __cplusplus
 }

--- a/tests/unittests/tests-checksum/tests-checksum-fletcher32.c
+++ b/tests/unittests/tests-checksum/tests-checksum-fletcher32.c
@@ -85,6 +85,20 @@ static void test_checksum_fletcher32_wrap_around(void)
                                           sizeof(wrap_around_data) - 1, expect));
 }
 
+static void test_checksum_fletcher32_wrap_around_piecewise(void)
+{
+    /* XXX: not verified with external implementation yet */
+    uint32_t expect = 0x5bac8c3d;
+    fletcher32_ctx_t ctx;
+    fletcher32_init(&ctx);
+    size_t full_len = sizeof(wrap_around_data) - 1;
+    size_t initial_len = full_len / 2;
+    fletcher32_update(&ctx, wrap_around_data, initial_len / 2);
+    fletcher32_update(&ctx, (wrap_around_data + initial_len), (full_len - initial_len) / 2);
+    uint32_t result = fletcher32_finish(&ctx);
+    TEST_ASSERT_EQUAL_INT(result, expect);
+}
+
 Test *tests_checksum_fletcher32_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -92,6 +106,7 @@ Test *tests_checksum_fletcher32_tests(void)
         new_TestFixture(test_checksum_fletcher32_0to1_undetected),
         new_TestFixture(test_checksum_fletcher32_atof),
         new_TestFixture(test_checksum_fletcher32_wrap_around),
+        new_TestFixture(test_checksum_fletcher32_wrap_around_piecewise),
     };
 
     EMB_UNIT_TESTCALLER(checksum_fletcher32_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

This PR extends the current fletcher32 checksum with an incremental API mode. This way the bytes to be checksummed can be supplied via multiple successive calls and do not have to be provided in a single consecutive buffer.

I've also rephrased the warning with the original function a bit as that function uses an `unaligned_get_u16` to access the data. The data thus does not require alignment, but the length does need to be supplied as number of 16 bit words.

### Testing procedure

The test has been extended


### Issues/PRs references

None