### PR TITLE
makefiles/arch/riscv.inc.mk: Always provide TARGET_ARCH_LLVM

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -66,11 +66,10 @@ ifeq (1,$(GCC_DEFAULTS_TO_NEW_RISCV_ISA))
   CFLAGS_CPU += -misa-spec=2.2
 endif
 
-ifeq ($(TOOLCHAIN),llvm)
-  # Always use riscv32-none-elf as target triple for clang, as some
-  # autodetected gcc target triples are incompatible with clang
-  TARGET_ARCH_LLVM := riscv32-none-elf
-else
+# Always use riscv32-none-elf as target triple for clang, as some
+# autodetected gcc target triples are incompatible with clang
+TARGET_ARCH_LLVM := riscv32-none-elf
+ifneq ($(TOOLCHAIN),llvm)
   CFLAGS_CPU += -mcmodel=medlow -msmall-data-limit=8
   # We cannot invoke the compiler on the host system if build in docker.
   # Instead, hard-code the required flags for the docker toolchain here


### PR DESCRIPTION
### Contribution description

This fixes issues with `make compile-commands`, as this by default generates clangd/LLVM compatible flags. Without `TARGET_ARCH_LLVM` exported, this will fall back to `TARGET_ARCH`, which is different for LLVM and GCC.

### Testing procedure

Run e.g. `make BOARD=hifive1b -C examples/default compile-commands` and open the `main.c` in that example with an LSP enabled editor (e.g. vim/nvim + ALE or vs code). In `master` it won't even dare linting due to `-target riscv-none-elf` not being technically correct. With this PR `-target riscv32-none-elf` is used instead.

### Issues/PRs references

None