### PR TITLE
pkg: 64-bit support preparations

### DIFF
--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -22,6 +22,11 @@ config HAS_ARCH_32BIT
     help
         Indicates that the CPU has a 32-bits architecture.
 
+config HAS_ARCH_64BIT
+    bool
+    help
+        Indicates that the CPU has a 64-bits architecture.
+
 config HAS_ARCH_ARM
     bool
     help

--- a/pkg/cifra/Kconfig
+++ b/pkg/cifra/Kconfig
@@ -8,7 +8,7 @@
 config PACKAGE_CIFRA
     bool "Cifra cryptographic primitives"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     help
         Cifra is a collection of cryptographic primitives targeted at
         embedded use.

--- a/pkg/cifra/Makefile.dep
+++ b/pkg/cifra/Makefile.dep
@@ -1,2 +1,2 @@
 # Cifra is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/cn-cbor/Kconfig
+++ b/pkg/cn-cbor/Kconfig
@@ -8,7 +8,7 @@
 config PACKAGE_CN-CBOR
     bool "Constrained Node CBOR"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     select MODULE_POSIX_HEADERS
     help
         A constrained node implementation of CBOR in C.

--- a/pkg/cn-cbor/Makefile.dep
+++ b/pkg/cn-cbor/Makefile.dep
@@ -1,4 +1,4 @@
 USEMODULE += posix_headers
 
 # CN-CBOR is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/flashdb/Makefile.dep
+++ b/pkg/flashdb/Makefile.dep
@@ -1,5 +1,5 @@
 # FlashDB is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit
 CFLAGS += -DFDB_USING_NATIVE_ASSERT
 
 ifneq (,$(filter flashdb_tsdb,$(USEMODULE)))

--- a/pkg/hacl/Kconfig
+++ b/pkg/hacl/Kconfig
@@ -9,4 +9,4 @@ config PACKAGE_HACL
     bool "High Assurance Cryptographic Library package"
     depends on TEST_KCONFIG
     depends on MODULE_RANDOM
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT

--- a/pkg/hacl/Makefile.dep
+++ b/pkg/hacl/Makefile.dep
@@ -1,4 +1,4 @@
 USEMODULE+=random
 
 # HACL is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/hacl/patches/0003-64-bit-fix.patch
