### PR TITLE
ci: migrate to github merge queues [backport 2023.10]

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -2,6 +2,8 @@ name: check-commits
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  merge_group:
+
 jobs:
   check-commits:
     runs-on: ubuntu-latest
@@ -24,3 +26,10 @@ jobs:
     - name: Run checks
       run: |
         ./dist/tools/${{ matrix.check }}/check.sh "${{ github.base_ref }}"
+  check-commits-success:
+    needs: check-commits
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+    - name: check-commits succeeded
+      run: exit 0

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -4,8 +4,11 @@ on:
     types: [opened, reopened, labeled, unlabeled, synchronize]
   pull_request_review:
     types: [submitted, dismissed]
+  merge_group:
+
 jobs:
   check-labels:
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: RIOT-OS/check-labels-action@v1.1.1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,10 +3,12 @@ name: pr-labeler
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     steps:
     - uses: actions/labeler@main
       with:

--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -22,11 +22,18 @@ jobs:
     - uses: actions/checkout@main
       with:
         fetch-depth: 0
+    - name: set CI_BASE_BRANCH
+      run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+              echo "CI_BASE_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
+          elif [ -n "${{ github.event.merge_group.base_ref }}" ]; then
+              echo "CI_BASE_BRANCH=${{ github.event.merge_group.base_ref }}" | sed s.=refs/heads/.=. >> $GITHUB_ENV
+          fi
     - name: Setup git
       run: |
-        # Note: ${{ github.base_ref }} is empty when not in a PR
-        if [ -n "${{ github.base_ref }}" ]; then
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --no-tags
+        # Note: CI_BASE_BRANCH is empty when not in a PR
+        if [ -n "${CI_BASE_BRANCH}" ]; then
+          git fetch origin ${CI_BASE_BRANCH}:${CI_BASE_BRANCH} --no-tags
         else
           git config diff.renameLimit 16384
         fi
@@ -35,9 +42,9 @@ jobs:
       run: docker pull riot/static-test-tools:latest
     - name: Run static-tests
       run: |
-        # Note: ${{ github.base_ref }} is empty when not in a PR
+        # Note: ${CI_BASE_BRANCH} is empty when not in a PR
         docker run --rm                             \
-          -e CI_BASE_BRANCH=${{ github.base_ref }}  \
+          -e CI_BASE_BRANCH                         \
           -e GITHUB_RUN_ID=${GITHUB_RUN_ID}         \
           -v $(pwd):/data/riotbuild                 \
           riot/static-test-tools:latest             \

--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   static-tests:

--- a/.github/workflows/tools-buildtest.yml
+++ b/.github/workflows/tools-buildtest.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   tools-build:

--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -9,9 +9,11 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
 
 jobs:
   python-tests:
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main

--- a/.murdock
+++ b/.murdock
@@ -192,17 +192,6 @@ is_merge_queue_build() {
     startswith "gh-readonly-queue/" "${CI_BUILD_BRANCH}"
 }
 
-# Set CI_BASE_COMMIT in case of a merge queue build.
-# This assumes that merge queue always adds a single merge commit (possibly itself
-# including multiple merges for PRs) on the base branch.
-# That git command outputs the hash of the second merge commit (the one before
-# the topmost merge), which should be the base branch HEAD.
-# (CI_BASE_COMMIT is used by `can_fast_ci_run.py` to only build changes.)
-if test -z "${CI_BASE_COMMIT}" && is_merge_queue_build; then
-    previous_merge="$(git log --merges --max-count 1 --skip 1 --pretty=format:%H)"
-    export CI_BASE_COMMIT="${previous_merge}"
-fi
-
 # fullbuild logic
 # non-full-builds are those where can_fast_ci_run might reduce the build
 # automatically

--- a/.murdock
+++ b/.murdock
@@ -178,19 +178,27 @@ check_label() {
     return $?
 }
 
-# this function returns 0 when this is build is building one of the two bors
-# branches ("staging" or "trying", 1 otherwise.
-is_bors_build() {
-    test "${CI_BUILD_BRANCH}" = "staging" || test "${CI_BUILD_BRANCH}" = "trying"
+# true if "$2" starts with "$1", false otherwise
+startswith() {
+  case "${2}" in
+    ${1}*) true ;;
+    *) false ;;
+  esac
 }
 
-# Set CI_BASE_COMMIT in case of a bors build.
-# This assumes that bors always adds a single merge commit (possibly itself
+# this function returns 0 when this is build is building one of the two merge
+# queue branches ("staging" or "trying", 1 otherwise.
+is_merge_queue_build() {
+    startswith "gh-readonly-queue/" "${CI_BUILD_BRANCH}"
+}
+
+# Set CI_BASE_COMMIT in case of a merge queue build.
+# This assumes that merge queue always adds a single merge commit (possibly itself
 # including multiple merges for PRs) on the base branch.
 # That git command outputs the hash of the second merge commit (the one before
 # the topmost merge), which should be the base branch HEAD.
 # (CI_BASE_COMMIT is used by `can_fast_ci_run.py` to only build changes.)
-if test -z "${CI_BASE_COMMIT}" && is_bors_build ; then
+if test -z "${CI_BASE_COMMIT}" && is_merge_queue_build; then
     previous_merge="$(git log --merges --max-count 1 --skip 1 --pretty=format:%H)"
     export CI_BASE_COMMIT="${previous_merge}"
 fi
@@ -216,8 +224,8 @@ fi
 # configurations.
 if [ -z "${QUICK_BUILD}" ]; then
     export QUICK_BUILD=0
-    if is_bors_build ; then
-        # always do full build for bors' branches
+    if is_merge_queue_build; then
+        # always do full build for merge queue' branches
         true
     elif [ ${FULL_BUILD} -eq 1 ]; then
         # full build if building nightly or full build requested by label
@@ -321,14 +329,6 @@ fi
 error() {
     echo "$@"
     exit 1
-}
-
-# true if "$2" starts with "$1", false otherwise
-startswith() {
-  case "${2}" in
-    ${1}*) true ;;
-    *) false ;;
-  esac
 }
 
 # if MURDOCK_HOOK is set, this function will execute it and pass on all it's

--- a/.murdock
+++ b/.murdock
@@ -186,8 +186,7 @@ startswith() {
   esac
 }
 
-# this function returns 0 when this is build is building one of the two merge
-# queue branches ("staging" or "trying", 1 otherwise.
+# this function returns 0 when this build is building a merge queue branch.
 is_merge_queue_build() {
     startswith "gh-readonly-queue/" "${CI_BUILD_BRANCH}"
 }


### PR DESCRIPTION
# Backport of #20063

### Contribution description

These are changes required to switch merging from bors to Merge Queues.

### Testing procedure

Ideally required tests pass and we can enter it into a merge queue.

### Issues/PRs references

Tracking issue: #20051