### PR TITLE
boards/weact-g030f6: add support for minimal break-out board

### DIFF
--- a/boards/stm32g0316-disco/Makefile.features
+++ b/boards/stm32g0316-disco/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32g031j6
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/stm32g0316-disco/include/periph_conf.h
+++ b/boards/stm32g0316-disco/include/periph_conf.h
@@ -45,6 +45,7 @@ static const timer_conf_t timer_config[] = {
 };
 
 #define TIMER_0_ISR         isr_tim1_cc
+#define TIMER_0_MAX_VALUE   0xffff
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/weact-g030f6/Makefile
+++ b/boards/weact-g030f6/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/weact-g030f6/Makefile.dep
+++ b/boards/weact-g030f6/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/weact-g030f6/Makefile.features
+++ b/boards/weact-g030f6/Makefile.features
@@ -1,0 +1,8 @@
+CPU = stm32
+CPU_MODEL = stm32g030f6
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_rtc

--- a/boards/weact-g030f6/Makefile.include
+++ b/boards/weact-g030f6/Makefile.include
@@ -1,0 +1,18 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+PROGRAMMER ?= openocd
+OPENOCD_DEBUG_ADAPTER ?= stlink
+
+# openocd programmer is supported
+PROGRAMMERS_SUPPORTED += openocd
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/weact-g030f6/dist/openocd.cfg
+++ b/boards/weact-g030f6/dist/openocd.cfg
@@ -1,0 +1,3 @@
+source [find target/stm32g0x.cfg]
+
+$_TARGETNAME configure -rtos auto

--- a/boards/weact-g030f6/doc.txt
+++ b/boards/weact-g030f6/doc.txt
@@ -1,0 +1,37 @@
+/**
+@defgroup    boards_weact-g030f6 WeAct-G030F6 board
+@ingroup     boards
+@brief       Support for the WeAct-G030F6 board
+
+## Overview
+
+WeAct-G030F6 is a cheap little board based on the STM32G030F6P6 MCU.
+It does not come with a programmer or USB connection, so an external
+programmer (ST-Link, DAP-Link, etc) has to be used.
+
+It is available on sites like AliExpress for less than 2€.
+
+## Hardware
+
+![WeAct-G030F6P4](https://github.com/RIOT-OS/RIOT/assets/1301112/d42a25e0-d331-4cae-ba48-1edfa01f35f9)
+
+### MCU
+| MCU              | STM32G030F6P6         |
+|:---------------- |:--------------------- |
+| Family           | ARM Cortex-M0+        |
+| Vendor           | ST Microelectronics   |
+| RAM              |  8KiB                 |
+| Flash            | 32KiB                 |
+| Frequency        | up to 64MHz           |
+| FPU              | no                    |
+| Timers           | 8 (2x watchdog, 1 SysTick, 5x 16-bit) |
+| ADCs             | 1x 12-bit             |
+| UARTs            | 2                     |
+| SPIs             | 2                     |
+| I2Cs             | 2                     |
+| RTC              | 1                     |
+| Vcc              | 2.0V - 3.6V           |
+| Datasheet        | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g030f6.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0454-stm32g0x0-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+
+*/

--- a/boards/weact-g030f6/include/board.h
+++ b/boards/weact-g030f6/include/board.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_weact-g030f6
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for WeAct-G030F6
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LED0_PIN_NUM        4
+#define LED0_PORT_NUM       PORT_A
+
+#define BTN0_PIN            GPIO_PIN(PORT_A, 14)
+#define BTN0_MODE           GPIO_IN
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "stm32_leds.h"
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/weact-g030f6/include/gpio_params.h
+++ b/boards/weact-g030f6/include/gpio_params.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_weact-g030f6
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(blue)",
+        .pin  = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags= SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "Button(A14)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/weact-g030f6/include/periph_conf.h
+++ b/boards/weact-g030f6/include/periph_conf.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_weact-g030f6
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for WeAct-G030F6
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+#include "clk_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM1,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APBENR2_TIM1EN,
+        .bus      = APB12,
+        .irqn     = TIM1_CC_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim1_cc
+#define TIMER_0_MAX_VALUE   0xffff
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APBENR1_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_usart2)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/examples/benchmark_udp/Makefile.ci
+++ b/examples/benchmark_udp/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -40,6 +40,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -32,5 +32,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -37,5 +37,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/dtls-echo/Makefile.ci
+++ b/examples/dtls-echo/Makefile.ci
@@ -55,6 +55,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -58,6 +58,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -52,5 +52,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     yunjia-nrf51822 \
     #

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -40,6 +40,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -35,5 +35,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/gcoap_block_server/Makefile.ci
+++ b/examples/gcoap_block_server/Makefile.ci
@@ -34,5 +34,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/gcoap_dtls/Makefile.ci
+++ b/examples/gcoap_dtls/Makefile.ci
@@ -59,6 +59,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/examples/gcoap_fileserver/Makefile.ci
+++ b/examples/gcoap_fileserver/Makefile.ci
@@ -39,5 +39,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -67,6 +67,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     weio \
     yunjia-nrf51822 \
     z1 \

