### PR TITLE
make help: show generate-Makefile.ci

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1031,7 +1031,8 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
 endif
 
 help:
-	@$(MAKE) -qp | sed -ne 's/\(^[a-z][a-z_-]*\):.*/\1/p' | sort | uniq
+  # filter all targets starting with lowercase and containing lowercase letters, hyphens, or underscores; explicitly include generate-Makefile.ci
+	@$(MAKE) -qp | sed -ne 's/\(^[a-z][a-z_-]*\|generate-Makefile.ci\):.*/\1/p' | sort -u
 
 ifeq (iotlab-m3,$(BOARD))
   ifneq (,$(filter iotlab-%,$(MAKECMDGOALS)))


### PR DESCRIPTION
### Contribution description

`generate-Makefile.ci` is the only target interesting to the user containing uppercase and a dot, which wasn't matched by the `sed` command used in `make help`. Changing that accordingly matches `*.module` and `*.xml` targets, too, which still shouldn't be part of the user-visible targets. Therefore, those are filtered out with `grep`.


### Testing procedure

1. on `master`: `make -C examples/hello-world help > before`
2. with this PR: `make -C examples/hello-world help > after`
3. `diff before after` results in:
```
46a47
> generate-Makefile.ci
```


### Issues/PRs references

`generate-Makefile.ci` was added with https://github.com/RIOT-OS/RIOT/pull/19244