### PR TITLE
boards/nucleo-f070rb: add SPI configuration

### DIFF
--- a/boards/nucleo-f070rb/Kconfig
+++ b/boards/nucleo-f070rb/Kconfig
@@ -16,9 +16,11 @@ config BOARD_NUCLEO_F070RB
 
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 

--- a/boards/nucleo-f070rb/Makefile.features
+++ b/boards/nucleo-f070rb/Makefile.features
@@ -3,12 +3,14 @@ CPU_MODEL = stm32f070rb
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 # For RTC, Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the
 # required LSE oscillator provided on the X2 slot.
 # See Nucleo User Manual UM1724 section 5.6.2.
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -148,6 +148,10 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
+static const spi_conf_t spi_config[] = {{},};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -103,6 +103,21 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 1  },
+    { .stream = 2  },
+};
+
+#define DMA_SHARED_ISR_0            isr_dma1_ch2_3_dma2_ch1_2
+#define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+/** @} */
+
+/**
  * @name    PWM configuration
  * @{
  */
@@ -148,9 +163,41 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
-static const spi_conf_t spi_config[] = {{},};
+/**
+ * @name   SPI configuration
+ *
+ * To find appriopate device and pins find in the MCU datasheet table
+ * concerning "Alternate function AF0 to AF7" a texts similar to
+ * SPI[X]_MOSI/_MISO/_SCK where SPI[X] is SPI device.
+ *
+ * For nucleo-f070rb this information is in the datasheet, Tables 11, 12 and 13,
+ * page 30.
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_UNDEF,
+        .mosi_af  = GPIO_AF0,
+        .miso_af  = GPIO_AF0,
+        .sclk_af  = GPIO_AF0,
+        .cs_af    = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 1,
+        .tx_dma_chan = 0,
+        .rx_dma   = 0,
+        .rx_dma_chan = 0,
+#endif
+    }
+};
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/tests/drivers/cc110x/Makefile.ci
+++ b/tests/drivers/cc110x/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f070rb \
     nucleo-f072rb \
     nucleo-f302r8 \
     nucleo-f303k8 \


### PR DESCRIPTION
### Contribution description

This PR adds SPI configuration to nucleo-f070rb board.

### Testing procedure

Flash the board using `tests/periph/spi` . Check if SPI works.

### Issues/PRs references

Lack of this feature reported in Issue #20071 