### PR TITLE
gcoap: fix underflow when correcting ETag from cache [backport 2023.01]

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1340,8 +1340,21 @@ static ssize_t _cache_check(const uint8_t *buf, size_t len,
         if ((resp_etag_len > 0) && ((size_t)resp_etag_len <= COAP_ETAG_LENGTH_MAX)) {
             uint8_t *tmp_etag;
             ssize_t tmp_etag_len = coap_opt_get_opaque(&req, COAP_OPT_ETAG, &tmp_etag);
-
             if (tmp_etag_len >= resp_etag_len) {
+                /* peak length without padding */
+                size_t rem_len = (len - (tmp_etag + tmp_etag_len - buf));
+
+                if ((tmp_etag < buf) || (tmp_etag > (buf + len)) ||
+                    (rem_len > (len - ((tmp_etag + COAP_ETAG_LENGTH_MAX) - buf)))) {
+                    DEBUG("gcoap: invalid calculated padding length (%lu) for ETag injection "
+                          "during cache lookup.\n", (long unsigned)rem_len);
+                    /* something fishy happened in the request. Better don't return cache entry */
+                    *cache_hit = false;
+#if IS_USED(MODULE_NANOCOAP_CACHE)
+                    memset(memo->cache_key, 0, sizeof(memo->cache_key));
+#endif
+                    return -EINVAL;
+                }
                 memcpy(tmp_etag, resp_etag, resp_etag_len);
                 /* shorten ETag option if necessary */
                 if ((size_t)resp_etag_len < COAP_ETAG_LENGTH_MAX) {
@@ -1354,7 +1367,6 @@ static ssize_t _cache_check(const uint8_t *buf, size_t len,
                      * bitmask resp_etag_len */
                     *start |= (uint8_t)resp_etag_len;
                     /* remove padding */
-                    size_t rem_len = (len - (tmp_etag + COAP_ETAG_LENGTH_MAX - buf));
                     memmove(tmp_etag + resp_etag_len, tmp_etag + COAP_ETAG_LENGTH_MAX, rem_len);
                     len -= (COAP_ETAG_LENGTH_MAX - resp_etag_len);
                 }


### PR DESCRIPTION
# Backport of #19968

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fixes an underflow error when getting a new ETag from cache, by returning early.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I repeated the testing procedures from https://github.com/RIOT-OS/RIOT/pull/17801#issuecomment-1123432269 (attention, the expected input for `examples/gcoap` changed slightly in the last year and a half)

```diff
diff --git a/aiocoap/cli/fileserver.py b/aiocoap/cli/fileserver.py
index 6af2b84..f5a9e71 100644
--- a/aiocoap/cli/fileserver.py
+++ b/aiocoap/cli/fileserver.py
@@ -154,6 +154,7 @@ class FileServer(Resource, aiocoap.interfaces.ObservableResource):
             elif S_ISREG(st.st_mode):
                 response = await self.render_get_file(request, path)
 
+        response.opt.max_age = 10
         response.opt.etag = etag
         return response
 
```
)

```console
$ sudo ./dist/tool/tapsetup/tapsetup
$ PORT=tap1 USEMODULE="gcoap_forward_proxy nanocoap_cache" make -C examples/gcoap -j flash term
...
> ifconfig
ifconfig
Iface  6  HWaddr: DA:27:1D:A8:64:24 
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::d827:1dff:fea8:6424  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffa8:6424

> 
[second terminal in aiocoap repo]
$ ip addr show dev tapbr0 scope link
5: tapbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether de:1a:a8:09:45:b3 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::dc1a:a8ff:fe09:45b3/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
$ mkdir -p test
$ echo "foobar" > test/a.txt
$ ./aiocoap-fileserver --bind "[$(ip addr show dev tapbr0 scope link | grep -o 'inet6 [0-9a-f:]\+' | sed 's/inet6 //')%tapbr0]" test/
...
[third terminal]
$ make -C examples/gcoap term
All up, running the shell now
> coap proxy set [fe80::d827:1dff:fea8:6424]:5683
coap proxy set [fe80::d827:1dff:fea8:6424]:5683
> coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
gcoap_cli: sending msg ID 17604, 63 bytes
> --- blockwise start ---
gcoap: response Success, code 2.05, 7 bytes
foobar

--- blockwise complete ---
coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
gcoap_cli: sending msg ID 17605, 63 bytes
--- blockwise start ---
gcoap: response Success, code 2.05, 7 bytes
foobar

--- blockwise complete ---

[wait >10 sec]

> coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
gcoap_cli: sending msg ID 17606, 63 bytes
> --- blockwise start ---
gcoap: response Success, code 2.05, 7 bytes
foobar

--- blockwise complete ---
coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
coap get [fe80::dc1a:a8ff:fe09:45b3]:5683 /a.txt
gcoap_cli: sending msg ID 17607, 63 bytes
--- blockwise start ---
gcoap: response Success, code 2.05, 7 bytes
foobar

--- blockwise complete ---
> ^C
native: exiting

```

Sniffing on `tapbr0` should show something like.

![image](https://github.com/RIOT-OS/RIOT/assets/675644/5c3b324d-5a40-4b3a-96ee-0f149e19f41f)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Reported off-band.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
