### PR TITLE
gcoap_dns: Housekeeping with regards to draft status

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -444,6 +444,11 @@ extern "C" {
  */
 #define COAP_FORMAT_TM_JSON                 (433)
 /**
+ * @brief   Content-Type `application/dns-message`
+ * @see     [draft-ietf-core-dns-over-coap](https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/)
+ */
+#define COAP_FORMAT_DNS_MESSAGE             (553)
+/**
  * @brief   Content-Type `application/voucher-cose+cbor`
  * @see     [draft-ietf-anima-constrained-voucher](https://datatracker.ietf.org/doc/draft-ietf-anima-constrained-voucher/)
  * @note    Temporary registration until April 12, 2024.
@@ -500,7 +505,6 @@ extern "C" {
  * @see     [RFC 2318](https://www.w3.org/TR/SVG/mimereg.html)
  */
 #define COAP_FORMAT_IMAGE_SVG_XML         (30000)
-#define COAP_FORMAT_DNS_MESSAGE           (65053)       /**< NON STANDARD! */
 /** @} */
 
 /**

--- a/sys/include/net/gcoap/dns.h
+++ b/sys/include/net/gcoap/dns.h
@@ -13,7 +13,7 @@
  * @brief   A DNS over CoAP client prototype based on gCoAP.
  *
  * DNS over CoAP allows a node to use a CoAP server to resolve DNS request, following
- * [draft-lenders-dns-over-coap](https://datatracker.ietf.org/doc/draft-lenders-dns-over-coap/).
+ * [draft-ietf-core-dns-over-coap](https://datatracker.ietf.org/doc/draft-ietf-core-dns-over-coap/).
  *
  * The `gcoap_dns` module does not replace the @ref sock_dns_query function when built, and is not
  * used as a back-end to @ref netutils_get_ipv6 automatically. It does, however, provide a drop-in


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Some housekeeping on `gcoap_dns`:
- Update URL to draft, it is a Working Group draft since last year (September 2022)
- Update `application/dns-message` Content-Format: In `draft-ietf-core-dns-over-coap-03` it was set to 553
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Only reading and successful compilation is required.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
:x: 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
