### PR TITLE
tests: use `native` terminal where necessary 

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -113,8 +113,12 @@ EEPROM_FILE ?= $(BINDIR)/native.eeprom
 
 # set the eeprom file flags only when the periph_eeprom feature is used.
 ifneq (,$(filter periph_eeprom,$(FEATURES_USED)))
-  EEPROM_FILE_FLAGS = --eeprom $(EEPROM_FILE)
-  TERMFLAGS += $(EEPROM_FILE_FLAGS)
+  ifeq (native,$(RIOT_TERMINAL))
+    EEPROM_FILE_FLAGS = --eeprom $(EEPROM_FILE)
+  else
+    EEPROM_FILE_FLAGS = '\-\-eeprom $(EEPROM_FILE)'
+  endif
+  TERMFLAGS += --process-args $(EEPROM_FILE_FLAGS)
 endif
 
 VCAN_IFNUM ?= 0

--- a/tests/periph/flashpage/Makefile
+++ b/tests/periph/flashpage/Makefile
@@ -10,6 +10,10 @@ USEMODULE += od
 USEMODULE += od_string
 USEMODULE += shell
 
+ifeq (native, $(BOARD))
+  RIOT_TERMINAL ?= native
+endif
+
 # avoid running Kconfig by default
 SHOULD_RUN_KCONFIG ?=
 

--- a/tests/sys/congure_abe/Makefile
+++ b/tests/sys/congure_abe/Makefile
@@ -7,6 +7,10 @@ USEMODULE += shell
 
 INCLUDES += -I$(CURDIR)
 
+ifeq (native, $(BOARD))
+  RIOT_TERMINAL ?= native
+endif
+
 include $(RIOTBASE)/Makefile.include
 
 ifndef CONFIG_SHELL_NO_ECHO

--- a/tests/sys/congure_quic/Makefile
+++ b/tests/sys/congure_quic/Makefile
@@ -7,6 +7,10 @@ USEMODULE += shell
 
 INCLUDES += -I$(CURDIR)
 
+ifeq (native, $(BOARD))
+  RIOT_TERMINAL ?= native
+endif
+
 include $(RIOTBASE)/Makefile.include
 
 ifndef CONFIG_SHELL_NO_ECHO

--- a/tests/sys/log_color/Makefile
+++ b/tests/sys/log_color/Makefile
@@ -2,6 +2,10 @@ include ../Makefile.sys_common
 
 USEMODULE += log_color
 
+ifeq (native, $(BOARD))
+  RIOT_TERMINAL ?= native
+endif
+
 # Enable debug log level
 CFLAGS += -DLOG_LEVEL=4
 

--- a/tests/sys/struct_tm_utility/Makefile
+++ b/tests/sys/struct_tm_utility/Makefile
@@ -6,4 +6,8 @@ USEMODULE += timex
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+ifeq (native, $(BOARD))
+  RIOT_TERMINAL ?= native
+endif
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For some reason those only are [detected](https://ci.riot-os.org/details/9b9947d6b7b14c7b829272316f527555) by CI when disabling Kconfig builds (#20211)


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

same as #20212
