### PR TITLE
drivers/at: fix at_send_cmd_wait_prompt()

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -67,6 +67,11 @@
 #define AT_EVENT_PRIO EVENT_PRIO_HIGHEST
 #endif
 
+
+#if defined(MODULE_AT_URC)
+static int _check_urc(clist_node_t *node, void *arg);
+#endif
+
 #if defined(MODULE_AT_URC_ISR)
 static void _event_process_urc(event_t *_event)
 {

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -371,13 +371,12 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command,
             return -2;
         }
     }
-    // Some devices (e.g. U-Blox LARA L6) issue '>' with no leading EOL
-    int res;
-    for (unsigned i = 0; i < sizeof(AT_RECV_EOL_1 AT_RECV_EOL_2) - 1 + 1; i++) {
+    // some modems (e.g. U-Blox LARA L6) reply '>' with no leading EOL
+    for (unsigned i = 0; i < sizeof(AT_RECV_EOL_1 AT_RECV_EOL_2 ">") - 1; i++) {
         char c;
-        res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout);
-        if (res != 1) {
-            return res;
+        if (isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout) !=
+            1) {
+            return -ETIMEDOUT;
         }
         if (c == '>') {
             return 0;

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -306,8 +306,7 @@ ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command,
 
     /* wait for OK */
     if (res >= 0) {
-        res_ok = at_readline_skip_empty(dev, ok_buf, sizeof(ok_buf), false,
-                                        timeout);
+        res_ok = at_readline_skip_empty(dev, ok_buf, sizeof(ok_buf), false, timeout);
         if (res_ok < 0) {
             return -1;
         }
@@ -315,7 +314,7 @@ ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command,
         if ((len_ok != 0) && (strcmp(ok_buf, CONFIG_AT_RECV_OK) == 0)) {
         }
         else {
-            /* Something else then OK */
+            /* Something else than OK */
             res = -1;
         }
     }
@@ -441,12 +440,11 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
         else if (strncmp(resp_buf, "+CMS ERROR:", len_cme_cms) == 0) {
             return -2;
         }
-        // probably a sneaky URC
+        /* probably a sneaky URC */
 #ifdef MODULE_AT_URC
         clist_foreach(&dev->urc_list, _check_urc, resp_buf);
 #endif
-        res = at_readline_skip_empty(dev, resp_buf, sizeof(resp_buf), false,
-                                     timeout);
+        res = at_readline_skip_empty(dev, resp_buf, sizeof(resp_buf), false, timeout);
     }
 
     return res;

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -82,7 +82,7 @@ static void _event_process_urc(event_t *_event)
 
 static void _isrpipe_write_one_wrapper(void *_dev, uint8_t data)
 {
-    at_dev_t *dev = (at_dev_t *)_dev;
+    at_dev_t *dev = (at_dev_t *) _dev;
     isrpipe_write_one(&dev->isrpipe, data);
 #if defined(MODULE_AT_URC_ISR)
     if (data == AT_RECV_EOL_2[0] && !dev->awaiting_response) {
@@ -91,8 +91,7 @@ static void _isrpipe_write_one_wrapper(void *_dev, uint8_t data)
 #endif
 }
 
-int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf,
-                size_t bufsize)
+int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize)
 {
     dev->uart = uart;
 
@@ -116,8 +115,7 @@ int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout)
 
     while (*bytes) {
         char c;
-        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1,
-                                        timeout)) == 1) {
+        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout)) == 1) {
             if (AT_PRINT_INCOMING) {
                 print(&c, 1);
             }
@@ -181,8 +179,8 @@ ssize_t at_recv_bytes(at_dev_t *dev, char *bytes, size_t len, uint32_t timeout)
     return (resp_pos - bytes);
 }
 
-int at_recv_bytes_until_string(at_dev_t *dev, const char *string, char *bytes,
-                               size_t *bytes_len, uint32_t timeout)
+int at_recv_bytes_until_string(at_dev_t *dev, const char *string,
+                               char *bytes, size_t *bytes_len, uint32_t timeout)
 {
     size_t len = 0;
     char *_string = (char *)string;
@@ -194,8 +192,7 @@ int at_recv_bytes_until_string(at_dev_t *dev, const char *string, char *bytes,
 
     while (*_string && len < *bytes_len) {
         char c;
-        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1,
-                                        timeout)) == 1) {
+        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout)) == 1) {
             if (AT_PRINT_INCOMING) {
                 print(&c, 1);
             }
@@ -258,8 +255,8 @@ void at_drain(at_dev_t *dev)
 #endif
 }
 
-ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command, char *resp_buf,
-                             size_t len, uint32_t timeout)
+ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command,
+                             char *resp_buf, size_t len, uint32_t timeout)
 {
     ssize_t res;
 
@@ -276,9 +273,8 @@ out:
     return res;
 }
 
-ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command,
-                                     const char *resp_prefix, char *resp_buf,
-                                     size_t len, uint32_t timeout)
+ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command, const char *resp_prefix,
+                                     char *resp_buf, size_t len, uint32_t timeout)
 {
     ssize_t res;
     ssize_t res_ok;
@@ -328,8 +324,7 @@ out:
 }
 
 ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
-                              char *resp_buf, size_t len, bool keep_eol,
-                              uint32_t timeout)
+                              char *resp_buf, size_t len, bool keep_eol, uint32_t timeout)
 {
     const char eol[] = AT_RECV_EOL_1 AT_RECV_EOL_2;
     assert(sizeof(eol) > 1);
@@ -362,12 +357,13 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
             bytes_left -= res;
             size_t len_ok = sizeof(CONFIG_AT_RECV_OK) - 1;
             size_t len_error = sizeof(CONFIG_AT_RECV_ERROR) - 1;
-            if (((size_t)res == (len_ok + keep_eol)) && (len_ok != 0) &&
+            if (((size_t )res == (len_ok + keep_eol)) &&
+                (len_ok != 0) &&
                 (strncmp(pos, CONFIG_AT_RECV_OK, len_ok) == 0)) {
                 res = len - bytes_left;
                 break;
             }
-            else if (((size_t)res == (len_error + keep_eol)) &&
+            else if (((size_t )res == (len_error + keep_eol)) &&
                      (len_error != 0) &&
                      (strncmp(pos, CONFIG_AT_RECV_ERROR, len_error) == 0)) {
                 return -1;
@@ -398,8 +394,7 @@ out:
     return res;
 }
 
-int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command,
-                            uint32_t timeout)
+int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout)
 {
     unsigned cmdlen = strlen(command);
 
@@ -455,8 +450,7 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
     return res;
 }
 
-ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol,
-                    uint32_t timeout)
+ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol, uint32_t timeout)
 {
     const char eol[] = AT_RECV_EOL_1 AT_RECV_EOL_2;
     assert(sizeof(eol) > 1);

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -363,23 +363,28 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command,
     uart_write(dev->uart, (const uint8_t *)command, cmdlen);
     uart_write(dev->uart, (const uint8_t *)CONFIG_AT_SEND_EOL, AT_SEND_EOL_LEN);
 
-    if (at_expect_bytes(dev, command, timeout)) {
-        return -1;
+    if (!IS_ACTIVE(CONFIG_AT_SEND_SKIP_ECHO)) {
+        if (at_expect_bytes(dev, command, timeout)) {
+            return -1;
+        }
+        if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL, timeout)) {
+            return -2;
+        }
+    }
+    // Some devices (e.g. U-Blox LARA L6) issue '>' with no leading EOL
+    int res;
+    for (unsigned i = 0; i < sizeof(AT_RECV_EOL_1 AT_RECV_EOL_2) - 1 + 1; i++) {
+        char c;
+        res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout);
+        if (res != 1) {
+            return res;
+        }
+        if (c == '>') {
+            return 0;
+        }
     }
 
-    // if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_2, timeout)) {
-    //     return -2;
-    // }
-    // LARA L6 just gives the prompt, no new line before
-    if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL, timeout)) {
-        return -2;
-    }
-
-    if (at_expect_bytes(dev, ">", timeout)) {
-        return -3;
-    }
-
-    return 0;
+    return -3;
 }
 
 int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -42,7 +42,7 @@ static void _event_process_urc(event_t *_event)
 
 static void _isrpipe_write_one_wrapper(void *_dev, uint8_t data)
 {
-    at_dev_t *dev = (at_dev_t *) _dev;
+    at_dev_t *dev = (at_dev_t *)_dev;
     isrpipe_write_one(&dev->isrpipe, data);
 #if defined(MODULE_AT_URC_ISR)
     if (data == AT_RECV_EOL_2[0] && !dev->awaiting_response) {
@@ -51,7 +51,8 @@ static void _isrpipe_write_one_wrapper(void *_dev, uint8_t data)
 #endif
 }
 
-int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize)
+int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf,
+                size_t bufsize)
 {
     dev->uart = uart;
 
@@ -62,8 +63,7 @@ int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t
 
     isrpipe_init(&dev->isrpipe, (uint8_t *)buf, bufsize);
 
-    return uart_init(uart, baudrate, _isrpipe_write_one_wrapper,
-                     dev);
+    return uart_init(uart, baudrate, _isrpipe_write_one_wrapper, dev);
 }
 
 int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout)
