### PR TITLE
examples/dtls-sock: fix error handling in client

### DIFF
--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -155,6 +155,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
         printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
+        sock_udp_close(&udp_sock);
         return -1;
     }
 
@@ -171,12 +172,14 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     if (res < 0 && res != CREDMAN_EXIST) {
         /* ignore duplicate credentials */
         printf("Error cannot add credential to system: %" PRIdSIZE "\n", res);
+        sock_udp_close(&udp_sock);
         return -1;
     }
 
     /* make the new credential available to the sock */
     if (sock_dtls_add_credential(&dtls_sock, SOCK_DTLS_CLIENT_TAG_1) < 0) {
         printf("Error cannot add credential to the sock: %" PRIdSIZE "\n", res);
+        sock_udp_close(&udp_sock);
         return -1;
     }
 
@@ -186,6 +189,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
 
     res = sock_dtls_session_init(&dtls_sock, &remote, &session);
     if (res <= 0) {
+        sock_udp_close(&udp_sock);
         return res;
     }
 


### PR DESCRIPTION
### Contribution description

This PR adds `sock_udp_close()` in the error paths, as otherwise the stack allocated sock structure gets out of scope while still being registered to the network stack. This fixes a crash when running both server and client on the same device, which triggers `credman_add()` to fail due to insufficient space.

### Testing procedure

Run the example app and start both server and client. On AVR I was able to trigger a blowing assertion on the second try to use the client.

### Issues/PRs references

Found while testing https://github.com/RIOT-OS/RIOT/pull/20196