### PR TITLE
gnrc_ipv6: fix double-free when pinging TNT loopback address [backport 2024.01]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -634,9 +634,13 @@ static void _send_multicast(gnrc_pktsnip_t *pkt, bool prep_hdr,
 static void _send_to_self(gnrc_pktsnip_t *pkt, bool prep_hdr,
                           gnrc_netif_t *netif)
 {
-    if (!_safe_fill_ipv6_hdr(netif, pkt, prep_hdr) ||
-        /* no netif header so we just merge the whole packet. */
-        (gnrc_pktbuf_merge(pkt) != 0)) {
+    /* _safe_fill_ipv6_hdr releases pkt on error */
+    if (!_safe_fill_ipv6_hdr(netif, pkt, prep_hdr)) {
+        DEBUG("ipv6: error looping packet to sender.\n");
+        return;
+    }
+    /* no netif header so we just merge the whole packet. */
+    else if (gnrc_pktbuf_merge(pkt) != 0) {
         DEBUG("ipv6: error looping packet to sender.\n");
         gnrc_pktbuf_release(pkt);
         return;


### PR DESCRIPTION
# Backport of #20309

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR provides a fix for a double-free in `gnrc_ipv6`.
This occurs because the `_safe_fill_ipv6_hdr` function already calls `gnrc_pktbuf_release`. Therefore, calling it again in `_send_to_self` crashes the devices
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try pinging to a TNT loopback address. Without this PR, it crashes:

```
2024-01-29 12:01:44,285 # ping 2001:67c:254:b0c1:204:2519:1801:bddb
2024-01-29 12:01:44,286 # 8841
2024-01-29 12:01:44,288 # *** RIOT kernel panic:
2024-01-29 12:01:44,290 # FAILED ASSERTION.
2024-01-29 12:01:44,290 # 
2024-01-29 12:01:44,299 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2024-01-29 12:01:44,308 # 	 - | isr_stack            | -        - |   - |    512 (  348) (  164) | 0x20000000 | 0x200001b8
2024-01-29 12:01:44,317 # 	 1 | main                 | pending  Q |   7 |   1536 (  740) (  796) | 0x20000490 | 0x200007ac 
2024-01-29 12:01:44,326 # 	 2 | pktdump              | bl rx    _ |   6 |   1472 (  184) ( 1288) | 0x2000319c | 0x200036a4 
2024-01-29 12:01:44,335 # 	 3 | 6lo                  | bl rx    _ |   3 |    960 (  364) (  596) | 0x200041c0 | 0x2000449c 
2024-01-29 12:01:44,344 # 	 4 | ipv6                 | running  Q |   4 |    960 (  660) (  300) | 0x20000bac | 0x20000e8c 
2024-01-29 12:01:44,353 # 	 5 | udp                  | bl rx    _ |   5 |    448 (  216) (  232) | 0x200045c4 | 0x200046ac 
2024-01-29 12:01:44,362 # 	 6 | at86rf2xx            | bl anyfl _ |   2 |    896 (  424) (  472) | 0x20001390 | 0x20001644 
2024-01-29 12:01:44,371 # 	 7 | RPL                  | bl rx    _ |   5 |   1024 (  216) (  808) | 0x200037b4 | 0x20003adc 
2024-01-29 12:01:44,378 # 	   | SUM                  |            |     |   7808 ( 3152) ( 4656)
2024-01-29 12:01:44,378 # 
2024-01-29 12:01:44,379 # *** halted.
2024-01-29 12:01:44,379 # 
2024-01-29 12:01:44,379 # 
2024-01-29 12:01:44,381 # Context before hardfault:
2024-01-29 12:01:44,383 #    r0: 0x0000000a
2024-01-29 12:01:44,384 #    r1: 0x00000000
2024-01-29 12:01:44,386 #    r2: 0x00000000
2024-01-29 12:01:44,388 #    r3: 0x00000000
2024-01-29 12:01:44,389 #   r12: 0x00000046
2024-01-29 12:01:44,391 #    lr: 0x000010df
2024-01-29 12:01:44,393 #    pc: 0x00001aac
2024-01-29 12:01:44,394 #   psr: 0x41000000
2024-01-29 12:01:44,394 # 
2024-01-29 12:01:44,395 # Misc
2024-01-29 12:01:44,397 # EXC_RET: 0xfffffffd
2024-01-29 12:01:44,399 # Active thread: 4 "ipv6"
2024-01-29 12:01:44,403 # Attempting to reconstruct state for debugging...
2024-01-29 12:01:44,404 # In GDB:
2024-01-29 12:01:44,405 #   set $pc=0x1aac
2024-01-29 12:01:44,406 #   frame 0
2024-01-29 12:01:44,407 #   bt
2024-01-29 12:01:44,407 # 
2024-01-29 12:01:44,411 # ISR stack overflowed by at least 8 bytes.
2024-01-29 12:01:44,412 # Inside isr -13
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

I can confirm this issue has been there since 2019.10 at least.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
