### PR TITLE
pkg/driver_sx126x: update to v2.3.2

### DIFF
--- a/pkg/driver_sx126x/Makefile
+++ b/pkg/driver_sx126x/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=driver_sx126x
 PKG_URL=https://github.com/Lora-net/sx126x_driver
-PKG_VERSION=ba61312213450ae94a4293d75285c1d8f30c04b3
+PKG_VERSION=9636dc4660ada4eeddf91eb7b3f7f241000bf202
+# TAG v2.3.2
 PKG_LICENSE=BSD
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/driver_sx126x/patches/0001-adapt-to-RIOT.patch
+++ b/pkg/driver_sx126x/patches/0001-adapt-to-RIOT.patch
@@ -1,24 +1,25 @@
-From c68e8e74d3de1235c4d818d96573e33e42cbcb74 Mon Sep 17 00:00:00 2001
-From: Alexandre Abadie <alexandre.abadie@inria.fr>
-Date: Thu, 11 Mar 2021 17:06:43 +0100
-Subject: [PATCH 1/1] adapt to RIOT
+From a0fe92c8382142688c4239eff3b380703ff52cfc Mon Sep 17 00:00:00 2001
+From: Didier DONSEZ <didier.donsez@gmail.com>
+Date: Sun, 14 Jan 2024 23:33:20 +0100
+Subject: [PATCH] [PATCH 1/1] adapt to RIOT
 
 ---
  src/sx126x.c                                | 4 ++--
  src/{sx126x.h => sx126x_driver.h}           | 6 +++---
  src/{sx126x_regs.h => sx126x_driver_regs.h} | 0
- 3 files changed, 5 insertions(+), 5 deletions(-)
+ src/sx126x_lr_fhss.c                        | 5 +++++
+ 4 files changed, 10 insertions(+), 5 deletions(-)
  rename src/{sx126x.h => sx126x_driver.h} (99%)
  rename src/{sx126x_regs.h => sx126x_driver_regs.h} (100%)
 
 diff --git a/src/sx126x.c b/src/sx126x.c
-index a61c3ce..2fa7d88 100644
+index 390ad2a..f8fc533 100644
 --- a/src/sx126x.c
 +++ b/src/sx126x.c
-@@ -35,9 +35,9 @@
+@@ -37,9 +37,9 @@
+  * --- DEPENDENCIES ------------------------------------------------------------
   */
- 
- #include <string.h>  // memcpy
+ #include <stddef.h>
 -#include "sx126x.h"
 +#include "sx126x_driver.h"
  #include "sx126x_hal.h"
@@ -31,11 +32,11 @@ diff --git a/src/sx126x.h b/src/sx126x_driver.h
 similarity index 99%
 rename from src/sx126x.h
 rename to src/sx126x_driver.h
-index 634ed82..e5ed101 100644
+index 29f15b3..35f279d 100644
 --- a/src/sx126x.h
 +++ b/src/sx126x_driver.h
-@@ -29,8 +29,8 @@
-  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@@ -32,8 +32,8 @@
+  * POSSIBILITY OF SUCH DAMAGE.
   */
  
 -#ifndef SX126X_H
@@ -45,7 +46,7 @@ index 634ed82..e5ed101 100644
  
  #ifdef __cplusplus
  extern "C" {
-@@ -1517,6 +1517,6 @@ sx126x_status_t sx126x_set_trimming_capacitor_values( const void* context, const
+@@ -1743,6 +1743,6 @@ sx126x_status_t sx126x_get_lora_params_from_header( const void* context, sx126x_
  }
  #endif
  
@@ -57,6 +58,29 @@ diff --git a/src/sx126x_regs.h b/src/sx126x_driver_regs.h
 similarity index 100%
 rename from src/sx126x_regs.h
 rename to src/sx126x_driver_regs.h
+diff --git a/src/sx126x_lr_fhss.c b/src/sx126x_lr_fhss.c
+index a55dc2a..6bd7595 100644
+--- a/src/sx126x_lr_fhss.c
++++ b/src/sx126x_lr_fhss.c
+@@ -135,6 +135,8 @@ static inline unsigned int sx126x_lr_fhss_get_grid_in_pll_steps( const sx126x_lr
+ 
+ sx126x_status_t sx126x_lr_fhss_init( const void* context, const sx126x_lr_fhss_params_t* params )
+ {
++	(void)params;
++
+     const uint8_t pkt_params_buf[] = {
+         SX126X_SET_PKT_PARAMS, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     };
+@@ -369,6 +371,9 @@ sx126x_status_t sx126x_lr_fhss_handle_hop( const void* context, const sx126x_lr_
+ sx126x_status_t sx126x_lr_fhss_handle_tx_done( const void* context, const sx126x_lr_fhss_params_t* params,
+                                                sx126x_lr_fhss_state_t* state )
+ {
++	(void)params;
++	(void)state;
++
+     const uint8_t ctrl = SX126X_LR_FHSS_DISABLE_HOPPING;
+ 
+     return sx126x_write_register( context, SX126X_LR_FHSS_REG_CTRL, &ctrl, 1 );
 -- 
-2.27.0
+2.39.0
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The PR is the update of pkg/sx126x_driver repository for the tag 2.3.2 of the source repository.

NB: the tag 2.3.2 includes the implementation of LR-FHSS driver for Semtech SX126x transceivers.


### Testing procedure

The update has been tested with a `lora-e5-dev` board with `tests/pkg/semtech-loramac` and a Chirpstack LNS (LoRaWAN network server) private instance.

```bash
make BOARD=lora-e5-dev LORA_DRIVER=sx126x_stm32wl
```
```
> main(): This is RIOT! (Version: 2022.01-devel-8326-gf7d01-pr/upgrade_driver_sx126x)
All up, running the shell now
> loramac set dr 5
> loramac set deveui 0a5acb4b41b95e51
> loramac set appkey 4B20EF23B1C3A9393F034F6527CA71F0
> loramac set adr on
> loramac join otaa
Join procedure succeeded!
> loramac get devaddr
DEVADDR: FC00AF6C
> loramac get appskey
APPSKEY: 5FECF818F9D72C7A5C3D56455C388508
> loramac get nwkskey
NWKSKEY: B770CCDD304045331EECA034821A0C7C
> loramac tx HELLO cnf 10
Received ACK from network
Message sent with success
> loramac get ul_cnt
Uplink Counter: 1
> loramac link_check
Link check request scheduled
> loramac tx BONJOUR uncnf 11
Link check information:
  - Demodulation margin: 10
  - Number of gateways: 1
Data received: HELLO_WORLD, port: 20
Message sent with success
> loramac get ul_cnt
Uplink Counter: 2
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
