### PR TITLE
core/debug: printf what asked to print

### DIFF
--- a/core/lib/include/debug.h
+++ b/core/lib/include/debug.h
@@ -44,17 +44,7 @@ extern "C" {
  */
 #ifdef DEVELHELP
 #include "cpu_conf.h"
-#define DEBUG_PRINT(...) \
-    do { \
-        if ((thread_get_active() == NULL) || \
-            (thread_get_active()->stack_size >= \
-             THREAD_EXTRA_STACKSIZE_PRINTF)) { \
-            printf(__VA_ARGS__); \
-        } \
-        else { \
-            puts("Cannot debug, stack too small. Consider using DEBUG_PUTS()."); \
-        } \
-    } while (0)
+#define DEBUG_PRINT(...) do { printf(__VA_ARGS__); } while (0)
 #else
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #endif


### PR DESCRIPTION
### Contribution description

removes the unhelpful stack-size-test from debug-print

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

this is much more sane than #20166 