### PR TITLE
ci: disable some more flakey native tests

### DIFF
--- a/tests/bench/xtimer_load/Makefile
+++ b/tests/bench/xtimer_load/Makefile
@@ -9,4 +9,7 @@ CFLAGS += -DTEST_HZ=$(TEST_HZ)LU
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/core/thread_flags/Makefile
+++ b/tests/core/thread_flags/Makefile
@@ -6,4 +6,7 @@ USEMODULE += xtimer
 # microbit qemu timing is off
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/evtimer_underflow/Makefile
+++ b/tests/sys/evtimer_underflow/Makefile
@@ -6,4 +6,7 @@ USEMODULE += ztimer_msec
 # microbit qemu lacks rtt
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/xtimer_hang/Makefile
+++ b/tests/sys/xtimer_hang/Makefile
@@ -21,4 +21,7 @@ DISABLE_MODULE := core_msg
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/ztimer_underflow/Makefile
+++ b/tests/sys/ztimer_underflow/Makefile
@@ -20,4 +20,7 @@ CFLAGS += -DTEST_ZTIMER_CLOCK=$(TEST_ZTIMER_CLOCK)
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This disables some more flakey native tests.
The failures are all timer related.

(I'm a bit sad about `tests/core/thread_flags`, maybe at some point we could split out or disable the timer test for native.)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
