### PR TITLE
cpu/stm32/periph_spi: only perform DMA transfer above threshold

### DIFF
--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -39,14 +39,6 @@
 #include "debug.h"
 
 /**
- * @brief   Threshold under which polling transfers are used instead of DMA
- *          TODO: determine at run-time based on SPI clock
- */
-#ifndef CONFIG_SPI_DMA_THRESHOLD_BYTES
-#define CONFIG_SPI_DMA_THRESHOLD_BYTES  16
-#endif
-
-/**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
 static mutex_t locks[SPI_NUMOF];

--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -390,7 +390,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     }
 
 #ifdef MODULE_PERIPH_DMA
-    if (_use_dma(&spi_config[bus])) {
+    if (_use_dma(&spi_config[bus]) && len > CONFIG_SPI_DMA_THRESHOLD_BYTES) {
         _transfer_dma(bus, out, in, len);
     }
     else {

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -81,6 +81,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Threshold under which polling transfers are used instead of DMA
+ *          TODO: determine at run-time based on SPI clock
+ */
+#ifndef CONFIG_SPI_DMA_THRESHOLD_BYTES
+#define CONFIG_SPI_DMA_THRESHOLD_BYTES  16
+#endif
+
+/**
  * @brief   Default SPI device access macro
  */
 #ifndef SPI_DEV


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Same as for sam0, only perform DMA transfer if there are more than `CONFIG_SPI_DMA_THRESHOLD_BYTES` to transfer to avoid a net slowdown for single byte transfers due to DMA setup overhead.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
