### PR TITLE
nanocoap: add coap_build_reply_header()

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -536,6 +536,11 @@ typedef enum {
 /** @} */
 
 /**
+ * @brief   Marks the boundary between header and payload
+ */
+#define COAP_PAYLOAD_MARKER      (0xFF)
+
+/**
  * @defgroup net_coap_conf    CoAP compile configurations
  * @ingroup  net_coap
  * @ingroup  config

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -2116,6 +2116,36 @@ ssize_t coap_payload_put_bytes(coap_pkt_t *pkt, const void *data, size_t len);
 ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c);
 
 /**
+ * @brief   Create CoAP reply header (convenience function)
+ *
+ * This function generates the reply CoAP header and sets
+ * the payload pointer inside the response buffer to point to
+ * the start of the payload, so that it can be written directly
+ * after the header.
+ *
+ * @param[in]   pkt         packet to reply to
+ * @param[in]   code        reply code (e.g., COAP_CODE_204)
+ * @param[out]  buf         buffer to write reply to
+ * @param[in]   len         size of @p buf
+ * @param[in]   ct          content type of payload
+ *                          if ct < 0 this will be ignored
+ * @param[out]  payload     Will be set to the start of the payload inside
+ *                          @p buf.
+ *                          May be set to NULL if no payload response is
+ *                          wanted (no-reply option)
+ * @param[out]  payload_len_max max length of payload left in @p buf
+ *
+ * @returns     size of reply header on success
+ * @returns     0 if no reply should be sent
+ * @returns     <0 on error
+ * @returns     -ENOSPC if @p buf too small
+ */
+ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
+                                void *buf, size_t len,
+                                int ct,
+                                void **payload, size_t *payload_len_max);
+
+/**
  * @brief   Create CoAP reply (convenience function)
  *
  * This is a simple wrapper that allows for building CoAP replies for simple

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -119,7 +119,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     while (pkt_pos < pkt_end) {
         uint8_t *option_start = pkt_pos;
         uint8_t option_byte = *pkt_pos++;
-        if (option_byte == 0xff) {
+        if (option_byte == COAP_PAYLOAD_MARKER) {
             pkt->payload = pkt_pos;
             pkt->payload_len = buf + len - pkt_pos;
             DEBUG("payload len = %u\n", pkt->payload_len);
@@ -232,7 +232,7 @@ static uint8_t *_parse_option(const coap_pkt_t *pkt,
     uint8_t *hdr_end = pkt->payload;
 
     if ((pkt_pos >= hdr_end)
-            || (((pkt_pos + 1) == hdr_end) && (*pkt_pos == 0xFF))) {
+            || (((pkt_pos + 1) == hdr_end) && (*pkt_pos == COAP_PAYLOAD_MARKER))) {
         return NULL;
     }
 
@@ -1112,7 +1112,7 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
             return -ENOSPC;
         }
 
-        *pkt->payload++ = 0xFF;
+        *pkt->payload++ = COAP_PAYLOAD_MARKER;
         pkt->payload_len--;
     }
     else {
@@ -1337,7 +1337,7 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \
     bufpos += coap_put_option_ct(bufpos, 0, COAP_FORMAT_LINK);
     bufpos += coap_opt_put_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &slicer, 1);
 
-    *bufpos++ = 0xff;
+    *bufpos++ = COAP_PAYLOAD_MARKER;
 
     for (unsigned i = 0; i < coap_resources_numof; i++) {
         if (i) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `coap_build_reply()` function is kind of awkward to use.
`coap_reply_simple()` is nicer, but always requires keeping a separate buffer for the payload that then gets copied into the reply buffer anyway.

Add a new function `coap_build_reply_header()` that covers all uses of `coap_build_reply()` but is simpler to use: It builds the response header in the response buffer and sets the payload pointer to after the header, so a user can write the payload directly into the response buffer without having to copy it.


### Testing procedure

`coap_reply_simple()` has been re-implemented using the new function.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
