### PR TITLE
sys/shell/ping: print error when DNS resolve fails

### DIFF
--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -183,7 +183,8 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
 
             res = netutils_get_ipv6(&data->host, (netif_t **)&data->netif, arg);
             if (res) {
-                break;
+                printf("can't resolve %s\n", arg);
+                return res;
             }
         }
         else {

--- a/tests/net/gcoap_fileserver/Makefile.ci
+++ b/tests/net/gcoap_fileserver/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If we can't resolve the address, that's not an input error - don't print the help message, instead show a more helpful message.


### Testing procedure

On `master`:

```
2024-02-07 16:04:48,519 # > ping global.azure-devices-provisioning.net
2024-02-07 16:04:48,520 # ping [-c <count>] [-h] [-i <ms interval>] [-s <packetsize>]
2024-02-07 16:04:48,520 #      [-t hoplimit] [-W <ms timeout>] <host>[%<interface>]
2024-02-07 16:04:48,521 #      count: number of pings (default: 3)
2024-02-07 16:04:48,522 #      ms interval: wait interval milliseconds between sending (default: 1000)"     packetsize: number of bytes in echo payload; must be >= 4 to measure round trip time (default: 4)
2024-02-07 16:04:48,523 #      hoplimit: Set the IP time to life/hoplimit (default: interface config)
2024-02-07 16:04:48,525 #      ms timeout: Time to wait for a response in milliseconds (default: 1000). The option affects only timeout in absence of any responses, otherwise wait for two RTTs
```

With this patch:

```
2024-02-07 16:01:33,685 # > ping global.azure-devices-provisioning.net
2024-02-07 16:01:34,117 # can't resolve global.azure-devices-provisioning.net
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
