### PR TITLE
ipv6/nib: fix router lifetime handling in RIO and fix gnrc_ipv6_nib_ft_add() api

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/ft.h
+++ b/sys/include/net/gnrc/ipv6/nib/ft.h
@@ -81,7 +81,7 @@ int gnrc_ipv6_nib_ft_get(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
  */
 int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
                          const ipv6_addr_t *next_hop, unsigned iface,
-                         uint16_t lifetime);
+                         uint32_t lifetime);
 
 /**
  * @brief   Deletes a route from forwarding table.

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1653,7 +1653,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
 
         if (valid_ltime < UINT32_MAX) { /* UINT32_MAX means infinite lifetime */
             /* the valid lifetime is given in seconds, but our timers work in
-             * microseconds, so we have to scale down to the smallest possible
+             * milliseconds, so we have to scale down to the smallest possible
              * value (UINT32_MAX - 1). This is however alright since we ask for
              * a new router advertisement before this timeout expires */
             valid_ltime = (valid_ltime > (UINT32_MAX / MS_PER_SEC)) ?
@@ -1720,20 +1720,11 @@ static uint32_t _handle_rio(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     DEBUG("     - Route lifetime: %" PRIu32 "\n",
           byteorder_ntohl(rio->route_ltime));
 
-    if (route_ltime < UINT32_MAX) { /* UINT32_MAX means infinite lifetime */
-        /* the valid lifetime is given in seconds, but our timers work in
-         * microseconds, so we have to scale down to the smallest possible
-         * value (UINT32_MAX - 1). This is however alright since we ask for
-         * a new router advertisement before this timeout expires */
-        route_ltime = (route_ltime > (UINT32_MAX / MS_PER_SEC)) ?
-                      (UINT32_MAX - 1) : route_ltime * MS_PER_SEC;
-    }
-
     if (route_ltime == 0) {
         gnrc_ipv6_nib_ft_del(&rio->prefix, rio->prefix_len);
     } else {
         gnrc_ipv6_nib_ft_add(&rio->prefix, rio->prefix_len, &ipv6->src,
-                             netif->pid, route_ltime);
+                             netif->pid, route_ltime == UINT32_MAX ? 0 : route_ltime);
     }
 
     return route_ltime;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -36,12 +36,23 @@ int gnrc_ipv6_nib_ft_get(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
 
 int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
                          const ipv6_addr_t *next_hop, unsigned iface,
-                         uint16_t ltime)
+                         uint32_t ltime)
 {
     int res = 0;
     bool is_default_route = ((dst == NULL) || (dst_len == 0) ||
                              ipv6_addr_is_unspecified(dst));
 
+    uint32_t ltime_ms;
+    /* The valid lifetime is given in seconds, but our timers work in
+     * milliseconds, so we have to scale down to the smallest possible
+     * value (UINT32_MAX ms). This is however alright since we ask for
+     * a new router advertisement before this timeout expires */
+    if (ltime > UINT32_MAX / MS_PER_SEC) {
+        ltime_ms = UINT32_MAX;
+    }
+    else {
+        ltime_ms = ltime * MS_PER_SEC;
+    }
     if ((iface == 0) || ((is_default_route) && (next_hop == NULL))) {
         return -EINVAL;
     }
@@ -55,9 +66,9 @@ int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
         }
         else {
             _prime_def_router = ptr;
-            if (ltime > 0) {
+            if (ltime_ms > 0) {
                 _evtimer_add(ptr, GNRC_IPV6_NIB_RTR_TIMEOUT,
-                             &ptr->rtr_timeout, ltime * MS_PER_SEC);
+                             &ptr->rtr_timeout, ltime_ms);
             }
         }
     }
@@ -70,9 +81,9 @@ int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
         if (ptr == NULL) {
             res = -ENOMEM;
         }
-        else if (ltime > 0) {
+        else if (ltime_ms > 0) {
             _evtimer_add(ptr, GNRC_IPV6_NIB_ROUTE_TIMEOUT,
-                         &ptr->route_timeout, ltime * MS_PER_SEC);
+                         &ptr->route_timeout, ltime_ms);
         }
     }
 #else /* CONFIG_GNRC_IPV6_NIB_ROUTER */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The lifetime of a prefix comes as a `uint32_t` and not as a `uint16_t`.
Infinite lifetime is assumed when `0` is passed to `gnrc_ipv6_nib_ft_add()`.
In `_handle_rio()` this was not correctly transformed from the option's value to the input of `gnrc_ipv6_nib_ft_add()`. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

The impact is not really big, it should just run fine.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
