### PR TITLE
boards/feather-nrf52840-sense: Add bootloader info

### DIFF
--- a/boards/feather-nrf52840-sense/doc.txt
+++ b/boards/feather-nrf52840-sense/doc.txt
@@ -23,4 +23,25 @@ Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
 Refer to [The Feather nRF52840 Express
 documentation](https://doc.riot-os.org/group__boards__feather-nrf52840.html) for further details.
 Both use the same flasher, bootloader, and terminal settings.
+
+On "fresh" boards the
+[bootloader may need to be updated](https://learn.adafruit.com/adafruit-feather-sense/update-bootloader)
+
+#### Updating Old Bootloaders
+
+In some cases the bootloader may be too old to even mount on startup.
+Double tap the reset button to get into bootloader mode and check the
+`INFO_UF2.TXT` for bootloader information.
+If the version is less than `0.4.0` then one can use the
+[Adafruit_nRF52_Bootloader](https://github.com/adafruit/Adafruit_nRF52_Bootloader)
+tool to update.
+
+For example, one can run the following if `arm-none-eabi-gcc` and
+`adafruit-nrfutil` are installed:
+```
+git clone https://github.com/adafruit/Adafruit_nRF52_Bootloader.git
+cd Adafruit_nRF52_Bootloader
+git submodule update --init
+make BOARD=feather_nrf52840_sense SERIAL=/dev/ttyACM0 flash-dfu
+```
 */


### PR DESCRIPTION
### Contribution description

Add some info on how to deal with really old bootloaders on the `boards/feather-nrf52840-sense`.


### Testing procedure

Read it and maybe try the example.

Here is the script I used:
<details><summary>update-bootloader-less-than-0.4.sh</summary>

```bash
# !/bin/bash
command -v arm-none-eabi-gcc >/dev/null 2>&1 || echo "gcc-arm-none-eabi must be installed!"


FOLDER="/tmp/Adafruit_nRF52_Bootloader"
if [ ! -d "$FOLDER" ] ; then
    git clone https://github.com/adafruit/Adafruit_nRF52_Bootloader.git $FOLDER
fi
cd $FOLDER
git submodule update --init
make BOARD=feather_nrf52840_sense SERIAL=/dev/ttyACM0 flash-dfu
```

stdout:
```
$ ./boards/feather-nrf52840-sense/update-bootloader.sh 
Submodule 'lib/nrfx' (https://github.com/NordicSemiconductor/nrfx.git) registered for path 'lib/nrfx'
Submodule 'lib/tinyusb' (https://github.com/hathach/tinyusb.git) registered for path 'lib/tinyusb'
Submodule 'lib/uf2' (https://github.com/microsoft/uf2.git) registered for path 'lib/uf2'
Cloning into '/tmp/Adafruit_nRF52_Bootloader/lib/nrfx'...
Cloning into '/tmp/Adafruit_nRF52_Bootloader/lib/tinyusb'...
Cloning into '/tmp/Adafruit_nRF52_Bootloader/lib/uf2'...
Submodule path 'lib/nrfx': checked out '7a4c9d946cf1801771fc180acdbf7b878f270093'
Submodule path 'lib/tinyusb': checked out '9775e76910d569ec73b8dd946f3fa5fe5414acdb'
Submodule path 'lib/uf2': checked out 'adbb8c7260f938e810eb37f2287f8e1a055ff402'
--2023-11-01 10:46:24--  https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases/download/0.8.0/feather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.hex
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/118896384/52889a99-9ffe-4e97-96d8-1fa79797db83?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231101T094625Z&X-Amz-Expires=300&X-Amz-Signature=e0f4f85d75d802691a9cce217c1f8d2ef0d2336665c221f44168c12c0331210f&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=118896384&response-content-disposition=attachment%3B%20filename%3Dfeather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.hex&response-content-type=application%2Foctet-stream [following]
--2023-11-01 10:46:24--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/118896384/52889a99-9ffe-4e97-96d8-1fa79797db83?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231101T094625Z&X-Amz-Expires=300&X-Amz-Signature=e0f4f85d75d802691a9cce217c1f8d2ef0d2336665c221f44168c12c0331210f&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=118896384&response-content-disposition=attachment%3B%20filename%3Dfeather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.hex&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.111.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 304 Not Modified
File ‘/tmp/feather_nrf52840_sense.hex/feather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.hex’ not modified on server. Omitting download.

make: Entering directory '/tmp/Adafruit_nRF52_Bootloader'
CC dfu_ble_svc.c
CC dfu_init.c
CC flash_nrf5x.c
CC main.c
CC boards.c
CC nrfx_power.c
CC nrfx_nvmc.c
CC system_nrf52840.c
CC bootloader.c
CC bootloader_settings.c
CC bootloader_util.c
CC dfu_transport_serial.c
CC dfu_transport_ble.c
CC dfu_single_bank.c
CC ble_dfu.c
CC ble_dis.c
CC pstorage_raw.c
CC app_timer.c
CC app_scheduler.c
CC app_error.c
CC app_util_platform.c
CC crc16.c
CC hci_mem_pool.c
CC hci_slip.c
CC hci_transport.c
CC nrf_assert.c
CC pinconfig.c
CC msc_uf2.c
CC usb_desc.c
CC usb.c
CC ghostfat.c
CC dcd_nrf5x.c
CC tusb_fifo.c
CC usbd.c
CC usbd_control.c
CC cdc_device.c
CC msc_device.c
CC tusb.c
AS gcc_startup_nrf52840.S
LD feather_nrf52840_sense_bootloader-0.8.0.out
Memory region         Used Size  Region Size  %age Used
           FLASH:       32776 B        38 KB     84.23%
BOOTLOADER_CONFIG:          88 B         2 KB      4.30%
 MBR_PARAMS_PAGE:          0 GB         4 KB      0.00%
BOOTLOADER_SETTINGS:          4 KB         4 KB    100.00%
             RAM:       20192 B       224 KB      8.80%
       DBL_RESET:          0 GB          4 B      0.00%
          NOINIT:          62 B        128 B     48.44%
 UICR_BOOTLOADER:           4 B          4 B    100.00%
UICR_MBR_PARAM_PAGE:           4 B          4 B    100.00%
   text    data     bss     dec     hex filename
  32864    1744   22614   57222    df86 _build/build-feather_nrf52840_sense/feather_nrf52840_sense_bootloader-0.8.0.out
Create feather_nrf52840_sense_bootloader-0.8.0.hex
Zip created at _build/build-feather_nrf52840_sense/feather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.zip
adafruit-nrfutil --verbose dfu serial --package _build/build-feather_nrf52840_sense/feather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.zip -p /dev/ttyACM0 -b 115200 --singlebank --touch 1200
Upgrading target on /dev/ttyACM0 with DFU package /tmp/Adafruit_nRF52_Bootloader/_build/build-feather_nrf52840_sense/feather_nrf52840_sense_bootloader-0.8.0_s140_6.1.1.zip. Flow control is disabled, Single bank, Touch 1200
Touched serial port /dev/ttyACM0
Opened serial port /dev/ttyACM0
Starting DFU upgrade of type 3, SoftDevice size: 151016, bootloader size: 39000, application size: 0
Sending DFU start packet
Sending DFU init packet
Sending firmware file
########################################
########################################
########################################
########################################
########################################
########################################
########################################
########################################
########################################
############
Activating new firmware

DFU upgrade took 20.308438777923584s
Device programmed.
make: Leaving directory '/tmp/Adafruit_nRF52_Bootloader'
```
</details>


### Issues/PRs references

