### PR TITLE
boards/p-nucleo-wb55: documentation update

### DIFF
--- a/boards/p-nucleo-wb55/doc.txt
+++ b/boards/p-nucleo-wb55/doc.txt
@@ -3,8 +3,15 @@
 @ingroup     boards
 @brief       Support for the STM32 p-nucleo-wb55
 
-Hardware
-========
+## Overview
+
+The p-nucleo-wb55 is a multi-protocol wireless and ultra-low-power
+device embedding a powerful and ultra-low-power radio compliant with the
+Bluetooth® Low Energy (BLE) SIG specification v5.0 and with IEEE
+802.15.4-2011 board. It integrates an ARM Cortex-M4 STM32WB55RG microcontroller
+with 256KB of RAM and 1MB of ROM Flash.
+
+## Hardware
 
 ![st-nucleo-wb55](https://miro.medium.com/max/700/1*9OG-4Ix4EzHX9uBpMve2IA.jpeg)
 
@@ -12,8 +19,7 @@ Hardware
 
 @image html pinouts/p-nucleo-wb55.svg "Pinout for the p-nucleo-wb55" width=50%
 
-MCU
----
+### MCU
 
 | MCU               | STM32WB55RG                           |
 |:----------------- |:------------------------------------- |
@@ -40,17 +46,9 @@ MCU
 [Reference Manual]: https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf
 [User Manual]: https://www.st.com/content/ccc/resource/technical/document/user_manual/group1/13/58/22/1a/f2/ff/43/5c/DM00517423/files/DM00517423.pdf/jcr:content/translations/en.DM00517423.pdf
 
-Overview
-========
+## Flashing the device
 
-The p-nucleo-wb55 is a multi-protocol wireless and ultra-low-power
-device embedding a powerful and ultra-low-power radio compliant with the
-Bluetooth® Low Energy (BLE) SIG specification v5.0 and with IEEE
-802.15.4-2011 board. It integrates an ARM Cortex-M4 STM32WB55RG microcontroller
-with 256KB of RAM and 1MB of ROM Flash.
-
-Flashing the device
--------------------
+### Flashing the Board Using OpenOCD
 
 The ST p-nucleo-wb55 board includes an on-board ST-LINK programmer and can be
 flashed using OpenOCD (use version 0.11.0 at least).
@@ -61,17 +59,36 @@ To flash this board, just use the following command:
 make BOARD=p-nucleo-wb55 flash -C examples/hello-world
 ```
 
-STDIO
------
-STDIO is available via the ST-Link programmer.
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task could be
+performed manually; however, the cpy2remed (copy to removable media) PROGRAMMER
+script does this automatically. To program board in this manner, use the command:
+
+```
+make BOARD=p-nucleo-wb55 PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
+-link007.html).
+
+
+## Accessing RIOT shell
+
+Default RIOT shell access utilize VCP (Virtual COM Port) via USB interface,
+provided by integrated ST-LINK programmer. In default configuration ST-LINK
+is connected to the microcontroller USART1. For more details See table 7,
+page 33 in board User Manual.
+
+The default baud rate is 115 200.
 
 Use the `term` target to open a terminal:
+```
+make BOARD=p-nucleo-wb55 -C examples/hello-world term
+```
 
-    make BOARD=p-nucleo-wb55 -C examples/hello-world term
-
-
-User Interface
---------------
+## User Interface
 
 4 Button:
 
@@ -87,8 +104,7 @@ User Interface
 | Pin    | PB5    | PB0    | PB1    |
 
 
-Implementation Status
----------------------
+## Implementation Status
 
 | Device            | ID                | Supported | Comments  |
 |:----------------- |:----------------- |:--------- |:--------- |
@@ -97,7 +113,7 @@ Implementation Status
 |                   | BLE               | no        |           |
 |                   | 802.15.4          | no        |           |
 | Low-level driver  | GPIO              | yes       |           |
-|                   | UART              | yes       | UART1     |
+|                   | UART              | yes       | USART1    |
 |                   | LPUART            | yes       | LPUART1   |
 |                   | I2C               | yes       | I2C1      |
 |                   | SPI               | yes       |           |


### PR DESCRIPTION
### Contribution description

This PR updates/cleans/enhance `p-nucleo-wb55' boards documentation page:
- move Overview section at the top,
- add section concerning `cpy2remed' PROGRAMMER (tested on real hardware),
- enhance section concerning STDIO/RIOT OS console access (Issue #17453)
- change Doxygen headings from `=======` and `--------` to `##` and `###` .

### Testing procedure

Generate documentation and see if everything is OK.
```
make doc
xdg-open doc/doxygen/html/group__boards__p-nucleo-wb55.html
```
### Issues/PRs references

Issue #17453 
