### PR TITLE
cpu/native/periph/uart: uart_poweroff() closes the file descriptor + extended baud-rate support on Linux

### DIFF
--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -81,6 +81,13 @@ void native_async_read_continue(int fd);
 void native_async_read_add_handler(int fd, void *arg, native_async_read_callback_t handler);
 
 /**
+ * @brief   stop monitoring of file descriptor
+ *
+ * @param[in] fd The file descriptor to stop monitoring
+ */
+void native_async_read_remove_handler(int fd);
+
+/**
  * @brief   start monitoring of file descriptor as interrupt
  *
  * @param[in] fd       The file descriptor to monitor

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -134,7 +134,22 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     case 38400: speed = B38400; break;
     case 57600: speed = B57600; break;
     case 115200: speed = B115200; break;
-    case 230400: speed = B230400 ; break;
+    case 230400: speed = B230400; break;
+#if __linux__
+    case 460800 : speed =  B460800; break;
+    case 500000 : speed =  B500000; break;
+    case 576000 : speed =  B576000; break;
+    case 921600 : speed =  B921600; break;
+    case 1000000: speed =  B1000000; break;
+    case 1152000: speed =  B1152000; break;
+    case 1500000: speed =  B1500000; break;
+    case 2000000: speed =  B2000000; break;
+    case 2500000: speed =  B2500000; break;
+    case 3000000: speed =  B3000000; break;
+    case 3500000: speed =  B3500000; break;
+    case 4000000: speed =  B4000000; break;
+#endif
+
     default:
         return UART_NOBAUD;
         break;
@@ -175,7 +190,9 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
     DEBUG("\n");
 
-    _native_write(tty_fds[uart], data, len);
+    if (tty_fds[uart] >= 0) {
+        _native_write(tty_fds[uart], data, len);
+    }
 }
 
 void uart_poweron(uart_t uart)
@@ -186,6 +203,9 @@ void uart_poweron(uart_t uart)
 
 void uart_poweroff(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    if (tty_fds[uart] >= 0) {
+        native_async_read_remove_handler(tty_fds[uart]);
+        real_close(tty_fds[uart]);
+        tty_fds[uart] = -1;
+    }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
 #### `uart_poweroff()` now closes the underlying file descriptor
  This is needed if for re-initializing the UART device. An example use-case is baud-rate probing.
 #### On Linux, extended baud-rate support
 On Linux, the extended baud-rates are defined in `bits/termios-baud.h` as follows:
```c
/* Extra output baud rates (not in POSIX).  */
#define  B57600    0010001
#define  B115200   0010002
#define  B230400   0010003
#define  B460800   0010004
...
```
As such, I'm not sure if they are available on other platforms too, so I enabled them for Linux only.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

The following should be a valid use-case:
```c
   static uint32_t const baud_rates[] = {
            230400,
            460800,
            921600,
            3000000,
    };
    int res;
    for (unsigned i = 0; i < ARRAY_SIZE(baud_rates); i++) {
        uart_poweroff(UART_DEV(0));
        res = uart_init(UART_DEV(0), baud_rates[i], device_rx_handler, dev);
        assert(res == 0);

        res = device_probing_procedure(UART_DEV(0));
        if (res == 0) {
            /* device responded */
            break;
        }
    }

```

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
