### PR TITLE
dist/tools/insufficient_memory: always update Makefile.ci

### DIFF
--- a/dist/tools/insufficient_memory/Makefile.for_sh
+++ b/dist/tools/insufficient_memory/Makefile.for_sh
@@ -6,7 +6,8 @@ define create_Makefile.ci
 	@echo "    #" >> $(1)
 endef
 
-BOARD_INSUFFICIENT_MEMORY += $(BOARD)
+BOARD_INSUFFICIENT_MEMORY += $(ADD_BOARDS)
+BOARD_INSUFFICIENT_MEMORY := $(filter-out $(REMOVE_BOARDS),$(BOARD_INSUFFICIENT_MEMORY))
 
 .PHONY: Makefile.ci
 ifeq ($(BOARD_INSUFFICIENT_MEMORY),)

--- a/dist/tools/insufficient_memory/create_makefile.ci.sh
+++ b/dist/tools/insufficient_memory/create_makefile.ci.sh
@@ -80,4 +80,4 @@ for BOARD in $(EXTERNAL_BOARD_DIRS="" make  --no-print-directory info-boards-sup
 done
 
 rm "${APP_DIR}/Makefile.ci"
-make -f "$(dirname "$0")"/Makefile.for_sh DIR="${APP_DIR}" BOARD="${BOARDS}" Makefile.ci > /dev/null
+make -f "$(dirname "$0")"/Makefile.for_sh DIR="${APP_DIR}" ADD_BOARDS="${BOARDS}" Makefile.ci > /dev/null

--- a/dist/tools/insufficient_memory/update_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/update_insufficient_memory_board.sh
@@ -53,6 +53,10 @@ APPLICATIONS="${APPLICATIONS} $(make -sC "${RIOTBASE}" info-applications)"
 
 for application in ${APPLICATIONS}; do
     printf "${CNORMAL}%-40s${CRESET}" "${application}"
+
+    # First, remove the board from Makefile.ci; otherwise linking step will be
+    # skipped with RIOT_CI_BUILD=1 when the board is already in the list.
+    make -f "$(dirname "$0")"/Makefile.for_sh DIR="${RIOTBASE}/${application}" REMOVE_BOARDS="${BOARD}" Makefile.ci > /dev/null
     # disable warning about globbing and word splitting for ${LOCAL_MAKE_ARGS}
     # as this is exactly what we want here
     # shellcheck disable=SC2086
@@ -62,7 +66,7 @@ for application in ${APPLICATIONS}; do
                 -e "wraps around address space" \
                 "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
-            make -f "$(dirname "$0")"/Makefile.for_sh DIR="${RIOTBASE}/${application}" BOARD="${BOARD}" Makefile.ci > /dev/null
+            make -f "$(dirname "$0")"/Makefile.for_sh DIR="${RIOTBASE}/${application}" ADD_BOARDS="${BOARD}" Makefile.ci > /dev/null
         elif grep -e "not whitelisted" \
                   -e "unsatisfied feature requirements" \
                   -e "Some feature requirements are blacklisted:" \


### PR DESCRIPTION
### Contribution description

Previously the `add_insufficient_memory_board.sh` script would only add the tested board to `Makefile.ci` when resource requirements grew, but never remove it when resource requirements got lower.

This updates the script to also remove boards from `Makefile.ci` if it is no longer needed. It is also rename (`add` --> `update`) to match the change in behavior.

### Testing procedure

Mess up some `Makefile.ci` files by randomly adding and remove board `$BOARD`. Run `./dist/tools/insufficient_memory/add_insufficient_memory_board.sh $BOARD`. The `Makefile.ci`s should be fixed by adding `$BOARD` where needed, and dropping it where it wasn't needed.

### Issues/PRs references

None