### PR TITLE
ci: fix github.base-ref for merge_group builds

### DIFF
--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -22,11 +22,18 @@ jobs:
     - uses: actions/checkout@main
       with:
         fetch-depth: 0
+    - name: set CI_BASE_BRANCH
+      run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+              echo "CI_BASE_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
+          elif [ -n "${{ github.event.merge_group.base_ref }}" ]; then
+              echo "CI_BASE_BRANCH=${{ github.event.merge_group.base_ref }}" | sed s.=refs/heads/.=. >> $GITHUB_ENV
+          fi
     - name: Setup git
       run: |
-        # Note: ${{ github.base_ref }} is empty when not in a PR
-        if [ -n "${{ github.base_ref }}" ]; then
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --no-tags
+        # Note: CI_BASE_BRANCH is empty when not in a PR
+        if [ -n "${CI_BASE_BRANCH}" ]; then
+          git fetch origin ${CI_BASE_BRANCH}:${CI_BASE_BRANCH} --no-tags
         else
           git config diff.renameLimit 16384
         fi
@@ -35,9 +42,9 @@ jobs:
       run: docker pull riot/static-test-tools:latest
     - name: Run static-tests
       run: |
-        # Note: ${{ github.base_ref }} is empty when not in a PR
+        # Note: ${CI_BASE_BRANCH} is empty when not in a PR
         docker run --rm                             \
-          -e CI_BASE_BRANCH=${{ github.base_ref }}  \
+          -e CI_BASE_BRANCH                         \
           -e GITHUB_RUN_ID=${GITHUB_RUN_ID}         \
           -v $(pwd):/data/riotbuild                 \
           riot/static-test-tools:latest             \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Update workflows to pass a correct `CI_BASE_BRANCH` when building a merge_group.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

"static-tests" on merge_groups should be fast.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
