### PR TITLE
sys/psa_crypto: allow repeated initialization

### DIFF
--- a/sys/crypto/psa_riot_cipher/aes_128_cbc.c
+++ b/sys/crypto/psa_riot_cipher/aes_128_cbc.c
@@ -71,7 +71,6 @@ psa_status_t psa_cipher_cbc_aes_128_decrypt(const psa_key_attributes_t *attribut
                                             size_t *output_length)
 {
     DEBUG("RIOT AES 128 Cipher");
-    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_cipher_operation_t operation = psa_cipher_operation_init();
     size_t required_output_buf_size = PSA_CIPHER_DECRYPT_OUTPUT_SIZE(PSA_KEY_TYPE_AES,
                                         PSA_ALG_CBC_NO_PADDING, input_length);

--- a/sys/psa_crypto/psa_crypto.c
+++ b/sys/psa_crypto/psa_crypto.c
@@ -113,6 +113,10 @@ const char *psa_status_to_humanly_readable(psa_status_t status)
 
 psa_status_t psa_crypto_init(void)
 {
+    if (lib_initialized) {
+        return PSA_SUCCESS;
+    }
+
     lib_initialized = 1;
 
 #if (IS_USED(MODULE_PSA_KEY_SLOT_MGMT))

--- a/tests/sys/psa_crypto/Makefile
+++ b/tests/sys/psa_crypto/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.sys_common
+
+USEMODULE += embunit
+
+USEMODULE += psa_crypto
+
+# FIXME: currently only needed for build to succeed
+USEMODULE += psa_cipher
+USEMODULE += psa_cipher_aes_128_cbc
+
+USEMODULE += psa_asymmetric
+USEMODULE += psa_asymmetric_ecc_ed25519
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/psa_crypto/Makefile.ci
+++ b/tests/sys/psa_crypto/Makefile.ci
@@ -1,0 +1,10 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atmega8 \
+    nucleo-l011k4 \
+    #

--- a/tests/sys/psa_crypto/main.c
+++ b/tests/sys/psa_crypto/main.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the PSA Cryptography API
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "embUnit.h"
+#include "psa/crypto.h"
+
+#define TEST_ASSERT_PSA(func_) TEST_ASSERT_MESSAGE(func_ == PSA_SUCCESS, #func_ " failed");
+
+/*
+ * A second call to psa_crypto_init() should not reset key data.
+ */
+static void test_init_twice(void)
+{
+    TEST_ASSERT_PSA(psa_crypto_init());
+
+
+    psa_key_id_t key_id = PSA_KEY_ID_NULL;
+    psa_key_attributes_t key_attr = psa_key_attributes_init();
+    psa_set_key_algorithm(&key_attr, PSA_ALG_PURE_EDDSA);
+    psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_EXPORT);
+    psa_set_key_bits(&key_attr, 255);
+    psa_set_key_type(&key_attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_TWISTED_EDWARDS));
+    TEST_ASSERT_PSA(psa_generate_key(&key_attr, &key_id));
+
+    uint8_t key_data[PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(psa_get_key_type(&key_attr), psa_get_key_bits(&key_attr))];
+    size_t key_data_len;
+
+    TEST_ASSERT_PSA(psa_export_public_key(key_id, key_data, sizeof(key_data), &key_data_len));
+    TEST_ASSERT_PSA(psa_crypto_init());
+    TEST_ASSERT_PSA(psa_export_public_key(key_id, key_data, sizeof(key_data), &key_data_len));
+
+}
+
+static Test *tests_psa_crypto(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_init_twice),
+    };
+
+    EMB_UNIT_TESTCALLER(tests, NULL, NULL, fixtures);
+    return (Test *)&tests;
+}
+
+int main(void)
+{
+    puts("psa_crypto test");
+    TESTS_START();
+    TESTS_RUN(tests_psa_crypto());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/sys/psa_crypto/tests/01-run.py
+++ b/tests/sys/psa_crypto/tests/01-run.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 TU Dresden
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run_check_unittests
+
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())


### PR DESCRIPTION
### Contribution description

- simple unit test which calls `psa_crypto_init()` twice
- fix to no re-initialize key slots (which left them in a broken state)

### Testing procedure

- `make -C tests/sys/psa_crypto all test` succeeds
- `git checkout HEAD~1 && make -C tests/sys/psa_crypto all test` fails

