### PR TITLE
nanocoap: implement coap_find_uri_query()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -862,6 +862,23 @@ static inline ssize_t coap_get_uri_query_string(coap_pkt_t *pkt, char *target,
 }
 
 /**
+ * @brief   Find a URI query option of the packet
+ *
+ * This function searches for a query option of the form "?key=value"
+ * and would, when present, return the pointer to "value" when searching
+ * for "key".
+ *
+ * @param[in]   pkt     pkt to work on
+ * @param[in]   key     key string to look for
+ * @param[out]  value   found value if present, may be NULL
+ * @param[out]  len     length of value if present, may be NULL if value is NULL
+ *
+ * @returns     true if the key was found, false if not
+ */
+bool coap_find_uri_query(coap_pkt_t *pkt, const char *key,
+                         const char **value, size_t *len);
+
+/**
  * @brief   Iterate over a packet's options
  *
  * To start iteration from the first option, set @p init_opt to true. To start

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -368,7 +368,19 @@ static void test_nanocoap__get_multi_query(void)
     coap_get_uri_query_string(&pkt, query, sizeof(query));
     /* skip initial '&' from coap_get_uri_query_string() */
     TEST_ASSERT_EQUAL_STRING((char *)qs, &query[1]);
+
+    const char *val;
+    size_t val_len;
+    TEST_ASSERT(coap_find_uri_query(&pkt, "ab", &val, &val_len));
+    TEST_ASSERT_EQUAL_INT(3, val_len);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(val, "cde", val_len));
+    TEST_ASSERT(coap_find_uri_query(&pkt, "f", &val, &val_len));
+    TEST_ASSERT_EQUAL_INT(0, val_len);
+    TEST_ASSERT_EQUAL_INT((uintptr_t)NULL, (uintptr_t)val);
+    TEST_ASSERT(!coap_find_uri_query(&pkt, "cde", &val, &val_len));
+    TEST_ASSERT(coap_find_uri_query(&pkt, "ab", NULL, 0));
 }
+
 /*
  * Builds on get_multi_query test, to use coap_opt_add_uri_query2().
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a new function `coap_find_uri_query()` with which we can find a URI query on a request packet.

This makes handling requests with query options easier as we don't have to manually iterate all options in the handler. 


### Testing procedure

`tests-nanocoap` was extended to exercise the new function.


### Issues/PRs references
suggested in #20197
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
