### PR TITLE
boards/e180-zg120b-tb: add support for OpenOCD

### DIFF
--- a/boards/e180-zg120b-tb/Makefile.include
+++ b/boards/e180-zg120b-tb/Makefile.include
@@ -1,4 +1,14 @@
 # setup JLink for flashing
-PROGRAMMER ?= jlink
 JLINK_DEVICE = EFR32MG1BxxxF256
 JLINK_PRE_FLASH = r
+
+# setup OpenOCD for flashing
+PROGRAMMERS_SUPPORTED += openocd
+OPENOCD_DEBUG_ADAPTER ?= stlink
+
+# default to jlink as programmer, but only if JLinkExe is in $PATH
+ifneq (,$(shell which JLinkExe))
+  PROGRAMMER ?= jlink
+else
+  PROGRAMMER ?= openocd
+endif

--- a/boards/e180-zg120b-tb/dist/openocd.cfg
+++ b/boards/e180-zg120b-tb/dist/openocd.cfg
@@ -1,0 +1,10 @@
+# Set the default reset option in cases where "SRST=none" is not used for make
+if { ![info exists SRST_OPT] } {
+   set SRST_OPT srst_only
+}
+
+reset_config none
+
+source [find target/efm32.cfg]
+
+$_TARGETNAME configure -rtos auto

--- a/boards/e180-zg120b-tb/doc.txt
+++ b/boards/e180-zg120b-tb/doc.txt
@@ -4,6 +4,8 @@
  * @brief       Support for Ebyte E180-ZG120B-TB Test Board
 
 ## Overview
+![Image of the E180-ZG120B test board](https://www.ebyte.com/Uploadfiles/Picture/2019-12-20/201912201352132348.jpg)
+
 Ebyte E180-ZG120B Test Board is equipped with the EFM32 microcontroller.
 It is specifically designed for low-power applications, having energy-saving
 peripherals, different energy modes and short wake-up times.
@@ -161,8 +163,20 @@ This MCU has extended pin mapping support. Each pin of a peripheral can be
 connected separately to one of the predefined pins for that peripheral.
 
 ## Flashing the device
-To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is
-required.
+The board has no integrated programmer/debugger and no bootloader. Hence,
+an external SWD programmer/debugger such as the [SEGGER JLink][prog-jlink]
+or the [ST-Link][prog-stlink] is required. Connect at least the SWDIO, SWCLK,
+and GND to the programmer. If `JLinkExe` is found in `$PATH`, `jlink` is used
+by default for flashing, otherwise `openocd` is the default. When using OpenOCD,
+the `stlink` is the default for `OPENOCD_DEBUG_ADAPTER`; provide a different
+value if you use other hardware.
+
+@note   When flashing with OpenOCD, leave the NRESET pin unconnected. The
+        configuration does a soft reset only to work around an issue attaching
+        with the hardware reset signal.
+
+[prog-jlink]: https://www.segger.com/jlink-software.html
+[prog-stlink]: https://www.aliexpress.com/wholesale?SearchText=stlink
 
 Flashing is supported by RIOT-OS using the command below:
 


### PR DESCRIPTION
### Contribution description

As the title says. The documentation is duly updated as well and an image of the board is added.

### Testing procedure

Flashing the board with OpenOCD e.g. with an ST-Link should now work.

```
git:(boards/e180-zg120b-tb/openocd) ~/Repos/software/RIOT/master ➜ make BOARD=e180-zg120b-tb -C examples/default/ flash
make: Entering directory '/home/maribu/Repos/software/RIOT/master/examples/default'
Building application "default" for "e180-zg120b-tb" with MCU "efm32".

"make" -C /home/maribu/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/master/pkg/gecko_sdk/ 
"make" -C /home/maribu/.cache/RIOT/pkg/gecko_sdk/dist
"make" -C /home/maribu/.cache/RIOT/pkg/gecko_sdk/dist/emlib-extra/src
"make" -C /home/maribu/.cache/RIOT/pkg/gecko_sdk/dist/emlib/src
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/e180-zg120b-tb
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32/drivers/coretemp
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32/families/efr32mg1b
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/saul
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/saul/init_devs
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/fmt
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/phydat
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/ps
"make" -C /home/maribu/Repos/software/RIOT/master/sys/rtc_utils
"make" -C /home/maribu/Repos/software/RIOT/master/sys/saul_reg
"make" -C /home/maribu/Repos/software/RIOT/master/sys/shell
"make" -C /home/maribu/Repos/software/RIOT/master/sys/shell/cmds
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  26244	   144	  2804	 29192	  7208	/home/maribu/Repos/software/RIOT/master/examples/default/bin/e180-zg120b-tb/default.elf
/home/maribu/Repos/software/RIOT/master/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/master/examples/default/bin/e180-zg120b-tb/default.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-snapshot (2023-06-12-09:31)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 1000 kHz
Info : STLINK V2J29S7 (API v2) VID:PID 0483:3748
Info : Target voltage: 3.231012
Info : [efm32.cpu] Cortex-M4 r0p1 processor detected
Info : [efm32.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for efm32.cpu on 0
Info : Listening on port 41377 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* efm32.cpu          hla_target little efm32.cpu          unknown
[efm32.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0fe10000 msp: 0x20000400
Info : detected part: EFR32MG1B Mighty Gecko, rev 165
Info : flash size = 256 KiB
Info : flash page size = 2048 B
auto erase enabled
wrote 26624 bytes from file /home/maribu/Repos/software/RIOT/master/examples/default/bin/e180-zg120b-tb/default.elf in 0.996979s (26.079 KiB/s)
verified 26388 bytes in 0.209874s (122.786 KiB/s)
shutdown command invoked
Done flashing
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/examples/default'
```

### Issues/PRs references

None