### PR TITLE
boards/common/nrf52: add OpenOCD's RIOT awareness

### DIFF
--- a/boards/common/nrf52/dist/openocd.cfg
+++ b/boards/common/nrf52/dist/openocd.cfg
@@ -1,1 +1,2 @@
 source [find target/nrf52.cfg]
+$_TARGETNAME configure -rtos auto


### PR DESCRIPTION
### Contribution description

This enables RIOT awareness in OpenOCD, so that `info threads` actually shows RIOT's threads.

### Testing procedure

Run `make debug`, at a point after the scheduler has started:

```
(gdb) info threads 
  Id   Target Id                                                Frame 
* 1    Thread 1 "main" (Name: main, Blocked mutex)              sched_arch_idle ()
    at /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/thread_arch.c:529
  2    Thread 2 "pktdump" (Name: pktdump, Blocked receive)      _msg_receive (m=0x0 <sched_change_priority>, 
    m@entry=0x200016c0 <_stack+1392>, block=block@entry=1)
    at /home/maribu/Repos/software/RIOT/master/core/include/thread.h:401
  3    Thread 3 "nrf802154" (Name: nrf802154, Blocked any flag) 0x00000898 in _thread_flags_wait_any (mask=mask@entry=32769)
    at /home/maribu/Repos/software/RIOT/master/core/thread_flags.c:106
```

In `master`, this looked something like this instead:

```
(gdb) info threads 
  Id   Target Id         Frame 
* 1    Remote target     sched_arch_idle () at /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/thread_arch.c:529
```

### Issues/PRs references

None