### PR TITLE
boards/gd32vf103c-start: new board 

### DIFF
--- a/boards/common/gd32v/Makefile.include
+++ b/boards/common/gd32v/Makefile.include
@@ -7,7 +7,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
 # configure the flasher
 PROGRAMMER ?= openocd
-OPENOCD_CONFIG ?= $(RIOTBOARD)/common/gd32v/dist/openocd.cfg
 OPENOCD_DEBUG_ADAPTER ?= ftdi
 OPENOCD_FTDI_ADAPTER ?= openocd-usb
 OPENOCD_TRANSPORT ?= jtag

--- a/boards/common/gd32v/Makefile.include
+++ b/boards/common/gd32v/Makefile.include
@@ -10,7 +10,7 @@ PROGRAMMER ?= openocd
 OPENOCD_CONFIG ?= $(RIOTBOARD)/common/gd32v/dist/openocd.cfg
 OPENOCD_DEBUG_ADAPTER ?= ftdi
 OPENOCD_FTDI_ADAPTER ?= openocd-usb
-OPENOCD_TRANSPORT = jtag
+OPENOCD_TRANSPORT ?= jtag
 OPENOCD_RESET_USE_CONNECT_ASSERT_SRST = 1
 
 # DFU programmer specific variables

--- a/boards/common/gd32v/include/cfg_usbdev_default.h
+++ b/boards/common/gd32v/include/cfg_usbdev_default.h
@@ -44,8 +44,8 @@ static const dwc2_usb_otg_fshs_config_t dwc2_usb_otg_fshs_config[] = {
         .type     = DWC2_USB_OTG_FS,
         .phy      = DWC2_USB_OTG_PHY_BUILTIN,
         .rcu_mask = RCU_AHBEN_USBFSEN_Msk,
-        .bus      = AHB,
         .irqn     = USBFS_IRQn,
+        .bus      = AHB,
     }
 };
 

--- a/boards/gd32vf103c-start/Makefile
+++ b/boards/gd32vf103c-start/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/gd32vf103c-start/Makefile.dep
+++ b/boards/gd32vf103c-start/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/gd32v/Makefile.dep

--- a/boards/gd32vf103c-start/Makefile.features
+++ b/boards/gd32vf103c-start/Makefile.features
@@ -1,0 +1,24 @@
+CPU_MODEL = gd32vf103cbt6
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += sdcard_spi
+
+# Other features provided by the board (in alphabetical order)
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_pwm
+FEATURES_PROVIDED += arduino_shield_uno
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += tinyusb_device
+
+include $(RIOTBOARD)/common/gd32v/Makefile.features

--- a/boards/gd32vf103c-start/Makefile.include
+++ b/boards/gd32vf103c-start/Makefile.include
@@ -1,0 +1,10 @@
+PORT_LINUX ?= /dev/ttyACM0
+PROGRAMMER ?= openocd
+OPENOCD_DEBUG_ADAPTER ?= dap
+OPENOCD_TRANSPORT := default
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ch341' --model 'USB2.0-Serial'
+
+include $(RIOTBOARD)/common/gd32v/Makefile.include

--- a/boards/gd32vf103c-start/dist/openocd.cfg
+++ b/boards/gd32vf103c-start/dist/openocd.cfg
@@ -1,0 +1,2 @@
+adapter speed 10000
+source [find target/gd32vf103.cfg]

