### PR TITLE
nanocoap_sock: always use coap_opt_put_uri_pathquery()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1763,6 +1763,7 @@ static inline size_t coap_opt_put_uri_query(uint8_t *buf, uint16_t lastonum,
  * @param[out]  buf         buffer to write to
  * @param[in,out] lastonum  number of previous option (for delta calculation),
  *                          or 0 if first option
+ *                          May be NULL, then previous option is assumed to be 0.
  * @param[in]   uri         ptr into a source URI, to the first character after
  *                          the authority component
  *

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -318,7 +318,7 @@ static inline void nanocoap_sock_close(nanocoap_sock_t *sock)
  * @brief   Simple synchronous CoAP (confirmable) GET
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[out]  buf     buffer to write response to
  * @param[in]   len     length of @p buffer
  *
@@ -332,7 +332,7 @@ ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf,
  * @brief   Simple synchronous CoAP (confirmable) PUT
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[in]   request buffer containing the payload
  * @param[in]   len     length of the payload to send
  * @param[out]  response buffer for the response, may be NULL
@@ -349,7 +349,7 @@ ssize_t nanocoap_sock_put(nanocoap_sock_t *sock, const char *path,
  * @brief   Simple non-confirmable PUT
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[in]   request buffer containing the payload
  * @param[in]   len     length of the payload to send
  * @param[out]  response buffer for the response, may be NULL
@@ -384,7 +384,7 @@ ssize_t nanocoap_sock_put_url(const char *url,
  * @brief   Simple synchronous CoAP (confirmable) POST
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[in]   request buffer containing the payload
  * @param[in]   len     length of the payload to send
  * @param[out]  response buffer for the response, may be NULL
@@ -401,7 +401,7 @@ ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
  * @brief   Simple non-confirmable POST
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[in]   request buffer containing the payload
  * @param[in]   len     length of the payload to send
  * @param[out]  response buffer for the response, may be NULL
@@ -437,7 +437,7 @@ ssize_t nanocoap_sock_post_url(const char *url,
  *          ([RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132))
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[in]   request buffer containing the payload
  * @param[in]   len     length of the payload to send
  * @param[out]  response buffer for the response, may be NULL
@@ -455,7 +455,7 @@ ssize_t nanocoap_sock_fetch(nanocoap_sock_t *sock, const char *path,
  *          ([RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132))
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path
+ * @param[in]   path    remote path and query
  * @param[in]   request buffer containing the payload
  * @param[in]   len     length of the payload to send
  * @param[out]  response buffer for the response, may be NULL
@@ -491,7 +491,7 @@ ssize_t nanocoap_sock_fetch_url(const char *url,
  * @brief   Simple synchronous CoAP (confirmable) DELETE
  *
  * @param[in]   sock    socket to use for the request
- * @param[in]   path    remote path to delete
+ * @param[in]   path    remote path (with query) to delete
  *
  * @returns     0 on success
  * @returns     <0 on error

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -904,6 +904,7 @@ size_t coap_opt_put_uri_pathquery(uint8_t *buf, uint16_t *lastonum, const char *
 {
     size_t len;
     const char *query = strchr(uri, '?');
+    uint16_t _lastonum = lastonum ? *lastonum : 0;
 
     if (query) {
         len = (query == uri) ? 0 : (query - uri - 1);
@@ -911,16 +912,20 @@ size_t coap_opt_put_uri_pathquery(uint8_t *buf, uint16_t *lastonum, const char *
         len = strlen(uri);
     }
 
-    size_t bytes_out = coap_opt_put_string_with_len(buf, *lastonum,
+    size_t bytes_out = coap_opt_put_string_with_len(buf, _lastonum,
                                                     COAP_OPT_URI_PATH,
                                                     uri, len, '/');
     if (query) {
         buf += bytes_out;
         bytes_out += coap_opt_put_uri_query(buf, COAP_OPT_URI_PATH, query + 1);
-        *lastonum = COAP_OPT_URI_QUERY;
+        _lastonum = COAP_OPT_URI_QUERY;
     }
     else if (bytes_out) {
-        *lastonum = COAP_OPT_URI_PATH;
+        _lastonum = COAP_OPT_URI_PATH;
+    }
+
+    if (lastonum) {
+        *lastonum = _lastonum;
     }
 
     return bytes_out;

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -384,7 +384,7 @@ ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf, si
 
     pktpos += coap_build_hdr(pkt.hdr, COAP_TYPE_CON, NULL, 0, COAP_METHOD_GET,
                              nanocoap_sock_next_msg_id(sock));
-    pktpos += coap_opt_put_uri_path(pktpos, 0, path);
+    pktpos += coap_opt_put_uri_pathquery(pktpos, NULL, path);
 
     pkt.payload = pktpos;
     pkt.payload_len = 0;
@@ -415,12 +415,13 @@ ssize_t _sock_put_post(nanocoap_sock_t *sock, const char *path, unsigned code,
         .iov_len  = max_len,
     };
 
+    uint16_t lastonum = 0;
     pktpos += coap_build_hdr(pkt.hdr, type, NULL, 0, code, nanocoap_sock_next_msg_id(sock));
-    pktpos += coap_opt_put_uri_path(pktpos, 0, path);
+    pktpos += coap_opt_put_uri_pathquery(pktpos, &lastonum, path);
 
     if (response == NULL && type == COAP_TYPE_NON) {
         /* all responses (2.xx, 4.xx and 5.xx) are ignored */
-        pktpos += coap_opt_put_uint(pktpos, COAP_OPT_URI_PATH,
+        pktpos += coap_opt_put_uint(pktpos, lastonum,
                                     COAP_OPT_NO_RESPONSE, 26);
     }
 
@@ -533,7 +534,7 @@ ssize_t nanocoap_sock_delete(nanocoap_sock_t *sock, const char *path)
 
     pktpos += coap_build_hdr(pkt.hdr, COAP_TYPE_CON, NULL, 0, COAP_METHOD_DELETE,
                              nanocoap_sock_next_msg_id(sock));
-    pktpos += coap_opt_put_uri_path(pktpos, 0, path);
+    pktpos += coap_opt_put_uri_pathquery(pktpos, NULL, path);
 
     pkt.payload = pktpos;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is pretty subtle: `coap_opt_put_uri_pathquery()` will detect the presense of a query parameter, `coap_opt_put_uri_path()` will not.

That means that when you request `path/to/resource?option=1` with `coap_opt_put_uri_path()` you get the path `resource?option=1` whereas with `coap_opt_put_uri_pathquery()` you get the path `resource` with query parameter `option=1`.

We really want the latter.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
