### PR TITLE
dist/tools/uf2: Ignore the .json file

### DIFF
--- a/dist/tools/uf2/.gitignore
+++ b/dist/tools/uf2/.gitignore
@@ -1,1 +1,2 @@
 uf2conv.py
+uf2families.json


### PR DESCRIPTION
### Contribution description

With the updated `uf2` tool it seems like the `uf2families.json` is not ignored, which can be annoying.

### Testing procedure

Run:

```
BUILD_IN_DOCKER=1 BOARD=feather-nrf52840-sense make flash -C examples/hello-world/
```

and check that the `git status` no longer shows:
```
$ git status
On branch master

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        dist/tools/uf2/uf2families.json
```

### Issues/PRs references

