### PR TITLE
boards/nucleo-l433rc: doc update - image and MCU table

### DIFF
--- a/boards/nucleo-l433rc/doc.txt
+++ b/boards/nucleo-l433rc/doc.txt
@@ -8,6 +8,33 @@
 The Nucleo-L433RC is a board from ST's Nucleo family supporting a ARM
 Cortex-M4 STM32L433RC microcontroller with 64KiB of RAM and 256KiB of Flash.
 
+### Hardware
+
+![Nucleo64 L433RC](https://www.st.com/bin/ecommerce/api/image.PF264788.en.feature-description-include-personalized-no-cpn-large.jpg)
+
+### MCU
+
+| MCU        |   STM32L476RG       |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M4       |
+| Vendor     | ST Microelectronics |
+| RAM        | 64KiB               |
+| Flash      | 256KiB              |
+| Frequency  | up to 80MHz         |
+| FPU        | yes                 |
+| Timers     | 11 (2x watchdog, 1 SysTick, 7x 16-bit, 1x 32-bit) |
+| ADCs       | 1x 12-bit           |
+| UARTs      | 5 (four USARTs and one Low-Power UART) |
+| SPIs       | 3                   |
+| I2Cs       | 3                   |
+| RTC        | 1                   |
+| CAN        | 1                   |
+| Vcc        | 1.71 V - 3.6V       |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l433rc.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0394-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](http://www.st.com/content/ccc/resource/technical/document/programming_manual/6c/3a/cb/e7/e4/ea/44/9b/DM00046982.pdf/files/DM00046982.pdf/jcr:content/translations/en.DM00046982.pdf) |
+| Board Manual   | [Board Manual](http://www.st.com/resource/en/user_manual/um2206-stm32-nucleo64p-boards-mb1319-stmicroelectronics.pdf) |
+
 ### Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.


### PR DESCRIPTION
### Contribution description

This PR adds to the `nucleo-l433rc` board documentation page:
- image, 
- MCU table with links to datasheets.

The issue was detected during working on PR #20071. 

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l433rc.html 
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Lacks in documentation detected during works on PR #20071