### PR TITLE
cpu/nrf51: fix periph_i2c driver

### DIFF
--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -103,7 +103,7 @@ static int write(i2c_t dev, uint16_t addr, const void *data, int len,
         }
     }
 
-    return len;
+    return 0;
 }
 
 void i2c_init(i2c_t dev)
@@ -198,7 +198,7 @@ int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,
     while (i2c(dev)->EVENTS_STOPPED == 0) {}
     NRF_PPI->CHENCLR = (1 << i2c_config[dev].ppi);
 
-    return length;
+    return 0;
 }
 
 int i2c_read_regs(i2c_t dev, uint16_t address, uint16_t reg,


### PR DESCRIPTION
### Contribution description

The `i2c_read_bytes()` and `i2c_write_bytes()` function return the number of bytes written / read, instead of `0` as the API contract says. This fixes the issue.

### Testing procedure

Combined with https://github.com/RIOT-OS/RIOT/pull/20106 the peripheral selftest app should now get past the `pcf857x` driver initialization. It still fails (hangs) during the SPI test, but at least the I2C part now works.

### Issues/PRs references

None