### PR TITLE
tests/drivers/at: add check if device is initialized before sending command

### DIFF
--- a/tests/drivers/at/main.c
+++ b/tests/drivers/at/main.c
@@ -35,8 +35,8 @@ static at_dev_t at_dev;
 static char buf[256];
 static char resp[1024];
 static char rp_buf[256];
-static bool initialized;
-static bool is_power_on;
+static bool initialized = false;
+static bool is_power_on = false;
 
 static int init(int argc, char **argv)
 {
@@ -489,9 +489,6 @@ static const shell_command_t shell_commands[] = {
 int main(void)
 {
     puts("AT command test app");
-
-    initialized = false;
-    is_power_on = false;
 
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/tests/drivers/at/main.c
+++ b/tests/drivers/at/main.c
@@ -35,6 +35,8 @@ static at_dev_t at_dev;
 static char buf[256];
 static char resp[1024];
 static char rp_buf[256];
+static bool initialized;
+static bool is_power_on;
 
 static int init(int argc, char **argv)
 {
@@ -72,6 +74,8 @@ static int init(int argc, char **argv)
         return 1;
     }
 
+    initialized = true;
+
     return res;
 }
 
@@ -79,6 +83,18 @@ static int send(int argc, char **argv)
 {
     if (argc < 2) {
         printf("Usage: %s <command>\n", argv[0]);
+        return 1;
+    }
+
+    if (initialized == false) {
+        puts("Error: AT device not initialized.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    if (is_power_on == false) {
+        puts("Error: AT device not power on.\n");
+        puts("Execute power_on function first.\n");
         return 1;
     }
 
@@ -100,6 +116,18 @@ static int send_ok(int argc, char **argv)
         return 1;
     }
 
+    if (initialized == false) {
+        puts("Error: AT device not initialized.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    if (is_power_on == false) {
+        puts("Error: AT device not power on.\n");
+        puts("Execute power_on function first.\n");
+        return 1;
+    }
+
     if (at_send_cmd_wait_ok(&at_dev, argv[1], 10 * US_PER_SEC) < 0) {
         puts("Error");
         return 1;
@@ -114,6 +142,18 @@ static int send_lines(int argc, char **argv)
 {
     if (argc < 2) {
         printf("Usage: %s <command>\n", argv[0]);
+        return 1;
+    }
+
+    if (initialized == false) {
+        puts("Error: AT device not initialized.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    if (is_power_on == false) {
+        puts("Error: AT device not power on.\n");
+        puts("Execute power_on function first.\n");
         return 1;
     }
 
@@ -138,6 +178,18 @@ static int send_recv_bytes(int argc, char **argv)
         return 1;
     }
 
+    if (initialized == false) {
+        puts("Error: AT device not initialized.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    if (is_power_on == false) {
+        puts("Error: AT device not power on.\n");
+        puts("Execute power_on function first.\n");
+        return 1;
+    }
+
     sprintf(buffer, "%s%s", argv[1], CONFIG_AT_SEND_EOL);
     at_send_bytes(&at_dev, buffer, strlen(buffer));
 
@@ -157,6 +209,18 @@ static int send_recv_bytes_until_string(int argc, char **argv)
 
     if (argc < 3) {
         printf("Usage: %s <command> <string to expect>\n", argv[0]);
+        return 1;
+    }
+
+    if (initialized == false) {
+        puts("Error: AT device not initialized.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    if (is_power_on == false) {
+        puts("Error: AT device not power on.\n");
+        puts("Execute power_on function first.\n");
         return 1;
     }
 
@@ -192,6 +256,7 @@ static int power_on(int argc, char **argv)
     (void)argv;
 
     at_dev_poweron(&at_dev);
+    is_power_on = true;
 
     puts("Powered on");
 
@@ -204,6 +269,7 @@ static int power_off(int argc, char **argv)
     (void)argv;
 
     at_dev_poweroff(&at_dev);
+    is_power_on = false;
 
     puts("Powered off");
 
@@ -423,6 +489,9 @@ static const shell_command_t shell_commands[] = {
 int main(void)
 {
     puts("AT command test app");
+
+    initialized = false;
+    is_power_on = false;
 
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];


### PR DESCRIPTION
### Contribution description

This PR adds to the `tests/driver/at` send... functions checks if AT device is initialized and power on.

### Testing procedure

Flash device with `tests/driver/at` program and try to send some AT command without initialization and power on.
Without this PR send... commands waits for timeout.
With this PR appropriate error message is shown.

### Issues/PRs references

None.