### PR TITLE
print: Added size_t print format specifier 

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -301,9 +301,7 @@ Some solutions to correctly handle compilation warnings.
 Solution for string formatting errors:
 
 * When printing a `size_t`
-    * use `%u` and cast the variable to `(unsigned)` because `newlib-nano` does
-      not support `%zu`
-      [example](https://github.com/RIOT-OS/RIOT/blob/e19f6463c09fc22c76c5b855799054cf27a697f1/tests/sizeof_tcb/main.c#L34)
+    * use `PRIuSIZE` from `architecture.h` because `newlib-nano` does not support `%zu`
 * When printing an `unsigned char/uint8_t`
     * Use `%u` because `newlib-nano` does not support `%hu/PRIu8`
       [example](https://github.com/RIOT-OS/RIOT/pull/4851)

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -158,8 +158,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
         /* current packet data + FCS too long */
         if ((len + iol->iol_len + IEEE802154_FCS_LEN) > AT86RF215_MAX_PKT_LENGTH) {
-            DEBUG("[at86rf215] error: packet too large (%u byte) to be send\n",
-                  (unsigned)len + IEEE802154_FCS_LEN);
+            DEBUG("[at86rf215] error: packet too large (%" PRIuSIZE
+                  " byte) to be send\n", len + IEEE802154_FCS_LEN);
             at86rf215_tx_abort(dev);
             return -EOVERFLOW;
         }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -30,6 +30,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include "architecture.h"
 #include "iolist.h"
 
 #include "net/eui64.h"
@@ -216,8 +217,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         /* current packet data + FCS too long */
         if ((len + iol->iol_len + 2) > AT86RF2XX_MAX_PKT_LENGTH) {
-            DEBUG("[at86rf2xx] error: packet too large (%u byte) to be send\n",
-                  (unsigned)len + 2);
+            DEBUG("[at86rf2xx] error: packet too large (%" PRIuSIZE
+                  " byte) to be send\n", len + 2);
             return -EOVERFLOW;
         }
         if (iol->iol_len) {

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -425,10 +425,9 @@ static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
         if (iol->iol_len) {
             if (size + iol->iol_len > CC110X_MAX_FRAME_SIZE) {
                 cc110x_release(dev);
-                DEBUG("[cc110x] netdev_driver_t::send(): Frame size of %uB "
-                      "exceeds maximum supported size of %uB\n",
-                      (unsigned)(size + iol->iol_len),
-                      (unsigned)CC110X_MAX_FRAME_SIZE);
+                DEBUG("[cc110x] netdev_driver_t::send(): Frame size of %"
+                      PRIuSIZE "B exceeds maximum supported size of %uB\n",
+                      size + iol->iol_len, (unsigned)CC110X_MAX_FRAME_SIZE);
                 return -1;
             }
             memcpy(dev->buf.data + size, iol->iol_base, iol->iol_len);

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -120,7 +120,7 @@ static int cc1xxx_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
     /* get the payload size and the dst address details */
     size = gnrc_pkt_len(pkt->next);
-    DEBUG("[cc1xxx-gnrc] send: payload of packet is %i\n", (int)size);
+    DEBUG("[cc1xxx-gnrc] send: payload of packet is %" PRIuSIZE "\n", size);
     netif_hdr = (gnrc_netif_hdr_t *)pkt->data;
 
     l2hdr.src_addr = cc1xxx_dev->addr;

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -133,7 +133,7 @@ size_t cc2420_tx_prepare(cc2420_t *dev, const iolist_t *iolist)
             cc2420_fifo_write(dev, iol->iol_base, iol->iol_len);
         }
     }
-    DEBUG("cc2420: tx_prep: loaded %i byte into the TX FIFO\n", (int)pkt_len);
+    DEBUG("cc2420: tx_prep: loaded %" PRIuSIZE " byte into the TX FIFO\n", pkt_len);
 
     return pkt_len;
 }

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -443,7 +443,7 @@ static int _recv(netdev_t *dev, void *buf, size_t len, void *info)
 
     size_t dummy;
     if (crb_get_chunk_size(&ctx->rb, &dummy)) {
-        DEBUG("dose: %u byte pkt in rx queue\n", (unsigned)dummy);
+        DEBUG("dose: %" PRIuSIZE " byte pkt in rx queue\n", dummy);
         netdev_trigger_event_isr(&ctx->netdev);
     }
 

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -330,8 +330,8 @@ static int nd_recv(netdev_t *netdev, void *buf, size_t max_len, void *info)
     next = (uint16_t)((head[1] << 8) | head[0]);
     size = (uint16_t)((head[3] << 8) | head[2]) - 4;  /* discard CRC */
 
-    DEBUG("[enc28j60] recv: size=%i next=%i buf=%p len=%d\n",
-          (int)size, (int)next, buf, max_len);
+    DEBUG("[enc28j60] recv: size=%u next=%u buf=%p len=%" PRIuSIZE "\n",
+          size, next, buf, max_len);
 
     if (buf != NULL) {
         /* read packet content into the supplied buffer */

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -243,14 +243,14 @@ static int kw41zrf_netdev_send(netdev_t *netdev, const iolist_t *iolist)
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         /* current packet data + FCS too long */
         if ((len + iol->iol_len) > (KW41ZRF_MAX_PKT_LENGTH - IEEE802154_FCS_LEN)) {
-            LOG_ERROR("[kw41zrf] packet too large (%u byte) to fit\n",
-                  (unsigned)len + IEEE802154_FCS_LEN);
+            LOG_ERROR("[kw41zrf] packet too large (%" PRIuSIZE " byte) to fit\n",
+                  len + IEEE802154_FCS_LEN);
             return -EOVERFLOW;
         }
         len = kw41zrf_tx_load(iol->iol_base, iol->iol_len, len);
     }
 
-    DEBUG("[kw41zrf] TX %u bytes\n", len);
+    DEBUG("[kw41zrf] TX %" PRIuSIZE " bytes\n", len);
 
     /*
      * First octet in the TX buffer contains the frame length.

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -428,8 +428,8 @@ void lcd_pixmap(lcd_t *dev, uint16_t x1, uint16_t x2,
     size_t num_pix = (x2 - x1 + 1) * (y2 - y1 + 1);
 
     DEBUG("[lcd]: Write x1: %" PRIu16 ", x2: %" PRIu16 ", "
-          "y1: %" PRIu16 ", y2: %" PRIu16 ". Num pixels: %lu\n",
-          x1, x2, y1, y2, (unsigned long)num_pix);
+          "y1: %" PRIu16 ", y2: %" PRIu16 ". Num pixels: %" PRIuSIZE "\n",
+          x1, x2, y1, y2, num_pix);
 
     lcd_ll_acquire(dev);
 

--- a/drivers/usbdev_mock/usbdev_mock.c
+++ b/drivers/usbdev_mock/usbdev_mock.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "periph/usbdev.h"
 #include "test_utils/expect.h"
 #include "usbdev_mock.h"
@@ -200,8 +201,8 @@ void _ep_esr(usbdev_ep_t *ep)
 
 int _xmit(usbdev_ep_t *ep, uint8_t *buf, size_t len)
 {
-    DEBUG("[mock]: Readying EP %u, dir %s, len %u\n",
-          ep->num, ep->dir == USB_EP_DIR_OUT ? "out" : "in", (unsigned)len);
+    DEBUG("[mock]: Readying EP %u, dir %s, len %" PRIuSIZE "\n",
+          ep->num, ep->dir == USB_EP_DIR_OUT ? "out" : "in", len);
     if (ep->num == 0) {
         usbdev_mock_t *usbdev_mock = _ep2dev(ep);
         usbdev_mock_ep_t *mock_ep = (usbdev_mock_ep_t *)ep;

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -111,7 +111,7 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
     /* get the payload size and the dst address details */
     size = gnrc_pkt_len(pkt->next);
-    DEBUG("[xbee-gnrc] send: payload of packet is %i\n", (int)size);
+    DEBUG("[xbee-gnrc] send: payload of packet is %" PRIuSIZE "\n", size);
     hdr = (gnrc_netif_hdr_t *)pkt->data;
     if (hdr->flags & BCAST) {
         uint16_t addr = 0xffff;

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -673,7 +673,7 @@ static int xbee_send(netdev_t *dev, const iolist_t *iolist)
     }
 
     /* send the actual data packet */
-    DEBUG("[xbee] send: now sending out %i byte\n", (int)size);
+    DEBUG("[xbee] send: now sending out %" PRIuSIZE " byte\n", size);
     mutex_lock(&(xbee->tx_lock));
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         if (iol->iol_len > 0) {
@@ -705,16 +705,16 @@ static int xbee_recv(netdev_t *dev, void *buf, size_t len, void *info)
     size = (size_t)(xbee->rx_limit - 1);
     if (buf == NULL) {
         if (len > 0) {
-            DEBUG("[xbee] recv: reading size and dropping: %u\n", (unsigned)size);
+            DEBUG("[xbee] recv: reading size and dropping: %" PRIuSIZE "\n", size);
             xbee->rx_count = 0;
         }
         else {
-            DEBUG("[xbee] recv: reading size without dropping: %u\n", (unsigned)size);
+            DEBUG("[xbee] recv: reading size without dropping: %" PRIuSIZE "\n", size);
         }
     }
     else {
         size = (size > len) ? len : size;
-        DEBUG("[xbee] recv: consuming packet: reading %u byte\n", (unsigned)size);
+        DEBUG("[xbee] recv: consuming packet: reading %" PRIuSIZE " byte\n", size);
         memcpy(buf, xbee->rx_buf, size);
         xbee->rx_count = 0;
     }

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -114,7 +114,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
 
     if (res <= 0) {
         if ((ENABLE_DEBUG) && (res != -EAGAIN) && (res != -ETIMEDOUT)) {
-            DEBUG("sock_udp_recv unexpected code error: %i\n", (int)res);
+            DEBUG("sock_udp_recv unexpected code error: %" PRIiSIZE "\n", res);
         }
         return 0;
     }

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -106,7 +106,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
 
     if (res <= 0) {
         if ((ENABLE_DEBUG) && (res != -EAGAIN) && (res != -ETIMEDOUT)) {
-            DEBUG("sock_udp_recv unexpected code error: %i\n", (int)res);
+            DEBUG("sock_udp_recv unexpected code error: %" PRIiSIZE "\n", res);
         }
         return 0;
     }

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -154,7 +154,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     res = credman_add(&credential0);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %d\n", (int)res);
+        printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
         return -1;
     }
 
@@ -170,13 +170,13 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     res = credman_add(&credential1);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %d\n", (int)res);
+        printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
         return -1;
     }
 
     /* make the new credential available to the sock */
     if (sock_dtls_add_credential(&dtls_sock, SOCK_DTLS_CLIENT_TAG_1) < 0) {
-        printf("Error cannot add credential to the sock: %d\n", (int)res);
+        printf("Error cannot add credential to the sock: %" PRIdSIZE "\n", res);
         return -1;
     }
 
@@ -192,7 +192,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     res = sock_dtls_recv(&dtls_sock, &session, buf, sizeof(buf),
                          SOCK_NO_TIMEOUT);
     if (res != -SOCK_DTLS_HANDSHAKE) {
-        printf("Error creating session: %d\n", (int)res);
+        printf("Error creating session: %" PRIdSIZE "\n", res);
         sock_dtls_close(&dtls_sock);
         sock_udp_close(&udp_sock);
         return -1;
@@ -208,7 +208,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
         uint8_t rcv[512];
         if ((res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv),
                                     SOCK_NO_TIMEOUT)) >= 0) {
-            printf("Received %d bytes: \"%.*s\"\n", (int)res, (int)res,
+            printf("Received %" PRIdSIZE " bytes: \"%.*s\"\n", res, (int)res,
                    (char *)rcv);
         }
     }

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -139,7 +139,7 @@ void *dtls_server_wrapper(void *arg)
     res = credman_add(&credential0);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %d\n", (int)res);
+        printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
         return NULL;
     }
 
@@ -163,13 +163,13 @@ void *dtls_server_wrapper(void *arg)
     res = credman_add(&credential1);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %d\n", (int)res);
+        printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
         return NULL;
     }
 
     /* make the new credential available to the sock */
     if (sock_dtls_add_credential(&sock, SOCK_DTLS_SERVER_TAG_1) < 0) {
-        printf("Error cannot add credential to the sock: %d\n", (int)res);
+        printf("Error cannot add credential to the sock: %" PRIdSIZE "\n", res);
         return NULL;
     }
 
@@ -187,10 +187,10 @@ void *dtls_server_wrapper(void *arg)
             res = sock_dtls_recv(&sock, &session, rcv, sizeof(rcv),
                                   10 * US_PER_SEC);
             if (res >= 0) {
-                printf("Received %d bytes -- (echo)\n", (int)res);
+                printf("Received %" PRIdSIZE " bytes -- (echo)\n", res);
                 res = sock_dtls_send(&sock, &session, rcv, (size_t)res, 0);
                 if (res < 0) {
-                    printf("Error resending DTLS message: %d", (int)res);
+                    printf("Error resending DTLS message: %" PRIdSIZE, res);
                 }
                 sock_dtls_session_destroy(&sock, &session);
             }

--- a/examples/emcute_mqttsn/main.c
+++ b/examples/emcute_mqttsn/main.c
@@ -159,8 +159,8 @@ static int cmd_pub(int argc, char **argv)
         return 1;
     }
 
-    printf("Published %i bytes to topic '%s [%i]'\n",
-            (int)strlen(argv[2]), t.name, t.id);
+    printf("Published %" PRIuSIZE " bytes to topic '%s [%i]'\n",
+           strlen(argv[2]), t.name, t.id);
 
     return 0;
 }

--- a/examples/gcoap/client.c
+++ b/examples/gcoap/client.c
@@ -368,8 +368,8 @@ int gcoap_cli_cmd(int argc, char **argv)
             len = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
         }
 
-        printf("gcoap_cli: sending msg ID %u, %u bytes\n", coap_get_id(&pdu),
-               (unsigned) len);
+        printf("gcoap_cli: sending msg ID %u, %" PRIuSIZE " bytes\n",
+               coap_get_id(&pdu), len);
         if (!_send(&buf[0], len, argv[apos])) {
             puts("gcoap_cli: msg send failed");
         }

--- a/examples/gcoap_block_server/gcoap_block.c
+++ b/examples/gcoap_block_server/gcoap_block.c
@@ -93,8 +93,8 @@ static ssize_t _sha256_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_r
 
     int blockwise = coap_get_block1(pdu, &block1);
 