--- a/boards/gd32vf103c-start/doc.txt
+++ b/boards/gd32vf103c-start/doc.txt
@@ -1,0 +1,103 @@
+/**
+@defgroup   boards_gd32vf103c_start GD32VF103C-START
+@ingroup    boards
+@brief      Support for the GD32VF103C-START board
+@author     Marian Buschsieweke
+
+## Overview
+
+The GD32VF103C-START development board is an official starter kit by GigaDevice
+for the GD32VF103CBT6 MCU, despite the lack of official documentation. It
+featrures:
+
+- GD32VF103CBT6 RISC-V MCU @108MHz
+- On-Board GD-Link Programmer/Debugger (middle mini-USB connector)
+- USB-OTG (left mini-USB connector)
+- Integrated USB to UART bridge (right mini-USB connector)
+- 1 user LED
+- 1 user Button
+- 1 reset button
+- Arduino UNO compatible pin headers (except ISP header)
+
+![Image of the GD32VF103C-START board](https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/a0ac2faf9bde45b176f1e8b315ffb1b8a9096166/boards/riscv/gd32vf103c_starter/doc/img/gd32vf103c_starter.jpg)
+
+@warning    The analog pins are labeled A1 - A6 rather than A0 - A5, as would
+            be the correct Arduino naming. The Arduino pin mapping uses the
+            correct Arduino naming, so that apps written for other boards
+            expecting Arduino UNO compatible shields remain compatible.
+
+## Hardware
+
+| MCU               | GD32VF103CBT6                             | Supported |
+|:----------------- |:----------------------------------------- | --------- |
+| Family            | RISC-V with ECLIC                         |           |
+| Vendor            | GigaDevice                                |           |
+| RAM               | 32 KiB                                    |           |
+| Flash             | 128 KiB                                   |           |
+| Frequency         | 108 MHz                                   |           |
+| Power Modes       | 3 (Sleep, Deep Sleep, Standby)            |   yes     |
+| GPIOs             | 37                                        |   yes     |
+| Timers            | 5 x 16-bit timer                          |   yes     |
+| RTC               | 1 x 32-bit counter, 20-bit prescaler      |   yes     |
+| WDT               | 2 x 12-bit counter, 3-bit prescaler       |   yes     |
+| ADC               | 2 x 12-bit units, 16 channels @ 1 Msps    |   yes     |
+| DAC               | 2 x 12-bit channel                        |   yes     |
+| UART              | -                                         |   yes     |
+| USART             | 3                                         |   yes     |
+| SPI               | 3                                         |   yes     |
+| I2C               | 2 x Fast Mode 400 kHz                     |   yes     |
+| I2S               | 2                                         |   no      |
+| CAN               | 2 x CAN 2.0B with up to 1 Mbps            |   no      |
+| PWM               | 6 Channels                                |   yes     |
+| USB               | 1 x USB FS OTG (+ GD-Link + UART bridge)  |   yes     |
+| Vcc               | 3.0V - 3.6V                               |           |
+| Datasheet         | [Datasheet][gd32vf103c-datasheet]         |           |
+| User Manual       | [User Manual][gd32vf103c-manual]          |           |
+| Board Manual      | [Board Manual][gd32vf103c-board-manual]   |           |
+
+[gd32vf103c-datasheet]: https://web.archive.org/web/20240117072854/https://gd32mcu.com/data/documents/datasheet/GD32VF103_Datasheet_Rev1.6.pdf
+[gd32vf103c-manual]: https://web.archive.org/web/20240117073025/https://gd32mcu.com/data/documents/userManual/GD32VF103_User_Manual_Rev1.5.pdf
+[gd32vf103c-board-manual]: https://web.archive.org/web/20240117072723/https://en.maritex.com.pl/product/attachment/154626/6f28fdabafb9dff852537ced7bc0aa71
+
+## Flashing
+
+@warning    Flashing seems to fail with some Arduino UNO compatible boards
+            attached. Remove them and try again.
+
+By default, flashing is done via OpenOCD using the GD-Link programmer/debugger
+using:
+
+```
+make BOARD=gd32vf103c-start -C path/to/app flash
+```
+
+It is also possible to flash via DFU-Util:
+
+1. Connect a mini USB cable to the USB connector labeled OTG.
+2. Power the board (e.g. by connecting a second mini USB cable to the GD-Link
+   programmer/debugger, even though we won't use it)
+3. Enter the DFU bootloader by placing the jumper on JP4 (below BOOT) in
+   position H. Press the reset button afterwards.
+4. Run `make BOARD=gd32vf103c-start PROGRAMMER=dfu-util -C path/to/app flash`
+5. Restore the JP4 jumper to position L. Afterwards press the reset button
+   again
+
+## Connecting to the Serial Output
+
+By default RIOT's uses UART for `stdio`. To access that, connect a mini USB
+cable to the connector labeled "USART". In addition a jumper needs to be
+placed on JP2 in the "Usart" position; otherwise RIOT's TXD is not connected
+to the RXD of the integrated USB UART bridge. Afterwards just run:
+
+```
+make BOARD=gd32vf103c-start -C path/to/app term
+```
+
+Alternatively, `stdio_cdc_acm` can be used. In this case the mini USB cable
+needs to be connected to the USB connector labeled OTG.
+
+@note   It is safe to keep the jumper at JP2 in "Usart" position or even
+        remove the jumper with RIOT. PA9 is still used as UART/TXD and VBUS
+        sensing is disabled anyway.
+
+ */

