### PR TITLE
boards/nucleo-f303re: add more timers

### DIFF
--- a/boards/common/stm32/include/cfg_timer_tim2_tim15_tim16.h
+++ b/boards/common/stm32/include/cfg_timer_tim2_tim15_tim16.h
@@ -36,7 +36,11 @@ static const timer_conf_t timer_config[] = {
     {
         .dev            = TIM2,
         .max            = 0xffffffff,
+#if defined(RCC_APB1ENR_TIM2EN)
+        .rcc_mask       = RCC_APB1ENR_TIM2EN,
+#else
         .rcc_mask       = RCC_APB1ENR1_TIM2EN,
+#endif
         .bus            = APB1,
         .irqn           = TIM2_IRQn
     },

--- a/boards/nucleo-f303re/include/periph_conf.h
+++ b/boards/nucleo-f303re/include/periph_conf.h
@@ -33,7 +33,7 @@
 
 #include "periph_cpu.h"
 #include "clk_conf.h"
-#include "cfg_timer_tim2.h"
+#include "cfg_timer_tim2_tim15_tim16.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

As trivial as the title says. The common timer config was tweaked a bit as the `.rcc_mask` was named a bit different on STM32F3.

### Testing procedure

<details><summary><code>$ make BOARD=nucleo-f303re flash test -j -C tests/periph/timer</code></summary>

```
Building application "tests_timer" for "nucleo-f303re" with MCU "stm32".

"make" -C /home/maribu/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/nucleo-f303re
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/nucleo
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32/stmclk
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32/vectors
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  11684	   124	  2808	 14616	  3918	/home/maribu/Repos/software/RIOT/master/tests/periph/timer/bin/nucleo-f303re/tests_timer.elf
/home/maribu/Repos/software/RIOT/master/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/master/tests/periph/timer/bin/nucleo-f303re/tests_timer.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-snapshot (2023-06-12-09:31)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
DEPRECATED! use 'adapter serial' not 'hla_serial'
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : clock speed 1000 kHz
Info : STLINK V2J40M27 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.264694
Info : [stm32f3x.cpu] Cortex-M4 r0p1 processor detected
Info : [stm32f3x.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f3x.cpu on 0
Info : Listening on port 33501 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f3x.cpu       hla_target little stm32f3x.cpu       unknown
Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
[stm32f3x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080017b0 msp: 0x20000200
Info : device id = 0x10036446
Info : flash size = 512 KiB
Warn : Adding extra erase range, 0x08002e20 .. 0x08002fff
auto erase enabled
wrote 11808 bytes from file /home/maribu/Repos/software/RIOT/master/tests/periph/timer/bin/nucleo-f303re/tests_timer.elf in 0.732160s (15.750 KiB/s)
verified 11808 bytes in 0.261911s (44.027 KiB/s)
Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
shutdown command invoked
Done flashing
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2023.10-devel-553-g3848a3-boards/nucleo-f303re)

Test for peripheral TIMERs

Available timers: 3

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: set channel 1 to 10000
TIMER_0: set channel 2 to 15000
TIMER_0: set channel 3 to 20000
TIMER_0: starting
TIMER_0: channel 0 fired at SW count    16362 - init:    16362
TIMER_0: channel 1 fired at SW count    32718 - diff:    16356
TIMER_0: channel 2 fired at SW count    49072 - diff:    16354
TIMER_0: channel 3 fired at SW count    65425 - diff:    16353

Testing TIMER_1:
TIMER_1: initialization successful
TIMER_1: stopped
TIMER_1: set channel 0 to 5000
TIMER_1: set channel 1 to 10000
TIMER_1: starting
TIMER_1: channel 0 fired at SW count    16362 - init:    16362
TIMER_1: channel 1 fired at SW count    32718 - diff:    16356

Testing TIMER_2:
TIMER_2: initialization successful
TIMER_2: stopped
TIMER_2: set channel 0 to 5000
TIMER_2: starting
TIMER_2: channel 0 fired at SW count    16362 - init:    16362

TEST SUCCEEDED
```

</details>

### Issues/PRs references

Needed to pass `tests/periph/selftest_shield` as one timer is used by `ztimer` via `periph_adc`, and another for the test itself.