-    printf("_sha256_handler: received data: offset=%u len=%u blockwise=%i more=%i\n",
-            (unsigned)block1.offset, pdu->payload_len, blockwise, block1.more);
+    printf("_sha256_handler: received data: offset=%" PRIuSIZE " len=%u blockwise=%i more=%i\n",
+            block1.offset, pdu->payload_len, blockwise, block1.more);
 
     /* initialize sha256 calculation and add payload bytes */
     if (block1.blknum == 0) {

--- a/examples/lua_REPL/main.c
+++ b/examples/lua_REPL/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "lua_run.h"
 #include "lua_builtin.h"
 #include "blob/repl.lua.h"
@@ -44,7 +45,7 @@ const size_t lua_riot_builtin_lua_table_len = 1;
 
 int main(void)
 {
-    printf("Using memory range for Lua heap: %p - %p, %zu bytes\n",
+    printf("Using memory range for Lua heap: %p - %p, %" PRIuSIZE " bytes\n",
            (void *)lua_memory, (void *)(lua_memory + MAIN_LUA_MEM_SIZE), sizeof(void *));
 
     while (1) {

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -128,8 +128,8 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_request_
     coap_block1_t block1;
     int blockwise = coap_get_block1(pkt, &block1);
 
-    printf("_sha256_handler(): received data: offset=%u len=%u blockwise=%i more=%i\n", \
-            (unsigned)block1.offset, pkt->payload_len, blockwise, block1.more);
+    printf("_sha256_handler(): received data: offset=%" PRIuSIZE " len=%u blockwise=%i more=%i\n",
+            block1.offset, pkt->payload_len, blockwise, block1.more);
 
     if (block1.offset == 0) {
         puts("_sha256_handler(): init");

--- a/examples/posix_sockets/udp.c
+++ b/examples/posix_sockets/udp.c
@@ -136,7 +136,7 @@ static int udp_send(char *addr_str, char *port_str, char *data, unsigned int num
             puts("could not send");
         }
         else {
-            printf("Success: send %u byte to %s:%u\n", (unsigned)data_len, addr_str, port);
+            printf("Success: send %" PRIuSIZE " byte to %s:%u\n", data_len, addr_str, port);
         }
 
         usleep(delay);

--- a/examples/riot_and_cpp/main.cpp
+++ b/examples/riot_and_cpp/main.cpp
@@ -21,6 +21,7 @@
  * @author      DangNhat Pham-Huu <51002279@hcmut.edu.vn>
  */
 
+#include "architecture.h"
 #include "thread.h"
 
 #include "c_functions.h"
@@ -64,7 +65,7 @@ int main()
     vInts.push_back(1);
     vInts.push_back(3);
     vInts.push_back(2);
-    printf("The vector vInts has been filled with %d numbers.\n", (int)vInts.size());
+    printf("The vector vInts has been filled with %" PRIuSIZE " numbers.\n", vInts.size());
 
     printf("\n-= Test iterator =-\n");
     printf("The content of vInts = { ");

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -349,8 +349,8 @@ static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
 
     mutex_lock(&fs->lock);
 
-    DEBUG("littlefs: write: filp=%p, fp=%p, src=%p, nbytes=%u\n",
-          (void *)filp, (void *)fp, (void *)src, (unsigned)nbytes);
+    DEBUG("littlefs: write: filp=%p, fp=%p, src=%p, nbytes=%" PRIuSIZE "\n",
+          (void *)filp, (void *)fp, (void *)src, nbytes);
 
     ssize_t ret = lfs_file_write(&fs->fs, fp, src, nbytes);
     mutex_unlock(&fs->lock);
@@ -365,8 +365,8 @@ static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 
     mutex_lock(&fs->lock);
 
-    DEBUG("littlefs: read: filp=%p, fp=%p, dest=%p, nbytes=%u\n",
-          (void *)filp, (void *)fp, (void *)dest, (unsigned)nbytes);
+    DEBUG("littlefs: read: filp=%p, fp=%p, dest=%p, nbytes=%" PRIuSIZE "\n",
+          (void *)filp, (void *)fp, (void *)dest, nbytes);
 
     ssize_t ret = lfs_file_read(&fs->fs, fp, dest, nbytes);
     mutex_unlock(&fs->lock);

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -354,8 +354,8 @@ static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
 
     mutex_lock(&fs->lock);
 
-    DEBUG("littlefs: write: filp=%p, fp=%p, src=%p, nbytes=%u\n",
-          (void *)filp, (void *)fp, (void *)src, (unsigned)nbytes);
+    DEBUG("littlefs: write: filp=%p, fp=%p, src=%p, nbytes=%" PRIuSIZE "\n",
+          (void *)filp, (void *)fp, (void *)src, nbytes);
 
     ssize_t ret = lfs_file_write(&fs->fs, fp, src, nbytes);
     mutex_unlock(&fs->lock);
@@ -370,8 +370,8 @@ static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 
     mutex_lock(&fs->lock);
 
-    DEBUG("littlefs: read: filp=%p, fp=%p, dest=%p, nbytes=%u\n",
-          (void *)filp, (void *)fp, (void *)dest, (unsigned)nbytes);
+    DEBUG("littlefs: read: filp=%p, fp=%p, dest=%p, nbytes=%" PRIuSIZE "\n",
+          (void *)filp, (void *)fp, (void *)dest, nbytes);
 
     ssize_t ret = lfs_file_read(&fs->fs, fp, dest, nbytes);
     mutex_unlock(&fs->lock);

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -118,7 +118,7 @@ static int _write(struct dtls_context_t *ctx, session_t *session, uint8_t *buf, 
     ssize_t res = sock_udp_send(sock->udp_sock, buf, len, &remote);
 
     if (res < 0) {
-        DEBUG("sock_dtls: failed to send DTLS record: %d\n", (int)res);
+        DEBUG("sock_dtls: failed to send DTLS record: %" PRIdSIZE "\n", res);
     }
     return res;
 }
@@ -793,7 +793,7 @@ ssize_t sock_dtls_recv_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
         res = sock_udp_recv_aux(sock->udp_sock, data, max_len, timeout,
                                 &ep, (sock_udp_aux_rx_t *)aux);
         if (res <= 0) {
-            DEBUG("sock_dtls: error receiving UDP packet: %d\n", (int)res);
+            DEBUG("sock_dtls: error receiving UDP packet: %" PRIdSIZE "\n", res);
             return res;
         }
 
@@ -858,7 +858,7 @@ ssize_t sock_dtls_recv_buf_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
             continue;
         }
         if (res < 0) {
-            DEBUG("sock_dtls: error receiving UDP packet: %d\n", (int)res);
+            DEBUG("sock_dtls: error receiving UDP packet: %" PRIdSIZE "\n", res);
             return res;
         }
 
@@ -974,7 +974,7 @@ void _udp_cb(sock_udp_t *udp_sock, sock_async_flags_t flags, void *ctx)
         ssize_t res = sock_udp_recv_buf(udp_sock, &data, &data_ctx, 0,
                                         &remote_ep);
         if (res <= 0) {
-            DEBUG("sock_dtls: error receiving UDP packet: %d\n", (int)res);
+            DEBUG("sock_dtls: error receiving UDP packet: %" PRIdSIZE "\n", res);
             return;
         }
 

--- a/pkg/tinyvcdiff/contrib/tinyvcdiff_mtd/mtd.c
+++ b/pkg/tinyvcdiff/contrib/tinyvcdiff_mtd/mtd.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include "architecture.h"
 #include "vcdiff_mtd.h"
 #include "assert.h"
 #include <string.h>
@@ -71,7 +72,7 @@ static int _align_write (vcdiff_mtd_t *mtd, uint8_t **src, size_t *len)
     mtd->offset += copy_len;
     *len -= copy_len;
     *src += copy_len;
-    DEBUG("_align_write: buffered %zuB for alignment\n", copy_len);
+    DEBUG("_align_write: buffered %" PRIuSIZE "B for alignment\n", copy_len);
 
     if (alignment_offset < CONFIG_TINYVCDIFF_MTD_WRITE_SIZE) {
         /* we haven't collected enough bytes, yet */
@@ -99,7 +100,7 @@ static int _write (void *dev, uint8_t *src, size_t offset, size_t len)
 
     assert(offset == mtd->offset);
 
-    DEBUG("_write: 0x%zx + %zuB\n", mtd->offset, len);
+    DEBUG("_write: 0x%" PRIxSIZE " + %" PRIuSIZE "B\n", mtd->offset, len);
 
     /* align writes */
     rc = _align_write(dev, &src, &len);
@@ -132,7 +133,7 @@ static int _write (void *dev, uint8_t *src, size_t offset, size_t len)
     /* copy remaining bytes into write_buffer */
     memcpy(mtd->write_buffer, src, len);
     mtd->offset += len;
-    DEBUG("_write: buffered %zuB for alignment\n", len);
+    DEBUG("_write: buffered %" PRIuSIZE "B for alignment\n", len);
 
     return rc;
 }
@@ -150,7 +151,7 @@ static int _flush (void *dev)
         return 0;
     }
 
-    DEBUG("_flush: write last %zuB\n", alignment_offset);
+    DEBUG("_flush: write last %" PRIuSIZE "B\n", alignment_offset);
 
     /* get present bytes from MTD to pad alignment */
     rc = mtd_read_page(mtd->dev, buf, 0, mtd->offset - alignment_offset,

--- a/pkg/tlsf/contrib/tlsf-malloc.c
+++ b/pkg/tlsf/contrib/tlsf-malloc.c
@@ -46,7 +46,8 @@ tlsf_t _tlsf_get_global_control(void)
 
 void tlsf_size_walker(void* ptr, size_t size, int used, void* user)
 {
-    printf("\t%p %s size: %u (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, ptr);
+    printf("\t%p %s size: %" PRIuSIZE " (%p)\n", ptr, used ? "used" : "free",
+           size, ptr);
 
     if (used) {
         ((tlsf_size_container_t *)user)->used += (unsigned int)size;

--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -182,7 +182,7 @@ static void *_lwm2m_client_run(void *arg)
             lwm2m_client_connection_t *conn = lwm2m_client_connection_find(
                                             _client_data->conn_list, &remote);
             if (conn) {
-                DEBUG("lwm2m_connection_handle_packet(%i)\n", (int)rcv_len);
+                DEBUG("lwm2m_connection_handle_packet(%" PRIiSIZE ")\n", rcv_len);
                 int result = lwm2m_connection_handle_packet(conn, rcv_buf,
                                                             rcv_len,
                                                             _client_data);
@@ -196,10 +196,10 @@ static void *_lwm2m_client_run(void *arg)
         }
         else if ((rcv_len < 0) &&
                  ((rcv_len != -EAGAIN) && (rcv_len != -ETIMEDOUT))) {
-            DEBUG("Unexpected sock_udp_recv error code %i\n", (int)rcv_len);
+            DEBUG("Unexpected sock_udp_recv error code %" PRIiSIZE "\n", rcv_len);
         }
         else {
-            DEBUG("UDP error code: %i\n", (int)rcv_len);
+            DEBUG("UDP error code: %" PRIiSIZE "\n", rcv_len);
         }
     }
     return NULL;

--- a/pkg/wakaama/contrib/lwm2m_client_connection.c
+++ b/pkg/wakaama/contrib/lwm2m_client_connection.c
@@ -214,7 +214,7 @@ static int _connection_send(lwm2m_client_connection_t *conn, uint8_t *buffer,
     ssize_t sent_bytes = sock_udp_send(&(client_data->sock), buffer,
                                        buffer_size, &(conn->remote));
     if (sent_bytes <= 0) {
-        DEBUG("[_connection_send] Could not send UDP packet: %i\n", (int)sent_bytes);
+        DEBUG("[_connection_send] Could not send UDP packet: %" PRIiSIZE "\n", sent_bytes);
         return -1;
     }
     conn->last_send = lwm2m_gettime();

--- a/pkg/wakaama/contrib/lwm2m_platform.c
+++ b/pkg/wakaama/contrib/lwm2m_platform.c
@@ -50,7 +50,7 @@ typedef struct {
 
  static void _tlsf_size_walker(void* ptr, size_t size, int used, void* user)
 {
-    printf("\t%p %s size: %u (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, ptr);
+    printf("\t%p %s size: %" PRIuSIZE " (%p)\n", ptr, used ? "used" : "free", size, ptr);
 
      if (used) {
         ((_tlsf_size_container_t *)user)->used += (unsigned int)size;

--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -76,10 +76,10 @@ int conn_can_raw_set_filter(conn_can_raw_t *conn, struct can_filter *filter, siz
     assert(conn != NULL);
     assert(filter != NULL || count == 0);
 
-    DEBUG("conn_can_raw_set_filter: conn=%p, filter=%p, count=%u\n",
-          (void *)conn, (void *)filter, (unsigned)count);
-    DEBUG("conn_can_raw_set_filter: conn->filter=%p, conn->count=%u\n",
-          (void *)conn->filter, (unsigned)conn->count);
+    DEBUG("conn_can_raw_set_filter: conn=%p, filter=%p, count=%" PRIuSIZE "\n",
+          (void *)conn, (void *)filter, count);
+    DEBUG("conn_can_raw_set_filter: conn->filter=%p, conn->count=%" PRIuSIZE "\n",
+          (void *)conn->filter, conn->count);
 
     /* unset previous filters */
     if (conn->count) {

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -497,7 +497,8 @@ static void _isotp_fill_dataframe(struct isotp *isotp, struct can_frame *frame, 
     frame->can_id = isotp->opt.tx_id;
     frame->can_dlc = num_bytes + pci_len;
 
-    DEBUG("_isotp_fill_dataframe: num_bytes=%d, pci_len=%d\n", (unsigned)num_bytes, (unsigned)pci_len);
+    DEBUG("_isotp_fill_dataframe: num_bytes=%" PRIuSIZE ", pci_len=%" PRIuSIZE "\n",
+          num_bytes, pci_len);
 
     if (num_bytes < space) {
         if (isotp->opt.flags & CAN_ISOTP_TX_PADDING) {

--- a/sys/clif/clif.c
+++ b/sys/clif/clif.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "architecture.h"
 #include "clif.h"
 #include "clif_internal.h"
 
@@ -83,7 +84,7 @@ ssize_t clif_decode_link(clif_t *link, clif_attr_t *attrs, unsigned attrs_len,
     link->attrs = attrs;
     pos += size + 1; /* escape the '>' */
 
-    DEBUG("Found target (%u): %.*s\n", (unsigned)size, (unsigned)size,
+    DEBUG("Found target (%" PRIiSIZE "): %.*s\n", size, (unsigned)size,
           link->target);
 
     /* if there is no attr array iterate over the buffer, if not until all
@@ -129,7 +130,7 @@ ssize_t clif_add_target_from_buffer(const char *target, size_t target_len, char 
     assert(target);
 
     size_t pos = 0;
-    DEBUG("Adding target: %.*s, len: %d\n", target_len, target, target_len);
+    DEBUG("Adding target: %.*s, len: %" PRIuSIZE "\n", (int)target_len, target, target_len);
 
     if (!buf) {
         return target_len + 2; /* size after adding '<' and '>' */

--- a/sys/coding/xor.c
+++ b/sys/coding/xor.c
@@ -19,6 +19,7 @@
  */
 
 #include <string.h>
+#include "architecture.h"
 #include "bitfield.h"
 #include "coding/xor.h"
 
@@ -107,7 +108,7 @@ static bool _recover_byte(const uint8_t *in, size_t width, uint8_t height,
         /* get index of neighbor byte in transposed matrix */
         size_t idx_in = _transpose_idx(i, height, width);
         if (!bf_isset(bitfield, idx_in / block_size)) {
-            DEBUG("missing chunk %u\n", idx_in / block_size);
+            DEBUG("missing chunk %" PRIuSIZE "\n", idx_in / block_size);
             return false;
         }
         res ^= in[idx_in];
@@ -133,7 +134,7 @@ static bool _recover_blocks(void *data, size_t len, const uint8_t *parity,
             continue;
         }
 
-        DEBUG("try to recover chunk %u / %u\n", i / block_size, num_data_blocks);
+        DEBUG("try to recover chunk %" PRIuSIZE " / %u\n", i / block_size, num_data_blocks);
         for (size_t j = i; j < i + block_size; ++j) {
 
             /* get original byte position */
@@ -142,7 +143,7 @@ static bool _recover_blocks(void *data, size_t len, const uint8_t *parity,
             /* we can only recover the byte if we have the matching parity block */
             size_t parity_block = idx / (CONFIG_CODING_XOR_CHECK_BYTES * block_size);
             if (!bf_isset(bitfield, num_data_blocks + parity_block)) {
-                DEBUG("missing parity block %u\n", parity_block);
+                DEBUG("missing parity block %" PRIuSIZE "\n", parity_block);
                 success = false;
                 goto next_block;
             }
@@ -191,7 +192,7 @@ bool coding_xor_recover(void *data, size_t len, uint8_t *parity,
             continue;
         }
 
-        DEBUG("regenerate parity block %u\n", i);
+        DEBUG("regenerate parity block %" PRIuSIZE "\n", i);
         size_t data_len = block_size * CONFIG_CODING_XOR_CHECK_BYTES;
         _gen_parity((uint8_t *)data + i * data_len,
                               data_len, parity + i * block_size);

--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "architecture.h"
 #include "fs/constfs.h"
 #include "vfs.h"
 
@@ -187,7 +188,7 @@ static int constfs_open(vfs_file_t *filp, const char *name, int flags, mode_t mo
 static ssize_t constfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
 {
     constfs_file_t *fp = filp->private_data.ptr;
-    DEBUG("constfs_read: %p, %p, %lu\n", (void *)filp, dest, (unsigned long)nbytes);
+    DEBUG("constfs_read: %p, %p, %" PRIuSIZE "\n", (void *)filp, dest, nbytes);
     if ((size_t)filp->pos >= fp->size) {
         /* Current offset is at or beyond end of file */
         return 0;
@@ -197,7 +198,7 @@ static ssize_t constfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
         nbytes = fp->size - filp->pos;
     }
     memcpy(dest, (const uint8_t *)fp->data + filp->pos, nbytes);
-    DEBUG("constfs_read: read %lu bytes\n", (long unsigned)nbytes);
+    DEBUG("constfs_read: read %" PRIuSIZE " bytes\n", nbytes);
     filp->pos += nbytes;
     return nbytes;
 }

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #include "architecture_arch.h"
 
@@ -104,6 +105,54 @@ typedef uintptr_t   uinttxtptr_t;
  */
 #define PRIxTXTPTR PRIxPTR
 #endif
+
+#if DOXYGEN
+/**
+ * @brief   Architecture specific modifier used for printing sizes
+ */
+#define PRI_SIZE_T_MODIFIER /* implementation defined */
+#elif (UINT_MAX == SIZE_MAX)
+#define PRI_SIZE_T_MODIFIER ""
+#elif (ULONG_MAX == SIZE_MAX)
+#define PRI_SIZE_T_MODIFIER "l"
+#else
+#error Unsupported size_t length
+#endif
+
+/**
+ * @brief   Macro holding the format specifier to print an `ssize_t` variable
+ *          in decimal representation.
+ */
+#define PRIdSIZE PRI_SIZE_T_MODIFIER "d"
+/**
+ * @brief   Macro holding the format specifier to print an `ssize_t` variable.
+ *
+ * Same as @ref PRIdSIZE for output. When used for input (e.g. in `scanf()`),
+ * `PRIiSIZE` will also accept hexadecimal and octal numbers if prefixed by
+ * `0x` or `0`, respectively.
+ */
+#define PRIiSIZE PRI_SIZE_T_MODIFIER "i"
+/**
+ * @brief   Macro holding the format specifier to print an `ssize_t` variable
+ *          in octal representation.
+ * `0x` or `0`, respectively.
+ */
+#define PRIoSIZE PRI_SIZE_T_MODIFIER "o"
+/**
+ * @brief   Macro holding the format specifier to print an `size_t` variable
+ *          in decimal representation.
+ */
+#define PRIuSIZE PRI_SIZE_T_MODIFIER "u"
+/**
+ * @brief   Macro holding the format specifier to print an `size_t` variable
+ *          in hexadecimal representation (e.g. `2a` for 42).
+ */
+#define PRIxSIZE PRI_SIZE_T_MODIFIER "x"
+/**
+ * @brief   Macro holding the format specifier to print an `size_t` variable
+ *          in hexadecimal representation (e.g. `2A` for 42).
+ */
+#define PRIXSIZE PRI_SIZE_T_MODIFIER "X"
 
 /**
  * @brief   Type qualifier to use to align data on word boundaries

--- a/sys/malloc_thread_safe/malloc_wrappers.c
+++ b/sys/malloc_thread_safe/malloc_wrappers.c
@@ -43,8 +43,8 @@ void __attribute__((used)) *__wrap_malloc(size_t size)
     void *ptr = __real_malloc(size);
     mutex_unlock(&_lock);
     if (IS_USED(MODULE_MALLOC_TRACING)) {
-        printf("malloc(%u) @ 0x%" PRIxTXTPTR " returned %p\n",
-               (unsigned)size, pc, ptr);
+        printf("malloc(%" PRIuSIZE ") @ 0x%" PRIxTXTPTR " returned %p\n",
+               size, pc, ptr);
     }
     return ptr;
 }
@@ -73,8 +73,8 @@ void * __attribute__((used)) __wrap_calloc(size_t nmemb, size_t size)
     size_t total_size;
     if (__builtin_mul_overflow(nmemb, size, &total_size)) {
         if (IS_USED(MODULE_MALLOC_TRACING)) {
-            printf("calloc(%u, %u) @ 0x%" PRIxTXTPTR " overflowed\n",
-                   (unsigned)nmemb, (unsigned)size, pc);
+            printf("calloc(%" PRIuSIZE ", %" PRIuSIZE ") @ 0x%" PRIxTXTPTR " overflowed\n",
+                   nmemb, size, pc);
         }
         return NULL;
     }
@@ -87,8 +87,8 @@ void * __attribute__((used)) __wrap_calloc(size_t nmemb, size_t size)
     }
 
     if (IS_USED(MODULE_MALLOC_TRACING)) {
-        printf("calloc(%u, %u) @ 0x%" PRIxTXTPTR " returned %p\n",
-               (unsigned)nmemb, (unsigned)size, pc, res);
+        printf("calloc(%" PRIuSIZE ", %" PRIuSIZE ") @ 0x%" PRIxTXTPTR " returned %p\n",
+               nmemb, size, pc, res);
     }
 
     return res;
@@ -107,8 +107,8 @@ void * __attribute__((used))__wrap_realloc(void *ptr, size_t size)
     mutex_unlock(&_lock);
 
     if (IS_USED(MODULE_MALLOC_TRACING)) {
-        printf("realloc(%p, %u) @0x%" PRIxTXTPTR " returned %p\n",
-               ptr, (unsigned)size, pc, new);
+        printf("realloc(%p, %" PRIuSIZE ") @0x%" PRIxTXTPTR " returned %p\n",
+               ptr, size, pc, new);
     }
     return new;
 }

--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "memarray.h"
 
 #define ENABLE_DEBUG 0
@@ -20,8 +21,8 @@ void memarray_init(memarray_t *mem, void *data, size_t size, size_t num)
     assert((mem != NULL) && (data != NULL) && (size >= sizeof(void *)) &&
            (num != 0));
 
-    DEBUG("memarray: Initialize memarray of %u times %u Bytes at %p\n",
-          (unsigned)num, (unsigned)size, data);
+    DEBUG("memarray: Initialize memarray of %" PRIuSIZE " times %" PRIuSIZE " Bytes at %p\n",
+          num, size, data);
 
     mem->free_data = NULL;
     mem->size = size;
@@ -62,8 +63,8 @@ int memarray_reduce(memarray_t *mem, void *data, size_t num)
 
             /* Save the element */
             memarray_element_t *found_element = *element_ptr;
-            DEBUG("memarray: Found %p in %p, at %u\n",
-                  (void*)found_element, data, (unsigned)remaining);
+            DEBUG("memarray: Found %p in %p, at %" PRIuSIZE "\n",
+                  (void*)found_element, data, remaining);
 
             /* Copy pointer over to previous element remove it from the pool
              * free list */

--- a/sys/net/application_layer/cord/lc/cord_lc.c
+++ b/sys/net/application_layer/cord/lc/cord_lc.c
@@ -246,7 +246,7 @@ static int _send_rd_init_req(coap_pkt_t *pkt, const sock_udp_ep_t *remote,
 
     ssize_t pkt_len = coap_opt_finish(pkt, COAP_OPT_FINISH_NONE);
     if (pkt_len < 0) {
-        DEBUG("cord_lc: error coap_opt_finish() %zd\n", pkt_len);
+        DEBUG("cord_lc: error coap_opt_finish() %" PRIdSIZE "\n", pkt_len);
         return CORD_LC_ERR;
     }
 
@@ -289,7 +289,7 @@ int cord_lc_rd_init(cord_lc_rd_t *rd, void *buf, size_t maxlen,
                                        _result_buf + parsed_len,
                                        _result_buf_len - parsed_len);
         if (ret < 0) {
-            DEBUG("cord_lc: error decoding payload %zd\n", ret);
+            DEBUG("cord_lc: error decoding payload %" PRIdSIZE "\n", ret);
             retval = CORD_LC_ERR;
             goto end;
         }

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -184,7 +184,7 @@ static void on_publish(size_t len, size_t pos)
         if (rbuf[pos + 1] & EMCUTE_QOS_1) {
             sock_udp_send(&sock, &buf, 7, &gateway);
         }
-        DEBUG("[emcute] on pub: got %i bytes of data\n", (int)(len - pos - 6));
+        DEBUG("[emcute] on pub: got %" PRIiSIZE " bytes of data\n", len - pos - 6);
         size_t dat_len = (len - pos - 6);
         void *dat = (dat_len > 0) ? &rbuf[pos + 6] : NULL;
         sub->cb(&sub->topic, dat, dat_len);

--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -549,7 +549,7 @@ static int _do_block(coap_pkt_t *pdu, const sock_udp_ep_t *remote,
     coap_block1_finish(&slicer);
 
     if ((len = _send(pdu->hdr, len, remote, slicer.start == 0, context, tl_type)) <= 0) {
-        DEBUG("gcoap_dns: msg send failed: %d\n", (int)len);
+        DEBUG("gcoap_dns: msg send failed: %" PRIdSIZE "\n", len);
         return len;
     }
     return len;
@@ -679,7 +679,7 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
 
         if ((block.offset + pdu->payload_len) > CONFIG_DNS_MSG_LEN) {
             DEBUG("gcoap_dns: No buffer space for block-wise transfer "
-                  "(%lu + %u) > %u\n", (long unsigned)block.offset,
+                  "(%" PRIuSIZE " + %u) > %u\n", block.offset,
                   pdu->payload_len, CONFIG_DNS_MSG_LEN);
             context->res = -ENOBUFS;
             goto unlock;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -214,7 +214,7 @@ static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *
                             _listen_buf, sizeof(_listen_buf),
                             CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_MSEC);
         if (res != -SOCK_DTLS_HANDSHAKE) {
-            DEBUG("gcoap: could not establish DTLS session: %zd\n", res);
+            DEBUG("gcoap: could not establish DTLS session: %" PRIdSIZE "\n", res);
             sock_dtls_session_destroy(sock, &socket.ctx_dtls_session);
             return;
         }
@@ -277,7 +277,7 @@ static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *
         ssize_t res = sock_dtls_recv(sock, &socket.ctx_dtls_session, _listen_buf,
                                     sizeof(_listen_buf), 0);
         if (res <= 0) {
-            DEBUG("gcoap: DTLS recv failure: %d\n", (int)res);
+            DEBUG("gcoap: DTLS recv failure: %" PRIdSIZE "\n", res);
             return;
         }
         sock_udp_ep_t ep;
@@ -331,7 +331,7 @@ static void _on_sock_udp_evt(sock_udp_t *sock, sock_async_flags_t type, void *ar
         while (true) {
             ssize_t res = sock_udp_recv_buf_aux(sock, &stackbuf, &buf_ctx, 0, &remote, &aux_in);
             if (res < 0) {
-                DEBUG("gcoap: udp recv failure: %d\n", (int)res);
+                DEBUG("gcoap: udp recv failure: %" PRIdSIZE "\n", res);
                 return;
             }
             if (res == 0) {
@@ -387,7 +387,7 @@ static void _process_coap_pdu(gcoap_socket_t *sock, sock_udp_ep_t *remote, sock_
 
     ssize_t res = coap_parse(&pdu, buf, len);
     if (res < 0) {
-        DEBUG("gcoap: parse failure: %d\n", (int)res);
+        DEBUG("gcoap: parse failure: %" PRIdSIZE "\n", res);
         /* If a response, can't clear memo, but it will timeout later.
          *
          * There are *some* error cases in which we could continue (eg. all
@@ -446,7 +446,7 @@ static void _process_coap_pdu(gcoap_socket_t *sock, sock_udp_ep_t *remote, sock_
             if (pdu_len > 0) {
                 ssize_t bytes = _tl_send(sock, _listen_buf, pdu_len, remote, aux);
                 if (bytes <= 0) {
-                    DEBUG("gcoap: send response failed: %d\n", (int)bytes);
+                    DEBUG("gcoap: send response failed: %" PRIdSIZE "\n", bytes);
                 }
             }
         }
@@ -539,7 +539,7 @@ static void _process_coap_pdu(gcoap_socket_t *sock, sock_udp_ep_t *remote, sock_
 
         ssize_t bytes = _tl_send(sock, buf, sizeof(coap_hdr_t), remote, aux);
         if (bytes <= 0) {
-            DEBUG("gcoap: empty response failed: %d\n", (int)bytes);
+            DEBUG("gcoap: empty response failed: %" PRIdSIZE "\n", bytes);
         }
     }
 }
@@ -576,7 +576,7 @@ static void _on_resp_timeout(void *arg) {
         ssize_t bytes = _tl_send(&memo->socket, memo->msg.data.pdu_buf,
                                  memo->msg.data.pdu_len, &memo->remote_ep, NULL);
         if (bytes <= 0) {
-            DEBUG("gcoap: sock resend failed: %d\n", (int)bytes);
+            DEBUG("gcoap: sock resend failed: %" PRIdSIZE "\n", bytes);
             _expire_request(memo);
         }
     }
@@ -1310,7 +1310,7 @@ static ssize_t _cache_check(const uint8_t *buf, size_t len,
     ssize_t res = coap_parse(&req, (uint8_t *)buf, len);
 
     if (res < 0) {
-        DEBUG("gcoap: parse failure for cache lookup: %d\n", (int)res);
+        DEBUG("gcoap: parse failure for cache lookup: %" PRIdSIZE "\n", res);
         return -EINVAL;
     }
     if (coap_get_code_class(&req) != COAP_CLASS_REQ) {
@@ -1624,8 +1624,8 @@ ssize_t gcoap_req_send_tl(const uint8_t *buf, size_t len,
                 event_timeout_clear(&memo->resp_evt_tmout);
             }
             memo->state = GCOAP_MEMO_UNUSED;
-        }
-        DEBUG("gcoap: sock send failed: %d\n", (int)res);
+    }
+        DEBUG("gcoap: sock send failed: %" PRIdSIZE "\n", res);
     }
     return ((res > 0 || res == -ENOTCONN) ? res : 0);
 }

--- a/sys/net/application_layer/nanocoap/cache.c
+++ b/sys/net/application_layer/nanocoap/cache.c
@@ -249,8 +249,8 @@ nanocoap_cache_entry_t *nanocoap_cache_add_by_key(const uint8_t *cache_key,
     bool add_to_cache = false;
 
     if (resp_len > CONFIG_NANOCOAP_CACHE_RESPONSE_SIZE) {
-        DEBUG("nanocoap_cache: response too large to cache (%lu > %d)\n",
-              (long unsigned)resp_len, CONFIG_NANOCOAP_CACHE_RESPONSE_SIZE);
+        DEBUG("nanocoap_cache: response too large to cache (%" PRIuSIZE "> %d)\n",
+              resp_len, CONFIG_NANOCOAP_CACHE_RESPONSE_SIZE);
         return NULL;
     }
 

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -220,7 +220,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
 
             res = _sock_sendv(sock, &head);
             if (res <= 0) {
-                DEBUG("nanocoap: error sending coap request, %d\n", (int)res);
+                DEBUG("nanocoap: error sending coap request, %" PRIdSIZE "\n", res);
                 return res;
             }
 
@@ -268,7 +268,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 continue;
             }
             if (res < 0) {
-                DEBUG("nanocoap: error receiving coap response, %d\n", (int)res);
+                DEBUG("nanocoap: error receiving coap response, %" PRIdSIZE "\n", res);
                 return res;
             }
 
@@ -794,7 +794,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
         res = sock_udp_recv_aux(&sock.udp, buf, bufsize, SOCK_NO_TIMEOUT,
                                 &remote, aux_in_ptr);
         if (res <= 0) {
-            DEBUG("error receiving UDP packet %d\n", (int)res);
+            DEBUG("error receiving UDP packet %" PRIdSIZE "\n", res);
             continue;
         }
         coap_pkt_t pkt;
@@ -803,7 +803,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
             continue;
         }
         if ((res = coap_handle_req(&pkt, buf, bufsize, &ctx)) <= 0) {
-            DEBUG("error handling request %d\n", (int)res);
+            DEBUG("error handling request %" PRIdSIZE "\n", res);
             continue;
         }
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -544,15 +544,15 @@ static void _handle_rtr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("     - IP Hop Limit: %u (should be %u)\n", ipv6->hl,
               NDP_HOP_LIMIT);
         DEBUG("     - ICMP code: %u (should be 0)\n", rtr_sol->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
-              (unsigned)sizeof(ndp_rtr_sol_t));
+        DEBUG("     - ICMP length: %" PRIuSIZE " (should > %" PRIuSIZE ")\n",
+              icmpv6_len, sizeof(ndp_rtr_sol_t));
         return;
     }
     /* pre-check option length */
     FOREACH_OPT(rtr_sol, opt, tmp_len) {
         if (tmp_len > icmpv6_len) {
-            DEBUG("nib: Payload length (%u) of RS doesn't align with options\n",
-                  (unsigned)icmpv6_len);
+            DEBUG("nib: Payload length (%" PRIuSIZE ") of RS doesn't align with options\n",
+                  icmpv6_len);
             return;
         }
         if (opt->len == 0U) {
@@ -659,8 +659,8 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("     - IP Hop Limit: %u (should be %u)\n", ipv6->hl,
               NDP_HOP_LIMIT);
         DEBUG("     - ICMP code: %u (should be 0)\n", rtr_adv->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
-              (unsigned)sizeof(ndp_rtr_adv_t));
+        DEBUG("     - ICMP length: %" PRIuSIZE " (should > %" PRIuSIZE ")\n",
+              icmpv6_len, sizeof(ndp_rtr_adv_t));
         DEBUG("     - Source address: %s (should be link-local)\n",
               ipv6_addr_to_str(addr_str, &ipv6->src, sizeof(addr_str)));
         DEBUG("     - Router lifetime: %u (should be <= 9000 on non-6LN)\n",
@@ -670,8 +670,8 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     /* pre-check option length */
     FOREACH_OPT(rtr_adv, opt, tmp_len) {
         if (tmp_len > icmpv6_len) {
-            DEBUG("nib: Payload length (%u) of RA doesn't align with options\n",
-                  (unsigned)icmpv6_len);
+            DEBUG("nib: Payload length (%" PRIuSIZE ") of RA doesn't align with options\n",
+                  icmpv6_len);
             return;
         }
         if (opt->len == 0U) {
@@ -984,8 +984,8 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("     - IP Hop Limit: %u (should be %u)\n", ipv6->hl,
               NDP_HOP_LIMIT);
         DEBUG("     - ICMP code: %u (should be 0)\n", nbr_sol->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
-              (unsigned)sizeof(ndp_nbr_sol_t));
+        DEBUG("     - ICMP length: %" PRIuSIZE " (should > %" PRIuSIZE ")\n",
+              icmpv6_len, sizeof(ndp_nbr_sol_t));
         DEBUG("     - Target address: %s (should not be multicast)\n",
               ipv6_addr_to_str(addr_str, &nbr_sol->tgt, sizeof(addr_str)));
         DEBUG("     - Source address: %s\n",
@@ -1005,8 +1005,8 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     /* pre-check option length */
     FOREACH_OPT(nbr_sol, opt, tmp_len) {
         if (tmp_len > icmpv6_len) {
-            DEBUG("nib: Payload length (%u) of NS doesn't align with options\n",
-                  (unsigned)icmpv6_len);
+            DEBUG("nib: Payload length (%" PRIuSIZE ") of NS doesn't align with options\n",
+                  icmpv6_len);
             return;
         }
         if (opt->len == 0U) {
@@ -1140,8 +1140,8 @@ static void _handle_nbr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         DEBUG("     - IP Hop Limit: %u (should be %u)\n", ipv6->hl,
               NDP_HOP_LIMIT);
         DEBUG("     - ICMP code: %u (should be 0)\n", nbr_adv->code);
-        DEBUG("     - ICMP length: %u (should > %u)\n", (unsigned)icmpv6_len,
-              (unsigned)sizeof(ndp_nbr_adv_t));
+        DEBUG("     - ICMP length: %" PRIuSIZE " (should > %" PRIuSIZE ")\n",
+              icmpv6_len, sizeof(ndp_nbr_adv_t));
         DEBUG("     - Target address: %s (should not be multicast)\n",
               ipv6_addr_to_str(addr_str, &nbr_adv->tgt, sizeof(addr_str)));
         DEBUG("     - Destination address: %s\n",
@@ -1155,8 +1155,8 @@ static void _handle_nbr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     /* pre-check option length */
     FOREACH_OPT(nbr_adv, opt, tmp_len) {
         if (tmp_len > icmpv6_len) {
-            DEBUG("nib: Payload length (%u) of NA doesn't align with options\n",
-                  (unsigned)icmpv6_len);
+            DEBUG("nib: Payload length (%" PRIuSIZE ") of NA doesn't align with options\n",
+                  icmpv6_len);
             return;
         }
         if (opt->len == 0U) {

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
@@ -477,9 +477,9 @@ int gnrc_sixlowpan_frag_sfr_forward(gnrc_pktsnip_t *pkt,
         gnrc_pktbuf_release(pkt);
         return -ENOMEM;
     }
-    DEBUG("6lo sfr: adapting old fragment size (%u) for forwarding to %u\n",
+    DEBUG("6lo sfr: adapting old fragment size (%u) for forwarding to %" PRIuSIZE "\n",
           sixlowpan_sfr_rfrag_get_frag_size(hdrsnip->data),
-          (unsigned)gnrc_pkt_len(pkt));
+          gnrc_pkt_len(pkt));
     /* due to compression, packet length of the original fragment might have
      * changed */
     sixlowpan_sfr_rfrag_set_frag_size(hdrsnip->data, gnrc_pkt_len(pkt));
@@ -1730,8 +1730,8 @@ static void _sched_arq_timeout(gnrc_sixlowpan_frag_fb_t *fbuf, uint32_t offset)
               (uint8_t)fbuf->tag);
         return;
     }
-    DEBUG("6lo sfr: arming ACK timeout in %lums for datagram %u\n",
-          (long unsigned)offset, fbuf->tag);
+    DEBUG("6lo sfr: arming ACK timeout in %" PRIu32 "ms for datagram %u\n",
+          offset, fbuf->tag);
     fbuf->sfr.arq_timeout_event.event.offset = offset;
     fbuf->sfr.arq_timeout_event.msg.content.ptr = fbuf;
     fbuf->sfr.arq_timeout_event.msg.type = GNRC_SIXLOWPAN_FRAG_SFR_ARQ_TIMEOUT_MSG;

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -120,8 +120,8 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
     }
 #if defined(MODULE_GNRC_SIXLOWPAN_FRAG) || defined(MODULE_GNRC_SIXLOWPAN_FRAG_SFR)
     else if (orig_datagram_size <= SIXLOWPAN_FRAG_MAX_LEN) {
-        DEBUG("6lo: Send fragmented (%u > %u)\n",
-              (unsigned int)datagram_size, netif->sixlo.max_frag_size);
+        DEBUG("6lo: Send fragmented (%" PRIuSIZE " > %u)\n",
+              datagram_size, netif->sixlo.max_frag_size);
         gnrc_sixlowpan_frag_fb_t *fbuf;
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_SFR
         bool sfr = gnrc_sixlowpan_frag_sfr_netif(netif);
@@ -161,8 +161,8 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
 #endif /* defined(MODULE_GNRC_SIXLOWPAN_FRAG) || defined(MODULE_GNRC_SIXLOWPAN_FRAG_SFR) */
     else {
         (void)orig_datagram_size;
-        DEBUG("6lo: packet too big (%u > %u)\n",
-              (unsigned int)datagram_size, netif->sixlo.max_frag_size);
+        DEBUG("6lo: packet too big (%" PRIuSIZE " > %u)\n",
+              datagram_size, netif->sixlo.max_frag_size);
         gnrc_pktbuf_release_error(pkt, EMSGSIZE);
     }
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -838,8 +838,8 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             DEBUG("6lo iphc: calculating payload length for SFR\n");
             DEBUG(" - rbuf->super.datagram_size: %u\n",
                   rbuf->super.datagram_size);
-            DEBUG(" - payload_offset: %u\n", (unsigned)payload_offset);
-            DEBUG(" - uncomp_hdr_len: %u\n", (unsigned)uncomp_hdr_len);
+            DEBUG(" - payload_offset: %" PRIuSIZE "\n", payload_offset);
+            DEBUG(" - uncomp_hdr_len: %" PRIuSIZE "\n", uncomp_hdr_len);
             /* set IPv6 header payload length field to the length of whatever is
              * left after removing the 6LoWPAN header and adding uncompressed
              * headers */

--- a/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
+++ b/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
@@ -118,9 +118,9 @@ static gnrc_pktsnip_t *_mark(gnrc_pktsnip_t *pkt, size_t size, gnrc_nettype_t ty
     void *header_data, *payload;
 
     if ((size == 0) || (pkt == NULL) || (size > pkt->size) || (pkt->data == NULL)) {
-        DEBUG("pktbuf: size == 0 (was %u) or pkt == NULL (was %p) or "
-              "size > pkt->size (was %u) or pkt->data == NULL (was %p)\n",
-              (unsigned)size, (void *)pkt, (pkt ? (unsigned)pkt->size : 0),
+        DEBUG("pktbuf: size == 0 (was %" PRIuSIZE ") or pkt == NULL (was %p) or "
+              "size > pkt->size (was %" PRIuSIZE ") or pkt->data == NULL (was %p)\n",
+              size, (void *)pkt, (pkt ? pkt->size : 0),
               (pkt ? pkt->data : NULL));
         return NULL;
     }

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -95,8 +95,8 @@ gnrc_pktsnip_t *gnrc_pktbuf_add(gnrc_pktsnip_t *next, const void *data, size_t s
     gnrc_pktsnip_t *pkt;
 
     if (size > CONFIG_GNRC_PKTBUF_SIZE) {
-        DEBUG("pktbuf: size (%u) > CONFIG_GNRC_PKTBUF_SIZE (%u)\n",
-              (unsigned)size, CONFIG_GNRC_PKTBUF_SIZE);
+        DEBUG("pktbuf: size (%" PRIuSIZE ") > CONFIG_GNRC_PKTBUF_SIZE (%u)\n",
+              size, CONFIG_GNRC_PKTBUF_SIZE);
         return NULL;
     }
     mutex_lock(&gnrc_pktbuf_mutex);
@@ -114,9 +114,9 @@ gnrc_pktsnip_t *gnrc_pktbuf_mark(gnrc_pktsnip_t *pkt, size_t size, gnrc_nettype_
 
     mutex_lock(&gnrc_pktbuf_mutex);
     if ((size == 0) || (pkt == NULL) || (size > pkt->size) || (pkt->data == NULL)) {
-        DEBUG("pktbuf: size == 0 (was %u) or pkt == NULL (was %p) or "
-              "size > pkt->size (was %u) or pkt->data == NULL (was %p)\n",
-              (unsigned)size, (void *)pkt, (pkt ? (unsigned)pkt->size : 0),
+        DEBUG("pktbuf: size == 0 (was %" PRIuSIZE ") or pkt == NULL (was %p) or "
+              "size > pkt->size (was %" PRIuSIZE ") or pkt->data == NULL (was %p)\n",
+              size, (void *)pkt, (pkt ? pkt->size : 0),
               (pkt ? pkt->data : NULL));
         mutex_unlock(&gnrc_pktbuf_mutex);
         return NULL;
@@ -243,8 +243,8 @@ gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt)
 #ifdef MODULE_OD
 static inline void _print_chunk(void *chunk, size_t size, int num)
 {
-    printf("=========== chunk %3d (%-10p size: %4u) ===========\n", num, chunk,
-           (unsigned int)size);
+    printf("=========== chunk %3" PRIuSIZE " (%-10p size: %4u) ===========\n", num, chunk,
+           size);
     od_hex_dump(chunk, size, OD_WIDTH_DEFAULT);
 }
 
@@ -430,8 +430,9 @@ static void *_pktbuf_alloc(size_t size)
     const void *mismatch;
     if (CONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE &&
         (mismatch = memchk(ptr + 1, CANARY, size - sizeof(_unused_t)))) {
-        printf("[%p] mismatch at offset %"PRIuPTR"/%u (ignoring %u initial bytes that were repurposed)\n",
-               (void *)ptr, (uintptr_t)mismatch - (uintptr_t)ptr, (unsigned)size, (unsigned)sizeof(_unused_t));
+        printf("[%p] mismatch at offset %"PRIuPTR"/%" PRIuSIZE
+               " (ignoring %" PRIuSIZE " initial bytes that were repurposed)\n",
+               (void *)ptr, (uintptr_t)mismatch - (uintptr_t)ptr, size, sizeof(_unused_t));
 #ifdef MODULE_OD
         od_hex_dump(ptr, size, 0);
 #endif

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -151,8 +151,8 @@ static void _dump(gnrc_pktsnip_t *pkt)
     gnrc_pktsnip_t *snip = pkt;
 
     while (snip != NULL) {
-        printf("~~ SNIP %2i - size: %3u byte, type: ", snips,
-               (unsigned int)snip->size);
+        printf("~~ SNIP %2" PRIuSIZE " - size: %3u byte, type: ", snips,
+               snip->size);
         _dump_snip(snip);
         ++snips;
         size += snip->size;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_validation.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_validation.c
@@ -23,10 +23,6 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#if IS_ACTIVE(ENABLE_DEBUG)
-static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
-
 bool gnrc_rpl_validation_options(int msg_type, gnrc_rpl_instance_t *inst,
                                  gnrc_rpl_opt_t *opt, uint16_t len)
 {

--- a/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
+++ b/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
@@ -30,10 +30,6 @@
 #define ENABLE_DEBUG                    0
 #include "debug.h"
 
-#if IS_ACTIVE(ENABLE_DEBUG)
-static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
-
 #define GNRC_RPL_P2P_RDO_LEN            (18)
 #define GNRC_RPL_P2P_RDO_FLAGS_LIFETIME (6)
 #define GNRC_RPL_P2P_RDO_FLAGS_HBH      (6)

--- a/sys/net/network_layer/fib/fib.c
+++ b/sys/net/network_layer/fib/fib.c
@@ -1464,7 +1464,7 @@ void fib_print_notify_rp(fib_table_t *table)
     mutex_lock(&(table->mtx_access));
 
     for (size_t i = 0; i < FIB_MAX_REGISTERED_RP; ++i) {
-        printf("[fib_print_notify_rp] pid[%d]: %d\n", (int)i, (int)(table->notify_rp[i]));
+        printf("[fib_print_notify_rp] pid[%" PRIuSIZE "]: %d\n", i, (int)(table->notify_rp[i]));
     }
 
     mutex_unlock(&(table->mtx_access));
@@ -1475,9 +1475,9 @@ void fib_print_fib_table(fib_table_t *table)
     mutex_lock(&(table->mtx_access));
 
     for (size_t i = 0; i < table->size; ++i) {
-        printf("[fib_print_table] %d) iface_id: %d, global: %p, next hop: %p, lifetime: %"
-               PRIu32"\n",
-               (int)i, (int)table->data.entries[i].iface_id,
+        printf("[fib_print_table] %" PRIuSIZE
+               ") iface_id: %d, global: %p, next hop: %p, lifetime: %" PRIu32"\n",
+               i, (int)table->data.entries[i].iface_id,
                (void *)table->data.entries[i].global,
                (void *)table->data.entries[i].next_hop,
                (uint32_t)(table->data.entries[i].lifetime / 1000));

--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -40,7 +40,7 @@ void __attribute__((weak)) *malloc(size_t size)
     if (size != 0) {
         void *ptr = sbrk(size);
 
-        DEBUG("malloc(): allocating block of size %u at %p.\n", (unsigned int) size, ptr);
+        DEBUG("malloc(): allocating block of size %" PRIuSIZE " at %p.\n", size, ptr);
 
         if (ptr != (void*) -1) {
             return ptr;

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "architecture.h"
 #include "thread.h"
 #include "sched.h"
 
@@ -115,7 +116,7 @@ void ps(void)
 #endif
                    " | %-8s %.1s | %3i"
 #ifdef DEVELHELP
-                   " | %6" PRIu32 " (%5i) (%5i) | %10p | %10p "
+                   " | %6" PRIuSIZE " (%5i) (%5i) | %10p | %10p "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    " | %2d.%03d%% |  %8u  | %10"PRIu32" "
@@ -127,7 +128,7 @@ void ps(void)
 #endif
                    sname, queued, thread_get_priority(p)
 #ifdef DEVELHELP
-                   , (uint32_t)thread_get_stacksize(p), stacksz, stack_free,
+                   , thread_get_stacksize(p), stacksz, stack_free,
                    thread_get_stackstart(p), thread_get_sp(p)
 #endif
 #ifdef MODULE_SCHEDSTATISTICS

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "riotboot/flashwrite.h"
 #include "riotboot/slot.h"
 #include "od.h"
@@ -107,7 +108,7 @@ int riotboot_flashwrite_flush(riotboot_flashwrite_t *state)
 int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
                                  const uint8_t *bytes, size_t len, bool more)
 {
-    LOG_DEBUG(LOG_PREFIX "processing bytes %u-%u\n", state->offset,
+    LOG_DEBUG(LOG_PREFIX "processing bytes %" PRIuSIZE "-%" PRIuSIZE "\n", state->offset,
               state->offset + len - 1);
 
     while (len) {

--- a/sys/riotboot/flashwrite_verify_sha256.c
+++ b/sys/riotboot/flashwrite_verify_sha256.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "hashes/sha256.h"
 #include "log.h"
 #include "riotboot/slot.h"
@@ -41,7 +42,7 @@ int riotboot_flashwrite_verify_sha256(const uint8_t *sha256_digest,
 
     uint8_t *img_start = (uint8_t *)riotboot_slot_get_hdr(target_slot);
 
-    LOG_INFO("riotboot: verifying digest at %p (img at: %p size: %u)\n",
+    LOG_INFO("riotboot: verifying digest at %p (img at: %p size: %" PRIuSIZE ")\n",
              sha256_digest, img_start, img_len);
 
     sha256_init(&sha256);

--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -340,13 +340,11 @@ static int _print_reply(gnrc_pktsnip_t *pkt, int corrupted, uint32_t triptime, v
 
     if (gnrc_netif_highlander() || (if_pid == KERNEL_PID_UNDEF) ||
         !ipv6_addr_is_link_local(&ipv6_hdr->src)) {
-        printf("%u bytes from %s: icmp_seq=%u ttl=%u",
-               (unsigned)icmpv6->size,
-               from_str, recv_seq, ipv6_hdr->hl);
+        printf("%" PRIuSIZE " bytes from %s: icmp_seq=%u ttl=%u",
+               icmpv6->size, from_str, recv_seq, ipv6_hdr->hl);
     } else {
-        printf("%u bytes from %s%%%u: icmp_seq=%u ttl=%u",
-               (unsigned)icmpv6->size,
-               from_str, if_pid, recv_seq, ipv6_hdr->hl);
+        printf("%" PRIuSIZE " bytes from %s%%%u: icmp_seq=%u ttl=%u",
+               icmpv6->size, from_str, if_pid, recv_seq, ipv6_hdr->hl);
 
     }
     /* check if payload size matches */

--- a/sys/shell/cmds/vfs.c
+++ b/sys/shell/cmds/vfs.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include "architecture.h"
 #include "macros/units.h"
 #include "shell.h"
 #include "tiny_strerror.h"
@@ -279,7 +280,7 @@ static int _read_handler(int argc, char **argv)
             return 5;
         }
         else if ((size_t)res > line_len) {
-            printf("BUFFER OVERRUN! %d > %lu\n", res, (unsigned long)line_len);
+            printf("BUFFER OVERRUN! %d > %" PRIuSIZE "\n", res, line_len);
             vfs_close(fd);
             return 6;
         }
@@ -491,8 +492,8 @@ static int _cp_handler(int argc, char **argv)
         while (bufspace > 0) {
             int res = vfs_read(fd_in, &_shell_vfs_data_buffer[pos], bufspace);
             if (res < 0) {
-                printf("Error reading %lu bytes @ 0x%lx in \"%s\" (%d): %s\n",
-                       (unsigned long)bufspace, (unsigned long)pos, src_name,
+                printf("Error reading %" PRIuSIZE " bytes @ 0x%" PRIxSIZE " in \"%s\" (%d): %s\n",
+                       bufspace, pos, src_name,
                        fd_in, tiny_strerror(res));
                 vfs_close(fd_in);
                 vfs_close(fd_out);
@@ -504,7 +505,7 @@ static int _cp_handler(int argc, char **argv)
                 break;
             }
             if (((unsigned)res) > bufspace) {
-                printf("READ BUFFER OVERRUN! %d > %lu\n", res, (unsigned long)bufspace);
+                printf("READ BUFFER OVERRUN! %d > %" PRIuSIZE "\n", res, bufspace);
                 vfs_close(fd_in);
                 vfs_close(fd_out);
                 return 3;
@@ -517,15 +518,15 @@ static int _cp_handler(int argc, char **argv)
         while (bufspace > 0) {
             int res = vfs_write(fd_out, &_shell_vfs_data_buffer[pos], bufspace);
             if (res <= 0) {
-                printf("Error writing %lu bytes @ 0x%lx in \"%s\" (%d): %s\n",
-                       (unsigned long)bufspace, (unsigned long)pos, dest_name,
+                printf("Error writing %" PRIuSIZE " bytes @ 0x%" PRIxSIZE " in \"%s\" (%d): %s\n",
+                       bufspace, pos, dest_name,
                        fd_out, tiny_strerror(res));
                 vfs_close(fd_in);
                 vfs_close(fd_out);
                 return 4;
             }
             if (((unsigned)res) > bufspace) {
-                printf("WRITE BUFFER OVERRUN! %d > %lu\n", res, (unsigned long)bufspace);
+                printf("WRITE BUFFER OVERRUN! %d > %" PRIuSIZE "\n", res, bufspace);
                 vfs_close(fd_in);
                 vfs_close(fd_out);
                 return 5;

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -26,6 +26,7 @@
 #include <nanocbor/nanocbor.h>
 #include <assert.h>
 
+#include "architecture.h"
 #include "hashes/sha256.h"
 
 #include "kernel_defines.h"
@@ -330,7 +331,7 @@ static inline void _print_download_progress(suit_manifest_t *manifest,
     (void)manifest;
     (void)offset;
     (void)len;
-    DEBUG("_suit_flashwrite(): writing %u bytes at pos %u\n", len, offset);
+    DEBUG("_suit_flashwrite(): writing %" PRIuSIZE " bytes at pos %" PRIuSIZE "\n", len, offset);
 #if defined(MODULE_PROGRESS_BAR)
     if (image_size != 0) {
         char _suffix[7] = { 0 };
@@ -368,14 +369,14 @@ static int _storage_helper(void *arg, size_t offset, uint8_t *buf, size_t len,
     if (image_size < offset + len) {
         /* Extra newline at the start to compensate for the progress bar */
         LOG_ERROR(
-            "\n_suit_coap(): Image beyond size, offset + len=%u, "
-            "image_size=%u\n", (unsigned)(total), (unsigned)image_size);
+            "\n_suit_coap(): Image beyond size, offset + len=%" PRIuSIZE ", "
+            "image_size=%" PRIu32 "\n", total, image_size);
         return -1;
     }
 
     if (!more && image_size != total) {
-        LOG_INFO("Incorrect size received, got %u, expected %u\n",
-                 (unsigned)total, (unsigned)image_size);
+        LOG_INFO("Incorrect size received, got %" PRIuSIZE ", expected %" PRIu32 "\n",
+                 total, image_size);
         return -1;
     }
 
@@ -427,8 +428,8 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     memcpy(manifest->urlbuf, url, url_len);
     manifest->urlbuf[url_len] = '\0';
 
-    LOG_DEBUG("_dtv_fetch() fetching \"%s\" (url_len=%u)\n", manifest->urlbuf,
-              (unsigned)url_len);
+    LOG_DEBUG("_dtv_fetch() fetching \"%s\" (url_len=%" PRIuSIZE ")\n", manifest->urlbuf,
+              url_len);
 
     if (_start_storage(manifest, comp) < 0) {
         LOG_ERROR("Unable to start storage backend\n");

--- a/sys/suit/storage/flashwrite.c
+++ b/sys/suit/storage/flashwrite.c
@@ -20,6 +20,7 @@
  */
 #include <string.h>
 
+#include "architecture.h"
 #include "kernel_defines.h"
 #include "log.h"
 #include "xfa.h"
@@ -41,7 +42,7 @@ static int _flashwrite_init(suit_storage_t *storage)
 {
     (void)storage;
 
-    LOG_DEBUG("Storage size %u\n", (unsigned)sizeof(suit_storage_flashwrite_t));
+    LOG_DEBUG("Storage size %" PRIuSIZE "\n", sizeof(suit_storage_flashwrite_t));
 
     return 0;
 }

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -116,7 +116,7 @@ int suit_handle_url(const char *url)
         return size;
     }
 
-    LOG_INFO("suit_worker: got manifest with size %u\n", (unsigned)size);
+    LOG_INFO("suit_worker: got manifest with size %" PRIdSIZE "\n", size);
 
     return suit_handle_manifest_buf(_manifest_buf, size);
 }

--- a/sys/test_utils/benchmark_udp/benchmark_udp.c
+++ b/sys/test_utils/benchmark_udp/benchmark_udp.c
@@ -88,7 +88,7 @@ static void *_listen_thread(void *ctx)
         res = sock_udp_recv(&sock, buf, sizeof(buf), 2 * delay_us, NULL);
         if (res < 0) {
             if (res != -ETIMEDOUT) {
-                printf("Error receiving message: %zd\n", res);
+                printf("Error receiving message: %" PRIdSIZE "\n", res);
             }
             continue;
         }

--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 
+#include "architecture.h"
 #include "event.h"
 #include "event/thread.h"
 #include "od.h"
@@ -56,7 +57,7 @@ void _recv(netdev_t *dev)
     printf("Src. addr.: %s\n", _addr_str);
 
     data_len -= sizeof(ethernet_hdr_t);
-    printf("Payload (%u bytes): \n", (unsigned)data_len);
+    printf("Payload (%" PRIdSIZE " bytes): \n", data_len);
     od_hex_dump(payload, data_len, 0);
 }
 

--- a/sys/test_utils/netdev_ieee802154_minimal/shell_commands.c
+++ b/sys/test_utils/netdev_ieee802154_minimal/shell_commands.c
@@ -264,7 +264,7 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst, size_t dst_len,
 
     be_uint16_t _dst_pan = byteorder_ltobs(dst_pan);
     l2util_addr_to_str(dst, dst_len, _addr_str);
-    printf("txtsnd: sending %u bytes to %s", (unsigned)iol_data.iol_len, _addr_str);
+    printf("txtsnd: sending %" PRIuSIZE " bytes to %s", iol_data.iol_len, _addr_str);
     l2util_addr_to_str((uint8_t*) &_dst_pan, sizeof(dst_pan), _addr_str);
     printf(" (PAN: %s)\n", _addr_str);
 

--- a/sys/trace/trace.c
+++ b/sys/trace/trace.c
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 
+#include "architecture.h"
 #include "irq.h"
 #include "ztimer.h"
 
@@ -54,9 +55,9 @@ void trace_dump(void)
     uint32_t t_last = 0;
 
     for (size_t i = 0; i < n; i++) {
-        printf("n=%4lu t=%s%8" PRIu32 " v=0x%08lx\n", (unsigned long)i,
+        printf("n=%4" PRIuSIZE " t=%s%8" PRIu32 " v=0x%08" PRIx32 "\n", i,
                i ? "+" : " ",
-               tracebuf[i].time - t_last, (unsigned long)tracebuf[i].val);
+               tracebuf[i].time - t_last, tracebuf[i].val);
         t_last = tracebuf[i].time;
     }
 }

--- a/sys/universal_address/universal_address.c
+++ b/sys/universal_address/universal_address.c
@@ -142,8 +142,8 @@ universal_address_container_t *universal_address_add(uint8_t *addr, size_t addr_
     pEntry->use_count++;
 
     if (pEntry->use_count == 1) {
-        DEBUG("[universal_address_add] universal_address_table_filled: %d\n", \
-              (int)universal_address_table_filled);
+        DEBUG("[universal_address_add] universal_address_table_filled: %" PRIuSIZE "\n", \
+              universal_address_table_filled);
         universal_address_table_filled++;
     }
 
@@ -166,8 +166,8 @@ void universal_address_rem(universal_address_container_t *entry)
             }
         }
         else {
-            DEBUG("[universal_address_rem] universal_address_table_filled: %d\n", \
-                  (int)universal_address_table_filled);
+            DEBUG("[universal_address_rem] universal_address_table_filled: %" PRIuSIZE "\n", \
+                  universal_address_table_filled);
         }
     }
 
@@ -359,8 +359,8 @@ int universal_address_get_num_used_entries(void)
 
 void universal_address_print_table(void)
 {
-    printf("[universal_address_print_table] universal_address_table_filled: %d\n", \
-           (int)universal_address_table_filled);
+    printf("[universal_address_print_table] universal_address_table_filled: %" PRIuSIZE "\n", \
+           universal_address_table_filled);
 
     /* cppcheck-suppress unsignedLessThanZero
      * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -352,8 +352,8 @@ static bool _urb_transfer_complete(usbus_t *usbus, usbdev_ep_t *ep,
                 _usbus_transfer_urb_submit(usbus_ep, next_urb);
             }
 
-            DEBUG("Done with the transfer, available: %u, len: %u\n",
-                  (unsigned)active_urb->transferred, (unsigned)active_urb->len);
+            DEBUG("Done with the transfer, available: %" PRIuSIZE ", len: %" PRIuSIZE "\n",
+                  active_urb->transferred, active_urb->len);
             handler->driver->transfer_handler(usbus, handler, ep,
                                               USBUS_EVENT_TRANSFER_COMPLETE);
         }

--- a/sys/ut_process/ut_process.c
+++ b/sys/ut_process/ut_process.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <stdbool.h>
 
+#include "architecture.h"
 #include "fmt.h"
 
 #include "ut_process.h"
@@ -71,9 +72,9 @@ int ut_process_expand(const char *ut, size_t ut_len,
                     res = _copy_str(exp_start, (&ut[i] - exp_start),
                                     &uri[uri_idx], uri_len - uri_idx);
                     if (res < 0) {
-                        DEBUG("ut_process: %p(%u) does not fit write-back %.*s "
+                        DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit write-back %.*s "
                               "of template %s\n",
-                              (void *)uri, (unsigned)uri_len,
+                              (void *)uri, uri_len,
                               (int)(&ut[i] - exp_start), exp_start, ut);
                         return res;
                     }
@@ -103,8 +104,8 @@ int ut_process_expand(const char *ut, size_t ut_len,
                 if (!exp_start) {
                     res = _copy_char(ut[i], &uri[uri_idx], uri_len - uri_idx);
                     if (res < 0) {
-                        DEBUG("ut_process: %p(%u) does not fit literal %c of "
-                              "template %s\n", (void *)uri, (unsigned)uri_len,
+                        DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit literal %c of "
+                              "template %s\n", (void *)uri, uri_len,
                               ut[i], ut);
                         return res;
                     }
@@ -119,9 +120,9 @@ int ut_process_expand(const char *ut, size_t ut_len,
         res = _copy_str(exp_start, (&ut[i] - exp_start),
                         &uri[uri_idx], uri_len - uri_idx);
         if (res < 0) {
-            DEBUG("ut_process: %p(%u) does not fit terminal write-back %.*s of "
+            DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit terminal write-back %.*s of "
                   "template %s\n",
-                  (void *)uri, (unsigned)uri_len,
+                  (void *)uri, uri_len,
                   (int)(&ut[i] - exp_start), exp_start, ut);
             return res;
         }
@@ -129,8 +130,8 @@ int ut_process_expand(const char *ut, size_t ut_len,
     }
     res = _copy_char('\0', &uri[uri_idx], uri_len - uri_idx);
     if (res < 0) {
-        DEBUG("ut_process: %p(%u) does not fit terminating '\\0' char\n",
-              (void *)uri, (unsigned)uri_len);
+        DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit terminating '\\0' char\n",
+              (void *)uri, uri_len);
         return res;
     }
     /* do not increment uri_idx. We want the string length so \0 does not count
@@ -353,8 +354,8 @@ static int _set_var(const char *var, size_t var_len,
         if (prefix) {
             res = _copy_char(prefix, &uri[uri_idx], uri_len - uri_idx);
             if (res < 0) {
-                DEBUG("ut_process: %p(%u) does not fit prefix %c\n",
-                      (void *)uri, (unsigned)uri_len, prefix);
+                DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit prefix %c\n",
+                      (void *)uri, uri_len, prefix);
                 return res;
             }
             uri_idx += res;
@@ -364,8 +365,8 @@ static int _set_var(const char *var, size_t var_len,
         assert(sep);    /* all operators have a separator defined */
         res = _copy_char(sep, &uri[uri_idx], uri_len - uri_idx);
         if (res < 0) {
-            DEBUG("ut_process: %p(%u) does not fit separator '%c'\n",
-                  (void *)uri, (unsigned)uri_len, sep);
+            DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit separator '%c'\n",
+                  (void *)uri, uri_len, sep);
             return -ENOBUFS;
         }
         uri_idx += res;
@@ -387,8 +388,8 @@ static int _fill_var(const ut_process_var_t *var, bool has_reserved,
         for (const char *c = var->name; *c != '\0'; c++) {
             res = _copy_char(*c, &uri[uri_idx], uri_len - uri_idx);
             if (res < 0) {
-                DEBUG("ut_process: %p(%u) does not var name %s\n", (void *)uri,
-                      (unsigned)uri_len, var->name);
+                DEBUG("ut_process: %p(%" PRIuSIZE ") does not var name %s\n", (void *)uri,
+                      uri_len, var->name);
                 return res;
             }
             uri_idx += res;
@@ -397,8 +398,8 @@ static int _fill_var(const ut_process_var_t *var, bool has_reserved,
         if ((var->value[0] != '\0') || empty_equal) {
             res = _copy_char('=', &uri[uri_idx], uri_len - uri_idx);
             if (res < 0) {
-                DEBUG("ut_process: %p(%u) does not fit =\n", (void *)uri,
-                      (unsigned)uri_len);
+                DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit =\n", (void *)uri,
+                      uri_len);
                 return res;
             }
             uri_idx += res;
@@ -416,8 +417,8 @@ static int _fill_var(const ut_process_var_t *var, bool has_reserved,
         }
         res = _copy_str(enc, enc_len, &uri[uri_idx], uri_len - uri_idx);
         if (res < 0) {
-            DEBUG("ut_process: %p(%u) does not fit value encoding %.*s\n",
-                  (void *)uri, (unsigned)uri_len, (unsigned)enc_len, enc);
+            DEBUG("ut_process: %p(%" PRIuSIZE ") does not fit value encoding %.*s\n",
+                  (void *)uri, uri_len, (unsigned)enc_len, enc);
             return res;
         }
         uri_idx += res;

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -315,7 +315,7 @@ int vfs_open(const char *name, int flags, mode_t mode)
 
 ssize_t vfs_read(int fd, void *dest, size_t count)
 {
-    DEBUG("vfs_read: %d, %p, %lu\n", fd, dest, (unsigned long)count);
+    DEBUG("vfs_read: %d, %p, %" PRIuSIZE "\n", fd, dest, count);
     if (dest == NULL) {
         return -EFAULT;
     }
@@ -337,7 +337,7 @@ ssize_t vfs_read(int fd, void *dest, size_t count)
 
 ssize_t vfs_write(int fd, const void *src, size_t count)
 {
-    DEBUG_NOT_STDOUT(fd, "vfs_write: %d, %p, %lu\n", fd, src, (unsigned long)count);
+    DEBUG_NOT_STDOUT(fd, "vfs_write: %d, %p, %" PRIuSIZE "\n", fd, src, count);
     if (src == NULL) {
         return -EFAULT;
     }
@@ -839,8 +839,8 @@ int vfs_bind(int fd, int flags, const vfs_file_ops_t *f_op, void *private_data)
 
 int vfs_normalize_path(char *buf, const char *path, size_t buflen)
 {
-    DEBUG("vfs_normalize_path: %p, \"%s\" (%p), %lu\n",
-          (void *)buf, path, (void *)path, (unsigned long)buflen);
+    DEBUG("vfs_normalize_path: %p, \"%s\" (%p), %" PRIuSIZE "\n",
+          (void *)buf, path, (void *)path, buflen);
     size_t len = 0;
     int npathcomp = 0;
     const char *path_end = path + strlen(path); /* Find the terminating null byte */

--- a/tests/bench/sizeof_coretypes/main.c
+++ b/tests/bench/sizeof_coretypes/main.c
@@ -38,9 +38,9 @@
 #endif
 #include "thread.h"
 
-#define P(NAME) printf("    tcb->%-11s            %3u     %3u\n", #NAME, \
-                       (unsigned)sizeof(((thread_t *) 0)->NAME), \
-                       (unsigned)offsetof(thread_t, NAME))
+#define P(NAME) printf("    tcb->%-11s            %3" PRIuSIZE "     %3" PRIuSIZE "\n", #NAME, \
+                       sizeof(((thread_t *) 0)->NAME), \
+                       offsetof(thread_t, NAME))
 
 int main(void)
 {
@@ -48,43 +48,43 @@ int main(void)
 
     puts("                                size");
 
-    printf("sizeof(cib_t):                  %3u\n",
-           (unsigned)sizeof(cib_t));
-    printf("sizeof(clist_node_t):           %3u\n",
-           (unsigned)sizeof(clist_node_t));
-    printf("sizeof(core_panic_t):           %3u\n",
-           (unsigned)sizeof(core_panic_t));
-    printf("sizeof(kernel_pid_t):           %3u\n",
-           (unsigned)sizeof(kernel_pid_t));
-    printf("sizeof(list_node_t):            %3u\n",
-           (unsigned)sizeof(list_node_t));
-    printf("sizeof(mbox_t):                 %3u\n",
-           (unsigned)sizeof(mbox_t));
+    printf("sizeof(cib_t):                  %3" PRIuSIZE "\n",
+           sizeof(cib_t));
+    printf("sizeof(clist_node_t):           %3" PRIuSIZE "\n",
+           sizeof(clist_node_t));
+    printf("sizeof(core_panic_t):           %3" PRIuSIZE "\n",
+           sizeof(core_panic_t));
+    printf("sizeof(kernel_pid_t):           %3" PRIuSIZE "\n",
+           sizeof(kernel_pid_t));
+    printf("sizeof(list_node_t):            %3" PRIuSIZE "\n",
+           sizeof(list_node_t));
+    printf("sizeof(mbox_t):                 %3" PRIuSIZE "\n",
+           sizeof(mbox_t));
 #ifdef MODULE_CORE_MSG
-    printf("sizeof(msg_t):                  %3u\n",
-           (unsigned)sizeof(msg_t));
+    printf("sizeof(msg_t):                  %3" PRIuSIZE "\n",
+           sizeof(msg_t));
 #else
     puts("sizeof(msg_t):                    0   (not enabled)");
 #endif
-    printf("sizeof(mutex_t):                %3u\n",
-           (unsigned)sizeof(mutex_t));
-    printf("sizeof(priority_queue_node_t):  %3u\n",
-           (unsigned)sizeof(priority_queue_node_t));
-    printf("sizeof(priority_queue_t):       %3u\n",
-           (unsigned)sizeof(priority_queue_t));
-    printf("sizeof(ringbuffer_t):           %3u\n",
-           (unsigned)sizeof(ringbuffer_t));
-    printf("sizeof(rmutex_t):               %3u\n",
-           (unsigned)sizeof(rmutex_t));
+    printf("sizeof(mutex_t):                %3" PRIuSIZE "\n",
+           sizeof(mutex_t));
+    printf("sizeof(priority_queue_node_t):  %3" PRIuSIZE "\n",
+           sizeof(priority_queue_node_t));
+    printf("sizeof(priority_queue_t):       %3" PRIuSIZE "\n",
+           sizeof(priority_queue_t));
+    printf("sizeof(ringbuffer_t):           %3" PRIuSIZE "\n",
+           sizeof(ringbuffer_t));
+    printf("sizeof(rmutex_t):               %3" PRIuSIZE "\n",
+           sizeof(rmutex_t));
 #ifdef MODULE_CORE_THREAD_FLAGS
-    printf("sizeof(thread_flags_t):         %3u\n",
-           (unsigned)sizeof(thread_flags_t));
+    printf("sizeof(thread_flags_t):         %3" PRIuSIZE "\n",
+           sizeof(thread_flags_t));
 #else
     puts("sizeof(thread_flags_t):           0   (not enabled)");
 #endif
     printf("\nTCB (thread_t) details:         size  offset\n");
-    printf("sizeof(thread_t):               %3u       -\n",
-           (unsigned)sizeof(thread_t));
+    printf("sizeof(thread_t):               %3" PRIuSIZE "       -\n",
+           sizeof(thread_t));
     P(sp);
     P(status);
     P(priority);

--- a/tests/core/thread_stack_alignment/main.c
+++ b/tests/core/thread_stack_alignment/main.c
@@ -27,6 +27,7 @@
  * so do not sort this one alphabetically */
 #include <stdatomic.h>
 
+#include "architecture.h"
 #include "irq.h"
 #include "sched.h"
 #include "thread.h"
@@ -79,7 +80,7 @@ int main(void)
            (unsigned)STACKSIZE, (unsigned)ALIGNMENT);
     for (size_t i = 0; i < ALIGNMENT; i++) {
         atomic_store(&test_failed, false);
-        printf("Testing for alignment %u: ", (unsigned)i);
+        printf("Testing for alignment %" PRIuSIZE ": ", i);
         kernel_pid_t p;
         p = thread_create(stack + i, STACKSIZE, THREAD_PRIORITY_MAIN - 1,
                           THREAD_CREATE_STACKTEST,

--- a/tests/drivers/at/main.c
+++ b/tests/drivers/at/main.c
@@ -80,7 +80,7 @@ static int send(int argc, char **argv)
         return 1;
     }
 
-    printf("Response (len=%d): %s\n", (int)len, resp);
+    printf("Response (len=%" PRIdSIZE "): %s\n", len, resp);
 
     return 0;
 }
@@ -115,7 +115,7 @@ static int send_lines(int argc, char **argv)
         return 1;
     }
 
-    printf("Response (len=%d): %s\n", (int)len, resp);
+    printf("Response (len=%" PRIdSIZE "): %s\n", len, resp);
 
     return 0;
 }
@@ -134,7 +134,7 @@ static int send_recv_bytes(int argc, char **argv)
 
     ssize_t len = at_recv_bytes(&at_dev, buffer, atoi(argv[2]), 10 * US_PER_SEC);
 
-    printf("Response (len=%d): %s\n", (int)len, buffer);
+    printf("Response (len=%" PRIdSIZE "): %s\n", len, buffer);
 
     return 0;
 }
@@ -163,7 +163,7 @@ static int send_recv_bytes_until_string(int argc, char **argv)
         return 1;
     }
 
-    printf("Response (len=%d): %s\n", (int)len, buffer);
+    printf("Response (len=%" PRIdSIZE "): %s\n", len, buffer);
     return 0;
 }
 

--- a/tests/drivers/at24cxxx/main.c
+++ b/tests/drivers/at24cxxx/main.c
@@ -113,7 +113,7 @@ int main(void)
     check = at24cxxx_write(&at24cxxx_dev, WRITE_POSITION, expected_write_data,
                          sizeof(expected_write_data));
     if (check != AT24CXXX_OK) {
-        printf("[FAILURE] at24cxxx_write: %d (size = %zu)\n", check,
+        printf("[FAILURE] at24cxxx_write: %d (size = %" PRIuSIZE ")\n", check,
                sizeof(expected_write_data));
         return 1;
     }

--- a/tests/drivers/ata8520e/main.c
+++ b/tests/drivers/ata8520e/main.c
@@ -80,7 +80,7 @@ int ata8520e_sigfox_cmd(int argc, char **argv)
         else {
             if (strlen(argv[2]) > SIGFOX_MAX_TX_LENGTH) {
                 printf("Message length cannot exceeds %d characters length, your "
-                       "message length is %u", SIGFOX_MAX_TX_LENGTH, (unsigned)strlen(argv[2]));
+                       "message length is %" PRIuSIZE, SIGFOX_MAX_TX_LENGTH, strlen(argv[2]));
                 return 1;
             }
             if (ata8520e_send_frame(&dev,
@@ -99,7 +99,7 @@ int ata8520e_sigfox_cmd(int argc, char **argv)
         }
         if (strlen(argv[2]) > SIGFOX_MAX_TX_LENGTH) {
             printf("Message length cannot exceeds %d characters length, your "
-                   "message length is %u", SIGFOX_MAX_TX_LENGTH, (unsigned)strlen(argv[2]));
+                   "message length is %" PRIuSIZE, SIGFOX_MAX_TX_LENGTH, strlen(argv[2]));
             return 1;
         }
         uint8_t rx_buf[SIGFOX_RX_LENGTH];

--- a/tests/drivers/matrix_keypad/main.c
+++ b/tests/drivers/matrix_keypad/main.c
@@ -27,7 +27,7 @@
 void _callback(void *arg, size_t col, size_t row, bool state)
 {
     (void)arg;
-    printf("Key switch at column %u and row %u is ", (unsigned)col, (unsigned)row);
+    printf("Key switch at column %" PRIuSIZE " and row %" PRIuSIZE " is ", col, row);
     if (state) {
         puts("pressed!");
     }

--- a/tests/drivers/rn2xx3/main.c
+++ b/tests/drivers/rn2xx3/main.c
@@ -214,7 +214,7 @@ int rn2xx3_mac_cmd(int argc, char **argv) {
                 puts("MAC transmission succeeded");
                 puts("Data received:");
                 printf(" -port: %d\n", rn2xx3_mac_get_rx_port(&rn2xx3_dev));
-                printf(" -payload len: %d\n", (uint8_t)strlen((char *)rn2xx3_dev.rx_buf));
+                printf(" -payload len: %" PRIuSIZE "\n", strlen((char *)rn2xx3_dev.rx_buf));
                 printf(" -payload: '%s'\n", rn2xx3_dev.rx_buf);
             }
                 break;

--- a/tests/drivers/sx126x/main.c
+++ b/tests/drivers/sx126x/main.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "msg.h"
 #include "thread.h"
 #include "shell.h"
@@ -68,9 +69,9 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
             netdev_lora_rx_info_t packet_info;
             dev->driver->recv(dev, message, len, &packet_info);
             printf(
-                "Received: \"%s\" (%d bytes) - [RSSI: %i, SNR: %i, TOA: %" PRIu32 "ms]\n",
-                message, (int)len,
-                packet_info.rssi, (int)packet_info.snr,
+                "Received: \"%s\" (%" PRIuSIZE " bytes) - [RSSI: %i, SNR: %i, TOA: %" PRIu32 "ms]\n",
+                message, len,
+                packet_info.rssi, packet_info.snr,
                 sx126x_get_lora_time_on_air_in_ms(&sx126x.pkt_params, &sx126x.mod_params)
                 );
             netopt_state_t state = NETOPT_STATE_RX;
@@ -273,8 +274,8 @@ static int sx126x_tx_cmd(netdev_t *netdev, int argc, char **argv)
         return -1;
     }
 
-    printf("sending \"%s\" payload (%u bytes)\n",
-           argv[2], (unsigned)strlen(argv[2]) + 1);
+    printf("sending \"%s\" payload (%" PRIuSIZE " bytes)\n",
+           argv[2], strlen(argv[2]) + 1);
     iolist_t iolist = {
         .iol_base = argv[2],
         .iol_len = (strlen(argv[2]) + 1)

--- a/tests/drivers/sx127x/main.c
+++ b/tests/drivers/sx127x/main.c
@@ -240,8 +240,8 @@ int send_cmd(int argc, char **argv)
         return -1;
     }
 
-    printf("sending \"%s\" payload (%u bytes)\n",
-           argv[1], (unsigned)strlen(argv[1]) + 1);
+    printf("sending \"%s\" payload (%" PRIuSIZE " bytes)\n",
+           argv[1], strlen(argv[1]) + 1);
 
     iolist_t iolist = {
         .iol_base = argv[1],
@@ -492,9 +492,9 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
             len = dev->driver->recv(dev, NULL, 0, 0);
             dev->driver->recv(dev, message, len, &packet_info);
             printf(
-                "{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %" PRIu32 "}\n",
-                message, (int)len,
-                packet_info.rssi, (int)packet_info.snr,
+                "{Payload: \"%s\" (%" PRIuSIZE " bytes), RSSI: %i, SNR: %i, TOA: %" PRIu32 "}\n",
+                message, len,
+                packet_info.rssi, packet_info.snr,
                 sx127x_get_time_on_air((const sx127x_t *)dev, len));
             break;
 

--- a/tests/drivers/sx1280/main.c
+++ b/tests/drivers/sx1280/main.c
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "msg.h"
 #include "thread.h"
 #include "shell.h"
@@ -69,8 +70,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
             netdev_lora_rx_info_t packet_info;
             dev->driver->recv(dev, message, len, &packet_info);
             printf(
-                "Received: \"%s\" (%d bytes) - [RSSI: %i, SNR: %i]\n",
-                message, (int)len, packet_info.rssi, (int)packet_info.snr);
+                "Received: \"%s\" (%" PRIuSIZE " bytes) - [RSSI: %i, SNR: %i]\n",
+                message, len, packet_info.rssi, packet_info.snr);
         }
         break;
 
@@ -282,8 +283,8 @@ static int sx1280_tx_cmd(netdev_t *netdev, int argc, char **argv)
         return -1;
     }
 
-    printf("sending \"%s\" payload (%u bytes)\n",
-           argv[2], (unsigned)strlen(argv[2]) + 1);
+    printf("sending \"%s\" payload (%" PRIuSIZE " bytes)\n",
+           argv[2], strlen(argv[2]) + 1);
     iolist_t iolist = {
         .iol_base = argv[2],
         .iol_len = (strlen(argv[2]) + 1)

--- a/tests/net/emcute/main.c
+++ b/tests/net/emcute/main.c
@@ -89,8 +89,8 @@ static unsigned _get_qos(const char *str)
 static void _on_pub(const emcute_topic_t *topic, void *data, size_t len)
 {
     (void)data;
-    printf("### got publication of %u bytes for topic '%s' [%d] ###\n",
-           (unsigned)len, topic->name, (int)topic->id);
+    printf("### got publication of %" PRIuSIZE " bytes for topic '%s' [%u] ###\n",
+           len, topic->name, topic->id);
 }
 
 static int _con(int argc, char **argv)
@@ -224,18 +224,18 @@ static int _pub(int argc, char **argv)
     t = &_topics[idx];
     len = atoi(argv[2]);
     if ((unsigned)len > sizeof(_pub_buf)) {
-        printf("error: len %d > %lu\n", len, (unsigned long)sizeof(_pub_buf));
+        printf("error: len %d > %" PRIuSIZE "\n", len, sizeof(_pub_buf));
         return 1;
     }
     memset(_pub_buf, 92, len);
     if (emcute_pub(t, _pub_buf, len, flags) != EMCUTE_OK) {
-        printf("error: unable to publish data to topic '%s [%d]'\n",
-                t->name, (int)t->id);
+        printf("error: unable to publish data to topic '%s [%u]'\n",
+                t->name, t->id);
         return 1;
     }
 
-    printf("success: published %d bytes to topic '%s [%d]'\n",
-           (int)len, t->name, t->id);
+    printf("success: published %d bytes to topic '%s [%u]'\n",
+           len, t->name, t->id);
 
     return 0;
 }

--- a/tests/net/gnrc_ipv6_ext_frag/main.c
+++ b/tests/net/gnrc_ipv6_ext_frag/main.c
@@ -604,8 +604,8 @@ static int shell_test_cmd(int argc, char **argv)
     }
     test_num = atoi(argv[2]);
     if ((unsigned)test_num >= ARRAY_SIZE(_shell_tests)) {
-        printf("<num> must be between 0 and %u\n",
-               (unsigned)ARRAY_SIZE(_shell_tests) - 1);
+        printf("<num> must be between 0 and %" PRIuSIZE "\n",
+               ARRAY_SIZE(_shell_tests) - 1);
         return 1;
     }
     printf("Running test %d\n", test_num);

--- a/tests/net/gnrc_ipv6_ext_frag/udp.c
+++ b/tests/net/gnrc_ipv6_ext_frag/udp.c
@@ -106,7 +106,7 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
         }
         /* access to `payload` was implicitly given up with the send operation above
          * => use original variable for output */
-        printf("Success: send %u byte to [%s]:%u\n", (unsigned)data_len, addr_str,
+        printf("Success: send %" PRIuSIZE " byte to [%s]:%u\n", data_len, addr_str,
                port);
         xtimer_usleep(delay);
     }

--- a/tests/net/gnrc_ipv6_fwd_w_sub/main.c
+++ b/tests/net/gnrc_ipv6_fwd_w_sub/main.c
@@ -110,9 +110,9 @@ static int _dump_etherframe(netdev_t *dev, const iolist_t *iolist)
     (void)dev;
     while (iolist) {
         if ((outbuf_len + iolist->iol_len) > sizeof(outbuf)) {
-            printf("Ignoring packet: %u > %u\n",
-                  (unsigned)(outbuf_len + iolist->iol_len),
-                  (unsigned)sizeof(outbuf));
+            printf("Ignoring packet: %" PRIuSIZE " > %" PRIuSIZE "\n",
+                  (outbuf_len + iolist->iol_len),
+                  sizeof(outbuf));
             /* ignore larger packets */
             return outbuf_len;
         }

--- a/tests/net/gnrc_tcp/main.c
+++ b/tests/net/gnrc_tcp/main.c
@@ -278,7 +278,7 @@ int gnrc_tcp_send_cmd(int argc, char **argv)
         sent += ret;
     } while (sent < to_send);
 
-    printf("%s: sent %u\n", argv[0], (unsigned)sent);
+    printf("%s: sent %" PRIuSIZE "\n", argv[0], sent);
     return sent;
 }
 
@@ -321,7 +321,7 @@ int gnrc_tcp_recv_cmd(int argc, char **argv)
         rcvd += ret;
     } while (rcvd < to_receive);
 
-    printf("%s: received %u\n", argv[0], (unsigned)rcvd);
+    printf("%s: received %" PRIuSIZE "\n", argv[0], rcvd);
     return 0;
 }
 

--- a/tests/net/gnrc_tx_sync/main.c
+++ b/tests/net/gnrc_tx_sync/main.c
@@ -230,7 +230,7 @@ int main(void)
     int sends_expected = (IS_USED(MODULE_NETDEV_IEEE802154)) ? 2 : 1;
     printf("transmissions expected = %d, transmissions completed = %d\n",
            sends_expected, sends);
-    printf("sent %u out of %u bytes\n", pld_pos, (unsigned)sizeof(test_msg));
+    printf("sent %u out of %" PRIuSIZE " bytes\n", pld_pos, sizeof(test_msg));
     expect(sends == sends_expected);
     expect(pld_pos == sizeof(test_msg));
 

--- a/tests/net/gnrc_udp/udp.c
+++ b/tests/net/gnrc_udp/udp.c
@@ -158,7 +158,7 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
         }
         /* access to `payload` was implicitly given up with the send operation above
          * => use original variable for output */
-        printf("Success: send %u byte to [%s]:%u\n", (unsigned)data_len, addr_str,
+        printf("Success: send %" PRIuSIZE " byte to [%s]:%u\n", data_len, addr_str,
                port);
         xtimer_usleep(delay);
     }

--- a/tests/net/ieee802154_submac/main.c
+++ b/tests/net/ieee802154_submac/main.c
@@ -344,7 +344,7 @@ static void submac_rx_done(ieee802154_submac_t *submac)
     printf("%u, ", (unsigned)((buffer[1] & IEEE802154_FCF_VERS_MASK) >> 4));
     printf("Seq.: %u\n", (unsigned)ieee802154_get_seq(buffer));
     od_hex_dump(buffer + mhr_len, data_len - mhr_len, 0);
-    printf("txt (%u chars): ", data_len - mhr_len);
+    printf("txt (%" PRIuSIZE " chars): ", data_len - mhr_len);
     for (int i = mhr_len; i < data_len; i++) {
         if ((buffer[i] > 0x1F) && (buffer[i] < 0x80)) {
             putchar((char)buffer[i]);

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -126,12 +126,12 @@ int nanotest_client_cmd(int argc, char **argv)
             len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
         }
 
-        printf("nanocli: sending msg ID %u, %u bytes\n", coap_get_id(&pkt),
-               (unsigned) len);
+        printf("nanocli: sending msg ID %u, %" PRIuSIZE " bytes\n", coap_get_id(&pkt),
+               len);
 
         ssize_t res = _send(&pkt, buflen, argv[2], argv[3]);
         if (res < 0) {
-            printf("nanocli: msg send failed: %d\n", (int)res);
+            printf("nanocli: msg send failed: %" PRIdSIZE "\n", res);
         }
         else {
             char *class_str = (coap_get_code_class(&pkt) == COAP_CLASS_SUCCESS)
@@ -171,7 +171,7 @@ static int _blockwise_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int
     (void)arg;
     (void)more;
 
-    printf("offset %03u: ", (unsigned)offset);
+    printf("offset %03" PRIuSIZE ": ", offset);
     for (unsigned i = 0; i < len; ++i) {
         putchar(buf[i]);
     }

--- a/tests/periph/eeprom/main.c
+++ b/tests/periph/eeprom/main.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "architecture.h"
 #include "shell.h"
 #include "test_utils/expect.h"
 
@@ -74,7 +75,7 @@ static int cmd_read(int argc, char **argv)
     size_t ret = eeprom_read(pos, (uint8_t *)buffer, count);
     buffer[count] = '\0';
 
-    printf("Data read from EEPROM (%d bytes): %s\n", (int)ret, buffer);
+    printf("Data read from EEPROM (%" PRIuSIZE " bytes): %s\n", ret, buffer);
 
     return 0;
 }
@@ -114,7 +115,7 @@ static int cmd_write(int argc, char **argv)
     }
 
     size_t ret = eeprom_write(pos, (uint8_t *)argv[2], strlen(argv[2]));
-    printf("%d bytes written to EEPROM\n", (int)ret);
+    printf("%" PRIuSIZE " bytes written to EEPROM\n", ret);
 
     return 0;
 }
@@ -162,7 +163,7 @@ static int cmd_set(int argc, char **argv)
     }
 
     size_t ret = eeprom_set(pos, c, count);
-    printf("%d bytes set to %c in EEPROM\n", (int)ret, c);
+    printf("%" PRIuSIZE " bytes set to %c in EEPROM\n", ret, c);
 
     return 0;
 }
@@ -183,7 +184,7 @@ static int cmd_clear(int argc, char **argv)
     }
 
     size_t ret = eeprom_clear(pos, count);
-    printf("%d bytes cleared in EEPROM\n", (int)ret);
+    printf("%" PRIuSIZE " bytes cleared in EEPROM\n", ret);
 
     return 0;
 }

--- a/tests/periph/flashpage/main.c
+++ b/tests/periph/flashpage/main.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "architecture.h"
 #include "od.h"
 #include "shell.h"
 #include "periph/flashpage.h"
@@ -233,10 +234,10 @@ static int cmd_write_raw(int argc, char **argv)
 
     flashpage_write((void*)addr, raw_buf, strlen(raw_buf));
 #if (__SIZEOF_POINTER__ == 2)
-    printf("wrote local data to flash address %#" PRIx16 " of len %u\n",
+    printf("wrote local data to flash address %#" PRIx16 " of len %" PRIuSIZE "\n",
            addr, strlen(raw_buf));
 #else
-    printf("wrote local data to flash address %#" PRIx32 " of len %u\n",
+    printf("wrote local data to flash address %#" PRIx32 " of len %" PRIuSIZE "\n",
            addr, strlen(raw_buf));
 #endif
     return 0;

--- a/tests/periph/spi/main.c
+++ b/tests/periph/spi/main.c
@@ -112,11 +112,11 @@ static void print_bytes(const char *title, const uint8_t *data, size_t len)
 {
     printf("%4s\n", title);
     for (size_t i = 0; i < len; i++) {
-        printf("  %2i ", (int)i);
+        printf("  %2" PRIuSIZE " ", i);
     }
     printf("\n ");
     for (size_t i = 0; i < len; i++) {
-        printf(" 0x%02x", (int)data[i]);
+        printf(" 0x%02x", data[i]);
     }
     printf("\n ");
     for (size_t i = 0; i < len; i++) {

--- a/tests/pkg/edhoc_c/initiator.c
+++ b/tests/pkg/edhoc_c/initiator.c
@@ -162,7 +162,7 @@ int _handshake_cmd(int argc, char **argv)
     _ctx.state = EDHOC_WAITING;
 
     if ((msg_len = edhoc_create_msg1(&_ctx, corr, _method, _suite, msg, sizeof(msg))) > 0) {
-        printf("[initiator]: sending msg1 (%d bytes):\n", (int)msg_len);
+        printf("[initiator]: sending msg1 (%" PRIdSIZE " bytes):\n", msg_len);
         print_bstr(msg, msg_len);
         _build_coap_pkt(&pkt, buf, sizeof(buf), msg, msg_len);
         len = _send(&pkt, COAP_BUF_SIZE, &addr, netif, port);
@@ -180,7 +180,7 @@ int _handshake_cmd(int argc, char **argv)
     print_bstr(pkt.payload, pkt.payload_len);
 
     if ((msg_len = edhoc_create_msg3(&_ctx, pkt.payload, pkt.payload_len, msg, sizeof(msg))) > 0) {
-        printf("[initiator]: sending msg3 (%d bytes):\n", (int)msg_len);
+        printf("[initiator]: sending msg3 (%" PRIdSIZE " bytes):\n", msg_len);
         print_bstr(msg, msg_len);
         _build_coap_pkt(&pkt, buf, sizeof(buf), msg, msg_len);
         len = _send(&pkt, COAP_BUF_SIZE, &addr, netif, port);

--- a/tests/pkg/edhoc_c/responder.c
+++ b/tests/pkg/edhoc_c/responder.c
@@ -74,7 +74,7 @@ ssize_t _edhoc_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_c
         uint8_t msg[COAP_BUF_SIZE];
         if ((msg_len =
                  edhoc_create_msg2(&_ctx, pkt->payload, pkt->payload_len, msg, sizeof(msg))) >= 0) {
-            printf("[responder]: sending msg2 (%d bytes):\n", (int) msg_len);
+            printf("[responder]: sending msg2 (%" PRIdSIZE " bytes):\n", msg_len);
             print_bstr(msg, msg_len);
             msg_len = coap_reply_simple(pkt, COAP_CODE_204, buf, len, COAP_FORMAT_OCTET, msg,
                                         msg_len);

--- a/tests/pkg/lwip/ip.c
+++ b/tests/pkg/lwip/ip.c
@@ -155,9 +155,8 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
             puts("could not send");
         }
         else {
-            printf("Success: send %u byte over %s to %s (next header: %u)\n",
-                   (unsigned)data_len,
-                   (dst.family == AF_INET6) ? "IPv6" : "IPv4",
+            printf("Success: send %" PRIuSIZE " byte over %s to %s (next header: %u)\n",
+                   data_len, (dst.family == AF_INET6) ? "IPv6" : "IPv4",
                    addr_str, protocol);
         }
         ztimer_sleep(ZTIMER_USEC, delay);

--- a/tests/pkg/lwip/tcp.c
+++ b/tests/pkg/lwip/tcp.c
@@ -172,7 +172,7 @@ static int tcp_send(char *data, unsigned int num, unsigned int delay)
             puts("could not send");
         }
         else {
-            printf("Success: send %u byte over TCP to server\n", (unsigned)data_len);
+            printf("Success: send %" PRIuSIZE " byte over TCP to server\n", data_len);
         }
         ztimer_sleep(ZTIMER_USEC, delay);
     }

--- a/tests/pkg/lwip/udp.c
+++ b/tests/pkg/lwip/udp.c
@@ -118,8 +118,8 @@ static int udp_send(char *addr_str, char *data, unsigned int num,
             puts("could not send");
         }
         else {
-            printf("Success: send %u byte over UDP to %s\n",
-                   (unsigned)data_len, addr_str);
+            printf("Success: send %" PRIuSIZE " byte over UDP to %s\n",
+                   data_len, addr_str);
         }
         ztimer_sleep(ZTIMER_USEC, delay);
     }

--- a/tests/pkg/nanors/main.c
+++ b/tests/pkg/nanors/main.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "kernel_defines.h"
 #include "random.h"
 #include "rs.h"
@@ -61,8 +62,8 @@ int main(void)
         return -1;
     }
 
-    printf("total: %u shards (%u bytes)\n",
-           (unsigned)ARRAY_SIZE(marks), (unsigned)sizeof(data));
+    printf("total: %" PRIuSIZE " shards (%" PRIuSIZE " bytes)\n",
+           ARRAY_SIZE(marks), sizeof(data));
 
     /* generate parity shards */
     reed_solomon_encode(rs, shards, ARRAY_SIZE(shards), SHARD_SIZE);

--- a/tests/pkg/nimble_l2cap/main.c
+++ b/tests/pkg/nimble_l2cap/main.c
@@ -186,7 +186,7 @@ static void _send(uint32_t type, uint32_t seq, size_t len)
     expect(_coc);
     expect(len >= 8);
     expect(len <= APP_MTU);
-    printf("# Sending: size %5u seq %5u\n", (unsigned)len, (unsigned)seq);
+    printf("# Sending: size %5" PRIuSIZE " seq %5" PRIu32 "\n", len, seq);
 
     _txbuf[POS_TYPE] = type;
     _txbuf[POS_SEQ] = seq;

--- a/tests/pkg/openwsn/udp.c
+++ b/tests/pkg/openwsn/udp.c
@@ -102,8 +102,8 @@ static int udp_send(char *addr_str, char *port_str, char *data,
 
     for (unsigned int i = 0; i < num; i++) {
 
-        printf("Send %u byte over UDP to [%s]:%s\n",
-               (unsigned)data_len, addr_str, port_str);
+        printf("Send %" PRIuSIZE " byte over UDP to [%s]:%s\n",
+               data_len, addr_str, port_str);
 
         /* don't run if not in synch */
         if (ieee154e_isSynch() == FALSE) {

--- a/tests/pkg/tinydtls_sock_async/dtls-server.c
+++ b/tests/pkg/tinydtls_sock_async/dtls-server.c
@@ -156,10 +156,10 @@ static void _dtls_handler(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
 
         res = sock_dtls_recv(sock, &session, _recv_buf, sizeof(_recv_buf), 0);
         if (res >= 0) {
-            printf("Received %d bytes -- (echo)\n", (int)res);
+            printf("Received %" PRIdSIZE " bytes -- (echo)\n", res);
             res = sock_dtls_send(sock, &session, _recv_buf, (size_t)res, 0);
             if (res < 0) {
-                printf("Error resending DTLS message: %d\n", (int)res);
+                printf("Error resending DTLS message: %" PRIdSIZE "\n", res);
             }
         }
     }
@@ -183,7 +183,7 @@ static int start_server(void)
     res = credman_add(&credential);
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
-        printf("Error cannot add credential to system: %d\n", (int)res);
+        printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
         return 1;
     }
     res = sock_dtls_create(&_dtls_sock, &_udp_sock, SOCK_DTLS_SERVER_TAG,

--- a/tests/pkg/umorse/main.c
+++ b/tests/pkg/umorse/main.c
@@ -78,8 +78,8 @@ int test_umorse_out(void)
 {
     uint8_t code[CODE_LEN];
 
-    printf("> Translate text of length %u into Morse code:\n\"%s\"\n",
-           (unsigned)strlen(text), text);
+    printf("> Translate text of length %" PRIuSIZE " into Morse code:\n\"%s\"\n",
+           strlen(text), text);
 
     memset(code, 0, CODE_LEN);
     printf("> using aligned encoding:\n");

--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -24,8 +24,9 @@ ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_requ
     coap_block1_t block1;
     int blockwise = coap_get_block1(pkt, &block1);
 
-    printf("_flashwrite_handler(): received data: offset=%u len=%u blockwise=%i more=%i\n", \
-            (unsigned)block1.offset, pkt->payload_len, blockwise, block1.more);
+    printf("_flashwrite_handler(): received data: offset=%" PRIuSIZE
+           " len=%u blockwise=%i more=%i\n",
+           block1.offset, pkt->payload_len, blockwise, block1.more);
 
     uint8_t *payload_start = pkt->payload;
     size_t payload_len = pkt->payload_len;
@@ -53,7 +54,8 @@ ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_requ
         riotboot_flashwrite_putbytes(writer, payload_start, payload_len, block1.more);
     }
     else {
-        printf("_flashwrite_handler(): skipping invalid offset (data=%u, writer=%u)\n", (unsigned)offset, (unsigned)writer->offset);
+        printf("_flashwrite_handler(): skipping invalid offset (data=%" PRIuSIZE
+               ", writer=%" PRIuSIZE ")\n", offset, writer->offset);
     }
 
     if (block1.more == 1) {

--- a/tests/sys/bloom_bytes/main.c
+++ b/tests/sys/bloom_bytes/main.c
@@ -62,8 +62,7 @@ int main(void)
     bloom_init(&bloom, BLOOM_BITS, bf, hashes, BLOOM_HASHF);
 
     printf("Testing Bloom filter.\n\n");
-    printf("m: %" PRIu32 " k: %" PRIu32 "\n\n", (uint32_t) bloom.m,
-           (uint32_t) bloom.k);
+    printf("m: %" PRIuSIZE " k: %" PRIuSIZE "\n\n", bloom.m, bloom.k);
 
     random_init(myseed);
 

--- a/tests/sys/malloc/main.c
+++ b/tests/sys/malloc/main.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "architecture.h"
 #include "test_utils/expect.h"
 
 #ifndef CHUNK_SIZE
@@ -128,7 +129,7 @@ static void check_calloc_returns_null_on_overflow(void)
      * allocation succeeded. It then optimized out the test `NULL == p` and
      * assumes it to always be false. We just print the address to prevent
      * that from happening */
-    printf("calloc(%zu, %zu) = %p\n", nmemb, size, p);
+    printf("calloc(%" PRIuSIZE ", %" PRIuSIZE ") = %p\n", nmemb, size, p);
     expect(NULL == p);
 #pragma GCC diagnostic pop
 }

--- a/tests/sys/memarray/main.c
+++ b/tests/sys/memarray/main.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "memarray.h"
 #include "ps.h"
 
@@ -67,8 +68,8 @@ void fill_memory(struct block_t *head)
         head->message[MESSAGE_SIZE - 1] = 0;
         head->number = aux;
 
-        printf("\t(%i, %s) Allocated %u Bytes at %p, total %d\n",
-               head->number, head->message, (unsigned)sizeof(struct block_t),
+        printf("\t(%i, %s) Allocated %" PRIuSIZE " Bytes at %p, total %d\n",
+               head->number, head->message, sizeof(struct block_t),
                (void *)head, total);
 
         /* NOTE: If there is not space, memarray_alloc returns zero */
@@ -86,8 +87,8 @@ void free_memory(struct block_t *head)
 
     while (head) {
         total -= sizeof(struct block_t);
-        printf("\tFree (%i) %u Bytes at %p, total %d\n", \
-               head->number, (unsigned)sizeof(struct block_t),
+        printf("\tFree (%i) %" PRIuSIZE " Bytes at %p, total %d\n", \
+               head->number, sizeof(struct block_t),
                (void *)head, total);
 
         if (head->next) {
@@ -142,45 +143,45 @@ int main(void)
 
     puts("Extend and reduce tests");
 
-    printf("Memarray available: %u\n",
-           (unsigned)memarray_available(&block_storage));
+    printf("Memarray available: %" PRIuSIZE "\n",
+           memarray_available(&block_storage));
 
     /* Extend with second block */
     memarray_extend(&block_storage, block_storage_data_extend,
                     MAX_NUMBER_BLOCKS);
-    printf("Memarray available: %u\n",
-           (unsigned)memarray_available(&block_storage));
+    printf("Memarray available: %" PRIuSIZE "\n",
+           memarray_available(&block_storage));
 
     /* remove the original block */
     int res = memarray_reduce(&block_storage, block_storage_data,
                               MAX_NUMBER_BLOCKS);
-    printf("Memarray reduction: %d available: %u\n",
-           res, (unsigned)memarray_available(&block_storage));
+    printf("Memarray reduction: %d available: %" PRIuSIZE "\n",
+           res, memarray_available(&block_storage));
 
     /* try to remove original block a second time */
     res = memarray_reduce(&block_storage, block_storage_data,
                           MAX_NUMBER_BLOCKS);
-    printf("Memarray reduction: %d available: %u\n",
-           res, (unsigned)memarray_available(&block_storage));
+    printf("Memarray reduction: %d available: %" PRIuSIZE "\n",
+           res, memarray_available(&block_storage));
 
     /* remove the extension block */
     res = memarray_reduce(&block_storage, block_storage_data_extend,
                           MAX_NUMBER_BLOCKS);
-    printf("Memarray reduction: %d available: %u\n",
-           res, (unsigned)memarray_available(&block_storage));
+    printf("Memarray reduction: %d available: %" PRIuSIZE "\n",
+           res, memarray_available(&block_storage));
 
     /* extend again with the original block */
     memarray_extend(&block_storage, block_storage_data, MAX_NUMBER_BLOCKS);
 
     /* remove one element */
     memarray_alloc(&block_storage);
-    printf("Memarray available: %u\n",
-           (unsigned)memarray_available(&block_storage));
+    printf("Memarray available: %" PRIuSIZE "\n",
+           memarray_available(&block_storage));
 
     /* try to reduce with a missing element */
     res = memarray_reduce(&block_storage, block_storage_data, MAX_NUMBER_BLOCKS);
-    printf("Memarray reduction: %d available: %u\n",
-           res, (unsigned)memarray_available(&block_storage));
+    printf("Memarray reduction: %d available: %" PRIuSIZE "\n",
+           res, memarray_available(&block_storage));
 
     printf("Finishing\n");
     ps();

--- a/tests/sys/pthread/main.c
+++ b/tests/sys/pthread/main.c
@@ -30,7 +30,7 @@ void *run(void *parameter) {
     size_t n = (size_t) parameter;
     size_t factorial = 1;
 
-    printf("pthread: parameter = %u\n", (unsigned int) n);
+    printf("pthread: parameter = %" PRIuSIZE "\n", n);
 
     if (n > 0) {
         for (size_t i = 1; i <= n; i++) {
@@ -38,7 +38,7 @@ void *run(void *parameter) {
         }
     }
 
-    printf("pthread: factorial = %u\n", (unsigned int) factorial);
+    printf("pthread: factorial = %" PRIuSIZE "\n",factorial);
     pthread_exit((void *)factorial);
 
     return NULL;

--- a/tests/sys/shell/main.c
+++ b/tests/sys/shell/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "shell.h"
 
 #if MODULE_STDIO_RTT
@@ -87,7 +88,7 @@ static int print_shell_bufsize(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-    printf("%d\n", sizeof(line_buf));
+    printf("%" PRIuSIZE "\n", sizeof(line_buf));
 
     return 0;
 }

--- a/tests/sys/usbus/main.c
+++ b/tests/sys/usbus/main.c
@@ -255,7 +255,7 @@ static void _handle_data(usbdev_mock_t *dev, usbdev_mock_ep_t *ep, size_t len)
 {
     if (ep->ep.dir == USB_EP_DIR_IN) {
         /* Zero length IN packet is not valid here */
-        DEBUG("[data]: Handling IN data from stack: %u\n", (unsigned)len);
+        DEBUG("[data]: Handling IN data from stack: %" PRIuSIZE "\n", len);
         TEST_ASSERT(len != 0);
         dev->usbdev.epcb(&dev->in[0].ep, USBDEV_EVENT_ESR);
         if (ep->available == dev->req_len) {
@@ -263,9 +263,8 @@ static void _handle_data(usbdev_mock_t *dev, usbdev_mock_ep_t *ep, size_t len)
             req_phase = TEST_REQ_PHASE_OUTACK;
         }
         else {
-            DEBUG("[data]: Expecting more data from stack: %u/%u\n",
-                  (unsigned)ep->available,
-                  (unsigned)dev->req_len);
+            DEBUG("[data]: Expecting more data from stack: %" PRIuSIZE "/%" PRIuSIZE "\n",
+                  ep->available, dev->req_len);
         }
     }
 }

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -28,20 +28,28 @@ static fib_table_t test_fib_table = { .data.entries = _entries,
                                       .notify_rp_pos = 0 };
 
 /*
+* @brief helper to create FIB test addresses
+*/
+static void _set_fib_test_addr(char * addr_dst, unsigned add_buf_size, unsigned i) {
+    TEST_ASSERT(i < 100 && add_buf_size >= 16);
+    snprintf(addr_dst, add_buf_size, "Test address %02u", i);
+}
+
+/*
 * @brief helper to fill FIB with unique entries
 */
-static void _fill_FIB_unique(size_t entries)
+static void _fill_fib_unique(unsigned entries)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
     char addr_nxt[add_buf_size];
     uint32_t addr_dst_flags = 0x00777777;
     uint32_t addr_nxt_flags = 0x00777777;
 
-    for (size_t i = 0; i < entries; ++i) {
+    for (unsigned i = 0; i < entries; ++i) {
         /* construct "addresses" for the FIB */
-        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
-        snprintf(addr_nxt, add_buf_size, "Test address %02" PRIuSIZE, entries + i);
+        _set_fib_test_addr(addr_dst, add_buf_size, i);
+        _set_fib_test_addr(addr_nxt, add_buf_size, entries + i);
         /* the terminating \0 is unnecessary here */
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
@@ -54,18 +62,18 @@ static void _fill_FIB_unique(size_t entries)
 * @brief helper to fill FIB with multiple used entries
 * The modulus adjusts the number of reused addresses
 */
-static void _fill_FIB_multiple(size_t entries, size_t modulus)
+static void _fill_fib_multiple(unsigned entries, unsigned modulus)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
     char addr_nxt[add_buf_size];
     uint32_t addr_dst_flags = 0x00333333;
     uint32_t addr_nxt_flags = 0x00333333;
 
-    for (size_t i = 0; i < entries; ++i) {
+    for (unsigned i = 0; i < entries; ++i) {
         /* construct "addresses" for the FIB */
-        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
-        snprintf(addr_nxt, add_buf_size, "Test address %02" PRIuSIZE, i % modulus);
+        _set_fib_test_addr(addr_dst, add_buf_size, i);
+        _set_fib_test_addr(addr_nxt, add_buf_size, i % modulus);
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
                       (uint8_t *)addr_nxt, add_buf_size - 1, addr_nxt_flags,
@@ -76,7 +84,7 @@ static void _fill_FIB_multiple(size_t entries, size_t modulus)
 /*
 * @brief helper to determine the prefix bits
 */
-static size_t _get_prefix_bits_num(char* addr, size_t addr_len)
+static unsigned _get_prefix_bits_num(char* addr, unsigned addr_len)
 {
     /* Get the index of the first trailing `0` */
     int i = 0;
@@ -102,7 +110,7 @@ static size_t _get_prefix_bits_num(char* addr, size_t addr_len)
 */
 static void test_fib_01_fill_unique_entries(void)
 {
-    _fill_FIB_unique(20);
+    _fill_fib_unique(20);
 #if (TEST_FIB_SHOW_OUTPUT == 1)
     fib_print_fib_table(&test_fib_table);
     puts("");
@@ -120,8 +128,8 @@ static void test_fib_01_fill_unique_entries(void)
  */
 static void test_fib_02_fill_multiple_entries(void)
 {
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
 #if (TEST_FIB_SHOW_OUTPUT == 1)
     fib_print_fib_table(&test_fib_table);
@@ -140,18 +148,18 @@ static void test_fib_02_fill_multiple_entries(void)
 */
 static void test_fib_03_removing_all_entries(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_unique(entries);
+    unsigned entries = 20;
+    _fill_fib_unique(entries);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(40, universal_address_get_num_used_entries());
 
-    for (size_t i = 0; i < entries; ++i) {
+    for (unsigned i = 0; i < entries; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
+        _set_fib_test_addr(addr_dst, add_buf_size, i);
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -174,18 +182,18 @@ static void test_fib_03_removing_all_entries(void)
 */
 static void test_fib_04_remove_lower_half(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
 
-    for (size_t i = 0; i < entries / 2; ++i) {
+    for (unsigned i = 0; i < entries / 2; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
+        _set_fib_test_addr(addr_dst, add_buf_size, i);
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -206,18 +214,18 @@ static void test_fib_04_remove_lower_half(void)
 */
 static void test_fib_05_remove_upper_half(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
 
-    for (size_t i = 0; i < entries / 2; ++i) {
+    for (unsigned i = 0; i < entries / 2; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, (entries / 2) + i);
+        _set_fib_test_addr(addr_dst, add_buf_size, (entries / 2) + i);
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -241,11 +249,11 @@ static void test_fib_05_remove_upper_half(void)
 */
 static void test_fib_06_remove_one_entry(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[] = "Test address 02";
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
@@ -270,11 +278,11 @@ static void test_fib_06_remove_one_entry(void)
 */
 static void test_fib_07_remove_one_entry_multiple_times(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 13";
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
@@ -301,11 +309,11 @@ static void test_fib_07_remove_one_entry_multiple_times(void)
 */
 static void test_fib_08_remove_unknown(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 99";
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
@@ -332,14 +340,14 @@ static void test_fib_08_remove_unknown(void)
 */
 static void test_fib_09_update_entry(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst13[] = "Test address 13";
     char addr_dst07[] = "Test address 07";
     char addr_nxt2[] = "Test address 99";
     char addr_nxt77[] = "Test address 77";
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
@@ -367,12 +375,12 @@ static void test_fib_09_update_entry(void)
 */
 static void test_fib_10_add_exceed(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 98";
     char addr_nxt[] = "Test address 99";
 
-    size_t entries = 20;
-    _fill_FIB_unique(entries);
+    unsigned entries = 20;
+    _fill_fib_unique(entries);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(40, universal_address_get_num_used_entries());
@@ -400,15 +408,15 @@ static void test_fib_10_add_exceed(void)
 */
 static void test_fib_11_get_next_hop_success(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 13";
     char addr_expect[] = "Test address 02";
     kernel_pid_t iface_id = KERNEL_PID_UNDEF;
     uint32_t next_hop_flags = 0;
     char addr_nxt[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
@@ -438,14 +446,14 @@ static void test_fib_11_get_next_hop_success(void)
 */
 static void test_fib_12_get_next_hop_fail(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 99";
     kernel_pid_t iface_id = KERNEL_PID_UNDEF;
     uint32_t next_hop_flags = 0;
     char addr_nxt[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
     int ret = fib_get_next_hop(&test_fib_table, &iface_id, (uint8_t *)addr_nxt,
@@ -469,15 +477,15 @@ static void test_fib_12_get_next_hop_fail(void)
 */
 static void test_fib_13_get_next_hop_fail_on_buffer_size(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 13";
     kernel_pid_t iface_id = KERNEL_PID_UNDEF;
     uint32_t next_hop_flags = 0;
-    size_t add_buf_size_nxt = 12;
+    unsigned add_buf_size_nxt = 12;
     char addr_nxt[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
     TEST_ASSERT_EQUAL_INT(20, fib_get_num_used_entries(&test_fib_table));
     TEST_ASSERT_EQUAL_INT(20, universal_address_get_num_used_entries());
 
@@ -504,7 +512,7 @@ static void test_fib_13_get_next_hop_fail_on_buffer_size(void)
 */
 static void test_fib_14_exact_and_prefix_match(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
     char addr_nxt[add_buf_size];
     kernel_pid_t iface_id = KERNEL_PID_UNDEF;
@@ -589,7 +597,7 @@ static void test_fib_15_get_lifetime(void)
     kernel_pid_t iface_id = 1;
     char addr_dst[] = "Test address151";
     char addr_nxt[] = "Test address152";
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     uint32_t addr_dst_flags = 0x77777777;
     uint32_t addr_nxt_flags = 0x77777777;
 
@@ -619,7 +627,7 @@ static void test_fib_15_get_lifetime(void)
 */
 static void test_fib_16_prefix_match(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
     char addr_nxt[add_buf_size];
     char addr_lookup[add_buf_size];
@@ -713,16 +721,16 @@ static void test_fib_17_get_entry_set(void)
     char addr_nxt[addr_buf_size];
 
     /* fill 20 addresses */
-    for (size_t i = 0; i < 20; ++i) {
+    for (unsigned i = 0; i < 20; ++i) {
         /* construct "addresses" for the FIB */
-        snprintf(addr_dst, addr_buf_size, "Test address %02" PRIuSIZE, i);
-        snprintf(addr_nxt, addr_buf_size, "Test address %02" PRIuSIZE, i % 11);
+        _set_fib_test_addr(addr_dst, addr_buf_size, i);
+        _set_fib_test_addr(addr_nxt, addr_buf_size, i % 11);
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, addr_buf_size - 1, 0x0,
                       (uint8_t *)addr_nxt, addr_buf_size - 1, 0x0, 100000);
     }
 
-    size_t arr_size = 20;
+    unsigned arr_size = 20;
     fib_destination_set_entry_t arr_dst[arr_size];
     char prefix[addr_buf_size];
     memset(prefix, 0, addr_buf_size);
@@ -768,8 +776,8 @@ static void test_fib_17_get_entry_set(void)
 
 #if (TEST_FIB_SHOW_OUTPUT == 1)
     puts("");
-    for (size_t i = 0; i < arr_size; ++i) {
-        for (size_t j = 0; j < arr_dst[i].dest_size; ++j) {
+    for (unsigned i = 0; i < arr_size; ++i) {
+        for (unsigned j = 0; j < arr_dst[i].dest_size; ++j) {
             printf("%c", (char)arr_dst[i].dest[j]);
         }
         puts("");
@@ -785,15 +793,15 @@ static void test_fib_17_get_entry_set(void)
 */
 static void test_fib_18_get_next_hop_invalid_parameters(void)
 {
-    size_t add_buf_size = 16; /* includes space for terminating \0 */
+    unsigned add_buf_size = 16; /* includes space for terminating \0 */
     char addr_dst[] = "Test address 13";
     char addr_expect[] = "Test address 02";
     kernel_pid_t iface_id = KERNEL_PID_UNDEF;
     uint32_t next_hop_flags = 0;
     char addr_nxt[add_buf_size];
 
-    size_t entries = 20;
-    _fill_FIB_multiple(entries, 11);
+    unsigned entries = 20;
+    _fill_fib_multiple(entries, 11);
 
     int ret = fib_get_next_hop(&test_fib_table, NULL, NULL,
                                NULL, NULL, NULL, add_buf_size - 1, 0x13);
@@ -823,7 +831,7 @@ static void test_fib_18_get_next_hop_invalid_parameters(void)
 */
 static void test_fib_19_default_gateway(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
     char addr_nxt_hop[add_buf_size];
     char addr_nxt[add_buf_size];
@@ -839,7 +847,7 @@ static void test_fib_19_default_gateway(void)
     snprintf(addr_lookup, add_buf_size, "Some address X1");
 
     /* set the bytes to 0x01..0x10 of the next-hop */
-    for (size_t i = 0; i < add_buf_size; i++) {
+    for (unsigned i = 0; i < add_buf_size; i++) {
         addr_nxt[i] = i+1;
     }
 
@@ -861,7 +869,7 @@ static void test_fib_19_default_gateway(void)
     memset(addr_nxt_hop, 0, add_buf_size);
 
     /* set the bytes to 0x02..0x11 of the new next-hop for the default gateway */
-    for (size_t i = 0; i < add_buf_size; ++i) {
+    for (unsigned i = 0; i < add_buf_size; ++i) {
         addr_nxt[i] = i+2;
     }
 
@@ -892,7 +900,7 @@ static void test_fib_19_default_gateway(void)
 */
 static void test_fib_20_replace_prefix(void)
 {
-    size_t add_buf_size = 16;
+    unsigned add_buf_size = 16;
     char addr_dst[add_buf_size];
     char addr_nxt_hop[add_buf_size];
     char addr_nxt[add_buf_size];
@@ -906,17 +914,17 @@ static void test_fib_20_replace_prefix(void)
     memset(addr_lookup, 0, add_buf_size);
 
     /* set the bytes to 0x01..0x10 of the next-hop */
-    for (size_t i = 0; i < add_buf_size; i++) {
+    for (unsigned i = 0; i < add_buf_size; i++) {
         addr_nxt[i] = i+1;
     }
 
     /* set the bytes to 0x01..0x08 of the destination prefix */
-    for (size_t i = 0; i < add_buf_size/2; i++) {
+    for (unsigned i = 0; i < add_buf_size/2; i++) {
         addr_dst[i] = i+1;
     }
 
     /* set the bytes to 0x01..0x0e of the lookup address */
-    for (size_t i = 0; i < 14; i++) {
+    for (unsigned i = 0; i < 14; i++) {
         addr_lookup[i] = i+1;
     }
 
@@ -942,12 +950,12 @@ static void test_fib_20_replace_prefix(void)
     memset(addr_nxt_hop, 0, add_buf_size);
 
     /* set the bytes to 0x02..0x11 of the new next-hop */
-    for (size_t i = 0; i < add_buf_size; ++i) {
+    for (unsigned i = 0; i < add_buf_size; ++i) {
         addr_nxt[i] = i+2;
     }
 
     /* set the bytes to 0x01..0x0d of the new destination prefix */
-    for (size_t i = 0; i < 13; i++) {
+    for (unsigned i = 0; i < 13; i++) {
         addr_dst[i] = i+1;
     }
 

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -40,8 +40,8 @@ static void _fill_FIB_unique(size_t entries)
 
     for (size_t i = 0; i < entries; ++i) {
         /* construct "addresses" for the FIB */
-        snprintf(addr_dst, add_buf_size, "Test address %02d", (int)i);
-        snprintf(addr_nxt, add_buf_size, "Test address %02d", (int)(entries + i));
+        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
+        snprintf(addr_nxt, add_buf_size, "Test address %02" PRIuSIZE, entries + i);
         /* the terminating \0 is unnecessary here */
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
@@ -64,8 +64,8 @@ static void _fill_FIB_multiple(size_t entries, size_t modulus)
 
     for (size_t i = 0; i < entries; ++i) {
         /* construct "addresses" for the FIB */
-        snprintf(addr_dst, add_buf_size, "Test address %02d", (int)i);
-        snprintf(addr_nxt, add_buf_size, "Test address %02d", (int)(i % modulus));
+        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
+        snprintf(addr_nxt, add_buf_size, "Test address %02" PRIuSIZE, i % modulus);
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, add_buf_size - 1, addr_dst_flags,
                       (uint8_t *)addr_nxt, add_buf_size - 1, addr_nxt_flags,
@@ -151,7 +151,7 @@ static void test_fib_03_removing_all_entries(void)
 
     for (size_t i = 0; i < entries; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02d", (int)i);
+        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -185,7 +185,7 @@ static void test_fib_04_remove_lower_half(void)
 
     for (size_t i = 0; i < entries / 2; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02d", (int)i);
+        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, i);
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -217,7 +217,7 @@ static void test_fib_05_remove_upper_half(void)
 
     for (size_t i = 0; i < entries / 2; ++i) {
         /* construct "addresses" to remove */
-        snprintf(addr_dst, add_buf_size, "Test address %02d", (int)((entries / 2) + i));
+        snprintf(addr_dst, add_buf_size, "Test address %02" PRIuSIZE, (entries / 2) + i);
         fib_remove_entry(&test_fib_table, (uint8_t *)addr_dst, add_buf_size - 1);
     }
 
@@ -715,8 +715,8 @@ static void test_fib_17_get_entry_set(void)
     /* fill 20 addresses */
     for (size_t i = 0; i < 20; ++i) {
         /* construct "addresses" for the FIB */
-        snprintf(addr_dst, addr_buf_size, "Test address %02d", (int)i);
-        snprintf(addr_nxt, addr_buf_size, "Test address %02d", (int)(i % 11));
+        snprintf(addr_dst, addr_buf_size, "Test address %02" PRIuSIZE, i);
+        snprintf(addr_nxt, addr_buf_size, "Test address %02" PRIuSIZE, i % 11);
         fib_add_entry(&test_fib_table, 42,
                       (uint8_t *)addr_dst, addr_buf_size - 1, 0x0,
                       (uint8_t *)addr_nxt, addr_buf_size - 1, 0x0, 100000);

--- a/tests/unittests/tests-fib_sr/tests-fib_sr.c
+++ b/tests/unittests/tests-fib_sr/tests-fib_sr.c
@@ -67,7 +67,7 @@ static int _create_sr(const char *pre, size_t from, size_t to, fib_sr_t *sr, siz
 
     for (size_t i = from; i < to; ++i) {
         int res;
-        snprintf(&(addr_nxt[strlen(pre)]), buf_size, "%d", (int)i);
+        snprintf(&(addr_nxt[strlen(pre)]), buf_size, "%" PRIuSIZE, i);
         /* append a  hop */
         res = fib_sr_entry_append(&test_fib_sr_table, sr, (uint8_t *)&addr_nxt, buf_size);
         if (res != 0) {

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include "architecture.h"
 #include "container.h"
 #include "embUnit.h"
 
@@ -57,7 +58,7 @@ static int _compare_string_buffer(const char *name, const char *input_uri, const
         return 0;
     }
     printf(
-        "\nWith given input uri '%s', expected %s '%s' with length '%d' but got '%.*s' with length '%d'\n",
+        "\nWith given input uri '%s', expected %s '%s' with length '%" PRIuSIZE "' but got '%.*s' with length '%d'\n",
         input_uri, name, expected_str, strlen(expected_str), actual_len, actual_str, actual_len);
     return -1;
 }
@@ -317,7 +318,7 @@ static void _result_component_scheme_matches_input_scheme(void)
              * but the uri_parser provides the length separately*/
             if (uri_res.scheme_len != strlen(test_vec[i]->scheme)) {
                 printf(
-                    "With given input uri '%s', expected a scheme with the length '%d' but got '%d'\n",
+                    "With given input uri '%s', expected a scheme with the length '%" PRIuSIZE "' but got '%d'\n",
                     test_vec[i]->input_uri, strlen(test_vec[i]->scheme), uri_res.scheme_len);
                 TEST_FAIL(failure_msg);
             }


### PR DESCRIPTION
### Contribution description

As discussed in #20182, this PR adds custom print format specifiers for `size_t` (e.g., `PRIuSIZE`) that doesn't assume `sizeof(unsigned) == sizeof(size_t)` to `architecture.h` and changes the `size_t` printing recommendation in `CODING_CONVENTIONS.md`

Furthermore, the bulk of this PR consists of changes that modify print statements with `size_t` arguments to use the new print format specifiers.

@maribu mentioned a possible switch to picolib in the near future. This would provide support for the currently problematic `%z` format specifier. If this is the preferred solution, I can easily replace the `PRIuSIZE`, `PRIxSIZE`, etc. macros with the corresponding `%z` modifiers and remove the custom print format specifiers. 

### Testing procedure

This shouldn't change any test or application.
To test the debug statement, set the appropriate `ENABLE_DEBUG` macro (or enable it globally).

### Issues/PRs references

See also #20182, #20154