### PR TITLE
cpu/native: fix bug in periph_timer

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -88,8 +88,6 @@ int (*real_pause)(void);
 int (*real_pipe)(int[2]);
 int (*real_select)(int nfds, ...);
 int (*real_poll)(struct pollfd *fds, ...);
-int (*real_setitimer)(int which, const struct itimerval
-        *restrict value, struct itimerval *restrict ovalue);
 int (*real_setsid)(void);
 int (*real_setsockopt)(int socket, ...);
 int (*real_socket)(int domain, int type, int protocol);
@@ -535,7 +533,6 @@ void _native_init_syscalls(void)
     *(void **)(&real_dup2) = dlsym(RTLD_NEXT, "dup2");
     *(void **)(&real_select) = dlsym(RTLD_NEXT, "select");
     *(void **)(&real_poll) = dlsym(RTLD_NEXT, "poll");
-    *(void **)(&real_setitimer) = dlsym(RTLD_NEXT, "setitimer");
     *(void **)(&real_setsid) = dlsym(RTLD_NEXT, "setsid");
     *(void **)(&real_setsockopt) = dlsym(RTLD_NEXT, "setsockopt");
     *(void **)(&real_socket) = dlsym(RTLD_NEXT, "socket");


### PR DESCRIPTION
### Contribution description

While debugging https://github.com/RIOT-OS/RIOT/pull/18977#issuecomment-1764258356 it became obvious that the `periph_timer` in `native` is broken and issues early IRQs. This replaces the use of `setitimer` that cannot use a monotonic clock source with `timer_settime()`.

### Testing procedure

I have some non-publishable code that tests if the time an ISR fires in terms of `timer_read()` is no earlier than the time expected. This occasionally triggered with `master`, but I didn't see any of these issues anymore with this PR. I guess I should revive my PR to spice up the periph timer tests and add a polished version of this and let this run for an hour or two.

The tests ins `tests/periph/timer*` should still succeed on `native`. (They do for me in a container running `riot/riotbuild`).

### Issues/PRs references

Found while debugging https://github.com/RIOT-OS/RIOT/pull/18977#issuecomment-1764258356