### PR TITLE
pkg: micropython: bump version

### DIFF
--- a/pkg/micropython/Makefile
+++ b/pkg/micropython/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=micropython
 PKG_URL=https://github.com/kaspar030/micropython
-PKG_VERSION=bb8e51f6da3e3e3fc65a8b9abaea1b0ebbbe104d
+PKG_VERSION=0e9a7e5d67873125cceb0d02faaf40c80730ac33
 PKG_LICENSE=MIT
 
 CFLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-error


### PR DESCRIPTION
### Contribution description

As part of [the effort](https://github.com/RIOT-OS/RIOT/pull/20154) to make RIOT 64 bit ready various data types in RIOT and in the packages needs to be updated. This PR includes a patch by @fzi-haxel to the Micropython repository we're using to make this package 64 bit ready.

### Testing procedure

`make -C examples/micropython all term`
and run your favorite (micro)python script on RIOT.

### Issues/PRs references

Prerequisite for #20154.