### PR TITLE
.vscode/settings.json: change vertical ruler to comply with coding conventions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.rulers": [
         80,
-        120
+        100
     ],
     "editor.detectIndentation": false,
     "files.insertFinalNewline": true,


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The vertical rulers in Visual Studio Code are set to 80 and 120, while the coding conventions says to aim for no more than 80 characters and a maximum of 100 ( https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md ).
So I changed the second ruler to 100.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


