### PR TITLE
cpu/native: Add support for periph_timer_query_freqs

### DIFF
--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -18,6 +18,7 @@ FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer_periodic
+FEATURES_PROVIDED += periph_timer_query_freqs
 ifeq ($(OS) $(OS_ARCH),Linux x86_64)
   FEATURES_PROVIDED += rust_target
 endif

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -49,7 +49,8 @@ extern "C" {
  * @name Timer peripheral configuration
  * @{
  */
-#define TIMER_NUMOF        (1U)
+#define TIMER_NUMOF            (1U)
+#define TIMER_CHANNEL_NUMOF    (1U)    /**< Number of timer channels */
 
 /**
  * @brief xtimer configuration

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -75,6 +75,28 @@ void native_isr_timer(void)
     _callback(_cb_arg, 0);
 }
 
+uword_t timer_query_freqs_numof(tim_t dev)
+{
+    (void)dev;
+
+    assert(TIMER_DEV(dev) < TIMER_NUMOF);
+
+    return 1;
+}
+
+uint32_t timer_query_freqs(tim_t dev, uword_t index)
+{
+    (void)dev;
+
+    assert(TIMER_DEV(dev) < TIMER_NUMOF);
+
+    if (index > 0) {
+        return 0;
+    }
+
+    return NATIVE_TIMER_SPEED;
+}
+
 int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     (void)freq;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This pull request adds support for the `periph_timer_query_freqs` feature to the `native` platform.
The feature allows software to query the supported frequency of the timer, which in this case is
a fixed frequency used internally for time conversions.

This allows software which depends on this feature to run on the `native` board. Since the `periph/timer`
test expects all timers supporting this feature to also define `TIMER_CHANNEL_NUMOF`, the necessary define
was added to the CPU configuration.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Build:
`make BOARD=native -C tests/periph/timer flash test`

> TIMER 0
> =======
>
>   - supported frequencies:
>     0: 1000000
>   - Calling timer_init(0, 1000000)
>     initialization successful
>   - timer_stop(0): stopped
>   - timer_set(0, 0, 5000)
>     Successfully set timeout 5000 for channel 0
>   - timer_start(0)
>   - Results:
>     - channel 0 fired at SW count   237578      - init:   237578
>   - Validating no spurious IRQs are triggered:
>     OK (no spurious IRQs)
>
> TEST SUCCEEDED
> { "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 436 }]}