### PR TITLE
gnrc/ipv6/nib: allow for predictable static link-local addresses

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -54,7 +54,7 @@ endif
 # this might be useful for testing, in cases where you cannot or do not want to
 # run a shell with ifconfig to get the real link lokal address.
 #IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
-#CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
+#CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
 
 # Uncomment this to join RPL DODAGs even if DIOs do not contain
 # DODAG Configuration Options (see the doc for more info)

--- a/examples/gnrc_networking_mac/Makefile
+++ b/examples/gnrc_networking_mac/Makefile
@@ -49,7 +49,7 @@ DEVELHELP ?= 1
 # this might be useful for testing, in cases where you cannot or do not want to
 # run a shell with ifconfig to get the real link lokal address.
 #IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
-#CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
+#CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
 
 # Uncomment this to join RPL DODAGs even if DIOs do not contain
 # DODAG Configuration Options (see the doc for more info)

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -164,18 +164,18 @@ extern "C" {
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
  * IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
- * CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(STATIC_IPV6_LLADDR)
+ * CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_LLADDR=$(STATIC_IPV6_LLADDR)
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-#define GNRC_IPV6_STATIC_LLADDR
+#define CONFIG_GNRC_IPV6_STATIC_LLADDR
 #endif /* DOXYGEN */
 /** @} */
 
 /**
  * @brief   Use the same static IPv6 link local address on every network interface
  *
- * When GNRC_IPV6_STATIC_LLADDR is used, to not add the interface pid to the set
- * static address but use the same static link local address for all interfaces.
+ * When CONFIG_GNRC_IPV6_STATIC_LLADDR is used, to not add the interface pid to the
+ * set static address but use the same static link local address for all interfaces.
  */
 #ifndef CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED
 #define CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED 0

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -157,7 +157,8 @@ extern "C" {
  * This macro allows to specify a certain link local IPv6 address to be assigned
  * to a network interface on startup, which might be handy for testing.
  * Note: a) a interface will keep its auto-generated link local address, too
- *       b) the address is incremented by 1, if multiple interfaces are present
+ *       b) the address is incremented by the interface PID unless
+            `CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED` is set.
  *
  * To use the macro just add it to `CFLAGS` in the application's Makefile, like:
  *
