### PR TITLE
examples/dtls-sock: Enable non 32-bit architectures

### DIFF
--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -45,9 +45,6 @@ CFLAGS += -DDTLS_DEFAULT_PORT=$(DTLS_PORT)
 # Uncomment to enable debug logs
 # CFLAGS += -DCONFIG_DTLS_DEBUG
 
-# FIXME: This is a temporary patch
-CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(2*THREAD_STACKSIZE_LARGE\)
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
@@ -56,3 +53,10 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+# FIXME: This is a temporary patch
+ifeq (,$(filter arch_avr8,$(FEATURES_USED)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(2*THREAD_STACKSIZE_LARGE\)
+else
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_LARGE\)
+endif

--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -7,9 +7,6 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-# TinyDTLS only has support for 32-bit architectures ATM
-FEATURES_REQUIRED += arch_32bit
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += netdev_default

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -1,5 +1,15 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-nano \
+    arduino-uno \
+    atmega1284p \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atmega8 \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
@@ -7,12 +17,18 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
     calliope-mini \
+    derfmega12 \
+    derfmega128 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     lsn50 \
+    mega-xplained \
     microbit \
+    microduino-corerf \
+    msb-430 \
+    msb-430h \
     nrf51dongle \
     nrf6310 \
     nucleo-f030r8 \
@@ -26,6 +42,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
+    olimex-msp430-h1611 \
+    olimex-msp430-h2618 \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
@@ -37,5 +55,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    telosb \
+    waspmote-pro \
     yunjia-nrf51822 \
+    z1 \
+    zigduino \
     #


### PR DESCRIPTION
### Contribution description
Minor change:
Remove the unnecessary `FEATURES_REQUIRED += arch_32bit` filter from the dtls-sock example.  
(Which the similar dtls-echo example also does not have.)

### Testing procedure

Test the dtls-sock example with non 32-bit boards.
***DISCLAIMER: I only compiled the example for all boards. I don't have an 8-bit board with enough memory to test this. If someone could test this, I would appreciate it.***