### PR TITLE
sys/shell: fix getopt() support

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -112,14 +112,14 @@ void shell_post_command_hook(int ret, int argc, char **argv);
 /**
  * @brief           Protype of a shell callback handler.
  * @details         The functions supplied to shell_run() must use this signature.
- *                  The argument list is terminated with a NULL, i.e ``argv[argc] == NULL`.
- *                  ``argv[0]`` is the function name.
+ *                  The argument list is terminated with a `NULL`, i.e `argv[argc] == NULL`.
+ *                  `argv[0]` is the function name.
  *
  *                  Escape sequences are removed before the function is called.
  *
  *                  The called function may edit `argv` and the contained strings,
  *                  but it must be taken care of not to leave the boundaries of the array.
- *                  This functionality can be used by getopt() or a similar function.
+ *                  This functionality can be used by `getopt()` or a similar function.
  * @param[in]       argc   Number of arguments supplied to the function invocation.
  * @param[in]       argv   The supplied argument list.
  *

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -110,16 +110,23 @@ void shell_pre_command_hook(int argc, char **argv);
 void shell_post_command_hook(int ret, int argc, char **argv);
 
 /**
- * @brief           Protype of a shell callback handler.
+ * @brief           Prototype of a shell callback handler.
  * @details         The functions supplied to shell_run() must use this signature.
- *                  The argument list is terminated with a `NULL`, i.e `argv[argc] == NULL`.
- *                  `argv[0]` is the function name.
+ *                  It is designed to mimic the function signature of `main()`.
+ *                  For this reason, the argument list is terminated with a
+ *                  `NULL`, i.e `argv[argc] == NULL` (which is an ANSI-C
+ *                  requirement, and a detail that newlib's `getopt()`
+ *                  implementation relies on). The function name is passed in
+ *                  `argv[0]`.
  *
  *                  Escape sequences are removed before the function is called.
  *
  *                  The called function may edit `argv` and the contained strings,
  *                  but it must be taken care of not to leave the boundaries of the array.
- *                  This functionality can be used by `getopt()` or a similar function.
+ *                  This functionality is another property that many `getopt()`
+ *                  implementations rely on to provide their so-called "permute"
+ *                  feature extension.
+ *
  * @param[in]       argc   Number of arguments supplied to the function invocation.
  * @param[in]       argv   The supplied argument list.
  *

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -13,11 +13,12 @@
  * @{
  *
  * @file
- * @brief       Implementation of a very simple command interpreter.
+ * @brief       Implementation of a simple command interpreter.
  *              For each command (i.e. "echo"), a handler can be specified.
  *              If the first word of a user-entered command line matches the
- *              name of a handler, the handler will be called with the whole
- *              command line as parameter.
+ *              name of a handler, the handler will be called with the remaining
+ *              arguments passed in a manner similar to `main()`'s argc/argv
+ *              parameters.
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -305,13 +305,19 @@ static void handle_input_line(const shell_command_t *command_list, char *line)
 
     /* then we fill the argv array */
     int collected;
-    char *argv[argc];
+
+    /* allocate argv on the stack leaving space for NULL termination */
+    char *argv[argc + 1];
 
     readpos = line;
     for (collected = 0; collected < argc; collected++) {
         argv[collected] = readpos;
         readpos += strlen(readpos) + 1;
     }
+
+    /* NULL terminate argv. See `shell_command_handler_t` doc in shell.h for
+       rationale. */
+    argv[argc] = NULL;
 
     /* then we call the appropriate handler */
     shell_command_handler_t handler = find_handler(command_list, argv[0]);


### PR DESCRIPTION
### Contribution description

This patch adds the missing NULL terminator to the argv passed to shell command handlers. Without it, Newlib's getop() was intermittently causing hardfaults. Closer inspection of NewLib's code revealed that it relies in this NULL termination. ANSI-C also requires it of the argv passed to main().

Also included are some minor improvements to the documentation.

### Testing procedure

For me `getopt()` no longer causes hardfaults. Also code in shell.c now does what the doc in shell.h advertises that it does.


### Issues/PRs references

- I suspect the bug was introduced in PR #12085, but I have not confirmed
- I suspect that this originally worked when argv/argc functionality was introduced in PR #760, but have not confirmed
