### PR TITLE
sys/psa_crypto: return proper error code for psa_verify_msg

### DIFF
--- a/pkg/c25519/psa_c25519/edsign.c
+++ b/pkg/c25519/psa_c25519/edsign.c
@@ -73,7 +73,7 @@ psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer,
 
     ret = edsign_verify(signature, key_buffer, input, input_length);
     if (!ret) {
-        return PSA_ERROR_GENERIC_ERROR;
+        return PSA_ERROR_INVALID_SIGNATURE;
     }
 
     (void)key_buffer_size;

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/error_conversion.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/error_conversion.c
@@ -133,7 +133,7 @@ psa_status_t CRYS_to_psa_error(CRYSError_t error)
     case CRYS_ECMONT_PKI_ERROR:
     case CRYS_ECMONT_IS_NOT_SUPPORTED:
     case CRYS_ECEDW_IS_NOT_SUPPORTED:
-            return PSA_ERROR_INVALID_ARGUMENT;
+        return PSA_ERROR_INVALID_ARGUMENT;
     default:
         return PSA_ERROR_GENERIC_ERROR;
     }


### PR DESCRIPTION
### Contribution description

Just a very small fixup for #19954, returning the proper error code in case signature validation fails because of an invalid signature, as documented in the API: https://arm-software.github.io/psa-api/crypto/1.1/api/ops/sign.html#c.psa_verify_message


### Testing procedure

All PSA Crypto tests should still pass.