### PR TITLE
boards/p-nucleo-wb55: add PWM configuration

### DIFF
--- a/boards/p-nucleo-wb55/Kconfig
+++ b/boards/p-nucleo-wb55/Kconfig
@@ -16,6 +16,7 @@ config BOARD_P_NUCLEO_WB55
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_I2C
     select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/p-nucleo-wb55/Makefile.features
+++ b/boards/p-nucleo-wb55/Makefile.features
@@ -5,6 +5,7 @@ CPU_MODEL = stm32wb55rg
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/p-nucleo-wb55/doc.txt
+++ b/boards/p-nucleo-wb55/doc.txt
@@ -106,25 +106,25 @@ make BOARD=p-nucleo-wb55 -C examples/hello-world term
 
 ## Implementation Status
 
-| Device            | ID                | Supported | Comments  |
-|:----------------- |:----------------- |:--------- |:--------- |
-| MCU               | stm32wb           | yes       |           |
-|                   | M0+ co-processor  | no        |           |
-|                   | BLE               | no        |           |
-|                   | 802.15.4          | no        |           |
-| Low-level driver  | GPIO              | yes       |           |
-|                   | UART              | yes       | USART1    |
-|                   | LPUART            | yes       | LPUART1   |
-|                   | I2C               | yes       | I2C1      |
-|                   | SPI               | yes       |           |
-|                   | ADC               | yes       |           |
-|                   | RTT               | yes       |           |
-|                   | RTC               | yes       |           |
-|                   | RNG               | yes       |           |
-|                   | Timer             | yes       | TIM2      |
-|                   | WDT               | yes       |           |
-|                   | USB               | yes       |           |
-|                   | PWM               | no        |           |
-|                   | AES               | no        |           |
+| Device            | ID                | Supported | Comments   |
+|:----------------- |:----------------- |:--------- |:---------- |
+| MCU               | stm32wb           | yes       |            |
+|                   | M0+ co-processor  | no        |            |
+|                   | BLE               | no        |            |
+|                   | 802.15.4          | no        |            |
+| Low-level driver  | GPIO              | yes       |            |
+|                   | UART              | yes       | USART1     |
+|                   | LPUART            | yes       | LPUART1    |
+|                   | I2C               | yes       | I2C1       |
+|                   | SPI               | yes       |            |
+|                   | ADC               | yes       |            |
+|                   | RTT               | yes       |            |
+|                   | RTC               | yes       |            |
+|                   | RNG               | yes       |            |
+|                   | Timer             | yes       | TIM2       |
+|                   | WDT               | yes       |            |
+|                   | USB               | yes       |            |
+|                   | PWM               | yes       | dev 0/4 ch |
+|                   | AES               | no        |            |
 
 */

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -106,9 +106,37 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-static const pwm_conf_t pwm_config[] = {{},};
+/**
+ * @name    PWM configuration
+ *
+ * To find appriopate device and channel find in the MCU datasheet table
+ * concerning "Alternate function AF0 to AF7" a text similar to TIM[X]_CH[Y],
+ * where:
+ * TIM[X] - is device,
+ * [Y] - describes used channel (indexed from 0), for example TIM2_CH1 is
+ * channel 0 in configuration structure (cc_chan - field),
+ * Port column in the table describes connected port.
+ *
+ * For Nucleo-WB55 this information is in the datasheet, Table 18, page 72.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A,  8) /*  CN9 D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_A,  9) /*  CN5 D9 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_A, 10) /*  CN9 D3 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_A, 11) /* CC10 14 */, .cc_chan = 3} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    },
+};
 
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+
+/** @} */
 
 /**
  * @brief USB device FS configuration

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -106,6 +106,10 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+static const pwm_conf_t pwm_config[] = {{},};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+
 /**
  * @brief USB device FS configuration
  */


### PR DESCRIPTION
### Contribution description

This PR adds to the Nucleo-wb55 PWM configuration.

### Testing procedure

Flash the board using `tests/periph/pwm` program. Check if you could, for example, change LED 
intensity using PWM. 

### Issues/PRs references

None.