### PR TITLE
nanocoap: defuse footgun in coap_get_uri_query()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -847,18 +847,17 @@ static inline ssize_t coap_get_uri_path(coap_pkt_t *pkt, uint8_t *target)
  * This function decodes the pkt's URI_QUERY option into a "&"-separated and
  * '\0'-terminated string.
  *
- * Caller must ensure @p target can hold at least CONFIG_NANOCOAP_URI_MAX bytes!
- *
  * @param[in]   pkt     pkt to work on
  * @param[out]  target  buffer for target URI
+ * @param[in]   max_len size of @p target in bytes
  *
- * @returns     -ENOSPC     if URI option is larger than CONFIG_NANOCOAP_URI_MAX
+ * @returns     -ENOSPC     if URI option is larger than @p max_len
  * @returns     nr of bytes written to @p target (including '\0')
  */
-static inline ssize_t coap_get_uri_query(coap_pkt_t *pkt, uint8_t *target)
+static inline ssize_t coap_get_uri_query(coap_pkt_t *pkt, char *target, size_t max_len)
 {
-    return coap_opt_get_string(pkt, COAP_OPT_URI_QUERY, target,
-                               CONFIG_NANOCOAP_URI_MAX, '&');
+    return coap_opt_get_string(pkt, COAP_OPT_URI_QUERY,
+                               (uint8_t *)target, max_len, '&');
 }
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -854,7 +854,8 @@ static inline ssize_t coap_get_uri_path(coap_pkt_t *pkt, uint8_t *target)
  * @returns     -ENOSPC     if URI option is larger than @p max_len
  * @returns     nr of bytes written to @p target (including '\0')
  */
-static inline ssize_t coap_get_uri_query(coap_pkt_t *pkt, char *target, size_t max_len)
+static inline ssize_t coap_get_uri_query_string(coap_pkt_t *pkt, char *target,
+                                                size_t max_len)
 {
     return coap_opt_get_string(pkt, COAP_OPT_URI_QUERY,
                                (uint8_t *)target, max_len, '&');

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -66,7 +66,7 @@ static void test_nanocoap__hdr_2(void)
     uint16_t msgid = 0xABCD;
     char path[] = "/test/abcd/efgh?foo=bar&baz=blub";
     unsigned char path_tmp[64] = {0};
-    unsigned char query_tmp[64] = {0};
+    char query_tmp[64] = {0};
 
     uint8_t *pktpos = &buf[0];
     uint16_t lastonum = 0;
@@ -83,7 +83,7 @@ static void test_nanocoap__hdr_2(void)
     TEST_ASSERT_EQUAL_INT(sizeof("/test/abcd/efgh"), res);
     TEST_ASSERT_EQUAL_STRING("/test/abcd/efgh", (char *)path_tmp);
 
-    res = coap_get_uri_query(&pkt, query_tmp);
+    res = coap_get_uri_query_string(&pkt, query_tmp, sizeof(query_tmp));
     TEST_ASSERT_EQUAL_INT(sizeof("&foo=bar&baz=blub"), res);
     TEST_ASSERT_EQUAL_STRING("&foo=bar&baz=blub", (char *)query_tmp);
 }
@@ -321,14 +321,14 @@ static void test_nanocoap__get_query(void)
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 
     char query[10] = {0};
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs, &query[1]);
 
     /* overwrite query to test buffer-based put */
     coap_opt_put_uri_query(query_pos, COAP_OPT_URI_PATH, qs);
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs, &query[1]);
 }
 
@@ -359,14 +359,14 @@ static void test_nanocoap__get_multi_query(void)
     TEST_ASSERT_EQUAL_INT(2, optlen);
 
     char query[20] = {0};
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs, &query[1]);
 
     /* overwrite query to test buffer-based put */
     coap_opt_put_uri_query(query_pos, COAP_OPT_URI_PATH, qs);
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs, &query[1]);
 }
 /*
@@ -399,24 +399,24 @@ static void test_nanocoap__add_uri_query2(void)
     char query[20] = {0};
     len = coap_opt_add_uri_query2(&pkt, keys, key1_len, vals, val1_len);
     TEST_ASSERT_EQUAL_INT(query1_opt_len, len);
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs1, &query[1]);
 
     /* includes key only */
     memset(query, 0, 20);
     len = coap_opt_add_uri_query2(&pkt, &keys[2], key2_len, NULL, 0);
     TEST_ASSERT_EQUAL_INT(query2_opt_len, len);
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs2, &query[1]);
 
     /* includes key only; value not NULL but zero length */
     memset(query, 0, 20);
     len = coap_opt_add_uri_query2(&pkt, &keys[2], key2_len, &vals[3], 0);
     TEST_ASSERT_EQUAL_INT(query3_opt_len, len);
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs3, &query[1]);
 
     /* fails an assert, so only run when disabled */
@@ -428,8 +428,8 @@ static void test_nanocoap__add_uri_query2(void)
     memset(query, 0, 20);
     len = coap_opt_add_uri_query2(&pkt, &keys[2], key2_len, NULL, 1);
     TEST_ASSERT_EQUAL_INT(query4_opt_len, len);
-    coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
-    /* skip initial '&' from coap_get_uri_query() */
+    coap_get_uri_query_string(&pkt, query, sizeof(query));
+    /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs4, &query[1]);
 #endif
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`coap_get_uri_query()` takes no size parameter and assumes the buffer supplied by the caller will be sufficiently large.

This is a huge foot-gun and we can actually supply the max length to the underlying `coap_opt_get_string()` function, so just do that.

Also that function is not very useful. It's nice for debugging, but when actually wanting to obtain the query parameters, we certainly don't want to first convert them into a string only to then parse the string. Rename the function to `coap_get_uri_query_string()` to better reflect what it does and to make the name available for a more useful query iterator function. 


### Testing procedure

The `tests-nanocoap` test in `tests/unittests` still works. 


### Issues/PRs references

includes #20195 because I don't like merge conflicts. 
