### PR TITLE
treewide: fix typos to make codespell happy [backport 2023.10]

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -257,7 +257,7 @@ Wrong:
   functionality.
 * Every function must be documented - including parameters and return value.
 
-An examplary doxygen documentation in a header file can look like this.
+An exemplary doxygen documentation in a header file can look like this.
 
 ```
 /*

--- a/boards/airfy-beacon/doc.txt
+++ b/boards/airfy-beacon/doc.txt
@@ -82,7 +82,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", \
 # If you share your linux system with other users, or just don't like the
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with
-# GROUP:="somegroupname" and mange access using standard unix groups.
+# GROUP:="somegroupname" and manage access using standard unix groups.
 
 > sudo cp 49-stlinkv2.rules /etc/udev/rules.d/
 > sudo udevadm control --reload-rules

--- a/boards/frdm-k64f/doc.txt
+++ b/boards/frdm-k64f/doc.txt
@@ -55,7 +55,7 @@ See also the ARMmbed
 [instructions](https://developer.mbed.org/platforms/FRDM-K64F/#getting-started-
 with-mbed).
 
-## Updating the Booloader
+## Updating the Bootloader
 A update of CMSIS-DAP firmware is necessary to using the board with OpenOCD.
 A good step by step guide is available
 [here](https://developer.mbed.org/handbook/Firmware-FRDM-K64F).

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -76,7 +76,7 @@ b <breakpoint>
 c
 ```
 For best debugging experience also change the `-Os` flag in
-`Makefile.inlcude`'s `CFLAGS` variable to `-O0`.
+`Makefile.include`'s `CFLAGS` variable to `-O0`.
 
 ## Details
 The M3 Open Node can reset, debug and program the STM32 on JTAG through the

--- a/boards/lsn50/doc.txt
+++ b/boards/lsn50/doc.txt
@@ -7,7 +7,7 @@
 
 This board is a waterproof board with a LoRa SX1276 radio.
 
