### PR TITLE
cpu/native: Enable Rust on 64bit

### DIFF
--- a/boards/native64/doc.txt
+++ b/boards/native64/doc.txt
@@ -6,7 +6,7 @@
 [Family: native](https://github.com/RIOT-OS/RIOT/wiki/Family:-native)
 
 Same board as \ref boards_native "native", but compiled for 64-bit instead of 32-bit.
-Currently only Linux x86-64 is supported, and Rust support is missing.
+Currently only Linux x86-64 is supported.
 Otherwise, everything works the same as for the 32-bit version.
 For more information on this board, see the \ref boards_native "native board" documentation.
 

--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -60,7 +60,7 @@ config NATIVE_OS_LINUX
     select HAS_PERIPH_GPIO
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_SPI
-    select HAS_RUST_TARGET if "$(OS_ARCH)" = "x86_64" && HAS_ARCH_32BIT
+    select HAS_RUST_TARGET if "$(OS_ARCH)" = "x86_64"
 
 config NATIVE_OS_FREEBSD
     bool

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -19,10 +19,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer_periodic
 FEATURES_PROVIDED += periph_timer_query_freqs
 ifeq ($(OS) $(OS_ARCH),Linux x86_64)
-  # TODO: Add rust support for native 64 bit.
-  ifneq ($(BOARD),native64)
-    FEATURES_PROVIDED += rust_target
-  endif
+  FEATURES_PROVIDED += rust_target
 endif
 FEATURES_PROVIDED += ssp
 

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "riot-sys"
 version = "0.7.10"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8ff2d350b6a82d0f5c21137ca78970819a73ec70"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#297c670d8c674eae20b2b398c4338d27e2d2d346"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9d2068af49706c7870653ede1684540b02a5206f"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#82bb9a4decedcc624a9540f7fd8013910044be9e"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "riot-sys"
 version = "0.7.10"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8ff2d350b6a82d0f5c21137ca78970819a73ec70"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#297c670d8c674eae20b2b398c4338d27e2d2d346"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9d2068af49706c7870653ede1684540b02a5206f"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#82bb9a4decedcc624a9540f7fd8013910044be9e"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "riot-sys"
 version = "0.7.10"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8ff2d350b6a82d0f5c21137ca78970819a73ec70"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#297c670d8c674eae20b2b398c4338d27e2d2d346"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9d2068af49706c7870653ede1684540b02a5206f"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#82bb9a4decedcc624a9540f7fd8013910044be9e"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "riot-sys"
 version = "0.7.10"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#8ff2d350b6a82d0f5c21137ca78970819a73ec70"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#297c670d8c674eae20b2b398c4338d27e2d2d346"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#9d2068af49706c7870653ede1684540b02a5206f"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#82bb9a4decedcc624a9540f7fd8013910044be9e"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",


### PR DESCRIPTION
### Contribution description

This updates the riot-sys dependency and then removes the lock-out of Rust on NATIVE_64BIT builds.

### Testing procedure

* Green CI

### Issues/PRs references

Back in https://github.com/RIOT-OS/RIOT/pull/20315, Rust was excluded because it had build failures. https://github.com/RIOT-OS/rust-riot-sys/pull/40 works around the failures.

Thanks @fzi-haxel for preparing everything!

[edit:] Found some more errors, which so far all look like i32 vs isize mismatches. I'm on it; definitely easier to fix here than when some 16bit arch support is added :-D