### PR TITLE
tests/periph/uart_locate_pins: new test/utility app

### DIFF
--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -56,7 +56,7 @@ static void *main_trampoline(void *arg)
         auto_init();
     }
 
-    if (!IS_ACTIVE(CONFIG_SKIP_BOOT_MSG)) {
+    if (!IS_ACTIVE(CONFIG_SKIP_BOOT_MSG) && !IS_USED(MODULE_STDIO_NULL)) {
         LOG_INFO(CONFIG_BOOT_MSG_STRING "\n");
     }
 

--- a/tests/periph/uart_locate_pins/Makefile
+++ b/tests/periph/uart_locate_pins/Makefile
@@ -1,0 +1,17 @@
+BOARD ?= nucleo-f767zi
+
+# This needs to be here so that this app's `soft_uart_params.h` is found used
+# of the one in $(RIOTBASE)/drivers/soft_uart/include.
+INCLUDES += -I$(abspath $(CURDIR))/include
+
+include ../Makefile.periph_common
+
+USEMODULE += soft_uart
+USEMODULE += fmt
+# we do not need stdio
+USEMODULE += stdio_null
+
+# We do not need multi-threading for this app
+DISBALE_MODULE += core_thread
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph/uart_locate_pins/README.md
+++ b/tests/periph/uart_locate_pins/README.md
@@ -1,0 +1,5 @@
+# Utility to locate GPIO pins
+
+This application bit-bangs the name of every GPIO pin via `soft_uart` on each
+GPIO. Connect an UART adapter to one pin at a time configured at symbol rate
+of 9600 Bd and check the output to know which pin you are connected to.

--- a/tests/periph/uart_locate_pins/include/soft_uart_params.h
+++ b/tests/periph/uart_locate_pins/include/soft_uart_params.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_uart_locate_pins
+ * @{
+ *
+ * @file
+ * @brief       Override "soft_uart_params.h" to conserve memory when
+ *              changing the pin configuration
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ *
+ * @}
+ */
+
+#ifndef SOFT_UART_PARAMS_H
+#define SOFT_UART_PARAMS_H
+
+#include "soft_uart.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Sotware UART port descriptor array
+ */
+extern soft_uart_conf_t soft_uart_config[];
+
+#define SOFT_UART_NUMOF 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOFT_UART_PARAMS_H */
+/** @} */

--- a/tests/periph/uart_locate_pins/main.c
+++ b/tests/periph/uart_locate_pins/main.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @defgroup    tests_periph_uart_locate_pins
+ * @{
+ *
+ * @file
+ * @brief       Test application to figure out pin mapping via UART
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ *
+ * @}
+ */
+#include <stdint.h>
+
+#include "container.h"
+#include "fmt.h"
+#include "macros/units.h"
+#include "periph/gpio.h"
+#include "periph/timer.h"
+#include "soft_uart.h"
+
+#ifndef UART_SYMBOL_RATE
+#  define UART_SYMBOL_RATE 9600
+#endif
+
+/* Adapt this list of pins to detect as needed. You may want to not use all
+ * pins, e.g. pins connected to crystals, etc. may not react friendly to be
+ * used as output */
+static const struct {
+    uint8_t port_num;
+    uint8_t pin_num;
+} pins[] = {
+    {
+        .port_num = 0,
+        .pin_num = 0,
+    },
+};
+
+soft_uart_conf_t soft_uart_config[] = {
+    {
+        .tx_pin = GPIO_UNDEF,
+        .rx_pin = GPIO_UNDEF,
+        .tx_timer = TIMER_DEV(0),
+        .timer_freq = MHZ(1),
+    },
+};
+
+int main(void)
+{
+    while (1) {
+        for (unsigned i = 0; i < ARRAY_SIZE(pins); i++) {
+            gpio_t pin = GPIO_PIN(pins[i].port_num, pins[i].pin_num);
+            soft_uart_config[0].tx_pin = pin;
+            soft_uart_init(0, UART_SYMBOL_RATE, NULL, NULL);
+            static char buf[32];
+            char *pos = buf;
+            *pos++ = 'P';
+            pos += fmt_u16_dec(pos, pins[i].port_num);
+            *pos++ = '.';
+            pos += fmt_u16_dec(pos, pins[i].pin_num);
+            *pos++ = ' ';
+            *pos++ = '/';
+            *pos++ = ' ';
+            *pos++ = 'P';
+            *pos++ = (char)((int)'A' + (int)pins[i].port_num);
+            pos += fmt_u16_dec(pos, pins[i].pin_num);
+            *pos++ = '\n';
+
+            soft_uart_write(0, (void *)buf, (size_t)pos - (size_t)buf);
+            soft_uart_poweroff(0);
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This application uses `soft_uart` to bit-bang the name of a number of configured GPIO pins via said pins at 9600 Bd. This way attaching an USB UART bridge to one pin at a time easily reveals which MCU GPIO pin a given pin on a board corresponds to. This is useful when no schematic and no silkscreen labeling is available, or when the information is misleading or outright incorrect (looking at the E180-ZG120B-TB).

### Testing procedure

1. Extend the list of pins in `main.c` to contain some pins to detect where they are routed to on the board.
    - beware: Some pins shouldn't be configured as output (e.g. pins connected to a crystal
2. Flash the app on a board
3. Connect an USB UART bridge configured at 9600 Bd to one pin at a time. Each pin should tell you its name

### Issues/PRs references

None