### PR TITLE
cpu/cortexm_common: work around bug on WFI for STM32

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -167,6 +167,10 @@ static inline void cortexm_sleep(int deep)
     unsigned state = irq_disable();
     __DSB();
     __WFI();
+    /* Some CPUs require an ISB after WFI to work around silicon bugs */
+#if CORTEXM_ISB_REQUIRED_AFTER_WFI
+    __ISB();
+#endif
     irq_restore(state);
 }
 

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -88,6 +88,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Enable workaround for bug in WFI by issuing an ISB
+ *
+ * This works around a bug on STM32 systems, see [1] for details, or [2] for
+ * an archive.org backup.
+ * [1]: https://cliffle.com/blog/stm32-wfi-bug
+ * [2]: https://web.archive.org/web/20231205101603/https://cliffle.com/blog/stm32-wfi-bug/
+ */
+#define CORTEXM_ISB_REQUIRED_AFTER_WFI  1
+
+/**
  * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description

See [1] for details. (archive.org backup at [2]).



[1]: https://cliffle.com/blog/stm32-wfi-bug/
[2]: https://web.archive.org/web/20231205101603/https://cliffle.com/blog/stm32-wfi-bug/

### Testing procedure

See https://github.com/RIOT-OS/RIOT/issues/13918

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/13918 
Fixes https://github.com/RIOT-OS/RIOT/issues/14015
