### PR TITLE
tests/drivers/at: fix device table overflow

### DIFF
--- a/tests/drivers/at/main.c
+++ b/tests/drivers/at/main.c
@@ -47,6 +47,11 @@ static int init(int argc, char **argv)
     uint8_t uart = atoi(argv[1]);
     uint32_t baudrate = atoi(argv[2]);
 
+    if (uart >= UART_NUMOF) {
+        printf("Wrong UART device number - should be in range 0-%d.\n", UART_NUMOF - 1);
+        return 1;
+    }
+
     int res = at_dev_init(&at_dev, UART_DEV(uart), baudrate, buf, sizeof(buf));
 
     /* check the UART initialization return value and respond as needed */


### PR DESCRIPTION
### Contribution description

This PR fix device table overflow in `tests/driver/at`, which could lead to device crash.

### Testing procedure

PR was tested on two nucleo boards with 2 and 3 UARTs (nucleo-l476rg and nucleo-l496zg).
Flash `tests/driver/at` with and without this PR.

Output with this PR:

```
> main(): This is RIOT! (Version: 2022.07-devel-5083-g2b9e8-tests-drivers-at)
AT command test app
> init 5 9600

Wrong UART device number - should by in range 0-2.
>
```

Output without this PR:

```
> main(): This is RIOT! (Version: 2022.07-devel-5083-g2b9e8)
AT command test app
> init 5 9600

8001afd
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.


Context before hardfault:
   r0: 0x0000000a
   r1: 0x00000000
   . . . 
```

### Issues/PRs references

None