### PR TITLE
board/native: set TZ to UTC by default

### DIFF
--- a/boards/common/native/board_init.c
+++ b/boards/common/native/board_init.c
@@ -80,6 +80,9 @@ VFS_AUTO_MOUNT(native, { .hostpath = FS_NATIVE_DIR }, VFS_DEFAULT_NVM(0), 0);
  */
 void board_init(void)
 {
+    if (!getenv("TZ")) {
+        puts("TZ not set, setting UTC");
+    }
     setenv("TZ", "UTC", 0);
     puts("RIOT " RIOT_BOARD " board initialized.");
 }

--- a/boards/common/native/board_init.c
+++ b/boards/common/native/board_init.c
@@ -14,6 +14,7 @@
  * @}
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include "board.h"
 
 #include "board_internal.h"
@@ -79,5 +80,6 @@ VFS_AUTO_MOUNT(native, { .hostpath = FS_NATIVE_DIR }, VFS_DEFAULT_NVM(0), 0);
  */
 void board_init(void)
 {
+    setenv("TZ", "UTC", 0);
     puts("RIOT " RIOT_BOARD " board initialized.");
 }

--- a/boards/common/native/doc.md
+++ b/boards/common/native/doc.md
@@ -26,6 +26,8 @@ and @ref boards_native64. Using `BOARD=native` will automatically select the rig
 - Network: Tap Interface
 - UART: Runtime configurable - `/dev/tty*` are supported
 - Timers: Host timer
+- RTC: host time at `UTC` for consistent behavior with embedded systems.
+  The environment variable `TZ` can be used to explicitly set a specific or hosts timezone (see [below](#setting-a-timezone)).
 - LEDs: One red and one green LED - state changes are printed to the UART
 - PWM: Dummy PWM
 - QDEC: Emulated according to PWM
@@ -76,6 +78,27 @@ Options:
 
 As with any platform, you can specify the sizes of your stacks, i.e. the amount of space your application can use.
 You may wish to use a more realistic stack size than native's `THREAD_STACKSIZE_DEFAULT` to increase realism.
+
+# Setting a timezone                                      {#setting-a-timezone}
+
+RIOT native defaults to `UTC` timezone if `TZ` is not set in the environment,
+to keep behavior of `time.h` functions like `mktime` consistent with embedded setups,
+which usually do not use timezones.
+If your application requires the same timezone as host, the `TZ` environment variable should be set accordingly.
+There are several ways to achieve that:
+- execute `export TZ=":/etc/localtime"` prior `make term`
+  in the very shell you intend to run `make term` in
+- add `export TZ=":/etc/localtime"` to your `~/.profile`
+- run `TZ=":/etc/localtime" make term`
+
+The timezone can also be set at runtime by the application for both native and embedded devices using `setenv("TZ", <timezonestring>, 1)`. `picolibc` and `newlibc` expect `<timezonestring>` to have the form `NAME+/-hh:mm:ss<DST-handling>` (`+` pointing west -> `CET-1` adds 1 hour to UTC, see `man timezone`)
+e.g., `ACST-9:30ACDT-10:30,M10.1.0,M4.1.0`.
+If the `TZ`-string can not be interpreted by the used `libc` (`newlib`,`picolibc`,`glibc`),
+they default back to `UTC`.
+
+@warning Some things will behave faulty, since the assumption of most pkgs and
+        system modules is to run on a embedded system with no timezone set.
+        One often used function that respect timezone setting is `mktime`
 
 # Known Issues
 Check the list of open issues labeled native in the [github issue tracker](https://github.com/RIOT-OS/RIOT/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Platform%3A%20native%22)


### PR DESCRIPTION
### Contribution description

board/native: set env TZ to UTC by default
also fix the failing minema test - that assumend to be run in Berlin/Paris/Hamburg/Rom/Wien

most (all) embedded libc do not care for TZ and time functions don't do timezone conversion,
making native  use UTC for time.h functions does the same

you can still force localtime timezone  

- `TZ=":/etc/localtime" <elf_file>` or  
- `TZ=":/etc/localtime" make term or test` or 
- `export TZ=":/etc/localtime"` or 

or another timezone 
- `export TZ="LEET+1:33:7"`  (timezone name and offset from UTC optional DST
-  see man timezone for TZ specifier (not all of it is supported  by new/picolib(c)

### Testing procedure

run the minema test in Berlin and see that the time stamp is now UTC

### Issues/PRs references
#20018 #20005