### PR TITLE
ci: make native tests show up in "tests"

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -383,8 +383,20 @@ compile() {
         if [ $RUN_TESTS -eq 1 -o "$board" = "native" -o "$EMULATED" = "1" ]; then
             if [ -f "${BINDIR}/.test" ]; then
                 if [ "$board" = "native" -o "${EMULATED}" = "1" ]; then
-                    EMULATE=${EMULATED} BOARD=$board make -C${appdir} test
-                    RES=$?
+                    # For native, we can run the test on the worker that also
+                    # compiled it (`make -C${appdir} test`).
+                    # "dwq-localjob" allows using some (locally run) command's
+                    # output as if it was its own CI job.
+                    # We use this here so the output shows up in the Murdock UI
+                    # under the "Tests" tab and not inlined with the "Build"
+                    # output.
+                    # "--command-override" is a hack that makes the job fake the
+                    # command. This is currently needed for the Murdock UI to
+                    # properly categorize the job result.
+                    EMULATE=${EMULATED} BOARD=$board TOOLCHAIN=$toolchain \
+                        dwq-localjob \
+                        --command-override "./.murdock run_test ${appdir} ${board}:${toolchain}" \
+                        -- make -C${appdir} test
                 elif is_in_list "$board" "$TEST_BOARDS_AVAILABLE"; then
                     echo "-- test_hash=$test_hash"
                     if test_cache_get $test_hash; then


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR makes .murdock make use of the newly introduced `dwq-localjob`, which allows injecting command output as if it were run as ci (dwq) job. "native" tests should now end up in the "test" tab in the CI results, instead of being inlined in the compilation output.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
