### PR TITLE
drivers/mtd: fix mtd_write_sector

### DIFF
--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -395,7 +395,8 @@ int mtd_write_sector(mtd_dev_t *mtd, const void *data, uint32_t sector,
     }
 
     uint32_t page = sector * mtd->pages_per_sector;
-    return mtd_write_page_raw(mtd, data, page, 0, page * mtd->page_size);
+    return mtd_write_page_raw(mtd, data, page, 0,
+                              count * mtd->pages_per_sector * mtd->page_size);
 }
 
 int mtd_power(mtd_dev_t *mtd, enum mtd_power_state power)


### PR DESCRIPTION
### Contribution description

This PR fixes `mtd_write_sector` function introduced with PR #20180.

`mtd_write_page_raw` requires the number of bytes to be written as parameter, which is the number of sectors to be written (parameter `count`) multiplied by the pages per sector `mtd->pages_per_sector` and the page size `mtd->page_size`.

### Testing procedure

Use any board with SPI SD Card interface and set `ENABLE_DEBUG` in `drivers/mtd_sdcard.c`. Without the PR, writing to the SD card fails because of the wrong size. Formatting the SD card doesn't hangs.
```
> vfs w /sd0/test1.txt ascii o hello
mtd_sdcard_read_page: page:1991 offset:0 size:512
mtd_sdcard_write_page: page:1991 offset:0 size:1019392
mtd_sdcard_write_page: error 4
Write error: -EIO
mtd_sdcard_write_page: page:1991 offset:0 size:1019392
mtd_sdcard_write_page: error 3
```
With the PR writing to the SD card and formatting it works as expected.
```
> vfs w /sd0/test1.txt ascii o hello
mtd_sdcard_read_page: page:1991 offset:0 size:512
mtd_sdcard_read_page: page:95 offset:0 size:512
mtd_sdcard_write_page: page:95 offset:0 size:512
mtd_sdcard_write_page: page:2055 offset:0 size:512
mtd_sdcard_read_page: page:1991 offset:0 size:512
mtd_sdcard_write_page: page:1991 offset:0 size:512
mtd_sdcard_write_page: page:64 offset:0 size:512
```

### Issues/PRs references

Fixes PR #20180 