### PR TITLE
gnrc/nib: allow prefix to be on-link without being used for address

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -52,7 +52,6 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
     }
 #ifdef MODULE_GNRC_NETIF
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
-    int idx;
 
     if (netif == NULL) {
         _nib_release();
@@ -64,9 +63,7 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
      * address resolution towards the LoWPAN and not the upstream interface
      * See https://github.com/RIOT-OS/RIOT/pull/10627 and follow-ups
      */
-    if ((!gnrc_netif_is_6ln(netif) || gnrc_netif_is_6lbr(netif)) &&
-        ((idx = gnrc_netif_ipv6_addr_match(netif, pfx)) >= 0) &&
-        (ipv6_addr_match_prefix(&netif->ipv6.addrs[idx], pfx) >= pfx_len)) {
+    if (!gnrc_netif_is_6ln(netif) || gnrc_netif_is_6lbr(netif)) {
         dst->flags |= _PFX_ON_LINK;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A prefix might be on-link without us using it for a address on that prefix.


### Testing procedure

Configure the address `fdea:dbee:f::1` on a host in the network.
On a RIOT node in the same network, execute

    nib prefix add 6 fdea:dbee:f::1/128

The host should now be reachable through that address. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
