### PR TITLE
boards/sodaq-sara-sff: add status pin for SARA

### DIFF
--- a/boards/sodaq-sara-sff/board.c
+++ b/boards/sodaq-sara-sff/board.c
@@ -38,6 +38,10 @@ void board_init(void)
     SARA_R4XX_PWR_ON_ON;
     gpio_init(SARA_R4XX_PWR_ON_PIN, GPIO_IN);
 
+    /* The SARA pin V_INT is available as SARA_STATUS_PIN.
+     */
+    gpio_init(SARA_STATUS_PIN, GPIO_IN);
+
     /* Disable GPS by default */
     GPS_ENABLE_OFF;
     gpio_init(GPS_ENABLE_PIN, GPIO_OUT);

--- a/boards/sodaq-sara-sff/include/board.h
+++ b/boards/sodaq-sara-sff/include/board.h
@@ -146,6 +146,8 @@ extern "C" {
 #define SARA_R4XX_PWR_ON_OFF    (SARA_R4XX_PWR_ON_PORT.OUTCLR.reg = SARA_R4XX_PWR_ON_MASK)
 /** @} */
 
+#define SARA_STATUS_PIN     GPIO_PIN(PA, 28) /**< This is the V_INT of the board */
+
 /**
  * @name    INT_MAG
  *


### PR DESCRIPTION
### Contribution description

This adds a pin definition for SARA_STATUS on the sodaq-sara-sff board.

### Testing procedure

Testing is only possible with this specific board, of course. Here is a code snippet to see it in operation.
```
    printf("SARA_STATUS: %d\n", gpio_read(SARA_STATUS_PIN));
    /* switch on the SARA Ublox */
    SARA_ENABLE_ON;
    SARA_TX_ENABLE_ON;
    /* Switch the PWR_ON pin to output */
    gpio_init(SARA_R4XX_PWR_ON_PIN, GPIO_OUT);
    SARA_R4XX_PWR_ON_OFF;
    xtimer_usleep(2000U * US_PER_MS);
    SARA_R4XX_PWR_ON_ON;
    /* Switch the PWR_ON pin back to input */
    gpio_init(SARA_R4XX_PWR_ON_PIN, GPIO_IN);
    printf("SARA_STATUS: %d\n", gpio_read(SARA_STATUS_PIN));
```

The output should then be:
```
SARA_STATUS: 0
SARA_STATUS: 1
```