### PR TITLE
sys/shell: fix reserved addresses in i2c_scan

### DIFF
--- a/sys/shell/cmds/i2c_scan.c
+++ b/sys/shell/cmds/i2c_scan.c
@@ -46,7 +46,7 @@ static int get_dev(i2c_t *dev, int argc, char **argv)
 
 static inline int is_addr_reserved(uint16_t addr)
 {
-    if ((addr < 0x0e) || (addr > 0x77))
+    if ((addr < 0x8) || (addr > 0x77))
         return 1;
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There are only 8 reserved addresses on the low end of the address space.



### Testing procedure

A sensor with address `0x8` is now detected by `i2c_scan`:

```
2024-01-18 15:11:40,685 # Scanning I2C device 0...
2024-01-18 15:11:40,691 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2024-01-18 15:11:40,695 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2024-01-18 15:11:40,699 # 0x00 R R R R R R R R X - - - - - - -
2024-01-18 15:11:40,704 # 0x10 - - - - - - - - - - - - - - - -
2024-01-18 15:11:40,709 # 0x20 - - - - - - - - - - - - - - - -
2024-01-18 15:11:40,714 # 0x30 - - - - - - - - - - - - - - - -
2024-01-18 15:11:40,719 # 0x40 - - - - - - - - - - - - - - - -
2024-01-18 15:11:40,724 # 0x50 - - - - - - - - - - - - - - - -
2024-01-18 15:11:40,729 # 0x60 - - - - - - - - - - - - - - - -
2024-01-18 15:11:40,733 # 0x70 - - - - - - - - R R R R R R R R
```


### Issues/PRs references

https://www.totalphase.com/support/articles/200349176-7-bit-8-bit-and-10-bit-i2c-slave-addressing/