--- a/examples/gnrc_lorawan/Makefile.ci
+++ b/examples/gnrc_lorawan/Makefile.ci
@@ -18,5 +18,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     telosb \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -41,6 +41,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/examples/gnrc_networking_subnets/Makefile.ci
+++ b/examples/gnrc_networking_subnets/Makefile.ci
@@ -34,5 +34,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -59,5 +59,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     yunjia-nrf51822 \
     #

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -101,6 +101,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     wemos-zero \
     yarm \
     yunjia-nrf51822 \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -45,4 +45,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/examples/lwm2m/Makefile.ci
+++ b/examples/lwm2m/Makefile.ci
@@ -43,5 +43,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     yunjia-nrf51822 \
     #

--- a/examples/micropython/Makefile.ci
+++ b/examples/micropython/Makefile.ci
@@ -35,4 +35,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -29,5 +29,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/paho-mqtt/Makefile.ci
+++ b/examples/paho-mqtt/Makefile.ci
@@ -54,6 +54,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/examples/posix_select/Makefile.ci
+++ b/examples/posix_select/Makefile.ci
@@ -31,5 +31,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -40,6 +40,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     #

--- a/examples/psa_crypto/Makefile.ci
+++ b/examples/psa_crypto/Makefile.ci
@@ -26,4 +26,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/examples/rust-gcoap/Makefile.ci
+++ b/examples/rust-gcoap/Makefile.ci
@@ -34,5 +34,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     yunjia-nrf51822 \
     #

--- a/examples/sniffer/Makefile.ci
+++ b/examples/sniffer/Makefile.ci
@@ -23,4 +23,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/examples/spectrum-scanner/Makefile.ci
+++ b/examples/spectrum-scanner/Makefile.ci
@@ -21,4 +21,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/examples/telnet_server/Makefile.ci
+++ b/examples/telnet_server/Makefile.ci
@@ -33,5 +33,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/examples/wasm/Makefile.ci
+++ b/examples/wasm/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/bench/xtimer/Makefile.ci
+++ b/tests/bench/xtimer/Makefile.ci
@@ -11,4 +11,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     slstk3400a \
     stk3200 \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/bench/ztimer/Makefile.ci
+++ b/tests/bench/ztimer/Makefile.ci
@@ -11,4 +11,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     slstk3400a \
     stk3200 \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/core/cond_order/Makefile.ci
+++ b/tests/core/cond_order/Makefile.ci
@@ -26,4 +26,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/core/mutex_order/Makefile.ci
+++ b/tests/core/mutex_order/Makefile.ci
@@ -21,4 +21,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/core/rmutex_cpp/Makefile.ci
+++ b/tests/core/rmutex_cpp/Makefile.ci
@@ -21,4 +21,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/core/thread_cooperation/Makefile.ci
+++ b/tests/core/thread_cooperation/Makefile.ci
@@ -19,4 +19,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/core/thread_float/Makefile.ci
+++ b/tests/core/thread_float/Makefile.ci
@@ -26,6 +26,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    weact-g030f6 \
     weio \
     yunjia-nrf51822 \
     #

--- a/tests/core/thread_stack_alignment/Makefile.ci
+++ b/tests/core/thread_stack_alignment/Makefile.ci
@@ -10,4 +10,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \
+    weact-g030f6 \
     #

