### PR TITLE
drivers/mtd: rename mtd_default_get_dev() -> mtd_dev_get()

### DIFF
--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -73,6 +73,7 @@
 #ifndef MTD_H
 #define MTD_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "xfa.h"
@@ -516,6 +517,19 @@ int mtd_erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t num);
  * @retval -EIO if I/O error occurred
  */
 int mtd_power(mtd_dev_t *mtd, enum mtd_power_state power);
+
+/**
+ * @brief   Get an MTD device by index
+ *
+ * @param[in] idx   Index of the MTD device
+ *
+ * @return  MTD_0 for @p idx 0 and so on
+ *          NULL if no MTD device exists for the given index
+ */
+static inline mtd_dev_t *mtd_dev_get(unsigned idx)
+{
+    return ((MTD_NUMOF != 0) && (idx < MTD_NUMOF)) ? mtd_dev_xfa[idx] : NULL;
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -69,6 +69,8 @@ extern mtd_emulated_t mtd_emulated_dev0;
 /**
  * @brief   Get the default MTD device by index
  *
+ * @deprecated  Use @ref mtd_dev_get instead
+ *
  * @param[in] idx   Index of the MTD device
  *
  * @return  MTD_0 for @p idx 0 and so on

--- a/sys/include/usb/usbus/msc.h
+++ b/sys/include/usb/usbus/msc.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include "usb/usbus.h"
 #include "usb/usbus/msc/scsi.h"
-#include "mtd_default.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -374,7 +374,7 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     /* Auto-configure all MTD devices */
     if (CONFIG_USBUS_MSC_AUTO_MTD) {
         for (unsigned i = 0; i < MTD_NUMOF; i++) {
-            usbus_msc_add_lun(usbus, mtd_default_get_dev(i));
+            usbus_msc_add_lun(usbus, mtd_dev_get(i));
         }
     }
 }

--- a/tests/drivers/mtd_raw/main.c
+++ b/tests/drivers/mtd_raw/main.c
@@ -25,7 +25,7 @@
 #include <string.h>
 
 #include "od.h"
-#include "mtd_default.h"
+#include "mtd.h"
 #include "shell.h"
 #include "board.h"
 #include "macros/units.h"
@@ -45,7 +45,7 @@ static mtd_dev_t *_get_dev(int argc, char **argv)
         return NULL;
     }
 
-    return mtd_default_get_dev(idx);
+    return mtd_dev_get(idx);
 }
 
 static uint64_t _get_size(mtd_dev_t *dev)
@@ -283,7 +283,7 @@ static int cmd_info(int argc, char **argv)
 
         for (unsigned i = 0; i < MTD_NUMOF; ++i) {
             printf(" -=[ MTD_%d ]=-\n", i);
-            _print_info(mtd_default_get_dev(i));
+            _print_info(mtd_dev_get(i));
         }
         return 0;
     }
@@ -453,7 +453,7 @@ int main(void)
     for (unsigned i = 0; i < MTD_NUMOF; ++i) {
         printf("init MTD_%d… ", i);
 
-        mtd_dev_t *dev = mtd_default_get_dev(i);
+        mtd_dev_t *dev = mtd_dev_get(i);
         int res = mtd_init(dev);
         if (res) {
             printf("error: %d\n", res);

--- a/tests/sys/usbus_msc/main.c
+++ b/tests/sys/usbus_msc/main.c
@@ -48,7 +48,7 @@ MTD_EMULATED_DEV(0, SECTOR_COUNT, PAGES_PER_SECTOR, PAGE_SIZE);
 
 #endif /* MODULE_MTD_EMULATED */
 
-#include "mtd_default.h"
+#include "mtd.h"
 #include "shell.h"
 #include "usb/usbus.h"
 #include "usb/usbus/msc.h"
@@ -76,7 +76,7 @@ static int _cmd_add_lun(int argc, char **argv)
         puts("error: invalid MTD device specified");
         return -2;
     }
-    mtd_dev = mtd_default_get_dev(dev);
+    mtd_dev = mtd_dev_get(dev);
     ret = usbus_msc_add_lun(usbus, mtd_dev);
     if (ret != 0) {
         printf("Cannot add LUN device (error:%d %s)\n", ret, strerror(-ret));
@@ -104,7 +104,7 @@ static int _cmd_remove_lun(int argc, char **argv)
         puts("error: invalid MTD device specified");
         return -2;
     }
-    mtd_dev = mtd_default_get_dev(dev);
+    mtd_dev = mtd_dev_get(dev);
     ret = usbus_msc_remove_lun(usbus, mtd_dev);
     if (ret == -EAGAIN) {
         printf("MTD device was not registered\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With the introduction of XFA based MTD registration, the canonical way to get an MTD is now via `mtd_default_get_dev()`.

This is a bit awkward as the `mtd_default.h` purely existed as a workaround for what is now provided by XFA.

Use a better name for the function to indicate that this is now really the only way to get e.g. the first MTD device. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

follow-up to #19465