### PR TITLE
cpu: Add start and end markers for flash_writable section

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -238,7 +238,9 @@ SECTIONS
     } > bkup_ram
 
     .flash_writable (NOLOAD) : {
+        _fp_mem_start = . ;
         KEEP(*(SORT(.flash_writable.*)))
+        _fp_mem_end = . ;
     } > rom
 
     .end_fw (NOLOAD) : ALIGN(4) {

--- a/cpu/msp430/ldscripts/msp430_common.ld
+++ b/cpu/msp430/ldscripts/msp430_common.ld
@@ -13,7 +13,9 @@ SECTIONS
     _erom = ORIGIN(ROM) + LENGTH(ROM);
 
     .flash_writable (NOLOAD) : {
+        _fp_mem_start = . ;
         KEEP(*(SORT(.flash_writable.*)))
+        _fp_mem_end = . ;
     } > ROM
 
     .end_fw (NOLOAD) : ALIGN(4) {

--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -232,7 +232,9 @@ SECTIONS
   } >ram AT>ram :ram
 
   .flash_writable (NOLOAD) : {
+    _fp_mem_start = . ;
     KEEP(*(SORT(.flash_writable.*)))
+    _fp_mem_end = . ;
   } > flash
 
   .end_fw (NOLOAD) : ALIGN(4) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds start and end markers for the `flash_writable` section. For the ESP32x SoCs these were already added in #19079.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

