### PR TITLE
drivers/w5100: make use of netdev_eui48_get()

### DIFF
--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -23,9 +23,9 @@
 #include <string.h>
 
 #include "log.h"
-#include "luid.h"
 #include "assert.h"
 
+#include "net/eui_provider.h"
 #include "net/ethernet.h"
 #include "net/netdev/eth.h"
 
@@ -134,7 +134,7 @@ static int init(netdev_t *netdev)
 {
     w5100_t *dev = (w5100_t *)netdev;
     uint8_t tmp;
-    uint8_t hwaddr[ETHERNET_ADDR_LEN];
+    eui48_t hwaddr;
 
     /* get access to the SPI bus for the duration of this function */
     spi_acquire(dev->p.spi, dev->p.cs, SPI_CONF, dev->p.clk);
@@ -152,9 +152,8 @@ static int init(netdev_t *netdev)
     while (rreg(dev, REG_MODE) & MODE_RESET) {}
 
     /* initialize the device, start with writing the MAC address */
-    luid_get(hwaddr, ETHERNET_ADDR_LEN);
-    hwaddr[0] &= ~0x03;         /* no group address and not globally unique */
-    wchunk(dev, REG_SHAR0, hwaddr, ETHERNET_ADDR_LEN);
+    netdev_eui48_get(netdev, &hwaddr);
+    wchunk(dev, REG_SHAR0, hwaddr.uint8, sizeof(hwaddr));
 
     /* configure all memory to be used by socket 0 */
     wreg(dev, REG_RMSR, RMSR_8KB_TO_S0);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This allows the use of EUI provider for setting a fixed MAC address. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
