### PR TITLE
drivers/mtd_flashpage: improve _write_page

### DIFF
--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -114,9 +114,9 @@ static int _write_page(mtd_dev_t *dev, const void *buf, uint32_t page, uint32_t 
                 __attribute__ ((aligned (FLASHPAGE_WRITE_BLOCK_ALIGNMENT)));
 
         offset = addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT;
-        size = MIN(size, FLASHPAGE_WRITE_BLOCK_ALIGNMENT - offset);
+        size = MIN(size, FLASHPAGE_WRITE_BLOCK_SIZE - offset);
 
-        DEBUG("flashpage: write %"PRIu32" unaligned bytes\n", size);
+        DEBUG("flashpage: write %"PRIu32" at %p - ""%"PRIu32"\n", size, (void *)addr, offset);
 
         memcpy(&tmp[0], (uint8_t *)addr - offset, sizeof(tmp));
         memcpy(&tmp[offset], buf, size);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Some time ago I noticed that the mtd_flashpage driver was not writing the size of a full block (`FLASHPAGE_WRITE_BLOCK_SIZE`) when it could be, on unaligned access.
It was only writing `FLASHPAGE_WRITE_BLOCK_ALIGNMENT`.
So this PR is just a tiny performance improvement.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

That case even happens in the test `tests/drivers/mtd_flashpage`.
And with his change it still passes on `same54-xpro`.

```
2023-12-13 00:07:20,959 # START
2023-12-13 00:07:20,967 # main(): This is RIOT! (Version: 2024.01-devel-360-ga5be0-pr/mtd_flashpage_improve_write_page)
2023-12-13 00:07:22,206 # .....
2023-12-13 00:07:22,207 # OK (5 tests)
2023-12-13 00:07:22,213 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 448 }]}
```



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
