### PR TITLE
tests/build_system/test_tools: use `native` terminal

### DIFF
--- a/tests/build_system/test_tools/Makefile
+++ b/tests/build_system/test_tools/Makefile
@@ -3,6 +3,10 @@ include ../Makefile.build_system_common
 
 USEMODULE += shell
 
+ifeq (native, $(BOARD))
+  RIOT_TERMINAL ?= native
+endif
+
 # No need for test_utils_interactive_sync in this test since the test
 # synchronizes by itself through `shellping` command.
 DISABLE_MODULE += test_utils_interactive_sync


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The test appears to expect the 'classic' `native` output. 


### Testing procedure

CI should work again.


### Issues/PRs references

#20172
