### PR TITLE
boards/wemos-zero: fix flashing and doc

### DIFF
--- a/boards/wemos-zero/Makefile.include
+++ b/boards/wemos-zero/Makefile.include
@@ -1,5 +1,16 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 # Include all definitions for flashing with bossa other USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 include $(RIOTBOARD)/common/arduino-zero/Makefile.include
+
+# Depending on whether the board is running RIOT or the bootloader, it has
+# registers using a different vendor and model. We try to detect either.
+TTY_BOARD_FILTER := --model $(BOARD) --vendor 'RIOT-os\.org'
+PROG_TTY_BOARD_FILTER := --vendor 'Arduino LLC' --model 'Arduino Zero'
+TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
+                  --most-recent \
+                  --format path serial \
+                  $(TTY_BOARD_FILTER) || \
+                  $(RIOTTOOLS)/usb-serial/ttys.py \
+                  --most-recent \
+                  --format path serial \
+                  $(PROG_TTY_BOARD_FILTER_CLONE)

--- a/boards/wemos-zero/doc.txt
+++ b/boards/wemos-zero/doc.txt
@@ -47,8 +47,7 @@ Metro M0 Express should also work with board definition.
 
 ## Flashing the device
 
-Assuming the [UF2 Bootloader](https://github.com/microsoft/uf2-samdx1) is
-installed, just run:
+Assuming the Arduino Bootloader is installed, just run:
 
 ```
 make BOARD=wemos-zero flash


### PR DESCRIPTION
### Contribution description

Fix flashing with `MOST_RECENT_PORT=1` by detecting the board when either in RIOT mode or in bootloader mode (which matches different USB vendor and model strings).

Support for programming with the nrf52-u2f bootloader was dropped apparently, but the documentation still recommends that over the Arduino Bootloader. This brings doc and code in sync.

### Testing procedure

```
make BOARD=wemos-zero MOST_RECENT_PORT=1 -C examples/default
```

should now succeed, even after double-pressing the reset button.

### Issues/PRs references

None