### PR TITLE
makefile: Don't $(info) when the output can break info-boards-supported

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -117,7 +117,6 @@ ifneq ($(RIOT_CI_BUILD),1)
   ifeq ($(MAKELEVEL),0)
     ifneq (,$(BOARDSDIR))
       $(warning Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead)
-      $(info EXTERNAL_BOARD_DIRS can contain multiple folders separated by space)
     endif
   endif
 endif


### PR DESCRIPTION
### Contribution description

This changes a Makefile info into a warning because the latter goes to stderr, whereas the former broke the output of `make info-boards-supported`

### Testing procedure

* Go to tests/build_system/external_board_native
* `BOARDS=samr21-xpro make info-boards-supported | wc`

Before this patch, this shows `2       8      69` (which is the info message "Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead"). After,  it shows `1 0 1`, which is the same as an empty output. (It may show more things through stderr now than before).

### Issues/PRs references

This helps riot-wrappers' CI work without workarounds, as tracked in (or experimented with in) https://github.com/RIOT-OS/rust-riot-wrappers/pull/68