@@ -76,7 +76,8 @@ int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout)
 
     while (*bytes) {
         char c;
-        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout)) == 1) {
+        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1,
+                                        timeout)) == 1) {
             if (AT_PRINT_INCOMING) {
                 print(&c, 1);
             }
@@ -131,8 +132,8 @@ ssize_t at_recv_bytes(at_dev_t *dev, char *bytes, size_t len, uint32_t timeout)
     return (resp_pos - bytes);
 }
 
-int at_recv_bytes_until_string(at_dev_t *dev, const char *string,
-                               char *bytes, size_t *bytes_len, uint32_t timeout)
+int at_recv_bytes_until_string(at_dev_t *dev, const char *string, char *bytes,
+                               size_t *bytes_len, uint32_t timeout)
 {
     size_t len = 0;
     char *_string = (char *)string;
@@ -144,7 +145,8 @@ int at_recv_bytes_until_string(at_dev_t *dev, const char *string,
 
     while (*_string && len < *bytes_len) {
         char c;
-        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout)) == 1) {
+        if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1,
+                                        timeout)) == 1) {
             if (AT_PRINT_INCOMING) {
                 print(&c, 1);
             }
@@ -179,7 +181,8 @@ int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout)
             return -1;
         }
 
-        if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_1 AT_RECV_EOL_2, timeout)) {
+        if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_1 AT_RECV_EOL_2,
+                            timeout)) {
             return -2;
         }
     }
@@ -206,8 +209,8 @@ void at_drain(at_dev_t *dev)
 #endif
 }
 
-ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command,
-                             char *resp_buf, size_t len, uint32_t timeout)
+ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command, char *resp_buf,
+                             size_t len, uint32_t timeout)
 {
     ssize_t res;
 
@@ -228,8 +231,9 @@ out:
     return res;
 }
 
-ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command, const char *resp_prefix,
-                                     char *resp_buf, size_t len, uint32_t timeout)
+ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command,
+                                     const char *resp_prefix, char *resp_buf,
+                                     size_t len, uint32_t timeout)
 {
     ssize_t res;
     ssize_t res_ok;
@@ -279,7 +283,8 @@ out:
 }
 
 ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
-                              char *resp_buf, size_t len, bool keep_eol, uint32_t timeout)
+                              char *resp_buf, size_t len, bool keep_eol,
+                              uint32_t timeout)
 {
     const char eol[] = AT_RECV_EOL_1 AT_RECV_EOL_2;
     assert(sizeof(eol) > 1);
@@ -312,13 +317,12 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
             bytes_left -= res;
             size_t len_ok = sizeof(CONFIG_AT_RECV_OK) - 1;
             size_t len_error = sizeof(CONFIG_AT_RECV_ERROR) - 1;
-            if (((size_t )res == (len_ok + keep_eol)) &&
-                (len_ok != 0) &&
+            if (((size_t)res == (len_ok + keep_eol)) && (len_ok != 0) &&
                 (strncmp(pos, CONFIG_AT_RECV_OK, len_ok) == 0)) {
                 res = len - bytes_left;
                 break;
             }
-            else if (((size_t )res == (len_error + keep_eol)) &&
+            else if (((size_t)res == (len_error + keep_eol)) &&
                      (len_error != 0) &&
                      (strncmp(pos, CONFIG_AT_RECV_ERROR, len_error) == 0)) {
                 return -1;
@@ -349,7 +353,8 @@ out:
     return res;
 }
 
-int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout)
+int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command,
+                            uint32_t timeout)
 {
     unsigned cmdlen = strlen(command);
 
@@ -362,7 +367,11 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout
         return -1;
     }
 
-    if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_2, timeout)) {
+    // if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_2, timeout)) {
+    //     return -2;
+    // }
+    // LARA L6 just gives the prompt, no new line before
+    if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL, timeout)) {
         return -2;
     }
 
