### PR TITLE
gnrc/ipv6/nib: fix GNRC_IPV6_STATIC_LLADDR when link state changes

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -143,6 +143,7 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
     _init_iface_arsm(netif);
     netif->ipv6.rs_sent = 0;
     netif->ipv6.na_sent = 0;
+    _add_static_lladdr(netif);
     _auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
     if (_should_search_rtr(netif)) {
         uint32_t next_rs_time = random_uint32_range(0, NDP_MAX_RS_MS_DELAY);
@@ -212,7 +213,6 @@ void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif)
         gnrc_netif_release(netif);
         return;
     }
-    _add_static_lladdr(netif);
 
     gnrc_netif_release(netif);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I forgot to take `GNRC_IPV6_STATIC_LLADDR` into account when doing the `gnrc_ipv6_nib_iface_up()`/`gnrc_ipv6_nib_iface_down()` changes.

When the interface goes down, we remove all link-local addresses - but when it goes up again we did not add back the static address.

Fix this by moving `_add_static_lladdr()` to `gnrc_ipv6_nib_iface_up()`.


### Testing procedure

Enable `GNRC_IPV6_STATIC_LLADDR` e.g. in `examples/gnrc_networking`. I tested this on `same54-xpro` where I can unplug the Ethernet cable to make the link go down.

#### master

```
2023-12-19 18:41:43,176 - INFO # Iface  5  HWaddr: FC:C2:3D:22:12:3B  Link: up 
2023-12-19 18:41:43,180 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2023-12-19 18:41:43,182 - INFO #           RTR_ADV  
2023-12-19 18:41:43,185 - INFO #           Source address length: 6
2023-12-19 18:41:43,187 - INFO #           Link type: wired
2023-12-19 18:41:43,193 - INFO #           inet6 addr: fe80::cafe:cafe:cafe:6  scope: link  VAL
2023-12-19 18:41:43,199 - INFO #           inet6 addr: fe80::fec2:3dff:fe22:123b  scope: link  VAL
2023-12-19 18:41:43,201 - INFO #           inet6 group: ff02::2
2023-12-19 18:41:43,204 - INFO #           inet6 group: ff02::1
2023-12-19 18:41:43,207 - INFO #           inet6 group: ff02::1:fffe:6
2023-12-19 18:41:43,210 - INFO #           inet6 group: ff02::1a
2023-12-19 18:41:43,214 - INFO #           inet6 group: ff02::1:ff22:123b
```

unplug the ethernet

```
2023-12-19 18:41:57,536 - INFO # Iface  5  HWaddr: FC:C2:3D:22:12:3B  Link: down 
2023-12-19 18:41:57,540 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2023-12-19 18:41:57,542 - INFO #           RTR_ADV  
2023-12-19 18:41:57,545 - INFO #           Source address length: 6
2023-12-19 18:41:57,547 - INFO #           Link type: wired
2023-12-19 18:41:57,550 - INFO #           inet6 group: ff02::2
2023-12-19 18:41:57,553 - INFO #           inet6 group: ff02::1
2023-12-19 18:41:57,555 - INFO #           inet6 group: ff02::1a
```

Plug it back in again

```
2023-12-19 18:42:09,728 - INFO # Iface  5  HWaddr: FC:C2:3D:22:12:3B  Link: up 
2023-12-19 18:42:09,733 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2023-12-19 18:42:09,734 - INFO #           RTR_ADV  
2023-12-19 18:42:09,737 - INFO #           Source address length: 6
2023-12-19 18:42:09,740 - INFO #           Link type: wired
2023-12-19 18:42:09,746 - INFO #           inet6 addr: fe80::fec2:3dff:fe22:123b  scope: link  VAL
2023-12-19 18:42:09,748 - INFO #           inet6 group: ff02::2
2023-12-19 18:42:09,751 - INFO #           inet6 group: ff02::1
2023-12-19 18:42:09,755 - INFO #           inet6 group: ff02::1:ff22:123b
2023-12-19 18:42:09,757 - INFO #           inet6 group: ff02::1a
```

static link-local address is gone

#### this PR

```
2023-12-19 18:38:53,706 - INFO # > ifconfig
2023-12-19 18:38:53,707 - INFO # 
2023-12-19 18:38:53,711 - INFO # Iface  5  HWaddr: FC:C2:3D:22:12:3B  Link: up 
2023-12-19 18:38:53,715 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2023-12-19 18:38:53,717 - INFO #           RTR_ADV  
2023-12-19 18:38:53,720 - INFO #           Source address length: 6
2023-12-19 18:38:53,722 - INFO #           Link type: wired
2023-12-19 18:38:53,728 - INFO #           inet6 addr: fe80::cafe:cafe:cafe:6  scope: link  VAL
2023-12-19 18:38:53,733 - INFO #           inet6 addr: fe80::fec2:3dff:fe22:123b  scope: link  VAL
2023-12-19 18:38:53,736 - INFO #           inet6 group: ff02::2
2023-12-19 18:38:53,739 - INFO #           inet6 group: ff02::1
2023-12-19 18:38:53,742 - INFO #           inet6 group: ff02::1a
2023-12-19 18:38:53,745 - INFO #           inet6 group: ff02::1:fffe:6
2023-12-19 18:38:53,748 - INFO #           inet6 group: ff02::1:ff22:123b
2023-12-19 18:38:53,749 - INFO #           
```

unplug the Ethernet

```
2023-12-19 18:38:57,774 - INFO # Iface  5  HWaddr: FC:C2:3D:22:12:3B  Link: down 
2023-12-19 18:38:57,778 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2023-12-19 18:38:57,780 - INFO #           RTR_ADV  
2023-12-19 18:38:57,783 - INFO #           Source address length: 6
2023-12-19 18:38:57,786 - INFO #           Link type: wired
2023-12-19 18:38:57,788 - INFO #           inet6 group: ff02::2
2023-12-19 18:38:57,791 - INFO #           inet6 group: ff02::1
2023-12-19 18:38:57,794 - INFO #           inet6 group: ff02::1a
2023-12-19 18:38:57,795 - INFO #           
```

plug it back in

```
2023-12-19 18:40:03,727 - INFO # Iface  5  HWaddr: FC:C2:3D:22:12:3B  Link: up 
2023-12-19 18:40:03,731 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2023-12-19 18:40:03,733 - INFO #           RTR_ADV  
2023-12-19 18:40:03,736 - INFO #           Source address length: 6
2023-12-19 18:40:03,739 - INFO #           Link type: wired
2023-12-19 18:40:03,744 - INFO #           inet6 addr: fe80::cafe:cafe:cafe:6  scope: link  VAL
2023-12-19 18:40:03,750 - INFO #           inet6 addr: fe80::fec2:3dff:fe22:123b  scope: link  VAL
2023-12-19 18:40:03,753 - INFO #           inet6 group: ff02::2
2023-12-19 18:40:03,755 - INFO #           inet6 group: ff02::1
2023-12-19 18:40:03,758 - INFO #           inet6 group: ff02::1a
2023-12-19 18:40:03,761 - INFO #           inet6 group: ff02::1:fffe:6
2023-12-19 18:40:03,765 - INFO #           inet6 group: ff02::1:ff22:123b
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