-![LSN50](https://wiki.dragino.com/images/thumb/e/e9/Introdution.png/600px-Introdution.png)
+![LSN50](https://docs.zephyrproject.org/latest/_images/dragino_lsn50.jpg)
 
 Documentation of the board is available
 [here](https://wiki.dragino.com/index.php?title=Lora_Sensor_Node-LSN50).

--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -52,7 +52,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="607f", \
 # If you share your linux system with other users, or just don't like the
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with
-# GROUP:="somegroupname" and mange access using standard unix groups.
+# GROUP:="somegroupname" and manage access using standard unix groups.
 
 sudo cp 50-openmoko.rules  /etc/udev/rules.d/
 sudo udevadm control --reload-rules

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -392,7 +392,7 @@ void mutex_unlock_and_sleep(mutex_t *mutex);
  *          @ref mutex_lock_cancelable. (You can reinitialize the same memory
  *          to safely reuse it.)
  * @warning You ***MUST NOT*** call this function once the thread referred to by
- *          @p mc re-uses the mutex object referred to by @p mc (not counting
+ *          @p mc reuses the mutex object referred to by @p mc (not counting
  *          the call to @ref mutex_lock_cancelable @p mc was used in).
  * @note    It is safe to call this function from IRQ context, e.g. from a timer
  *          interrupt.

--- a/core/msg.c
+++ b/core/msg.c
@@ -216,7 +216,7 @@ static int _msg_send_oneway(msg_t *m, kernel_pid_t target_pid)
 
         sched_set_status(target, STATUS_PENDING);
 
-        /* Interrupts are disabled here, we can set / re-use
+        /* Interrupts are disabled here, we can set / reuse
            sched_context_switch_request. */
         sched_context_switch_request = 1;
 
@@ -280,7 +280,7 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
     sched_set_status(me, STATUS_REPLY_BLOCKED);
     me->wait_data = reply;
 
-    /* we re-use (abuse) reply for sending, because wait_data might be
+    /* we reuse (abuse) reply for sending, because wait_data might be
      * overwritten if the target is not in RECEIVE_BLOCKED */
     *reply = *m;
     /* msg_send blocks until reply received */

--- a/cpu/esp8266/periph/adc.c
+++ b/cpu/esp8266/periph/adc.c
@@ -37,7 +37,7 @@ int adc_init(adc_t line)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
 
-    /* no special inialization needed */
+    /* no special initialization needed */
     return 0;
 }
 

--- a/cpu/esp_common/esp-wifi/doc.txt
+++ b/cpu/esp_common/esp-wifi/doc.txt
@@ -88,7 +88,7 @@ following configuration parameters have to be defined:
 Parameter          | Default   | Description
 :------------------|:----------|:------------
 WIFI_SSID          | "RIOT_AP" | SSID of the AP to be used.
-WIFI_EAP_ID        | none      | Optional anonymous identity used in phase 1 (outer) EAP authentication. If it is not defined, the user name defined for phase 2 (inner) EAP authentication is used as idendity in phase 1.
+WIFI_EAP_ID        | none      | Optional anonymous identity used in phase 1 (outer) EAP authentication. If it is not defined, the user name defined for phase 2 (inner) EAP authentication is used as identity in phase 1.
 WIFI_EAP_USER      | none      | User name used in phase 2 (inner) EAP authentication.
 WIFI_EAP_PASS      | none      | Password used in phase 2 (inner) EAP authentication.
 ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -566,7 +566,7 @@ void isr_radio(void)
         case STATE_ACK:
             _state = STATE_IDLE;
 
-            /* We disable the radio to avoid unwanted emmissions (see ERRATA
+            /* We disable the radio to avoid unwanted emissions (see ERRATA
              * ID 204, "Switching between TX and RX causes unwanted emissions")
              */
             _disable();

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -310,7 +310,7 @@ unsigned int timer_read(tim_t tim)
         return 0;
     }
 
-    /* request syncronisation */
+    /* request synchronisation */
 #ifdef TC_CTRLBSET_CMD_READSYNC_Val
     dev(tim)->CTRLBSET.reg = TC_CTRLBSET_CMD_READSYNC;
      /* work around a possible hardware bug where it takes some

--- a/cpu/sam0_common/sam0_sdhc/sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/sdhc.c
@@ -1038,7 +1038,7 @@ static bool sdio_test_type(sdhc_state_t *state)
 
     /*
      * Wait card ready
-     * Timeout 1s = 400KHz / ((6+4)*8) cylces = 5000 retry
+     * Timeout 1s = 400KHz / ((6+4)*8) cycles = 5000 retry
      * 6 = cmd byte size
      * 4(SPI) 6(MCI) = response byte size
      */

--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -219,7 +219,7 @@ static inline uint32_t _multi_read_reg32(volatile uint32_t *addr, bool *glitch)
  * Think of this as a STM32-specific version of the Rowhammer attack.
  *
  * RDP may not be set correctly due to manufacturing error, glitch or
- * intentional attack.  It's done thrice to reduce the probablility of a
+ * intentional attack.  It's done thrice to reduce the probability of a
  * glitch attack succeeding amongst all of the multireads desgned to make it
  * tougher.
  *

--- a/cpu/stm32/periph/can.c
+++ b/cpu/stm32/periph/can.c
@@ -480,7 +480,7 @@ static int read_frame(can_t *dev, struct can_frame *frame, int mailbox)
         frame->data[j] = (can->sFIFOMailBox[mailbox].RDHR >> ((j - 4) * 8)) & 0xFF;
     }
 
-    /* filter number matching the reveived frame */
+    /* filter number matching the received frame */
     /* filter = (can->sFIFOMailBox[mailbox].RDTR & CAN_RDT0R_FMI) >> CAN_RDTxR_FMI_SHIFT; */
 
     /* Release input mailbox */

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -168,3 +168,9 @@ rsource
 
 # SHS (abbreviation for Secure Hash Standard) => SSH, NHS
 shs
+
+# FRAM (abbreviation for ferroelectric random access memory, a non-volatile memory)
+fram
+
+# MIS (mask interrupt register)
+mis

--- a/dist/tools/lpc2k_pgm/README.txt
+++ b/dist/tools/lpc2k_pgm/README.txt
@@ -66,7 +66,7 @@ been tested with Linux kernel 2.4.20 and 2.6.8, and should work with
 almost any linux system.
 
 You must have the "xterm" program installed.  Nearly all linux
-distrubtions provide this, and it is often installed by default.  If
+distributions provide this, and it is often installed by default.  If
 you do not have it, simply install from your linux distribution.
 
 Your serial port device file (usually /dev/ttyS0 or /dev/ttyS1) must

--- a/dist/tools/lpc2k_pgm/src/gui.c
+++ b/dist/tools/lpc2k_pgm/src/gui.c
@@ -395,7 +395,7 @@ void create_window(int *argc, char ***argv)
     gtk_widget_set_sensitive(reboot_button, TRUE);
     gtk_widget_show(reboot_button);
 
-    bootloader_button = gtk_button_new_with_label("Booloader");
+    bootloader_button = gtk_button_new_with_label("Bootloader");
     gtk_widget_show(bootloader_button);
 
     quit_button = gtk_button_new_with_label("Quit");

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -574,7 +574,7 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev);
 bool at86rf2xx_cca(at86rf2xx_t *dev);
 
 /**
- * @brief   Enable the smart receive tecnology (SRT)
+ * @brief   Enable the smart receive technology (SRT)
  *
  * The SRT reduces the power consumption during RX listening periods.
  *
@@ -584,7 +584,7 @@ bool at86rf2xx_cca(at86rf2xx_t *dev);
 void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev);
 
 /**
- * @brief   Disable the smart receive tecnology (SRT)
+ * @brief   Disable the smart receive technology (SRT)
  *
  * @param[in]  dev          device to use
  *

--- a/drivers/include/bme680.h
+++ b/drivers/include/bme680.h
@@ -281,7 +281,7 @@ int bme680_force_measurement(bme680_t *dev);
  *
  * @param[in,out]   dev     device descriptor of the sensor
  *
- * @return  duration of one THPG measurement cylce in milliseconds.
+ * @return  duration of one THPG measurement cycle in milliseconds.
  * @return  < 0 on error
  */
 int bme680_get_duration(bme680_t* dev);

