### PR TITLE
sys/flash_utils: Minor bug fixes

### DIFF
--- a/cpu/avr8_common/Makefile.include
+++ b/cpu/avr8_common/Makefile.include
@@ -7,4 +7,8 @@ ifneq (,$(filter printf_float,$(USEMODULE)))
   LINKFLAGS += -Wl,-u,vfprintf -lprintf_flt -lm
 endif
 
+# Add aliases for flash_printf, flash_fprintf, flash_snprintf:
+LINKFLAGS += -Wl,--defsym=flash_printf=printf_P
+LINKFLAGS += -Wl,--defsym=flash_fprintf=fprintf_P
+LINKFLAGS += -Wl,--defsym=flash_snprintf=snprintf_P
 include $(RIOTMAKE)/arch/avr8.inc.mk

--- a/cpu/avr8_common/include/flash_utils_arch.h
+++ b/cpu/avr8_common/include/flash_utils_arch.h
@@ -21,7 +21,7 @@
 #define FLASH_UTILS_ARCH_H
 
 #include <stdio.h>
-#include <string.h>
+#include <stdarg.h>
 #include <avr/pgmspace.h>
 
 #ifdef __cplusplus
@@ -35,20 +35,68 @@ extern "C" {
 #define FLASH_ATTR __flash
 #define PRIsflash "S"
 #define TO_FLASH(x) __extension__({static FLASH_ATTR const char __c[] = (x); &__c[0];})
-#define flash_strcmp strcmp_P
-#define flash_strncmp strncmp_P
-#define flash_strlen strlen_P
-#define flash_strcpy strcpy_P
-#define flash_strncpy strncpy_P
-#define flash_printf printf_P
-/* avrlibc seemingly forgot to provide vprintf_P(), but vfprintf_P() is there */
-#define flash_vprintf(fmt, arglist) vfprintf_P(stdout, fmt, arglist)
-#define flash_fprintf fprintf_P
-#define flash_vfprintf vfprintf_P
-#define flash_snprintf snprintf_P
-#define flash_vsnprintf vsnprintf_P
-#define flash_puts puts_P
-#define flash_memcpy memcpy_P
+
+static inline int flash_strcmp(const char *ram, FLASH_ATTR const char *flash)
+{
+    return strcmp_P(ram, (const char *)flash);
+}
+
+static inline int flash_strncmp(const char *ram, FLASH_ATTR const char *flash, size_t n)
+{
+    return strncmp_P(ram, (const char *)flash, n);
+}
+
+static inline size_t flash_strlen(FLASH_ATTR const char *flash)
+{
+    return strlen_P((const char *)flash);
+}
+
+static inline char * flash_strcpy(char *ram, FLASH_ATTR const char *flash)
+{
+    return strcpy_P(ram, (const char *)flash);
+}
+
+static inline char * flash_strncpy(char *ram, FLASH_ATTR const char *flash, size_t n)
+{
+    return strncpy_P(ram, (const char *)flash, n);
+}
+
+
+static inline int flash_vprintf(FLASH_ATTR const char *flash, va_list args)
+{
+    /* vprintf_P() is not provided by avr-libc. But vfprintf_P() with
+     * stdout as stream can be used to implement it */
+    return vfprintf_P(stdout, (const char *)flash, args);
+}
+
+static inline int flash_vfprintf(FILE *stream, FLASH_ATTR const char *flash,
+                                 va_list args)
+{
+    return vfprintf_P(stream, (const char *)flash, args);
+}
+
+static inline int flash_vsnprintf(char *buf, size_t buf_len,
+                                  FLASH_ATTR const char *flash, va_list args)
+{
+    return vsnprintf_P(buf, buf_len, (const char *)flash, args);
+}
+
+static inline void flash_puts(FLASH_ATTR const char *flash)
+{
+    puts_P((const char *)flash);
+}
+
+static inline void * flash_memcpy(void *dest, FLASH_ATTR const void *src,
+                                  size_t n)
+{
+    return memcpy_P(dest, (const void *)src, n);
+}
+
+/* aliases need to be provided by the linker, as passing through va-args is
+ * not possible */
+int flash_printf(FLASH_ATTR const char *flash, ...);
+int flash_fprintf(FILE *stream, FLASH_ATTR const char *flash, ...);
+int flash_snprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash, ...);
 
 #endif /* Doxygen */
 

--- a/cpu/avr8_common/work_around_for_shitty_ubuntu_toolchain.c
+++ b/cpu/avr8_common/work_around_for_shitty_ubuntu_toolchain.c
@@ -1,0 +1,15 @@
+#include <avr/pgmspace.h>
+#include <stdio.h>
+
+/* The outdated linker from Ubuntu's toolchain contains a bug in which it will
+ * garbage collect symbols referenced only by --defsym= command line options,
+ * and subsequently complain that the symbols are not defined. Adding other
+ * references to those symbols from an unused function makes that buggy linker
+ * happy. Since this function is never used, it will be garbage collected and
+ * not impact the ROM size. */
+void work_around_for_shitty_ubuntu_toolchain_and_not_expected_to_be_called(void)
+{
+    printf_P(NULL);
+    fprintf_P(stdout, NULL);
+    snprintf_P(NULL, 0, NULL);
+}

--- a/sys/include/flash_utils.h
+++ b/sys/include/flash_utils.h
@@ -207,7 +207,7 @@ void flash_puts(FLASH_ATTR const char *flash);
  * @param[in]   n       number of bytes to copy
  *
  */
-void * flash_memcpy(void *dest, FLASH_ATTR const char *src, size_t n);
+void * flash_memcpy(void *dest, FLASH_ATTR const void *src, size_t n);
 #elif !IS_ACTIVE(HAS_FLASH_UTILS_ARCH)
 #  define FLASH_ATTR
 #  define PRIsflash "s"


### PR DESCRIPTION
### Contribution description

- The signature of `flash_memcpy()` in the Doxygen output was incorrect. This is fixed by the first commit
- Using the prepocessor to alias the `<funcname>_P()` functions to `flash_<funcname>()` doesn't work with LLVM
    - unlike GCC, LLVM doesn't like dropping `FLASH_ATTR` (or `__flash`) silently, but wants a cast
    - using C code (`static inline` wrappers) in place of the preprocessor makes the use of clangd much easier with AVR, and will make future support of LLVM for AVR easier
    - for `flash_printf()`, `flash_fprintf()`, and `flash_snprintf()` the `static inline` wrapper would have to be implemented by calling `vprintf_P()`, `vfprintf_P()` and `vsnprintf_P()` with added impedance matching. This impedance matching would add 400 B of `.text`, so instead the linker is used to create aliases
    - finally, a work around for Ubuntu's toolchain is added so that the linker aliases also work there

### Testing procedure

`printf()` on AVR (which is converted to `flash_printf()` on AVR to place string literals in the flash) should still work.

### Issues/PRs references

None