### PR TITLE
tests/touch_dev_gestures: Fix default board

### DIFF
--- a/tests/drivers/touch_dev_gestures/Makefile
+++ b/tests/drivers/touch_dev_gestures/Makefile
@@ -1,4 +1,4 @@
-BOARD ?= stm32f746-disco
+BOARD ?= stm32f746g-disco
 include ../Makefile.drivers_common
 
 DISABLE_MODULE += test_utils_interactive_sync


### PR DESCRIPTION
### Contribution description

The test has a nonexistent board as its default.

### Testing procedure

```
# for p in $(make -f makefiles/app_dirs.inc.mk info-applications); do echo $p; make -C$p clean || break; done
```

shows that this was the only test that had this issue.