### PR TITLE
core/xfa: ensure XFA is aligned to word boundary

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -26,6 +26,7 @@
 #define XFA_H
 
 #include <inttypes.h>
+#include "architecture.h"
 #include "compiler_hints.h"
 
 /*
@@ -45,7 +46,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  */
 #define _XFA(name, prio) \
     NO_SANITIZE_ARRAY \
-    __attribute__((used, section(".xfa." #name "." #prio)))
+    __attribute__((used, section(".xfa." #name "." #prio), aligned(ARCHITECTURE_WORD_BYTES)))
 
 /**
  * @brief helper macro for other XFA_* macros
@@ -54,7 +55,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  */
 #define _XFA_CONST(name, prio) \
     NO_SANITIZE_ARRAY \
-    __attribute__((used, section(".roxfa." #name "." #prio)))
+    __attribute__((used, section(".roxfa." #name "." #prio), aligned(ARCHITECTURE_WORD_BYTES)))
 
 /**
  * @brief Define a read-only cross-file array
@@ -138,6 +139,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
  *
+ * @warning The `driver_params_t` struct must be aligned with the word size
+ *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa
  */
@@ -151,6 +154,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * Add this to the type in a variable definition, e.g.:
  *
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
+ *
+ * @warning The `driver_params_t` struct must be aligned with the word size
  *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Add 3 XFA members:

```C
#include "net/gnrc/ipv6/firewall.h"
GNRC_IPV6_FIREWALL_ADD(my_rule) = {
    .flags = GNRC_IPV6_FW_FLAG_MATCH_SRC,
    .prio = 42,
};
GNRC_IPV6_FIREWALL_ADD(my_rule2) = {
    .flags = GNRC_IPV6_FW_FLAG_MATCH_DST,
    .prio = 23,
};
GNRC_IPV6_FIREWALL_ADD(my_rule3) = {
    .flags = GNRC_IPV6_FW_FLAG_MATCH_DST,
    .prio = 17,
};

extern gnrc_ipv6_firewall_rule_t gnrc_ipv6_firewall_rules_const;
extern gnrc_ipv6_firewall_rule_t gnrc_ipv6_firewall_rules_const_end;

int main(void)
{
    printf("struct size: %u\n", sizeof(gnrc_ipv6_firewall_rule_t));
    printf("gnrc_ipv6_firewall_rules_const: %p\n", (void *)&gnrc_ipv6_firewall_rules_const);
    printf("my_rule: %p\n", (void *)&my_rule);
    printf("my_rule2: %p\n", (void *)&my_rule2);
    printf("my_rule3: %p\n", (void *)&my_rule3);
    printf("gnrc_ipv6_firewall_rules_const_end: %p\n", (void *)&gnrc_ipv6_firewall_rules_const_end);

    return 0;
}
```

#### master

```
struct size: 34
gnrc_ipv6_firewall_rules_const: 0x8073e68
my_rule: 0x8073f00
my_rule2: 0x8073ec0
my_rule3: 0x8073e80
gnrc_ipv6_firewall_rules_const_end: 0x8073f22
```

#### with this patch & struct padding

```
struct size: 36
gnrc_ipv6_firewall_rules_const: 0x80735a0
my_rule: 0x80735e8
my_rule2: 0x80735c4
my_rule3: 0x80735a0
gnrc_ipv6_firewall_rules_const_end: 0x807360c
```


### Issues/PRs references

Discovered in #19991
