### PR TITLE
pkg/nanocbor: Update for fixed nanocbor_skip_simple() [backport 2023.10]

### DIFF
--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nanocbor
 PKG_URL     = https://github.com/bergzand/nanocbor
-PKG_VERSION = 1bc789705057c42be32aea17aeec97763aece3c7
+PKG_VERSION = ae01e393f152b8294028986256f8451c93f75cfc
 PKG_LICENSE = CC-0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nanocbor
 PKG_URL     = https://github.com/bergzand/nanocbor
-PKG_VERSION = ae01e393f152b8294028986256f8451c93f75cfc
+PKG_VERSION = 54e8938e60ba6a74d8aeafffc2d4a1dfc0392498
 PKG_LICENSE = CC-0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
# backport of #19975 and #19983

### Contribution description

Manually created the backport this time :cry: 

Includes both #19975 and #19983 to include the nanocbor bug fix for the `nanocbor_skip_simple()` function

### Testing procedure

The usual nanocbor test in `tests/pkg/nanocbor`

### Issues/PRs references

None