### PR TITLE
drivers: make use of busy_wait()

### DIFF
--- a/cpu/sam0_common/sam0_sdhc/sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/sdhc.c
@@ -48,6 +48,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "busy_wait.h"
 #include "periph_cpu.h"
 #include "periph/pm.h"
 #include "macros/math.h"
@@ -127,8 +128,7 @@ static void _delay(unsigned us)
     } else if (IS_USED(MODULE_ZTIMER_MSEC)) {
         ztimer_sleep(ZTIMER_MSEC, 1);
     } else {
-        volatile unsigned count = (us * CLOCK_CORECLOCK) / US_PER_SEC;
-        while (--count) {}
+        busy_wait_us(us);
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We can use this as a fallback when no ZTimer is enabled (e.g. in riotboot).


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
