### PR TITLE
treewise: typo "or RAM"

### DIFF
--- a/boards/nucleo-f439zi/doc.txt
+++ b/boards/nucleo-f439zi/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-F439ZI is a board from ST's Nucleo family supporting ARM Cortex-M4
-STM32F439ZI microcontroller with, 256KiB or RAM and 2MiB of Flash.
+STM32F439ZI microcontroller with, 256KiB of RAM and 2MiB of Flash.
 
 ## Flashing the device
 

--- a/boards/nucleo-l031k6/doc.txt
+++ b/boards/nucleo-l031k6/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
-STM32L031K6T6 microcontroller with 8KiB or RAM and 32KiB of Flash.
+STM32L031K6T6 microcontroller with 8KiB of RAM and 32KiB of Flash.
 
 
 ## Flashing the Board Using ST-LINK Removable Media

--- a/boards/nucleo-l073rz/doc.txt
+++ b/boards/nucleo-l073rz/doc.txt
@@ -7,7 +7,7 @@
 ## Overview
 
 The Nucleo-L073RZ is a board from ST's Nucleo family supporting ARM Cortex-M0
-STM32L073RZT6 microcontroller with 20KiB or RAM and 192KiB of Flash.
+STM32L073RZT6 microcontroller with 20KiB of RAM and 192KiB of Flash.
 
 ## Pinout
 

--- a/boards/nucleo-l432kc/doc.txt
+++ b/boards/nucleo-l432kc/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L432KC is a board from ST's Nucleo family supporting ARM Cortex-M4
-STM32L432KCU6 microcontroller with 64KiB or RAM and 256KiB of Flash.
+STM32L432KCU6 microcontroller with 64KiB of RAM and 256KiB of Flash.
 
 
 ## Flashing the Board Using ST-LINK Removable Media

--- a/boards/nucleo-l476rg/doc.txt
+++ b/boards/nucleo-l476rg/doc.txt
@@ -7,7 +7,7 @@
 ## Overview
 
 The Nucleo-L476RG is a board from ST's Nucleo family supporting ARM Cortex-M4
-STM32L476RG microcontroller with 128KiB or RAM and 1MiB of Flash.
+STM32L476RG microcontroller with 128KiB of RAM and 1MiB of Flash.
 
 ## Pinout
 

--- a/boards/nucleo-l552ze-q/doc.txt
+++ b/boards/nucleo-l552ze-q/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L552ZE-Q is a board from ST's Nucleo family supporting ARM Cortex-M33
-STM32L552ZE ultra-low-pawer microcontroller with TrustZone, 256KiB or RAM and 512KiB
+STM32L552ZE ultra-low-pawer microcontroller with TrustZone, 256KiB of RAM and 512KiB
 of Flash.
 
 ## Hardware

--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -316,7 +316,7 @@ void isr_exti(void)
         /* emulate level triggered IRQs by asserting the IRQ again in software, if needed */
         if (level_triggered & (1UL << pin)) {
             /* Trading a couple of CPU cycles to not having to store port connected to EXTI in RAM.
-             * A simple look up table would save ~6 instructions for the cost 64 byte or RAM. */
+             * A simple look up table would save ~6 instructions for the cost 64 bytes of RAM. */
             gpio_port_t port = GPIO_PORT(get_exti_port(pin));
             uint32_t actual_level = gpio_ll_read(port) & (1UL << pin);
             uint32_t trigger_level = EXTI_REG_RTSR & (1UL << pin);


### PR DESCRIPTION
### Contribution description

In PR #20207 @mguetschow point out typo "or RAM" instead of "of RAM"  ... this typo appears in some
nucleo boards doc as well one other comment.

This PR fixes this typo.

_**Happy New Year for all RIOT OS users and developers!**_

### Testing procedure

```make doc``` and see if all pages are generated properly.

### Issues/PRs references
None