### PR TITLE
boards/olimex-msp430-h2618: change UART config 

### DIFF
--- a/boards/olimex-msp430-h1611/doc.txt
+++ b/boards/olimex-msp430-h1611/doc.txt
@@ -80,7 +80,7 @@ make BOARD=olimex-msp430-h1611 flash
 ## Using the shell
 
 stdio is available via the UART interface with `TXD = P3.6`
-(pin 35 on the header) and `RXD = P3.7` (pin 34 on the header) at 115,200 Baud.
+(pin 35 on the header) and `RXD = P3.7` (pin 34 on the header) at 9,600 Baud.
 
 The easiest way is to connect an USB TTL adapter (such as the cheap `cp210x`
 or `ch341` based adapters) as follows:

--- a/boards/olimex-msp430-h2618/doc.txt
+++ b/boards/olimex-msp430-h2618/doc.txt
@@ -93,8 +93,8 @@ make BOARD=olimex-msp430-h2618 flash
 
 ## Using the shell
 
-stdio is available via the UART interface with `TXD = P3.4`
-(pin 35 on the header) and `RXD = P3.5` (pin 34 on the header) at 115,200 Baud.
+stdio is available via the UART interface with `TXD = P3.6`
+(pin 35 on the header) and `RXD = P3.7` (pin 34 on the header) at 115,200 Baud.
 
 The easiest way is to connect an USB TTL adapter (such as the cheap `cp210x`
 or `ch341` based adapters) as follows:
@@ -104,8 +104,8 @@ TTL adapter    Olimex MSP430-H2618
 -----------    -------------------
 
        GND --- 63 (DV_SS)
-       TXD --- 33 (P3.5)
-       RXD --- 32 (P3.4)
+       TXD --- 35 (P3.7)
+       RXD --- 34 (P3.6)
 ```
 
  */

--- a/boards/olimex-msp430-h2618/include/periph_conf.h
+++ b/boards/olimex-msp430-h2618/include/periph_conf.h
@@ -49,17 +49,17 @@ static const msp430_clock_params_t clock_params = {
  */
 #define UART_NUMOF          (1U)
 
-#define UART_BASE           (&USCI_A0)
-#define UART_IE             (IE2)
-#define UART_IF             (IFG2)
+#define UART_BASE           (&USCI_A1)
+#define UART_IE             (UC1IE)
+#define UART_IF             (UC1IFG)
 #define UART_IE_RX_BIT      (1 << 0)
 #define UART_IE_TX_BIT      (1 << 1)
 #define UART_RX_PORT        (&PORT_3)
-#define UART_RX_PIN         (1 << 5)
+#define UART_RX_PIN         (1 << 7)
 #define UART_TX_PORT        (&PORT_3)
-#define UART_TX_PIN         (1 << 4)
-#define UART_RX_ISR         (USCIAB0RX_VECTOR)
-#define UART_TX_ISR         (USCIAB0TX_VECTOR)
+#define UART_TX_PIN         (1 << 6)
+#define UART_RX_ISR         (USCIAB1RX_VECTOR)
+#define UART_TX_ISR         (USCIAB1TX_VECTOR)
 /** @} */
 
 /**

--- a/cpu/msp430/include/x1xx/periph_cpu.h
+++ b/cpu/msp430/include/x1xx/periph_cpu.h
@@ -220,7 +220,7 @@ extern const msp430_usart_uart_params_t usart1_as_uart;
 extern const msp430_usart_spi_params_t usart0_as_spi;
 
 /**
- * @brief   MSP430 x1xx USART1 in UART configuration
+ * @brief   MSP430 x1xx USART1 in SPI configuration
  */
 extern const msp430_usart_spi_params_t usart1_as_spi;
 


### PR DESCRIPTION
### Contribution description

Change UART configuration to match `olimex-msp430-h1611`. This allows using the [olimex-msp430-arduino-uno][board] breakout board to be used with the `olimex-msp430-h2618` as well.

[board]: https://github.com/RIOT-OS/RIOT-Open-Hardware/tree/main/olimex-msp430-arduino-uno

In addition, to minor MSP430 related doc fixes are sneaked in a individual commits.

### Testing procedure

With said breakout board attached to the `olimex-msp430-h2618`:

```
make BOARD=olimex-msp430-h2618 -C examples/default flash term
make: Entering directory '/home/maribu/Repos/software/RIOT/master/examples/default'
Building application "default" for "olimex-msp430-h2618" with MCU "msp430".

