### PR TITLE
tests: don't explicitly set RIOT_TERMINAL=native

### DIFF
--- a/tests/net/gcoap_dns/Makefile
+++ b/tests/net/gcoap_dns/Makefile
@@ -28,9 +28,6 @@ CFLAGS += -DHAS_SOCK_DNS_MOCK=1
 include $(RIOTBASE)/Makefile.include
 
 ifeq (native,$(BOARD))
-RIOT_TERMINAL=native
-TERMPROG=$(ELFFILE)
-TERMFLAGS=
 test: PORT=
 $(call target-export-variables,test,PORT)
 endif

--- a/tests/net/gcoap_fileserver/Makefile
+++ b/tests/net/gcoap_fileserver/Makefile
@@ -37,7 +37,6 @@ ifeq (native, $(BOARD))
   USEMODULE += socket_zep
   USEMODULE += socket_zep_hello
   USEMODULE += netdev
-  RIOT_TERMINAL = native
   TERMFLAGS += -z 127.0.0.1:17754 # Murdock has no IPv6 support
   # make sure each instance gets their own fs
   CFLAGS += -DCONFIG_NATIVE_ISOLATE_FS=1

--- a/tests/net/gnrc_dhcpv6_client_6lbr/Makefile
+++ b/tests/net/gnrc_dhcpv6_client_6lbr/Makefile
@@ -15,7 +15,6 @@ USEMODULE += shell_cmds_default
 
 # use Ethernet as link-layer protocol
 ifeq (native,$(BOARD))
-  RIOT_TERMINAL = native
   TERMFLAGS += -z [::1]:17754
 else
   ETHOS_BAUDRATE ?= 115200

--- a/tests/net/gnrc_netif_ieee802154/Makefile
+++ b/tests/net/gnrc_netif_ieee802154/Makefile
@@ -4,7 +4,6 @@ include ../Makefile.net_common
 
 ifeq (native, $(BOARD))
   USEMODULE += socket_zep
-  RIOT_TERMINAL = native
   TERMFLAGS ?= -z "0.0.0.0:17755,localhost:17754"
   USEMODULE += netdev
   # somehow this breaks the test

--- a/tests/net/gnrc_rpl/Makefile
+++ b/tests/net/gnrc_rpl/Makefile
@@ -13,7 +13,6 @@ ifeq (native, $(BOARD))
   USEMODULE += socket_zep
   USEMODULE += socket_zep_hello
   USEMODULE += netdev
-  RIOT_TERMINAL = native
   TERMFLAGS += -z 127.0.0.1:17754 # Murdock has no IPv6 support
 else
   USEMODULE += netdev_default

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
@@ -28,7 +28,6 @@ ifeq (native, $(BOARD))
   USEMODULE += socket_zep
   USEMODULE += socket_zep_hello
   USEMODULE += netdev
-  RIOT_TERMINAL = native
   TERMFLAGS = -z 127.0.0.1:17754 # Murdock has no IPv6 support
 else
   USEMODULE += netdev_default

--- a/tests/net/ieee802154_hal/Makefile
+++ b/tests/net/ieee802154_hal/Makefile
@@ -27,7 +27,6 @@ BOARD_WHITELIST += adafruit-clue \
 
 ifeq ($(BOARD), native)
   ZEP_PORT_BASE ?= 17754
-  RIOT_TERMINAL = native
   TERMFLAGS += -z [::1]:$(ZEP_PORT_BASE)
   USEMODULE += socket_zep
   # the same for Kconfig

--- a/tests/net/socket_zep/Makefile
+++ b/tests/net/socket_zep/Makefile
@@ -6,7 +6,6 @@ USEMODULE += od
 USEMODULE += socket_zep
 USEMODULE += netdev
 
-RIOT_TERMINAL = native
 TERMFLAGS ?= -z [::1]:17754
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`RIOT_TERMINAL=pyterm` is now only used with the `term` target, the `native` term is the default for everything else, including tests. So we don't have to set it for every test.


### Testing procedure

CI should do the job


### Issues/PRs references

follow-up to #20264
