### PR TITLE
tests: Slightly increase coverage of fmt unittests

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -85,6 +85,19 @@ size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n)
     return len;
 }
 
+size_t fmt_bytes_hex_reverse(char *out, const uint8_t *ptr, size_t n)
+{
+    size_t len = n * 2;
+
+    if (out) {
+        while (n--) {
+            out += fmt_byte_hex(out, ptr[n]);
+        }
+    }
+
+    return len;
+}
+
 size_t fmt_strlen(const char *str)
 {
     const char *tmp = str;
@@ -120,16 +133,6 @@ size_t fmt_str(char *out, const char *str)
         }
     }
     return len;
-}
-
-size_t fmt_bytes_hex_reverse(char *out, const uint8_t *ptr, size_t n)
-{
-    size_t i = n;
-
-    while (i--) {
-        out += fmt_byte_hex(out, ptr[i]);
-    }
-    return (n << 1);
 }
 
 static uint8_t _byte_mod25(uint8_t x)

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -147,10 +147,13 @@ uint8_t fmt_hex_byte(const char *hex);
  *
  * The sequence of hex characters must have an even length:
  * 2 hex character => 1 byte. If the sequence of hex has an odd length, this
- * function returns 0 and an empty @p out.
+ * function returns 0 and does not write to @p out.
  *
  * The hex characters sequence must contain valid hexadecimal characters
  * otherwise the result in @p out is undefined.
+ *
+ * If @p out is NULL, will only return the number of bytes that would have
+ * been written.
  *
  * @param[out] out  Pointer to converted bytes, or NULL
  * @param[in]  hex  Pointer to input buffer


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🦙

this adds a few new test cases to the `tests-fmt` unit tests.
The changes only apply to these functions:
* `fmt_is_digit()`
* `fmt_is_upper()`
* `fmt_is_number()`
* `fmt_byte_hex()`
* `fmt_bytes_hex()`
* `fmt_bytes_hex_reverse()`
* `fmt_hex_byte()`
* `fmt_hex_bytes()`

I found the behavior of `fmt_bytes_hex_reverse()` to be not conform with the API description. In this case, a null-pointer de-reference could be triggered while complying with the API, by passing a `NULL` pointer as the output buffer. A search through the code base returned only few usage of this function and none of it was affected. I applied a fix and also moved the function closer to its relative `fmt_bytes_hex()`, thereby mimicking the order present in `fmt.h`. As an extra, I refactored the function to look even more similar to its relative. 

In addition, one statement in the API of `fmt_hex_byte()` in `fmt.h` was clarified and a missing statement was added.

Thanks, 🐮

### Testing procedure

`make -C tests/unittests/ tests-fmt test`

### Issues/PRs references

Most tests touched were introduced in #8343
