### PR TITLE
dist/testbed-support: Add openmote board [backport 2023.10]

### DIFF
--- a/dist/testbed-support/makefile.iotlab.archi.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.archi.inc.mk
@@ -10,6 +10,7 @@ IOTLAB_ARCHI_microbit       = microbit:ble
 IOTLAB_ARCHI_nrf52dk        = nrf52dk:ble
 IOTLAB_ARCHI_nrf52840dk     = nrf52840dk:multi
 IOTLAB_ARCHI_nucleo-wl55jc  = nucleo-wl55jc:stm32wl
+IOTLAB_ARCHI_openmote-b     = openmoteb
 IOTLAB_ARCHI_samr21-xpro    = samr21:at86rf233
 IOTLAB_ARCHI_samr30-xpro    = samr30:at86rf212b
 IOTLAB_ARCHI_samr34-xpro    = samr34:sx1276


### PR DESCRIPTION
# Backport of #19979

### Contribution description

As part of fixing the automated release specs test we will need support for another `cc2538` based board.  I was able to get the tests passing with adaption here and to the release specs.

### Testing procedure

### Issues/PRs references