--- a/tests/drivers/xbee/Makefile.ci
+++ b/tests/drivers/xbee/Makefile.ci
@@ -16,4 +16,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    weact-g030f6 \
     #

--- a/tests/net/emcute/Makefile.ci
+++ b/tests/net/emcute/Makefile.ci
@@ -61,6 +61,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/gcoap_dns/Makefile.ci
+++ b/tests/net/gcoap_dns/Makefile.ci
@@ -51,6 +51,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/gcoap_fileserver/Makefile.ci
+++ b/tests/net/gcoap_fileserver/Makefile.ci
@@ -49,6 +49,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_client/Makefile.ci
@@ -39,5 +39,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -68,6 +68,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/gnrc_dhcpv6_client_stateless/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_client_stateless/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/gnrc_dhcpv6_relay/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_relay/Makefile.ci
@@ -39,5 +39,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext/Makefile.ci
@@ -40,5 +40,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     thingy52 \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext_frag/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext_opt/Makefile.ci
@@ -32,5 +32,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_ipv6_fwd_w_sub/Makefile.ci
+++ b/tests/net/gnrc_ipv6_fwd_w_sub/Makefile.ci
@@ -27,5 +27,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_ipv6_nib/Makefile.ci
+++ b/tests/net/gnrc_ipv6_nib/Makefile.ci
@@ -22,5 +22,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/net/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -29,5 +29,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/net/gnrc_ipv6_nib_dns/Makefile.ci
@@ -31,5 +31,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_mac_timeout/Makefile.ci
+++ b/tests/net/gnrc_mac_timeout/Makefile.ci
@@ -23,4 +23,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/gnrc_ndp/Makefile.ci
+++ b/tests/net/gnrc_ndp/Makefile.ci
@@ -26,5 +26,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_netif/Makefile.ci
+++ b/tests/net/gnrc_netif/Makefile.ci
@@ -69,6 +69,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/gnrc_netif_ipv6_wait_for_global_address/Makefile.ci
+++ b/tests/net/gnrc_netif_ipv6_wait_for_global_address/Makefile.ci
@@ -30,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/gnrc_rpl/Makefile.ci
+++ b/tests/net/gnrc_rpl/Makefile.ci
@@ -37,5 +37,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_rpl_p2p/Makefile.ci
+++ b/tests/net/gnrc_rpl_p2p/Makefile.ci
@@ -34,5 +34,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_rpl_srh/Makefile.ci
+++ b/tests/net/gnrc_rpl_srh/Makefile.ci
@@ -40,5 +40,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     thingy52 \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_sixlowpan/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan/Makefile.ci
@@ -38,5 +38,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -50,6 +50,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure/Makefile.ci
@@ -49,6 +49,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile.ci
@@ -55,6 +55,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
@@ -29,5 +29,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_sock_dns/Makefile.ci
+++ b/tests/net/gnrc_sock_dns/Makefile.ci
@@ -34,5 +34,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     thingy52 \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_sock_dodtls/Makefile.ci
+++ b/tests/net/gnrc_sock_dodtls/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_sock_ip/Makefile.ci
+++ b/tests/net/gnrc_sock_ip/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32g0316-disco \
     telosb \
+    weact-g030f6 \
     wsn430-v1_3b \
     wsn430-v1_4 \
     #