@@ -378,7 +387,8 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
     int res;
     char resp_buf[64];
 
-    res = at_send_cmd_get_resp(dev, command, resp_buf, sizeof(resp_buf), timeout);
+    res = at_send_cmd_get_resp(dev, command, resp_buf, sizeof(resp_buf),
+                               timeout);
 
     if (res > 0) {
         ssize_t len_ok = sizeof(CONFIG_AT_RECV_OK) - 1;
@@ -393,7 +403,8 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
     return res;
 }
 
-ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol, uint32_t timeout)
+ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol,
+                    uint32_t timeout)
 {
     const char eol[] = AT_RECV_EOL_1 AT_RECV_EOL_2;
     assert(sizeof(eol) > 1);

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -306,6 +306,18 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command, char *resp_buf
 int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
 
 /**
+ * @brief   Repeatedly calls at_expect_bytes() until a match or timeout occurs
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   bytes   buffer containing bytes to expect (NULL-terminated)
+ * @param[in]   timeout timeout (in usec)
+ *
+ * @returns     0 on success
+ * @returns     <0 otherwise
+ */
+int at_wait_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
+
+/**
  * @brief   Receives bytes into @p bytes buffer until the string pattern
  * @p string is received or the buffer is full.
  *
@@ -370,6 +382,21 @@ int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout);
  * @returns     <0 on error
  */
 ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol, uint32_t timeout);
