### PR TITLE
sys/suit: introduce suit_worker_done_cb()

### DIFF
--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -82,6 +82,15 @@ void suit_worker_trigger_prepared(const uint8_t *manifest, size_t size);
 int suit_worker_try_prepare(uint8_t **buffer, size_t *size);
 
 /**
+ * @brief   Callback that is executed after the SUIT process has finished
+ *
+ * @param[in] res   Result of the SUIT update, 0 on success
+ *
+ * By default this will reboot the board, can be overwritten by the application.
+ */
+void suit_worker_done_cb(int res);
+
+/**
  * @brief   Trigger a SUIT update
  *
  * @note Make sure the thread calling this function has enough stack space to fit


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This makes the SUIT worker a bit more flexible: Currently the board will always reboot after the update process, there is no way for the application to tell whether the update was successful.

This patch moves the 'reboot after update' policy to a `suit_worker_done_cb()` function that can be overwritten by custom application logic. 

### Testing procedure

No change in default behavior. 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
