### PR TITLE
ci: support git-cache-rs

### DIFF
--- a/pkg/cmsis/Makefile
+++ b/pkg/cmsis/Makefile
@@ -3,10 +3,6 @@ PKG_URL=https://github.com/ARM-software/CMSIS_5
 PKG_VERSION=2b7495b8535bdcb306dac29b9ded4cfb679d7e5c  # 5.9.0
 PKG_LICENSE=Apache-2.0
 
-include $(RIOTBASE)/pkg/pkg.mk
-
-CFLAGS += -Wno-cast-align
-
 CMSIS_NN_MODULES =                 \
   cmsis-nn_activationfunctions     \
   cmsis-nn_convolutionfunctions    \
@@ -15,13 +11,6 @@ CMSIS_NN_MODULES =                 \
   cmsis-nn_poolingfunctions        \
   cmsis-nn_softmaxfunctions        \
   #
-
-DIR_activationfunctions        := ActivationFunctions
-DIR_convolutionfunctions       := ConvolutionFunctions
-DIR_fullyconnectedfunctions    := FullyConnectedFunctions
-DIR_nnsupportfunctions         := NNSupportFunctions
-DIR_poolingfunctions           := PoolingFunctions
-DIR_softmaxfunctions           := SoftmaxFunctions
 
 CMSIS_DSP_MODULES =              \
   cmsis-dsp_basicmathfunctions   \
@@ -36,6 +25,32 @@ CMSIS_DSP_MODULES =              \
   cmsis-dsp_transformfunctions   \
   #
 
+CMSIS_DSP_MODULES_USED = $(filter $(CMSIS_DSP_MODULES),$(USEMODULE))
+CMSIS_NN_MODULES_USED = $(filter $(CMSIS_NN_MODULES),$(USEMODULE))
+CMSIS_MODULES_USED = $(CMSIS_DSP_MODULES_USED) $(CMSIS_NN_MODULES_USED)
+
+PKG_SPARSE_PATHS=CMSIS/Core/Include
+
+ifneq (, $(CMSIS_NN_MODULES_USED))
+  PKG_SPARSE_PATHS+=CMSIS/NN
+  CMSIS_DSP_NEEDED=1
+endif
+ifneq (, $(CMSIS_DSP_MODULES_USED)$(CMSIS_DSP_NEEDED))
+  PKG_SPARSE_PATHS+=CMSIS/DSP
+endif
+
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+CFLAGS += -Wno-cast-align
+
+DIR_activationfunctions        := ActivationFunctions
+DIR_convolutionfunctions       := ConvolutionFunctions
+DIR_fullyconnectedfunctions    := FullyConnectedFunctions
+DIR_nnsupportfunctions         := NNSupportFunctions
+DIR_poolingfunctions           := PoolingFunctions
+DIR_softmaxfunctions           := SoftmaxFunctions
+
 DIR_basicmathfunctions      := BasicMathFunctions
 DIR_commontables            := CommonTables
 DIR_complexmathfunctions    := ComplexMathFunctions
@@ -48,8 +63,6 @@ DIR_supportfunctions        := SupportFunctions
 DIR_transformfunctions      := TransformFunctions
 
 .PHONY: cmsis-dsp_% cmsis-nn_%
-
-CMSIS_MODULES_USED = $(filter $(CMSIS_DSP_MODULES) $(CMSIS_NN_MODULES),$(USEMODULE))
 
 all: $(CMSIS_MODULES_USED)
 

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -128,7 +128,12 @@ $(PKG_DOWNLOADED): $(MAKEFILE_LIST) | $(PKG_SOURCE_DIR)/.git
 	fi
 	$(Q)echo $(PKG_VERSION) > $@
 
-ifeq ($(GIT_CACHE_DIR),$(wildcard $(GIT_CACHE_DIR)))
+ifneq (,$(GIT_CACHE_RS))
+$(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
+	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME)))
+	$(Q)rm -Rf $(PKG_SOURCE_DIR)
+	$(Q)$(GIT_CACHE_RS) clone --commit $(PKG_VERSION) $(addprefix --sparse-add ,$(PKG_SPARSE_PATHS)) -- $(PKG_URL) $(PKG_SOURCE_DIR)
+else ifeq ($(GIT_CACHE_DIR),$(wildcard $(GIT_CACHE_DIR)))
 $(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
 	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME)))
 	$(Q)rm -Rf $(PKG_SOURCE_DIR)

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -128,8 +128,24 @@ $(PKG_DOWNLOADED): $(MAKEFILE_LIST) | $(PKG_SOURCE_DIR)/.git
 	fi
 	$(Q)echo $(PKG_VERSION) > $@
 
+# This snippet ensures that for packages that have dynamic sparse paths (e.g.,
+# pkg/cmsis), the sparse paths of the time of checkout are the same as needed
+# now.
+# E.g., build a) only needs CMSIS/Core. Build b) also needs CMSIS/DSP.
+# If b) is built after a) and the cmsis checkout does not contain CMSIS/DSP,
+# the sources need to be checked out again.
+# (Inside, this is doing an ad-hoc "|$(LAZYSPONGE)", but using the python version turned out
+# to be significantly slower).
+ifneq (, $(PKG_SPARSE_PATHS))
+PKG_SPARSE_TAG = $(PKG_SOURCE_DIR).sparse
+$(PKG_SPARSE_TAG): FORCE
+	$(Q)if test -f $@; then \
+		test "$$(cat $@)" = "$(PKG_SPARSE_PATHS)" && exit 0; \
+	fi ; mkdir -p $$(dirname $@) && echo "$(PKG_SPARSE_PATHS)" > $@
+endif
+
 ifneq (,$(GIT_CACHE_RS))
-$(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
+$(PKG_SOURCE_DIR)/.git: $(PKG_SPARSE_TAG) | $(PKG_CUSTOM_PREPARED)
 	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME)))
 	$(Q)rm -Rf $(PKG_SOURCE_DIR)
 	$(Q)$(GIT_CACHE_RS) clone --commit $(PKG_VERSION) $(addprefix --sparse-add ,$(PKG_SPARSE_PATHS)) -- $(PKG_URL) $(PKG_SOURCE_DIR)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds support for the [Rust version of git-cache](https://github.com/kaspar030/git-cache-rs).

The shell version that we've integrated in `dist/tools/git` is quite a mess, barely maintainable. But most importantly, it is slow, and gets slower over time, due to the way the cache stores tags. Also, it doesn't support sparse checkouts. Crude measurements show that for our CI builds, for cortex-m builds **20-50%** of time spent on each built are spent on checking out "pkg/cmsis".

git-cache-rs' syntax is compatible with regular `git clone` to the point where any `git clone ...` command that doesn't work with just changing to `git cache clone` is considered a bug.
Unfortunately that requires some changes. This PR introduces git-cache-rs support as fully optional, it'll only be used if `GIT_CACHE_RS` is set to the binary name. The legacy built-in shell git-cache should continue working like before.

git-cache-rs works a bit differently than the shell git-cache: instead of having one large bare cache repository that adds repos as remote, git-cache-rs just stores a "--mirror" repository for each cached repo. This is *much* simpler, although it might use a bit more space.

git-cache-rs supports sparse checkouts, which has been implemented here for `pkg/cmsis`. I've updated dwq and the murdock container, and am currently testing those changes on ci-staging.riot-os.org.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've been testing this PR together with the CI support in https://github.com/RIOT-OS/riotdocker/pull/240 for a day or so on https://ci-staging.riot-os.org/.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
