### PR TITLE
boards: remove `extern mtd_dev_t *mtd<n>` declarations from board definitions

### DIFF
--- a/boards/adafruit-grand-central-m4-express/include/board.h
+++ b/boards/adafruit-grand-central-m4-express/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,12 +65,10 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;     /**< Flash MTD device pointer */
-#define MTD_0 mtd0          /**< Flash MTD device */
-extern mtd_dev_t *mtd1;     /**< MTD device pointer for SD Card */
-#define MTD_1 mtd1          /**< MTD device for SD Card */
+#define MTD_0 mtd_dev_get(0)    /**< MTD device for the 8 MByte QSPI Flash */
+#define MTD_1 mtd_dev_get(1)    /**< MTD device for the SD Card */
 
-#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1   /**< mtd1 is used for SD Card */
+#define CONFIG_SDCARD_GENERIC_MTD_OFFSET    1   /**< MTD_1 is used for SD Card */
 /** @} */
 
 /**

--- a/boards/adafruit-itsybitsy-m4/include/board.h
+++ b/boards/adafruit-itsybitsy-m4/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,8 +52,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 /**

--- a/boards/adafruit-pybadge/include/board.h
+++ b/boards/adafruit-pybadge/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus
@@ -101,8 +100,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;                                         /**< pointer to mtd0 */
-#define MTD_0 mtd0                                              /**< mtd0 constant */
+#define MTD_0 mtd_dev_get(0)                                    /**< MTD_0 constant */
 /** @} */
 
 /**

--- a/boards/common/esp32x/include/board_common.h
+++ b/boards/common/esp32x/include/board_common.h
@@ -34,10 +34,6 @@
 #include "periph/gpio.h"
 #include "sdkconfig.h"
 
-#if MODULE_MTD
-#include "mtd.h"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -103,14 +99,10 @@ extern "C" {
 #define SPI_FLASH_DRIVE_START  0
 #endif
 
-#define MTD_0 mtd0          /**< Flash MTD device */
-extern mtd_dev_t *mtd0;     /**< Flash MTD device pointer */
+#define MTD_0 mtd_dev_get(0)          /**< MTD device for the internal Flash */
 
 #if MODULE_MTD_SDCARD_DEFAULT || DOXYGEN
-
-#define MTD_1 mtd1          /**< SD Card MTD device */
-extern mtd_dev_t *mtd1;     /**< SD Card MTD device pointer */
-
+#define MTD_1 mtd_dev_get(1)          /**< MTD device for the SD Card */
 #endif /* MODULE_MTD_SDCARD_DEFAULT || DOXYGEN */
 
 /**

--- a/boards/common/esp8266/include/board_common.h
+++ b/boards/common/esp8266/include/board_common.h
@@ -87,13 +87,9 @@ extern "C" {
  * a system MTD device has to be defined.
  * @{
  */
-#include "mtd.h"
 
 /** Default MTD device definition */
-#define MTD_0 mtd0
-
-/** Pointer to the default MTD device structure */
-extern mtd_dev_t *mtd0;
+#define MTD_0 mtd_dev_get(0)
 
 /**
  * @brief   MTD offset for SD Card interfaces

--- a/boards/common/weact-f4x1cx/include/board.h
+++ b/boards/common/weact-f4x1cx/include/board.h
@@ -25,7 +25,6 @@
 extern "C" {
 #endif
 
-#include "mtd.h"
 #include "periph_cpu.h"
 
 /**
@@ -73,8 +72,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -25,8 +25,6 @@
 #include "periph/gpio.h"
 #include "periph/spi.h"
 
-#include "mtd.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -100,8 +98,7 @@ extern "C" {
  * @name    MTD configuration
  */
 /** @{ */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -27,7 +27,6 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "board_common.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,8 +69,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;     /**< SPI NOR Flash device */
