### PR TITLE
tests: Add NULL pointer argument test for fmt_lpad/to_lower/str

### DIFF
--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -393,8 +393,13 @@ size_t fmt_str(char *out, const char *str);
 /**
  * @brief   Copy null-terminated string to a lowercase string (excluding terminating \0)
  *
+ * If @p out is NULL, will only return the number of characters that would have
+ * been written.
+ *
  * @param[out]  out     Pointer to output buffer, or NULL
  * @param[in]   str     Pointer to null-terminated source string
+ *
+ * @return      nr of characters written to (or needed in) @p out
  */
 size_t fmt_to_lower(char *out, const char *str);
 

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -814,6 +814,7 @@ static void test_fmt_str(void)
     const char *string1 = "string1";
     char string2[]      = "StRiNg2";
 
+    TEST_ASSERT_EQUAL_INT(7, fmt_str(NULL, string1));
     TEST_ASSERT_EQUAL_INT(fmt_strlen(string1), fmt_str(&string2[0], string1));
     TEST_ASSERT_EQUAL_STRING(string1, &string2[0]);
 }
@@ -833,6 +834,7 @@ static void test_fmt_to_lower(void)
     const char string_up[]  = "AbCdeFGHijkLM";
     char string[]           = "zzzzzzzzzzzzzzz";
 
+    TEST_ASSERT_EQUAL_INT(fmt_strlen(string_up), fmt_to_lower(NULL, string_up));
     TEST_ASSERT_EQUAL_INT(fmt_strlen(string_up), fmt_to_lower(string, string_up));
     string[fmt_strlen(string_up)] = '\0';
     TEST_ASSERT_EQUAL_STRING("abcdefghijklm", &string[0]);
@@ -865,6 +867,8 @@ static void test_fmt_lpad(void)
     char string[9] = {0};
 
     strcpy(string, base);
+
+    TEST_ASSERT_EQUAL_INT(8, fmt_lpad(NULL, 4, 8, ' '));
 
     fmt_lpad(string, 4, 8, ' ');
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Moin :octopus: 

This adds three missed test-cases for `NULL` arguments.


### Testing procedure

`make -C tests/unittests/ tests-fmt test`

