### PR TITLE
drivers/mtd: improve doc consistency

### DIFF
--- a/cpu/sam0_common/include/mtd_sam0_sdhc.h
+++ b/cpu/sam0_common/include/mtd_sam0_sdhc.h
@@ -7,9 +7,10 @@
  */
 
 /**
+ * @defgroup    drivers_mtd_sam0_sdhc MTD wrapper for SAM0 SDHC devices
  * @ingroup     drivers_storage
  * @ingroup     cpu_sam0_common_sdhc
- * @brief       Driver for SD-cards using mtd interface
+ * @brief       Driver for SD Cards connected to the SAM0 SDHC peripheral using the MTD interface
  *
  * @{
  *

--- a/drivers/include/mtd_emulated.h
+++ b/drivers/include/mtd_emulated.h
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @defgroup    drivers_mtd_emulated MTD wrapper for emulated MTD devices
  * @ingroup     drivers_mtd
  * @{
  * @brief       MTD device that is emulated in RAM for test purposes

--- a/drivers/include/mtd_flashpage.h
+++ b/drivers/include/mtd_flashpage.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    drivers_mtd_flashpage   Flashpage MTD
+ * @defgroup    drivers_mtd_flashpage MTD wrapper for Flashpage devices
  * @ingroup     drivers_storage
  * @brief       Driver for internal flash devices implementing flashpage interface
  *

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -7,14 +7,14 @@
  */
 
 /**
- * @defgroup    drivers_mtd_sdcard mtd wrapper for sdcard_spi
+ * @defgroup    drivers_mtd_sdcard MTD wrapper for SPI SD Cards
  * @ingroup     drivers_storage
- * @brief       Driver for SD-cards using mtd interface
+ * @brief       Driver for SPI SD Cards using the MTD interface
  *
  * @{
  *
  * @file
- * @brief       Interface definition for mtd_sdcard driver
+ * @brief       Interface definition for the mtd_sdcard driver
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */

--- a/drivers/include/mtd_sdmmc.h
+++ b/drivers/include/mtd_sdmmc.h
@@ -8,14 +8,14 @@
  */
 
 /**
- * @defgroup    drivers_mtd_sdmmc mtd wrapper for sdmmc
+ * @defgroup    drivers_mtd_sdmmc MTD wrapper for SD/MMC devices
  * @ingroup     drivers_storage
- * @brief       Driver for SD Memory Cards and MMCs/eMMCs using mtd interface
+ * @brief       Driver for SD Memory Cards and MMCs/eMMCs using the MTD interface
  *
  * @{
  *
  * @file
- * @brief       Interface definition for mtd_sdmmc driver
+ * @brief       Interface definition for the mtd_sdmmc driver
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  * @author      Gunar Schorcht <gunar@schorcht.net>
@@ -46,7 +46,7 @@ typedef struct {
 } mtd_sdmmc_t;
 
 /**
- * @brief   sdcard device operations table for mtd
+ * @brief   SD/MMC device operations table for mtd
  */
 extern const mtd_desc_t mtd_sdmmc_driver;
 

--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    drivers_sdcard_spi SPI SD-Card driver
+ * @defgroup    drivers_sdcard_spi SPI SD Card driver
  * @ingroup     drivers_storage
- * @brief       Driver for reading and writing sd-cards via spi interface.
+ * @brief       Driver for reading and writing SD Cards using the SPI.
  * @anchor      drivers_sdcard_spi
  * @{
  *


### PR DESCRIPTION
### Contribution description

This PR provides some small changes in documentation to improve the consistency of documentation for MTD devices.

While fixing PR #19786, I realized that the list of MTD devices is inconsistent: 
- Some entries use "MTD wrapper for ..."
- Some entries use "mtd wrapper for ..."
- Other entries just use "xxxx MTD"
- SAM0 SDHC is just listed as file
- The MTD wrapper for emulated MTD devices isn't listed at all but part of the MTD main page by acciedent

![Bildschirmfoto vom 2023-12-14 15-23-12](https://github.com/RIOT-OS/RIOT/assets/31932013/b73d7e04-f45c-4e0e-b253-17a959814614)

This PR tries to make the list a bit more consistent to improve its readability.

![Bildschirmfoto vom 2023-12-14 15-22-24](https://github.com/RIOT-OS/RIOT/assets/31932013/b25ed235-8b91-4c56-9f1c-988592f5fa80)

I'm a bit unsure about Serial NOR flash which is also just a MTD.

### Testing procedure

Generae the doc and check the output.

### Issues/PRs references
