### PR TITLE
boards/p-nucleo-wb55: provide Arduino features

### DIFF
--- a/boards/common/nucleo64/include/arduino_iomap.h
+++ b/boards/common/nucleo64/include/arduino_iomap.h
@@ -41,10 +41,13 @@ extern "C" {
  * @name    Arduino's SPI buses
  * @{
  */
-/**
- * @brief   SPI_DEV(1) is connected to D11/D12/D13
- */
 #if !defined(ARDUINO_SPI_D11D12D13) && defined(SPI_NUMOF)
+/**
+ * @brief   SPI_DEV(0) is connected to D11/D12/D13 for most Nucleo-64 boards
+ *
+ * This can be overwritten in `boards/nucleo-<foobar>/include/periph_conf.h` by
+ * providing a custom `ARDUINO_SPI_D11D12D13`.
+ */
 #define ARDUINO_SPI_D11D12D13   SPI_DEV(0)
 #endif
 /** @} */

--- a/boards/p-nucleo-wb55/Kconfig
+++ b/boards/p-nucleo-wb55/Kconfig
@@ -26,8 +26,11 @@ config BOARD_P_NUCLEO_WB55
 
     # Put other features for this board (in alphabetical order)
     select HAS_ARDUINO_ANALOG
+    select HAS_ARDUINO_I2C
     select HAS_ARDUINO_PINS
     select HAS_ARDUINO_SHIELD_UNO
+    select HAS_ARDUINO_SPI
+    select HAS_ARDUINO_UART
     select HAS_RIOTBOOT
     select HAS_TINYUSB_DEVICE
 

--- a/boards/p-nucleo-wb55/Makefile.features
+++ b/boards/p-nucleo-wb55/Makefile.features
@@ -14,7 +14,10 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
 FEATURES_PROVIDED += arduino_pins
 FEATURES_PROVIDED += arduino_shield_uno
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/p-nucleo-wb55/include/arduino_iomap.h
+++ b/boards/p-nucleo-wb55/include/arduino_iomap.h
@@ -88,6 +88,33 @@ extern "C" {
 #define ARDUINO_ANALOG_PIN_LAST 5
 /** @} */
 
+/**
+ * @name    Arduino's default UART device
+ * @{
+ */
+#define ARDUINO_UART_D0D1        UART_DEV(1)
+/** @} */
+
+/**
+ * @name    Arduino's I2C buses
+ * @{
+ */
+/**
+ * @brief   The only configured I2C
+ */
+#define ARDUINO_I2C_UNO         I2C_DEV(0)
+/** @} */
+
+/**
+ * @name    Arduino's SPI buses
+ * @{
+ */
+/**
+ * @brief   SPI_DEV(0) is connected to D11/D12/D13
+ */
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(0)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

This provides the features:
- `arduino_i2c`
- `arduino_spi`
- `arduino_uart`

A second commit is sneaked in that fixes doc.

### Testing procedure

The selftest shield app should now run more tests. But also code review should be sufficient.

### Issues/PRs references

None