### PR TITLE
pkg: allow the omission of the --filter argument 

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -62,6 +62,10 @@ ifeq ($(QUIET),1)
   GIT_QUIET ?= --quiet
 endif
 
+ifeq (,$(NO_GIT_FILTERING))
+  GIT_FILTER ?= --filter=blob:none
+endif
+
 GITFLAGS ?= -c user.email=buildsystem@riot -c user.name="RIOT buildsystem"
 GITAMFLAGS ?= $(GIT_QUIET) --no-gpg-sign --ignore-whitespace --whitespace=nowarn
 
@@ -144,7 +148,7 @@ $(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
 	$(Q)$(GIT_IN_PKG) remote add origin $(PKG_URL)
 	$(Q)$(GIT_IN_PKG) config extensions.partialClone origin
 	$(Q)$(GIT_IN_PKG) config advice.detachedHead false
-	$(Q)$(GIT_IN_PKG) fetch $(GIT_QUIET) --depth=1 -t --filter=blob:none origin $(PKG_VERSION)
+	$(Q)$(GIT_IN_PKG) fetch $(GIT_QUIET) --depth=1 -t $(GIT_FILTER) origin $(PKG_VERSION)
 	$(Q)$(GIT_IN_PKG) checkout $(GIT_QUIET) $(PKG_VERSION) 2>&1 | cat
 endif
 


### PR DESCRIPTION
This will allow the explicit omission of the --filter argument  in the case of git servers that do not support filtering (reduces warnings on output)

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If you provide a definition for the variable `NO_GIT_FILTERING`, then the `--filter=blob:none` argument to the `git fetch` operation will be omitted.  This helps clean up occurrences of this message on build: `warning: filtering not recognized by server, ignoring` which makes the build output cleaner.


### Testing procedure

I built with and without a definition of `NO_GIT_FILTERING`.  The message `warning: filtering not recognized by server, ignoring` shows up in the log when it is NOT defined, and does not show up when it IS defined (in both cases I cleared out build/pkg to ensure it was doing a full fetch).


### Issues/PRs references

N/A
