### PR TITLE
boards/native: only use pyterm wrapper with term target

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -10,6 +10,11 @@ else
   DEBUGGER ?= gdb
 endif
 
+# only use pyterm wrapper if term target is requested
+ifeq (,$(filter term,$(MAKECMDGOALS)))
+  RIOT_TERMINAL ?= native
+endif
+
 RESET ?= $(RIOTBOARD)/native/dist/reset.sh
 FLASHER ?=
 FLASHFILE ?= $(ELFFILE)

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -13,24 +13,36 @@ endif
 # only use pyterm wrapper if term target is requested
 ifeq (,$(filter term,$(MAKECMDGOALS)))
   RIOT_TERMINAL ?= native
+else
+  RIOT_TERMINAL ?= pyterm
 endif
 
 RESET ?= $(RIOTBOARD)/native/dist/reset.sh
 FLASHER ?=
 FLASHFILE ?= $(ELFFILE)
 
-ifeq (native,$(RIOT_TERMINAL))
-  TERMPROG ?= $(FLASHFILE)
-else
+ifeq (pyterm,$(RIOT_TERMINAL))
   TERMFLAGS += -ps $(FLASHFILE)
-  ifeq (1,$(USE_ZEP))
-    ZEP_IP ?= [::1]
-    ZEP_PORT_BASE ?= 17754
-    TERMFLAGS += --process-args '-z $(ZEP_IP):$(ZEP_PORT_BASE)'
-  endif
-  ifneq (,$(ZEP_MAC))
-    TERMFLAGS += --process-args '\-\-eui64=$(ZEP_MAC)'
-  endif
+  PROCARGS := --process-args
+else
+  TERMPROG ?= $(FLASHFILE)
+endif
+
+ZEP_IP ?= [::1]
+ZEP_PORT_BASE ?= 17754
+ifeq (1,$(USE_ZEP))
+ifeq (pyterm,$(RIOT_TERMINAL))
+  TERMFLAGS += --process-args '-z $(ZEP_IP):$(ZEP_PORT_BASE)'
+else
+  TERMFLAGS += -z $(ZEP_IP):$(ZEP_PORT_BASE)
+endif
+endif
+ifneq (,$(ZEP_MAC))
+ifeq (pyterm,$(RIOT_TERMINAL))
+  TERMFLAGS += --process-args '\-\-eui64=$(ZEP_MAC)'
+else
+  TERMFLAGS += --eui64=$(ZEP_MAC)
+endif
 endif
 
 export VALGRIND ?= valgrind
@@ -106,12 +118,7 @@ LINKFLAGS += -ffunction-sections
 
 # set the tap interface for term/valgrind
 PORT ?= tap0
-
-ifeq (native,$(RIOT_TERMINAL))
-  TERMFLAGS += $(PORT)
-else
-  TERMFLAGS += --process-args $(PORT)
-endif
+TERMFLAGS += $(PROCARGS) $(PORT)
 
 # Configure default eeprom file
 EEPROM_FILE ?= $(BINDIR)/native.eeprom
@@ -119,10 +126,10 @@ EEPROM_FILE ?= $(BINDIR)/native.eeprom
 # set the eeprom file flags only when the periph_eeprom feature is used.
 ifneq (,$(filter periph_eeprom,$(FEATURES_USED)))
   EEPROM_FILE_FLAGS = --eeprom $(EEPROM_FILE)
-  ifeq (native,$(RIOT_TERMINAL))
-    TERMFLAGS += $(EEPROM_FILE_FLAGS)
-  else
+  ifeq (pyterm,$(RIOT_TERMINAL))
     TERMFLAGS += --process-args '$(EEPROM_FILE_FLAGS)'
+  else
+    TERMFLAGS += $(EEPROM_FILE_FLAGS)
   endif
 endif
 

--- a/dist/pythonlibs/riotctrl_ctrl/native.py
+++ b/dist/pythonlibs/riotctrl_ctrl/native.py
@@ -27,6 +27,5 @@ class NativeRIOTCtrl(riotctrl.ctrl.RIOTCtrl):
     def start_term(self, *args, **kwargs):
         super().start_term(*args, **kwargs)
         for child in psutil.Process(pid=self._term_pid()).children():
-            for grandchild in child.children():
-                if self._set_debug_adapter_id(grandchild):
-                    break
+            if self._set_debug_adapter_id(child):
+                break

--- a/dist/pythonlibs/riotctrl_ctrl/requirements.txt
+++ b/dist/pythonlibs/riotctrl_ctrl/requirements.txt
@@ -1,3 +1,2 @@
 psutil
-pyserial
 riotctrl

--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -22,10 +22,6 @@ TEST_DEPS += $(TERMDEPS)
 TEST_EXECUTOR ?=
 TEST_EXECUTOR_FLAGS ?=
 
-ifeq (native, $(BOARD))
-  TEST_EXECUTOR := RIOT_TERMINAL=native $(TEST_EXECUTOR)
-endif
-
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$(TEST_EXECUTOR) $(TEST_EXECUTOR_FLAGS) $$t || exit 1; \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Only enable the pyterm wrapper if we are executing the `term` target to avoid breaking things.


### Testing procedure

`make debug` should work again on `native`.
So does e.g. `tests/sys/log_color` without the previously added workaround.


### Issues/PRs references

reverts #20215
fixes #20265
