### PR TITLE
boards/common/esp32x: fix doxygen group

### DIFF
--- a/boards/common/esp32x/doc.txt
+++ b/boards/common/esp32x/doc.txt
@@ -8,9 +8,10 @@
 
 /**
  * @defgroup    boards_common_esp32x  ESP32x Common
+ * @ingroup     boards_common
  * @brief       Definitions and configurations that are common for
- *              all ESP32 boards.
+ *              all ESP32x boards.
  *
- * For detailed information about the ESP32, configuring and compiling RIOT
- * for ESP32 boards, please refer \ref esp32_riot.
+ * For detailed information about ESP32x SoCs, configuring and compiling RIOT
+ * for ESP32x boards, please refer \ref esp32_riot.
  */


### PR DESCRIPTION
### Contribution description

The PR fixes the doxygen group for ESP32x boards so that `ESP32x Common` isn't shown any longer as top level entry in `Modules` menu.

![Bildschirmfoto vom 2023-11-09 16-47-58](https://github.com/RIOT-OS/RIOT/assets/31932013/ee17b188-1481-42a3-90e9-7bdad1637891)

### Testing procedure

`make doc` and check documentation locally.

### Issues/PRs references