--- a/boards/gd32vf103c-start/include/arduino_iomap.h
+++ b/boards/gd32vf103c-start/include/arduino_iomap.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_gd32vf103c_start
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef ARDUINO_IOMAP_H
+#define ARDUINO_IOMAP_H
+
+#include "macros/units.h"
+#include "periph/adc.h"
+#include "periph/gpio.h"
+#include "periph/pwm.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Arduino's UART devices
+ * @{
+ */
+#define ARDUINO_UART_D0D1       UART_DEV(0)
+/** @} */
+
+/**
+ * @name    Arduino's SPI buses
+ * @{
+ */
+/**
+ * @brief   SPI_DEV(0) is connected to D11/D12/D13
+ */
+#define ARDUINO_SPI_D11D12D13       SPI_DEV(0)
+/** @} */
+
+/**
+ * @name    Arduino's I2C buses
+ * @{
+ */
+/**
+ * @brief   The first I2C bus is where shields for the Arduino UNO expect it
+ */
+#define ARDUINO_I2C_UNO             I2C_DEV(0)
+/** @} */
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0               GPIO_PIN(PORT_A, 10)
+#define ARDUINO_PIN_1               GPIO_PIN(PORT_A, 9)
+#define ARDUINO_PIN_2               GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_3               GPIO_PIN(PORT_B, 5)
+#define ARDUINO_PIN_4               GPIO_PIN(PORT_B, 6)
+#define ARDUINO_PIN_5               GPIO_PIN(PORT_B, 7)
+#define ARDUINO_PIN_6               GPIO_PIN(PORT_B, 8)
+#define ARDUINO_PIN_7               GPIO_PIN(PORT_B, 9)
+
+#define ARDUINO_PIN_8               GPIO_PIN(PORT_B, 1)
+#define ARDUINO_PIN_9               GPIO_PIN(PORT_B, 0)
+#define ARDUINO_PIN_10              GPIO_PIN(PORT_B, 12)
+#define ARDUINO_PIN_11              GPIO_PIN(PORT_B, 15)
+#define ARDUINO_PIN_12              GPIO_PIN(PORT_B, 14)
+#define ARDUINO_PIN_13              GPIO_PIN(PORT_B, 13)
+#define ARDUINO_PIN_14              GPIO_PIN(PORT_B, 11)
+#define ARDUINO_PIN_15              GPIO_PIN(PORT_B, 10)
+
+#define ARDUINO_PIN_16              GPIO_PIN(PORT_A, 1)
+#define ARDUINO_PIN_17              GPIO_PIN(PORT_A, 2)
+#define ARDUINO_PIN_18              GPIO_PIN(PORT_A, 3)
+#define ARDUINO_PIN_19              GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_20              GPIO_PIN(PORT_C, 5)
+#define ARDUINO_PIN_21              GPIO_PIN(PORT_C, 6)
+
+#define ARDUINO_PIN_LAST            21
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @warning Silkscreen label is A1 - A6 instead of A0 - A5. We stick with
+ *          Arduino UNO labeling here so that e.g. board independent drivers
+ *          for shields can be provided.
+ * @{
+ */
+#define ARDUINO_PIN_A0              ARDUINO_PIN_16
+#define ARDUINO_PIN_A1              ARDUINO_PIN_17
+#define ARDUINO_PIN_A2              ARDUINO_PIN_18
+#define ARDUINO_PIN_A3              ARDUINO_PIN_19
+#define ARDUINO_PIN_A4              ARDUINO_PIN_20
+#define ARDUINO_PIN_A5              ARDUINO_PIN_21
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0                  ADC_LINE(0)
+#define ARDUINO_A1                  ADC_LINE(1)
+#define ARDUINO_A2                  ADC_LINE(2)
+#define ARDUINO_A3                  ADC_LINE(3)
+#define ARDUINO_A4                  ADC_LINE(4)
+#define ARDUINO_A5                  ADC_LINE(5)
+
+#define ARDUINO_ANALOG_PIN_LAST 5
+/** @} */
+
+/**
+ * @name    Mapping of Arduino pins to RIOT PWM dev and channel pairs
+ * @{
+ */
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU           KHZ(100)
+
+#define ARDUINO_PIN_3_PWM_DEV       PWM_DEV(0)
+#define ARDUINO_PIN_3_PWM_CHAN      0
+
+#define ARDUINO_PIN_5_PWM_DEV       PWM_DEV(1)
+#define ARDUINO_PIN_5_PWM_CHAN      0
+
+#define ARDUINO_PIN_6_PWM_DEV       PWM_DEV(1)
+#define ARDUINO_PIN_6_PWM_CHAN      1
+
+#define ARDUINO_PIN_9_PWM_DEV       PWM_DEV(0)
+#define ARDUINO_PIN_9_PWM_CHAN      1
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_IOMAP_H */
+/** @} */

--- a/boards/gd32vf103c-start/include/board.h
+++ b/boards/gd32vf103c-start/include/board.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_gd32vf103c_start
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the GD32VF103C-START board
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_A, 0)
+#define BTN0_MODE           GPIO_IN_PU
+#define BTN0_INT_FLANK      GPIO_FALLING
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_A, 7)
+#define LED0_MASK           (1 << 7)
+#define LED0_ON             (GPIOA->BC = LED0_MASK)
+#define LED0_OFF            (GPIOA->BOP = LED0_MASK)
+#define LED0_TOGGLE         (GPIOA->OCTL ^= LED0_MASK)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/gd32vf103c-start/include/gpio_params.h
+++ b/boards/gd32vf103c-start/include/gpio_params.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_gd32vf103c_start
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED/Button SAUL configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "Wakeup",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+    },
+    {
+        .name  = "LED0",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/gd32vf103c-start/include/periph_conf.h
+++ b/boards/gd32vf103c-start/include/periph_conf.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2023 Gunar Schorcht <gunar@schorcht.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_gd32vf103c_start
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the GD32VF103C-START board
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "macros/units.h"
+
+#ifndef CONFIG_BOARD_HAS_HXTAL
+#define CONFIG_BOARD_HAS_HXTAL  1   /**< The board provides a high frequency oscillator. */
+#endif
+
+#ifndef CONFIG_BOARD_HAS_LXTAL
+#define CONFIG_BOARD_HAS_LXTAL  1   /**< The board provides a low frequency oscillator. */
+#endif
+
+#ifndef CONFIG_CLOCK_HXTAL
+#define CONFIG_CLOCK_HXTAL      MHZ(8)      /**< HXTAL frequency */
+#endif
+
+#ifndef I2C_DEV_1_USED
+#define I2C_DEV_1_USED          1   /**< Enable I2C_DEV(1) by default */
+#endif
+
+#include "periph_cpu.h"
+#include "periph_common_conf.h"
+
+#include "cfg_spi_default.h"
+#include "cfg_uart_default.h"
+#include "cfg_usbdev_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ /**
+ * @name    I2C configuration
+ *
+ * @note    This board may require external pullup resistors for i2c operation.
+ * @{
+ */
+
+/**
+ * @brief   PB10/PB11 (D15/D14) as I2C for Arduino UNO compatibility
+ *
+ * PB10/PB11 are located where Arduino UNO shields expect I2C.
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 10),
+        .sda_pin        = GPIO_PIN(PORT_B, 11),
+        .rcu_mask       = RCU_APB1EN_I2C1EN_Msk,
+        .irqn           = I2C1_EV_IRQn,
+    }
+};
+
+#define I2C_NUMOF   ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan = 1 },
+    { .pin = GPIO_PIN(PORT_A, 2), .dev = 0, .chan = 2 },
+    { .pin = GPIO_PIN(PORT_A, 3), .dev = 0, .chan = 3 },
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
+    { .pin = GPIO_PIN(PORT_A, 5), .dev = 0, .chan = 5 },
+    { .pin = GPIO_PIN(PORT_A, 6), .dev = 0, .chan = 6 },
+    /* ADC Temperature channel */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },
+    /* ADC VREF channel */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 17 },
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIMER0,
+        .max      = 0x0000ffff,
+        .rcu_mask = RCU_APB2EN_TIMER0EN_Msk,
+        .bus      = APB2,
+        .irqn     = TIMER0_Channel_IRQn
+    },
+    {
+        .dev      = TIMER1,
+        .max      = 0x0000ffff,
+        .rcu_mask = RCU_APB1EN_TIMER1EN_Msk,
+        .bus      = APB1,
+        .irqn     = TIMER1_IRQn
+    },
+    /* TIMER2 and TIMER3 are used for PWM pins */
+    {
+        .dev      = TIMER4,
+        .max      = 0x0000ffff,
+        .rcu_mask = RCU_APB1EN_TIMER4EN_Msk,
+        .bus      = APB1,
+        .irqn     = TIMER4_IRQn
+    }
+};
+
+#define TIMER_0_IRQN        TIMER0_Channel_IRQn
+#define TIMER_1_IRQN        TIMER1_IRQn
+#define TIMER_2_IRQN        TIMER4_IRQn
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIMER2,
+        .rcu_mask = RCU_APB1EN_TIMER2EN_Msk,
+        .chan     = {
+                        { .pin = GPIO_PIN(PORT_B, 5), .cc_chan = 1 },
+                        { .pin = GPIO_PIN(PORT_B, 0), .cc_chan = 2 },
+                        /* unused channels have to be defined by GPIO_UNDEF */
+                        { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                        { .pin = GPIO_UNDEF, .cc_chan = 3 },
+                    },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB1,
+    },
+    {
+        .dev      = TIMER3,
+        .rcu_mask = RCU_APB1EN_TIMER3EN_Msk,
+        .chan     = {
+                        { .pin = GPIO_PIN(PORT_B, 7), .cc_chan = 1 },
+                        { .pin = GPIO_PIN(PORT_B, 8), .cc_chan = 2 },
+                        /* unused channels have to be defined by GPIO_UNDEF */
+                        { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                        { .pin = GPIO_UNDEF, .cc_chan = 3 },
+                    },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB1,
+    },
+};
+
+#define PWM_NUMOF ARRAY_SIZE(pwm_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/seeedstudio-gd32/Makefile.include
+++ b/boards/seeedstudio-gd32/Makefile.include
@@ -1,2 +1,3 @@
 PORT_LINUX ?= /dev/ttyACM0
