### PR TITLE
cpu/sam0_common: adc_continuous: fix uninitialized access

### DIFF
--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -357,6 +357,8 @@ static void _get_adcs(bool *adc0, bool *adc1)
     *adc1 = false;
     return;
 #else
+    *adc0 = false;
+    *adc1 = false;
     for (unsigned i = 0; i < ADC_NUMOF; ++i) {
         if (adc_channels[i].dev == ADC0) {
             *adc0 = true;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This one slipped through. When only ADC1 is used, `adc0` remains uninitialized. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
