### PR TITLE
cpu/sam0_common: fix adc_continuous_sample()

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -24,6 +24,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#include "cpu.h"
 #include "mutex.h"
 #include "thread.h"
 #include "sched.h"

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -389,14 +389,10 @@ void adc_continuous_begin(adc_res_t res)
 
 int32_t adc_continuous_sample(adc_t line)
 {
-    int val;
     assert(line < ADC_NUMOF);
+    assert(mutex_trylock(&_lock) == 0);
 
-    mutex_lock(&_lock);
-    val = _sample(line) << _shift;
-    mutex_unlock(&_lock);
-
-    return val;
+    return _sample(line) << _shift;
 }
 
 void adc_continuous_stop(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The mutex is already locked in `adc_continuous_begin()`, so don't try to lock it again in `adc_continuous_sample()`.


### Testing procedure

`tests/periph/adc_continuous` no longer hangs.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