+OPENOCD_CONFIG ?= $(RIOTBOARD)/common/gd32v/dist/openocd.cfg
 include $(RIOTBOARD)/common/gd32v/Makefile.include

--- a/boards/sipeed-longan-nano/Makefile.include
+++ b/boards/sipeed-longan-nano/Makefile.include
@@ -1,4 +1,5 @@
 PORT_LINUX ?= /dev/ttyACM0
 PROGRAMMER ?= dfu-util
+OPENOCD_CONFIG ?= $(RIOTBOARD)/common/gd32v/dist/openocd.cfg
 
 include $(RIOTBOARD)/common/gd32v/Makefile.include

--- a/cpu/gd32v/cpu.c
+++ b/cpu/gd32v/cpu.c
@@ -33,6 +33,15 @@ void cpu_init(void)
     periph_clk_en(APB1, RCU_APB1EN_PMUEN_Msk);
     /* Common RISC-V initialization */
     riscv_init();
+
+    /* Apply configured SWJ_CFG, unless it is configured to the reset value */
+    if (CONFIG_AFIO_PCF0_SWJ_CFG != SWJ_CFG_FULL_JTAG) {
+        /* The remapping periph clock must first be enabled */
+        RCU->APB2EN |= RCU_APB2EN_AFEN_Msk;
+        /* Then the remap can occur */
+        AFIO->PCF0 |= CONFIG_AFIO_PCF0_SWJ_CFG;
+    }
+
     early_init();
     periph_init();
 }

