### PR TITLE
cpu/avr8_common: allow to build with !periph_pm

### DIFF
--- a/core/lib/panic.c
+++ b/core/lib/panic.c
@@ -79,16 +79,18 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
     /* disable watchdog and all possible sources of interrupts */
     irq_disable();
     panic_arch();
-#ifndef DEVELHELP
+#if !defined(DEVELHELP) && defined(MODULE_PERIPH_PM)
     /* DEVELHELP not set => reboot system */
     pm_reboot();
 #else
     /* DEVELHELP set => power off system */
     /*               or start bootloader */
-#ifdef MODULE_USB_BOARD_RESET
+#if defined(MODULE_USB_BOARD_RESET)
     usb_board_reset_in_bootloader();
-#else
+#elif defined(MODULE_PERIPH_PM)
     pm_off();
+#else
+    while (1) {}
 #endif
 #endif /* DEVELHELP */
 

--- a/cpu/avr8_common/Makefile.dep
+++ b/cpu/avr8_common/Makefile.dep
@@ -5,7 +5,7 @@ USEMODULE += avr_libc_extra
 USEMODULE += avr8_common avr8_common_periph
 
 # All avr8 CPUs provide PM
-USEMODULE += pm_layered
+DEFAULT_MODULE += pm_layered
 
 # The AVR-libc provides no thread safe malloc implementation and has no hooks
 # to inject. Use malloc_thread_safe to link calls to malloc to safe wrappers


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`pm_layered` is a `DEFAULT_MODULE` for all other arches so we can disable it - do the same for AVR8.

Also add a fallback for `panic()` if `periph_pm` is not enabled. 


### Testing procedure

```
DISABLE_MODULE += core_thread pm_layered
FEATURES_BLACKLIST += periph_pm
```

now allows to minimize simple programs.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
