### PR TITLE
boards/nrf52dk: Minimal Arduino pinout support

### DIFF
--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,3 +1,7 @@
 CPU_MODEL = nrf52832xxaa
 
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_shield_uno
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52832xxaa
 
 FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_spi
 FEATURES_PROVIDED += arduino_pins
 FEATURES_PROVIDED += arduino_shield_uno
 

--- a/boards/nrf52dk/include/arduino_iomap.h
+++ b/boards/nrf52dk/include/arduino_iomap.h
@@ -30,7 +30,7 @@ extern "C" {
 /**
  * @brief   Mapping of MCU pins to Arduino pins
  *
- * For refernce, see schematic file `nRF52 Development Kit - Hardware files
+ * For reference, see schematic file `nRF52 Development Kit - Hardware files
  * 3_0_0/PCA10040-nRF52832 Development Board 3_0_0/Schematic_Layout pdf
  * files/PCA10040_Schematic_And_PCB.pdf` in
  * `nrf52-development-kit---hardware-files-3_0_0.zip` from

--- a/boards/nrf52dk/include/arduino_iomap.h
+++ b/boards/nrf52dk/include/arduino_iomap.h
@@ -96,6 +96,15 @@ extern "C" {
 #define ARDUINO_I2C_UNO         I2C_DEV(0)
 /** @} */
 
+/**
+ * @name    Arduino's SPI buses
+ * @{
+ */
+/**
+ * @brief   D11..13 is 0.23..0.25, which is called SPI_DEV(0) here
+ */
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(0)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/nrf52dk/include/arduino_iomap.h
+++ b/boards/nrf52dk/include/arduino_iomap.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C)  2024 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52dk
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ *
+ */
+
+#ifndef ARDUINO_IOMAP_H
+#define ARDUINO_IOMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ *
+ * For refernce, see schematic file `nRF52 Development Kit - Hardware files
+ * 3_0_0/PCA10040-nRF52832 Development Board 3_0_0/Schematic_Layout pdf
+ * files/PCA10040_Schematic_And_PCB.pdf` in
+ * `nrf52-development-kit---hardware-files-3_0_0.zip` from
+ * <https://www.nordicsemi.com/Products/Development-hardware/nRF52-DK/Download?lang=en#infotabs>,
+ * page 2 areas CD123
+ *
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(0, 11)
+#define ARDUINO_PIN_1           GPIO_PIN(0, 12)
+
+#define ARDUINO_PIN_2           GPIO_PIN(0, 13)
+#define ARDUINO_PIN_3           GPIO_PIN(0, 14)
+#define ARDUINO_PIN_4           GPIO_PIN(0, 15)
+#define ARDUINO_PIN_5           GPIO_PIN(0, 16)
+
+/* Those interact with LEDs, SWO and IOEXP_IRQ */
+#define ARDUINO_PIN_6           GPIO_PIN(0, 17)
+#define ARDUINO_PIN_7           GPIO_PIN(0, 18)
+#define ARDUINO_PIN_8           GPIO_PIN(0, 19)
+#define ARDUINO_PIN_9           GPIO_PIN(0, 20)
+
+#define ARDUINO_PIN_10          GPIO_PIN(0, 22)
+#define ARDUINO_PIN_11          GPIO_PIN(0, 23)
+#define ARDUINO_PIN_12          GPIO_PIN(0, 24)
+#define ARDUINO_PIN_13          GPIO_PIN(0, 25)
+#define ARDUINO_PIN_14          GPIO_PIN(0, 0)
+#define ARDUINO_PIN_15          GPIO_PIN(0, 1)
+/* Also RESET */
+#define ARDUINO_PIN_16          GPIO_PIN(0, 21)
+
+/* These are also UART ports */
+#define ARDUINO_PIN_17          GPIO_PIN(0, 5)
+#define ARDUINO_PIN_18          GPIO_PIN(0, 6)
+#define ARDUINO_PIN_19          GPIO_PIN(0, 7)
+#define ARDUINO_PIN_20          GPIO_PIN(0, 8)
+
+#define ARDUINO_PIN_21          GPIO_PIN(0, 9)
+#define ARDUINO_PIN_22          GPIO_PIN(0, 10)
+
+#define ARDUINO_PIN_LAST        22
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0          GPIO_PIN(0, 3)
+#define ARDUINO_PIN_A1          GPIO_PIN(0, 4)
+#define ARDUINO_PIN_A2          GPIO_PIN(0, 28)
+#define ARDUINO_PIN_A3          GPIO_PIN(0, 29)
+#define ARDUINO_PIN_A4          GPIO_PIN(0, 30)
+#define ARDUINO_PIN_A5          GPIO_PIN(0, 31)
+/** @} */
+
+/**
+ * @name    Arduino's I2C buses
+ * @{
+ */
+/**
+ * @brief   The only configured I2C
+ */
+#define ARDUINO_I2C_UNO         I2C_DEV(0)
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_IOMAP_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This defines the Arduino GPIO pins, sets the shield I2C bus and the form factor.

### Testing procedure

Run tests/periph/selftest_shield with an nrf52dk and a [Peripheral Selftest Shield](https://github.com/RIOT-OS/RIOT-Open-Hardware/tree/main/selftesting-shield) in "all off, D-3-4 on" configuration.

### Issues/PRs references

This simplifies testing https://github.com/RIOT-OS/RIOT/pull/20282

### PR status

I'm keeping this as Draft PR because I'm still looking at whether there are cheap extras to enable (maybe SPI bus, maybe the ADC pins). If I find none, this will be changed to "ready for review" without further comment.