### PR TITLE
makefiles/tools/serial.inc.mk: make use of pyterm session names

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -153,7 +153,7 @@ class SerCmd(cmd.Cmd):
             self.run_name = defaultrunname
 
         if not self.log_dir_name:
-            self.log_dir_name = self.host
+            self.log_dir_name = self.configdir + os.path.sep + self.host
 
         if not os.path.exists(self.configdir):
             os.makedirs(self.configdir)
@@ -183,7 +183,7 @@ class SerCmd(cmd.Cmd):
         # create formatter
         formatter = logging.Formatter(self.fmt_str)
 
-        directory = self.configdir + os.path.sep + self.log_dir_name
+        directory = self.log_dir_name
         if not os.path.exists(directory):
             os.makedirs(directory)
         logging.basicConfig(filename=directory + os.path.sep + self.run_name +

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -43,8 +43,9 @@ endif
 
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
+  PYTERMSESSION ?= $(shell date +%Y-%m-%d_%H.%M.%S)-$(APPLICATION)-$(BOARD)
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
-  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)" $(PYTERMFLAGS)
+  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)" -rn "$(PYTERMSESSION)" $(PYTERMFLAGS)
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
   TERMPROG ?= $(RIOT_TERMINAL)

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -44,8 +44,9 @@ endif
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
   PYTERMSESSION ?= $(shell date +%Y-%m-%d_%H.%M.%S)-$(APPLICATION)-$(BOARD)
+  PYTERMLOGDIR ?= "/tmp/pyterm-$(USER)"
   TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
-  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)" -rn "$(PYTERMSESSION)" $(PYTERMFLAGS)
+  TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)" -ln $(PYTERMLOGDIR) -rn "$(PYTERMSESSION)" $(PYTERMFLAGS)
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
   TERMPROG ?= $(RIOT_TERMINAL)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`pyterm` loggs all terminal output but the feature is very under-utilized.
Especially when multiple terminals are opened, this is very unreliable as all output goes to the default log file, so it is rather random which output gets logged.

Instead, create a session name based on the current time, the application and the board.
This helps recovering output later on.

### Testing procedure

Run `make term` as usual, but now you will find multiple log files in `~/.pyterm`:

```
/home/benpicco/.pyterm/T430s:
2023-11-29_20.13.51-gnrc_networking-same54-xpro.log
2023-11-29_20.17.53-hello-world-saml21-xpro.log
````


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
