### PR TITLE
nanocoap: introduce coap_get_method()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -500,6 +500,18 @@ static inline unsigned coap_get_code_raw(const coap_pkt_t *pkt)
 }
 
 /**
+ * @brief   Get a request's method type
+ *
+ * @param[in]   pkt   CoAP request packet
+ *
+ * @returns     request method type
+ */
+static inline coap_method_t coap_get_method(const coap_pkt_t *pkt)
+{
+    return pkt->hdr->code;
+}
+
+/**
  * @brief   Get the message ID of the given CoAP packet
  *
  * @param[in]   pkt   CoAP packet

--- a/sys/net/application_layer/nanocoap/fileserver.c
+++ b/sys/net/application_layer/nanocoap/fileserver.c
@@ -434,7 +434,7 @@ static ssize_t _delete_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 static ssize_t nanocoap_fileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                              struct requestdata *request)
 {
-    switch (coap_get_code_raw(pdu)) {
+    switch (coap_get_method(pdu)) {
         case COAP_METHOD_GET:
             return _get_file(pdu, buf, len, request);
 #if IS_USED(MODULE_NANOCOAP_FILESERVER_PUT)
@@ -568,7 +568,7 @@ static ssize_t nanocoap_fileserver_directory_handler(coap_pkt_t *pdu, uint8_t *b
                                                   struct requestdata *request,
                                                   const char *root, const char* resource_dir)
 {
-    switch (coap_get_code_raw(pdu)) {
+    switch (coap_get_method(pdu)) {
         case COAP_METHOD_GET:
             return _get_directory(pdu, buf, len, request, root, resource_dir);
 #if IS_USED(MODULE_NANOCOAP_FILESERVER_PUT)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is just an alias for `coap_get_code_raw()`.
When writing a CoAP handler function, it's very unintuitive that the 'raw Code' is needed to obtain the request method.

This also gives us the opportunity to use the `coap_method_t` type to avoid ambiguity. 


### Testing procedure

No functional changes.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
