### PR TITLE
gcoap: add some client-side observe handling

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -371,7 +371,8 @@
  * - Message Type: Supports non-confirmable (NON) messaging. Additionally
  *   provides a callback on timeout. Provides piggybacked ACK response to a
  *   confirmable (CON) request.
- * - Observe extension: Provides server-side registration and notifications.
+ * - Observe extension: Provides server-side registration and notifications
+ *   and client-side observe.
  * - Server and Client provide helper functions for writing the
  *   response/request. See the CoAP topic in the source documentation for
  *   details. See the gcoap example for sample implementations.

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -1075,6 +1075,37 @@ size_t gcoap_obs_send(const uint8_t *buf, size_t len,
                       const coap_resource_t *resource);
 
 /**
+ * @brief   Forgets (invalidates) an existing observe request.
+ *
+ * This invalidates the internal (local) observe request state without actually
+ * sending a deregistration request to the server. Ths mechanism may be referred
+ * to as passive deregistration, as it does not send a deregistration request.
+ * This is implemented according to the description in RFC 7641,
+ * Section 3.6 (Cancellation): 'A client that is no longer interested in
+ * receiving notifications for a resource can simply "forget" the observation.'
+ * Successfully invalidating the request by calling this function guarantees
+ * that the corresponding observe response handler will not be called anymore.
+ *
+ * NOTE: There are cases were active deregistration is preferred instead.
+ * A server may continue sending notifications if it chooses to ignore the RST
+ * which is meant to indicate the client did not recognize the notification.
+ * For such server implementations this function must be called *before*
+ * sending an explicit deregister request (i.e., a GET request with the token
+ * of the registration and the observe option set to COAP_OBS_DEREGISTER).
+ * This will instruct the server to stop sending further notifications.
+ *
+ * @param[in] remote    remote endpoint that hosts the observed resource
+ * @param[in] token     token of the original GET request used for registering
+ *                      an observe
+ * @param[in] tokenlen  the length of the token in bytes
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gcoap_obs_req_forget(const sock_udp_ep_t *remote, const uint8_t *token,
+                         size_t tokenlen);
+
+/**
  * @brief   Provides important operational statistics
  *
  * Useful for monitoring.

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -837,6 +837,7 @@ typedef struct {
     sock_udp_ep_t *observer;            /**< Client endpoint; unused if null */
     const coap_resource_t *resource;    /**< Entity being observed */
     uint8_t token[GCOAP_TOKENLEN_MAX];  /**< Client token for notifications */
+    uint16_t last_msgid;                /**< Message ID of last notification */
     unsigned token_len;                 /**< Actual length of token attribute */
     gcoap_socket_t socket;              /**< Transport type to observer */
 } gcoap_observe_memo_t;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -536,6 +536,13 @@ static void _process_coap_pdu(gcoap_socket_t *sock, sock_udp_ep_t *remote, sock_
                 messagelayer_emptyresponse_type = COAP_TYPE_RST;
                 DEBUG("gcoap: Answering unknown CON response with RST to "
                       "shut up sender\n");
+            } else {
+                /* if the response was a (NON) observe notification and there is no
+                 * matching request, the server must be informed that this node is
+                 * no longer interested in this notification. */
+                if (coap_has_observe(&pdu)) {
+                    messagelayer_emptyresponse_type = COAP_TYPE_RST;
+                }
             }
         }
         break;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1535,6 +1535,23 @@ int gcoap_req_init_path_buffer(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     return (res > 0) ? 0 : res;
 }
 
