### PR TITLE
boards/nucleo-l552ze: add PWM configuration

### DIFF
--- a/boards/nucleo-l552ze-q/Kconfig
+++ b/boards/nucleo-l552ze-q/Kconfig
@@ -17,6 +17,7 @@ config BOARD_NUCLEO_L552ZE_Q
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_I2C
     select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART

--- a/boards/nucleo-l552ze-q/Makefile.features
+++ b/boards/nucleo-l552ze-q/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32l552ze
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_lpuart
 

--- a/boards/nucleo-l552ze-q/include/periph_conf.h
+++ b/boards/nucleo-l552ze-q/include/periph_conf.h
@@ -94,6 +94,59 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+
+/**
+ * @name    PWM configuration
+ *
+ * To find appriopate device and channel find in the MCU datasheet table
+ * concerning "Alternate function AF0 to AF7" a text similar to TIM[X]_CH[Y],
+ * where:
+ * TIM[X] - is device,
+ * [Y] - describes used channel (indexed from 0), for example TIM2_CH1 is
+ * channel 0 in configuration structure (cc_chan - field),
+ * Port column in the table describes connected port.
+ *
+ * For Nucleo-L552ZE-Q this information is in the datasheet, Table 22, page 122.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR1_TIM2EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 0) /* CN10 D32 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_A, 1) /* CN10  A8 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_A, 2) /*  CN9  A1 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_A, 3) /*  CN9  A0 */, .cc_chan = 3} },
+        .af       = GPIO_AF1,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR1_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /*  CN7 D25 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_B, 5) /*  CN7 D22 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_B, 0) /*  CN9  A3 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_B, 1) /* CN10  A6 */, .cc_chan = 3} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR1_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 12) /*  CN7 D19 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_B, 7)  /* Blue LD2 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_D, 14) /*  CN7 D10 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_D, 15) /*  CN7  D9 */, .cc_chan = 3} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-l552ze-q PWM configuration

### Testing procedure

Flash the board using `tests/periph/pwm` program. Check if you could, for example, change LED 
intensity using PWM. 

### Issues/PRs references

None.