### PR TITLE
gnrc: make message queues static

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -46,7 +46,8 @@ static int queue_msg(thread_t *target, const msg_t *m)
     int n = cib_put(&(target->msg_queue));
 
     if (n < 0) {
-        DEBUG("queue_msg(): message queue is full (or there is none)\n");
+        DEBUG("queue_msg(): message queue of thread %" PRIkernel_pid
+              " is full (or there is none)\n", target->pid);
         return 0;
     }
 

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -122,9 +122,13 @@ extern "C" {
  */
 /**
  * @brief   Default stack size to use for the IPv6 thread
+ *
+ * @note    The message queue was previously allocated on the stack.
+ *          The default number of messages is 2³.
+ *          Given sizeof(msg_t) == 8, the stack size is reduced by 64 bytes.
  */
 #ifndef GNRC_IPV6_STACK_SIZE
-#define GNRC_IPV6_STACK_SIZE        (THREAD_STACKSIZE_DEFAULT)
+#define GNRC_IPV6_STACK_SIZE        ((THREAD_STACKSIZE_DEFAULT) - 64)
 #endif
 
 /**

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -62,9 +62,13 @@ extern "C" {
 
 /**
  * @brief   Stack size used for the pktdump thread
+ *
+ * @note    The message queue was previously allocated on the stack.
+ *          The default number of messages is 2³.
+ *          Given sizeof(msg_t) == 8, the stack size is reduced by 64 bytes.
  */
 #ifndef GNRC_PKTDUMP_STACKSIZE
-#define GNRC_PKTDUMP_STACKSIZE          (THREAD_STACKSIZE_MAIN)
+#define GNRC_PKTDUMP_STACKSIZE          ((THREAD_STACKSIZE_MAIN) - 64)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -30,9 +30,13 @@ extern "C" {
 
 /**
  * @brief   Default stack size to use for the 6LoWPAN thread.
+ *
+ * @note    The message queue was previously allocated on the stack.
+ *          The default number of messages is 2³.
+ *          Given sizeof(msg_t) == 8, the stack size is reduced by 64 bytes.
  */
 #ifndef GNRC_SIXLOWPAN_STACK_SIZE
-#define GNRC_SIXLOWPAN_STACK_SIZE           (THREAD_STACKSIZE_DEFAULT)
+#define GNRC_SIXLOWPAN_STACK_SIZE           ((THREAD_STACKSIZE_DEFAULT) - 64)
 #endif
 
 /**

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -57,9 +57,13 @@ extern "C" {
 
 /**
  * @brief   Default stack size to use for the UDP thread
+ *
+ * @note    The message queue was previously allocated on the stack.
+ *          The default number of messages is 2³.
+ *          Given sizeof(msg_t) == 8, the stack size is reduced by 64 bytes.
  */
 #ifndef GNRC_UDP_STACK_SIZE
-#define GNRC_UDP_STACK_SIZE     (THREAD_STACKSIZE_SMALL)
+#define GNRC_UDP_STACK_SIZE     ((THREAD_STACKSIZE_SMALL) - 64)
 #endif
 /** @} */
 

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -50,6 +50,7 @@
 #define _MAX_L2_ADDR_LEN    (8U)
 
 static char _stack[GNRC_IPV6_STACK_SIZE + DEBUG_EXTRA_STACKSIZE];
+static msg_t _msg_q[GNRC_IPV6_MSG_QUEUE_SIZE];
 
 #ifdef MODULE_FIB
 /**
@@ -172,12 +173,12 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply, msg_q[GNRC_IPV6_MSG_QUEUE_SIZE];
+    msg_t msg, reply;
     gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             thread_getpid());
 
     (void)args;
-    msg_init_queue(msg_q, GNRC_IPV6_MSG_QUEUE_SIZE);
+    msg_init_queue(_msg_q, GNRC_IPV6_MSG_QUEUE_SIZE);
 
     /* initialize fragmentation data-structures */
 #ifdef MODULE_GNRC_IPV6_EXT_FRAG

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -36,6 +36,7 @@
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 
 static char _stack[GNRC_SIXLOWPAN_STACK_SIZE + DEBUG_EXTRA_STACKSIZE];
+static msg_t _msg_q[GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
 
 /* handles GNRC_NETAPI_MSG_TYPE_RCV commands */
 static void _receive(gnrc_pktsnip_t *pkt);
@@ -385,12 +386,12 @@ static void _continue_fragmenting(gnrc_sixlowpan_frag_fb_t *fbuf)
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply, msg_q[GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
+    msg_t msg, reply;
     gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             thread_getpid());
 
     (void)args;
-    msg_init_queue(msg_q, GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
+    msg_init_queue(_msg_q, GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
 
     /* register interest in all 6LoWPAN packets */
     gnrc_netreg_register(GNRC_NETTYPE_SIXLOWPAN, &me_reg);

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -44,6 +44,7 @@ kernel_pid_t gnrc_pktdump_pid = KERNEL_PID_UNDEF;
  * @brief   Stack for the pktdump thread
  */
 static char _stack[GNRC_PKTDUMP_STACKSIZE];
+static msg_t _msg_queue[GNRC_PKTDUMP_MSG_QUEUE_SIZE];
 
 static void _dump_snip(gnrc_pktsnip_t *pkt)
 {
@@ -166,10 +167,9 @@ static void *_eventloop(void *arg)
 {
     (void)arg;
     msg_t msg, reply;
-    msg_t msg_queue[GNRC_PKTDUMP_MSG_QUEUE_SIZE];
 
     /* setup the message queue */
-    msg_init_queue(msg_queue, GNRC_PKTDUMP_MSG_QUEUE_SIZE);
+    msg_init_queue(_msg_queue, GNRC_PKTDUMP_MSG_QUEUE_SIZE);
 
     reply.content.value = (uint32_t)(-ENOTSUP);
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -43,6 +43,7 @@ static kernel_pid_t _pid = KERNEL_PID_UNDEF;
  * @brief   Allocate memory for the UDP thread's stack
  */
 static char _stack[GNRC_UDP_STACK_SIZE + DEBUG_EXTRA_STACKSIZE];
+static msg_t _msg_queue[GNRC_UDP_MSG_QUEUE_SIZE];
 
 /**
  * @brief   Calculate the UDP checksum dependent on the network protocol
@@ -220,14 +221,13 @@ static void *_event_loop(void *arg)
 {
     (void)arg;
     msg_t msg, reply;
-    msg_t msg_queue[GNRC_UDP_MSG_QUEUE_SIZE];
     gnrc_netreg_entry_t netreg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             thread_getpid());
     /* preset reply message */
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
     reply.content.value = (uint32_t)-ENOTSUP;
     /* initialize message queue */
-    msg_init_queue(msg_queue, GNRC_UDP_MSG_QUEUE_SIZE);
+    msg_init_queue(_msg_queue, GNRC_UDP_MSG_QUEUE_SIZE);
     /* register UPD at netreg */
     gnrc_netreg_register(GNRC_NETTYPE_UDP, &netreg);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

I saw messages sent to the IPv6 thread being dropped.
I think it could happen that an address does not become valid for that reason.
So I increased `CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE_EXP` and a stack overflow happened.
This is not supposed to happen for a `CONFIG_` variable. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- internal application

```
2023-10-19 17:19:17,118 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,148 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,149 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,422 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,438 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,693 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,724 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:17,950 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:18,029 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:18,318 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:18,332 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:18,589 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:18,590 # queue_msg(): Cannot send message 0x2000a7b0 to message queue of thread 4 is full (or there is none)
2023-10-19 17:19:18,798 # queue_msg(): Cannot send message 0x20008888 to message queue of thread 4 is full (or there is none)
```

```
2023-10-19 17:32:33,253 # ps
2023-10-19 17:32:33,270 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2023-10-19 17:32:33,272 # 	  - | isr_stack            | -        - |   - |   2048 (  492) ( 1556) | 0x20000000 | 0x200007c8
2023-10-19 17:32:33,287 # 	  2 | pktdump              | bl rx    _ |   6 |   5120 (  240) ( 4880) | 0x2001b0ec | 0x2001c3fc 
2023-10-19 17:32:33,301 # 	  3 | 6lo                  | bl rx    _ |   3 |   1152 (  416) (  736) | 0x2001c74c | 0x2001ca44 
2023-10-19 17:32:33,303 # 	  4 | ipv6                 | bl rx    _ |   4 |   1152 (  844) (  308) | 0x2000854c | 0x2000883c 
2023-10-19 17:32:33,318 # 	  5 | udp                  | bl rx    _ |   5 |    576 (  312) (  264) | 0x2001cbcc | 0x2001cd0c 

```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
