### PR TITLE
boards/esp32s3-usb-otg: fix the table of contents in documentation

### DIFF
--- a/boards/esp32s3-usb-otg/doc.txt
+++ b/boards/esp32s3-usb-otg/doc.txt
@@ -21,7 +21,7 @@
     1. [MCU](#esp32s3_usb_otg_mcu)
     2. [Board Configuration](#esp32s3_usb_otg_board_configuration)
 3. [Flashing the Device](#esp32s3_usb_otg_flashing)
-4. [Using STDIO](esp32s3_usb_otg_stdio)
+4. [Using STDIO](#esp32s3_usb_otg_stdio)
 
 ## Overview {#esp32s3_usb_otg_overview}
 


### PR DESCRIPTION
### Contribution description

This PR provides a small fix in the documentation for the `esp32s3-usb-otg` board.

![Snapshot 2023-12-06 10-55-55](https://github.com/RIOT-OS/RIOT/assets/31932013/8db23647-0ba4-4333-838b-a16e7a2861c7)

### Testing procedure

`make doc` and check the documentation.

![Snapshot 2023-12-06 10-57-19](https://github.com/RIOT-OS/RIOT/assets/31932013/dba2542f-6531-4a07-8fe7-446001072a9d)

### Issues/PRs references