--- a/tests/net/gnrc_sock_neterr/Makefile.ci
+++ b/tests/net/gnrc_sock_neterr/Makefile.ci
@@ -15,4 +15,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/net/gnrc_sock_tcp/Makefile.ci
+++ b/tests/net/gnrc_sock_tcp/Makefile.ci
@@ -42,6 +42,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_sock_udp/Makefile.ci
+++ b/tests/net/gnrc_sock_udp/Makefile.ci
@@ -20,5 +20,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/gnrc_tcp/Makefile.ci
+++ b/tests/net/gnrc_tcp/Makefile.ci
@@ -43,6 +43,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_tx_sync/Makefile.ci
+++ b/tests/net/gnrc_tx_sync/Makefile.ci
@@ -46,6 +46,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/gnrc_udp/Makefile.ci
+++ b/tests/net/gnrc_udp/Makefile.ci
@@ -53,6 +53,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/net/ieee802154_security/Makefile.ci
+++ b/tests/net/ieee802154_security/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/nanocoap_cli/Makefile.ci
+++ b/tests/net/nanocoap_cli/Makefile.ci
@@ -36,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/net/netdev_common/Makefile.ci
+++ b/tests/net/netdev_common/Makefile.ci
@@ -23,4 +23,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/netstats_neighbor/Makefile.ci
+++ b/tests/net/netstats_neighbor/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/netutils/Makefile.ci
+++ b/tests/net/netutils/Makefile.ci
@@ -28,4 +28,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/slip/Makefile.ci
+++ b/tests/net/slip/Makefile.ci
@@ -29,4 +29,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/net/sntp/Makefile.ci
+++ b/tests/net/sntp/Makefile.ci
@@ -31,5 +31,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/net/sock_udp_aux/Makefile.ci
+++ b/tests/net/sock_udp_aux/Makefile.ci
@@ -34,5 +34,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/pkg/elk/Makefile.ci
+++ b/tests/pkg/elk/Makefile.ci
@@ -13,5 +13,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32g0316-disco \
     telosb \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/pkg/emlearn/Makefile.ci
+++ b/tests/pkg/emlearn/Makefile.ci
@@ -29,4 +29,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/flashdb_vfs/Makefile.ci
+++ b/tests/pkg/flashdb_vfs/Makefile.ci
@@ -8,4 +8,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/libb2/Makefile.ci
+++ b/tests/pkg/libb2/Makefile.ci
@@ -13,5 +13,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32g0316-disco \
     telosb \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/pkg/libcose/Makefile.ci
+++ b/tests/pkg/libcose/Makefile.ci
@@ -15,4 +15,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/libfixmath_unittests/Makefile.ci
+++ b/tests/pkg/libfixmath_unittests/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/pkg/libschc/Makefile.ci
+++ b/tests/pkg/libschc/Makefile.ci
@@ -8,4 +8,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/littlefs2/Makefile.ci
+++ b/tests/pkg/littlefs2/Makefile.ci
@@ -23,4 +23,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/pkg/lvgl/Makefile.ci
+++ b/tests/pkg/lvgl/Makefile.ci
@@ -28,4 +28,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/pkg/lvgl_touch/Makefile.ci
+++ b/tests/pkg/lvgl_touch/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/pkg/lwip/Makefile.ci
+++ b/tests/pkg/lwip/Makefile.ci
@@ -28,5 +28,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     yunjia-nrf51822 \
     #

--- a/tests/pkg/lwip_sock_ip/Makefile.ci
+++ b/tests/pkg/lwip_sock_ip/Makefile.ci
@@ -17,4 +17,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/lwip_sock_tcp/Makefile.ci
+++ b/tests/pkg/lwip_sock_tcp/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/pkg/lwip_sock_udp/Makefile.ci
+++ b/tests/pkg/lwip_sock_udp/Makefile.ci
@@ -17,4 +17,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/lz4/Makefile.ci
+++ b/tests/pkg/lz4/Makefile.ci
@@ -49,6 +49,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     wemos-zero \
     yarm \
     yunjia-nrf51822 \

--- a/tests/pkg/microcoap/Makefile.ci
+++ b/tests/pkg/microcoap/Makefile.ci
@@ -29,6 +29,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     wsn430-v1_3b \
     wsn430-v1_4 \
     z1 \

--- a/tests/pkg/monocypher/Makefile.ci
+++ b/tests/pkg/monocypher/Makefile.ci
@@ -6,4 +6,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
+    weact-g030f6 \
     #

--- a/tests/pkg/relic/Makefile.ci
+++ b/tests/pkg/relic/Makefile.ci
@@ -19,4 +19,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/pkg/spiffs/Makefile.ci
+++ b/tests/pkg/spiffs/Makefile.ci
@@ -28,5 +28,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/pkg/tflite-micro/Makefile.ci
+++ b/tests/pkg/tflite-micro/Makefile.ci
@@ -102,6 +102,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     teensy31 \
     usb-kw41z \
     weact-f401cc \
+    weact-g030f6 \
     wemos-zero \
     yarm \
     yunjia-nrf51822 \

--- a/tests/pkg/tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg/tinydtls_sock_async/Makefile.ci
@@ -68,6 +68,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     zigduino \

