### PR TITLE
Bump version of UF2 package

### DIFF
--- a/dist/tools/uf2/Makefile
+++ b/dist/tools/uf2/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=UF2
 PKG_URL=https://github.com/microsoft/uf2.git
-PKG_VERSION=41394bd604e341ebcfdf0a8c4acce9ec8fd73d93
+PKG_VERSION=27e322fcdcc6eee0642242638d4f2557efb32559
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Bump UF2 package version. The new version, besides many other things, also includes an improvement to search more potential mount paths, which gives better compatibility for different distros.


### Testing procedure

Test if flashing still works for boards that use UF2 (e.g., `feather-nrf52840`, `feather-nrf52840-sense`, `nrf52840-mdk-dongle`):
`BUILD_IN_DOCKER=1 BOARD=feather-nrf52840-sense make -C examples/hello-world all flash term`

With master you should get this error, during flashing: `No drive to deploy.` if you run it on a distro that mounts your device under something like `/run/media/<username>/FTHRSNSBOOT`, or other paths not supported by the old version. To me this happened on Arch.
**Note: you will still get this error if your system doesn't auto mount the device.** But now it will be found when mounted ;)

With this PR try again with the UF2 util:
`rm -rf build/pkg/UF2`
`BUILD_IN_DOCKER=1 BOARD=feather-nrf52840-sense make -C examples/hello-world all flash term`
It should use the new pkg version and flash successfully:
```
...
[INFO] uf2conv.py not found - fetching it from GitHub now
CC= CFLAGS= make -C /home/michel/devel/riot/dist/tools/uf2
[INFO] uf2conv.py successfully fetched!
...
Flashing /run/media/michel/FTHRSNSBOOT (nRF52840-Feather-Sense)
Wrote 63488 bytes to /run/media/michel/FTHRSNSBOOT/NEW.UF2
...
```


### Issues/PRs references

Fixes the mount path problem described in #20027.
