### PR TITLE
sys/benchmark: fix integer overflow in benchmark_print_time()

### DIFF
--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -26,7 +26,7 @@
 void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
 {
     uint32_t full = (time / runs);
-    uint32_t div  = (time - (full * runs)) * 1000 / runs;
+    uint32_t div  = (uint32_t)(((uint64_t)(time - (full * runs))) * 1000 / runs);
 
     uint32_t per_sec = (uint32_t)(((uint64_t)US_PER_SEC * runs) / time);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR fixes an integer overflow, that causes incorrect results to be reported when running a benchmark that takes longer than 4.2s.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run a benchmark that takes longer than 4.2s with less than 1us per function call.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
