### PR TITLE
tools/openocd-rtt: also open GDB port

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -484,7 +484,7 @@ do_term() {
             -c 'bindto ${OPENOCD_SERVER_ADDRESS}' \
             -c 'tcl_port 0' \
             -c 'telnet_port 0' \
-            -c 'gdb_port 0' \
+            -c 'gdb_port 3333' \
             -c init \
             -c 'rtt setup '${RAM_START_ADDR}' '${RAM_LEN}' \"SEGGER RTT\"' \
             -c 'rtt start' \


### PR DESCRIPTION
### Contribution description

When using OpenOCD RTT (real-time transfer) for stdio with `USEMODULE=stdio_rtt make ...`, it is no longer possible to debug while being connected to stdio. By also opening gdb at RIOT's default GDB port, `make debug-client` can be used to connect from GDB to the OpenOCD instance providing stdio via RTT.

### Testing procedure

1. `USEMODULE=stdio_rtt make BOARD=<some_board_with_openocd-support> -C examples/default flash term`
2. `make BOARD=<same_board_with_openocd-support> -C examples/default debug-client`

Note: `make debug-client` will only work when the connection to RIOT's serial via OpenOCD RTT is still open.

### Issues/PRs references

None