### PR TITLE
gcoap_fileserver: rename to nanocoap_fileserver

### DIFF
--- a/examples/gcoap_fileserver/Makefile
+++ b/examples/gcoap_fileserver/Makefile
@@ -21,9 +21,9 @@ USEMODULE += shell_cmds_default
 
 # enable the fileserver module
 USEMODULE += gcoap_fileserver
-USEMODULE += gcoap_fileserver_callback
-USEMODULE += gcoap_fileserver_delete
-USEMODULE += gcoap_fileserver_put
+USEMODULE += nanocoap_fileserver_callback
+USEMODULE += nanocoap_fileserver_delete
+USEMODULE += nanocoap_fileserver_put
 
 # select network modules
 USEMODULE += gnrc_ipv6_default

--- a/examples/gcoap_fileserver/main.c
+++ b/examples/gcoap_fileserver/main.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include "kernel_defines.h"
 #include "net/gcoap.h"
-#include "net/gcoap/fileserver.h"
+#include "net/nanocoap/fileserver.h"
 #include "shell.h"
 #include "vfs_default.h"
 
@@ -31,14 +31,14 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 static const coap_resource_t _resources[] = {
     { "/vfs",
       COAP_GET |
-#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
+#if IS_USED(MODULE_NANOCOAP_FILESERVER_PUT)
       COAP_PUT |
 #endif
-#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
+#if IS_USED(MODULE_NANOCOAP_FILESERVER_DELETE)
       COAP_DELETE |
 #endif
       COAP_MATCH_SUBTREE,
-      gcoap_fileserver_handler, VFS_DEFAULT_DATA },
+      nanocoap_fileserver_handler, VFS_DEFAULT_DATA },
 };
 
 static gcoap_listener_t _listener = {
@@ -46,22 +46,22 @@ static gcoap_listener_t _listener = {
     .resources_len = ARRAY_SIZE(_resources),
 };
 
-static void _event_cb(gcoap_fileserver_event_t event, gcoap_fileserver_event_ctx_t *ctx)
+static void _event_cb(nanocoap_fileserver_event_t event, nanocoap_fileserver_event_ctx_t *ctx)
 {
     switch (event) {
-    case GCOAP_FILESERVER_GET_FILE_START:
+    case NANOCOAP_FILESERVER_GET_FILE_START:
         printf("gcoap fileserver: Download started: %s\n", ctx->path);
         break;
-    case GCOAP_FILESERVER_GET_FILE_END:
+    case NANOCOAP_FILESERVER_GET_FILE_END:
         printf("gcoap fileserver: Download finished: %s\n", ctx->path);
         break;
-    case GCOAP_FILESERVER_PUT_FILE_START:
+    case NANOCOAP_FILESERVER_PUT_FILE_START:
         printf("gcoap fileserver: Upload started: %s\n", ctx->path);
         break;
-    case GCOAP_FILESERVER_PUT_FILE_END:
+    case NANOCOAP_FILESERVER_PUT_FILE_END:
         printf("gcoap fileserver: Upload finished: %s\n", ctx->path);
         break;
-    case GCOAP_FILESERVER_DELETE_FILE:
+    case NANOCOAP_FILESERVER_DELETE_FILE:
         printf("gcoap fileserver: Delete %s\n", ctx->path);
         break;
     }
@@ -72,8 +72,8 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     gcoap_register_listener(&_listener);
 
-    if (IS_USED(MODULE_GCOAP_FILESERVER_CALLBACK)) {
-        gcoap_fileserver_set_event_cb(_event_cb, NULL);
+    if (IS_USED(MODULE_NANOCOAP_FILESERVER_CALLBACK)) {
+        nanocoap_fileserver_set_event_cb(_event_cb, NULL);
     }
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -47,12 +47,8 @@ endif
 HIGH_MEMORY_BOARDS := native same54-xpro mcb2388
 
 ifneq (,$(filter $(BOARD),$(HIGH_MEMORY_BOARDS)))
-  USEMODULE += gcoap_fileserver
+  USEMODULE += nanocoap_fileserver
   USEMODULE += vfs_default
-
-  # we don't want to run GCoAP
-  CFLAGS += -DCONFIG_GCOAP_NO_AUTO_INIT=1
-  CFLAGS += -DCONFIG_NANOCOAP_SERVER_WELL_KNOWN_CORE=1
 
   # always enable auto-format for native
   ifeq ($(BOARD),native)

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -183,21 +183,21 @@ NANOCOAP_RESOURCE(sha256) {
 };
 
 /* we can also include the fileserver module */
-#ifdef MODULE_GCOAP_FILESERVER
-#include "net/gcoap/fileserver.h"
+#ifdef MODULE_NANOCOAP_FILESERVER
+#include "net/nanocoap/fileserver.h"
 #include "vfs_default.h"
 
 NANOCOAP_RESOURCE(fileserver) {
     .path = "/vfs",
     .methods = COAP_GET
-#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
+#if IS_USED(MODULE_NANOCOAP_FILESERVER_PUT)
       | COAP_PUT
 #endif
-#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
+#if IS_USED(MODULE_NANOCOAP_FILESERVER_DELETE)
       | COAP_DELETE
 #endif
       | COAP_MATCH_SUBTREE,
-    .handler = gcoap_fileserver_handler,
+    .handler = nanocoap_fileserver_handler,
     .context = VFS_DEFAULT_DATA
 };
 #endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -70,9 +70,6 @@ PSEUDOMODULES += fatfs_vfs_format
 PSEUDOMODULES += fmt_%
 PSEUDOMODULES += gcoap_forward_proxy
 PSEUDOMODULES += gcoap_fileserver
-PSEUDOMODULES += gcoap_fileserver_callback
-PSEUDOMODULES += gcoap_fileserver_delete
-PSEUDOMODULES += gcoap_fileserver_put
 PSEUDOMODULES += gcoap_dtls
 ## @addtogroup net_gcoap_dns
 ## @{
@@ -341,6 +338,9 @@ PSEUDOMODULES += md5sum
 ## @}
 PSEUDOMODULES += mtd_write_page
 PSEUDOMODULES += nanocoap_%
+PSEUDOMODULES += nanocoap_fileserver_callback
+PSEUDOMODULES += nanocoap_fileserver_delete
+PSEUDOMODULES += nanocoap_fileserver_put
 PSEUDOMODULES += netdev_default
 PSEUDOMODULES += netdev_ieee802154_%
 PSEUDOMODULES += netdev_ieee802154_rx_timestamp

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -472,6 +472,10 @@ endif
 
 ifneq (,$(filter gcoap_fileserver,$(USEMODULE)))
   USEMODULE += gcoap
+  USEMODULE += nanocoap_fileserver
+endif
+
+ifneq (,$(filter nanocoap_fileserver,$(USEMODULE)))
   USEMODULE += checksum
   USEMODULE += vfs
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -480,13 +480,13 @@ ifneq (,$(filter nanocoap_fileserver,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
-ifneq (,$(filter gcoap_fileserver_delete,$(USEMODULE)))
-  USEMODULE += gcoap_fileserver
+ifneq (,$(filter nanocoap_fileserver_delete,$(USEMODULE)))
+  USEMODULE += nanocoap_fileserver
   USEMODULE += vfs_util
 endif
 
-ifneq (,$(filter gcoap_fileserver_put,$(USEMODULE)))
-  USEMODULE += gcoap_fileserver
+ifneq (,$(filter nanocoap_fileserver_put,$(USEMODULE)))
+  USEMODULE += nanocoap_fileserver
 endif
 
 ifneq (,$(filter gcoap_forward_proxy,$(USEMODULE)))

--- a/sys/include/net/nanocoap/fileserver.h
+++ b/sys/include/net/nanocoap/fileserver.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_gcoap_fileserver GCoAP file server
- * @ingroup     net_gcoap
+ * @defgroup    net_nanocoap_fileserver CoAP file server
+ * @ingroup     net_nanocoap
  * @brief       Library for serving files from the VFS to CoAP clients
  *
  * # About
@@ -41,9 +41,9 @@
  *
  * # Usage
  *
- * * ``USEMODULE += gcoap_fileserver``
+ * * ``USEMODULE += nanocoap_fileserver``
  *
- * * Enter a @ref gcoap_fileserver_handler handler into your CoAP server's
+ * * Enter a @ref nanocoap_fileserver_handler handler into your CoAP server's
  *   resource list like this:
  *
  *   ```
@@ -52,7 +52,7 @@
  *       {
  *          .path = "/files/sd",
  *          .methods = COAP_GET | COAP_MATCH_SUBTREE,
- *          .handler = gcoap_fileserver_handler,
+ *          .handler = nanocoap_fileserver_handler,
  *          .context = "/sd0"
  *       },
  *       ...
@@ -65,7 +65,7 @@
  *   The allowed methods dictate whether it's read-only (``COAP_GET``) or
  *   read-write (``COAP_GET | COAP_PUT | COAP_DELETE``).
  *   If you want to support ``PUT`` and `DELETE`, you need to enable the modules
- *   ``gcoap_fileserver_put`` and ``gcoap_fileserver_delete``.
+ *   ``nanocoap_fileserver_put`` and ``nanocoap_fileserver_delete``.
  *
  * @{
  *
@@ -75,8 +75,8 @@
  * @author      chrysn <chrysn@fsfe.org>
  */
 
-#ifndef NET_GCOAP_FILESERVER_H
-#define NET_GCOAP_FILESERVER_H
+#ifndef NET_NANOCOAP_FILESERVER_H
+#define NET_NANOCOAP_FILESERVER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,16 +93,16 @@ extern "C" {
 /**
  * @brief   GCoAP fileserver event types
  *
- * @note This requires the gcoap_fileserver_callback module.
+ * @note This requires the nanocoap_fileserver_callback module.
  */
 typedef enum {
-    GCOAP_FILESERVER_GET_FILE_START,     /**< file download started   */
-    GCOAP_FILESERVER_GET_FILE_END,       /**< file download finished  */
-    GCOAP_FILESERVER_PUT_FILE_START,     /**< file upload started     */
-    GCOAP_FILESERVER_PUT_FILE_END,       /**< file upload finished    */
-    GCOAP_FILESERVER_DELETE_FILE,        /**< file deletion requested
+    NANOCOAP_FILESERVER_GET_FILE_START, /**< file download started   */
+    NANOCOAP_FILESERVER_GET_FILE_END,   /**< file download finished  */
+    NANOCOAP_FILESERVER_PUT_FILE_START, /**< file upload started     */
+    NANOCOAP_FILESERVER_PUT_FILE_END,   /**< file upload finished    */
+    NANOCOAP_FILESERVER_DELETE_FILE,    /**< file deletion requested
                                          (called before file is deleted) */
-} gcoap_fileserver_event_t;
+} nanocoap_fileserver_event_t;
 
 /**
  * @brief   GCoAP fileserver event context
@@ -110,7 +110,7 @@ typedef enum {
 typedef struct {
     const char *path;               /**< VFS path of the affected file  */
     void *user_ctx;                 /**< Optional user supplied context */
-} gcoap_fileserver_event_ctx_t;
+} nanocoap_fileserver_event_ctx_t;
 
 /**
  * @brief   GCoAP fileserver event callback type
@@ -119,12 +119,12 @@ typedef struct {
  * @param[in] ctx       Event context information
  *
  */
-typedef void (*gcoap_fileserver_event_handler_t)(gcoap_fileserver_event_t event,
-                                                 gcoap_fileserver_event_ctx_t *ctx);
+typedef void (*nanocoap_fileserver_event_handler_t)(nanocoap_fileserver_event_t event,
+                                                    nanocoap_fileserver_event_ctx_t *ctx);
 
 /**
  * @brief   Register a consumer for GCoAP fileserver events
- *          Requires the `gcoap_fileserver_callback` module
+ *          Requires the `nanocoap_fileserver_callback` module
  *
  *          The Callback is called on each fileserver event and executed
  *          within the GCoAP thread.
@@ -133,13 +133,13 @@ typedef void (*gcoap_fileserver_event_handler_t)(gcoap_fileserver_event_t event,
  * @param[in]  arg  Custom callback function context
  *
  */
-void gcoap_fileserver_set_event_cb(gcoap_fileserver_event_handler_t cb, void *arg);
+void nanocoap_fileserver_set_event_cb(nanocoap_fileserver_event_handler_t cb, void *arg);
 
 /**
  * @brief File server handler
  *
  * Serve a directory from the VFS as a CoAP resource tree.
- * @see net_gcoap_fileserver
+ * @see net_nanocoap_fileserver
  *
  * @param[in] pdu   CoAP request package
  * @param[out] buf  Buffer for the response
@@ -149,12 +149,13 @@ void gcoap_fileserver_set_event_cb(gcoap_fileserver_event_handler_t cb, void *ar
  * @return size of the response on success
  *         negative error
  */
-ssize_t gcoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
+ssize_t nanocoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                                    coap_request_ctx_t *ctx);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NET_GCOAP_FILESERVER_H */
+#endif /* NET_NANOCOAP_FILESERVER_H */
 
 /** @} */

--- a/tests/net/gcoap_fileserver/Makefile
+++ b/tests/net/gcoap_fileserver/Makefile
@@ -10,7 +10,7 @@ USEMODULE += shell
 USEMODULE += shell_cmds_default
 
 USEMODULE += gcoap_fileserver
-USEMODULE += gcoap_fileserver_put
+USEMODULE += nanocoap_fileserver_put
 
 USEMODULE += nanocoap_vfs
 

--- a/tests/net/gcoap_fileserver/main.c
+++ b/tests/net/gcoap_fileserver/main.c
@@ -19,7 +19,7 @@
 
 #include "fs/constfs.h"
 #include "net/gcoap.h"
-#include "net/gcoap/fileserver.h"
+#include "net/nanocoap/fileserver.h"
 #include "shell.h"
 #include "vfs_default.h"
 
@@ -31,13 +31,13 @@ static const coap_resource_t _resources[] = {
     {
         .path = "/const",
         .methods = COAP_GET | COAP_MATCH_SUBTREE,
-        .handler = gcoap_fileserver_handler,
+        .handler = nanocoap_fileserver_handler,
         .context = "/const"
     },
     {
         .path = "/vfs",
         .methods = COAP_GET | COAP_PUT | COAP_MATCH_SUBTREE,
-        .handler = gcoap_fileserver_handler,
+        .handler = nanocoap_fileserver_handler,
         .context = VFS_DEFAULT_DATA
     },
 };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There isn't really anything GCoAP specific about the fileserver module, it can just as well be used with nanoCoAP. Move and rename it to reflect that.


### Testing procedure

Both `examples/gcoap_fileserver` and `examples/nanocoap_server` keep serving files, but the latter one without pulling in a GCoAP dependency. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
