### PR TITLE
drivers/periph_gpio_ll: Implement API to switch direction

### DIFF
--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -12,6 +12,7 @@ FEATURES_PROVIDED += periph_gpio_ll_input_pull_up
 FEATURES_PROVIDED += periph_gpio_ll_irq
 FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_low
 FEATURES_PROVIDED += periph_gpio_ll_irq_unmask
+FEATURES_PROVIDED += periph_gpio_ll_switch_dir
 FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += periph_rtc_ms
 FEATURES_PROVIDED += periph_rtt_overflow

--- a/cpu/atmega_common/include/gpio_ll_arch.h
+++ b/cpu/atmega_common/include/gpio_ll_arch.h
@@ -184,6 +184,22 @@ static inline uword_t gpio_ll_prepare_write(gpio_port_t port, uword_t mask,
     return result;
 }
 
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs)
+{
+    unsigned irq_state = irq_disable();
+    atmega_gpio_port_t *p = (void *)port;
+    p->ddr |= outputs;
+    irq_restore(irq_state);
+}
+
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
+{
+    unsigned irq_state = irq_disable();
+    atmega_gpio_port_t *p = (void *)port;
+    p->ddr &= ~(inputs);
+    irq_restore(irq_state);
+}
+
 static inline gpio_port_t gpio_port_pack_addr(void *addr)
 {
     return (gpio_port_t)addr;

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -21,6 +21,7 @@ FEATURES_PROVIDED += periph_gpio_ll_irq
 FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_high
 FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_low
 FEATURES_PROVIDED += periph_gpio_ll_irq_unmask
+FEATURES_PROVIDED += periph_gpio_ll_switch_dir
 FEATURES_PROVIDED += periph_i2c_reconfigure
 FEATURES_PROVIDED += periph_rtt_overflow
 FEATURES_PROVIDED += periph_rtt_set_counter

--- a/cpu/sam0_common/include/gpio_ll_arch.h
+++ b/cpu/sam0_common/include/gpio_ll_arch.h
@@ -106,6 +106,18 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t mask)
     p->OUT.reg = mask;
 }
 
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs)
+{
+    PortGroup *p = (PortGroup *)port;
+    p->DIRSET.reg = outputs;
+}
+
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
+{
+    PortGroup *p = (PortGroup *)port;
+    p->DIRCLR.reg = inputs;
+}
+
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
     return (gpio_port_t)(pin & ~(0x1f));

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -69,13 +69,13 @@
 #ifndef PERIPH_GPIO_LL_H
 #define PERIPH_GPIO_LL_H
 
-#include <inttypes.h>
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "architecture.h"
-#include "periph_cpu.h"
 #include "periph/gpio.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -707,6 +707,47 @@ static inline uword_t gpio_ll_prepare_write(gpio_port_t port, uword_t mask,
 #endif
 
 /**
+ * @brief       Turn GPIO pins specified by the bitmask @p outputs to outputs
+ *
+ * @param[in]   port        GPIO port to modify
+ * @param[in]   outputs     Bitmask specifying the GPIO pins to set in output
+ *                          mode
+ * @pre         The feature `gpio_ll_switch_dir` is available
+ * @pre         Each affected GPIO pin is either configured as input or as
+ *              push-pull output.
+ *
+ * @note        This is a makeshift solution to implement bit-banging of
+ *              bidirectional protocols on less sophisticated GPIO peripherals
+ *              that do not support open drain mode.
+ * @warning     Use open drain mode instead, if supported.
+ */
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs);
+
+/**
+ * @brief       Turn GPIO pins specified by the bitmask @p inputs to inputs
+ *
+ * @param[in]   port        GPIO port to modify
+ * @param[in]   inputs      Bitmask specifying the GPIO pins to set in input
+ *                          mode
+ * @pre         The feature `gpio_ll_switch_dir` is available
+ * @pre         Each affected GPIO pin is either configured as input or as
+ *              push-pull output.
+ *
+ * @warning     The state of the output register may be intermixed with the
+ *              input configuration. Specifically, on AVR the output register
+ *              enables/disables the internal pull up, on SAM0 MCUs the output
+ *              register controls the pull resistor direction (if the pull
+ *              resistor is enabled). Hence, the bits in the output
+ *              register of the pins switched to input should be restored
+ *              just after this call.
+ * @note        This is a makeshift solution to implement bit-banging of
+ *              bidirectional protocols on less sophisticated GPIO peripherals
+ *              that do not support open drain mode.
+ * @warning     Use open drain mode instead, if supported.
+ */
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs);
+
+/**
  * @brief   Perform a masked write operation on the I/O register of the port
  *
  *  Some platforms multiplex the "write" I/O register with additional
@@ -785,6 +826,39 @@ static inline gpio_port_t gpio_port_pack_addr(void *addr);
  * `NULL`), or retrieve the device descriptor.
  */
 static inline void * gpio_port_unpack_addr(gpio_port_t port);
