### PR TITLE
cpu/msp430: consistently use msp430 prefix in names

### DIFF
--- a/cpu/msp430/include/f2xx_g2xx/msp430_regs.h
+++ b/cpu/msp430/include/f2xx_g2xx/msp430_regs.h
@@ -47,7 +47,7 @@ typedef struct {
     REG8    STAT;       /**< status register */
     REG8    RXBUF;      /**< receive buffer */
     REG8    TXBUF;      /**< transmit buffer */
-} msp_usci_a_t;
+} msp430_usci_a_t;
 
 /**
  * @brief   Universal Serial Control Interface Type B (USCI_B) Registers
@@ -61,7 +61,7 @@ typedef struct {
     REG8    STAT;       /**< status register */
     REG8    RXBUF;      /**< receive buffer */
     REG8    TXBUF;      /**< transmit buffer */
-} msp_usci_b_t;
+} msp430_usci_b_t;
 
 /**
  * @name    USCI clock selection
@@ -111,10 +111,10 @@ typedef struct {
  * | USCI A | ✔     | ✔     | ✗     | ✔     |
  * | USCI B | ✗     | ✔     | ✔     | ✗     |
  */
-static inline msp_usci_b_t * msp430_usci_b_from_usci_a(msp_usci_a_t *usci_a)
+static inline msp430_usci_b_t * msp430_usci_b_from_usci_a(msp430_usci_a_t *usci_a)
 {
-    uintptr_t usci_b = (uintptr_t)usci_a + offsetof(msp_usci_a_t, CTL0);
-    return (msp_usci_b_t *)usci_b;
+    uintptr_t usci_b = (uintptr_t)usci_a + offsetof(msp430_usci_a_t, CTL0);
+    return (msp430_usci_b_t *)usci_b;
 }
 
 /**
@@ -126,25 +126,25 @@ static inline msp_usci_b_t * msp430_usci_b_from_usci_a(msp_usci_a_t *usci_a)
  *
  * @details Provided by linker
  */
-extern msp_usci_a_t USCI_A0;
+extern msp430_usci_a_t USCI_A0;
 /**
  * @brief   USCI_A1 register map
  *
  * @details Provided by linker
  */
-extern msp_usci_a_t USCI_A1;
+extern msp430_usci_a_t USCI_A1;
 /**
  * @brief   USCI_B0 register map
  *
  * @details Provided by linker
  */
-extern msp_usci_a_t USCI_B0;
+extern msp430_usci_a_t USCI_B0;
 /**
  * @brief   USCI_B1 register map
  *
  * @details Provided by linker
  */
-extern msp_usci_a_t USCI_B1;
+extern msp430_usci_a_t USCI_B1;
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/msp430/include/msp430_regs_common.h
+++ b/cpu/msp430/include/msp430_regs_common.h
@@ -87,26 +87,26 @@ typedef struct {
     REG8    IN;         /**< input data */
     REG8    OD;         /**< output data */
     REG8    DIR;        /**< pin direction */
-} msp_port_t;
+} msp430_port_t;
 
 /**
  * @brief   GPIO Port 1/2 (with interrupt functionality)
  */
 typedef struct {
-    msp_port_t base;    /**< common GPIO port registers */
+    msp430_port_t base; /**< common GPIO port registers */
     REG8    IFG;        /**< interrupt flag */
     REG8    IES;        /**< interrupt edge select */
     REG8    IE;         /**< interrupt enable */
     REG8    SEL;        /**< alternative function select */
-} msp_port_p1_p2_t;
+} msp430_port_p1_p2_t;
 
 /**
  * @brief   GPIO Port 3..6 (without interrupt functionality)
  */
 typedef struct {
-    msp_port_t base;    /**< common GPIO port registers */
+    msp430_port_t base; /**< common GPIO port registers */
     REG8    SEL;        /**< alternative function select */
-} msp_port_p3_p6_t;
+} msp430_port_p3_p6_t;
 
 
 /**
@@ -114,9 +114,9 @@ typedef struct {
  */
 typedef struct {
     REG16   TBIV;       /**< TIMER_A interrupt status */
-    REG16   reserved[7];    /**< reserved */
+    REG16   reserved[7];/**< reserved */
     REG16   TAIV;       /**< TIMER_B interrupt status */
-} msp_timer_ivec_t;
+} msp430_timer_ivec_t;
 
 /**
  * @brief   Timer module registers
@@ -126,7 +126,7 @@ typedef struct {
     REG16   CCTL[7];    /**< capture compare channel control */
     REG16   R;          /**< current counter value */
     REG16   CCR[7];     /**< capture compare channel values */
-} msp_timer_t;
+} msp430_timer_t;
 
 /**
  * @name    MSP430 Common Peripheral Register Maps
@@ -138,42 +138,42 @@ typedef struct {
 /**
  * @brief   Register map of GPIO PORT 1
  */
-extern msp_port_p1_p2_t PORT_1;
+extern msp430_port_p1_p2_t PORT_1;
 /**
  * @brief   Register map of GPIO PORT 2
  */
-extern msp_port_p1_p2_t PORT_2;
+extern msp430_port_p1_p2_t PORT_2;
 /**
  * @brief   Register map of GPIO PORT 3
  */
-extern msp_port_p3_p6_t PORT_3;
+extern msp430_port_p3_p6_t PORT_3;
 /**
  * @brief   Register map of GPIO PORT 4
  */