--- a/cpu/gd32v/include/cpu_conf.h
+++ b/cpu/gd32v/include/cpu_conf.h
@@ -46,6 +46,34 @@ extern "C" {
 #define CPU_FLASH_BASE                  0x08000000
 /** @} */
 
+/**
+ * @brief   Possible values of the `SWJ_CFG` field in the AFIO->PCF0 register
+ */
+typedef enum {
+     /**
+      * @brief  Full JTAG interface (reset value)
+      */
+    SWJ_CFG_FULL_JTAG    = 0,
+    /**
+     * @brief   JTAG enabled, but NJTRST disabled and pin PB4 usable as GPIO
+     */
+    SWJ_CFG_NO_NJTRST   = 1U << AFIO_PCF0_SWJ_CFG_Pos,
+    /**
+     * @brief   JTAG disabled, all debug pins usable as GPIOs
+     */
+    SWJ_CFG_NO_JTAG     = 4U << AFIO_PCF0_SWJ_CFG_Pos,
+} afio_pcf0_swj_cfg_t;
+
+#ifndef CONFIG_AFIO_PCF0_SWJ_CFG
+/**
+ * @brief   By default, enable JTAG but disable NJTRST
+ *
+ * This default makes PB4 usable as GPIO while still being able to debug and
+ * flash via JTAG.
+ */
+#define CONFIG_AFIO_PCF0_SWJ_CFG    SWJ_CFG_NO_NJTRST
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \
+    gd32vf103c-start \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103cb \
     e104-bt5010a-tb \
     e104-bt5011a-tb \
+    gd32vf103c-start \
     lsn50 \
     msb-430 \
     msb-430h \

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -13,7 +13,9 @@ RESET_FLAGS ?= reset
 
 ifneq (,$(OPENOCD_DEBUG_ADAPTER))
   include $(RIOTMAKE)/tools/openocd-adapters/$(OPENOCD_DEBUG_ADAPTER).inc.mk
-  OPENOCD_ADAPTER_INIT += -c 'transport select $(OPENOCD_TRANSPORT)'
+  ifneq (default,$(OPENOCD_TRANSPORT))
+    OPENOCD_ADAPTER_INIT += -c 'transport select $(OPENOCD_TRANSPORT)'
+  endif
 endif
 
 OPENOCD_CONFIG ?= $(BOARDDIR)/dist/openocd.cfg

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,12 +1,16 @@
 # Select the most recently attached tty interface
 ifeq (1,$(MOST_RECENT_PORT))
   ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
-    TTY_BOARD_FILTER ?= --model $(BOARD) --vendor 'RIOT-os\.org'
+    TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
+                      --most-recent \
+                      --format path serial \
+                      --model '$(BOARD)' --vendor 'RIOT-os\.org'
+  else
+    TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
+                      --most-recent \
+                      --format path serial \
+                      $(TTY_BOARD_FILTER)
   endif
-  TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
-                    --most-recent \
-                    --format path serial \
-                    $(TTY_BOARD_FILTER)
   TTY_DETECTED := $(shell $(TTY_SELECT_CMD) || echo 'no-tty-detected no-serial-detected')
   PORT_DETECTED := $(firstword $(TTY_DETECTED))
   PORT_SERIAL_DETECTED := $(lastword $(TTY_DETECTED))

--- a/tests/pkg/utensor/Makefile.ci
+++ b/tests/pkg/utensor/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
+    gd32vf103c-start \
     i-nucleo-lrwan1 \
     im880b \
     lobaro-lorabox \

--- a/tests/pkg/wolfssl/Makefile.ci
+++ b/tests/pkg/wolfssl/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
+    gd32vf103c-start \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-stm32f103cb \
     bluepill-stm32f103c8 \
     bluepill-stm32f103cb \
+    gd32vf103c-start \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     esp8266-sparkfun-thing \
     firefly \
     frdm-kl43z \
+    gd32vf103c-start \
     generic-cc2538-cc2592-dk \
     hamilton \
     hifive1 \


### PR DESCRIPTION
### Contribution description

This pull request adds support for the GD32VF103C-START board, the official evaluation board of the GD32VF103C MCU by the MCU vendor. Sadly, there is relatively little documentation provided on the board.

### Testing procedure

Output when testing with the selftesting shield:

```
main(): This is RIOT! (Version: 2024.01-devel-611-gc01b6b4-boards/gd32vf103c-start)
self-testing peripheral drivers
===============================
Starting test for GPIO at tests/periph/selftest_shield/main.c:346
[OK]
Starting test for GPIO at tests/periph/selftest_shield/main.c:368
[OK]
Starting test for GPIO at tests/periph/selftest_shield/main.c:398
[OK]
Starting test for GPIO at tests/periph/selftest_shield/main.c:428
(skipped)
Starting test for GPIO at tests/periph/selftest_shield/main.c:454
(skipped)
Starting test for GPIO-IRQ at tests/periph/selftest_shield/main.c:501
[OK]
Starting test for GPIO-IRQ at tests/periph/selftest_shield/main.c:564
[OK]
Starting test for GPIO-IRQ at tests/periph/selftest_shield/main.c:627
[OK]
Starting test for I2C at tests/periph/selftest_shield/main.c:701
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for SPI at tests/periph/selftest_shield/main.c:829
[OK]
Starting test for PWM at tests/periph/selftest_shield/main.c:958
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 426 <= 64: FAILED
[FAILED]
Starting test for PWM at tests/periph/selftest_shield/main.c:958
[OK]
Starting test for PWM at tests/periph/selftest_shield/main.c:958
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 199 <= 64: FAILED
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 937 <= 68: FAILED
[FAILED]
Starting test for PWM at tests/periph/selftest_shield/main.c:958
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 1018 <= 64: FAILED
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 936 <= 68: FAILED
[FAILED]
Starting test for PWM at tests/periph/selftest_shield/main.c:958
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 199 <= 64: FAILED
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 941 <= 68: FAILED
[FAILED]
Starting test for PWM at tests/periph/selftest_shield/main.c:958
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 1017 <= 64: FAILED
FAILURE in tests/periph/selftest_shield/main.c:979
0 <= 928 <= 68: FAILED
[FAILED]
Starting test for ADC at tests/periph/selftest_shield/main.c:1027
FAILURE in tests/periph/selftest_shield/main.c:1042
0 <= 545 <= 102: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
0 <= 407 <= 166: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
26 <= 358 <= 230: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
90 <= 343 <= 294: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
346 <= 328 <= 550: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
410 <= 333 <= 614: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
474 <= 336 <= 678: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
538 <= 338 <= 742: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
602 <= 338 <= 806: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
666 <= 337 <= 870: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
730 <= 338 <= 934: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
794 <= 337 <= 998: FAILED
FAILURE in tests/periph/selftest_shield/main.c:1042
858 <= 338 <= 1023: FAILED
[FAILED]


SOME TESTS FAILED
{ "threads": [{ "name": "idle", "stack_size": 256, "stack_used": 228 }]}
{ "threads": [{ "name": "main", "stack_size": 1280, "stack_used": 740 }]}
```

Note: There are apparently some issues with at least the ADC. (The ADC is used to test the PWM output via a "low-pass filter DAC", but also via an R-2R DAC. Both tests fail. But just something broken with the ADC would be sufficient to explain this.)

Otherwise, the test result indicates correct configuration and Arduino mapping.

### Issues/PRs references

None