### PR TITLE
hashes/sha2{24,56}: Remove static variables from sha256

### DIFF
--- a/sys/hashes/sha224.c
+++ b/sys/hashes/sha224.c
@@ -19,6 +19,7 @@
  */
 
 #include <string.h>
+#include <assert.h>
 
 #include "hashes/sha224.h"
 #include "hashes/sha2xx_common.h"
@@ -40,18 +41,12 @@ void sha224_init(sha224_context_t *ctx)
     ctx->state[7] = 0xBEFA4FA4;
 }
 
-void *sha224(const void *data, size_t len, void *digest)
+void sha224(const void *data, size_t len, void *digest)
 {
     sha224_context_t c;
-    static unsigned char m[SHA224_DIGEST_LENGTH];
-
-    if (digest == NULL) {
-        digest = m;
-    }
+    assert(digest);
 
     sha224_init(&c);
     sha224_update(&c, data, len);
     sha224_final(&c, digest);
-
-    return digest;
 }

--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -68,20 +68,14 @@ void sha256_init(sha256_context_t *ctx)
     ctx->state[7] = 0x5BE0CD19;
 }
 
-void *sha256(const void *data, size_t len, void *digest)
+void sha256(const void *data, size_t len, void *digest)
 {
     sha256_context_t c;
-    static unsigned char m[SHA256_DIGEST_LENGTH];
-
-    if (digest == NULL) {
-        digest = m;
-    }
+    assert(digest);
 
     sha256_init(&c);
     sha2xx_update(&c, data, len);
     sha256_final(&c, digest);
-
-    return digest;
 }
 
 void hmac_sha256_init(hmac_context_t *ctx, const void *key, size_t key_length)
@@ -135,19 +129,13 @@ void hmac_sha256_final(hmac_context_t *ctx, void *digest)
 {
     unsigned char tmp[SHA256_DIGEST_LENGTH];
 
-    static unsigned char m[SHA256_DIGEST_LENGTH];
-
-    if (digest == NULL) {
-        digest = m;
-    }
-
     sha256_final(&ctx->c_in, tmp);
     sha2xx_update(&ctx->c_out, tmp, SHA256_DIGEST_LENGTH);
     sha256_final(&ctx->c_out, digest);
 }
 
-const void *hmac_sha256(const void *key, size_t key_length,
-                        const void *data, size_t len, void *digest)
+void hmac_sha256(const void *key, size_t key_length,
+                 const void *data, size_t len, void *digest)
 {
 
     hmac_context_t ctx;
@@ -155,8 +143,6 @@ const void *hmac_sha256(const void *key, size_t key_length,
     hmac_sha256_init(&ctx, key, key_length);
     hmac_sha256_update(&ctx,data, len);
     hmac_sha256_final(&ctx, digest);
-
-    return digest;
 }
 
 /**

--- a/sys/include/hashes/sha224.h
+++ b/sys/include/hashes/sha224.h
@@ -110,11 +110,10 @@ static inline void sha224_final(sha224_context_t *ctx, void *digest)
  *
  * @param[in] data   pointer to the buffer to generate hash from
  * @param[in] len    length of the buffer
- * @param[out] digest optional pointer to an array for the result, length must
+ * @param[out] digest Pointer to an array for the result, length must
  *                    be SHA224_DIGEST_LENGTH
- *                    if digest == NULL, one static buffer is used
  */
-void *sha224(const void *data, size_t len, void *digest);
+void sha224(const void *data, size_t len, void *digest);
 
 #ifdef __cplusplus
 }

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -128,11 +128,10 @@ static inline void sha256_final(sha256_context_t *ctx, void *digest)
  *
  * @param[in] data   pointer to the buffer to generate hash from
  * @param[in] len    length of the buffer
- * @param[out] digest optional pointer to an array for the result, length must
+ * @param[out] digest Pointer to an array for the result, length must
  *                    be SHA256_DIGEST_LENGTH
- *                    if digest == NULL, one static buffer is used
  */
-void *sha256(const void *data, size_t len, void *digest);
+void sha256(const void *data, size_t len, void *digest);
 
 /**
  * @brief hmac_sha256_init HMAC SHA-256 calculation. Initiate calculation of a HMAC
@@ -153,9 +152,7 @@ void hmac_sha256_update(hmac_context_t *ctx, const void *data, size_t len);
 /**
  * @brief hmac_sha256_final HMAC SHA-256 finalization. Finish HMAC calculation and export the value
  * @param[in] ctx hmac_context_t handle to use
- * @param[out] digest the computed hmac-sha256,
- *             length MUST be SHA256_DIGEST_LENGTH
- *             if digest == NULL, a static buffer is used
+ * @param[out] digest the computed hmac-sha256, length MUST be SHA256_DIGEST_LENGTH
  */
 void hmac_sha256_final(hmac_context_t *ctx, void *digest);
 
@@ -168,11 +165,8 @@ void hmac_sha256_final(hmac_context_t *ctx, void *digest);
  * @param[in] len the length of the message in bytes
  * @param[out] digest the computed hmac-sha256,
  *             length MUST be SHA256_DIGEST_LENGTH
- *             if digest == NULL, a static buffer is used
- * @returns pointer to the resulting digest.
- *          if result == NULL the pointer points to the static buffer
  */
-const void *hmac_sha256(const void *key, size_t key_length,
+void hmac_sha256(const void *key, size_t key_length,
                         const void *data, size_t len, void *digest);
 
 /**


### PR DESCRIPTION
### Contribution description

This removes the static (thread-unsafe) variables from sha256 and hmac_sha256 to remove a potential footgun. The static variable is only used when the caller does not supply a pointer to store the digest and it is returned via the (undocumented) return value.

This commit removes this option and makes the digest argument mandatory.

### Testing procedure

The tests-hashes unittest should still work:
```
main(): This is RIOT! (Version: 2024.01-devel-240-gc98f3-pr/sha256/no_static)
Help: Press s to start test, r to print it is ready
s
START
...........................................
OK (43 tests)
```

### Issues/PRs references

Introduced in #124 