### PR TITLE
Fix labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'merge_group'
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION


### Contribution description

Due to the [breaking changes](https://github.com/actions/labeler#breaking-changes-in-v5) in the `labeler` github action we need to adapt our config.  I will also set the major version since deprecation messages would seem preferable to failing actions.

### Testing procedure

Labeler action passes now


### Issues/PRs references
[Example of the issue](https://github.com/RIOT-OS/RIOT/actions/runs/7087797156/job/19290204707?pr=20135)