### PR TITLE
examples/gnrc_border_router: enable setting ZEP topology

### DIFF
--- a/dist/tools/zep_dispatch/start_network.sh
+++ b/dist/tools/zep_dispatch/start_network.sh
@@ -62,7 +62,7 @@ start_radvd() {
 }
 
 start_zep_dispatch() {
-    ${ZEP_DISPATCH} :: "${ZEP_PORT_BASE}" > /dev/null &
+    ${ZEP_DISPATCH} ${ZEP_DISPATCH_FLAGS} :: "${ZEP_PORT_BASE}" > /dev/null &
     ZEP_DISPATCH_PID=$!
 }
 
@@ -93,6 +93,17 @@ if [ "$1" = "-z" ] || [ "$1" = "--use-zep-dispatch" ]; then
     shift 2
 else
     USE_ZEP_DISPATCH=0
+fi
+
+if [ "$1" = "-t" ] || [ "$1" = "--topology" ]; then
+    ZEP_DISPATCH_FLAGS+="-t $2 "
+    shift 2
+fi
+
+if [ "$1" = "-w" ] || [ "$1" = "--monitor" ]; then
+    modprobe mac802154_hwsim
+    ZEP_DISPATCH_FLAGS+="-w wpan0 "
+    shift 1
 fi
 
 ELFFILE=$1

--- a/examples/gnrc_border_router/Makefile.native.conf
+++ b/examples/gnrc_border_router/Makefile.native.conf
@@ -23,6 +23,14 @@ endif
 # enable the ZEP dispatcher
 FLAGS_EXTRAS += -z $(ZEP_PORT_BASE)
 
+ifneq (, $(ZEP_TOPO_FILE))
+  FLAGS_EXTRAS += --topology $(ZEP_TOPO_FILE)
+endif
+
+ifeq (1, $(ZEP_MONITOR))
+  FLAGS_EXTRAS += --monitor
+endif
+
 # Configure terminal parameters
 TERMDEPS += host-tools
 TERMPROG_FLAGS = $(FLAGS_EXTRAS) $(ELFFILE) $(IPV6_PREFIX)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When simulating a IEEE 802.15.4 network, it is handy being able to specify a topoloy.


### Testing procedure

    make -C examples/gnrc_border_router ZEP_TOPO_FILE=network.topo ZEP_MONITOR=1 term

will make use of the file `network.topo` and create a `wpan0` with which the traffic on the simulated wireless network can be monitored with Wireshark.

##### network.topo

```
A	B
B	C
C	D
```

To start the wireless nodes, run 3 instances of `examples/gnrc_networking` with `USE_ZEP=1`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
