### PR TITLE
drivers/mtd: fix the order of entries in the MTD pointer XFA `mtd_dev_xfa`

### DIFF
--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -162,7 +162,8 @@ mtd_dev_t * const mtd_dev_xfa[];
  * @param   dev     MTD device
  * @param   idx     Priority of the MTD device pointer within the XFA
  */
-#define MTD_XFA_ADD(dev, idx) XFA_CONST(mtd_dev_xfa, 0) mtd_dev_t *mtd ## idx = (mtd_dev_t *)&(dev)
+#define MTD_XFA_ADD(dev, idx) \
+    XFA_CONST(mtd_dev_xfa, idx) mtd_dev_t *mtd ## idx = (mtd_dev_t *)&(dev)
 
 /**
  * @brief   Number of MTDs defined in the MTD device array in XFA


### PR DESCRIPTION
### Contribution description

The commit fixes the order of entries in the MTD pointer XFA `mtd_dev_xfa` according to their index by using the index as the priority in the XFA.

Since PR #19465, the pointers to existing MTD devices `mtd0`, `mtd1`, ... `mtd<n>` are hold in the MTD pointer XFA `mtd_dev_xfa`. The order of these pointers in the XFA should correspond to their index so that `mtd_dev_xfa[i]` gives `mtd<i>` which points to the i-th MTD. For that purpose the `idx` parameter of the `MTD_XFA_ADD` macro has to be used as priority.

### Testing procedure

Compile 
```
BOARD=same54-xpro make -j8 -C tests/sys/vfs_default/
```
with and without this PR. Without this PR, command
```
nm -s tests/sys/vfs_default/bin/same54-xpro/tests_vfs_default.elf | sort | grep "mtd[0-9]"
```
will give
```
0001039c T mtd1
000103a0 T mtd0
000103a4 T mtd2
```
With this PR, the command should give:
```
000103c4 T mtd0
000103c8 T mtd1
000103cc T mtd2
```

### Issues/PRs references