### PR TITLE
tests/periph/selftest_shield: re-enable ADC test

### DIFF
--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -93,10 +93,9 @@
  * - periph_adc support (so that we have something to test)
  * - Arduino I/O mapping for ADC (so that we know which line to test)
  * - The PCF857x driver (so that we can control the R-2R resistor ladder
- *   connected to the GPIO expander.
+ *   connected to the GPIO expander).
  */
-#if defined(MODULE_PERIPH_ADC) && defined(ARDUINO_A0) && defined(MODULE_PCF857X) && 0
-// TODO: Re-anble when PCB is fixed
+#if defined(MODULE_PERIPH_ADC) && defined(ARDUINO_A0) && defined(MODULE_PCF857X)
 #  define ENABLE_ADC_TEST       1
 #else
 #  define ENABLE_ADC_TEST       0
@@ -979,9 +978,9 @@ static bool periph_adc_test(void)
         uint16_t sample = adc_sample(ARDUINO_A0, ADC_RES_10BIT);
         uint16_t expected = i << 6;
 
-        /* the resistors are said to be rather accurate, so lets be a bit
-         * more strict here */
-        const uint16_t delta = 16;
+        /* The resistors on board v0.3 are not that accurate, so allow for 10%
+         * error margin */
+        const uint16_t delta = 1024 / 10;
         uint16_t lower = expected <= delta ? 0 : expected - delta;
         uint16_t upper = MIN(1023, expected + delta);
         bool test_failed = TEST((lower <= sample) && (upper >= sample));

--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "arduino_iomap.h"
 #include "macros/units.h"
 #include "macros/utils.h"
@@ -40,9 +41,6 @@
 #include "stdio_uart.h" /* for STDIO_UART_DEV */
 
 /* BEGIN: controls of the behavior of the testing app: */
-#define ENABLE_DEBUG            1
-#include "debug.h"
-
 #ifndef STOP_ON_FAILURE
 #define STOP_ON_FAILURE         0
 #endif
@@ -715,8 +713,8 @@ static bool periph_uart_rxtx_test(uint32_t symbolrate)
         /* expecting actual duration within 75% to 200% of the expected. */
         failed |= TEST(stop - start > duration_ticks - (duration_ticks >> 2));
         failed |= TEST(stop - start < (duration_ticks << 1));
-        if (failed) {
-            DEBUG("%" PRIu32 " Bd, expected %" PRIu16 " ticks, got %" PRIu16
+        if (failed && DETAILED_OUTPUT) {
+            printf("%" PRIu32 " Bd, expected %" PRIu16 " ticks, got %" PRIu16
                   " ticks\n",
                   symbolrate, duration_ticks, (uint16_t)(stop - start));
         }


### PR DESCRIPTION
### Contribution description

The R-2R resistor ladder dac --> ADC test was disabled due to a bug in the v0.1 version of the shield. Since this has been fixed in v0.2 and v0.3 of the shield, it can be re-enabled.

The comment regarding the high accuracy of the resistor is dropped, as v0.3 has been ordered with cost efficient resistors rather than with accurate ones. As a result, the tolerance for error has been increased to 10%. This quite a bit more lax than I have hoped for, but false positives would be something to avoid.

A second commit drops the abuse of `DEBUG()` for more detailed error messages. Instead, now `make DETAILED_OUTPUT=1 flash test-with-config` will be sufficient now to get detailed output.

### Testing procedure

Running the test on a board with the features `periph_adc`, `periph_i2c`, `arduino_analog`, `arduino_i2c`, and `arduino_shield_uno` (e.g. most of the Nucleo-64 boards) should now include the ADC test.

### Issues/PRs references

None