### PR TITLE
makefiles/tests/tests.inc.mk: use native term for tests

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -114,7 +114,11 @@ EEPROM_FILE ?= $(BINDIR)/native.eeprom
 # set the eeprom file flags only when the periph_eeprom feature is used.
 ifneq (,$(filter periph_eeprom,$(FEATURES_USED)))
   EEPROM_FILE_FLAGS = --eeprom $(EEPROM_FILE)
-  TERMFLAGS += $(EEPROM_FILE_FLAGS)
+  ifeq (native,$(RIOT_TERMINAL))
+    TERMFLAGS += $(EEPROM_FILE_FLAGS)
+  else
+    TERMFLAGS += --process-args '$(EEPROM_FILE_FLAGS)'
+  endif
 endif
 
 VCAN_IFNUM ?= 0

--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -22,6 +22,10 @@ TEST_DEPS += $(TERMDEPS)
 TEST_EXECUTOR ?=
 TEST_EXECUTOR_FLAGS ?=
 
+ifeq (native, $(BOARD))
+  TEST_EXECUTOR := RIOT_TERMINAL=native $(TEST_EXECUTOR)
+endif
+
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$(TEST_EXECUTOR) $(TEST_EXECUTOR_FLAGS) $$t || exit 1; \

--- a/tests/build_system/test_tools/Makefile
+++ b/tests/build_system/test_tools/Makefile
@@ -3,10 +3,6 @@ include ../Makefile.build_system_common
 
 USEMODULE += shell
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
-
 # No need for test_utils_interactive_sync in this test since the test
 # synchronizes by itself through `shellping` command.
 DISABLE_MODULE += test_utils_interactive_sync

--- a/tests/periph/rtt_min/Makefile
+++ b/tests/periph/rtt_min/Makefile
@@ -6,9 +6,6 @@ USEMODULE += xtimer
 FEATURES_REQUIRED += periph_rtt
 DISABLE_MODULE += periph_init_rtt
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
 RIOT_TERMINAL ?= socat
 
 # microbit qemu lacks rtt

--- a/tests/rust_libs/Makefile
+++ b/tests/rust_libs/Makefile
@@ -5,10 +5,6 @@ USEMODULE += shell_democommands
 
 FEATURES_REQUIRED += rust_target
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
-
 # Testing on stable to ensure that no nightly features are needed when Rust is
 # pulled in through modules.
 CARGO_CHANNEL = stable

--- a/tests/sys/congure_reno/Makefile
+++ b/tests/sys/congure_reno/Makefile
@@ -7,9 +7,6 @@ USEMODULE += shell_cmds_default
 
 INCLUDES += -I$(CURDIR)
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 

--- a/tests/sys/congure_test/Makefile
+++ b/tests/sys/congure_test/Makefile
@@ -7,9 +7,6 @@ USEMODULE += shell_cmds_default
 
 INCLUDES += -I$(CURDIR)
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 

--- a/tests/sys/shell/Makefile
+++ b/tests/sys/shell/Makefile
@@ -5,9 +5,6 @@ USEMODULE += app_metadata
 USEMODULE += shell_cmds_default
 USEMODULE += ps
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 

--- a/tests/sys/shell_ble/Makefile
+++ b/tests/sys/shell_ble/Makefile
@@ -14,9 +14,6 @@ TESTRUNNER_SHELL_SKIP_REBOOT = 1
 TESTRUNNER_RESET_BOARD_ON_STARTUP = 0
 
 ifneq (,$(filter term,$(MAKECMDGOALS)))
-  ifeq (native, $(BOARD))
-    RIOT_TERMINAL ?= native
-  endif
   # Use a terminal that does not introduce extra characters into the stream.
   RIOT_TERMINAL ?= socat
 else ifneq (,$(filter test,$(MAKECMDGOALS)))

--- a/tests/sys/shell_lock/Makefile
+++ b/tests/sys/shell_lock/Makefile
@@ -19,8 +19,6 @@ DISABLE_MODULE += test_utils_interactive_sync_shell
 # for z1, socat doesn't work (unknown reason)
 ifeq (z1, $(BOARD))
   RIOT_TERMINAL ?= pyterm
