### PR TITLE
drivers/sdmmc: fix placement of #endif

### DIFF
--- a/drivers/sdmmc/sdmmc_sdhc.c
+++ b/drivers/sdmmc/sdmmc_sdhc.c
@@ -631,8 +631,8 @@ void _core_init(sdhc_dev_t *sdhc_dev)
         GCLK->PCHCTRL[SDHC1_GCLK_ID_SLOW].reg = GCLK_PCHCTRL_CHEN
                                               | GCLK_PCHCTRL_GEN(SDHC_CLOCK_SLOW);
         MCLK->AHBMASK.bit.SDHC1_ = 1;
-#endif /* SDHC1 */
     }
+#endif /* SDHC1 */
 }
 
 static void _init_pins(sdhc_dev_t *sdhc_dev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Otherwise this won't compile if there is no `SDHC1`


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
