### PR TITLE
examples/dtls-sock: fix credman capacity

### DIFF
--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -61,3 +61,8 @@ ifeq (,$(filter arch_avr8,$(FEATURES_USED)))
 else
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_LARGE\)
 endif
+
+# We have two credentials for client and server, each. If we are to run both
+# server and client, we need four slots in total. The default (2) would be
+# sufficient if only client or server is ever run.
+CFLAGS += -DCONFIG_CREDMAN_MAX_CREDENTIALS=4


### PR DESCRIPTION
### Contribution description

It should be possible to test DTLS via `::1`, but this requires 4 slots in the credman instead of just two.

### Testing procedure

Running both server and client on the same app should now succeed; or at least no longer fail when adding the credentials.

### Issues/PRs references

Found while testing https://github.com/RIOT-OS/RIOT/pull/20196