### PR TITLE
nanocoap: add coap_iterate_uri_query()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -989,6 +989,31 @@ bool coap_find_uri_query(coap_pkt_t *pkt, const char *key,
                          const char **value, size_t *len);
 
 /**
+ * @brief   Iterate over a packet's URI Query options
+ *
+ * This expects that the Uri-Query options follow the widespread format `key=value`
+ * or just `key`
+ *
+ * Key and Value will be copied into the supplied buffers as a NULL-terminated
+ * string.
+ *
+ * @param[in]   pkt           packet to read from
+ * @param[out]  ctx           opaque, must be set to `NULL` on first call
+ * @param[out]  key           Output buffer for the key
+ * @param[in]   key_len_max   Size of the key output buffer
+ * @param[out]  value         Output buffer for the value
+ * @param[in]   value_len_max Size of the value output buffer
+ *
+ * @return      2           if key and value were found
+ * @return      1           if key was found
+ * @return      0           if no key was found
+ * @return -E2BIG           if key or value does not fit the supplied space
+ */
+int coap_iterate_uri_query(coap_pkt_t *pkt, void **ctx,
+                           char *key, size_t key_len_max,
+                           char *value, size_t value_len_max);
+
+/**
  * @brief   Iterate over a packet's options
  *
  * To start iteration from the first option, set @p init_opt to true. To start


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a convenience function to iterate over a packets's URI query options.
Options have the format `key=value`, but options that only consist of a key may also exist.
For consistency, in this case the value is set to `"1"`.


### Testing procedure

I extended the `tests-nanocoap` unit test with the new function. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