--- a/tests/pkg/tinyvcdiff/Makefile.ci
+++ b/tests/pkg/tinyvcdiff/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/pkg/ubasic/Makefile.ci
+++ b/tests/pkg/ubasic/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
+    weact-g030f6 \
     #

--- a/tests/pkg/ucglib/Makefile.ci
+++ b/tests/pkg/ucglib/Makefile.ci
@@ -13,4 +13,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     waspmote-pro \
+    weact-g030f6 \
     #

--- a/tests/pkg/utensor/Makefile.ci
+++ b/tests/pkg/utensor/Makefile.ci
@@ -50,4 +50,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/pkg/wolfssl/Makefile.ci
+++ b/tests/pkg/wolfssl/Makefile.ci
@@ -36,4 +36,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    weact-g030f6 \
     #

--- a/tests/sys/cpp11_condition_variable/Makefile.ci
+++ b/tests/sys/cpp11_condition_variable/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
+    weact-g030f6 \
     #

--- a/tests/sys/cpp11_thread/Makefile.ci
+++ b/tests/sys/cpp11_thread/Makefile.ci
@@ -8,4 +8,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/sys/crypto/Makefile.ci
+++ b/tests/sys/crypto/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/sys/crypto_aes_ccm/Makefile.ci
+++ b/tests/sys/crypto_aes_ccm/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     telosb \
     waspmote-pro \
+    weact-g030f6 \
     z1 \
     zigduino \
     #

--- a/tests/sys/posix_semaphore/Makefile.ci
+++ b/tests/sys/posix_semaphore/Makefile.ci
@@ -28,5 +28,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     yunjia-nrf51822 \
     #

--- a/tests/sys/ps_schedstatistics/Makefile.ci
+++ b/tests/sys/ps_schedstatistics/Makefile.ci
@@ -23,5 +23,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/sys/pthread_rwlock/Makefile.ci
+++ b/tests/sys/pthread_rwlock/Makefile.ci
@@ -26,4 +26,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    weact-g030f6 \
     #

--- a/tests/sys/senml_phydat/Makefile.ci
+++ b/tests/sys/senml_phydat/Makefile.ci
@@ -15,4 +15,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \
+    weact-g030f6 \
     #

--- a/tests/sys/suit_manifest/Makefile.ci
+++ b/tests/sys/suit_manifest/Makefile.ci
@@ -19,5 +19,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \
+    weact-g030f6 \
     z1 \
     #

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -107,6 +107,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     teensy31 \
     telosb \
+    weact-g030f6 \
     yunjia-nrf51822 \
     z1 \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds support for a [cheap little board](https://aliexpress.com/item/1005005748496495.html) based on STM32G030F6.

![Weact-stm32g030f6p6](https://github.com/RIOT-OS/RIOT/assets/1301112/d42a25e0-d331-4cae-ba48-1edfa01f35f9)

It is pretty straightforward, except that there is no RTT. This uncovered a bug in `stm32g0316-disco` which I based this on where the board would not set `TIMER_0_MAX_VALUE` for the 16 bit timer, leading to way too early timeouts with `ztimer_msec`.

Since it's just a single line, I added the fix to this PR.

I also noticed that `periph_rtc` was not supported for this CPU family yet, so I added the required definitions.

I also noticed that I sometimes have trouble flashing the device with a DAP-Link Programmer with

```
Error: Error connecting DP: cannot read IDR
``` 

I then have to hold the reset button and release it once OpenOCD starts probing the CPU - I have NRST connected, so maybe my debugger is just not using it.

### Testing procedure

RTC works with alarm:

```
2024-02-04 19:57:36,308 # > rtc gettime
2024-02-04 19:57:36,308 # 
2024-02-04 19:57:36,309 # 2024-02-04 19:57:33

2024-02-04 19:57:52,373 # > rtc setalarm 2024-02-04 19:58:00
2024-02-04 19:57:52,373 # 
2024-02-04 19:58:03,438 # > The alarm rang
```

I am a bit wondering if the alarm is working on STM32G4 as I would expect that it should select the same code path as STM32G0 (and STM32L5).
With the default the alarm would not get cleared and keep triggering.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
