### PR TITLE
sys/busy_wait: add busy wait helper

### DIFF
--- a/cpu/avr8_common/include/cpu.h
+++ b/cpu/avr8_common/include/cpu.h
@@ -58,6 +58,11 @@ extern "C"
 /** @} */
 
 /**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (7)
+
+/**
  * @name    Use shared I2C functions
  * @{
  */

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -170,6 +170,14 @@ extern "C" {
  */
 #define IRQ_API_INLINED     (1)
 
+#if defined(CPU_CORE_CORTEX_M0) || defined(CPU_CORE_CORTEX_M0PLUS) \
+ || defined(CPU_CORE_CORTEX_M23)
+/**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (4)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/include/periph_cpu_esp32.h
+++ b/cpu/esp32/include/periph_cpu_esp32.h
@@ -29,6 +29,11 @@ extern "C" {
 #define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 
 /**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (6)
+
+/**
  * @name   Predefined GPIO names
  * @{
  */

--- a/cpu/esp32/include/periph_cpu_esp32c3.h
+++ b/cpu/esp32/include/periph_cpu_esp32c3.h
@@ -29,6 +29,11 @@ extern "C" {
 #define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ)
 
 /**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (4)
+
+/**
  * @name   Predefined GPIO names
  * @{
  */

--- a/cpu/esp32/include/periph_cpu_esp32s2.h
+++ b/cpu/esp32/include/periph_cpu_esp32s2.h
@@ -29,6 +29,11 @@ extern "C" {
 #define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32S2_DEFAULT_CPU_FREQ_MHZ)
 
 /**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (6)
+
+/**
  * @name   Predefined GPIO names
  * @{
  */

--- a/cpu/esp32/include/periph_cpu_esp32s3.h
+++ b/cpu/esp32/include/periph_cpu_esp32s3.h
@@ -19,12 +19,17 @@
 #ifndef PERIPH_CPU_ESP32S3_H
 #define PERIPH_CPU_ESP32S3_H
 
-/** Mapping configured ESP32-S3 default clock to CLOCK_CORECLOCK define */
-#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Mapping configured ESP32-S3 default clock to CLOCK_CORECLOCK define */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32S3_DEFAULT_CPU_FREQ_MHZ)
+
+/**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (5)
 
 /**
  * @name   Predefined GPIO names

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -35,6 +35,11 @@ extern "C" {
 #define CPUID_LEN           (4U)
 
 /**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (5)
+
+/**
  * @name   GPIO configuration
  * @{
  */

--- a/cpu/msp430/clock.c
+++ b/cpu/msp430/clock.c
@@ -25,6 +25,7 @@
 #include <stdint.h>
 
 #include "debug.h"
+#include "busy_wait.h"
 #include "macros/math.h"
 #include "macros/units.h"
 #include "periph_conf.h"
@@ -96,22 +97,6 @@ static void check_config(void)
             && (clock_params.target_dco_frequency == 0)) {
         extern void dco_configured_as_clock_source_but_is_disabled(void);
         dco_configured_as_clock_source_but_is_disabled();
-    }
-}
-
-static void busy_wait(uint16_t loops)
-{
-    while (loops) {
-        /* This empty inline assembly should be enough to convince the
-         * compiler that the loop cannot be optimized out. Tested with
-         * GCC 12.2 and clang 16.0.0 successfully. */
-        __asm__ __volatile__ (
-            ""
-            : /* no outputs */
-            : /* no inputs */
-            : /* no clobbers */
-        );
-        loops--;
     }
 }
 

--- a/sys/include/busy_wait.h
+++ b/sys/include/busy_wait.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    busy_wait   Busy Waiting low-level helpers
+ * @ingroup     sys
+ *
+ * @brief       This modules provides helper functions for busy waiting
+ *              on short intervals before timers are initialized, e.g.
+ *              in `board_init()`.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @{
+ */
+
+#ifndef BUSY_WAIT_H
+#define BUSY_WAIT_H
+
+#include <stdint.h>
+#include "periph_conf.h"
+#include "time_units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   CPU cycles per busy wait loop iteration
+ *
+ * This can be used to roughly estimate the number of cycles
+ * for a given wait time.
+ */
+#ifndef CPU_CYCLES_PER_LOOP
+#define CPU_CYCLES_PER_LOOP 3
+#endif
+
+/**
+ * @brief   Spin for a number of cycles.
+ *
+ * This will not take into account cycles spent on interrupts
+ * if they are enabled and occur.
+ *
+ * @param loops Number of loop iterations to take
+ */
+static inline void busy_wait(unsigned loops)
+{
+    while (loops) {
+        /* This empty inline assembly should be enough to convince the
+         * compiler that the loop cannot be optimized out. Tested with
+         * GCC 12.2 and clang 16.0.0 successfully. */
+        __asm__ __volatile__ (
+            ""
+            : /* no outputs */
+            : /* no inputs */
+            : /* no clobbers */
+        );
+        loops--;
+    }
+}
+
+/**
+ * @brief   Spin for a number of microseconds.
+ *
+ * This will roughly try to match the requested delay time, but don't
+ * expect high accuracy.
+ *
+ * This will not take into account cycles spent on interrupts
+ * if they are enabled and occur.
+ *
+ * @param usec  Number of µs to spin for.
+ */
+static inline void busy_wait_us(unsigned usec)
+{
+    unsigned loops = ((uint64_t)usec * CLOCK_CORECLOCK)
+                   / (US_PER_SEC * CPU_CYCLES_PER_LOOP);
+    busy_wait(loops);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BUSY_WAIT_H */
+/** @} */

--- a/tests/sys/busy_wait/Makefile
+++ b/tests/sys/busy_wait/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.sys_common
+
+USEMODULE += ztimer_usec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/busy_wait/Makefile.ci
+++ b/tests/sys/busy_wait/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    atmega8 \
+    #

--- a/tests/sys/busy_wait/main.c
+++ b/tests/sys/busy_wait/main.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   Busy Wait loop Test Application
+ *
+ *          This can be used to determine `CPU_CYCLES_PER_LOOP` by
+ *          comparing the time the busy wait loop took with the
+ *          actual µsec timer.
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <stdio.h>
+#include "busy_wait.h"
+#include "ztimer/stopwatch.h"
+
+static inline void _measure_interval(ztimer_stopwatch_t *clock, unsigned usec)
+{
+    unsigned usec_real;
+
+    printf("waiting for %u µs…\n", usec);
+    ztimer_stopwatch_start(clock);
+    busy_wait_us(usec);
+    usec_real = ztimer_stopwatch_measure(clock);
+    printf("took %u µs (diff: %d µs)\n", usec_real, (int)usec_real - usec);
+}
+
+int main(void)
+{
+    ztimer_stopwatch_t clock;
+    ztimer_stopwatch_init(ZTIMER_USEC, &clock);
+
+    _measure_interval(&clock, 10);
+    _measure_interval(&clock, 100);
+    _measure_interval(&clock, 1000);
+    _measure_interval(&clock, 10000);
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We often need to wait for a short period of time before timers are initialized, e.g. in `board_init()`.

Instead of ad-hoc busy wait implementations, provide a common `busy_wait()` helper function (taken from msp430) and add a `busy_wait_us()` for a rough time approximation based on the CPU frequency. 


### Testing procedure

A new test application is provided in `tests/sys/busy_wait` that will measure the diversion from the usec timer:

#### samd20-xpro (Cortex M0+)

```
2024-01-09 18:34:38,799 # waiting for 10 µs…
2024-01-09 18:34:38,801 # took 29 µs (diff: 19 µs)
2024-01-09 18:34:38,803 # waiting for 100 µs…
2024-01-09 18:34:38,806 # took 119 µs (diff: 19 µs)
2024-01-09 18:34:38,808 # waiting for 1000 µs…
2024-01-09 18:34:38,812 # took 1012 µs (diff: 12 µs)
2024-01-09 18:34:38,814 # waiting for 10000 µs…
2024-01-09 18:34:38,827 # took 9942 µs (diff: -58 µs)
```

#### saml10-xpro (Cortex M23)

```
2024-01-09 19:06:53,208 # waiting for 10 µs…
2024-01-09 19:06:53,211 # took 38 µs (diff: 28 µs)
2024-01-09 19:06:53,213 # waiting for 100 µs…
2024-01-09 19:06:53,216 # took 128 µs (diff: 28 µs)
2024-01-09 19:06:53,218 # waiting for 1000 µs…
2024-01-09 19:06:53,222 # took 1029 µs (diff: 29 µs)
2024-01-09 19:06:53,224 # waiting for 10000 µs…
2024-01-09 19:06:53,237 # took 10028 µs (diff: 28 µs)
```

#### same54-xpro (Cortex M4F)

```
2024-01-09 19:07:30,669 # waiting for 10 µs…
2024-01-09 19:07:30,671 # took 14 µs (diff: 4 µs)
2024-01-09 19:07:30,673 # waiting for 100 µs…
2024-01-09 19:07:30,676 # took 103 µs (diff: 3 µs)
2024-01-09 19:07:30,678 # waiting for 1000 µs…
2024-01-09 19:07:30,681 # took 1003 µs (diff: 3 µs)
2024-01-09 19:07:30,683 # waiting for 10000 µs…
2024-01-09 19:07:30,696 # took 10003 µs (diff: 3 µs)
```

#### avr-rss2 (AVR8)

```
2024-01-09 23:07:08,152 # waiting for 10 µs…
2024-01-09 23:07:08,153 # took 96 µs (diff: 86 µs)
2024-01-09 23:07:08,153 # waiting for 100 µs…
2024-01-09 23:07:08,153 # took 208 µs (diff: 108 µs)
2024-01-09 23:07:08,154 # waiting for 1000 µs…
2024-01-09 23:07:08,154 # took 1104 µs (diff: 104 µs)
2024-01-09 23:07:08,155 # waiting for 10000 µs…
2024-01-09 23:07:08,155 # took 10112 µs (diff: 112 µs)
```

#### esp8266-esp-12x (ESP8266)
```
2024-01-09 23:19:50,829 # waiting for 10 µs…
2024-01-09 23:19:50,829 # took 20 µs (diff: 10 µs)
2024-01-09 23:19:50,830 # waiting for 100 µs…
2024-01-09 23:19:50,830 # took 106 µs (diff: 6 µs)
2024-01-09 23:19:50,830 # waiting for 1000 µs…
2024-01-09 23:19:50,831 # took 1007 µs (diff: 7 µs)
2024-01-09 23:19:50,831 # waiting for 10000 µs…
2024-01-09 23:19:50,832 # took 10007 µs (diff: 7 µs)
```

#### esp32-wroom-32 (ESP32)

```
2024-01-09 23:11:12,958 # waiting for 10 µs…
2024-01-09 23:11:12,959 # took 12 µs (diff: 2 µs)
2024-01-09 23:11:12,959 # waiting for 100 µs…
2024-01-09 23:11:12,960 # took 102 µs (diff: 2 µs)
2024-01-09 23:11:12,960 # waiting for 1000 µs…
2024-01-09 23:11:12,960 # took 1002 µs (diff: 2 µs)
2024-01-09 23:11:12,961 # waiting for 10000 µs…
2024-01-09 23:11:12,961 # took 10002 µs (diff: 2 µs)
```

#### esp32s2-wemos-mini (ESP32S2)

```
2024-01-09 23:30:08,115 # waiting for 10 µs…
2024-01-09 23:30:08,117 # took 20 µs (diff: 10 µs)
2024-01-09 23:30:08,119 # waiting for 100 µs…
2024-01-09 23:30:08,121 # took 151 µs (diff: 51 µs)
2024-01-09 23:30:08,123 # waiting for 1000 µs…
2024-01-09 23:30:08,127 # took 1010 µs (diff: 10 µs)
2024-01-09 23:30:08,129 # waiting for 10000 µs…
2024-01-09 23:30:08,142 # took 10010 µs (diff: 10 µs)
```

#### esp32s3-devkit (ESP32S3)

```
2024-01-09 23:23:44,314 # waiting for 10 µs…
2024-01-09 23:23:44,314 # took 13 µs (diff: 3 µs)
2024-01-09 23:23:44,315 # waiting for 100 µs…
2024-01-09 23:23:44,315 # took 103 µs (diff: 3 µs)
2024-01-09 23:23:44,315 # waiting for 1000 µs…
2024-01-09 23:23:44,316 # took 1002 µs (diff: 2 µs)
2024-01-09 23:23:44,316 # waiting for 10000 µs…
2024-01-09 23:23:44,317 # took 10003 µs (diff: 3 µs)
```

#### esp32c3-devkit (RISC-V)

```
2024-01-09 23:33:23,096 # waiting for 10 µs…
2024-01-09 23:33:23,097 # took 14 µs (diff: 4 µs)
2024-01-09 23:33:23,100 # waiting for 100 µs…
2024-01-09 23:33:23,102 # took 103 µs (diff: 3 µs)
2024-01-09 23:33:23,105 # waiting for 1000 µs…
2024-01-09 23:33:23,107 # took 1002 µs (diff: 2 µs)
2024-01-09 23:33:23,108 # waiting for 10000 µs…
2024-01-09 23:33:23,112 # took 10003 µs (diff: 3 µs)
```

#### sipeed-longan-nano (RISC-V)

```
2024-01-09 23:37:05,709 # waiting for 10 µs…
2024-01-09 23:37:05,709 # took 13 µs (diff: 3 µs)
2024-01-09 23:37:05,709 # waiting for 100 µs…
2024-01-09 23:37:05,710 # took 113 µs (diff: 13 µs)
2024-01-09 23:37:05,711 # waiting for 1000 µs…
2024-01-09 23:37:05,711 # took 1013 µs (diff: 13 µs)
2024-01-09 23:37:05,712 # waiting for 10000 µs…
2024-01-09 23:37:05,718 # took 10014 µs (diff: 14 µs)
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