+
+/**
+ * @brief   Read a line from device, skipping a possibly empty line.
+ *
+ * @param[in]   dev         device to operate on
+ * @param[in]   resp_buf    buffer to store line
+ * @param[in]   len         size of @p resp_buf
+ * @param[in]   keep_eol    true to keep the CR character in the response
+ * @param[in]   timeout     timeout (in usec)
+ *
+ * @returns     line length on success
+ * @returns     <0 on error
+ */
+ssize_t at_readline_skip_empty(at_dev_t *dev, char *resp_buf, size_t len,
+                               bool keep_eol, uint32_t timeout);
 
 /**
  * @brief   Drain device input buffer

--- a/tests/drivers/at/main.c
+++ b/tests/drivers/at/main.c
@@ -280,6 +280,67 @@ static int remove_urc(int argc, char **argv)
 }
 #endif
 
+static int sneaky_urc(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    int res = 0;
+    char resp_buf[128];
+
+#ifdef MODULE_AT_URC
+    at_urc_t urc = {.cb = _urc_cb, .code = "+CSCON"};
+    at_add_urc(&at_dev, &urc);
+#endif
+
+    res = at_send_cmd_wait_ok(&at_dev, "AT+CFUN=1", US_PER_SEC);
+
+    if (res) {
+        puts("Error AT+CFUN=1");
+        res = 1;    
+        goto exit;
+    }
+
+    res = at_send_cmd_get_resp_wait_ok(&at_dev, "AT+CEREG?",
+                                    "+CEREG:", resp_buf,
+                                    sizeof(resp_buf), US_PER_SEC);
+    if (res < 0) {
+        puts("Error AT+CEREG?");
+        res = 1;
+        goto exit;
+    }
+
+    res = at_send_cmd_wait_prompt(&at_dev, "AT+USECMNG=0,0,\"cert\",128", US_PER_SEC);
+    if (res) {
+        puts("Error AT+USECMNG");
+        res =  1;
+        goto exit;
+    }
+
+    res = at_send_cmd_wait_ok(&at_dev, "AT+CFUN=8", US_PER_SEC);
+
+    if (res != -1) {
+        puts("Error AT+CFUN=8");
+        res =  1;
+        goto exit;
+    }
+
+    res = at_send_cmd_wait_ok(&at_dev, "AT+CFUN=9", US_PER_SEC);
+
+    if (res != -2) {
+        puts("Error AT+CFUN=9");
+        res =  1;
+        goto exit;
+    }
+
+    res = 0;
+exit:
+#ifdef MODULE_AT_URC
+    at_remove_urc(&at_dev, &urc);
+#endif
+    return res;
+}
+
 static const shell_command_t shell_commands[] = {
     { "init", "Initialize AT device", init },
     { "send", "Send a command and wait response", send },
@@ -291,6 +352,7 @@ static const shell_command_t shell_commands[] = {
     { "drain", "Drain AT device", drain },
     { "power_on", "Power on AT device", power_on },
     { "power_off", "Power off AT device", power_off },
+    { "sneaky_urc", "Test sneaky URC interference", sneaky_urc},
 #ifdef MODULE_AT_URC
     { "add_urc", "Register an URC", add_urc },
     { "remove_urc", "De-register an URC", remove_urc },

--- a/tests/drivers/at/sneaky_urc.py
+++ b/tests/drivers/at/sneaky_urc.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# 1. Adapt the `eol_in`, `eol_out`, `echo` variables below to match your use case
+# 2. Bind this script to the serial line the device is connected at:
+#   $ ./sneaky_urc /dev/ttyUSB0
+# 4. run the test (e.g. make term)
+# 5. inside the test console:
+#   a) run the `init` command (e.g. init 0 115200)
+#   b) run `sneaky_urc` command
+# 
+# This script sends a "sneaky URC", an URC that happens exactly after the
+# command is received, but before the first line of answer is sent. This is possible
+# behaviour at least on the U-Blox LTE modules.
+#
+# If the command echoing is enabled, you will miss the URCs, but the commands
+# should work (e.g. the URC should not interfere with response parsing).
+#
+# If command echoing is enabled AND `MODULE_AT_URC` is defined, you should see 
+# the URCs being parsed.
+
+import sys
+import pexpect
+
+ser = sys.argv[1]
+tty = pexpect.spawn(f'picocom --baud 115200 {ser}')
+
+# EOL sent by the device
+eol_in = '\r'
+# EOL to send back to the device
+eol_out = '\r\n'
+# Command echoing enabled
+echo = False
+
+cfun_c = "AT+CFUN=1" + eol_in
+cfun_err_c = "AT+CFUN=8" + eol_in
+cfun_cme_c = "AT+CFUN=9" + eol_in
+cereg_c = "AT+CEREG?" + eol_in
+usecmng_c = "AT+USECMNG=0,0,\"cert\",128" + eol_in
+
+while True:
+    try:
+        idx = tty.expect_exact([cfun_c, cfun_err_c, cfun_cme_c, cereg_c, usecmng_c])
+        if idx == 0:
+            print(cfun_c)
+            tty.send(eol_out + "+CSCON: 1" + eol_out)
+            if echo:
+                tty.send(cfun_c)
+            tty.send(eol_out + "OK" + eol_out)
+        if idx == 1:
+            print(cfun_err_c)
+            tty.send(eol_out + "+CSCON: 1" + eol_out)
+            if echo:
+                tty.send(cfun_err_c)
+            tty.send(eol_out + "ERROR" + eol_out)
+        if idx == 2:
+            print(cfun_cme_c)
+            tty.send(eol_out + "+CSCON: 1" + eol_out)
+            if echo:
+                tty.send(cfun_cme_c)
+            tty.send(eol_out + "+CME ERROR:" + eol_out)
+        elif idx == 3:
+            print(cereg_c)
+            tty.send(eol_out + "+CSCON: 1" + eol_out)
+            if echo:
+                tty.send(cereg_c)
+            tty.send(eol_out + "+CEREG: 0,1" + eol_out)
+            tty.send(eol_out + "OK" + eol_out)
+        elif idx == 4:
+            print(usecmng_c)
+            tty.send(eol_out + "+CSCON: 1" + eol_out)
+            if echo:
+                tty.send(usecmng_c)
+            tty.send(">")
+    except pexpect.EOF:
+        print("ERROR: EOF")
+    except pexpect.TIMEOUT:
+        print("ERROR: TIMEOUT")


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
in `drivers/at/at.c:at_send_cmd_wait_prompt()`:
 1. do not expect echoed bytes when `CONFIG_AT_SEND_SKIP_ECHO == 1`
 2. do not expect `EOL` before `>`. Some modems (e.g. U-Blox LARA L6) do not issue any `EOL` character before `>`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tested with U-Blox LARA-L6004D, with command echoing turned both on and off (respectively `CONFIG_AT_SEND_SKIP_ECHO` undefined and defined).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
