### PR TITLE
gnrc/ipv6/nib: don't do multicast address resolution on 6LoWPAN

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1397,7 +1397,8 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
         return false;
     }
 
-    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ARSM)) {
+    /* don't do multicast address resolution on 6lo */
+    if (!gnrc_netif_is_6ln(netif)) {
         _probe_nbr(entry, reset);
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The border router would send multicast neighbor solicitations when resolving node addresses. 
This is against the specification.
Check if the interface is 6lo before starting multicast address resolution.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16988#discussion_r778008765