### PR TITLE
riotboot: fix build errors

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -86,6 +86,7 @@ riotboot/flash-bootloader: riotboot/bootloader/flash
 riotboot/bootloader/%: $$(if $$(filter riotboot/bootloader/clean,$$@),,$$(BUILDDEPS) pkg-prepare)
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)" USER="$(USER)"\
+		INCLUDES="$(INCLUDES)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
 		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID) \
 		IOTLAB_NODE=$(IOTLAB_NODE) \

--- a/sys/include/riotboot/slot.h
+++ b/sys/include/riotboot/slot.h
@@ -116,8 +116,10 @@ void riotboot_slot_dump_addrs(void);
 static inline size_t riotboot_slot_size(unsigned slot)
 {
     switch (slot) {
+#if NUM_SLOTS >= 1
     case 0:
         return SLOT0_LEN;
+#endif
 #if NUM_SLOTS == 2
     case 1:
         return SLOT1_LEN;


### PR DESCRIPTION
### Contribution description

These patches fix some builds errors I experienced when playing with riotboot. The commit comments contain the details of each.

### Testing procedure

Include riotboot/slots.h with riotbuild not enabled and observe that without this patch, the build will fail.

Attempt to build with an externally defined board which adds to the INCLUDES make macro and riotbuild enabled. Observe that without this patch, doing so will result in headers not being found which are located in those added include folders. 

### Issues/PRs references

- none known
