### PR TITLE
sys/shell: add firmware version to version cmd

### DIFF
--- a/boards/samd20-xpro/Makefile.features
+++ b/boards/samd20-xpro/Makefile.features
@@ -11,3 +11,5 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+FEATURES_PROVIDED += riotboot

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -15,3 +15,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += tinyusb_device
+FEATURES_PROVIDED += riotboot

--- a/sys/shell/cmds/sys.c
+++ b/sys/shell/cmds/sys.c
@@ -26,6 +26,9 @@
 #ifdef MODULE_USB_BOARD_RESET
 #include "usb_board_reset.h"
 #endif
+#ifdef MODULE_RIOTBOOT_SLOT
+#include "riotboot/slot.h"
+#endif
 
 static int _reboot_handler(int argc, char **argv)
 {
@@ -59,6 +62,14 @@ static int _version_handler(int argc, char **argv)
     (void) argv;
 
     puts(RIOT_VERSION);
+
+#ifdef MODULE_RIOTBOOT_SLOT
+    int slot = riotboot_slot_current();
+    if (slot >= 0) {
+        const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(slot);
+        printf("%s v%"PRIu32", slot %u\n", RIOT_APPLICATION, hdr->version, slot);
+    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We don't have a way to tell which firmware version is currently running on the device, so add this information to the `version` command when running with `riotboot_slot`.
 

### Testing procedure

The current firmware version is now printed when entering `version` (tested with `examples/suit_update`):

```
2024-01-11 14:40:33,170 # > version
2024-01-11 14:40:33,170 # 
2024-01-11 14:40:33,172 # 2024.01-devel-567-gbb4c4d
2024-01-11 14:40:33,175 # suit_update v1704980244, slot 0
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
