### PR TITLE
Bumb nanopb to 0.4.8

### DIFF
--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=nanopb
 PKG_URL=https://github.com/nanopb/nanopb
-# 0.4.7
-PKG_VERSION=b97aa657a706d3ba4a9a6ccca7043c9d6fe41cba
+# 0.4.8
+PKG_VERSION=6cfe48d6f1593f8fa5c0f90437f5e6522587745e
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
simply bumps the version of nanopb to `0.4.8`

### Testing procedure

`tests/pkg/nanopb` runs as it should on `native`


### Issues/PRs references
no PR related
