### PR TITLE
ci: fix murdock tests after dwq change

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -415,24 +415,23 @@ test_job() {
     local board=$(echo $2 | cut -f 1 -d':')
     local toolchain=$(echo $2 | cut -f 2 -d':')
 
+    # this points to the dwq checkout root folder
+    local basedir="$(pwd)"
+
     # interpret any extra arguments as file names.
     # They will be sent along with the job to the test worker
     # and stored in the application's binary folder.
     shift 2
     local files=""
     for filename in "$@"; do
-        # check if the file is within $(BINDIR)
-        if startswith "${BINDIR}" "${filename}"; then
-          # get relative (to $(BINDIR) path
-          local relpath="$(realpath --relative-to ${BINDIR} ${filename})"
+        # check if the file is within $(basedir)
+        if startswith "${basedir}" "${filename}"; then
+            filename="$(realpath --relative-to ${basedir} ${filename})"
         else
-          error "$0: error: extra test files not within \${BINDIR}!"
+          error "$0: error: extra test files not within \${basedir}!"
         fi
 
-        # set remote file path.
-        # currently, the test workers build in the default build path.
-        local remote_bindir="${appdir}/bin/${board}"
-        files="${files} --file ${filename}:${remote_bindir}/${relpath}"
+        files="${files} --file ${filename}"
     done
 
     dwqc \
@@ -448,6 +447,10 @@ run_test() {
     local appdir=$1
     local board=$(echo $2 | cut -f 1 -d':')
     local toolchain=$(echo $2 | cut -f 2 -d':')
+
+    # set build directory to match the builder
+    export BINDIR="$(pwd)/build"
+
     print_worker
     echo "-- executing tests for $appdir on $board (compiled with $toolchain toolchain):"
     hook run_test_pre

--- a/.murdock
+++ b/.murdock
@@ -454,6 +454,10 @@ run_test() {
 
     # do flashing and building of termdeps simultaneously
     BOARD=$board TOOLCHAIN=${toolchain} make -C$appdir flash-only termdeps -j2
+    RES=$?
+    if [ $RES -ne 0 ]; then
+        error "- flashing failed!"
+    fi
 
     # now run the actual test
     if is_in_list "${appdir}" "${TEST_WITH_CONFIG_SUPPORTED}"; then


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With https://github.com/RIOT-OS/riotdocker/pull/237 I broke murdock tests on the pifleet. This should fix them.

*edit*

So what happened here is that dwq dropped support for specifying the target path of a file sent along with a job.
That feature might come back.

In the meantime, this PR makes BINDIR match on compiler (mobi*, breeze, ...) and tester (pifleet).

(I've piggybacked a commit that makes the tester fail early if flashing returned an error code.)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
