### PR TITLE
examples/rust-gcoap: Fix transitive unbounded dependency

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -526,7 +526,7 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#5aa33e8e8f7912049e09a5b1379131038d70641f"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#de9fb3332c2a5125ac97ee29f5f61deba444aa99"
 dependencies = [
  "coap-handler",
  "coap-handler-implementations",


### PR DESCRIPTION
### Contribution description

The older version of the external module used to have an `embedded-hal = "*"` dependency that finally broke; the updated version is fixed.

This did not cause trouble in test builds, but would cause

```
   --> /github/home/.cargo/git/checkouts/riot-module-examples-d2e3e2ff5ccfa52a/5aa33e8/riot-coap-handler-demos/src/graphics.rs:10:19
   |
10 | use embedded_hal::blocking::i2c::{Write, Read};
```

when any part of the build runs a `cargo update`.

### Testing procedure

Green CI.

### Issues/PRs references

The commit in the external module that fixes this is https://gitlab.com/etonomy/riot-module-examples/-/commit/de9fb3332c2a5125ac97ee29f5f61deba444aa99; the 3 commits before it that are pulled in as well contain various minor fixes or add unrelated modules.