### PR TITLE
tests/sys/timer_overhead: disable test on native in CI

### DIFF
--- a/tests/sys/ztimer_overhead/Makefile
+++ b/tests/sys/ztimer_overhead/Makefile
@@ -9,4 +9,8 @@ USEMODULE += ztimer_usec
 # microbit qemu timing is off
 TEST_ON_CI_BLACKLIST += microbit
 
+# The test is sensitive to background CPU load. On the CI workers a lot of
+# compilation tasks are run in parallel, making this test randomly fail.
+TEST_ON_CI_BLACKLIST += native
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This disables the `tests/sys/timer_overhead` test run on `native` in the CI. Citing the comment in the `Makefile`:

```
# The test is sensitive to background CPU load. On the CI workers a lot of
# compilation tasks are run in parallel, making this test randomly fail.
```

### Testing procedure

Green CI

### Issues/PRs references

None