### PR TITLE
boards/nucleo-wl55jc: Fix Arduino SPI bus

### DIFF
--- a/boards/nucleo-wl55jc/include/periph_conf.h
+++ b/boards/nucleo-wl55jc/include/periph_conf.h
@@ -117,7 +117,12 @@ static const spi_conf_t spi_config[] = {
 #endif
 };
 
-#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+#define SPI_NUMOF               ARRAY_SIZE(spi_config)
+/**
+ * @brief   Provide ARDUINO_SPI_D11D12D13 explicitly, as the first SPI
+ *          interface is connected to the radio.
+ */
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(1)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

The macro `ARDUINO_SPI_D11D12D13` is used to refer to the SPI bus on the pins D11/D12/D13 on Arduino UNO compatible boards. For all Nucleo64 boards this is `SPI_DEV(0)`, but for this board `SPI_DEV(0)` is internally connected to the radio. Instead `SPI_DEV(1)` is connected to the correct pins. This provides the macro explicitly in `periph_conf.h`, which takes preference over the fallback in `boards/common/nucleo64` when provided.

### Testing procedure

Check the lines above the macro in `periph_conf.h` and confirm that the GPIO pins match the Arduino pin names.

Or run the peripheral self test using the shield. With this, it hopefully passes.

### Issues/PRs references

None