### PR TITLE
cpu/efm32: implement periph_timer_periodic for series 0/1

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -23,6 +23,10 @@ FEATURES_PROVIDED += periph_rtt_overflow
 FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_wdt
 
+ifneq (,$(filter $(EFM32_SERIES),0 1))
+  FEATURES_PROVIDED += periph_timer_periodic
+endif
+
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware peripheral."
 


### PR DESCRIPTION
### Contribution description

This implements the features `periph_timer_periodic` for EFM32 MCUs of Series 0 and Series 1.

### Testing procedure

```
git:(cpu/efm32/series_0_1/periph_timer_periodic) ~/Repos/software/RIOT/master ➜ make BOARD=e180-zg120b-tb flash test -C tests/periph/timer_periodic   
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/periph/timer_periodic'
Building application "tests_timer_periodic" for "e180-zg120b-tb" with MCU "efm32".

"make" -C /home/maribu/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/master/pkg/gecko_sdk/ 
"make" -C /home/maribu/.cache/RIOT/pkg/gecko_sdk/dist
"make" -C /home/maribu/.cache/RIOT/pkg/gecko_sdk/dist/emlib-extra/src
"make" -C /home/maribu/.cache/RIOT/pkg/gecko_sdk/dist/emlib/src
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/e180-zg120b-tb
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32/families/efr32mg1b
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/efm32/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/fmt
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  16900	   144	  2748	 19792	  4d50	/home/maribu/Repos/software/RIOT/master/tests/periph/timer_periodic/bin/e180-zg120b-tb/tests_timer_periodic.elf
/home/maribu/Repos/software/RIOT/master/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/master/tests/periph/timer_periodic/bin/e180-zg120b-tb/tests_timer_periodic.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-snapshot (2023-06-12-09:31)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 1000 kHz
Info : STLINK V2J29S7 (API v2) VID:PID 0483:3748
Info : Target voltage: 3.229435
Info : [efm32.cpu] Cortex-M4 r0p1 processor detected
Info : [efm32.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for efm32.cpu on 0
Info : Listening on port 41269 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* efm32.cpu          hla_target little efm32.cpu          unknown
[efm32.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0fe10000 msp: 0x20000400
Info : detected part: EFR32MG1B Mighty Gecko, rev 165
Info : flash size = 256 KiB
Info : flash page size = 2048 B
auto erase enabled
wrote 18432 bytes from file /home/maribu/Repos/software/RIOT/master/tests/periph/timer_periodic/bin/e180-zg120b-tb/tests_timer_periodic.elf in 0.669535s (26.884 KiB/s)
verified 17044 bytes in 0.138398s (120.266 KiB/s)
shutdown command invoked
Done flashing
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2024.01-devel-600-gb5cdd-cpu/efm32/series_0_1/periph_timer_periodic)

Running Timer 0 at 250000 Hz.
One counter cycle is 6250 ticks or 25 ms
Will print 'tick' every cycle.

TEST START
Running iteration 1 of 3
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick

Cycles:
channel 0 = 12	[OK]
Running iteration 2 of 3
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick

Cycles:
channel 0 = 12	[OK]
Running iteration 3 of 3
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick
[0] tick

Cycles:
channel 0 = 12	[OK]
TEST SUCCEEDED

make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/periph/timer_periodic'
git:(cpu/efm32/series_0_1/periph_timer_periodic) ~/Repos/software/RIOT/master ➜ echo $?         
0
```

### Issues/PRs references

None
