### PR TITLE
tests/periph/selftest_shield: timer allocation conflict

### DIFF
--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -126,7 +126,17 @@
 #  define UART_TEST_DEV UART_DEV(0)
 #endif
 #ifndef TIMER
-#  define TIMER         TIMER_DEV(0)
+#  if IS_USED(MODULE_ZTIMER_PERIPH_TIMER) && CONFIG_ZTIMER_USEC_DEV == TIMER_DEV(0)
+#    define TIMER         TIMER_DEV(1)
+#  else
+#    define TIMER         TIMER_DEV(0)
+#  endif
+#endif
+
+#if IS_USED(MODULE_ZTIMER_PERIPH_TIMER)
+#  if CONFIG_ZTIMER_USEC_DEV == TIMER
+#    error "Same timer used for ztimer and test"
+#  endif
 #endif
 
 /* A higher clock frequency is beneficial in being able to actually measure the


### PR DESCRIPTION
### Contribution description

- Detect when the same timer is used by `ztimer` (pulled in as dependency for a peripheral driver, e.g. `periph_adc` on STM32F3) and the test application
- Try to provide a better default (e.g. `TIMER_DEV(1)` when `ztimer_periph_timer` is in use, `TIMER_DEV(0)` otherwise)

### Testing procedure

- Run the app on the `nucleo-f303re` in `master`: A hard fault is triggered during `adc_init()` due to a conflict in the use of the same `periph_timer` peripheral by the app and ztimer
- In this branch, the test will no longer hard fault, but rather fail to do `timer_init()` failing (because the board only has a single timer peripheral exposed)

### Issues/PRs references

None