### PR TITLE
net/gnrc/netif: set 6LN flag for ethernet if gnrc_sixloenc is used

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -115,6 +115,9 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif)
         }
         /* intentionally falls through */
         case NETDEV_TYPE_BLE:
+#ifdef MODULE_GNRC_SIXLOENC
+        case NETDEV_TYPE_ETHERNET:
+#endif
 #ifdef MODULE_CC110X
         case NETDEV_TYPE_CC110X:
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

AFAIU the `gnrc_sixloenc` enables 6lo encoding on ethernet.
This can be useful for very slow busses, where we want to reduce traffic as much as possible.

I noticed that GNRC would still perform duplicate address detection on startup - this was because the 6LN flag was not set yet. 


### Testing procedure

I enabled

```
USEMODULE += gnrc_sixloenc
CFLAGS += -DCONFIG_GNRC_IPV6_NIB_SLAAC=1
CFLAGS += -DCONFIG_GNRC_IPV6_NIB_NO_RTR_SOL=1
CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ARSM=0
```

and now get serene silence on the bus if there is no traffic. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
