### PR TITLE
tools/edbg: fix `make reset`

### DIFF
--- a/dist/tools/edbg/edbg.sh
+++ b/dist/tools/edbg/edbg.sh
@@ -25,7 +25,7 @@ do_flash() {
 }
 
 do_reset() {
-    sh -c "${EDBG} ${EDBG_ARGS}"
+    sh -c "${EDBG} ${EDBG_ARGS} -x 10"
 }
 
 #


### PR DESCRIPTION
### Contribution description

Likely a change in the command line interface of EDBG broke the `make reset` integration. This adds the missing flag.

Note: Since the binary is build on demand with our build system, we
      can in fact rely on every using the same version of EDBG. Hence,
      we don't need to be backwards compatible with the flag.

### Testing procedure

In one terminal session run

```
make -C examples/default BOARD=samr21-xpro flash term
```

While connected to the RIOT shell, run

```
make -C examples/default BOARD=samr21-xpro reset
```

With `master`, the board won't reboot. With this PR, it will reboot on the `make reset` command again.

### Issues/PRs references

None