### PR TITLE
.murdock: rely on murdock for CI_BASE_COMMIT

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -192,17 +192,6 @@ is_merge_queue_build() {
     startswith "gh-readonly-queue/" "${CI_BUILD_BRANCH}"
 }
 
-# Set CI_BASE_COMMIT in case of a merge queue build.
-# This assumes that merge queue always adds a single merge commit (possibly itself
-# including multiple merges for PRs) on the base branch.
-# That git command outputs the hash of the second merge commit (the one before
-# the topmost merge), which should be the base branch HEAD.
-# (CI_BASE_COMMIT is used by `can_fast_ci_run.py` to only build changes.)
-if test -z "${CI_BASE_COMMIT}" && is_merge_queue_build; then
-    previous_merge="$(git log --merges --max-count 1 --skip 1 --pretty=format:%H)"
-    export CI_BASE_COMMIT="${previous_merge}"
-fi
-
 # fullbuild logic
 # non-full-builds are those where can_fast_ci_run might reduce the build
 # automatically

--- a/.murdock
+++ b/.murdock
@@ -212,9 +212,6 @@ if [ -z "${FULL_BUILD}" ]; then
     elif check_label "CI: full build"; then
         # full build if requested by label
         FULL_BUILD=1
-    elif is_merge_queue_build; then
-        # always do full build for merge queue' branches
-        FULL_BUILD=1
     else
         FULL_BUILD=0
     fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Previously, the CI_BASE_COMMIT logic for bors rollup builds expected bors layout of the target branch, which doesn't work for merge_groups.
murdock [now](https://github.com/RIOT-OS/murdock-scripts/pull/49) passes that info, so drop fetching it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
