### PR TITLE
tests/unittests/tests-hashes: fix wrong string length

### DIFF
--- a/tests/unittests/tests-hashes/tests-hashes-sha512.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha512.c
@@ -341,7 +341,7 @@ static void test_hashes_sha512_hash_sequence_binary(void)
 
 static void test_hashes_sha512_hash_update_twice(void)
 {
-    static const char *teststring = "abcdef";
+    static const char teststring[] = "abcdef";
 
     static uint8_t hash_update_once[SHA512_DIGEST_LENGTH];
     static uint8_t hash_update_twice[SHA512_DIGEST_LENGTH];


### PR DESCRIPTION
### Contribution description

Incorrect use of `sizeof` for string length in test `test_hashes_sha512_hash_update_twice`.

`static const char *teststring` is a pointer, therefore `sizeof(teststring)` returns the pointer size instead of the intended string length. ~~This PR uses `strlen` instead of `sizeof` to fix this. Alternatively, we could change the type of the string to `static const char teststring[]`.~~

~~Note the subtle difference between `sizeof(char[])` and `strlen`: The former includes the null terminator, while `strlen` does not. This should not change the test behavior.~~

Edit:
This PR changes the type to `static const char teststring[]` so that `sizeof` returns the string length (including the null terminator). 

### Testing procedure

Compile and run unittests.

Note for 32-bit architectures: The test also passed before, but only used 4 and 3+1 bytes of the string.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->