"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/olimex-msp430-h2618
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/saul
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/saul/init_devs
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/fmt
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/phydat
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/ps
"make" -C /home/maribu/Repos/software/RIOT/master/sys/saul_reg
"make" -C /home/maribu/Repos/software/RIOT/master/sys/shell
"make" -C /home/maribu/Repos/software/RIOT/master/sys/shell/cmds
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
/usr/lib/gcc/msp430-elf/13.2.0/../../../../msp430-elf/bin/ld: warning: /home/maribu/Repos/software/RIOT/master/examples/default/bin/olimex-msp430-h2618/default.elf has a LOAD segment with RWX permissions
   text	  data	   bss	   dec	   hex	filename
  14872	   178	  1132	 16182	  3f36	/home/maribu/Repos/software/RIOT/master/examples/default/bin/olimex-msp430-h2618/default.elf
[INFO] mspdebug binary not found - building it from source now
[INFO] mspdebug requires readline and libusb-compat headers to build
CC= CFLAGS= make -C /home/maribu/Repos/software/RIOT/master/dist/tools/mspdebug
[INFO] mspdebug binary successfully built!
/home/maribu/Repos/software/RIOT/master/dist/tools/mspdebug/mspdebug -j --expect-id "MSP430F2618" olimex "prog /home/maribu/Repos/software/RIOT/master/examples/default/bin/olimex-msp430-h2618/default.hex"
MSPDebug version 0.25 - debugging tool for MSP430 MCUs
Copyright (C) 2009-2017 Daniel Beer <dlbeer@gmail.com>
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Chip info database from MSP430.dll v3.15.0.1 Copyright (C) 2013 TI, Inc.

Resetting Olimex command processor...
Initializing FET...
FET protocol version is 20000007
Set Vcc: 3000 mV
Configured for JTAG (2)
Sending reset...
Using Olimex identification procedure
Device ID: 0xf26f
  Code start address: 0x3100
  Code size         : 118528 byte = 115 kb
  RAM  start address: 0x200
  RAM  end   address: 0x9ff
  RAM  size         : 2048 byte = 2 kb
Device: MSP430F2618
Number of breakpoints: 8
fet: FET returned error code 34 (Not supported by selected interface or interface is not initialized)
fet: warning: message C_IDENT3 failed
fet: FET returned NAK
warning: device does not support power profiling
Device: MSP430F2618
Erasing...
Programming...
Writing 4096 bytes at 3100...
Writing 4096 bytes at 4100...
Writing 4096 bytes at 5100...
Writing 2758 bytes at 6100...
Writing    2 bytes at ffe2...
Writing    2 bytes at fffe...
Done, 15050 bytes total
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200"  
2024-02-07 20:08:25,595 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
2024-02-07 20:08:26,613 # main(): This is RIOT! (Version: 2024.04-devel-148-gcbd91-boards/msp-fixup)
2024-02-07 20:08:26,613 # Welcome to RIOT!
> help
2024-02-07 20:08:28,808 # help
2024-02-07 20:08:28,811 # Command              Description
2024-02-07 20:08:28,813 # ---------------------------------------
2024-02-07 20:08:28,819 # pm                   interact with layered PM subsystem
2024-02-07 20:08:28,825 # ps                   Prints information about running threads.
2024-02-07 20:08:28,828 # reboot               Reboot the node
2024-02-07 20:08:28,833 # saul                 interact with sensors and actuators using SAUL
2024-02-07 20:08:28,836 # version              Prints current RIOT_VERSION
```

### Issues/PRs references

None