-else ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
 endif
 
 # Use a terminal that does not introduce extra characters into the stream.

--- a/tests/turo/Makefile
+++ b/tests/turo/Makefile
@@ -3,10 +3,6 @@ include ../Makefile.tests_common
 USEMODULE += test_utils_result_output
 USEMODULE += shell
 
-ifeq (native, $(BOARD))
-  RIOT_TERMINAL ?= native
-endif
-
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Always use the `native` terminal for the automatic tests when using the `native` board.


### Testing procedure

The affected tests should still succeed on `native`.

<details><summary>tests/sys/log_color on native</summary>

```
% make test
r
/home/benpicco/dev/RIOT/tests/sys/log_color/bin/native/tests_log_color.elf tap0 
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2024.01-devel-461-g5898c)
Logging value '42' and string 'test'
Logging value '42' and string 'test'
Logging value '42' and string 'test'
Logging value '42' and string 'test'
{ "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 436 }]}
{ "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2328 }]}
```
</details>

non-`native` tests should still work.

<details><summary>tests/sys/log_color on samr21-xpro</summary>

```
% make BOARD=samr21-xpro flash test
Building application "tests_log_color" for "samr21-xpro" with MCU "samd21".

"make" -C /home/benpicco/dev/RIOT/pkg/cmsis/ 
"make" -C /home/benpicco/dev/RIOT/boards/common/init
"make" -C /home/benpicco/dev/RIOT/boards/samr21-xpro
"make" -C /home/benpicco/dev/RIOT/core
"make" -C /home/benpicco/dev/RIOT/core/lib
"make" -C /home/benpicco/dev/RIOT/cpu/samd21
"make" -C /home/benpicco/dev/RIOT/cpu/cortexm_common
"make" -C /home/benpicco/dev/RIOT/cpu/cortexm_common/periph
"make" -C /home/benpicco/dev/RIOT/cpu/sam0_common
"make" -C /home/benpicco/dev/RIOT/cpu/sam0_common/periph
"make" -C /home/benpicco/dev/RIOT/cpu/samd21/periph
"make" -C /home/benpicco/dev/RIOT/cpu/samd21/vectors
"make" -C /home/benpicco/dev/RIOT/drivers
"make" -C /home/benpicco/dev/RIOT/drivers/periph_common
"make" -C /home/benpicco/dev/RIOT/sys
"make" -C /home/benpicco/dev/RIOT/sys/auto_init
"make" -C /home/benpicco/dev/RIOT/sys/div
"make" -C /home/benpicco/dev/RIOT/sys/isrpipe
"make" -C /home/benpicco/dev/RIOT/sys/libc
"make" -C /home/benpicco/dev/RIOT/sys/log_color
"make" -C /home/benpicco/dev/RIOT/sys/malloc_thread_safe
"make" -C /home/benpicco/dev/RIOT/sys/newlib_syscalls_default
"make" -C /home/benpicco/dev/RIOT/sys/pm_layered
"make" -C /home/benpicco/dev/RIOT/sys/preprocessor
"make" -C /home/benpicco/dev/RIOT/sys/stdio_uart
"make" -C /home/benpicco/dev/RIOT/sys/test_utils/interactive_sync
"make" -C /home/benpicco/dev/RIOT/sys/test_utils/print_stack_usage
"make" -C /home/benpicco/dev/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  13776	    132	   2356	  16264	   3f88	/home/benpicco/dev/RIOT/tests/sys/log_color/bin/samr21-xpro/tests_log_color.elf
/home/benpicco/dev/RIOT/dist/tools/edbg/edbg.sh flash /home/benpicco/dev/RIOT/tests/sys/log_color/bin/samr21-xpro/tests_log_color.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800010523 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification..... done.
Done flashing
r
/home/benpicco/dev/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2024.01-devel-464-ga7cd27-tests/native-term)
Logging value '42' and string 'test'
Logging value '42' and string 'test'
Logging value '42' and string 'test'
Logging value '42' and string 'test'

```
</details>

### Issues/PRs references

alternative to #20213
