### PR TITLE
drivers/at24cxxx: add defines for AT24CS04 & AT24CS08

### DIFF
--- a/drivers/at24cxxx/include/at24cxxx_defines.h
+++ b/drivers/at24cxxx/include/at24cxxx_defines.h
@@ -276,6 +276,52 @@ extern "C" {
 /** @} */
 
 /**
+ * @name AT24CS04 constants
+ * @{
+ */
+/**
+ * @brief 512 Byte memory
+ */
+#define AT24CS04_EEPROM_SIZE            (512U)
+/**
+ * @brief   32 pages of 16 bytes each
+ */
+#define AT24CS04_PAGE_SIZE              (16U)
+/**
+ * @brief   Delay to complete write operation
+ */
+#define AT24CS04_PAGE_WRITE_DELAY_US    (5000U)
+/**
+ * @brief   Number of poll attempts
+ */
+#define AT24CS04_MAX_POLLS              (1 + (AT24CS04_PAGE_WRITE_DELAY_US \
+                                         / AT24CXXX_POLL_DELAY_US))
+/** @} */
+
+/**
+ * @name AT24CS08 constants
+ * @{
+ */
+/**
+ * @brief 1 kiB memory
+ */
+#define AT24CS08_EEPROM_SIZE            (1024U)
+/**
+ * @brief   64 pages of 16 bytes each
+ */
+#define AT24CS08_PAGE_SIZE              (16U)
+/**
+ * @brief   Delay to complete write operation
+ */
+#define AT24CS08_PAGE_WRITE_DELAY_US    (5000U)
+/**
+ * @brief   Number of poll attempts
+ */
+#define AT24CS08_MAX_POLLS              (1 + (AT24CS08_PAGE_WRITE_DELAY_US \
+                                         / AT24CXXX_POLL_DELAY_US))
+/** @} */
+
+/**
  * @name AT24C1024 constants
  * @{
  */
@@ -369,6 +415,14 @@ extern "C" {
 #define AT24CXXX_EEPROM_SIZE            (AT24C01A_EEPROM_SIZE)
 #define AT24CXXX_PAGE_SIZE              (AT24C01A_PAGE_SIZE)
 #define AT24CXXX_MAX_POLLS              (AT24C01A_MAX_POLLS)
+#elif IS_USED(MODULE_AT24CS04)
+#define AT24CXXX_EEPROM_SIZE            (AT24CS04_EEPROM_SIZE)
+#define AT24CXXX_PAGE_SIZE              (AT24CS04_PAGE_SIZE)
+#define AT24CXXX_MAX_POLLS              (AT24CS04_MAX_POLLS)
+#elif IS_USED(MODULE_AT24CS08)
+#define AT24CXXX_EEPROM_SIZE            (AT24CS08_EEPROM_SIZE)
+#define AT24CXXX_PAGE_SIZE              (AT24CS08_PAGE_SIZE)
+#define AT24CXXX_MAX_POLLS              (AT24CS08_MAX_POLLS)
 #elif IS_USED(MODULE_AT24MAC)
 #define AT24CXXX_EEPROM_SIZE            (AT24MAC_EEPROM_SIZE)
 #define AT24CXXX_PAGE_SIZE              (AT24MAC_PAGE_SIZE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Those are 512 Byte / 1024 Byte EEPROMS, [Datasheet](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/20006350A.pdf)


### Testing procedure

`tests/drivers/mtd_raw` on a board with `at24cs08` passes the self-test

```
2023-11-16 14:24:48,310 - INFO # Manual MTD test
2023-11-16 14:24:48,324 - INFO # init MTD_0… OK (1 kiB)

2023-11-16 14:27:12,239 - INFO # > test 0
2023-11-16 14:27:12,239 - INFO # 
2023-11-16 14:27:12,239 - INFO # [START]
2023-11-16 14:27:12,286 - INFO # [SUCCESS]

2023-11-16 14:30:31,510 - INFO # > info
2023-11-16 14:30:31,511 - INFO # 
2023-11-16 14:30:31,511 - INFO # mtd devices: 1
2023-11-16 14:30:31,511 - INFO #  -=[ MTD_0 ]=-
2023-11-16 14:30:31,511 - INFO # sectors: 64
2023-11-16 14:30:31,512 - INFO # pages per sector: 1
2023-11-16 14:30:31,526 - INFO # page size: 16
2023-11-16 14:30:31,527 - INFO # total: 1 kiB
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
