### PR TITLE
vfs: fix FATFS_VFS_FILE_BUFFER_SIZE for increased VFS_NAME_MAX

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -141,11 +141,11 @@ extern "C" {
 
 #  if (__SIZEOF_POINTER__ == 8)
 #    define FATFS_VFS_DIR_BUFFER_SIZE      (64 + _FATFS_DIR_LFN + _FATFS_DIR_EXFAT)
-#    define FATFS_VFS_FILE_BUFFER_SIZE     (57 + VFS_NAME_MAX + _FATFS_FILE_CACHE + \
+#    define FATFS_VFS_FILE_BUFFER_SIZE     (64 + VFS_NAME_MAX + _FATFS_FILE_CACHE + \
                                            _FATFS_FILE_SEEK_PTR + _FATFS_FILE_EXFAT)
 #  else
 #    define FATFS_VFS_DIR_BUFFER_SIZE      (44 + _FATFS_DIR_LFN + _FATFS_DIR_EXFAT)
-#    define FATFS_VFS_FILE_BUFFER_SIZE     (41 + VFS_NAME_MAX + _FATFS_FILE_CACHE + \
+#    define FATFS_VFS_FILE_BUFFER_SIZE     (44 + VFS_NAME_MAX + _FATFS_FILE_CACHE + \
                                            _FATFS_FILE_SEEK_PTR + _FATFS_FILE_EXFAT)
 #  endif
 #else


### PR DESCRIPTION
### Contribution description

At least for `same54-xpro`, when `fatf_vfs` is used and `VFS_NAME_MAX` is increased a static assert triggers.

### Testing procedure

`BOARD=same54-xpro CFLAGS+=-DVFS_NAME_MAX=44 make -C tests/sys/vfs_default`

```
"make" -C /home/fabian.huessler@ml-pa.loc/RIOT/pkg/fatfs/fatfs_vfs
In file included from /home/fabian.huessler@ml-pa.loc/RIOT/pkg/fatfs/fatfs_vfs/fatfs_vfs.c:21:
/home/fabian.huessler@ml-pa.loc/RIOT/pkg/fatfs/fatfs_vfs/fatfs_vfs.c: In function '_mount':
/home/fabian.huessler@ml-pa.loc/RIOT/core/lib/include/assert.h:148:28: error: static assertion failed: "fatfs_file_desc_t must fit into VFS_FILE_BUFFER_SIZE"
  148 | #define static_assert(...) _Static_assert(__VA_ARGS__)
      |                            ^~~~~~~~~~~~~~
/home/fabian.huessler@ml-pa.loc/RIOT/pkg/fatfs/fatfs_vfs/fatfs_vfs.c:123:5: note: in expansion of macro 'static_assert'
  123 |     static_assert(VFS_FILE_BUFFER_SIZE >= sizeof(fatfs_file_desc_t),
      |     ^~~~~~~~~~~~~
make[2]: *** [/home/fabian.huessler@ml-pa.loc/RIOT/Makefile.base:146: /home/fabian.huessler@ml-pa.loc/RIOT/tests/sys/vfs_default/bin/same54-xpro/fatfs_vfs/fatfs_vfs.o] Error 1
make[1]: *** [/home/fabian.huessler@ml-pa.loc/RIOT/Makefile.base:31: ALL--/home/fabian.huessler@ml-pa.loc/RIOT/pkg/fatfs/fatfs_vfs] Error 2
make: *** [/home/fabian.huessler@ml-pa.loc/RIOT/tests/sys/vfs_default/../../../Makefile.include:760: application_tests_vfs_default.module] Error 2
```

`fatfs_vfs.c`
```C
    /* if one of the lines below fail to compile you probably need to adjust
       vfs buffer sizes ;) */
    static_assert(VFS_DIR_BUFFER_SIZE >= sizeof(DIR),
                  "DIR must fit into VFS_DIR_BUFFER_SIZE");
    static_assert(VFS_FILE_BUFFER_SIZE >= sizeof(fatfs_file_desc_t),
                  "fatfs_file_desc_t must fit into VFS_FILE_BUFFER_SIZE");
```

I modified `FATFS_VFS_FILE_BUFFER_SIZE` but I cannot explain how it fixes the issue :(
I would more like to know how someone figured out 41 before.

My guess would be that some expression depending of `sizeof(fatfs_file_desc_t)` should be there instead of just 41 or 48.