+
+#ifndef DOXYGEN
+#if !MODULE_PERIPH_GPIO_LL_SWITCH_DIR
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs)
+{
+    (void)port;
+    (void)outputs;
+    /* Hack: If this function is only used guarded by some
+     *
+     *      if (IS_USED(MODULE_PERIPH_GPIO_LL_SWITCH_DIR)) {
+     *          ...
+     *      }
+     *
+     * as intended, all calls to the following fake function will be optimized
+     * due to the elimination of dead branches. If used incorrectly, a linking
+     * failure will be the result. The error message will not be ideal, but a
+     * compile time error is much better than a runtime error.
+     */
+    extern void gpio_ll_switch_dir_output_used_but_feature_gpio_ll_switch_dir_is_not_provided(void);
+    gpio_ll_switch_dir_output_used_but_feature_gpio_ll_switch_dir_is_not_provided();
+}
+
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
+{
+    (void)port;
+    (void)inputs;
+    /* Same hack as above */
+    extern void gpio_ll_switch_dir_input_used_but_feature_gpio_ll_switch_dir_is_not_provided(void);
+    gpio_ll_switch_dir_input_used_but_feature_gpio_ll_switch_dir_is_not_provided();
+}
+
+#endif /* !MODULE_PERIPH_GPIO_LL_SWITCH_DIR */
+#endif /* !DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/drivers/periph_common/Makefile.dep
+++ b/drivers/periph_common/Makefile.dep
@@ -1,14 +1,15 @@
 # Always use hardware features, if available
 ifneq (,$(filter periph_gpio_ll%,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_gpio_ll_disconnect
-  FEATURES_OPTIONAL += periph_gpio_ll_irq_level_triggered_high
   FEATURES_OPTIONAL += periph_gpio_ll_input_pull_down
   FEATURES_OPTIONAL += periph_gpio_ll_input_pull_keep
   FEATURES_OPTIONAL += periph_gpio_ll_input_pull_up
+  FEATURES_OPTIONAL += periph_gpio_ll_irq_level_triggered_high
   FEATURES_OPTIONAL += periph_gpio_ll_irq_level_triggered_low
   FEATURES_OPTIONAL += periph_gpio_ll_irq_unmask
   FEATURES_OPTIONAL += periph_gpio_ll_open_drain
   FEATURES_OPTIONAL += periph_gpio_ll_open_drain_pull_up
   FEATURES_OPTIONAL += periph_gpio_ll_open_source
   FEATURES_OPTIONAL += periph_gpio_ll_open_source_pull_down
+  FEATURES_OPTIONAL += periph_gpio_ll_switch_dir
 endif


### PR DESCRIPTION
### Contribution description

This adds two functions:

    void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs);
    void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs);

The first configures GPIO pins specified by a bitmask as output, the second configures the specified pins as input.

The main use case is to allow bit-banging bidirectional protocols using more basic GPIO peripherals that do not implement open drain mode, such as found e.g. on MSP430, ATmega, or SAM0.

It is not intended to implement this feature on modern MCUs with sophisticated GPIO peripherals.

This PR provides implementations for ATmega and SAM0, the only two GPIO peripherals currently supported by GPIO LL that lack open drain mode.

### Testing procedure

The GPIO LL test was extended to also test for switching the direction, if supported.

<details><summary><code> make BOARD=samr21-xpro flash test-with-config -j</code></summary>

