### PR TITLE
cpu/avr8_common: fix build with !core_thread

### DIFF
--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -106,8 +106,11 @@ void kernel_init(void)
                       main_trampoline, NULL, "main");
     }
     else {
+        /* RIOT without threads */
         irq_enable();
         main_trampoline(NULL);
+        while (1) {}
+        return;
     }
 
     cpu_switch_context_exit();

--- a/cpu/avr8_common/thread_arch.c
+++ b/cpu/avr8_common/thread_arch.c
@@ -260,6 +260,10 @@ void NORETURN avr8_enter_thread_mode(void)
 
 void thread_yield_higher(void)
 {
+    if (!IS_USED(MODULE_CORE_THREAD)) {
+        return;
+    }
+
     if (irq_is_in() == 0) {
         avr8_context_save();
         sched_run();
@@ -278,7 +282,8 @@ void avr8_exit_isr(void)
     __asm__ volatile ("" : : : "memory");
 
     /* schedule should switch context when returning from a non nested interrupt */
-    if (sched_context_switch_request && avr8_state_irq_count == 0) {
+    if (sched_context_switch_request && avr8_state_irq_count == 0 &&
+        IS_USED(MODULE_CORE_THREAD)) {
         avr8_context_save();
         sched_run();
         avr8_context_restore();

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -156,7 +156,8 @@ void isr_cpu_switch_context_exit(void)
     ucontext_t *ctx;
 
     DEBUG("isr_cpu_switch_context_exit\n");
-    if ((sched_context_switch_request == 1) || (thread_get_active() == NULL)) {
+    if (((sched_context_switch_request == 1) || (thread_get_active() == NULL))
+        && IS_USED(MODULE_CORE_THREAD)) {
         sched_run();
     }
 
@@ -210,7 +211,11 @@ void isr_thread_yield(void)
         native_irq_handler();
     }
 
+    if (!IS_USED(MODULE_CORE_THREAD)) {
+        return;
+    }
     sched_run();
+
     /* Use intermediate cast to uintptr_t to silence -Wcast-align.
      * stacks are manually word aligned in thread_static_init() */
     ucontext_t *ctx = (ucontext_t *)(uintptr_t)(thread_get_active()->sp);

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -83,7 +83,9 @@ USEMODULE += $(filter cortexm_svc, $(FEATURES_USED))
 
 # select core_idle_thread if the feature no_idle_thread is *not* used
 ifeq (, $(filter no_idle_thread, $(FEATURES_USED)))
-  USEMODULE += core_idle_thread
+  ifneq (,$(filter core_thread, $(USEMODULE)))
+    USEMODULE += core_idle_thread
+  endif
 endif
 
 # use mpu_stack_guard if the feature is used


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When we don't enable thread mode, all schedule functions should be no-ops.

We also don't want to pull in `core_idle_thread` here. 


### Testing procedure

Run a simple application that does not make use of threads with

    DISABLE_MODULE += core_thread


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
