### PR TITLE
cpu/kinetis: implement periph_timer_query_freqs

### DIFF
--- a/cpu/kinetis/Kconfig
+++ b/cpu/kinetis/Kconfig
@@ -11,6 +11,7 @@ config CPU_COMMON_KINETIS
     select HAS_PERIPH_GPIO
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_PM
+    select HAS_PERIPH_TIMER_QUERY_FREQS
 
     # enable kinetis periph drivers if available
     imply MODULE_PERIPH_ICS

--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -1,5 +1,6 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_timer_query_freqs
 
 # TRNG driver is not implemented for mkw41z models
 _KINETIS_CPU_MODELS_WITHOUT_HWRNG += mkw41z256vht4 mkw41z512vht4

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -145,6 +145,11 @@ typedef uint32_t spi_cs_t;
 #define PERIPH_TIMER_PROVIDES_SET
 
 /**
+ * @brief   Only a single channel supported by the driver/hardware
+ */
+#define TIMER_CHANNEL_NUMOF             1
+
+/**
  * @name    Kinetis power mode configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

Run the test provided by https://github.com/RIOT-OS/RIOT/pull/16349.

### Issues/PRs references

Depends on https://github.com/RIOT-OS/RIOT/pull/16349 and includes the first commit of it.