### PR TITLE
cpu/native/periph_timer: make clock agnostic to CPU load

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -63,6 +63,8 @@
 #include <sys/uio.h>
 #include <dirent.h>
 
+#include "time_units.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -201,6 +203,45 @@ int register_interrupt(int sig, _native_callback_t handler);
  * unregister interrupt handler for interrupt sig
  */
 int unregister_interrupt(int sig);
+
+/**
+ * @brief   Time the process voluntarily paused (e.g. by `pm_set_lowest()`)
+ *
+ * @note    You should disable IRQs while accessing it.
+ */
+extern struct timespec native_time_spend_sleeping;
+
+/**
+ * @brief   Subtract @p subtrahend from @p minuend in-place
+ *
+ * @note    If both values are normalized, the result will be normalized
+ */
+static inline void timespec_subtract(struct timespec *minuend,
+                                     const struct timespec *subtrahend)
+{
+    minuend->tv_sec -= subtrahend->tv_sec;
+    minuend->tv_nsec -= subtrahend->tv_nsec;
+    if (minuend->tv_nsec < 0) {
+        minuend->tv_nsec += NS_PER_SEC;
+        minuend->tv_sec--;
+    }
+}
+
+/**
+ * @brief   Add @p second from @p first in-place
+ *
+ * @note    If both values are normalized, the result will be normalized
+ */
+static inline void timespec_add(struct timespec *first,
+                                const struct timespec *second)
+{
+    first->tv_sec += second->tv_sec;
+    first->tv_nsec += second->tv_nsec;
+    if (first->tv_nsec > (long)NS_PER_SEC) {
+        first->tv_nsec -= NS_PER_SEC;
+        first->tv_sec++;
+    }
+}
 
 #ifdef __cplusplus
 }

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -36,6 +36,7 @@
 
 #include "cpu.h"
 #include "cpu_conf.h"
+#include "irq.h"
 #include "native_internal.h"
 #include "periph/timer.h"
 #include "time_units.h"
@@ -236,9 +237,13 @@ unsigned int timer_read(tim_t dev)
 
     _native_syscall_enter();
 
-    if (clock_gettime(CLOCK_MONOTONIC, &t) == -1) {
+    if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t) == -1) {
         err(EXIT_FAILURE, "timer_read: clock_gettime");
     }
+
+    unsigned irq_state = irq_disable();
+    timespec_add(&t, &native_time_spend_sleeping);
+    irq_restore(irq_state);
 
     _native_syscall_leave();
 


### PR DESCRIPTION
### Contribution description

This changes the POSIX clock backing `timer_read()` to `CLOCK_PROCESS_CPUTIME_ID` in the hope that this make tests in the CI more repeatable, regardless of background CPU load.

For timeouts still `CLOCK_MONOTONIC` is used, as
`CLOCK_PROCESS_CPUTIME_ID` will not advance when no (RIOT) threads are runnable and a timeout would never occur.

To do some impedance matching, bookkeeping is added to the time spent sleeping. This is added on top of the time got from `CLOCK_PROCESS_CPUTIME_ID`.

#### **WARNING**

This makes the test even more flaky then before. Either I mess something up in my implementation, or maybe `CLOCK_PROCESS_CPUTIME_ID` is just too coarse grained to be of use for us. This is not intended to be merged in this buggy state, but rather a proof of concept.

My conclusion is that we disable CI tests on `native` that have the assumption baked in that RIOT is running exclusively on the target board.

### Testing procedure

Run `tests/sys/ztimer_overhead` with and without a CPU heavy benchmark running in background. The hope was that this makes the test passing more reliably. But the current state is that it makes everything worse.

### Issues/PRs references

None