### PR TITLE
tests/sys/psa_crypto_se_cipher: disable test on esp32-wroom-32

### DIFF
--- a/tests/sys/psa_crypto_se_cipher/Makefile
+++ b/tests/sys/psa_crypto_se_cipher/Makefile
@@ -2,6 +2,9 @@ BOARD ?= nrf52840dk
 
 include ../Makefile.sys_common
 
+# Test fails systematically on the CI
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 USEMODULE += ztimer
 USEMODULE += ztimer_usec
 


### PR DESCRIPTION
### Contribution description

The test fails systematically on the CI and prevents merging PRs.

### Testing procedure

The test should pass the CI.

### Issues/PRs references

Similar to https://github.com/RIOT-OS/RIOT/pull/20150