### PR TITLE
.github/workflows/*: Allow merge_groups and prs to be required

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -2,6 +2,8 @@ name: check-commits
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  merge_group:
+
 jobs:
   check-commits:
     runs-on: ubuntu-latest
@@ -24,3 +26,10 @@ jobs:
     - name: Run checks
       run: |
         ./dist/tools/${{ matrix.check }}/check.sh "${{ github.base_ref }}"
+  check-commits-success:
+    needs: check-commits
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+    - name: check-commits succeeded
+      run: exit 0

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -4,8 +4,11 @@ on:
     types: [opened, reopened, labeled, unlabeled, synchronize]
   pull_request_review:
     types: [submitted, dismissed]
+  merge_group:
+
 jobs:
   check-labels:
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: RIOT-OS/check-labels-action@v1.1.1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,10 +3,12 @@ name: pr-labeler
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     steps:
     - uses: actions/labeler@main
       with:

--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   static-tests:

--- a/.github/workflows/tools-buildtest.yml
+++ b/.github/workflows/tools-buildtest.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   tools-build:

--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -9,9 +9,11 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   python-tests:
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main

--- a/.murdock
+++ b/.murdock
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # uncomment and change this to limit builds, e.g.,
-#export BOARDS="samr21-xpro native"
+export BOARDS="samr21-xpro native"
 # and / or
 #export APPS="examples/hello-world tests/unittests"
 


### PR DESCRIPTION
### Contribution description

This allows merge_groups on all "required" checks for a PR and skips the ones that would not be required when merging though the merge queue such as `check_labels`.  This will allow simple branch protection rules for all checks run in a PR that would also apply (or be skipped) when merging with the queue.


### Testing procedure

Setup the branch protections and try to fail and make sure thing cannot get merged in.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