```
Building application "tests_gpio_ll" for "samr21-xpro" with MCU "samd21".

"make" -C /home/maribu/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/samr21-xpro
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/samd21
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/sam0_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/samd21/periph
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/samd21/vectors
"make" -C /home/maribu/Repos/software/RIOT/master/sys/frac
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/sam0_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/master/sys/ztimer
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/periph
   text	  data	   bss	   dec	   hex	filename
  22012	   176	  2708	 24896	  6140	/home/maribu/Repos/software/RIOT/master/tests/periph/gpio_ll/bin/samr21-xpro/tests_gpio_ll.elf
/home/maribu/Repos/software/RIOT/master/dist/tools/edbg/edbg.sh flash /home/maribu/Repos/software/RIOT/master/tests/periph/gpio_ll/bin/samr21-xpro/tests_gpio_ll.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009225 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x4 expected 0x6d, read 0x15
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009225 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming...... done.
Verification...... done.
Done flashing
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2024.01-devel-683-g93372-drivers/periph/gpio_ll/switch_dir)
Test / Hardware Details:
========================
Cabling:
(INPUT -- OUTPUT)
  P1.23 (PB23) -- P0.8 (PA8)
  P1.2 (PB2) -- P0.14 (PA14)
Number of pull resistor values supported: 1
Number of drive strengths supported: 2
Number of slew rates supported: 1
Valid GPIO ports:
- PORT 0 (PORT A)
- PORT 1 (PORT B)
- PORT 2 (PORT C)

Testing gpio_port_pack_addr()
=============================

All OK

Testing gpip_ng_init()
======================

Testing is_gpio_port_num_valid() is true for PORT_OUT and PORT_IN:

Testing input configurations for PIN_IN_0:
Support for input with pull up: yes
state: in, pull: up, value: on, drive: weak
Support for input with pull down: yes
state: in, pull: down, value: off, drive: weak
Support for input with pull to bus level: no
Support for floating input (no pull resistors): yes
state: in, pull: none, value: off, drive: weak

Testing output configurations for PIN_OUT_0:
Support for output (push-pull) with initial value of LOW: yes
state: out-pp, value: off, drive: weak
Output is indeed LOW: yes
state: out-pp, value: on, drive: weak
Output can be pushed HIGH: yes
Support for output (push-pull) with initial value of HIGH: yes
state: out-pp, value: on, drive: weak
Output is indeed HIGH: yes
Support for output (open drain with pull up) with initial value of LOW: no
Support for output (open drain with pull up) with initial value of HIGH: no
Support for output (open drain) with initial value of LOW: no
Support for output (open drain) with initial value of HIGH: no
Support for output (open source) with initial value of LOW: no
Support for output (open source) with initial value of HIGH: no
Support for output (open source with pull down) with initial value of HIGH: no
Support for output (open source with pull down) with initial value of LOW: no

Support for disconnecting GPIO: yes
state: off, pull: none, value: off, drive: weak
Output can indeed be pulled LOW: yes
Output can indeed be pulled HIGH: yes

Testing Reading/Writing GPIO Ports
==================================

testing initial value of 0 after init
...OK
testing setting both outputs_optional simultaneously
...OK
testing clearing both outputs_optional simultaneously
...OK
testing toggling first output (0 --> 1)
...OK
testing toggling first output (1 --> 0)
...OK
testing toggling second output (0 --> 1)
...OK
testing toggling second output (1 --> 0)
...OK
testing setting first output and clearing second with write
...OK
testing setting second output and clearing first with write
...OK
All input/output operations worked as expected

Testing External IRQs
=====================

Testing rising edge on PIN_IN_0
... OK
Testing falling edge on PIN_IN_0
... OK
Testing both edges on PIN_IN_0
... OK
Testing masking of IRQs (still both edges on PIN_IN_0)
... OK
Testing level-triggered on HIGH on PIN_IN_0 (when input is LOW when setting up IRQ)
... OK
Testing level-triggered on HIGH on PIN_IN_0 (when input is HIGH when setting up IRQ)
... OK
Testing level-triggered on LOW on PIN_IN_0 (when input is HIGH when setting up IRQ)
... OK
Testing level-triggered on LOW on PIN_IN_0 (when input is LOW when setting up IRQ)
... OK

Testing Switching Direction
===========================

Input pin can be switched to output (push-pull) mode: yes
Pin behaves as output after switched to output mode: yes
Returning back to input had no side effects on config: yes
Pin behaves as input after switched back to input mode: yes


TEST SUCCEEDED
```

</details>

### Issues/PRs references

Depends on and includes: https://github.com/RIOT-OS/RIOT/pull/20290
