### PR TITLE
cpu/native: Fix executable stack warning

### DIFF
--- a/cpu/native/tramp.S
+++ b/cpu/native/tramp.S
@@ -93,3 +93,7 @@ _native_sig_leave_handler:
     movl $0x0, _native_in_isr
     ret
 #endif
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The tramp assembly was missing a `.note.GNU-stack` section, meaning the compiler was forced to assume that we require an executable stack.

Fix this by adding the necessary section.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Build:
`make BOARD=native -C tests/core/thread_basic flash test`

> main(): This is RIOT! (Version: 2024.04-devel-20-gd04df-exec_stack)
> first thread
>
> { "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 436 }]}
> { "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2452 }]}
> second thread
>
> { "threads": [{ "name": "nr2", "stack_size": 12288, "stack_used": 736 }]}
