### PR TITLE
build_system: let DISABLE_MODULE disable optional features

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -104,14 +104,9 @@ ifneq (,$(filter tinyusb_%, $(USEMODULE)))
   USEPKG += tinyusb
 endif
 
-# always select gpio (until explicit dependencies are sorted out)
+# always select gpio & pm (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
-
-# always select power management unless building the bootloader
-# pm is not needed by the bootloader and omitting it saves some ROM
-ifneq (1, $(RIOTBOOT_BUILD))
-  FEATURES_OPTIONAL += periph_pm
-endif
+FEATURES_OPTIONAL += periph_pm
 
 # don't use idle thread if architecture has needed support
 FEATURES_OPTIONAL += no_idle_thread

--- a/bootloaders/riotboot_common.mk
+++ b/bootloaders/riotboot_common.mk
@@ -14,6 +14,9 @@ CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 DISABLE_MODULE += core_init core_msg core_panic
 DISABLE_MODULE += auto_init auto_init_%
 DISABLE_MODULE += pm_layered
+ifeq (,$(filter riotboot_%_dfu, $(USEMODULE)))
+  DISABLE_MODULE += periph_pm
+endif
 
 # avoid using stdio
 USEMODULE += stdio_null

--- a/makefiles/features_check.inc.mk
+++ b/makefiles/features_check.inc.mk
@@ -20,7 +20,7 @@ FEATURES_USABLE := $(filter-out $(FEATURES_BLACKLIST) $(FEATURES_WOULD_CONFLICT)
                      $(FEATURES_PROVIDED))
 
 # Features that may be used, if provided.
-FEATURES_OPTIONAL_ONLY := $(sort $(filter-out $(FEATURES_REQUIRED),$(FEATURES_OPTIONAL)))
+FEATURES_OPTIONAL_ONLY := $(sort $(filter-out $(FEATURES_REQUIRED) $(DISABLE_MODULE),$(FEATURES_OPTIONAL)))
 
 # Optional features that end up being used
 FEATURES_OPTIONAL_USED := $(sort $(filter $(FEATURES_USABLE),$(FEATURES_OPTIONAL_ONLY)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I was a bit surprised when I could not disable optional features with `DISABLE_MODULE`.
riotbot uses a hack to still disable `periph_pm`, but with this we can remove that special case and handle all via `DISABLE_MODULE`.

### Testing procedure

Still no `periph_pm` in `info-modules` of `bootloaders/riotboot`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
