### PR TITLE
cpu/cc2538: fix EUI provider

### DIFF
--- a/cpu/cc2538/include/cc2538_eui_primary.h
+++ b/cpu/cc2538/include/cc2538_eui_primary.h
@@ -31,15 +31,13 @@ extern "C" {
 /**
  * @brief   Get the primary (burned-in) EUI-64 of the device
  *
- * @param arg       unused
- * @param[out] addr The EUI-64
  * @param index     unused
+ * @param[out] addr The EUI-64
  *
  * @return  0
  */
-static inline int cc2538_get_eui64_primary(const void *arg, eui64_t *addr, uint8_t index)
+static inline int cc2538_get_eui64_primary(uint8_t index, eui64_t *addr)
 {
-    (void)arg;
     (void)index;
 
     /*

--- a/sys/net/link_layer/eui_provider/include/eui64_provider_params.h
+++ b/sys/net/link_layer/eui_provider/include/eui64_provider_params.h
@@ -20,6 +20,7 @@
 #if __has_include("eui_provider_params.h")
 #include "eui_provider_params.h"
 #endif
+#include "board.h"
 #include "net/eui_provider.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `cc2538_get_eui64_primary` function was not used because `cc2538_eui_primary.h` gets included by `board.h` but `board.h` is not included by `eui64_provider_params.h`.


### Testing procedure

```
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:18:F1:D6:5E
    Erase before write done                 
Writing 524288 bytes starting at address 0x00200000
Write 16 bytes at 0x0027FFF0F8
    Write done                              
/home/benpicco/dev/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB1" -b "115200"  
2024-01-04 13:15:16,895 # Connect to serial port /dev/ttyUSB1
Welcome to pyterm!
Type '/exit' to exit.
ifconfig
2024-01-04 13:15:29,967 # > ifconfig
2024-01-04 13:15:29,983 # Iface  6  HWaddr: 56:5E  Channel: 26  NID: 0x23  PHY: O-QPSK 
2024-01-04 13:15:29,983 #           Long HWaddr: 00:12:4B:00:18:F1:D6:5E 
2024-01-04 13:15:29,984 #            State: IDLE 
2024-01-04 13:15:29,984 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2024-01-04 13:15:29,999 #           RTR_ADV  6LO  IPHC  
2024-01-04 13:15:29,999 #           Source address length: 8
2024-01-04 13:15:30,000 #           Link type: wireless
2024-01-04 13:15:30,000 #           inet6 addr: fe80::212:4b00:18f1:d65e  scope: link  VAL
2024-01-04 13:15:30,014 #           inet6 group: ff02::2
2024-01-04 13:15:30,015 #           inet6 group: ff02::1
2024-01-04 13:15:30,015 #           inet6 group: ff02::1:fff1:d65e
2024-01-04 13:15:30,016 #           inet6 group: ff02::1a
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
