### PR TITLE
gnrc_ipv6_nib: fix config for mixed 6lo/classic setup

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -99,6 +99,7 @@ PSEUDOMODULES += gnrc_dhcpv6_client_simple_pd
 ## @}
 PSEUDOMODULES += gnrc_ipv6_auto_subnets_auto_init
 PSEUDOMODULES += gnrc_ipv6_auto_subnets_simple
+PSEUDOMODULES += gnrc_ipv6_classic
 PSEUDOMODULES += gnrc_ipv6_default
 PSEUDOMODULES += gnrc_ipv6_ext_frag_stats
 PSEUDOMODULES += gnrc_ipv6_router

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -35,12 +35,6 @@ extern "C" {
 #ifndef CONFIG_GNRC_IPV6_NIB_6LBR
 #define CONFIG_GNRC_IPV6_NIB_6LBR                     1
 #endif
-#ifndef CONFIG_GNRC_IPV6_NIB_SLAAC
-#define CONFIG_GNRC_IPV6_NIB_SLAAC                    1
-#endif
-#ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT
-#define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT                1
-#endif
 #ifndef CONFIG_GNRC_IPV6_NIB_NUMOF
 #define CONFIG_GNRC_IPV6_NIB_NUMOF                   (16)
 #endif
@@ -50,20 +44,20 @@ extern "C" {
 #ifndef CONFIG_GNRC_IPV6_NIB_6LR
 #define CONFIG_GNRC_IPV6_NIB_6LR                      1
 #endif
-#ifndef CONFIG_GNRC_IPV6_NIB_SLAAC
-#define CONFIG_GNRC_IPV6_NIB_SLAAC                    0
-#endif
 #endif
 
 #ifdef MODULE_GNRC_IPV6_NIB_6LN
 #ifndef CONFIG_GNRC_IPV6_NIB_6LN
 #define CONFIG_GNRC_IPV6_NIB_6LN                      1
 #endif
-#ifndef CONFIG_GNRC_IPV6_NIB_SLAAC
-#define CONFIG_GNRC_IPV6_NIB_SLAAC                    0
-#endif
+
+/* We are only a 6lo node with no 'classic' IPv6 interface */
+#ifndef MODULE_GNRC_IPV6_CLASSIC
 #ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT
 #define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT                0
+#endif
+#ifndef CONFIG_GNRC_IPV6_NIB_SLAAC
+#define CONFIG_GNRC_IPV6_NIB_SLAAC                    0
 #endif
 #if !CONFIG_GNRC_IPV6_NIB_6LR
 # ifndef CONFIG_GNRC_IPV6_NIB_ARSM
@@ -73,6 +67,7 @@ extern "C" {
 /* only needs to store default router */
 # define CONFIG_GNRC_IPV6_NIB_NUMOF                  (1)
 # endif
+#endif
 #endif
 #endif
 
@@ -178,11 +173,7 @@ extern "C" {
  * @brief    queue packets for address resolution
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT
-#if CONFIG_GNRC_IPV6_NIB_6LN
-#define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT                0
-#else
 #define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT                1
-#endif
 #endif
 
 /**

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -172,6 +172,14 @@ ifneq (,$(filter gnrc_netif_bus,$(USEMODULE)))
   USEMODULE += core_msg_bus
 endif
 
+ifneq (,$(filter netdev_eth slipdev, $(USEMODULE)))
+  ifeq (,$(filter gnrc_sixloenc, $(USEMODULE)))
+    ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
+      USEMODULE += gnrc_ipv6_classic
+    endif
+  endif
+endif
+
 ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When mixing 6lo interfaces with 'classic' IPv6 interfaces we would always see strange behavior in RIOT. E.g. if we enable `gnrc_ipv6_default` together with an Ethernet interface and a IEEE 802.15.4 interface, the node would get a global address on the Ethernet interface but seemingly can't be reached via that address. (After manually enabling `CONFIG_GNRC_IPV6_NIB_SLAAC` and `CONFIG_GNRC_IPV6_NIB_ARSM`)

This is because the 6lo optimizations would always get turned on globally when the `gnrc_ipv6_nib_6ln` module is in use, disregarding what other interfaces might be present.

In this case the `CONFIG_GNRC_IPV6_NIB_NUMOF` would get set to 1, leading to no space being left for any neighbor's address, other than the default router, so address resolution would always fail.

Fix this by introducing a pseudo-module `gnrc_ipv6_classic` that gets selected by non-6lo interfaces. Now we can only enable the 6lo optimizations when there are no 'classic' interfaces present.

### Testing procedure

In `examples/gnrc_networking` replace `gnrc_ipv6_router_default` with `gnrc_ipv6_default` (or don't, it's just most apparent with that), then add `USEMODULE += netdev_tap` and build and run with `USE_ZEP=1`.

#### master

```
SLAAC not activated; will not auto-configure IPv6 address for interface 7.
    Use CONFIG_GNRC_IPV6_NIB_SLAAC=1 to activate.
main(): This is RIOT! (Version: 2024.01-devel-356-gfd3d92)
RIOT network stack example application
All up, running the shell now
> SLAAC not activated; will not auto-configure IPv6 address for interface 7.
    Use CONFIG_GNRC_IPV6_NIB_SLAAC=1 to activate.
ifconfig
ifconfig
Iface  7  HWaddr: E2:B9:1D:C4:14:21 
          L2-PDU:1500  MTU:1492  HL:255  Source address length: 6
          Link type: wired
          inet6 group: ff02::1
          
          Statistics for Layer 2
            RX packets 29  bytes 5112
            TX packets 1 (Multicast: 1)  bytes 62
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 13  bytes 2384
            TX packets 1 (Multicast: 1)  bytes 48
            TX succeeded 1 errors 0

Iface  8  HWaddr: 12:82  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: 66:BE:55:A0:3B:18:92:82 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::64be:55a0:3b18:9282  scope: link  VAL
          inet6 group: ff02::1
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 0
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0
```

let's manually enable SLAAC and ARSM…
But still no success:

```
Iface  7  HWaddr: E2:B9:1D:C4:14:21 
          L2-PDU:1500  MTU:1492  HL:255  Source address length: 6
          Link type: wired
          inet6 addr: fe80::e0b9:1dff:fec4:1421  scope: link  VAL
          inet6 addr: 2001:9e8:141e:bf00:e0b9:1dff:fec4:1421  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc4:1421
          
          Statistics for Layer 2
            RX packets 10  bytes 1204
            TX packets 3 (Multicast: 3)  bytes 218
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 5  bytes 552
            TX packets 3 (Multicast: 3)  bytes 176
            TX succeeded 3 errors 0

> ping 2001:9e8:141e:bf00:7dbd:ffa9:3dbb:7784   

--- 2001:9e8:141e:bf00:7dbd:ffa9:3dbb:7784 PING statistics ---
3 packets transmitted, 0 packets received, 100% packet loss
> nib neigh

fe80::de39:6fff:fe6a:6980 dev #7 lladdr DC:39:6F:6A:69:80 router STALE
```

#### this PR

```
main(): This is RIOT! (Version: 2024.01-devel-358-g6ba4e-gnrc_ipv6_classic)
RIOT network stack example application
All up, running the shell now
> ifconfig

Iface  7  HWaddr: E2:B9:1D:C4:14:21 
          L2-PDU:1500  MTU:1492  HL:255  Source address length: 6
          Link type: wired
          inet6 addr: fe80::e0b9:1dff:fec4:1421  scope: link  VAL
          inet6 addr: 2001:9e8:141e:bf00:e0b9:1dff:fec4:1421  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc4:1421
          
          Statistics for Layer 2
            RX packets 29  bytes 5112
            TX packets 3 (Multicast: 3)  bytes 218
            TX succeeded 3 errors 0
          Statistics for IPv6
            RX packets 13  bytes 2384
            TX packets 3 (Multicast: 3)  bytes 176
            TX succeeded 3 errors 0

Iface  8  HWaddr: 6F:E5  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: A6:4E:42:76:7E:03:6F:E5 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::a44e:4276:7e03:6fe5  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff03:6fe5
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 0
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0

> ping 2001:9e8:141e:bf00:4876:5bff:fec8:eb84   
12 bytes from 2001:9e8:141e:bf00:4876:5bff:fec8:eb84: icmp_seq=0 ttl=255 time=1.073 ms
12 bytes from 2001:9e8:141e:bf00:4876:5bff:fec8:eb84: icmp_seq=1 ttl=255 time=0.204 ms
12 bytes from 2001:9e8:141e:bf00:4876:5bff:fec8:eb84: icmp_seq=2 ttl=255 time=0.429 ms

--- 2001:9e8:141e:bf00:4876:5bff:fec8:eb84 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.204/0.568/1.073 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
