### PR TITLE
nanocoap/cache: Extend with option-only cache keygen

### DIFF
--- a/sys/include/net/nanocoap/cache.h
+++ b/sys/include/net/nanocoap/cache.h
@@ -221,6 +221,26 @@ int nanocoap_cache_del(const nanocoap_cache_entry_t *ce);
 void nanocoap_cache_key_generate(const coap_pkt_t *req, uint8_t *cache_key);
 
 /**
+ * @brief   Generates a cache key based on only the options in @p req
+ *
+ * @param[in] req           The request to generate the cache key from
+ * @param[out] cache_key    The generated cache key of SHA256_DIGEST_LENGTH bytes
+ */
+void nanocoap_cache_key_options_generate(const coap_pkt_t *req, void *cache_key);
+
+/**
+ * @brief   Generates a cache key based on only the options in @p req without
+ * any of the blockwise options included in the key
+ *
+ * This function can be used to correlate individual requests that are part of a
+ * blockwise transfer with each other.
+ *
+ * @param[in] req           The request to generate the cache key from
+ * @param[out] cache_key    The generated cache key of SHA256_DIGEST_LENGTH bytes
+ */
+void nanocoap_cache_key_blockreq_options_generate(const coap_pkt_t *req, void *cache_key);
+
+/**
  * @brief   Compares two cache keys.
  *
  * @param[in] cache_key1    The first cache key in the comparison


### PR DESCRIPTION
### Contribution description

This adds a pair of functions to the nanocoap_cache module to generate cache keys only based on the options in a request. These can be used to correlate individual requests of a blockwise tranfer with each other. For example in a larger coreconf request.

It would still be up to the user to match the peers and the coap method code in the requests involved.

### Testing procedure

I've extended the unittest for the nanocoap_cache module


### Issues/PRs references

Could be useful for CORECONF and such.
