### PR TITLE
boards/nucleo-l4r5zi : add PWM configuration

### DIFF
--- a/boards/nucleo-l4r5zi/Kconfig
+++ b/boards/nucleo-l4r5zi/Kconfig
@@ -18,6 +18,7 @@ config BOARD_NUCLEO_L4R5ZI
     select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/nucleo-l4r5zi/Makefile.features
+++ b/boards/nucleo-l4r5zi/Makefile.features
@@ -5,6 +5,7 @@ CPU_MODEL = stm32l4r5zi
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -167,6 +167,11 @@ static const adc_conf_t adc_config[] = {
 
 /** @} */
 
+static const pwm_conf_t pwm_config[] = {{},};
+
+#define PWM_NUMOF              ARRAY_SIZE(pwm_config)
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -167,10 +167,49 @@ static const adc_conf_t adc_config[] = {
 
 /** @} */
 
-static const pwm_conf_t pwm_config[] = {{},};
+/**
+ * @name    PWM configuration
+ *
+ * To find appriopate device and channel find in the MCU datasheet table
+ * concerning "Alternate function AF0 to AF7" a text similar to TIM[X]_CH[Y
+],
+ * where:
+ * TIM[X] - is device,
+ * [Y] - describes used channel (indexed from 0), for example TIM2_CH1 is
+ * channel 0 in configuration structure (cc_chan - field),
+ * Port column in the table describes connected port.
+ *
+ * For Nucleo-L4R5ZI this information is in the datasheet, Table 16, page
+ * 117.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR1_TIM2EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 0) /* CN10 D32 */, .cc_chan  = 0},
+                      { .pin = GPIO_PIN(PORT_A, 1) /* CN10  A8 */, .cc_chan  = 1},
+                      { .pin = GPIO_PIN(PORT_A, 2) /* CN10 D26 */, .cc_chan  = 2},
+                      { .pin = GPIO_PIN(PORT_A, 3) /*  CN9  A0 */, .cc_chan  = 3} },
+        .af       = GPIO_AF1,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR1_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /*  CN7 D25 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 4) /*  CN9 D57 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_B, 0) /* CN10 D33 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_B, 1) /* CN10  A6 */, .cc_chan = 3} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+};
 
 #define PWM_NUMOF              ARRAY_SIZE(pwm_config)
 
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-l4r5zi PWM configuration

### Testing procedure

Flash the board using `tests/periph/pwm` program. Check if you could, for example, change LED 
intensity using PWM. 

### Issues/PRs references

None.