### PR TITLE
gnrc/ipv6: only send link-local loopback if it's on the same interface

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -714,6 +714,11 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
     else {
         gnrc_netif_t *tmp_netif = gnrc_netif_get_by_ipv6_addr(&ipv6_hdr->dst);
 
+        /* only consider link-local addresses on the interface we are sending on */
+        if (tmp_netif != netif && ipv6_addr_is_link_local(&ipv6_hdr->dst)) {
+            tmp_netif = NULL;
+        }
+
         if (ipv6_addr_is_loopback(&ipv6_hdr->dst) ||    /* dst is loopback address */
             /* or dst registered to a local interface */
             (tmp_netif != NULL)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When we send a packet out, GNRC checks with `gnrc_netif_get_by_ipv6_addr()` if the destination address is configured on a local interface. If this is the case, it won't send the packet, but directly deliver it to a local thread.

This has a tiny bug though: When the destination is link-local, we only must consider addresses on the interface we are sending on, not all addresses.


### Testing procedure

On a board with two interfaces (e.g. two UARTS with SLIP) connect them in loop-back mode.

```
2024-01-22 20:14:37,850 # Iface  6  HWaddr: 7A:F4:3C:20:AB:61 
2024-01-22 20:14:37,853 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2024-01-22 20:14:37,854 #           Link type: wired
2024-01-22 20:14:37,856 #           inet6 addr: fe80::78f4:3cff:fe20:ab61  scope: link  VAL
2024-01-22 20:14:37,867 #           inet6 group: ff02::1
2024-01-22 20:14:37,868 #           inet6 group: ff02::1:ff20:ab61
2024-01-22 20:14:37,869 #           
2024-01-22 20:14:37,870 # Iface  7  HWaddr: 7A:F4:3C:20:AB:60 
2024-01-22 20:14:37,872 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2024-01-22 20:14:37,883 #           Link type: wired
2024-01-22 20:14:37,885 #           inet6 addr: fe80::78f4:3cff:fe20:ab60  scope: link  VAL
2024-01-22 20:14:37,886 #           inet6 group: ff02::1
2024-01-22 20:14:37,888 #           inet6 group: ff02::1:ff20:ab60
```

If you do a link-local ping on `master` you will find that the responses have no netif header, ping does not show the source interface.

```
2024-01-22 20:12:42,143 # ping ff02::1%7
2024-01-22 20:12:42,146 # 12 bytes from fe80::78f4:3cff:fe20:ab60: icmp_seq=0 ttl=64 time=1.625 ms
2024-01-22 20:12:43,151 # 12 bytes from fe80::78f4:3cff:fe20:ab60: icmp_seq=1 ttl=64 time=1.457 ms
2024-01-22 20:12:44,145 # 12 bytes from fe80::78f4:3cff:fe20:ab60: icmp_seq=2 ttl=64 time=2.031 ms
2024-01-22 20:12:44,145 # 
2024-01-22 20:12:44,146 # --- ff02::1%7 PING statistics ---
2024-01-22 20:12:44,159 # 3 packets transmitted, 3 packets received, 0% packet loss
2024-01-22 20:12:44,161 # round-trip min/avg/max = 1.457/1.704/2.031 ms
```

With this patch the netif header is present as the packet was actually sent through the interface.

```
2024-01-22 20:11:42,962 # ping ff02::1%7
2024-01-22 20:11:42,979 # 12 bytes from fe80::78f4:3cff:fe20:ab61%7: icmp_seq=0 ttl=64 time=7.454 ms
2024-01-22 20:11:43,985 # 12 bytes from fe80::78f4:3cff:fe20:ab61%7: icmp_seq=1 ttl=64 time=3.442 ms
2024-01-22 20:11:44,979 # 12 bytes from fe80::78f4:3cff:fe20:ab61%7: icmp_seq=2 ttl=64 time=2.999 ms
2024-01-22 20:11:44,980 # 
2024-01-22 20:11:44,981 # --- ff02::1%7 PING statistics ---
2024-01-22 20:11:44,993 # 3 packets transmitted, 3 packets received, 0% packet loss
2024-01-22 20:11:44,995 # round-trip min/avg/max = 2.999/4.631/7.454 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
