### PR TITLE
ci: build github merge train branches with murdock [backport 2023.10]

### DIFF
--- a/.murdock.yml
+++ b/.murdock.yml
@@ -3,6 +3,8 @@ push:
     # these two enable potential bors support:
     - '^staging$'
     - '^trying$'
+    # github merge trains:
+    - '^gh-readonly-queue/'
 
 pr:
   enable_comments: true


### PR DESCRIPTION
# Backport of #20052

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds the [github merge train branch spec](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-third-party-ci-providers) to our Murdock config.

It's a prerequisite for murdock even looking at those branches.

Let's add it now, even if we don't need it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#20051 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
