### PR TITLE
tests/pkg/lwip: include default-radio-settings.inc.mk [backport 2024.01]

### DIFF
--- a/tests/pkg/lwip/Makefile
+++ b/tests/pkg/lwip/Makefile
@@ -48,3 +48,6 @@ DISABLE_MODULE += test_utils_interactive_sync
 TEST_ON_CI_BLACKLIST += all
 
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-radio-settings.inc.mk


### PR DESCRIPTION
# Backport of #20325

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
For the release tests we decided to randomize the PAN ID to not interfere with ongoing RIOT-based experiments in the testbed (see https://github.com/RIOT-OS/Release-Specs/pull/300). However, lwIP currently does not include the Makefile to set the PAN ID at compile time. This fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Apply the following patch

```diff
diff --git a/drivers/netdev/ieee802154.c b/drivers/netdev/ieee802154.c
index cf5a39d4b4..9068a1e8fa 100644
--- a/drivers/netdev/ieee802154.c
+++ b/drivers/netdev/ieee802154.c
@@ -44,6 +44,7 @@ void netdev_ieee802154_reset(netdev_ieee802154_t *dev)
 
     /* Initialize PAN ID and call netdev::set to propagate it */
     dev->pan = CONFIG_IEEE802154_DEFAULT_PANID;
+    printf("PANID: 0x%04x\n", dev->pan);
     dev->netdev.driver->set(&dev->netdev, NETOPT_NID, &dev->pan, sizeof(dev->pan));
 
 #if IS_USED(MODULE_IEEE802154_SECURITY)
```

Then compile and flash `tests/pkg/lwip` to a board that has an IEEE 802.15.4 radio. Open a terminal and reboot. The node should now print `PANID: 0x0023`. If you then recompile and flash `tests/pkg/lwip` with `DEFAULT_PAN_ID` set to another value in the environment variables, e.g. `DEFAULT_PAN_ID=0x1234`, without this PR, the output will still be `PANID: 0x0023`, with this PR it will be `PANID: 0x1234`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Required for https://github.com/RIOT-OS/Release-Specs/pull/300.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
