### PR TITLE
drivers/at: fix URC collision with command response

### DIFF
--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -195,8 +195,8 @@ typedef struct {
  * @param[in]   buf         input buffer
  * @param[in]   bufsize     size of @p buf
  *
- * @returns     success code UART_OK on success
- * @returns     error code UART_NODEV or UART_NOBAUD otherwise
+ * @retval     success code UART_OK on success
+ * @retval     error code UART_NODEV or UART_NOBAUD otherwise
  */
 int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize);
 
@@ -209,8 +209,8 @@ int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t
  * @param[in]   command command string to send
  * @param[in]   timeout timeout (in usec)
  *
- * @returns     0 when device answers "OK"
- * @returns     <0 otherwise
+ * @retval      0 when device answers "OK"
+ * @retval     <0 otherwise
  */
 int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout);
 
@@ -224,8 +224,8 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout);
  * @param[in]   command command string to send
  * @param[in]   timeout timeout (in usec)
  *
- * @return      0 when prompt is received
- * @return      <0 otherwise
+ * @retval       0 when prompt is received
+ * @retval      <0 otherwise
  */
 int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout);
 
@@ -243,8 +243,8 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout
  * @param[in]   len         len of @p buffer
  * @param[in]   timeout     timeout (in usec)
  *
- * @returns     length of response on success
- * @returns     <0 on error
+ * @retval      n length of response on success
+ * @retval     <0 on error
  */
 ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command, char *resp_buf, size_t len, uint32_t timeout);
 
@@ -263,8 +263,8 @@ ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command, char *resp_buf,
  * @param[in]   len         len of @p buffer
  * @param[in]   timeout     timeout (in usec)
  *
- * @returns     length of response on success
- * @returns     <0 on error
+ * @retval      n length of response on success
+ * @retval     <0 on error
  */
 ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command, const char *resp_prefix,
                                      char *resp_buf, size_t len, uint32_t timeout);
@@ -286,9 +286,9 @@ ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command, const c
  * @param[in]   keep_eol    true to keep the CR character in the response
  * @param[in]   timeout     timeout (in usec)
  *
- * @returns     length of response on success
- * @returns     -1 on error
- * @returns     -2 on CMS or CME error
+ * @retval      n length of response on success
+ * @retval     -1 on error
+ * @retval     -2 on CMS or CME error
  */
 ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command, char *resp_buf,
                               size_t len, bool keep_eol, uint32_t timeout);
@@ -300,10 +300,22 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command, char *resp_buf
  * @param[in]   bytes   buffer containing bytes to expect (NULL-terminated)
  * @param[in]   timeout timeout (in usec)
  *
- * @returns     0 on success
- * @returns     <0 otherwise
+ * @retval      0 on success
+ * @retval     <0 otherwise
  */
 int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
+
+/**
+ * @brief   Repeatedly calls at_expect_bytes() until a match or timeout occurs
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   bytes   buffer containing bytes to expect (NULL-terminated)
+ * @param[in]   timeout timeout (in usec)
+ *
+ * @retval      0 on success
+ * @retval     <0 otherwise
+ */
+int at_wait_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
 
 /**
  * @brief   Receives bytes into @p bytes buffer until the string pattern
@@ -317,8 +329,8 @@ int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
  *                              bytes.
  * @param[in] timeout           timeout (in usec) of inactivity to finish read
  *
- * @returns                     0 on success
- * @returns                     <0 on error
+ * @retval                      0 on success
+ * @retval                     <0 on error
  */
 int at_recv_bytes_until_string(at_dev_t *dev, const char *string,
                                char *bytes, size_t *bytes_len,
@@ -341,7 +353,7 @@ void at_send_bytes(at_dev_t *dev, const char *bytes, size_t len);
  * @param[in]   len     maximum number of bytes to receive
  * @param[in]   timeout timeout (in usec) of inactivity to finish read
  *
- * @returns     Number of bytes read, eventually zero if no bytes available
+ * @retval      n Number of bytes read, eventually zero if no bytes available
  */
 ssize_t at_recv_bytes(at_dev_t *dev, char *bytes, size_t len, uint32_t timeout);
 
@@ -352,8 +364,8 @@ ssize_t at_recv_bytes(at_dev_t *dev, char *bytes, size_t len, uint32_t timeout);
  * @param[in]   command command to send
  * @param[in]   timeout timeout (in usec)
  *
- * @returns     0 on success
- * @returns     <0 otherwise
+ * @retval      0 on success
+ * @retval     <0 otherwise
  */
 int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout);
 
