### PR TITLE
dist/tools/uf2: add target to also copy families.json file

### DIFF
--- a/dist/tools/uf2/Makefile
+++ b/dist/tools/uf2/Makefile
@@ -5,8 +5,11 @@ PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all: $(CURDIR)/uf2conv.py
+all: $(CURDIR)/uf2conv.py $(CURDIR)/uf2families.json
 
 $(CURDIR)/uf2conv.py:
 	cp $(PKG_SOURCE_DIR)/utils/uf2conv.py .
 	chmod a+x uf2conv.py
+
+$(CURDIR)/uf2families.json:
+	cp $(PKG_SOURCE_DIR)/utils/uf2families.json .


### PR DESCRIPTION
### Contribution description

The updated UF2 pkg (#20035) stores the family ID in an external .json file. I overlooked that and flashing fails if this file is not present. This PR fixes it by also copying the json into the tool folder.

### Testing procedure
Check if the `feather-nrf52840-sense` can be flashed when the new UF2 pkg is cloned freshly.


### Issues/PRs references
 Fixes a regression introduced with #20035 
