### PR TITLE
pkg - add optional post-patch target, to allow updates to packages after cloning and patching, but before compilation

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -79,6 +79,11 @@ PKG_DOWNLOADED = $(PKG_STATE)-downloaded
 # Custom prepared target that can be defined in packages Makefile.
 PKG_CUSTOM_PREPARED ?=
 
+# Custom post-patched target that can be defined in packages Makefile.
+# this is useful if something more complex than a static patch can address
+# needs to be done *after checkout*
+PKG_CUSTOM_POST_PATCH ?=
+
 # Declare 'all' first to have it being the default target
 all: prepare
 
@@ -88,7 +93,14 @@ prepare: $(PKG_PREPARED)
 
 # Allow packages to add a custom step to be `prepared`.
 # It should be a dependency of `$(PKG_PREPARED)` and depend on `$(PKG_PATCHED)`
-$(PKG_PREPARED): $(PKG_PATCHED)
+# as well as `$(PKG_CUSTOM_POST_PATCH)`
+#
+# An example might be if you need to generate code after checkout, to be
+# compiled into the target application.  This needs to run before the
+# build step in order for header files to be available on the include path.
+# You can define a "PHONY" PKG_CUSTOM_POST_PATCH target in your package makefile
+# and execute whatever operation you need within it.
+$(PKG_PREPARED): $(PKG_PATCHED) $(PKG_CUSTOM_POST_PATCH)
 	@touch $@
 
 # Use explicit '--git-dir' and '--work-tree' to prevent issues when the


### PR DESCRIPTION
### Contribution description
There may be a need to have a package modified in a more complex way than a patch can cover.  And furthermore, this might need to happen before building, such as in case a header file is generated or modified that is needed at the build/link stage.  This PR introduces `PKG_CUSTOM_POST_PATCH` which defaults to empty - but when it is non-empty, it can be used to introduce a new operation after patching but prior to compilation.


### Testing procedure

- with an external package, add a `PKG_CUSTOM_POST_PATCH` definition in that package's Makefile.


