### PR TITLE
print: Missing size_t print format specifiers

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -645,7 +645,7 @@ static int _atwinc15x0_get(netdev_t *netdev, netopt_t opt, void *val,
     assert(dev);
     assert(dev == atwinc15x0);
 
-    DEBUG("%s dev=%p opt=%u val=%p max_len=%u\n", __func__,
+    DEBUG("%s dev=%p opt=%u val=%p max_len=%" PRIuSIZE "\n", __func__,
           (void *)netdev, opt, val, max_len);
 
     switch (opt) {
@@ -755,7 +755,7 @@ static int _atwinc15x0_set(netdev_t *netdev, netopt_t opt, const void *val,
 {
     atwinc15x0_t *dev = (atwinc15x0_t *)netdev;
 
-    DEBUG("%s dev=%p opt=%u val=%p max_len=%u\n", __func__,
+    DEBUG("%s dev=%p opt=%u val=%p max_len=%" PRIuSIZE "\n", __func__,
           (void *)netdev, opt, val, max_len);
 
     int ret;

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -292,7 +292,7 @@ void lcd_ll_release(lcd_t *dev)
 void lcd_ll_write_cmd(lcd_t *dev, uint8_t cmd, const uint8_t *data,
                       size_t len)
 {
-    DEBUG("[%s] command 0x%02x (%u) ", __func__, cmd, len);
+    DEBUG("[%s] command 0x%02x (%" PRIuSIZE ") ", __func__, cmd, len);
     if (IS_USED(ENABLE_DEBUG) && len) {
         for (uint8_t i = 0; i < len; i++) {
              DEBUG("0x%02x ", data[i]);
@@ -310,7 +310,7 @@ void lcd_ll_read_cmd(lcd_t *dev, uint8_t cmd, uint8_t *data, size_t len)
 {
     assert(len);
 
-    DEBUG("[%s] command 0x%02x (%u) ", __func__, cmd, len);
+    DEBUG("[%s] command 0x%02x (%" PRIuSIZE ") ", __func__, cmd, len);
 
     lcd_ll_cmd_start(dev, cmd, true);
     lcd_ll_read_bytes(dev, false, data, len);

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -323,7 +323,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     }
     /* drop frame, content in buf becomes invalid and return -ENOBUFS */
     if (len < frame_len) {
-        DEBUG("[nrf24l01p_ng] Buffer too small: %u < %u, dropping frame\n",
+        DEBUG("[nrf24l01p_ng] Buffer too small: %" PRIuSIZE " < %u, dropping frame\n",
               len, frame_len);
         uint8_t garbage[pl_width];
         nrf24l01p_ng_read_rx_payload(dev, garbage, pl_width);

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <errno.h>
 
+#include "architecture.h"
 #include "iolist.h"
 #include "net/netopt.h"
 #include "net/netdev.h"
@@ -78,7 +79,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         return 0;
     }
 
-    DEBUG("[sx126x] netdev: sending packet now (size: %d).\n", pos);
+    DEBUG("[sx126x] netdev: sending packet now (size: %" PRIuSIZE ").\n", pos);
     sx126x_set_lora_payload_length(dev, pos);
 
     state = NETOPT_STATE_TX;

--- a/drivers/sx1280/sx1280_netdev.c
+++ b/drivers/sx1280/sx1280_netdev.c
@@ -73,7 +73,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         return 0;
     }
 
-    DEBUG("[sx1280] netdev: sending packet now (size: %d).\n", pos);
+    DEBUG("[sx1280] netdev: sending packet now (size: %" PRIuSIZE ").\n", pos);
     sx1280_set_lora_payload_length(dev, pos);
 
     state = NETOPT_STATE_TX;

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -243,7 +243,7 @@ gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt)
 #ifdef MODULE_OD
 static inline void _print_chunk(void *chunk, size_t size, int num)
 {
-    printf("=========== chunk %3" PRIuSIZE " (%-10p size: %4u) ===========\n", num, chunk,
+    printf("=========== chunk %3i (%-10p size: %4" PRIuSIZE ") ===========\n", num, chunk,
            size);
     od_hex_dump(chunk, size, OD_WIDTH_DEFAULT);
 }

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -151,7 +151,7 @@ static void _dump(gnrc_pktsnip_t *pkt)
     gnrc_pktsnip_t *snip = pkt;
 
     while (snip != NULL) {
-        printf("~~ SNIP %2" PRIuSIZE " - size: %3u byte, type: ", snips,
+        printf("~~ SNIP %2i - size: %3" PRIuSIZE " byte, type: ", snips,
                snip->size);
         _dump_snip(snip);
         ++snips;

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -57,9 +57,10 @@ static int _compare_string_buffer(const char *name, const char *input_uri, const
         (strncmp(actual_str, expected_str, actual_len) == 0)) {
         return 0;
     }
-    printf(
-        "\nWith given input uri '%s', expected %s '%s' with length '%" PRIuSIZE "' but got '%.*s' with length '%d'\n",
-        input_uri, name, expected_str, strlen(expected_str), actual_len, actual_str, actual_len);
+    printf("\nWith given input uri '%s', expected %s '%s' with length '%"
+           PRIuSIZE "' but got '%.*s' with length '%" PRIuSIZE "'\n",
+           input_uri, name, expected_str, strlen(expected_str),
+           (unsigned) actual_len, actual_str, actual_len);
     return -1;
 }
 


### PR DESCRIPTION
### Contribution description

I seem to have missed some `size_t` prints without casts in `drivers` and `tests/unittests/tests-uri_parser/tests-uri_parser.c`.
I also made two mistakes in `sys/net/gnrc`.
This PR fixes them.

### Testing procedure

This should have no functional impact on currently supported architectures, as `sizeof(size_t) == sizeof(unsigned)` is true for all them. Test as usual.

### Issues/PRs references

Fixes #20194
