### PR TITLE
increase GNRC_NETIF_IPV6_ADDRS_NUMOF

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -60,6 +60,10 @@ endif
 # DODAG Configuration Options (see the doc for more info)
 # CFLAGS += -DCONFIG_GNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN
 
+ifndef CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF
+  CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=3
+endif
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 

--- a/tests/net/gnrc_udp/Makefile
+++ b/tests/net/gnrc_udp/Makefile
@@ -22,5 +22,9 @@ ifndef CONFIG_GNRC_PKTBUF_SIZE
   CFLAGS += -DCONFIG_GNRC_PKTBUF_SIZE=8192
 endif
 
+ifndef CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF
+  CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=3
+endif
+
 # Set a custom channel if needed
 include $(RIOTMAKE)/default-radio-settings.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It seems something happened and we have no available slot for adding an address.  This makes the release tests fail.

Here is a solution but maybe someone has something better

### Testing procedure

```
BUILD_IN_DOCKER=1 BOARD=samr21-xpro make flash term -C tests/net/gnrc_udp/
```

```
ifconfig 5 add beef::1
```

It should be able to add.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
