### PR TITLE
examples/dtls-sock: make use of helper functions

### DIFF
--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -13,6 +13,7 @@ USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
+USEMODULE += netutils
 
 # Specify DTLS implementation
 USEPKG += tinydtls

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -151,11 +151,10 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     else {
         printf("Sent DTLS message\n");
 
-        uint8_t rcv[512];
-        if ((res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv),
+        if ((res = sock_dtls_recv(&dtls_sock, &session, buf, sizeof(buf),
                                     SOCK_NO_TIMEOUT)) >= 0) {
             printf("Received %" PRIdSIZE " bytes: \"%.*s\"\n", res, (int)res,
-                   (char *)rcv);
+                   (char *)buf);
         }
     }
 

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -27,6 +27,7 @@
 #include "net/ipv6/addr.h"
 #include "net/credman.h"
 #include "net/sock/util.h"
+#include "net/utils.h"
 
 #include "tinydtls_keys.h"
 
@@ -88,27 +89,6 @@ static const credman_credential_t credential1 = {
         }
     },
 };
-
-static credman_tag_t _client_psk_cb(sock_dtls_t *sock, sock_udp_ep_t *ep, credman_tag_t tags[],
-                                    unsigned tags_len, const char *hint, size_t hint_len)
-{
-    (void) sock;
-    (void) tags;
-    (void) tags_len;
-
-    /* this callback is here just to show the functionality, it only prints the received hint */
-    char addrstr[IPV6_ADDR_MAX_STR_LEN];
-    uint16_t port;
-
-    sock_udp_ep_fmt(ep, addrstr, &port);
-    printf("From [%s]:%d\n", addrstr, port);
-
-    if (hint && hint_len) {
-        printf("Client got hint: %.*s\n", (unsigned)hint_len, hint);
-    }
-
-    return CREDMAN_TAG_EMPTY;
-}
 #endif
 
 static int client_send(char *addr_str, char *data, size_t datalen)
@@ -122,46 +102,23 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     local.port = 12345;
     remote.port = DTLS_DEFAULT_PORT;
     uint8_t buf[DTLS_HANDSHAKE_BUFSIZE];
+    credman_tag_t tag = SOCK_DTLS_CLIENT_TAG_0;
 
     /* get interface */
-    char* iface = ipv6_addr_split_iface(addr_str);
-    if (iface) {
-        int pid = atoi(iface);
-        if (gnrc_netif_get_by_pid(pid) == NULL) {
-            puts("Invalid network interface");
-            return -1;
-        }
-        remote.netif = pid;
-    } else if (gnrc_netif_numof() == 1) {
-        /* assign the single interface found in gnrc_netif_numof() */
-        remote.netif = gnrc_netif_iter(NULL)->pid;
-    } else {
-        /* no interface is given, or given interface is invalid */
-        /* FIXME This probably is not valid with multiple interfaces */
-        remote.netif = SOCK_ADDR_ANY_NETIF;
+    netif_t *netif;
+    res = netutils_get_ipv6((void *)&remote.addr, &netif, addr_str);
+    if (res) {
+        printf("Error parsing remote address\n");
+        return res;
     }
-
-    if (!ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, addr_str)) {
-        puts("Error parsing destination address");
-        return -1;
-    }
-
-    if (sock_udp_create(&udp_sock, &local, NULL, 0) < 0) {
-        puts("Error creating UDP sock");
-        return -1;
+    if (netif) {
+        remote.netif = netif_get_id(netif);
     }
 
     res = credman_add(&credential0);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
         printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
-        sock_udp_close(&udp_sock);
-        return -1;
-    }
-
-    if (sock_dtls_create(&dtls_sock, &udp_sock, SOCK_DTLS_CLIENT_TAG_0,
-                         SOCK_DTLS_1_2, SOCK_DTLS_CLIENT) < 0) {
-        puts("Error creating DTLS sock");
         sock_udp_close(&udp_sock);
         return -1;
     }
@@ -175,32 +132,17 @@ static int client_send(char *addr_str, char *data, size_t datalen)
         sock_udp_close(&udp_sock);
         return -1;
     }
-
-    /* make the new credential available to the sock */
-    if (sock_dtls_add_credential(&dtls_sock, SOCK_DTLS_CLIENT_TAG_1) < 0) {
-        printf("Error cannot add credential to the sock: %" PRIdSIZE "\n", res);
-        sock_udp_close(&udp_sock);
-        return -1;
-    }
-
-    /* register a callback for PSK credential selection */
-    sock_dtls_set_client_psk_cb(&dtls_sock, _client_psk_cb);
+    tag = SOCK_DTLS_CLIENT_TAG_1;
 #endif
 
-    res = sock_dtls_session_init(&dtls_sock, &remote, &session);
-    if (res <= 0) {
+    res = sock_dtls_establish_session(&udp_sock, &dtls_sock, &session, tag,
+                                      &local, &remote, buf, sizeof(buf));
+   if (res) {
         sock_udp_close(&udp_sock);
+        printf("Error establishing connection: %d\n", (int)res);
         return res;
     }
 
-    res = sock_dtls_recv(&dtls_sock, &session, buf, sizeof(buf),
-                         SOCK_NO_TIMEOUT);
-    if (res != -SOCK_DTLS_HANDSHAKE) {
-        printf("Error creating session: %" PRIdSIZE "\n", res);
-        sock_dtls_close(&dtls_sock);
-        sock_udp_close(&udp_sock);
-        return -1;
-    }
     printf("Connection to server successful\n");
 
     if (sock_dtls_send(&dtls_sock, &session, data, datalen, 0) < 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We have helper functions for parsing the destination address and establishing a DTLS connection now, so don't open-code it.


### Testing procedure
The app still works as described

```
main(): This is RIOT! (Version: 2024.01-devel-246-gde89f7-examples/dtls-sock-cleanup)
DTLS sock example application
All up, running the shell now
> dtlsc fe80::581a:98ff:fe23:2d6c test
Connection to server successful
Sent DTLS message
Received 4 bytes: "test"
Terminating
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
