### PR TITLE
boards: add support for Adafruit Feather nRF52840 Sense

### DIFF
--- a/boards/feather-nrf52840-sense/Kconfig
+++ b/boards/feather-nrf52840-sense/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "feather-nrf52840-sense" if BOARD_FEATHER_NRF52840_SENSE
+
+config BOARD_FEATHER_NRF52840_SENSE
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO
+
+    select HAVE_APDS9960
+    select HAVE_BMP280_I2C
+    select HAVE_LIS3MDL
+    select HAVE_SAUL_GPIO
+    select HAVE_SHT3X
+    select MODULE_USB_BOARD_RESET if KCONFIG_USB && TEST_KCONFIG
+
+config FORCE_USB_STDIO
+    default y
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/feather-nrf52840-sense/Makefile
+++ b/boards/feather-nrf52840-sense/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/feather-nrf52840-sense/Makefile.dep
+++ b/boards/feather-nrf52840-sense/Makefile.dep
@@ -1,0 +1,11 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += apds9960
+  USEMODULE += bmp280_i2c
+  USEMODULE += lis3mdl
+  USEMODULE += saul_gpio
+  USEMODULE += sht3x
+endif
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/feather-nrf52840-sense/Makefile.features
+++ b/boards/feather-nrf52840-sense/Makefile.features
@@ -1,0 +1,12 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/feather-nrf52840-sense/Makefile.include
+++ b/boards/feather-nrf52840-sense/Makefile.include
@@ -1,0 +1,1 @@
+../feather-nrf52840/Makefile.include

--- a/boards/feather-nrf52840-sense/doc.txt
+++ b/boards/feather-nrf52840-sense/doc.txt
@@ -1,0 +1,26 @@
+/**
+@defgroup    boards_feather-nrf52840-sense Adafruit Feather nRF52840 Sense
+@ingroup     boards
+@brief       Support for the Adafruit Feather nRF52840 Sense
+
+### General information
+
+[The Feather nRF52840 Sense][feather-nrf52840-sense] is a development board
+from Adafruits Feather board family. It is very similar to the [The Feather
+nRF52840 Express][feather-nrf52840] but comes with more sensors.
+
+It provides native USB support, Bluetooth
+Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
+
+![top-down view on feather-nrf52840-sense][top-down view]
+
+[feather-nrf52840]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/
+[feather-nrf52840-sense]: https://learn.adafruit.com/adafruit-feather-sense
+[top-down view]: https://cdn-learn.adafruit.com/assets/assets/000/089/096/original/sensors_Feather_Sense_top.jpg
+
+### Flashing, Bootloader, and Terminal
+
+Refer to [The Feather nRF52840 Express
+documentation](https://doc.riot-os.org/group__boards__feather-nrf52840.html) for further details.
+Both use the same flasher, bootloader, and terminal settings.
+*/

--- a/boards/feather-nrf52840-sense/include/board.h
+++ b/boards/feather-nrf52840-sense/include/board.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ * Copyright (C) 2023 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840-sense
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Adafruit Feather nRF52840
+ *              Sense
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(1, 9)
+#define LED1_PIN            GPIO_PIN(1, 10)
+
+#define LED_PORT            (NRF_P1)
+#define LED0_MASK           (1 << 9)
+#define LED1_MASK           (1 << 10)
+#define LED_MASK            (LED0_MASK | LED1_MASK)
+
+#define LED0_ON             (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(1, 2)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    BMP280 sensor configuration
+ * @{
+ */
+#define BMX280_PARAM_I2C_DEV   I2C_DEV(0)   /**< I2C device */
+/** @} */
+
+/**
+ * @name    LIS3MDL 3-axis magnetometer
+ * @{
+ */
+#define LIS3MDL_PARAM_I2C      I2C_DEV(0)   /**< I2C device */
+#define LIS3MDL_PARAM_ADDR     (0x1C)       /**< I2C address */
+/** @} */
+
+/**
+ * @name    SHT30 temperature and humidity sensor
+ * @{
+ */
+#define SHT3X_PARAM_I2C_DEV    I2C_DEV(0)          /**< I2C device */
+#define SHT3X_PARAM_I2C_ADDR   (SHT3X_I2C_ADDR_1)  /**< I2C address */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/feather-nrf52840-sense/include/gpio_params.h
+++ b/boards/feather-nrf52840-sense/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ * Copyright (C) 2023 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840-sense
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED Red (D13)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Blue (Conn)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "UserSw",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/feather-nrf52840-sense/include/periph_conf.h
+++ b/boards/feather-nrf52840-sense/include/periph_conf.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ * Copyright (C) 2023 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840-sense
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Adafruit Feather nRF52840
+ *              Sense
+ *
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_0.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 24),
+        .tx_pin     = GPIO_PIN(0, 25),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = 14,
+        .mosi = 13,
+        .miso = 15,
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = 11,
+        .sda = 12,
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/feather-nrf52840-sense/reset.c
+++ b/boards/feather-nrf52840-sense/reset.c
@@ -1,0 +1,1 @@
+../feather-nrf52840/reset.c


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds support for the [Adafruit Feather nRF52840 Sense](https://learn.adafruit.com/adafruit-feather-sense). A nice prototyping board that comes with many onboard sensors. RIOT already supports most of it.

Note: you may need to [update the bootloader](https://learn.adafruit.com/adafruit-feather-sense/update-bootloader) in order to make flashing work. Version 0.7 worked fine for me. Note that some OSes do not auto mount the UF2 drive which prevents flashing. The uf2 helper `dist/tools/uf2/uf2conv.py` could use some improvements for handling distro-specific mount paths properly, which also applies to existing boards.

#### Unsupported features
Making use of the LSM6DS33 gyro/accelerometer might need some work on an existing driver (https://github.com/RIOT-OS/RIOT/issues/17053). Currently there is no support for the PDM peripheral used by the [digital MEMS microphone](https://www.st.com/resource/en/datasheet/mp34dt01-m.pdf). The NeoPixel LED lacks an nrf52-specific integration for the `ws281x` driver. All of that can be done in follow ups.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash and run some apps e.g., `examples/gnrc_networking` and `examples/saul` and check that both work as intended.
In the saul app `> saul read all` should give you a bunch of correct readings for the sensors. Both worked fine for me.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
