### PR TITLE
Fix for `periph_timer` on `native`

### DIFF
--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -26,7 +26,6 @@
  * @}
  */
 
-#include <err.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -37,6 +36,7 @@
 #include "cpu.h"
 #include "cpu_conf.h"
 #include "native_internal.h"
+#include "panic.h"
 #include "periph/timer.h"
 #include "time_units.h"
 
@@ -201,7 +201,7 @@ void timer_start(tim_t dev)
 
     _native_syscall_enter();
     if (timer_settime(itimer_monotonic, 0, &its, NULL) == -1) {
-        err(EXIT_FAILURE, "timer_start: timer_settime");
+        core_panic(PANIC_GENERAL_ERROR, "Failed to set monotonic timer");
     }
     _native_syscall_leave();
 }
@@ -214,7 +214,7 @@ void timer_stop(tim_t dev)
     _native_syscall_enter();
     struct itimerspec zero = {0};
     if (timer_settime(itimer_monotonic, 0, &zero, &its) == -1) {
-        err(EXIT_FAILURE, "timer_stop: timer_settime");
+        core_panic(PANIC_GENERAL_ERROR, "Failed to set monotonic timer");
     }
     _native_syscall_leave();
 
@@ -234,7 +234,7 @@ unsigned int timer_read(tim_t dev)
     _native_syscall_enter();
 
     if (clock_gettime(CLOCK_MONOTONIC, &t) == -1) {
-        err(EXIT_FAILURE, "timer_read: clock_gettime");
+        core_panic(PANIC_GENERAL_ERROR, "Failed to read monotonic clock");
     }
 
     _native_syscall_leave();

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -99,7 +99,6 @@ uint32_t timer_query_freqs(tim_t dev, uword_t index)
 
 int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    (void)freq;
     DEBUG("%s\n", __func__);
     if (dev >= TIMER_NUMOF) {
         return -1;
@@ -172,8 +171,6 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags)
 {
-    (void)flags;
-
     if (channel != 0) {
         return -1;
     }

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -121,6 +121,7 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 
     if (register_interrupt(SIGALRM, native_isr_timer) != 0) {
         DEBUG_PUTS("Failed to register SIGALRM handler");
+        timer_delete(itimer_monotonic);
         return -1;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This pull request contains some fixes for the `periph_timer` module of the `native` platform.
The first patch is a minor cleanup patch while the next two patches fix some issues
regarding the handling of errors.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Build:
`make BOARD=native -C tests/periph/timer flash test`

> TIMER 0
> =======
>
>  - supported frequencies:
>     0: 1000000
>   - Calling timer_init(0, 1000000)
>     initialization successful
>   - timer_stop(0): stopped
>   - timer_set(0, 0, 5000)
>     Successfully set timeout 5000 for channel 0
>   - timer_start(0)
>   - Results:
>     - channel 0 fired at SW count   240171      - init:   240171
>   - Validating no spurious IRQs are triggered:
>     OK (no spurious IRQs)
>
> TEST SUCCEEDED
> { "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 436 }]}
> { "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2652 }]}