--- a/drivers/include/l3gxxxx.h
+++ b/drivers/include/l3gxxxx.h
@@ -633,7 +633,7 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * If module `l3gxxxx_fifo` is used, the corresponding interrupt sources can
- * be testsed.
+ * be tested.
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
  * l3gxxxx_int_src_t int_src = l3gxxxx_wait_int(&dev);
@@ -1278,7 +1278,7 @@ typedef struct {
                                       for threshold comparison */
 
     bool and_or;       /**< Combination of interrupt events (true=AND, false=OR):<br>
-                            AND - all enabled axes passed their tresholds<br>
+                            AND - all enabled axes passed their thresholds<br>
                             OR - at least one axis passed its threshold */
     bool latch;        /**< Latch the interrupt when true until the interrupt
                             source has been read by function l3gxxxx_wait_int. */

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -311,7 +311,7 @@ int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 *
 * @ note
 * This function sets the payload width for one packet. If the maximum of 32 bytes is
-* exeeded, this value is set to 32.
+* exceeded, this value is set to 32.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pipe   RX pipe to set the payload width.

--- a/drivers/include/sdmmc/sdmmc.h
+++ b/drivers/include/sdmmc/sdmmc.h
@@ -36,7 +36,7 @@
  *
  * 1. The high-level API that implements the SD Host Controller driver and
  *    allows
- *    - to inititialize and identify different types of cards,
+ *    - to initialize and identify different types of cards,
  *    - to access them either blockwise or bytewise,
  *    - to get information about the used card, and
  *    - to send single commands or application specific commands to the card.
@@ -676,7 +676,7 @@ typedef struct __attribute__((packed)) {
 /**
  * @brief   CSD register structure Version 2.0 and Version 3.0
  *
- * A combined format is used vor CSD Version 2.0 and 3.0 to reduce the code
+ * A combined format is used for CSD Version 2.0 and 3.0 to reduce the code
  * size. The only difference is the bit length of `C_SIZE`.
  *
  * @see Physical Layer Simplified Specification Version 9.00

--- a/drivers/include/shtcx.h
+++ b/drivers/include/shtcx.h
@@ -81,7 +81,7 @@ int8_t shtcx_init(shtcx_t* const dev, const shtcx_params_t* params);
 
 /**
  * @brief Reads all register values from the device.
- * @details The values as raw data will be saved into reveived.
+ * @details The values as raw data will be saved into received.
  *
  * @param[in] dev             The I2C device descriptor.
  * @param[in] rel_humidity    Humidity in centi %.

--- a/drivers/mpu9x50/mpu9x50.c
+++ b/drivers/mpu9x50/mpu9x50.c
@@ -455,7 +455,7 @@ int mpu9x50_set_compass_sample_rate(mpu9x50_t *dev, uint8_t rate)
 /**
  * Initialize compass
  * Caution: This internal function does not acquire exclusive access to the I2C bus.
- *          Acquisation and release is supposed to be handled by the calling function.
+ *          Acquisition and release is supposed to be handled by the calling function.
  */
 static int compass_init(mpu9x50_t *dev)
 {
@@ -524,7 +524,7 @@ static int compass_init(mpu9x50_t *dev)
 /**
  * Configure bypass mode
  * Caution: This internal function does not acquire exclusive access to the I2C bus.
- *          Acquisation and release is supposed to be handled by the calling function.
+ *          Acquisition and release is supposed to be handled by the calling function.
  */
 static void conf_bypass(const mpu9x50_t *dev, uint8_t bypass_enable)
 {
@@ -548,7 +548,7 @@ static void conf_bypass(const mpu9x50_t *dev, uint8_t bypass_enable)
 /**
  * Configure low pass filter
  * Caution: This internal function does not acquire exclusive access to the I2C bus.
- *          Acquisation and release is supposed to be handled by the calling function.
+ *          Acquisition and release is supposed to be handled by the calling function.
  */
 static void conf_lpf(const mpu9x50_t *dev, uint16_t half_rate)
 {

--- a/drivers/saul/init_devs/auto_init_sdp3x.c
+++ b/drivers/saul/init_devs/auto_init_sdp3x.c
@@ -64,7 +64,7 @@ void auto_init_sdp3x(void)
         saul_reg_add(&saul_entries[se_ix]);
         se_ix++;
 
-        /* differential presure */
+        /* differential pressure */
         saul_entries[se_ix].dev = &sdp3x_devs[i];
         saul_entries[se_ix].name = sdp3x_saul_info[i].name;
         saul_entries[se_ix].driver = &sdp3x_differential_pressure_saul_driver;

--- a/makefiles/defaultmodules_deps.inc.mk
+++ b/makefiles/defaultmodules_deps.inc.mk
@@ -1,6 +1,6 @@
 # This files contains dependencies for default modules. They are parsed at the
-# end of the dependency loop. They MAY inlcude new modules, but this modules
-# MUST NOT have dependencies themselfs.
+# end of the dependency loop. They MAY include new modules, but this modules
+# MUST NOT have dependencies themselves.
 
 ifneq (,$(filter auto_init%,$(USEMODULE)))
   USEMODULE += preprocessor preprocessor_successor

--- a/pkg/flashdb/doc.txt
+++ b/pkg/flashdb/doc.txt
@@ -61,11 +61,11 @@
  * ==================
  * To enable the Key-Value database, select the `flashdb_kvdb` module.
  *
- * For use of the FlashDB API, reffer to the [FlashDB documentation](http://armink.gitee.io/flashdb/#/sample-kvdb-basic).
+ * For use of the FlashDB API, refer to the [FlashDB documentation](http://armink.gitee.io/flashdb/#/sample-kvdb-basic).
  *
  * Time series database
  * ====================
  * To enable the Key-Value database, select the `flashdb_tsdb` module.
  *
- * For use of the FlashDB API, reffer to the [FlashDB documentation](http://armink.gitee.io/flashdb/#/sample-tsdb-basic).
+ * For use of the FlashDB API, refer to the [FlashDB documentation](http://armink.gitee.io/flashdb/#/sample-tsdb-basic).
  */

--- a/pkg/micropython/doc.txt
+++ b/pkg/micropython/doc.txt
@@ -35,7 +35,7 @@
  * The RIOT port of MicroPython currently resides in a fork at
  * https://github.com/kaspar030/micropython (in branch add_riot_port). It is
  * based on Micropython's "ports/minimal" with some extra modules enabled.
- * It re-uses the gc_collect code from ports/unix, which has special support
+ * It reuses the gc_collect code from ports/unix, which has special support
  * for i386 and Cortex-M. On other platforms, it uses setjmp() to collect
  * registers.
  *

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -142,7 +142,7 @@ void nimble_riot_init(void)
     while (!ble_hs_synced()) {}
 
     /* for reducing code duplication, we read our own address type once here
-     * so it can be re-used later on */
+     * so it can be reused later on */
     res = ble_hs_util_ensure_addr(0);
     assert(res == 0);
     res = ble_hs_id_infer_auto(0, &nimble_riot_own_addr_type);

--- a/pkg/tinyusb/hw/include/nrf52/nrf_clock.h
+++ b/pkg/tinyusb/hw/include/nrf52/nrf_clock.h
@@ -43,7 +43,7 @@ typedef enum {
 } nrf_clock_task_t;
 
 /**
- * @brief   Status HF clock acitvation/deactivation in `dcd_nrf52.c`
+ * @brief   Status HF clock activation/deactivation in `dcd_nrf52.c`
  *
  * The `clock_hfxo_request` and `clock_hfxo_release` functions are used in
  * RIOT to enable/disable the HF clock if necessary. Since `hfclk_enable`

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1442,7 +1442,7 @@ Build System / Tooling
 + .vscode: import initial RIOT-OS style (#18945)
 + build-system: add capability to execute scripts with custom executor (#18770)
 + dist/tools: add "RESET_PIN" value for the dwm1001 (#18815)
-+ examples/gnrc_border_router: add option to re-use existing TAP
++ examples/gnrc_border_router: add option to reuse existing TAP
   interface (#18836)
 + makefiles/tools/serial.inc.mk: add support for bootterm (#18749)
 + tapsetup: add --loss & --delay option (#18885)
@@ -3633,7 +3633,7 @@ Packages
 * pkg/littlefs2: bump version to 2.4.2 (#17837)
 * pkg/lv_drivers: initial commit (#17713)
 * pkg/lvgl: bump to 8.2.0 (#17681)
-* pkg/lvlgl: allow cusomizing LV_MEM_SIZE (#17759)
+* pkg/lvlgl: allow customizing LV_MEM_SIZE (#17759)
 + pkg/mbedtls: initial pkg import to use entropy module (#15671)
 * pkg/mynewt-core: fix semaphore (#17771)
 * pkg/semtech-loramac: enable setting channels mask (#17824)
@@ -5848,7 +5848,7 @@ System Libraries (21)
 + sys/event: add periodic timeout event (#16507)
 + sys/ps: enable runtime_usec output for the ps command (#16470)
 * gnrc_dhcpv6_client_6lbr: choose downstream if as !upstream (#16530)
-* net/emcute: Allow RETAIN flag to be set on incoming PUBLISHs (#16326)
+* net/emcute: Allow RETAIN flag to be set on incoming PUBLISHes (#16326)
 * net/gnrc/rpl: use ztimer_msec if available (#16339)
 * net/grnc/sixlowpan/ctx: use ztimer_msec if available (#16340)
 * sys/arduino: replace xtimer by ztimer as high-level background timer (#15317)
@@ -13615,7 +13615,7 @@ Drivers
 Build System
 ------------
 + Experimental distributed building using Murdock
-+ most makfiles moved from root into makefiles/
++ most makefiles moved from root into makefiles/
 + added submodule support
 
 Special Thanks

--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -317,7 +317,7 @@ void swap(thread& lhs, thread& rhs) noexcept;
 /** @cond INTERNAL */
 template <class Tuple>
 void* thread_proxy(void* vp) {
-  { // without this scope, the objects here are not cleaned up corrctly
+  { // without this scope, the objects here are not cleaned up correctly
     std::unique_ptr<Tuple> p(static_cast<Tuple*>(vp));
     auto tmp = std::get<0>(*p);
     std::unique_ptr<thread_data, thread_data_deleter> data{tmp};

--- a/sys/crypto/chacha.c
+++ b/sys/crypto/chacha.c
@@ -26,7 +26,7 @@
  *  - This implementation of the ChaCha stream cipher is very stripped down.
  *  - It assumes a little-endian system.
  *  - It is implemented for little code and data size, but will likely be
- *    slower than the refenrence implementation. Optimized implementation will
+ *    slower than the reference implementation. Optimized implementation will
  *    out-perform the code even more.
  */
 

--- a/sys/fido2/ctap/ctap.c
+++ b/sys/fido2/ctap/ctap.c
@@ -616,7 +616,7 @@ static int _get_assertion(ctap_req_t *req_raw)
         goto done;
     }
 
-    /* find eligble credentials */
+    /* find eligible credentials */
     _assert_state.count = _find_matching_rks(_assert_state.rks,
                                              CTAP_MAX_EXCLUDE_LIST_SIZE,
                                              req.allow_list,
@@ -693,7 +693,7 @@ static int _get_assertion(ctap_req_t *req_raw)
     memcpy(_assert_state.client_data_hash, req.client_data_hash,
            SHA256_DIGEST_LENGTH);
 
-    /* most recently created eligble rk found */
+    /* most recently created eligible rk found */
     rk = &_assert_state.rks[_assert_state.cred_counter++];
 
     /* last moment where transaction can be cancelled */
@@ -780,7 +780,7 @@ static int _get_next_assertion(void)
         goto done;
     }
 
-    /* next eligble rk */
+    /* next eligible rk */
     rk = &_assert_state.rks[_assert_state.cred_counter];
     _assert_state.cred_counter++;
 

--- a/sys/fido2/ctap/ctap_cbor.c
+++ b/sys/fido2/ctap/ctap_cbor.c
@@ -1557,7 +1557,7 @@ static int _parse_options(CborValue *it, ctap_options_t *options)
         }
         else {
             /* ignore unknown options */
-            DEBUG("Ctap parse options, unknown uption: %s \n", key);
+            DEBUG("Ctap parse options, unknown option: %s \n", key);
         }
 
         cbor_value_advance(&map);

--- a/sys/fido2/ctap/transport/hid/ctap_hid.c
+++ b/sys/fido2/ctap/transport/hid/ctap_hid.c
@@ -395,7 +395,7 @@ static void _process_transaction(event_t *arg)
         _handle_init_packet(cid, bcnt, buf);
     }
     else {
-        /* readding deleted cid */
+        /* re-adding deleted cid */
         if (!_cid_exists(cid) && _add_cid(cid) == -1) {
             _send_error_response(cid, CTAP_HID_ERR_CHANNEL_BUSY);
         }

--- a/sys/hashes/md5.c
+++ b/sys/hashes/md5.c
@@ -142,7 +142,7 @@ static void permute(uint32_t abcd[4], const uint8_t block[64] )
     uint32_t keep_abcd[4];
     uint32_t x[16];
 
-    /* Store the current ABCD values for later re-use */
+    /* Store the current ABCD values for later reuse */
     for (int i = 0; i < 4; i++) {
         keep_abcd[i] = abcd[i];
     }

--- a/sys/include/congure/test.h
+++ b/sys/include/congure/test.h
@@ -144,7 +144,7 @@ int congure_test_call_setup(int argc, char **argv);
  * @param[in] argc  Number of @p argv. Needs to be at least 2.
  * @param[in] argv  Command line arguments. `argv[0]` needs to be the command
  *                  name and `argv[1]` needs to be a hexadecimal integer of
- *                  format 0xXXXX, represending a pointer to the object used as
+ *                  format 0xXXXX, representing a pointer to the object used as
  *                  the `ctx` parameter for `init()`.
  *
  * This function will generate the following JSON objects in STDOUT on error:

--- a/sys/include/crypto/modes/ecb.h
+++ b/sys/include/crypto/modes/ecb.h
@@ -53,7 +53,7 @@ int cipher_encrypt_ecb(const cipher_t *cipher, const uint8_t *input,
  * @param input      pointer to input data to decrypt
  * @param length     length of the input data
  * @param output     pointer to allocated memory for plaintext data. It has to
- *                   be of size `lengh`.
+ *                   be of size `length`.
  *
  * @return           Length of decrypted data on a successful decryption
  * @return           A negative error code if something went wrong

--- a/sys/include/hashes/sha3.h
+++ b/sys/include/hashes/sha3.h
@@ -71,7 +71,7 @@ typedef struct {
  *
  * @param[out] ctx             context handle to initialise
  * @param[in] rate             the desired rate of the sponge
- * @param[in] capacity         the desired capcity of the sponge
+ * @param[in] capacity         the desired capacity of the sponge
  * @param[in] delimitedSuffix  suffix to be appended to the message after the absorbation phase
  */
 void Keccak_init(keccak_state_t *ctx, unsigned int rate, unsigned int capacity,

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -288,7 +288,7 @@ struct asymcute_con {
  */
 struct asymcute_topic {
     asymcute_con_t *con;        /**< connection used for registration */
-    char name[CONFIG_ASYMCUTE_TOPIC_MAXLEN + 1];   /**< topic string (ACSII only) */
+    char name[CONFIG_ASYMCUTE_TOPIC_MAXLEN + 1];   /**< topic string (ASCII only) */
     uint8_t flags;              /**< normal, short, or pre-defined */
     uint16_t id;                /**< topic id */
 };

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -214,7 +214,7 @@ enum {
  * @brief   MQTT-SN topic
  */
 typedef struct {
-    const char *name;           /**< topic string (currently ACSII only) */
+    const char *name;           /**< topic string (currently ASCII only) */
     uint16_t id;                /**< topic id, as assigned by the gateway */
 } emcute_topic_t;
 

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -183,7 +183,7 @@
  * First, the data to be sent is added to the @ref net_gnrc_pktbuf "packet buffer".
  * This ensures its intactness during the sending process. After the data to be
  * sent has been added to the packet buffer, its parent data structure can safely
- * be freed or re-used.
+ * be freed or reused.
  *
  * Then, the @ref net_gnrc_pkt "pkt" will be sent to all threads that registered
  * for @ref GNRC_NETTYPE_UDP and the demux context `80`. Every registered thread

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -227,7 +227,7 @@ typedef struct gnrc_netreg_entry {
  * There is an exclusive counterpart to the lock, which is
  * internal to netreg (and used through functions such as @ref
  * gnrc_netreg_register and @ref gnrc_netreg_unregister). The current
- * implementation priorizes shared locks. This means that shared locks are
+ * implementation prioritizes shared locks. This means that shared locks are
  * generally acquired fast (they only block if an exclusive operation has
  * already started), but constant access through shared locks might starve
  * registration and deregistration.

--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -87,7 +87,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
  * @brief   Generate reassembly buffer from a header's forwarding information.
  *
  * @param[in] base  Base data of the datagram. Must not be `NULL`.
- * @param[in] netif Restict route to this interface. May be `NULL` for any
+ * @param[in] netif Restrict route to this interface. May be `NULL` for any
  *                  interface.
  * @param[in] hdr   Header from which to take the forwarding information from
  *                  (e.g. IPv6 header implies `hdr->type == GNRC_NETTYPE_IPV6`).

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -49,7 +49,7 @@ extern "C" {
 #endif
 
 #ifdef SOCK_HAS_IPV6
-/* Re-use sock endpoint if sock is available and supporting IPv6. */
+/* Reuse sock endpoint if sock is available and supporting IPv6. */
 typedef struct _sock_tl_ep gnrc_tcp_ep_t;
 
 #else

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -287,7 +287,7 @@ typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len,
 typedef int (*coap_blockwise_cb_t)(void *arg, size_t offset, uint8_t *buf, size_t len, int more);
 
 /**
- * @brief   Coap equest callback descriptor
+ * @brief   Coap request callback descriptor
  *
  * @param[in] arg      Pointer to be passed as arguments to the callback
  * @param[in] pkt      The received CoAP response.

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -74,7 +74,7 @@
  * The actual code very much depends on the used `sock` type. Please refer to
  * their documentation for specific examples.
  *
- * Implementor Notes
+ * Implementer Notes
  * =================
  * ### Type definition
  * For simplicity and modularity this API doesn't put any restriction on the

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -599,7 +599,7 @@ enum {
 /**
  * @brief   Type for a DTLS sock object
  *
- * @note    API implementors: `struct sock_dtls` needs to be defined by
+ * @note    API implementers: `struct sock_dtls` needs to be defined by
  *          an implementation-specific `sock_dtls_types.h`.
  */
 typedef struct sock_dtls sock_dtls_t;

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -289,7 +289,7 @@ extern "C" {
 /**
  * @brief   Type for a raw IPv4/IPv6 sock object
  *
- * @note API implementors: `struct sock_ip` needs to be defined by
+ * @note API implementers: `struct sock_ip` needs to be defined by
  *       implementation-specific `sock_types.h`.
  */
 typedef struct sock_ip sock_ip_t;

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -322,7 +322,7 @@ typedef struct _sock_tl_ep sock_tcp_ep_t;   /**< An end point for a TCP sock obj
 /**
  * @brief   Type for a TCP sock object
  *
- * @note API implementors: `struct sock_tcp` needs to be defined by
+ * @note API implementers: `struct sock_tcp` needs to be defined by
  *       implementation-specific `sock_types.h`.
  */
 typedef struct sock_tcp sock_tcp_t;
@@ -330,7 +330,7 @@ typedef struct sock_tcp sock_tcp_t;
 /**
  * @brief   Type for a TCP listening queue
  *
- * @note API implementors: `struct sock_tcp_queue` needs to be defined by
+ * @note API implementers: `struct sock_tcp_queue` needs to be defined by
  *                          implementation-specific `sock_types.h`.
  */
 typedef struct sock_tcp_queue sock_tcp_queue_t;

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -295,7 +295,7 @@ typedef struct _sock_tl_ep sock_udp_ep_t;   /**< An end point for a UDP sock obj
 /**
  * @brief   Type for a UDP sock object
  *
- * @note    API implementors: `struct sock_udp` needs to be defined by
+ * @note    API implementers: `struct sock_udp` needs to be defined by
  *         implementation-specific `sock_types.h`.
  */
 typedef struct sock_udp sock_udp_t;

--- a/sys/include/test_utils/result_output.h
+++ b/sys/include/test_utils/result_output.h
@@ -68,7 +68,7 @@ extern "C" {
 /**
  * @brief   Type for a TURO object
  *
- * @note    API implementors: `struct turo` needs to be defined by
+ * @note    API implementers: `struct turo` needs to be defined by
  *         implementation-specific `result_output_types.h`.
  */
 typedef struct turo turo_t;

--- a/sys/include/usb/dfu.h
+++ b/sys/include/usb/dfu.h
@@ -50,7 +50,7 @@ extern "C" {
 #define USB_DFU_CAN_DOWNLOAD            0x01    /**< DFU Download attribute */
 #define USB_DFU_CAN_UPLOAD              0x02    /**< DFU Upload attribute */
 #define USB_DFU_MANIFEST_TOLERANT       0x04    /**< DFU Manifest tolerant attribute */
-#define USB_DFU_WILL_DETACH             0x08    /**< DFU Detach capabability attribute */
+#define USB_DFU_WILL_DETACH             0x08    /**< DFU Detach capability attribute */
 /** @} */
 
 /**

--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -85,7 +85,7 @@ static bool entry_is_dir(char *path, const char *name)
         return false;
     }
 
-    /* re-use path buffer, it is already COAPFILESERVER_PATH_MAX bytes long */
+    /* reuse path buffer, it is already COAPFILESERVER_PATH_MAX bytes long */
     path[path_len] = '/';
     path[path_len + 1] = 0;
     strncat(path, name, COAPFILESERVER_PATH_MAX - 1);

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -39,8 +39,8 @@
 /**
  * @brief Calculates the maximum of two unsigned numbers.
  *
- * @param[in] x   First comparrison value.
- * @param[in] y   Second comparrison value.
+ * @param[in] x   First comparison value.
+ * @param[in] y   Second comparison value.
  *
  * @returns   X if x is larger than y, if not y is returned.
  */

--- a/sys/psa_crypto/doc.txt
+++ b/sys/psa_crypto/doc.txt
@@ -745,7 +745,7 @@
  *
  * **cpu/myCPU/Makefile.features:**
  * @code
- * FEATURES_PROVIDED += periph_speedycrypt      // General feature for the acclerator
+ * FEATURES_PROVIDED += periph_speedycrypt      // General feature for the accelerator
  * FEATURES_PROVIDED += periph_hash_sha_256
  * FEATURES_PROVIDED += periph_ecc_p256r1
  * @endcode

--- a/sys/psa_crypto/include/psa_crypto_se_driver.h
+++ b/sys/psa_crypto/include/psa_crypto_se_driver.h
@@ -756,7 +756,7 @@ typedef psa_status_t (*psa_drv_se_aead_encrypt_t)(psa_drv_se_context_t *drv_cont
                                                   size_t *p_ciphertext_length);
 
 /**
- * @brief   A function that peforms a secure element authenticated decryption operation
+ * @brief   A function that performs a secure element authenticated decryption operation
  *
  * @param   drv_context             The driver context structure.
  * @param   key_slot                Slot containing the key to use

--- a/tests/drivers/candev/README.native.can.md
+++ b/tests/drivers/candev/README.native.can.md
@@ -134,7 +134,7 @@ CFLAGS=-DCAN_DLL_NUMOF=2 BOARD=native PERIPH_CAN_FLAGS="--can 0:vcan1 --can 1:vc
 
 To send or receive bytes from the interface `can-utils` can be used:
 
-- send raw CAN frames: by using `cansend` or altenatively `cangen` to send random can messages:
+- send raw CAN frames: by using `cansend` or alternatively `cangen` to send random can messages:
 
 ```shell
 $ cansend <interface> <can_id>:<hexbytes>

--- a/tests/net/gnrc_dhcpv6_client_stateless/tests-as-root/01-run.py
+++ b/tests/net/gnrc_dhcpv6_client_stateless/tests-as-root/01-run.py
@@ -75,7 +75,7 @@ class StatelessDHCPv6Test(Automaton):
         """
             The initial state.
 
-            The Automaton waits for an NDP Router Solication.
+            The Automaton waits for an NDP Router Solicitation.
         """
         pass
 

--- a/tests/pkg/nimble_esp_wifi_coexist/README.md
+++ b/tests/pkg/nimble_esp_wifi_coexist/README.md
@@ -6,7 +6,7 @@ ESP32x WiFi interface simultaneously.
 
 # Usage
 
-Comile and flash the application with command
+Compile and flash the application with command
 ```
 CFLAGS='-DWIFI_SSID=\"myssid\" -DWIFI_PASS=\"mypass\"'
 BOARD=esp32-wroom-32 make -C tests/nimble_esp_wifi_coexist flash term

--- a/tests/pkg/tinyvcdiff/main.c
+++ b/tests/pkg/tinyvcdiff/main.c
@@ -71,7 +71,7 @@ static void test_tinyvcdiff_mtd(void)
     rc = vcdiff_finish(&vcdiff);
     TEST_ASSERT_EQUAL_INT(0, rc);
 
-    /* check reconsturcted target */
+    /* check reconstructed target */
     mtd_read(target_mtd, target_buf, 0, sizeof(target_buf));
     TEST_ASSERT_EQUAL_INT(0, memcmp(target_bin, target_buf, sizeof(target_buf)));
 }
@@ -109,7 +109,7 @@ static void test_tinyvcdiff_vfs(void)
     vfs_close(source_fd);
     vfs_close(target_fd);
 
-    /* check reconsturcted target */
+    /* check reconstructed target */
     memset(target_buf, 0, sizeof(target_buf));
     target_fd = vfs_open("/mnt/target", O_RDONLY, 0);
     vfs_read(target_fd, target_buf, sizeof(target_buf));

--- a/tests/sys/rng/test.h
+++ b/tests/sys/rng/test.h
@@ -109,7 +109,7 @@ void test_fips(void);
 void test_entropy(uint32_t samples);
 
 /**
- * @brief   Run the speed test for a given duration. It utillizes xtimer for
+ * @brief   Run the speed test for a given duration. It utilizes xtimer for
  *          setting an alarm.
  *
  * @param[in] duration  Test duration (in seconds)
@@ -118,7 +118,7 @@ void test_speed(uint32_t duration);
 
 /**
  * @brief   Run the speed test for random numbers r with a <= r < b and a given duration.
- *          It utillizes xtimer for setting an alarm.
+ *          It utilizes xtimer for setting an alarm.
  *
  * @param[in] duration  Test duration (in seconds)
  * @param[in] a         Minimum for random number

--- a/tests/sys/sema_inv/main.c
+++ b/tests/sys/sema_inv/main.c
@@ -85,7 +85,7 @@ static void test_counter_mode(void)
     sema_inv_wait(&sync);
     puts("thread synced");
 
-    /* wait for all threads to terminate, we are going to re-use the stack */
+    /* wait for all threads to terminate, we are going to reuse the stack */
     ztimer_sleep(ZTIMER_MSEC, 50);
 }
 
@@ -112,7 +112,7 @@ static void test_mask_mode(void)
     sema_inv_wait(&sync);
     puts("thread synced");
 
-    /* wait for all threads to terminate, we are going to re-use the stack */
+    /* wait for all threads to terminate, we are going to reuse the stack */
     ztimer_sleep(ZTIMER_MSEC, 50);
 }
 


### PR DESCRIPTION
# Backport of #19978

### Contribution description

- fixes typos in comments and docs (no generated firmware changes expected)
- fixes a typo in a string in a GUI of a utility program
- add some false positives to the ignore list

### Testing procedure

- No generated binaries (except for the GUI version of the utility program to flash the MSB-A2) should change
- The diff should not look too scary

### Issues/PRs references

None