### PR TITLE
dist/tools/zsh-completion: fix typo

### DIFF
--- a/dist/tools/zsh-completion/zsh-riot.sh
+++ b/dist/tools/zsh-completion/zsh-riot.sh
@@ -50,7 +50,7 @@ function _programmers {
         "elf2uf2:program via UF2 bootloader (RP2040)"
         "cpy2remed:program via ST-Link using filesystem disk interface"
         "adafruit-nrfutil:program via Adafruits nRF5x bootloader"
-        "bmp:Black Magic Probe",
+        "bmp:Black Magic Probe"
         "dfu-util:Flash using DFU Bootloader"
         "pyocd:Python based tool and API for debugging, programming, and exploring Arm Cortex microcontrollers"
         "robotis-loader:Flash using ROBOTIS Bootloader"


### PR DESCRIPTION
### Contribution description

This fixes a typo in a description.

### Testing procedure

When completing `PROGRAMMER=`, there is a stray `,` after the description of `bmp`:

```
adafruit-nrfutil  -- program via Adafruits nRF5x bootloader
avrdude           -- default for AVR boards
bmp               -- Black Magic Probe,
bossa             -- for SAM based Arduino boards
cc2538-bsl        -- for CC2538 boards
cpy2remed         -- program via ST-Link using filesystem disk interface
dfu-util          -- Flash using DFU Bootloader
edbg              -- for SAM based evaluation board
elf2uf2           -- program via UF2 bootloader (RP2040)
esptool           -- program ESP32 (S2,S3,C2,C3,C6,...) ESP8266 via UART
goodfet           -- for some MSP430 boards
jlink             -- use Segger's JLinkExe for programming (requires original Segger programmers)
lpc2k_pgm         -- default for lpc23xx boards
mspdebug          -- for MSP430 boards
nrfutil           -- for nRF5x boards with nRF bootloader
openocd           -- use OpenOCD for programming via JTAG/SWD (default for most boards)
pyocd             -- Python based tool and API for debugging, programming, and exploring Arm Cortex microcontrollers
robotis-loader    -- Flash using ROBOTIS Bootloader
stm32flash        -- for STM32 boards via UART bootloader
stm32loader       -- Flash using STM32 Bootloader
uf2conv           -- program via UF2 bootloader (except RP2040)
uniflash          -- for CC13xx / CC26xx boards
```

This should be fixed with this PR.

### Issues/PRs references

None