+++ b/pkg/hacl/patches/0003-64-bit-fix.patch
@@ -1,0 +1,25 @@
+From 286677362a0f78f799e71e12614f72c02b007640 Mon Sep 17 00:00:00 2001
+From: Frederik Haxel <haxel@fzi.de>
+Date: Mon, 14 Aug 2023 17:32:51 +0200
+Subject: [PATCH] 64 bit fix
+
+---
+ haclnacl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/haclnacl.c b/haclnacl.c
+index 072a2db..e7c25e7 100644
+--- a/haclnacl.c
++++ b/haclnacl.c
+@@ -149,7 +149,7 @@ int crypto_box(unsigned char *cipher, const unsigned char *msg, unsigned long lo
+   return crypto_box_easy(cipher, (unsigned char *)msg, msg_len - 32, (unsigned char *)nonce, (unsigned char *)pk, (unsigned char *)sk);
+ }
+ 
+-int crypto_box_open(uint8_t *msg, const uint8_t *cipher, uint64_t cipher_len, const uint8_t *nonce, const uint8_t *pk, const uint8_t *sk){
++int crypto_box_open(unsigned char *msg, const unsigned char *cipher, unsigned long long cipher_len, const unsigned char *nonce, const unsigned char *pk, const unsigned char *sk){
+   return crypto_box_open_easy(msg, cipher, cipher_len - 32, nonce, pk, sk);
+ }
+ 
+-- 
+2.34.1
+

--- a/pkg/jerryscript/Kconfig
+++ b/pkg/jerryscript/Kconfig
@@ -8,7 +8,7 @@
 config PACKAGE_JERRYSCRIPT
     bool "Ultra-lightweight Javascript interpreter"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
 
     select MODULE_JERRYSCRIPT-PORT-DEFAULT
     select MODULE_JERRYSCRIPT-EXT

--- a/pkg/jerryscript/Makefile.dep
+++ b/pkg/jerryscript/Makefile.dep
@@ -2,4 +2,4 @@ USEMODULE += jerryscript-port-default
 USEMODULE += jerryscript-ext
 
 # Jerryscript is only supported by 32-bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/libhydrogen/Kconfig
+++ b/pkg/libhydrogen/Kconfig
@@ -9,4 +9,4 @@ config PACKAGE_LIBHYDROGEN
     bool "LibHydrogen Crypto Library package"
     depends on TEST_KCONFIG
     depends on MODULE_RANDOM
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT

--- a/pkg/libhydrogen/Makefile.dep
+++ b/pkg/libhydrogen/Makefile.dep
@@ -3,4 +3,4 @@ USEMODULE += random
 # libhydrogen is only supported by 32 bit architectures
 # AVR boards: require avr-gcc >= 7.0 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60040)
 # MSP430 boards: invalid alignment of 'hydro_random_context'
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/lorabasics/Makefile.dep
+++ b/pkg/lorabasics/Makefile.dep
@@ -7,5 +7,5 @@ ifneq (,$(filter lorabasics_sx1280_driver,$(USEMODULE)))
   USEMODULE += lorabasics_driver_sx1280_hal
 endif
 # This package has assumptions that only work for 32-bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit
 USEMODULE += lorabasics_smtc_ral

--- a/pkg/lua/Kconfig
+++ b/pkg/lua/Kconfig
@@ -8,7 +8,7 @@
 config PACKAGE_LUA
     bool "LUA language package"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     depends on !HAS_ARCH_RISCV
     depends on !MODULE_PICOLIBC
 

--- a/pkg/lua/Makefile.dep
+++ b/pkg/lua/Makefile.dep
@@ -3,7 +3,7 @@ USEMODULE += lua-contrib
 USEMODULE += printf_float
 
 # LUA is only supported by 32-bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit
 
 # LUA is not supported on RISCV because of build issues with the toolchain
 # (undefined reference to _times, _unlink and _link functions in provided

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -1,6 +1,6 @@
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit
 
 DEFAULT_MODULE += auto_init_lwip
 

--- a/pkg/lwip/Makefile.include
+++ b/pkg/lwip/Makefile.include
@@ -17,6 +17,11 @@ PSEUDOMODULES += lwip_udp
 PSEUDOMODULES += lwip_udplite
 PSEUDOMODULES += lwip_sock_async
 
+ifneq (,$(filter arch_64bit,$(FEATURES_USED)))
+# Required for platforms where sizeof(void*) > 4
+    CFLAGS += -DIPV6_FRAG_COPYHEADER=1
+endif
+
 ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/lwip/contrib
 endif

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -616,7 +616,7 @@ ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
     struct netconn *tmp;
     struct netbuf *buf = NULL;
     size_t payload_len = 0;
-    int res;
+    ssize_t res;
     err_t err= ERR_OK;
     u16_t remote_port = 0;
 

--- a/pkg/micro-ecc/patches/0001-int128-fix-for-GCC.patch
+++ b/pkg/micro-ecc/patches/0001-int128-fix-for-GCC.patch
@@ -1,0 +1,33 @@
+From 25813b458f3b48f6b5b6ec65edf73ab069b9a0f8 Mon Sep 17 00:00:00 2001
+From: Frederik Haxel <haxel@fzi.de>
+Date: Thu, 11 Jan 2024 12:59:28 +0100
+Subject: [PATCH] __int128 fix for GCC
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC throws the following warning if `-Wpedantic` is set and `__int128` is supported.
+```
+types.h:100:18: warning: ISO C does not support ‘__int128’ types [-Wpedantic]
+  100 | typedef unsigned __int128 uECC_dword_t;
+```
+---
+ types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/types.h b/types.h
+index 9ee81438fac3..ff7de8204765 100644
+--- a/types.h
++++ b/types.h
+@@ -95,7 +95,7 @@ typedef uint64_t uECC_dword_t;
+ 
+ typedef uint64_t uECC_word_t;
+ #if SUPPORTS_INT128
+-typedef unsigned __int128 uECC_dword_t;
++typedef unsigned int uECC_dword_t __attribute__((mode(TI)));
+ #endif
+ 
+ #define HIGH_BIT_SET 0x8000000000000000ull
+-- 
+2.34.1
+

--- a/pkg/monocypher/Kconfig
+++ b/pkg/monocypher/Kconfig
@@ -8,7 +8,7 @@
 config PACKAGE_MONOCYPHER
     bool "Monocypher high performance cryptographic library package"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     select MODULE_MONOCYPHER_OPTIONAL
     help
         Provides functions for authenticated encryption, hashing,

--- a/pkg/monocypher/Makefile.dep
+++ b/pkg/monocypher/Makefile.dep
@@ -2,4 +2,4 @@
 USEMODULE += monocypher_optional
 
 # monocypher is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/qcbor/Kconfig
+++ b/pkg/qcbor/Kconfig
@@ -8,4 +8,4 @@
 config PACKAGE_QCBOR
     bool "QCBOR CBOR encoder/decoder"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT

--- a/pkg/qcbor/Makefile.dep
+++ b/pkg/qcbor/Makefile.dep
@@ -1,1 +1,1 @@
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/tinycbor/Kconfig
+++ b/pkg/tinycbor/Kconfig
@@ -8,7 +8,7 @@
 menuconfig PACKAGE_TINYCBOR
     bool "Tiny CBOR encode/decoder package"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     help
         TinyCBOR is a CBOR encoder and decoder with a very small
         footprint, optimized for very fast operation.

--- a/pkg/tinycbor/Makefile.dep
+++ b/pkg/tinycbor/Makefile.dep
@@ -1,2 +1,2 @@
 # tinycbor is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/tinycrypt/Kconfig
+++ b/pkg/tinycrypt/Kconfig
@@ -8,4 +8,4 @@
 config PACKAGE_TINYCRYPT
     bool "TinyCrypt crypto library package"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT

--- a/pkg/tinycrypt/Makefile.dep
+++ b/pkg/tinycrypt/Makefile.dep
@@ -1,1 +1,1 @@
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/tinydtls/patches/0001-fix-printf-warning-for-64-bit-systems.patch
+++ b/pkg/tinydtls/patches/0001-fix-printf-warning-for-64-bit-systems.patch
@@ -1,0 +1,27 @@
+From bdf2d7bc11382cb2628863305b773a554ea08669 Mon Sep 17 00:00:00 2001
+From: Frederik Haxel <haxel@fzi.de>
+Date: Wed, 17 Jan 2024 22:06:12 +0100
+Subject: [PATCH] Fix printf warning for 64 bit systems
+
+---
+ dtls_debug.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dtls_debug.h b/dtls_debug.h
+index add0d58e2829..a02cab4e393b 100644
+--- a/dtls_debug.h
++++ b/dtls_debug.h
+@@ -139,8 +139,8 @@ void dtls_dsrv_log_addr(log_t level, const char *name, const session_t *addr);
+ #define dtls_notice(...) LOG_INFO(__VA_ARGS__)
+ #define dtls_info(...) LOG_INFO(__VA_ARGS__)
+ #define dtls_debug(...) LOG_DEBUG(__VA_ARGS__)
+-#define dtls_debug_hexdump(name, buf, length) { if (LOG_DEBUG <= LOG_LEVEL) { LOG_DEBUG("-= %s (%zu bytes) =-\n", name, length); od_hex_dump(buf, length, 0); }}
+-#define dtls_debug_dump(name, buf, length) { if (LOG_DEBUG <= LOG_LEVEL) { LOG_DEBUG("%s (%zu bytes):", name, length); od_hex_dump(buf, length, 0); }}
++#define dtls_debug_hexdump(name, buf, length) { if (LOG_DEBUG <= LOG_LEVEL) { LOG_DEBUG("-= %s (%zu bytes) =-\n", name, (size_t)(length)); od_hex_dump(buf, length, 0); }}
++#define dtls_debug_dump(name, buf, length) { if (LOG_DEBUG <= LOG_LEVEL) { LOG_DEBUG("%s (%zu bytes):", name, (size_t)(length)); od_hex_dump(buf, length, 0); }}
+ #else /* neither RIOT nor Zephyr */
+ #define dtls_emerg(...) dsrv_log(DTLS_LOG_EMERG, __VA_ARGS__)
+ #define dtls_alert(...) dsrv_log(DTLS_LOG_ALERT, __VA_ARGS__)
+-- 
+2.34.1
+

--- a/pkg/tinyusb/Kconfig
+++ b/pkg/tinyusb/Kconfig
@@ -32,7 +32,7 @@ choice USB_IMPLEMENTATION
 menuconfig PACKAGE_TINYUSB
     bool "TinyUSB stack package"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     depends on HAS_TINYUSB_DEVICE || HAS_TINYUSB_HOST
     select MODULE_FMT
     select MODULE_LUID

--- a/pkg/tlsf/Kconfig
+++ b/pkg/tlsf/Kconfig
@@ -8,7 +8,7 @@
 menuconfig PACKAGE_TLSF
     bool "TLFS malloc/realloc/free/etc package"
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
     help
         TLSF provides an implementation of malloc/realloc/free/etc.
 

--- a/pkg/tlsf/Makefile.dep
+++ b/pkg/tlsf/Makefile.dep
@@ -9,4 +9,4 @@ ifneq (,$(filter tlsf-malloc,$(USEMODULE)))
 endif
 
 # tlsf is not compatible with 8bit and 16bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/uwb-dw1000/Kconfig
+++ b/pkg/uwb-dw1000/Kconfig
@@ -14,7 +14,7 @@ menuconfig PACKAGE_UWB-DW1000
     select MODULE_PERIPH_GPIO_IRQ
     depends on HAS_PERIPH_SPI
     select MODULE_PERIPH_SPI
-    depends on HAS_ARCH_32BIT
+    depends on HAS_ARCH_32BIT || HAS_ARCH_64BIT
 
 if PACKAGE_UWB-DW1000
 

--- a/pkg/uwb-dw1000/Makefile.dep
+++ b/pkg/uwb-dw1000/Makefile.dep
@@ -7,4 +7,4 @@ FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_spi
 
 # Some of the pkg operation would overflow on 16bit
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/wolfssl/Makefile.dep
+++ b/pkg/wolfssl/Makefile.dep
@@ -91,4 +91,4 @@ ifneq (,$(filter native,$(CPU)))
 endif
 
 # wolfssl is only supported by 32 bit architectures
-FEATURES_REQUIRED += arch_32bit
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit

--- a/pkg/wolfssl/include/user_settings.h
+++ b/pkg/wolfssl/include/user_settings.h
@@ -73,7 +73,7 @@ extern "C" {
 #endif
 
 /* defined somewhere else */
-int strncasecmp(const char *s1, const char * s2, unsigned int sz);
+int strncasecmp(const char *s1, const char * s2, size_t sz);
 
 #define SINGLE_THREADED
 

--- a/pkg/wolfssl/sock_tls/sock_tls.c
+++ b/pkg/wolfssl/sock_tls/sock_tls.c
@@ -85,7 +85,7 @@ void sock_dtls_session_destroy(sock_tls_t *sk)
 #endif
 
 #include <ctype.h>
-int strncasecmp(const char *s1, const char * s2, unsigned int sz)
+int strncasecmp(const char *s1, const char * s2, size_t sz)
 {
     unsigned int i;
     for( i = 0; i < sz; i++) {


### PR DESCRIPTION
### Contribution description

Part 2 of the 64-bit preparation. This PR contains the changes to `pkg`. 
Most of the changed files are related to the addition of `arch_64bit`. 

Other non-patch fixes are:
- hacl, wolfssl: Fixed different types between function declaration and implementation.
- lwip: Add required flag for 64 bit and bug fix in `lwip_sock`.

Since #20154, most of the patches are upstream (thanks again to @OlegHahm for his support).
But three patches remain:
- micro-ecc: Workaround for GCC warning when using `__int128`.
    - Open issue: kmackay/micro-ecc#222
- tinydtls: Fix debug message 
    - Open PR: eclipse/tinydtls#217
- hacl: Fixed different types between function declaration and implementation.
    - RIOT is currently using an archived repository (https://github.com/RIOT-OS-pkgmirror/hacl-c_archived)

The commits are part of this patch series
- #19890

### Testing procedure

All tests and applications should remain unchanged for existing platforms.

### Issues/PRs references

See also #19890, #20154, and #20257
