### PR TITLE
boards/esp32*: add TTY board filter

### DIFF
--- a/boards/esp32-ethernet-kit-v1_0/Makefile.include
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.include
@@ -6,4 +6,8 @@ ifneq (,$(filter esp_jtag,$(USEMODULE)))
   OPENOCD_CONFIG ?= board/esp32-ethernet-kit-3.3v.cfg
 endif
 
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ftdi_sio' --vendor FTDI --model 'Dual RS232-HS' --iface-num 1
+
 include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-mh-et-live-minikit/Makefile.include
+++ b/boards/esp32-mh-et-live-minikit/Makefile.include
@@ -1,1 +1,5 @@
 include $(RIOTBOARD)/common/esp32/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2104 USB to UART Bridge Controller'

--- a/boards/esp32-olimex-evb/Makefile.include
+++ b/boards/esp32-olimex-evb/Makefile.include
@@ -1,3 +1,7 @@
 PSEUDOMODULES += olimex_esp32_gateway
 
 include $(RIOTBOARD)/common/esp32/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB2.0-Serial'

--- a/boards/esp32-ttgo-t-beam/Makefile.include
+++ b/boards/esp32-ttgo-t-beam/Makefile.include
@@ -1,3 +1,7 @@
 PSEUDOMODULES += esp32_ttgo_t_beam_v1_0
 
 include $(RIOTBOARD)/common/esp32/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2104 USB to UART Bridge Controller'

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.include
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.include
@@ -1,3 +1,7 @@
 PSEUDOMODULES += esp_lolin_tft
 
 include $(RIOTBOARD)/common/esp32/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB2.0-Serial'

--- a/boards/esp32-wroom-32/Makefile.include
+++ b/boards/esp32-wroom-32/Makefile.include
@@ -1,1 +1,5 @@
 include $(RIOTBOARD)/common/esp32/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102 USB to UART Bridge Controller'

--- a/boards/esp32-wrover-kit/Makefile.include
+++ b/boards/esp32-wrover-kit/Makefile.include
@@ -3,6 +3,10 @@ PSEUDOMODULES += esp32_wrover_kit_camera
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB1
 
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ftdi_sio' --vendor FTDI --model 'Dual RS232-HS' --iface-num 1
+
 ifneq (,$(filter esp_jtag,$(USEMODULE)))
   OPENOCD_CONFIG ?= board/esp32-wrover-kit-3.3v.cfg
 endif

--- a/boards/esp32c3-devkit/Makefile.include
+++ b/boards/esp32c3-devkit/Makefile.include
@@ -1,1 +1,5 @@
 include $(RIOTBOARD)/common/esp32c3/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32s2-devkit/Makefile.include
+++ b/boards/esp32s2-devkit/Makefile.include
@@ -6,3 +6,7 @@ PSEUDOMODULES += esp32s2_saola_1
 PSEUDOMODULES += esp32s2_saola_1r
 
 include $(RIOTBOARD)/common/esp32s2/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile.include
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile.include
@@ -5,3 +5,7 @@ ifneq (,$(filter esp32s2-lilygo-ttgo-t8-usb,$(USEMODULE)))
 endif
 
 include $(RIOTBOARD)/common/esp32s2/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB Serial'

--- a/boards/esp32s3-devkit/Makefile.include
+++ b/boards/esp32s3-devkit/Makefile.include
@@ -10,3 +10,7 @@ PSEUDOMODULES += esp32s3_devkitm_1_n8r8
 PSEUDOMODULES += esp32s3_devkitm_1u_n8r8
 
 include $(RIOTBOARD)/common/esp32s3/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'


### PR DESCRIPTION
### Contribution description

This adds a TTY board filter to only select TTYs that match the attributes of the correct TTY interface. When using `make flash` or `make term` with `MOST_RECENT_PORT=1`, RIOT should now select relatively robustly the most recently connected ESP32 Ethernet Kit board, even with other TTYs present.

### Testing procedure

Connect a bunch of boards including at least one Ethernet Kit board and run

```sh
make MOST_RECENT_PORT=1 BOARD=esp32-ethernet-kit-v1_2 BUILD_IN_DOCKER=1 -j flash -C examples/default
```

This should now pick the most recently connected Ethernet Kit board. It may pick a different board when another Dual RS232-HS USB<-->UART adapter is connected, though. But those are relatively rare as integrated UART<-->USB converters, as they are (unless they are used to bit-bang JTAG) an overkill for a simple USB2UART bridge.

### Issues/PRs references

None