### PR TITLE
doc/getting-started: point out where to run make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,17 @@ distclean: docclean pkg-clean
 	@echo "Cleaning all build products"
 	@for dir in $(APPLICATION_DIRS); do "$(MAKE)" -C$$dir distclean; done
 
+print-versions:
+	@./dist/tools/ci/print_toolchain_versions.sh
+
+include makefiles/boards.inc.mk
+include makefiles/app_dirs.inc.mk
+
+include makefiles/tools/riotgen.inc.mk
+-include makefiles/tests.inc.mk
+
+include makefiles/color.inc.mk
+
 welcome:
 	@echo "Welcome to RIOT - The friendly OS for IoT!"
 	@echo ""
@@ -47,12 +58,7 @@ welcome:
 	@echo " print-versions"
 	@echo " clean distclean pkg-clean"
 	@echo " doc doc-{man,latex}"
-
-print-versions:
-	@./dist/tools/ci/print_toolchain_versions.sh
-
-include makefiles/boards.inc.mk
-include makefiles/app_dirs.inc.mk
-
-include makefiles/tools/riotgen.inc.mk
--include makefiles/tests.inc.mk
+	@echo ""
+	@echo "==> tl;dr Try running:"
+	@echo "    cd examples/default"
+	@echo "    make BOARD=<INSERT_BOARD_NAME>"

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -202,7 +202,8 @@ Building and executing an example           {#building-and-executing-an-example}
 ---------------------------------
 RIOT provides a number of examples in the `examples/` directory. Every example
 has a README that documents its usage and its purpose. You can build them by
-typing
+opening a shell, navigating to an example (e.g. `examples/default`), and
+running:
 
 ~~~~~~~~ {.sh}
 make BOARD=samr21-xpro
@@ -214,9 +215,7 @@ or
 make all BOARD=samr21-xpro
 ~~~~~~~~
 
-into your shell.
-
-To flash the application to a board just type
+To flash the application to a board just run:
 
 ~~~~~~~~ {.sh}
 make flash BOARD=samr21-xpro


### PR DESCRIPTION
### Contribution description

This improves documentation at two locations:

1. The getting started section previously never stated that `make` is supposed to be run in an applications folder
2. The help message when `make` in the root directory got a `tl'dr` section at the end

### Testing procedure

1. The CI will add a link to the doc
2. Run `make` in the root directory of the repo. The output should be:

```
make
Welcome to RIOT - The friendly OS for IoT!

You executed 'make' from the base directory.
Usually, you should run 'make' in your application's directory instead.

Please see our Quick Start Guide at:
    https://doc.riot-os.org/getting-started.html
You can ask questions or discuss with other users on our forum:
    https://forum.riot-os.org

Available targets for the RIOT base directory include:
 generate-{board,driver,example,module,pkg,test}
 info-{applications,boards,emulated-boards} info-applications-supported-boards
 print-versions
 clean distclean pkg-clean
 doc doc-{man,latex}

==> tl;dr Try running:
    cd examples/default
    make BOARD=<INSERT_BOARD_NAME>

make: *** [Makefile:7: all] Error 1
```

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/20322#issuecomment-1925818784