### PR TITLE
Kconfig: update status message about Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -41,7 +41,7 @@ menu "External Packages"
 osource "$(KCONFIG_EXTERNAL_PKG_CONFIGS)"
 endmenu # External Packages
 
-comment "RIOT is in a migration phase."
+comment "Kconfig is slated for removal."
 comment "Some configuration options may not be here. Use CFLAGS instead."
 
 comment "!! ERROR: There are conflicting modules active !!"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We concluded the Kconfig migration phase. Update the message in `menuconfig` accordingly. 


### Testing procedure

Run `make menuconfig` for any application.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
