### PR TITLE
cpu/stm32: uart: don't do DMA for small transfers

### DIFF
--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -390,10 +390,8 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     }
 #endif
 #ifdef MODULE_PERIPH_DMA
-    if (!len) {
-        return;
-    }
-    if (uart_config[uart].dma != DMA_STREAM_UNDEF) {
+    if (len > CONFIG_UART_DMA_THRESHOLD_BYTES &&
+        uart_config[uart].dma != DMA_STREAM_UNDEF) {
         if (irq_is_in()) {
             uint16_t todo = 0;
             if (dev(uart)->CR3 & USART_CR3_DMAT) {

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -71,6 +71,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Threshold under which polling transfers are used instead of DMA
+ *          TODO: determine at run-time based on baudrate
+ */
+#ifndef CONFIG_UART_DMA_THRESHOLD_BYTES
+#define CONFIG_UART_DMA_THRESHOLD_BYTES 8
+#endif
+
+/**
  * @brief   Define default UART type identifier
  */
 #ifndef HAVE_UART_T


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For small transfers, setting up the DMA will take much longer than sending the bytes, so avoid doing DMA there to avoid a slowdown with DMA enabled. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
