### PR TITLE
cpu/sam0/uart: implement uart_pin_cts()/uart_pin_rts()

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -318,6 +318,28 @@ void uart_deinit_pins(uart_t uart)
 #endif
 }
 
+gpio_t uart_pin_cts(uart_t uart)
+{
+#ifdef MODULE_PERIPH_UART_HW_FC
+    if (uart_config[uart].tx_pad == UART_PAD_TX_0_RTS_2_CTS_3) {
+        return uart_config[uart].cts_pin;
+    }
+#endif
+    (void)uart;
+    return GPIO_UNDEF;
+}
+
+gpio_t uart_pin_rts(uart_t uart)
+{
+#ifdef MODULE_PERIPH_UART_HW_FC
+    if (uart_config[uart].tx_pad == UART_PAD_TX_0_RTS_2_CTS_3) {
+        return uart_config[uart].rts_pin;
+    }
+#endif
+    (void)uart;
+    return GPIO_UNDEF;
+}
+
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     if (uart_config[uart].tx_pin == GPIO_UNDEF) {

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -255,6 +255,31 @@ gpio_t uart_pin_rx(uart_t uart);
 gpio_t uart_pin_tx(uart_t uart);
 
 #endif /* DOXYGEN */
+
+/**
+ * @brief   Get the CTS pin of the given UART.
+ *
+ * @param[in] uart      The device to query
+ *
+ * @note Until this is implemented on all platforms, this requires the
+ *       periph_uart_reconfigure feature to be used.
+ *
+ * @return              The GPIO used for the UART CTS line.
+ */
+gpio_t uart_pin_cts(uart_t uart);
+
+/**
+ * @brief   Get the RTS pin of the given UART.
+ *
+ * @param[in] uart      The device to query
+ *
+ * @note Until this is implemented on all platforms, this requires the
+ *       periph_uart_reconfigure feature to be used.
+ *
+ * @return              The GPIO used for the UART RTS line.
+ */
+gpio_t uart_pin_rts(uart_t uart);
+
 #endif /* MODULE_PERIPH_UART_RECONFIGURE */
 
 #if defined(MODULE_PERIPH_UART_RXSTART_IRQ) || DOXYGEN


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Just like `uart_pin_tx()`/`uart_pin_rx()` we want to have a function to query the RTS/CTS pins.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