-#define MTD_0     mtd0      /**< Indicate presence of MTD device */
+#define MTD_0     mtd_dev_get(0)      /**< SPI NOR Flash device */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "lpc23xx.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,8 +109,7 @@ extern "C" {
  * @{
  */
 #ifdef MODULE_MTD_MCI
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 #endif
 /** @} */
 

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "lpc23xx.h"
-#include "mtd.h"
 #include "bitarithm.h"
 
 #ifdef __cplusplus
@@ -51,8 +50,7 @@ extern "C" {
  * @{
  */
 #ifdef MODULE_MTD_MCI
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 #endif
 /** @} */
 

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -22,7 +22,6 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "mulle-nvram.h"
-#include "mtd.h"
 
 /* Use the on board RTC 32kHz clock for LPTMR clocking. */
 #undef LPTIMER_CLKSRC
@@ -150,8 +149,7 @@ extern "C" {
  * @name MTD configuration
  */
 /** @{ */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 /**

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -31,10 +31,6 @@
 extern "C" {
 #endif
 
-#ifdef MODULE_MTD
-#include "mtd_native.h"
-#endif
-
 /**
  * @name    LED handlers
  * @{
@@ -90,11 +86,8 @@ void _native_LED_RED_TOGGLE(void);
 #endif
 /** @} */
 
-/** Default MTD device */
-#define MTD_0 mtd0
-
-/** mtd flash emulation device */
-extern mtd_dev_t *mtd0;
+/** Default MTD device (mtd flash emulation device) */
+#define MTD_0 mtd_dev_get(0)
 #endif
 
 /**

--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -21,7 +21,6 @@
 #define BOARD_H
 
 #include "board_common.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,10 +76,7 @@ extern "C" {
 /** @} */
 
 /** Default MTD device */
-#define MTD_0 mtd0
-
-/** mtd flash emulation device */
-extern mtd_dev_t *mtd0;
+#define MTD_0 mtd_dev_get(0)
 
 /**
  * @name    Button pin configuration

--- a/boards/nrf5340dk-app/include/board.h
+++ b/boards/nrf5340dk-app/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,8 +99,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0       mtd0
+#define MTD_0       mtd_dev_get(0)
 
 #define BOARD_QSPI_PIN_CS       GPIO_PIN(0, 18)     /**< SPI Flash Chip Select */
 #define BOARD_QSPI_PIN_WP       GPIO_PIN(0, 15)     /**< SPI Flash Write Protect */

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -23,7 +23,6 @@
 
 #include "cpu.h"
 #include "board_common.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,8 +96,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 /**

--- a/boards/qn9080dk/include/board.h
+++ b/boards/qn9080dk/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
@@ -63,8 +62,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -23,7 +23,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 #include "board_common.h"
 
 #ifdef __cplusplus
@@ -124,10 +123,7 @@
 /** @} */
 
 /** Default MTD device */
-#define MTD_0 mtd0
-
-/** mtd flash emulation device */
-extern mtd_dev_t *mtd0;
+#define MTD_0 mtd_dev_get(0)
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -21,7 +21,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,12 +70,11 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0, *mtd1, *mtd2;
-#define MTD_0       mtd0
-#define MTD_1       mtd1
-#define MTD_2       mtd2
+#define MTD_0   mtd_dev_get(0)  /**< MTD device for the QSPI Flash */
+#define MTD_1   mtd_dev_get(1)  /**< MTD device for the AT24MAC402 serial EEPROM */
+#define MTD_2   mtd_dev_get(2)  /**< MTD device for the SD/MMC Card */
 
-#define CONFIG_SDMMC_GENERIC_MTD_OFFSET     2   /**< mtd2 is used for SD Card */
+#define CONFIG_SDMMC_GENERIC_MTD_OFFSET     2   /**< MTD_2 is used for the SD Card */
 /** @} */
 
 /**

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -21,7 +21,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,8 +79,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;             /**< First memory type device */
-#define MTD_0 mtd0                  /**< First memory type device */
+#define MTD_0 mtd_dev_get(0)                  /**< First memory type device */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/seeedstudio-gd32/include/board.h
+++ b/boards/seeedstudio-gd32/include/board.h
@@ -22,7 +22,6 @@
 #define BOARD_H
 
 #include "board_common.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,8 +71,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-#define MTD_0 mtd0          /**< MTD device for SD Card */
-extern mtd_dev_t *mtd0;     /**< MTD device pointer for SD Card */
+#define MTD_0 mtd_dev_get(0)          /**< MTD device for the SD Card */
 /** @} */
 
 /**

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -25,7 +25,6 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -164,11 +163,10 @@ extern "C" {
 
 #if defined(MODULE_MTD_SDCARD) || defined(DOXYGEN)
 /**
- * @brief MTD device 0 (SD Card) definition. mtd0 is defined in board.c
+ * @brief MTD device 0 (SD Card) definition. mtd_dev_get(0) is defined in board.c
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 #endif /* MODULE_MTD_SDCARD || DOXYGEN */
 

--- a/boards/serpente/include/board.h
+++ b/boards/serpente/include/board.h
@@ -23,7 +23,6 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,8 +77,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+#define MTD_0 mtd_dev_get(0)
 /** @} */
 
 /**

--- a/boards/sipeed-longan-nano/include/board.h
+++ b/boards/sipeed-longan-nano/include/board.h
@@ -21,7 +21,6 @@
 #define BOARD_H
 
 #include "board_common.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,8 +66,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-#define MTD_0 mtd0          /**< MTD device for SD Card */
-extern mtd_dev_t *mtd0;     /**< MTD device pointer for SD Card */
+#define MTD_0 mtd_dev_get(0)          /**< MTD device for the SD Card */
 /** @} */
 
 /**

--- a/boards/teensy31/include/board.h
+++ b/boards/teensy31/include/board.h
@@ -21,7 +21,6 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -21,7 +21,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "mtd.h"
 #include "waspmote_pinmap.h"
 
 #ifdef __cplusplus
@@ -197,10 +196,7 @@ extern "C" {
 /** @} */
 
 /** Default MTD device */
-#define MTD_0 mtd0
-
-/** mtd flash emulation device */
-extern mtd_dev_t *mtd0;
+#define MTD_0 mtd_dev_get(0)
 
 #ifdef __cplusplus
 }

--- a/boards/waveshare-nrf52840-eval-kit/include/board.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/board.h
@@ -20,7 +20,6 @@
 #define BOARD_H
 
 #include "board_common.h"
-#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -87,8 +86,7 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-#define MTD_0 mtd0          /**< MTD device for SD Card */
-extern mtd_dev_t *mtd0;     /**< MTD device pointer for SD Card */
+#define MTD_0 mtd_dev_get(0)          /**< MTD device for the SD Card */
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -534,7 +534,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
                 break;
 #ifdef MODULE_MTD_NATIVE
             case 'm':
-                ((mtd_native_dev_t *)mtd0)->fname = strndup(optarg, PATH_MAX - 1);
+                ((mtd_native_dev_t *)mtd_dev_get(0))->fname = strndup(optarg, PATH_MAX - 1);
                 break;
 #endif
 #if defined(MODULE_PERIPH_CAN)

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -529,7 +529,10 @@ int mtd_power(mtd_dev_t *mtd, enum mtd_power_state power);
  */
 static inline mtd_dev_t *mtd_dev_get(unsigned idx)
 {
-    return ((MTD_NUMOF != 0) && (idx < MTD_NUMOF)) ? mtd_dev_xfa[idx] : NULL;
+    assert(MTD_NUMOF != 0);
+    assert(idx < MTD_NUMOF);
+
+    return mtd_dev_xfa[idx];
 }
 
 #ifdef __cplusplus

--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -33,31 +33,6 @@ extern "C" {
 #include "mtd_emulated.h"
 #endif
 
-#if !DOXYGEN
-
-/**
- * @brief   Declare `mtd*` according to the `MTD_*` symbols defined by the board
- */
-#ifdef MTD_0
-extern mtd_dev_t *MTD_0;
-#endif
-#ifdef MTD_1
-extern mtd_dev_t *MTD_1;
-#endif
-#ifdef MTD_2
-extern mtd_dev_t *MTD_2;
-#endif
-#ifdef MTD_3
-extern mtd_dev_t *MTD_3;
-#endif
-#ifdef MTD_4
-extern mtd_dev_t *MTD_4;
-#endif
-#ifdef MTD_5
-extern mtd_dev_t *MTD_5;
-#endif
-#endif /* !DOXYGEN */
-
 #if defined(MODULE_MTD_SDCARD_DEFAULT)
 extern mtd_sdcard_t mtd_sdcard_dev0;
 #endif

--- a/tests/pkg/fatfs/main.c
+++ b/tests/pkg/fatfs/main.c
@@ -52,7 +52,6 @@ FATFS fat_fs; /* FatFs work area needed for each volume */
 
 #ifdef MODULE_MTD_NATIVE
 /* mtd device for native is provided in boards/native/board_init.c */
-extern mtd_dev_t *mtd0;
 mtd_dev_t *fatfs_mtd_devs[1];
 #elif MODULE_MTD_SDCARD
 #include "mtd_sdcard.h"
@@ -400,7 +399,7 @@ int main(void)
     #endif
 
     #if MODULE_MTD_NATIVE
-    fatfs_mtd_devs[0] = mtd0;
+    fatfs_mtd_devs[0] = mtd_dev_get(0);
     #elif MODULE_MTD_SDCARD
     for (unsigned int i = 0; i < SDCARD_SPI_NUM; i++){
         mtd_sdcard_devs[i].base.driver = &mtd_sdcard_driver;

--- a/tests/pkg/fatfs_vfs/main.c
+++ b/tests/pkg/fatfs_vfs/main.c
@@ -64,7 +64,6 @@ static vfs_mount_t _test_vfs_mount = {
 
 #if defined(MODULE_MTD_NATIVE) || defined(MODULE_MTD_MCI)
 /* mtd devices are provided in the board's board_init.c*/
-extern mtd_dev_t *mtd0;
 #endif
 
 #if defined(MODULE_MTD_SDCARD)
@@ -409,7 +408,7 @@ int main(void)
 #endif
 
 #if defined(MODULE_MTD_NATIVE) || defined(MODULE_MTD_MCI)
-    fatfs.dev = mtd0;
+    fatfs.dev = mtd_dev_get(0);
 #endif
 
 #if defined(MODULE_MTD_SDCARD)

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -16,8 +16,8 @@
 
 #include "embUnit.h"
 
-#include "mtd.h"
 #include "board.h"
+#include "mtd.h"
 
 #if MODULE_VFS
 #include <fcntl.h>


### PR DESCRIPTION
### Contribution description

The PR removes the `extern mld_dev_t *mtd<n>` declarations from board definitions.

For that purpose, the `extern mtd_dev_t *mtd<n>` declarations that use the `MTD_<n>` definitions of the board are moved from `mtd_default.h` to `mtd.h` to declare them even if the `mtd_default` module is not used. 

### Testing procedure

Green CI.

### Issues/PRs references

Prerequisite for PR #19786
Prerequisite for PR #19540