### PR TITLE
nanocoap: don't add content type option in coap_reply_simple() if ct=0

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -516,7 +516,9 @@ ssize_t coap_reply_simple(coap_pkt_t *pkt,
     uint8_t *bufpos = payload_start;
 
     if (payload_len) {
-        bufpos += coap_put_option_ct(bufpos, 0, ct);
+        if (ct) {
+            bufpos += coap_put_option_ct(bufpos, 0, ct);
+        }
         *bufpos++ = 0xff;
     }
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Content Type 0 is implicit if there is no content type option, so no need to add the option in that case.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
