### PR TITLE
release-test.yml: Add strasbourg creds [backport 2023.10]

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -78,11 +78,19 @@ jobs:
         ssh -oStrictHostKeyChecking=accept-new \
           ${IOTLAB_USER}@saclay.iot-lab.info exit
     - name: Fetch host key from IoT-LAB lille site
+      # Not being used in the most recent release specs but kept in for
+      # backwords compatibility
       if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
       run: |
         IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
         ssh -oStrictHostKeyChecking=accept-new \
           ${IOTLAB_USER}@lille.iot-lab.info exit
+    - name: Fetch host key from IoT-LAB stasbourg site
+      if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
+      run: |
+        IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
+        ssh -oStrictHostKeyChecking=accept-new \
+          ${IOTLAB_USER}@stasbourg.iot-lab.info exit
     - name: Checkout Release-Specs
       uses: actions/checkout@main
       with:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -85,12 +85,12 @@ jobs:
         IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
         ssh -oStrictHostKeyChecking=accept-new \
           ${IOTLAB_USER}@lille.iot-lab.info exit
-    - name: Fetch host key from IoT-LAB stasbourg site
+    - name: Fetch host key from IoT-LAB strasbourg site
       if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
       run: |
         IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
         ssh -oStrictHostKeyChecking=accept-new \
-          ${IOTLAB_USER}@stasbourg.iot-lab.info exit
+          ${IOTLAB_USER}@strasbourg.iot-lab.info exit
     - name: Checkout Release-Specs
       uses: actions/checkout@main
       with:


### PR DESCRIPTION
# Backport of #20007 and #20008


### Contribution description

This adds creds for stasbourg needed for the `openmote-b` tests in the release specs.

### Testing procedure

Hmmm... I don't know how easy it is.  I will try to link results of the workflow from my personal fork maybe?

### Issues/PRs references

Needed for https://github.com/RIOT-OS/Release-Specs/pull/289
