### PR TITLE
treewide: make use of new IPv4 static init macro

### DIFF
--- a/sys/include/net/dns_mock.h
+++ b/sys/include/net/dns_mock.h
@@ -34,9 +34,9 @@ extern "C" {
 
 /**
  * @brief IPv4 address for @ref SOCK_DNS_MOCK_EXAMPLE_COM_HOSTNAME.
- *        Address represents "93.184.216.34".
  */
-static const ipv4_addr_t sock_dns_mock_example_com_addr_ipv4 = { { 0x5d, 0xb8, 0xd8, 0x22 } };
+static const ipv4_addr_t sock_dns_mock_example_com_addr_ipv4 =
+    IPV4_ADDR_INIT(93, 184, 216, 34);
 
 /**
  * @brief IPv6 address for @ref SOCK_DNS_MOCK_EXAMPLE_COM_HOSTNAME.

--- a/tests/net/netutils/main.c
+++ b/tests/net/netutils/main.c
@@ -151,7 +151,7 @@ static void test_ipv4_addr_from_str__address_NULL(void)
 
 static void test_ipv4_addr_from_str__success(void)
 {
-    static const ipv4_addr_t a = { { 0x01, 0x02, 0x03, 0x04 } };
+    static const ipv4_addr_t a = IPV4_ADDR_INIT(1, 2, 3, 4);
     ipv4_addr_t address;
 
     TEST_ASSERT_EQUAL_INT(netutils_get_ipv4(&address, "1.2.3.4"), 0);


### PR DESCRIPTION
### Contribution description

This commit makes use of the newly added static initializer for IPv4 addresses. I should have included this in the PR that added the macro but did not think to seek out and make these changes until after it was already merged.

### Testing procedure

The patch includes an update to the test suite that should prove the macro works.

### Issues/PRs references

- PR which added the new macro: #20354
