### PR TITLE
cpu/native: fix native_async_read_remove_handler() + enable all baudrates

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -103,7 +103,7 @@ void native_async_read_remove_handler(int fd)
     if (res < 0) {
         err(EXIT_FAILURE, "native_async_read_remove_handler(): fcntl(F_GETFL)");
     }
-    unsigned flags = (unsigned)res & !O_ASYNC;
+    unsigned flags = (unsigned)res & ~O_ASYNC;
     res = real_fcntl(fd, F_SETFL, flags);
     if (res < 0) {
         err(EXIT_FAILURE, "native_async_read_remove_handler(): fcntl(F_SETFL)");

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -135,7 +135,6 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     case 57600: speed = B57600; break;
     case 115200: speed = B115200; break;
     case 230400: speed = B230400; break;
-#if __linux__
     case 460800 : speed =  B460800; break;
     case 500000 : speed =  B500000; break;
     case 576000 : speed =  B576000; break;
@@ -148,7 +147,6 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     case 3000000: speed =  B3000000; break;
     case 3500000: speed =  B3500000; break;
     case 4000000: speed =  B4000000; break;
-#endif
 
     default:
         return UART_NOBAUD;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fix previous [PR](https://github.com/RIOT-OS/RIOT/pull/20365).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/20365
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
