### PR TITLE
pkg/libcose: fix auto_init compilation

### DIFF
--- a/pkg/libcose/init/init.c
+++ b/pkg/libcose/init/init.c
@@ -25,6 +25,7 @@
 #include "xfa.h"
 
 #include "cose/crypto.h"
+#include "cose/crypto/riot.h"
 
 #if IS_USED(MODULE_AUTO_INIT)
 #include "auto_init_utils.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The file `pkg/libcose/init/init.c` is just missing the include of  `pkg/libcose/include/cose/crypto/riot.h` to know about `AUTO_INIT_PRIO_MOD_LIBCOSE`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`CFLAGS+=-DCONFIG_AUTO_INIT_ENABLE_DEBUG=1 USEPKG+=libcose BOARD=same54-xpro make -C examples/suit_update` compiles with this fix.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
