### PR TITLE
drivers/periph_spi: Add `spi_transfer_u16_be()`

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -66,8 +66,8 @@
 #ifndef PERIPH_SPI_H
 #define PERIPH_SPI_H
 
+#include <endian.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -429,6 +429,25 @@ uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out);
  */
 void spi_transfer_regs(spi_t bus, spi_cs_t cs, uint8_t reg,
                        const void *out, void *in, size_t len);
+
+/**
+ * @brief   Transfer a 16 bit number in big endian byte order
+ *
+ * @param[in]   bus             SPI device to use
+ * @param[in]   cs              chip select pin/line to use, set to
+ *                              SPI_CS_UNDEF if chip select should not be
+ *                              handled by the SPI driver
+ * @param[in]   cont            if true, keep device selected after transfer
+ * @param[in]   host_number     number to transfer in host byte order
+ * @return      The 16 bit number received in host byte order
+ */
+static inline uint16_t spi_transfer_u16_be(spi_t bus, spi_cs_t cs, bool cont, uint16_t host_number)
+{
+    const uint16_t send = htobe16(host_number);
+    uint16_t receive;
+    spi_transfer_bytes(bus, cs, cont, &send, &receive, sizeof(receive));
+    return be16toh(receive);
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -47,13 +47,7 @@ static const netdev_driver_t netdev_driver_w5100;
 
 static inline void send_addr(w5100_t *dev, uint16_t addr)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    spi_transfer_byte(dev->p.spi, dev->p.cs, true, (addr >> 8));
-    spi_transfer_byte(dev->p.spi, dev->p.cs, true, (addr & 0xff));
-#else
-    spi_transfer_byte(dev->p.spi, dev->p.cs, true, (addr & 0xff));
-    spi_transfer_byte(dev->p.spi, dev->p.cs, true, (addr >> 8));
-#endif
+    spi_transfer_u16_be(dev->p.spi, dev->p.cs, true, addr);
 }
 
 static uint8_t rreg(w5100_t *dev, uint16_t reg)


### PR DESCRIPTION
### Contribution description

This adds `spi_transfer_u16_be()` intended to replace the free coded (and buggy) variant in the w5100 driver. This will also be useful for https://github.com/RIOT-OS/RIOT/pull/20301 that needs the same functionality.

### Testing procedure

The W5100 should work as before on little endian systems, and show now also work on big endian systems. (E.g. running `native` on a MIPS router with OpenWRT and using the SPI sysfs interface may work.)

### Issues/PRs references

- [x] Depends on and includes https://github.com/RIOT-OS/RIOT/pull/20310