### PR TITLE
nanocoap: prevent integer underflow in coap_opt_put_uri_pathquery() [backport 2023.10]

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -902,8 +902,15 @@ size_t coap_opt_put_string_with_len(uint8_t *buf, uint16_t lastonum, uint16_t op
 
 size_t coap_opt_put_uri_pathquery(uint8_t *buf, uint16_t *lastonum, const char *uri)
 {
+    size_t len;
     const char *query = strchr(uri, '?');
-    size_t len = query ? (size_t)(query - uri - 1) : strlen(uri);
+
+    if (query) {
+        len = (query == uri) ? 0 : (query - uri - 1);
+    } else {
+        len = strlen(uri);
+    }
+
     size_t bytes_out = coap_opt_put_string_with_len(buf, *lastonum,
                                                     COAP_OPT_URI_PATH,
                                                     uri, len, '/');


### PR DESCRIPTION
# Backport of #19994



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
If uri contains no path but only a query "?foo=bar" `len` would underflow. Fix this by detecting if there is no path.

Reported by @Yu3H0
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-4hvc-7m7r-78xq