### PR TITLE
nanocoap_sock: implement separate response

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -47,6 +47,13 @@ endif
 HIGH_MEMORY_BOARDS := native same54-xpro mcb2388
 
 ifneq (,$(filter $(BOARD),$(HIGH_MEMORY_BOARDS)))
+  # enable separate response
+  USEMODULE += nanocoap_server_separate
+  USEMODULE += event_callback
+  USEMODULE += event_thread
+  USEMODULE += event_timeout_ztimer
+
+  # enable fileserver
   USEMODULE += nanocoap_fileserver
   USEMODULE += vfs_default
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -544,6 +544,11 @@ ifneq (,$(filter nanocoap_server_auto_init,$(USEMODULE)))
   USEMODULE += nanocoap_server
 endif
 
+ifneq (,$(filter nanocoap_server_separate,$(USEMODULE)))
+  USEMODULE += nanocoap_server
+  USEMODULE += sock_aux_local
+endif
+
 ifneq (,$(filter nanocoap_server,$(USEMODULE)))
   USEMODULE += nanocoap_resources
   USEMODULE += nanocoap_sock

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -115,6 +115,11 @@ void event_timeout_clear(event_timeout_t *event_timeout);
  */
 static inline bool event_timeout_is_pending(const event_timeout_t *event_timeout)
 {
+    if (event_timeout->clock == NULL || event_timeout->queue == NULL ||
+        event_timeout->event == NULL) {
+        return false;
+    }
+
     return ztimer_is_set(event_timeout->clock, &event_timeout->timer)
         || event_is_queued(event_timeout->queue, event_timeout->event);
 }

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1957,6 +1957,22 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
                          uint8_t *rbuf, unsigned rlen, unsigned payload_len);
 
 /**
+ * @brief   Build empty reply to CoAP request
+ *
+ * This function can be used to create an empty ACK so that a later, separate
+ * response can be sent independently.
+ *
+ * If the request was non-confirmable, this will generate nothing.
+ *
+ * @param[in]   pkt         packet to reply to
+ * @param[out]  ack         buffer to write reply to
+ *
+ * @returns     size of reply packet on success
+ * @returns     -ENOSPC if @p rbuf too small
+ */
+ssize_t coap_build_empty_ack(coap_pkt_t *pkt, coap_hdr_t *ack);
+
+/**
  * @brief   Handle incoming CoAP request
  *
  * This function will find the correct handler, call it and write the reply

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1922,7 +1922,7 @@ ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,
  *
  * @returns      length of resulting header
  */
-ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token,
+ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, const void *token,
                        size_t token_len, unsigned code, uint16_t id);
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -338,6 +338,9 @@ void coap_request_ctx_init(coap_request_ctx_t *ctx, sock_udp_ep_t *remote);
 struct _coap_request_ctx {
     const coap_resource_t *resource;    /**< resource of the request */
     sock_udp_ep_t *remote;              /**< remote endpoint of the request */
+#if defined(MODULE_SOCK_AUX_LOCAL) || DOXYGEN
+    sock_udp_ep_t *local;               /**< local endpoint of the request */
+#endif
 #if defined(MODULE_GCOAP) || DOXYGEN
     /**
      * @brief   transport the packet was received over

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -210,6 +210,55 @@ typedef struct {
 } coap_block_request_t;
 
 /**
+ * @brief   Context from CoAP request for separate response
+ */
+typedef struct {
+    sock_udp_ep_t remote;           /**< remote to send response to         */
+#if defined(MODULE_SOCK_AUX_LOCAL) || DOXYGEN
+    sock_udp_ep_t local;            /**< local from which to send response  */
+#endif
+    uint8_t token[COAP_TOKEN_LENGTH_MAX];   /**< request token              */
+    uint8_t tkl;                    /**< request token length               */
+    uint8_t no_response;            /**< no-response bitmap                 */
+} nanocoap_server_response_ctx_t;
+
+/**
+ * @brief   Prepare the context for a separate response
+ *
+ * This function serializes the CoAP request information so that
+ * a separate response can be generated outside the CoAP handler.
+ *
+ * The CoAP handler should then respond with an empty ACK by calling
+ * @ref coap_build_empty_ack
+ *
+ * @param[out]  ctx     Context information for separate response
+ * @param[in]   pkt     CoAP packet to which the response will be generated
+ * @param[in]   req     Context of the CoAP request
+ */
+void nanocoap_server_prepare_separate(nanocoap_server_response_ctx_t *ctx,
+                                      coap_pkt_t *pkt, const coap_request_ctx_t *req);
+
+/**
+ * @brief   Send a separate response to a CoAP request
+ *
+ *  This sends a response to a CoAP request outside the CoAP handler
+ *
+ * @pre     @ref nanocoap_server_prepare_separate has been called on @p ctx
+ *          inside the CoAP handler
+ *
+ * @param[in]   ctx     Context information for the CoAP response
+ * @param[in]   code    CoAP response code
+ * @param[in]   type    Response type, may be `COAP_TYPE_NON`
+ * @param[in]   payload Response payload
+ * @param[in]   len     Payload length
+ *
+ * @returns     0 on success
+ *              negative error (see @ref sock_udp_sendv_aux)
+ */
+int nanocoap_server_send_separate(const nanocoap_server_response_ctx_t *ctx,
+                                  unsigned code, unsigned type,
+                                  const void *payload, size_t len);
+/**
  * @brief   Get next consecutive message ID for use when building a new
  *          CoAP request.
  *

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -675,9 +675,6 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
 
     coap_build_hdr((coap_hdr_t *)rbuf, type, coap_get_token(pkt), tkl, code,
                    ntohs(pkt->hdr->id));
-    coap_hdr_set_type((coap_hdr_t *)rbuf, type);
-    coap_hdr_set_code((coap_hdr_t *)rbuf, code);
-
     len += payload_len;
 
     return len;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -683,7 +683,7 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
     return len;
 }
 
-ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token,
+ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, const void *token,
                        size_t token_len, unsigned code, uint16_t id)
 {
     assert(!(type & ~0x3));

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -626,6 +626,18 @@ ssize_t coap_reply_simple(coap_pkt_t *pkt,
     return header_len + payload_len;
 }
 
+ssize_t coap_build_empty_ack(coap_pkt_t *pkt, coap_hdr_t *ack)
+{
+    if (coap_get_type(pkt) != COAP_TYPE_CON) {
+        return 0;
+    }
+
+    coap_build_hdr(ack, COAP_TYPE_ACK, NULL, 0,
+                   COAP_CODE_EMPTY, ntohs(pkt->hdr->id));
+
+    return sizeof(*ack);
+}
+
 ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
                          uint8_t *rbuf, unsigned rlen, unsigned payload_len)
 {

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -789,7 +789,7 @@ ssize_t nanocoap_get_blockwise_url_to_buf(const char *url,
 
 int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
 {
-    nanocoap_sock_t sock;
+    sock_udp_t sock;
     sock_udp_ep_t remote;
     coap_request_ctx_t ctx = {
         .remote = &remote,
@@ -799,7 +799,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
         local->port = COAP_PORT;
     }
 
-    ssize_t res = sock_udp_create(&sock.udp, local, NULL, 0);
+    ssize_t res = sock_udp_create(&sock, local, NULL, 0);
     if (res != 0) {
         return -1;
     }
@@ -814,7 +814,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
         aux_in_ptr = &aux_in;
 #endif
 
-        res = sock_udp_recv_aux(&sock.udp, buf, bufsize, SOCK_NO_TIMEOUT,
+        res = sock_udp_recv_aux(&sock, buf, bufsize, SOCK_NO_TIMEOUT,
                                 &remote, aux_in_ptr);
         if (res <= 0) {
             DEBUG("nanocoap: error receiving UDP packet %" PRIdSIZE "\n", res);
@@ -844,7 +844,7 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
             continue;
         }
 
-        sock_udp_send_aux(&sock.udp, buf, res, &remote, aux_out_ptr);
+        sock_udp_send_aux(&sock, buf, res, &remote, aux_out_ptr);
     }
 
     return 0;

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -825,10 +825,6 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
             DEBUG("nanocoap: error parsing packet\n");
             continue;
         }
-        if ((res = coap_handle_req(&pkt, buf, bufsize, &ctx)) <= 0) {
-            DEBUG("nanocoap: error handling request %" PRIdSIZE "\n", res);
-            continue;
-        }
 
         sock_udp_aux_tx_t *aux_out_ptr = NULL;
 #ifdef MODULE_SOCK_AUX_LOCAL
@@ -841,7 +837,13 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
         if (!sock_udp_ep_is_multicast(&aux_in.local)) {
             aux_out_ptr = &aux_out;
         }
+        ctx.local = &aux_in.local;
 #endif
+        if ((res = coap_handle_req(&pkt, buf, bufsize, &ctx)) <= 0) {
+            DEBUG("nanocoap: error handling request %" PRIdSIZE "\n", res);
+            continue;
+        }
+
         sock_udp_send_aux(&sock.udp, buf, res, &remote, aux_out_ptr);
     }
 

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -423,6 +423,7 @@ ssize_t sock_udp_sendv_aux(sock_udp_t *sock,
     if ((aux != NULL) && (aux->flags & SOCK_AUX_SET_LOCAL)) {
         local.family = aux->local.family;
         local.netif = aux->local.netif;
+        src_port = aux->local.port;
         memcpy(&local.addr, &aux->local.addr, sizeof(local.addr));
 
         aux->flags &= ~SOCK_AUX_SET_LOCAL;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the capability to `nanocoap_server` to send separate response, that is a delayed response outside the CoAP handler.
The CoAP handler will first send an empty ACK (if the request was conformable), then some other function can send the actual response at a later time, using `nanocoap_sock_send_separate()` with the request context information serialized into `nanocoap_sock_response_ctx_t`.


### Testing procedure

A `/separate` endpoint was added to `examples/nanocoap_server`:

```
$ aiocoap-client coap://[fe80::748f:e6ff:fed7:426d%tapbr0]/separate
This is a delayed response.
```

```
2024-01-16 19:47:29,617 # main(): This is RIOT! (Version: 2024.01-devel-601-gbd62d-nanocoap_reply_separate)
2024-01-16 19:47:29,618 # RIOT nanocoap example application
2024-01-16 19:47:29,618 # Waiting for address autoconfiguration...
2024-01-16 19:47:31,616 # {"IPv6 addresses": ["fe80::748f:e6ff:fed7:426d"]}
2024-01-16 19:47:33,248 # _separate_handler(): send ACK, schedule response
2024-01-16 19:47:34,248 # _separate_handler(): send delayed response
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