@@ -169,6 +170,16 @@ extern "C" {
 #define GNRC_IPV6_STATIC_LLADDR
 #endif /* DOXYGEN */
 /** @} */
+
+/**
+ * @brief   Use the same static IPv6 link local address on every network interface
+ *
+ * When GNRC_IPV6_STATIC_LLADDR is used, to not add the interface pid to the set
+ * static address but use the same static link local address for all interfaces.
+ */
+#ifndef CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED
+#define CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED 0
+#endif
 
 /**
  * @brief Message queue size to use for the IPv6 thread.

--- a/sys/net/gnrc/network_layer/ipv6/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/Kconfig
@@ -22,6 +22,29 @@ config GNRC_IPV6_MSG_QUEUE_SIZE_EXP
         represents the exponent of 2^n, which will be used as the size of
         the queue.
 
+config GNRC_IPV6_STATIC_LLADDR_ENABLE
+    bool "Add a static IPv6 link local address to any network interface"
+    help
+         This allows to specify a certain link local IPv6 address to be assigned
+         to a network interface on startup, which might be handy for testing.
+
+         A interface will keep its auto-generated link local address, too.
+
+config GNRC_IPV6_STATIC_LLADDR
+    string "Static link-local address"
+    depends on GNRC_IPV6_STATIC_LLADDR_ENABLE
+    default "fe80::cafe:cafe:cafe:1"
+    help
+         The address is configured on each interface and incremented by the
+         interface PID.
+
+config GNRC_IPV6_STATIC_LLADDR_IS_FIXED
+    bool "Same link-local address on every interface"
+    depends on GNRC_IPV6_STATIC_LLADDR_ENABLE
+    help
+         Don't add the interface PID to the least significant byte
+         of the address.
+
 endif # KCONFIG_USEMODULE_GNRC_IPV6
 
 rsource "blacklist/Kconfig"

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -115,12 +115,12 @@ void gnrc_ipv6_nib_init(void)
 
 static void _add_static_lladdr(gnrc_netif_t *netif)
 {
-#ifdef GNRC_IPV6_STATIC_LLADDR
+#ifdef CONFIG_GNRC_IPV6_STATIC_LLADDR
     /* parse addr from string and explicitly set a link local prefix
      * if ifnum > 1 each interface will get its own link local address
-     * with GNRC_IPV6_STATIC_LLADDR + i
+     * with CONFIG_GNRC_IPV6_STATIC_LLADDR + i
      */
-    char lladdr_str[] = GNRC_IPV6_STATIC_LLADDR;
+    const char lladdr_str[] = CONFIG_GNRC_IPV6_STATIC_LLADDR;
     ipv6_addr_t lladdr;
 
     if (ipv6_addr_from_str(&lladdr, lladdr_str) != NULL) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -124,7 +124,9 @@ static void _add_static_lladdr(gnrc_netif_t *netif)
     ipv6_addr_t lladdr;
 
     if (ipv6_addr_from_str(&lladdr, lladdr_str) != NULL) {
-        lladdr.u8[15] += netif->pid;
+        if (!IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED)) {
+            lladdr.u8[15] += netif->pid;
+        }
         assert(ipv6_addr_is_link_local(&lladdr));
         gnrc_netif_ipv6_addr_add_internal(
                 netif, &lladdr, 64U, GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With `GNRC_IPV6_STATIC_LLADDR` we can set static link-local addresses.
They are however not predictable: the interface ID gets added to least significant byte of the address. Add another option `CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED` to avoid that.


### Testing procedure

#### with CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED=0

```
2024-01-03 13:56:03,778 # Iface  7  HWaddr: 42:72  Channel: 26  NID: 0x23  PHY: O-QPSK 
2024-01-03 13:56:03,778 #           Long HWaddr: EE:9A:35:CC:EB:C8:42:72 
2024-01-03 13:56:03,779 #            State: IDLE 
2024-01-03 13:56:03,779 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2024-01-03 13:56:03,779 #           RTR_ADV  6LO  IPHC  
2024-01-03 13:56:03,779 #           Source address length: 8
2024-01-03 13:56:03,780 #           Link type: wireless
2024-01-03 13:56:03,780 #           inet6 addr: fe80::cafe:cafe:cafe:8  scope: link  VAL
2024-01-03 13:56:03,780 #           inet6 addr: fe80::ec9a:35cc:ebc8:4272  scope: link  VAL
2024-01-03 13:56:03,780 #           inet6 group: ff02::2
2024-01-03 13:56:03,780 #           inet6 group: ff02::1
2024-01-03 13:56:03,781 #           inet6 group: ff02::1:fffe:8
2024-01-03 13:56:03,781 #           inet6 group: ff02::1:ffc8:4272
2024-01-03 13:56:03,781 #           inet6 group: ff02::1a
```

#### with CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED=1

```
2024-01-03 13:56:45,673 # Iface  7  HWaddr: 16:BE  Channel: 26  NID: 0x23  PHY: O-QPSK 
2024-01-03 13:56:45,673 #           Long HWaddr: AE:8A:E9:6C:B7:14:16:BE 
2024-01-03 13:56:45,674 #            State: IDLE 
2024-01-03 13:56:45,674 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2024-01-03 13:56:45,675 #           RTR_ADV  6LO  IPHC  
2024-01-03 13:56:45,675 #           Source address length: 8
2024-01-03 13:56:45,675 #           Link type: wireless
2024-01-03 13:56:45,676 #           inet6 addr: fe80::cafe:cafe:cafe:1  scope: link  VAL
2024-01-03 13:56:45,677 #           inet6 addr: fe80::ac8a:e96c:b714:16be  scope: link  VAL
2024-01-03 13:56:45,677 #           inet6 group: ff02::2
2024-01-03 13:56:45,678 #           inet6 group: ff02::1
2024-01-03 13:56:45,678 #           inet6 group: ff02::1:fffe:1
2024-01-03 13:56:45,678 #           inet6 group: ff02::1:ff14:16be
2024-01-03 13:56:45,678 #           inet6 group: ff02::1a
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