+int gcoap_obs_req_forget(const sock_udp_ep_t *remote, const uint8_t *token,
+                         size_t tokenlen) {
+    int res = -ENOENT;
+    gcoap_request_memo_t *obs_req_memo;
+    mutex_lock(&_coap_state.lock);
+    /* Find existing request memo of the observe */
+    obs_req_memo = _find_req_memo_by_token(remote, token, tokenlen);
+    if (obs_req_memo) {
+        /* forget the existing observe memo. */
+        obs_req_memo->state = GCOAP_MEMO_UNUSED;
+        res = 0;
+    }
+
+    mutex_unlock(&_coap_state.lock);
+    return res;
+}
+
 ssize_t gcoap_req_send_tl(const uint8_t *buf, size_t len,
                           const sock_udp_ep_t *remote,
                           gcoap_resp_handler_t resp_handler, void *context,


### PR DESCRIPTION
### Contribution description
Enables some client-side observe operation of gcoap (and improve server side a bit).
Currently, when registering an observe from a gcoap client, the first notification consumes the request memo state. Any following notifications are therefore dropped silently afterwards.
When I Initially saw this behavior I thought it's a bug, but turns out gcoap never had client-side observe handling :open_mouth: 
This PR tries to improve the situation like this: requests initiated with an observe option are simply kept open beyond the first response.


### Testing procedure
The first commit of this PR adds some client side observe functionality to examples/gcoap to reproduce this behavior.
With two `native` instances, check out the first commit and follow below steps.

#### Step 1: Reproduce missing feature.

```
sudo ./dist/tools/tapsetup/tapsetup
BOARD=native PORT=tap0 make -C examples/gcoap all term
> ifconfig
(...)
# *copy node_1_IP IP* and  continue on node_2 in second term
coap get -o [<node_2_IP>] /cli/stats
gcoap_cli: sending msg ID 9556, 17 bytes
> gcoap: response Success, code 2.05, 1 bytes
0
```

Meanwhile in a second terminal:
```
BOARD=native PORT=tap1 make -C examples/gcoap all term
> ifconfig
(...)
# *copy node_2_IP IP*
coap get [<node_1_IP>] /.well-known/core
# sad, no notification arrived on node_1, try again?
coap get [<node_1_IP>] /.well-known/core
# nope, nothing happening, but wireshark says the server is doing what it should do
```

#### Step 2: hopefully make it better.
The second commit of this PR should fix this. So `git checkout somethingsomething`, and repeat.
This time, doing many `coap get [<node_1_IP>] /.well-known/core` (term2) should something like this on node_1:

```
(...)
coap get -o [<node_2_IP>] /cli/stats
gcoap_cli: sending msg ID 1769, 17 bytes
> gcoap: response Success, code 2.05, 1 bytes
0
gcoap: response Success, code 2.05, 1 bytes
1
gcoap: response Success, code 2.05, 1 bytes
2
gcoap: response Success, code 2.05, 1 bytes
3
gcoap: response Success, code 2.05, 1 bytes
4
gcoap: response Success, code 2.05, 1 bytes
5
(...)
```

Noice. Done, right? ...and if we want to get rid of that perma-request again? ...no problem, just, ahh `reboot`? :raised_eyebrow:
Jump to commit No.6 of this PR for a solution (and more problems).

Repeat step 1 and 2, then make node1 forget about the observe via the new `-d` (deregister) option like this:
`coap get -d [<node_2_IP>] /cli/stats`
According to [RFC7641, 3.6 Cancellation](https://www.rfc-editor.org/rfc/rfc7641.html#section-3.6) this implementation variant of simply "forgetting about the observe" should do.
For node1 (the ~~observed~~ observing client) it indeed looks fine now as the response handler isn't called anymore. But wireshark shows that node2 is still sending all the notifications.
This is actually a shortcoming of the server-side handling, as gcoap currently does not handle a received RST after it sent a notification.
This is fixed with commit No.7.

The last "REMOVEME" commit shows an attempt of how explicitly sending a de-registration request could reuse the existing request memo of the observe. It also shows why we probably shouldn't do that ;)
It is much more nasty than I expected. Some not really related changes to nanocoap are also part of that droppable commit.
Luckily, with the other changes of this PR this is not strictly necessary. Maybe it helps finding a more elegant solution.

TODO: interop with some aiocoap-ish thing?


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
