### PR TITLE
pkg/lwip: add support for slipdev

### DIFF
--- a/drivers/slipdev/include/slipdev_params.h
+++ b/drivers/slipdev/include/slipdev_params.h
@@ -34,9 +34,13 @@ extern "C" {
  */
 #ifndef SLIPDEV_PARAM_UART
 # ifndef MODULE_SLIPDEV_STDIO
-#  define SLIPDEV_PARAM_UART        (UART_DEV(0))
+#  ifdef MODULE_USBUS_CDC_ACM
+#   define SLIPDEV_PARAM_UART       UART_DEV(0)
+#  else
+#   define SLIPDEV_PARAM_UART       UART_DEV(1)
+#  endif
 # else  /* MODULE_SLIPDEV_STDIO */
-#  define SLIPDEV_PARAM_UART        (STDIO_UART_DEV)
+#  define SLIPDEV_PARAM_UART        STDIO_UART_DEV
 # endif /* MODULE_SLIPDEV_STDIO */
 #endif  /* SLIPDEV_PARAM_UART */
 #ifndef SLIPDEV_PARAM_BAUDRATE

--- a/pkg/lwip/init_devs/auto_init_slipdev.c
+++ b/pkg/lwip/init_devs/auto_init_slipdev.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for the SLIP module
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include "slipdev.h"
+#include "slipdev_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_SLIPDEV_NUMOF ARRAY_SIZE(slipdev_params)
+
+static lwip_netif_t netif[NETIF_SLIPDEV_NUMOF];
+static slipdev_t slipdev_devs[NETIF_SLIPDEV_NUMOF];
+
+static void auto_init_slipdev(void)
+{
+    for (unsigned i = 0; i < NETIF_SLIPDEV_NUMOF; i++) {
+        slipdev_setup(&slipdev_devs[i], &slipdev_params[i], i);
+        if (lwip_add_ethernet(&netif[i], &slipdev_devs[i].netdev) == NULL) {
+            DEBUG("Could not add slipdev device\n");
+            return;
+        }
+    }
+}
+
+LWIP_INIT_ETH_NETIF(auto_init_slipdev);
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This hooks up support for `slipdev` in LWIP.

### Testing procedure

I tested with `examples/gcoap` with `LWIP_IPV6=1` and `USEMODULE += slipdev_l2addr` on one side and `tests/net/nanocoap_cli` on the other side with two `saml21-xpro` boards where the pins of UART1 are connected.

Issuing a CoAP request via the SLIP interface returns the expected respnose:

```
2023-10-26 15:54:43,302 - INFO # > ncget coap://[fe80::e858:4ed2:564e:215a]/.well-known/core -
2023-10-26 15:54:43,302 - INFO # 
2023-10-26 15:54:43,327 - INFO # </cli/stats>;ct=0;rt="count";obs,</riot/board>
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
