### PR TITLE
sys/cpp_new_delete: always enable the module when C++ is used

### DIFF
--- a/cpu/avr8_common/Makefile.dep
+++ b/cpu/avr8_common/Makefile.dep
@@ -19,8 +19,3 @@ USEMODULE += tiny_strerror_as_strerror
 ifneq (,$(filter cpp,$(FEATURES_USED)))
   USEMODULE += cxx_ctor_guards
 endif
-
-# new and delete operators needed
-ifneq (,$(filter cpp,$(FEATURES_USED)))
-  USEMODULE += cpp_new_delete
-endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -41,6 +41,10 @@ ifneq (,$(filter crc32_fast,$(USEMODULE)))
   USEMODULE += checksum
 endif
 
+ifneq (,$(filter cpp,$(USEMODULE)))
+  USEMODULE += cpp_new_delete
+endif
+
 ifneq (,$(filter debug_irq_disable,$(USEMODULE)))
   USEMODULE += fmt
 endif

--- a/sys/cpp11-compat/Makefile.dep
+++ b/sys/cpp11-compat/Makefile.dep
@@ -1,4 +1,3 @@
-USEMODULE += cpp_new_delete
 USEMODULE += ztimer64_usec
 USEMODULE += timex
 FEATURES_REQUIRED += cpp


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Newer toolchains appear to expect the presence of `__dso_handle`, so always enable the module.
The linker will collect unused sections anyway.


### Testing procedure

`sys/cpp_ctors` builds again on Ubuntu 23.10.

On `master` it would produce

```
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libstdc++_nano.a(eh_globals.o): in function `_GLOBAL__sub_I___cxa_get_globals_fast':
./build_nano/thumb/v7e-m/nofp/libstdc++/libsupc++/../../../../../../src/libstdc++-v3/libsupc++/eh_globals.cc:85: undefined reference to `__dso_handle'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/benpicco/dev/RIOT/tests/sys/cpp_ctors/bin/nucleo-wl55jc/tests_cpp_ctors.elf: hidden symbol `__dso_handle' isn't defined
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
