### PR TITLE
make all: document targets for RIOT base module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,19 @@ welcome:
 	@echo "Welcome to RIOT - The friendly OS for IoT!"
 	@echo ""
 	@echo "You executed 'make' from the base directory."
-	@echo "You should run 'make' in your application's directory instead."
+	@echo "Usually, you should run 'make' in your application's directory instead."
 	@echo ""
 	@echo "Please see our Quick Start Guide at:"
 	@echo "    https://doc.riot-os.org/getting-started.html"
 	@echo "You can ask questions or discuss with other users on our forum:"
 	@echo "    https://forum.riot-os.org"
+	@echo ""
+	@echo "Available targets for the RIOT base directory include:"
+	@echo " generate-{board,driver,example,module,pkg,test}"
+	@echo " info-{applications,boards,emulated-boards} info-applications-supported-boards"
+	@echo " print-versions"
+	@echo " clean distclean pkg-clean"
+	@echo " doc doc-{man,latex}"
 
 print-versions:
 	@./dist/tools/ci/print_toolchain_versions.sh


### PR DESCRIPTION
### Contribution description

There is no target similar to `make help` available when calling `make` from the RIOT base directory, although there are several useful targets that are supposed to be called from there. Instead of adding a new `help` target, this PR lists the available targets manually in the `welcome` message.

### Testing procedure

With these changes, `make` or `make all` from the RIOT base directory gives:

```
Welcome to RIOT - The friendly OS for IoT!

You executed 'make' from the base directory.
Usually, you should run 'make' in your application's directory instead.

Please see our Quick Start Guide at:
    https://doc.riot-os.org/getting-started.html
You can ask questions or discuss with other users on our forum:
    https://forum.riot-os.org

Available targets for the RIOT base directory include:
 generate-{board,driver,example,module,pkg,test}
 info-{applications,boards,emulated-boards} info-applications-supported-boards
 print-versions
 clean distclean pkg-clean
 doc doc-{man,latex}

make: *** [Makefile:7: all] Error 1
```
