### PR TITLE
core: fix xfa for unaligned structs

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -141,12 +141,12 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
  *
- *
- * @warning The `driver_params_t` struct must be aligned with the word size.
+ * @warning `driver_params_t` struct must be aligned at multiples of the word
+ *          size.
  *
  * @note    The `WORD_ALIGNED` macro from `#include "architecture.h" provides
  *          the appropriate attribute to ensure word-alignment. Just add this to
- *          the `typedef` statement.
+ *          the `typedef` statement if necessary.
  *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa
@@ -162,7 +162,12 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
  *
- * @warning The `driver_params_t` struct must be aligned with the word size
+ * @warning `driver_params_t` struct must be aligned at multiples of the word
+ *          size.
+ *
+ * @note    The `WORD_ALIGNED` macro from `#include "architecture.h" provides
+ *          the appropriate attribute to ensure word-alignment. Just add this to
+ *          the `typedef` statement if necessary.
  *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa

--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -142,7 +142,11 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
  *
  *
- * @warning The `driver_params_t` struct must be aligned with the word size
+ * @warning The `driver_params_t` struct must be aligned with the word size.
+ *
+ * @note    The `WORD_ALIGNED` macro from `#include "architecture.h" provides
+ *          the appropriate attribute to ensure word-alignment. Just add this to
+ *          the `typedef` statement.
  *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa

--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -26,6 +26,7 @@
 #define XFA_H
 
 #include <inttypes.h>
+#include "architecture.h"
 #include "compiler_hints.h"
 
 /*
@@ -76,6 +77,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
     _XFA_CONST(name, 0_) type name [0] = {}; \
     _XFA_CONST(name, 9_) type name ## _end [0] = {}; \
     _Pragma("GCC diagnostic pop") \
+    _Static_assert(__alignof__(type) >= ARCHITECTURE_WORD_BYTES, #type " is not aligned properly"); \
     extern const unsigned __xfa_dummy
 
 /**
@@ -97,6 +99,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
     _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
     _XFA(name, 0_) type name [0] = {}; \
     _XFA(name, 9_) type name ## _end [0] = {}; \
+    _Static_assert(__alignof__(type) >= ARCHITECTURE_WORD_BYTES, #type " is not aligned properly"); \
     _Pragma("GCC diagnostic pop") \
     extern const unsigned __xfa_dummy
 
@@ -138,6 +141,9 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
  *
+ *
+ * @warning The `driver_params_t` struct must be aligned with the word size
+ *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa
  */
@@ -151,6 +157,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * Add this to the type in a variable definition, e.g.:
  *
  *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
+ *
+ * @warning The `driver_params_t` struct must be aligned with the word size
  *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa

--- a/cpu/native/ldscripts/xfa.ld
+++ b/cpu/native/ldscripts/xfa.ld
@@ -1,6 +1,6 @@
 SECTIONS
 {
-    .data :
+    .data : SUBALIGN(0)
     {
         KEEP (*(SORT(.xfa.*)))
     }
@@ -10,7 +10,7 @@ INSERT AFTER .text;
 
 SECTIONS
 {
-    .rodata :
+    .rodata : SUBALIGN(0)
     {
         KEEP (*(SORT(.roxfa.*)))
     }

--- a/tests/unittests/tests-core/tests-core-xfa-data3.c
+++ b/tests/unittests/tests-core/tests-core-xfa-data3.c
@@ -38,4 +38,22 @@ XFA_CONST(xfatest_noalign_const_sameprio, 0) xfatest_noalign_t _xfatest_noalign_
 XFA_CONST(xfatest_noalign_const_sameprio, 0) xfatest_noalign_t _xfatest_noalign_const_sameprio_3 =
     { .text = "noalign const sameprio 3" };
 
+XFA_CONST(xfatest_noalign_33_const, 2) xfatest_noalign_33_t _xfatest_noalign_33_const_1 =
+    { .text = "noalign 33 const 1" };
+
+XFA_CONST(xfatest_noalign_33_const, 1) xfatest_noalign_33_t _xfatest_noalign_33_const_2 =
+    { .text = "noalign 33 const 2" };
+
+XFA_CONST(xfatest_noalign_33_const, 0) xfatest_noalign_33_t _xfatest_noalign_33_const_3 =
+    { .text = "noalign 33 const 3" };
+
+XFA_CONST(xfatest_noalign_33_const_sameprio, 0) xfatest_noalign_33_t _xfatest_noalign_33_const_sameprio_1 =
+    { .text = "noalign 33 const sameprio 1" };
+
+XFA_CONST(xfatest_noalign_33_const_sameprio, 0) xfatest_noalign_33_t _xfatest_noalign_33_const_sameprio_2 =
+    { .text = "noalign 33 const sameprio 2" };
+
+XFA_CONST(xfatest_noalign_33_const_sameprio, 0) xfatest_noalign_33_t _xfatest_noalign_33_const_sameprio_3 =
+    { .text = "noalign 33 const sameprio 3" };
+
 /** @} */

--- a/tests/unittests/tests-core/tests-core-xfa-data3.c
+++ b/tests/unittests/tests-core/tests-core-xfa-data3.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Freie Universität Berlin
+ *               2023 Inria
+ *               2023 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Data elements for the core/xfa unit test
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#include "xfa.h"
+#include "tests-core-xfa.h"
+
+XFA_CONST(xfatest_noalign_const, 2) xfatest_noalign_t _xfatest_noalign_const_1 =
+    { .text = "noalign const 1" };
+
+XFA_CONST(xfatest_noalign_const, 1) xfatest_noalign_t _xfatest_noalign_const_2 =
+    { .text = "noalign const 2" };
+
+XFA_CONST(xfatest_noalign_const, 0) xfatest_noalign_t _xfatest_noalign_const_3 =
+    { .text = "noalign const 3" };
+
+XFA_CONST(xfatest_noalign_const_sameprio, 0) xfatest_noalign_t _xfatest_noalign_const_sameprio_1 =
+    { .text = "noalign const sameprio 1" };
+
+XFA_CONST(xfatest_noalign_const_sameprio, 0) xfatest_noalign_t _xfatest_noalign_const_sameprio_2 =
+    { .text = "noalign const sameprio 2" };
+
+XFA_CONST(xfatest_noalign_const_sameprio, 0) xfatest_noalign_t _xfatest_noalign_const_sameprio_3 =
+    { .text = "noalign const sameprio 3" };
+
+/** @} */

--- a/tests/unittests/tests-core/tests-core-xfa.c
+++ b/tests/unittests/tests-core/tests-core-xfa.c
@@ -23,6 +23,9 @@ XFA_USE_CONST(xfatest_t, xfatest_use_const);
 XFA_INIT_CONST(xfatest_noalign_t, xfatest_noalign_const);
 XFA_INIT_CONST(xfatest_noalign_t, xfatest_noalign_const_sameprio);
 
+XFA_INIT_CONST(xfatest_noalign_33_t, xfatest_noalign_33_const);
+XFA_INIT_CONST(xfatest_noalign_33_t, xfatest_noalign_33_const_sameprio);
+
 /* Verifying that cross file array linking is correct by iterating over an external array */
 static void test_xfa_data(void)
 {
@@ -149,6 +152,24 @@ static void test_xfa_noalign_const_sameprio(void)
     TEST_ASSERT_EQUAL_STRING("noalign const sameprio 1", xfatest_noalign_const_sameprio[2].text);
 }
 
+static void test_xfa_noalign_33_const(void)
+{
+    unsigned n = XFA_LEN(xfatest_noalign_33_t, xfatest_noalign_33_const);
+    TEST_ASSERT_EQUAL_INT(3, n);
+    TEST_ASSERT_EQUAL_STRING("noalign 33 const 3", xfatest_noalign_33_const[0].text);
+    TEST_ASSERT_EQUAL_STRING("noalign 33 const 2", xfatest_noalign_33_const[1].text);
+    TEST_ASSERT_EQUAL_STRING("noalign 33 const 1", xfatest_noalign_33_const[2].text);
+}
+
+static void test_xfa_noalign_33_const_sameprio(void)
+{
+    unsigned n = XFA_LEN(xfatest_noalign_33_t, xfatest_noalign_33_const_sameprio);
+    TEST_ASSERT_EQUAL_INT(3, n);
+    TEST_ASSERT_EQUAL_STRING("noalign 33 const sameprio 3", xfatest_noalign_33_const_sameprio[0].text);
+    TEST_ASSERT_EQUAL_STRING("noalign 33 const sameprio 2", xfatest_noalign_33_const_sameprio[1].text);
+    TEST_ASSERT_EQUAL_STRING("noalign 33 const sameprio 1", xfatest_noalign_33_const_sameprio[2].text);
+}
+
 Test *tests_core_xfa_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -158,6 +179,8 @@ Test *tests_core_xfa_tests(void)
         new_TestFixture(test_xfa_use_const_data),
         new_TestFixture(test_xfa_noalign_const),
         new_TestFixture(test_xfa_noalign_const_sameprio),
+        new_TestFixture(test_xfa_noalign_33_const),
+        new_TestFixture(test_xfa_noalign_33_const_sameprio),
     };
 
     EMB_UNIT_TESTCALLER(core_xfa_tests, NULL, NULL,

--- a/tests/unittests/tests-core/tests-core-xfa.c
+++ b/tests/unittests/tests-core/tests-core-xfa.c
@@ -20,6 +20,9 @@ XFA_INIT_CONST(xfatest_t, xfatest_const);
 XFA_USE(xfatest_t, xfatest_use);
 XFA_USE_CONST(xfatest_t, xfatest_use_const);
 
+XFA_INIT_CONST(xfatest_noalign_t, xfatest_noalign_const);
+XFA_INIT_CONST(xfatest_noalign_t, xfatest_noalign_const_sameprio);
+
 /* Verifying that cross file array linking is correct by iterating over an external array */
 static void test_xfa_data(void)
 {
@@ -128,6 +131,24 @@ static void test_xfa_use_const_data(void)
     TEST_ASSERT_EQUAL_INT(n, found);
 }
 
+static void test_xfa_noalign_const(void)
+{
+    unsigned n = XFA_LEN(xfatest_noalign_t, xfatest_noalign_const);
+    TEST_ASSERT_EQUAL_INT(3, n);
+    TEST_ASSERT_EQUAL_STRING("noalign const 3", xfatest_noalign_const[0].text);
+    TEST_ASSERT_EQUAL_STRING("noalign const 2", xfatest_noalign_const[1].text);
+    TEST_ASSERT_EQUAL_STRING("noalign const 1", xfatest_noalign_const[2].text);
+}
+
+static void test_xfa_noalign_const_sameprio(void)
+{
+    unsigned n = XFA_LEN(xfatest_noalign_t, xfatest_noalign_const_sameprio);
+    TEST_ASSERT_EQUAL_INT(3, n);
+    TEST_ASSERT_EQUAL_STRING("noalign const sameprio 3", xfatest_noalign_const_sameprio[0].text);
+    TEST_ASSERT_EQUAL_STRING("noalign const sameprio 2", xfatest_noalign_const_sameprio[1].text);
+    TEST_ASSERT_EQUAL_STRING("noalign const sameprio 1", xfatest_noalign_const_sameprio[2].text);
+}
+
 Test *tests_core_xfa_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -135,6 +156,8 @@ Test *tests_core_xfa_tests(void)
         new_TestFixture(test_xfa_const_data),
         new_TestFixture(test_xfa_use_data),
         new_TestFixture(test_xfa_use_const_data),
+        new_TestFixture(test_xfa_noalign_const),
+        new_TestFixture(test_xfa_noalign_const_sameprio),
     };
 
     EMB_UNIT_TESTCALLER(core_xfa_tests, NULL, NULL,

--- a/tests/unittests/tests-core/tests-core-xfa.h
+++ b/tests/unittests/tests-core/tests-core-xfa.h
@@ -33,6 +33,10 @@ typedef struct WORD_ALIGNED {
     const char text[31];
 } xfatest_noalign_t;
 
+typedef struct WORD_ALIGNED {
+    const char text[33];
+} xfatest_noalign_33_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unittests/tests-core/tests-core-xfa.h
+++ b/tests/unittests/tests-core/tests-core-xfa.h
@@ -18,6 +18,8 @@
 #ifndef TESTS_CORE_XFA_H
 #define TESTS_CORE_XFA_H
 
+#include "architecture.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -27,7 +29,7 @@ typedef struct {
     const char *text;
 } xfatest_t;
 
-typedef struct {
+typedef struct WORD_ALIGNED {
     const char text[31];
 } xfatest_noalign_t;
 

--- a/tests/unittests/tests-core/tests-core-xfa.h
+++ b/tests/unittests/tests-core/tests-core-xfa.h
@@ -27,6 +27,10 @@ typedef struct {
     const char *text;
 } xfatest_t;
 
+typedef struct {
+    const char text[31];
+} xfatest_noalign_t;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is basically #20012 implemented slightly differently, and adding unit tests around the issues.

Fixes:

1. on native, the zero-sized XFA marker array might get aligned wrongly. Fixed by adding `SUBALIGN(0)` to the corresponding linker sections
2. same file same priority XFA entries always get word aligned by the linker, even if the type's alignment is different. Fixed by adding a static assert

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#20012 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
