### PR TITLE
tests/net/gnrc_sixlowpan_frag_sfr_congure_impl: disable test on native

### DIFF
--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
@@ -1,5 +1,12 @@
 include ../Makefile.net_common
 
+# This tests fails sporadically in the CI on native with both GCC and LLVM
+# toolchains. Maybe it just fluke and due to high load on the machines,
+# maybe it is an actual race condition.
+#
+# TODO: Solve the issue and re-enable
+TEST_ON_CI_BLACKLIST += native
+
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_sixlowpan_frag_sfr


### PR DESCRIPTION
### Contribution description

This test sporadically failed on multiple machines compiled with both GNU and LLVM toolchains. To not waste more CI time by sporadically failing unrelated CI runs, let's disable the test for now.

### Testing procedure

The test should no longer be run automatically in the CI.

### Issues/PRs references

None