-extern msp_port_p3_p6_t PORT_4;
+extern msp430_port_p3_p6_t PORT_4;
 /**
  * @brief   Register map of GPIO PORT 5
  */
-extern msp_port_p3_p6_t PORT_5;
+extern msp430_port_p3_p6_t PORT_5;
 /**
  * @brief   Register map of GPIO PORT 6
  */
-extern msp_port_p3_p6_t PORT_6;
+extern msp430_port_p3_p6_t PORT_6;
 
 /**
  * @brief   Register map of the timer interrupt control registers
  */
-extern msp_timer_ivec_t TIMER_IVEC;
+extern msp430_timer_ivec_t TIMER_IVEC;
 
 /**
  * @brief   Register map of the timer A control registers
  */
-extern msp_timer_t TIMER_A;
+extern msp430_timer_t TIMER_A;
 
 /**
  * @brief   Register map of the timer B control registers
  */
-extern msp_timer_t TIMER_B;
+extern msp430_timer_t TIMER_B;
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/msp430/include/x1xx/msp430_regs.h
+++ b/cpu/msp430/include/x1xx/msp430_regs.h
@@ -43,7 +43,7 @@ typedef struct {
     REG8    BR1;        /**< baud rate control 1 */
     REG8    RXBUF;      /**< receive buffer */
     REG8    TXBUF;      /**< transmit buffer */
-} msp_usart_t;
+} msp430_usart_t;
 
 /**
  * @brief   USART Special Function Registers (SFR)
@@ -62,7 +62,7 @@ typedef struct {
     REG8    IFG;        /**< USART Interrupt Flag Register */
     const uint8_t _pad2;/**< Padding */
     REG8    ME;         /**< Module Enable Register */
-} msp_usart_sfr_t;
+} msp430_usart_sfr_t;
 
 /**
  * @name    USART clock selection
@@ -86,23 +86,23 @@ typedef struct {
 /**
  * @brief   USART 0 SFR register map
  */
-extern msp_usart_sfr_t USART_0_SFR;
+extern msp430_usart_sfr_t USART_0_SFR;
 /**
  * @brief   USART 1 SFR register map
  */
-extern msp_usart_sfr_t USART_1_SFR;
+extern msp430_usart_sfr_t USART_1_SFR;
 /**
  * @brief   USART 0 register map
  *
  * @details The address is provided by the linker script
  */
-extern msp_usart_t USART_0;
+extern msp430_usart_t USART_0;
 /**
  * @brief   USART 1 register map
  *
  * @details The address is provided by the linker script
  */
-extern msp_usart_t USART_1;
+extern msp430_usart_t USART_1;
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/msp430/ldscripts/msp430_common.ld
+++ b/cpu/msp430/ldscripts/msp430_common.ld
@@ -32,7 +32,7 @@ PROVIDE(PORT_4      = P4IN);
 PROVIDE(PORT_5      = P5IN);
 PROVIDE(PORT_6      = P6IN);
 
-/* no typo: TBIV indeed comes before TAIV in memory, see msp_timer_ivec_t */
+/* no typo: TBIV indeed comes before TAIV in memory, see msp430_timer_ivec_t */
 PROVIDE(TIMER_IVEC  = TBIV);
 
 PROVIDE(TIMER_A     = TACTL);

--- a/cpu/msp430/periph/uart_usart.c
+++ b/cpu/msp430/periph/uart_usart.c
@@ -59,7 +59,7 @@ static int init_base(uart_t uart, uint32_t baudrate)
     }
 
     /* get the default UART for now -> TODO: enable for multiple devices */
-    msp_usart_t *dev = UART_BASE;
+    msp430_usart_t *dev = UART_BASE;
 
     /* power off and reset device */
     uart_poweroff(uart);
@@ -76,7 +76,7 @@ static int init_base(uart_t uart, uint32_t baudrate)
     dev->MCTL = 0;
     /* configure pins -> TODO: move into GPIO driver (once implemented) */
     UART_PORT->SEL |= (UART_RX_PIN | UART_TX_PIN);
-    msp_port_t *port = &UART_PORT->base;
+    msp430_port_t *port = &UART_PORT->base;
     port->OD |= UART_RX_PIN;
     port->OD &= ~(UART_TX_PIN);
     port->DIR |= UART_TX_PIN;
@@ -91,7 +91,7 @@ static int init_base(uart_t uart, uint32_t baudrate)
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     (void)uart;
-    msp_usart_t *dev = UART_BASE;
+    msp430_usart_t *dev = UART_BASE;
 
     for (size_t i = 0; i < len; i++) {
         while (!(dev->TCTL & TXEPT)) {}

--- a/cpu/msp430/periph/uart_usci.c
+++ b/cpu/msp430/periph/uart_usci.c
@@ -58,7 +58,7 @@ static int init_base(uart_t uart, uint32_t baudrate)
     }
 
     /* get the default UART for now -> TODO: enable for multiple devices */
-    msp_usci_a_t *dev = UART_BASE;
+    msp430_usci_a_t *dev = UART_BASE;
 
     /* put device in reset mode while configuration is going on */
     dev->CTL1 = UCSWRST;


### PR DESCRIPTION
### Contribution description

Previously sometimes `msp_` was used as prefix, sometimes `msp430_`. This makes the naming consistent.

### Testing procedure

This only changes type names, not semantics. The generated binaries should be the same, except for debug symbols.

### Issues/PRs references

None