### PR TITLE
core/mutex: Fix debug message for mutex priority inheritance

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -222,8 +222,8 @@ void mutex_unlock(mutex_t *mutex)
     thread_t *owner = thread_get(mutex->owner);
     if ((owner) && (owner->priority != mutex->owner_original_priority)) {
         DEBUG("PID[%" PRIkernel_pid "] prio %u --> %u\n",
-              owner->pid,
-              (unsigned)owner->priority, (unsigned)owner->priority);
+              owner->pid, (unsigned)owner->priority,
+              (unsigned)mutex->owner_original_priority);
         sched_change_priority(owner, mutex->owner_original_priority);
     }
 #endif


### PR DESCRIPTION
### Contribution description
Minor fix for debug message for mutex priority inheritance.

### Testing procedure

Set `#define ENABLE_DEBUG 1` in `core/mutex.c`
`make -C tests/core/thread_priority_inversion all test`

```
...
PID[3] mutex_unlock(): waking up waiting thread 5
PID[3] prio 4 --> 6
high priority thread started to work on its task
...
```