### PR TITLE
sys/net/netif: constify netif access

### DIFF
--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -21,7 +21,7 @@
 #include "lwip/netifapi.h"
 #include "net/netif.h"
 
-int netif_get_name(netif_t *iface, char *name)
+int netif_get_name(const netif_t *iface, char *name)
 {
     lwip_netif_t *lwip_netif = (lwip_netif_t*) iface;
     struct netif *netif = &lwip_netif->lwip_netif;
@@ -34,7 +34,7 @@ int netif_get_name(netif_t *iface, char *name)
     return res;
 }
 
-int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
+int netif_get_opt(const netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t max_len)
 {
     (void)context;
@@ -83,7 +83,7 @@ int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
     return res;
 }
 
-int netif_set_opt(netif_t *iface, netopt_t opt, uint16_t context,
+int netif_set_opt(const netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t value_len)
 {
     (void)context;

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -104,7 +104,7 @@ netif_t *netif_iter(const netif_t *last);
  * @return  length of @p name on success
  */
 
-int netif_get_name(netif_t *netif, char *name);
+int netif_get_name(const netif_t *netif, char *name);
 
 /**
  * @brief   Gets the numeric identifier of an interface
@@ -170,7 +170,7 @@ netif_t *netif_get_by_id(int16_t id);
  * @return  Number of bytes written to @p value.
  * @return  `< 0` on error, 0 on success.
  */
-int netif_get_opt(netif_t *netif, netopt_t opt, uint16_t context,
+int netif_get_opt(const netif_t *netif, netopt_t opt, uint16_t context,
                   void *value, size_t max_len);
 
 /**
@@ -187,7 +187,7 @@ int netif_get_opt(netif_t *netif, netopt_t opt, uint16_t context,
  * @return Number of bytes used from @p value.
  * @return `< 0` on error, 0 on success.
  */
-int netif_set_opt(netif_t *netif, netopt_t opt, uint16_t context,
+int netif_set_opt(const netif_t *netif, netopt_t opt, uint16_t context,
                   void *value, size_t value_len);
 
 /**

--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -24,7 +24,7 @@
 
 #include "net/netif.h"
 
-int netif_get_name(netif_t *iface, char *name)
+int netif_get_name(const netif_t *iface, char *name)
 {
     gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
 
@@ -45,14 +45,14 @@ netif_t *netif_get_by_id(int16_t id)
     return &gnrc_netif_get_by_pid((kernel_pid_t)id)->netif;
 }
 
-int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
+int netif_get_opt(const netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t max_len)
 {
     const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
     return gnrc_netapi_get(netif->pid, opt, context, value, max_len);
 }
 
-int netif_set_opt(netif_t *iface, netopt_t opt, uint16_t context,
+int netif_set_opt(const netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t value_len)
 {
     const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We don't modify the contents of `netif`, so the pointer can be `const`.


### Testing procedure

Code still compiles.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
