### PR TITLE
boards/e180-zg120b-tb: Document correct pin mapping

### DIFF
--- a/boards/e180-zg120b-tb/doc.txt
+++ b/boards/e180-zg120b-tb/doc.txt
@@ -35,6 +35,59 @@ peripherals, different energy modes and short wake-up times.
 | Manual        | [Manual](https://www.silabs.com/documents/public/reference-manuals/efr32xg1-rm.pdf)     |
 | Board Manual  | [Board Manual](http://www.ebyte.com/en/downpdf.aspx?id=896)                             |
 
+### Pin Mapping
+
+@warning    At least for revision `10199-V1.0` of the test board most of the
+            silkscreen labels are incorrect.
+
+@note   Everything here assumes the board is oriented so that the USB connector
+        is on the top.
+
+#### Right Header
+
+(Top-left pin is 1, top-right pin is 2, and so on.)
+
+| Description                   | Pin (left)    | Pin (right)   | Description                       |
+|:----------------------------- |:------------- |:------------- |:--------------------------------- |
+| GND                           | 1             | 2             | VCC                               |
+| PB13                          | 3             | 4             | PB12                              |
+| PB11                          | 5             | 6             | PD15                              |
+| NC (pin 8 on E180-ZG120B)     | 7             | 8             | NC (pin 7 on E180-ZG120B)         |
+| PA1                           | 9             | 10            | PA0                               |
+| PD14                          | 11            | 12            | PD13                              |
+| GND                           | 13            | 14            | GND                               |
+
+#### Top Header
+
+(Leftmost pin is 1, second from left is 2, and so on.)
+
+| Description                   | Pin (left to right)   |
+|:----------------------------- |:--------------------- |
+| NC (pin 23 on E180-ZG120B)    | 1                     |
+| NC (pin 22 on E180-ZG120B)    | 2                     |
+| PC11                          | 3                     |
+| NC (pin 20 on E180-ZG120B)    | 4                     |
+| PF2                           | 5                     |
+| PC10                          | 6                     |
+| NC (pin 17 on E180-ZG120B)    | 7                     |
+| NC (pin 16 on E180-ZG120B)    | 8                     |
+| NC (pin 16 on E180-ZG120B)    | 9                     |
+
+#### Left Header
+
+(Top-left pin is 1, top-right pin is 2, and so on.)
+
+| Description                   | Pin (left)    | Pin (right)   | Description                   |
+|:----------------------------- |:------------- |:------------- |:----------------------------- |
+| NC (pin 24 on E180-ZG120B)    | 1             | 2             | SWCLK                         |
+| SWDIO                         | 3             | 4             | PB14                          |
+| PB15                          | 5             | 6             | NC (pin 29 on E180-ZG120B)    |
+| PF3                           | 7             | 8             | NC (pin 31 on E180-ZG120B)    |
+| NC (pin 32 on E180-ZG120)     | 9             | 10            | NC (pin 33 on E180-ZG120B)    |
+| NC (pin 34 on E180-ZG120)     | 11            | 12            | NC (pin 35 on E180-ZG120B)    |
+| GND                           | 13            | 14            | Reset                         |
+
+
 ### Peripheral mapping
 | Peripheral | Number  | Hardware        | Pins                        | Comments                                            |
 |------------|---------|-----------------|-----------------------------|-----------------------------------------------------|


### PR DESCRIPTION
### Contribution description

Revision 1.0 of the board has an incorrect pin labeling on the silkscreen, presumably because the board was initially developed for a different E180 module and the silkscreen was not updated when populated with a different E180 module.

It is very likely that if newer revisions of the test board get produced, they will use the same very systematical routing as revision 1.0 and only the silkscreen labeling will be fixed. Hence, documenting the correct pin mapping will be useful even for newer revisions.

### Testing procedure

The pins on the header not routed to an NC pin on the module can be identified using https://github.com/RIOT-OS/RIOT/pull/20253 and the remaining can be traced with a multi-meter.

Note: The routing is pretty systematically and the pattern is quite obvious (only pin 1, the ANT pin, is not routed). This is how the module pins are routed to the header pins:


```
       23 | 22 | 21 | 20 | 19 | 18 | 17 | 16 | 16

24 | 25                                           14 | 13
26 | 27                                           12 | 11
28 | 29                                           10 | 9
30 | 31                                           8  | 7
32 | 33                                           6  | 5
34 | 35                                           4  | 3
36 | 37                                           2  | 2
```

With [the datasheet of the E180-ZG120B](https://www.ebyte.com/en/downpdf.aspx?id=842) module the pin mapping can therefore be easily checked.

### Issues/PRs references

Found while trying to understand why https://github.com/RIOT-OS/RIOT/pull/20236 didn't pass on this board. (Because I connected two pairs of GPIOs based on the incorrect silkscreen labels.)