### PR TITLE
boards/nucleo-f030r8: enable SPI and I2C

### DIFF
--- a/boards/nucleo-f030r8/Kconfig
+++ b/boards/nucleo-f030r8/Kconfig
@@ -16,8 +16,10 @@ config BOARD_NUCLEO_F030R8
 
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 

--- a/boards/nucleo-f030r8/Makefile.features
+++ b/boards/nucleo-f030r8/Makefile.features
@@ -3,11 +3,13 @@ CPU_MODEL = stm32f030r8
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 # For RTC, Nucleos with MB1136 C-02 or MB1136 C-03 -sticker on it have the
 # required LSE oscillator provided on the X2 slot.
 # See Nucleo User Manual UM1724 section 5.6.2.
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -33,6 +33,7 @@
 
 #include "periph_cpu.h"
 #include "clk_conf.h"
+#include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/drivers/atwinc15x0/Makefile.ci
+++ b/tests/drivers/atwinc15x0/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \
+    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \

--- a/tests/drivers/cc110x/Makefile.ci
+++ b/tests/drivers/cc110x/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     microduino-corerf \
     msb-430 \
     msb-430h \
+    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f070rb \

--- a/tests/drivers/nrf24l01p_ng/Makefile.ci
+++ b/tests/drivers/nrf24l01p_ng/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
+    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \
+    nucleo-f030r8 \
     nucleo-f302r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \


### PR DESCRIPTION
### Contribution description

This enables the SPI and I2C feature for the `nucleo-f030r8`. The SPI configuration was already provided, but the feature never exposed. The common PB8/PB9 I2C config is used to for I2C.

### Testing procedure

The two peripheral test apps or the peripheral selftesting shield can be used. I tested it with the selftesting shield.

### Issues/PRs references

None