@@ -366,10 +378,25 @@ int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout);
  * @param[in]   keep_eol    true to keep the CR character in the response
  * @param[in]   timeout     timeout (in usec)
  *
- * @returns     line length on success
- * @returns     <0 on error
+ * @retval      n line length on success
+ * @retval     <0 on error
  */
 ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol, uint32_t timeout);
+
+/**
+ * @brief   Read a line from device, skipping a possibly empty line.
+ *
+ * @param[in]   dev         device to operate on
+ * @param[in]   resp_buf    buffer to store line
+ * @param[in]   len         size of @p resp_buf
+ * @param[in]   keep_eol    true to keep the CR character in the response
+ * @param[in]   timeout     timeout (in usec)
+ *
+ * @retval      n line length on success
+ * @retval     <0 on error
+ */
+ssize_t at_readline_skip_empty(at_dev_t *dev, char *resp_buf, size_t len,
+                               bool keep_eol, uint32_t timeout);
 
 /**
  * @brief   Drain device input buffer

--- a/tests/drivers/at/tests-with-config/sneaky_urc.py
+++ b/tests/drivers/at/tests-with-config/sneaky_urc.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# This script simulates a modem sending a "sneaky URC", a URC that happens exactly
+# after the command is received, but before the first line of answer is sent. This
+# is possible behavior at least on the U-Blox LTE modules.
+#
+# Running this test requires the board to be connected twice
+#  - one connection simulating the modem (e.g.: /dev/ttyUSB0), connected to the
+#    serial device this script is listening to
+#  - one to access the RIOT CLI (e.g.: debugger, USB or a second serial connection)
+#
+# How to get it running:
+#  1. Adapt the `EOL_IN`, `EOL_OUT`, `ECHO_ON` variables below to match your use case
+#  2. Run this script with the baud rate and the serial dev the device is connected
+#     to, e.g.:
+#       $ ./sneaky_urc 115200 /dev/ttyUSB0
+#  4. run the test (e.g. make term)
+#  5. inside the test console:
+#    a) run the `init` command (e.g. init 0 115200)
+#    b) run `sneaky_urc` command
+#
+# If the command echoing is enabled, you will miss the URCs, but the commands
+# should work (e.g. the URC should not interfere with response parsing).
+#
+# If command echoing is enabled AND `MODULE_AT_URC` is defined, you should see
+# *some* of the URCs being parsed.
+
+import sys
+import pexpect
+
+baud = sys.argv[1]
+ser = sys.argv[2]
+tty = pexpect.spawn(f'picocom --baud {baud} {ser}')
+
+# EOL sent by the device
+EOL_IN = '\r'
+# EOL to send back to the device
+EOL_OUT = '\r\n'
+# Command echoing enabled
+ECHO_ON = False
+
+CFUN_CMD = "AT+CFUN=1" + EOL_IN
+CFUN_ERR_CMD = "AT+CFUN=8" + EOL_IN
+CFUN_CME_CMD = "AT+CFUN=9" + EOL_IN
+CEREG_CMD = "AT+CEREG?" + EOL_IN
+USECMNG_CMD = "AT+USECMNG=0,0,\"cert\",128" + EOL_IN
+
+while True:
+    try:
+        idx = tty.expect_exact([CFUN_CMD, CFUN_ERR_CMD, CFUN_CME_CMD, CEREG_CMD, USECMNG_CMD])
+        if idx == 0:
+            print(CFUN_CMD)
+            tty.send(EOL_OUT + "+CSCON: 1" + EOL_OUT)
+            if ECHO_ON:
+                tty.send(CFUN_CMD)
+            tty.send(EOL_OUT + "OK" + EOL_OUT)
+        if idx == 1:
+            print(CFUN_ERR_CMD)
+            tty.send(EOL_OUT + "+CSCON: 1" + EOL_OUT)
+            if ECHO_ON:
+                tty.send(CFUN_ERR_CMD)
+            tty.send(EOL_OUT + "ERROR" + EOL_OUT)
+        if idx == 2:
+            print(CFUN_CME_CMD)
+            tty.send(EOL_OUT + "+CSCON: 1" + EOL_OUT)
+            if ECHO_ON:
+                tty.send(CFUN_CME_CMD)
+            tty.send(EOL_OUT + "+CME ERROR:" + EOL_OUT)
+        elif idx == 3:
+            print(CEREG_CMD)
+            tty.send(EOL_OUT + "+CSCON: 1" + EOL_OUT)
+            if ECHO_ON:
+                tty.send(CEREG_CMD)
+            tty.send(EOL_OUT + "+CEREG: 0,1" + EOL_OUT)
+            tty.send(EOL_OUT + "OK" + EOL_OUT)
+        elif idx == 4:
+            print(USECMNG_CMD)
+            tty.send(EOL_OUT + "+CSCON: 1" + EOL_OUT)
+            if ECHO_ON:
+                tty.send(USECMNG_CMD)
+            tty.send(">")
+    except pexpect.EOF:
+        print("ERROR: EOF")
+    except pexpect.TIMEOUT:
+        print("ERROR: TIMEOUT")


### PR DESCRIPTION
### Contribution description

Fix URCs being occasionally mistaken for command response.  

#### Causes
  Some DCEs (e.g. LTE modules from uBlox) define a grace period where URCs are
  guaranteed NOT to be sent as the time span between:
   - the command EOL character reception AND command being internally accepted
   - the EOL character of the last response line
  
  As follows, there is an indeterminate amount of time between:
   - the command EOL character being sent
   - the command EOL character reception AND command being internally accepted,
     i.e. the begin of the grace period  
  
  In other words, we can get a URC (or more?) just after issueing the command 
  and before the first line of response. The net effect is that such URCs will 
  appear to be the first line of response to the last issued command.
  
  The current solution is to skip characters that don't match the expected 
  response, at the expense of losing these URCs. Note, we may already lose URCs
  when calling at_drain() just before any at_send_cmd(). Success partially depends 
  on whether command echoing is enabled or not:
   1. echo enabled: by observation, it seems that the grace period begins
    BEFORE the echoed command (@aaltuntas  can you please confirm this?). 
    This has the advantage that we ALWAYS know what 
    the first line of response must look like and so if it doesn't, then it's a 
    URC. Thus, any procedure that calls at_send_cmd() will catch and discard 
    these URCs.
   2. echo disabled: commands that expect a response (e.g. at_send_cmd_get_resp_wait_ok())
    will catch and discard any URC (or, if MODULE_AT_URC enabled, hand it over to 
    the URC callbacks). For the rest, it is the application's responsibility to 
    handle it.

#### If missing URCs is unacceptable
As already mentioned, 100% URC coverage is already not guaranteed, but if that needs to be improved, the approach suggested by @aaltuntas [here](https://github.com/RIOT-OS/RIOT/pull/14327#issuecomment-651788427) should be implemented.

### Testing procedure

I added a [python script](tests/drivers/at/sneaky_urc.py) that simulates some hard-coded responses, with URCs right before the response. Follow the instructions inside.

This is not tested against at_urc_isr, as it introduces some timing issues nevertheless. See #20059 

### Issues/PRs references

#20059
#14327 