### PR TITLE
gnrc_ipv6_nib/SLAAC: rfc8981 temporary address (privacy extensions)

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -244,6 +244,7 @@ extern "C" {
  */
 #define GNRC_IPV6_NIB_IFACE_DOWN            (0x4fd5U)
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 /**
  * @brief   Temporary address: regenerate
  *
@@ -253,6 +254,7 @@ extern "C" {
  * @see "REGEN_ADVANCE time units before" - https://datatracker.ietf.org/doc/html/rfc8981#section-3.6
  */
 #define GNRC_IPV6_NIB_REGEN_TEMP_ADDR       (0x4fd6U)
+#endif
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -243,6 +243,16 @@ extern "C" {
  * @brief   Interface down event
  */
 #define GNRC_IPV6_NIB_IFACE_DOWN            (0x4fd5U)
+
+/**
+ * @brief   Temporary address: regenerate
+ *
+ * This message type is for the event of a regeneration of a temporary address.
+ * The expected message context is a valid off-link entry representing the associated SLAAC prefix.
+ *
+ * @see "REGEN_ADVANCE time units before" - https://datatracker.ietf.org/doc/html/rfc8981#section-3.6
+ */
+#define GNRC_IPV6_NIB_REGEN_TEMP_ADDR       (0x4fd6U)
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -251,7 +251,7 @@ extern "C" {
  * This message type is for the event of a regeneration of a temporary address.
  * The expected message context is a valid off-link entry representing the associated SLAAC prefix.
  *
- * @see "REGEN_ADVANCE time units before" - https://datatracker.ietf.org/doc/html/rfc8981#section-3.6
+ * @see "REGEN_ADVANCE time units before" - https://www.rfc-editor.org/rfc/rfc8981.html#section-3.6
  */
 #define GNRC_IPV6_NIB_REGEN_TEMP_ADDR       (0x4fd6U)
 #endif

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -186,6 +186,10 @@ extern "C" {
 #define CONFIG_GNRC_IPV6_NIB_SLAAC                    1
 #endif
 
+#ifndef CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES
+#define CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES 0
+#endif
+
 /**
  * @brief    handle Redirect Messages
  */

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -186,6 +186,10 @@ extern "C" {
 #define CONFIG_GNRC_IPV6_NIB_SLAAC                    1
 #endif
 
+/**
+ * @brief Use temporary addresses (rfc8981)
+ * @see [RFC 8981](https://www.rfc-editor.org/rfc/rfc8981.html)
+ */
 #ifndef CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES
 #define CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES 0
 #endif

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -104,7 +104,7 @@ bool gnrc_ipv6_nib_pl_has_prefix(const unsigned int iface, const ipv6_addr_t *pf
  * @brief Reschedule the regeneration timer for this prefix's preferred temporary address.
  * @param[in] iface The interface on which the prefix is present.
  * @param[in] pfx The SLAAC prefix that is to be found.
- * @param[in] offset The offset in milliseconds at which the regeneration event shall occur.
+ * @param[in] offset The offset in milliseconds at which the regeneration event shall occur. 0 to remove.
  * @return false if prefix was not found, otherwise true.
  */
 bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx, const uint32_t offset);

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -128,6 +128,15 @@ bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx, uint8_t
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
                            gnrc_ipv6_nib_pl_t *ple);
 
+/**
+ * Reschedule the regeneration timer for this prefix's preferred temporary address.
+ * @param iface The interface on which the prefix is present.
+ * @param pfx The prefix that is to be found.
+ * @param offset The offset in milliseconds at which the regeneration event shall occur.
+ * @return false if prefix was not found, otherwise true.
+ */
+bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, uint32_t offset);
+
 #if IS_USED(MODULE_EVTIMER) || defined(DOXYGEN)
 /**
  * @brief   Provides the time in milliseconds for which the prefix list

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -90,6 +90,8 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
 void gnrc_ipv6_nib_pl_del(unsigned iface,
                           const ipv6_addr_t *pfx, unsigned pfx_len);
 
+bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx, uint8_t pfx_len);
+
 /**
  * @brief   Iterates over all prefix list entries in the NIB.
  *

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -90,7 +90,18 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
 void gnrc_ipv6_nib_pl_del(unsigned iface,
                           const ipv6_addr_t *pfx, unsigned pfx_len);
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx, uint8_t pfx_len);
+
+/**
+ * Reschedule the regeneration timer for this prefix's preferred temporary address.
+ * @param iface The interface on which the prefix is present.
+ * @param pfx The prefix that is to be found.
+ * @param offset The offset in milliseconds at which the regeneration event shall occur.
+ * @return false if prefix was not found, otherwise true.
+ */
+bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, uint32_t offset);
+#endif
 
 /**
  * @brief   Iterates over all prefix list entries in the NIB.
@@ -127,15 +138,6 @@ bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx, uint8_t
  */
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
                            gnrc_ipv6_nib_pl_t *ple);
-
-/**
- * Reschedule the regeneration timer for this prefix's preferred temporary address.
- * @param iface The interface on which the prefix is present.
- * @param pfx The prefix that is to be found.
- * @param offset The offset in milliseconds at which the regeneration event shall occur.
- * @return false if prefix was not found, otherwise true.
- */
-bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, uint32_t offset);
 
 #if IS_USED(MODULE_EVTIMER) || defined(DOXYGEN)
 /**

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -98,16 +98,20 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
  * @param[in] pfx_len Length of @p pfx in bits.
  * @return true if such prefix is present, false otherwise
  */
-bool gnrc_ipv6_nib_pl_has_prefix(const unsigned int iface, const ipv6_addr_t *pfx, const uint8_t pfx_len);
+bool gnrc_ipv6_nib_pl_has_prefix(const unsigned int iface, const ipv6_addr_t *pfx,
+                                 const uint8_t pfx_len);
 
 /**
  * @brief Reschedule the regeneration timer for this prefix's preferred temporary address.
  * @param[in] iface The interface on which the prefix is present.
  * @param[in] pfx The SLAAC prefix that is to be found.
- * @param[in] offset The offset in milliseconds at which the regeneration event shall occur. 0 to remove.
+ * @param[in] offset The offset in milliseconds at which the regeneration event shall occur.
+ *                   0 to remove the timer event.
  * @return false if prefix was not found, otherwise true.
  */
-bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx, const uint32_t offset);
+bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx,
+                                       const uint32_t offset);
+
 #endif
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -91,16 +91,23 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
                           const ipv6_addr_t *pfx, unsigned pfx_len);
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
-bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx, uint8_t pfx_len);
+/**
+ * @brief Check whether the prefix list has a prefix as specified
+ * @param[in] iface The interface @p pfx is expected to be on (0 for any).
+ * @param[in] pfx The prefix to check for.
+ * @param[in] pfx_len Length of @p pfx in bits.
+ * @return true if such prefix is present, false otherwise
+ */
+bool gnrc_ipv6_nib_pl_has_prefix(const unsigned int iface, const ipv6_addr_t *pfx, const uint8_t pfx_len);
 
 /**
- * Reschedule the regeneration timer for this prefix's preferred temporary address.
- * @param iface The interface on which the prefix is present.
- * @param pfx The prefix that is to be found.
- * @param offset The offset in milliseconds at which the regeneration event shall occur.
+ * @brief Reschedule the regeneration timer for this prefix's preferred temporary address.
+ * @param[in] iface The interface on which the prefix is present.
+ * @param[in] pfx The SLAAC prefix that is to be found.
+ * @param[in] offset The offset in milliseconds at which the regeneration event shall occur.
  * @return false if prefix was not found, otherwise true.
  */
-bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, uint32_t offset);
+bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx, const uint32_t offset);
 #endif
 
 /**

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -103,6 +103,27 @@ extern "C" {
 #endif
 
 /**
+ * @brief Maximum assumed number of valid (preferred or deprecated) temporary addresses.
+ * (see _nib-slaac.h)
+ *
+ * This value is not enforced but only used to increase
+ * the amount of configurable addresses, to make space for temporary addresses.
+ *
+ * Assuming continued use of the same prefix,
+ * the number of simultaneous temporary addresses can be expressed by the following (not considering REGEN_ADVANCE):
+ * @ref TEMP_VALID_LIFETIME / min_pref_lft=(@ref TEMP_PREFERRED_LIFETIME - @ref MAX_DESYNC_FACTOR)
+ * (Calculates the addresses that are generated within an address's lifetime.)
+ * -> floor(...) to only consider already generated addresses
+ * -> +1 to also account for the first address itself
+ *
+ * @see CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF
+ *      May need to be increased; each temporary address has a /128 prefix to manage its maximum total lifetimes.
+ */
+#ifndef MAX_TEMP_ADDRESSES
+#define MAX_TEMP_ADDRESSES 4
+#endif
+
+/**
  * @brief   Maximum number of unicast and anycast addresses per interface
  *
  * @note    If you change this, please make sure that
@@ -110,11 +131,12 @@ extern "C" {
  *          addresses' solicited nodes multicast addresses.
  *
  * Default: 2 (1 link-local + 1 global address) + any additional address via
- * configuration protocol (e.g. DHCPv6 leases).
+ * configuration protocol (e.g. DHCPv6 leases) + temporary addresses.
  */
 #ifndef CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF
 #define CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF    (2 + \
-                                               DHCPV6_CLIENT_ADDRS_NUMOF)
+                                               DHCPV6_CLIENT_ADDRS_NUMOF + \
+                                               MAX_TEMP_ADDRESSES)
 #endif
 
 /**

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -110,14 +110,16 @@ extern "C" {
  * the amount of configurable addresses, to make space for temporary addresses.
  *
  * Assuming continued use of the same prefix,
- * the number of simultaneous temporary addresses can be expressed by the following (not considering REGEN_ADVANCE):
+ * the number of simultaneous temporary addresses
+ * can be expressed by the following (not considering REGEN_ADVANCE):
  * @ref TEMP_VALID_LIFETIME / min_pref_lft=(@ref TEMP_PREFERRED_LIFETIME - @ref MAX_DESYNC_FACTOR)
  * (Calculates the addresses that are generated within an address's lifetime.)
  * -> floor(...) to only consider already generated addresses
  * -> +1 to also account for the first address itself
  *
  * @see CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF
- *      May need to be increased; each temporary address has a /128 prefix to manage its maximum total lifetimes.
+ *      May need to be increased; each temporary address has a /128 prefix
+ *      to manage its maximum total lifetimes.
  */
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 #ifndef MAX_TEMP_ADDRESSES

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -119,8 +119,12 @@ extern "C" {
  * @see CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF
  *      May need to be increased; each temporary address has a /128 prefix to manage its maximum total lifetimes.
  */
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 #ifndef MAX_TEMP_ADDRESSES
-#define MAX_TEMP_ADDRESSES 4
+#define MAX_TEMP_ADDRESSES (4)
+#endif
+#else
+#define MAX_TEMP_ADDRESSES (0)
 #endif
 
 /**

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -216,9 +216,6 @@ int gnrc_netif_ipv6_addr_match(gnrc_netif_t *netif,
  * @todo Rule 6 from RFC 6724 is currently not implemented. Has to updated as
  *       soon as gnrc supports flow labels.
  *
- * @todo Rule 7 from RFC 6724 is currently not implemented. Has to updated as
- *       soon as gnrc supports temporary addresses.
- *
  * @return  The best source address for a packet addressed to @p dst
  * @return  NULL, if no matching address can be found on the interface.
  */

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -564,6 +564,14 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif);
 void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif);
 
 /**
+ * @brief Get DupAddrDetectTransmits
+ * @return  DupAddrDetectTransmits
+ * @return  `-ENOTSUP`, when unimplemented for
+ *          gnrc_netif_t::device_type of @p netif
+*/
+int gnrc_netif_ipv6_dad_transmits(const gnrc_netif_t *netif);
+
+/**
  * @brief   Converts a given hardware address to an IPv6 IID.
  *
  * @note      The IPv6 IID is derived from the EUI-64 for most link-layers by

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -131,6 +131,28 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
                              const ipv6_addr_t *addr);
 
 /**
+ * @brief   Returns the index of the first pfx
+ *          in gnrc_netif_t::ipv6_addrs of @p netif
+ *          where the first @p pfx_len bits match with @p pfx
+ *
+ * @pre `(netif != NULL) && (pfx != NULL)`
+ *
+ * Can be used to check if an address is assigned to an interface.
+ *
+ * @param[in] netif the network interface
+ * @param[in] pfx  the address to check
+ * @param[in] pfx_len the amount of bits to compare
+ *
+ * @note    Only available with @ref net_gnrc_ipv6 "gnrc_ipv6".
+ *
+ * @return  index of the first matching address
+ *          in gnrc_netif_t::ipv6_addrs of @p netif
+ * @return  -1, if no matching address found for @p netif
+ */
+int gnrc_netif_ipv6_addr_pfx_idx(gnrc_netif_t *netif,
+                                 const ipv6_addr_t *pfx, uint8_t pfx_len);
+
+/**
  * @brief   Gets state from address flags
  *
  * @param[in] netif the network interface

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -173,7 +173,8 @@ static inline uint8_t gnrc_netif_ipv6_addr_dad_trans(const gnrc_netif_t *netif,
 static inline uint8_t gnrc_netif_ipv6_addr_gen_retries(const gnrc_netif_t *netif,
                                                      int idx)
 {
-    return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES) >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
+    return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES)
+            >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
 }
 #endif
 

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -131,7 +131,7 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
                              const ipv6_addr_t *addr);
 
 /**
- * @brief   Returns the index of the first pfx
+ * @brief   Returns the index of the first addr
  *          in gnrc_netif_t::ipv6_addrs of @p netif
  *          where the first @p pfx_len bits match with @p pfx
  *

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -160,6 +160,7 @@ static inline uint8_t gnrc_netif_ipv6_addr_dad_trans(const gnrc_netif_t *netif,
     return netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE;
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 /**
  * @brief   Gets number of address generation retries already performed for an address
  *
@@ -174,6 +175,7 @@ static inline uint8_t gnrc_netif_ipv6_addr_gen_retries(const gnrc_netif_t *netif
 {
     return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES) >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
 }
+#endif
 
 /**
  * @brief   Returns the index of an address in gnrc_netif_t::ipv6_addrs of @p
@@ -575,6 +577,7 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif);
  */
 void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif);
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 /**
  * @brief Get DupAddrDetectTransmits
  * @return  DupAddrDetectTransmits
@@ -582,6 +585,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif);
  *          gnrc_netif_t::device_type of @p netif
 */
 int gnrc_netif_ipv6_dad_transmits(const gnrc_netif_t *netif);
+#endif
 
 /**
  * @brief   Converts a given hardware address to an IPv6 IID.

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -580,6 +580,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 /**
  * @brief Get DupAddrDetectTransmits
+ * @see https://datatracker.ietf.org/doc/html/rfc4862#section-5.1
  * @return  DupAddrDetectTransmits
  * @return  `-ENOTSUP`, when unimplemented for
  *          gnrc_netif_t::device_type of @p netif

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -140,7 +140,7 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
  * Can be used to check if an address is assigned to an interface.
  *
  * @param[in] netif the network interface
- * @param[in] pfx  the address to check
+ * @param[in] pfx  the prefix to match
  * @param[in] pfx_len the amount of bits to compare
  *
  * @note    Only available with @ref net_gnrc_ipv6 "gnrc_ipv6".

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -161,6 +161,21 @@ static inline uint8_t gnrc_netif_ipv6_addr_dad_trans(const gnrc_netif_t *netif,
 }
 
 /**
+ * @brief   Gets number of address generation retries already performed for an address
+ *
+ * @param[in] netif the network interface
+ * @param[in] idx   index of the address (and its flags)
+ *
+ * @return  the number of address generation retries already
+ *          performed
+ */
+static inline uint8_t gnrc_netif_ipv6_addr_gen_retries(const gnrc_netif_t *netif,
+                                                     int idx)
+{
+    return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES) >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
+}
+
+/**
  * @brief   Returns the index of an address in gnrc_netif_t::ipv6_addrs of @p
  *          netif that matches @p addr best
  *

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -69,6 +69,7 @@ extern "C" {
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST                (0x20U)
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 /**
  * @brief Number of address generation retries
  * Used for temporary addresses, where the upper limit is defined by @ref TEMP_IDGEN_RETRIES
@@ -78,6 +79,7 @@ extern "C" {
  * @brief Shift position of address generation retries
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS      (6)
+#endif
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -68,6 +68,16 @@ extern "C" {
  * @brief   Address is an anycast address
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST                (0x20U)
+
+/**
+ * @brief Number of address generation retries
+ * Used for temporary addresses, where the upper limit is defined by @ref TEMP_IDGEN_RETRIES
+ */
+#define GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES          (0xC0U)
+/**
+ * @brief Shift position of address generation retries
+ */
+#define GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS      (6)
 /** @} */
 
 /**

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -46,7 +46,9 @@
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/internal.h"
 #include "net/gnrc/tx_sync.h"
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 #include "../network_layer/ipv6/nib/_nib-slaac.h"
+#endif
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -690,7 +692,9 @@ void gnrc_netif_ipv6_addr_remove_internal(gnrc_netif_t *netif,
 {
     bool remove_sol_nodes = true;
     ipv6_addr_t sol_nodes;
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
     ipv6_addr_t addr_backup = *addr;
+#endif
 
     assert((netif != NULL) && (addr != NULL));
     ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
@@ -716,12 +720,14 @@ void gnrc_netif_ipv6_addr_remove_internal(gnrc_netif_t *netif,
     }
     gnrc_netif_release(netif);
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
     // for temporary addresses (deleted on DAD failure or manually),
     // also their prefix needs to be removed
     gnrc_ipv6_nib_pl_del(netif->pid, &addr_backup, IPV6_ADDR_BIT_LEN);
     // only expected to find a prefix if it's a temporary address.
     // on prefix deletion, it won't find an address to delete
     // this is fine, to avoid infinite loop
+#endif
 }
 
 int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
@@ -1246,10 +1252,12 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
          */
 
         /* Rule 7: Prefer temporary addresses. */
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
         if (is_temporary_addr(netif, ptr)) {
             DEBUG("winner for rule 7 found\n");
             winner_set[i] += RULE_7_PTS;
         }
+#endif
 
         if (winner_set[i] > max_pts) {
             idx = i;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1119,6 +1119,8 @@ static int _create_candidate_set(const gnrc_netif_t *netif,
 /* number of "points" assigned to an source address candidate in preferred
  * state */
 #define RULE_3_PTS          (1)
+/* number of "points" assigned to a temporary source address candidate */
+#define RULE_7_PTS          (1)
 
 /**
  * @brief   Caps the match at a source addresses prefix length
@@ -1243,10 +1245,11 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
          * TODO: update as soon as gnrc supports flow labels
          */
 
-        /* Rule 7: Prefer temporary addresses.
-         * Temporary addresses are currently not supported by gnrc.
-         * TODO: update as soon as gnrc supports temporary addresses
-         */
+        /* Rule 7: Prefer temporary addresses. */
+        if (is_temporary_addr(netif, ptr)) {
+            DEBUG("winner for rule 7 found\n");
+            winner_set[i] += RULE_7_PTS;
+        }
 
         if (winner_set[i] > max_pts) {
             idx = i;

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -219,6 +219,22 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
     }
 }
 
+int gnrc_netif_ipv6_dad_transmits(const gnrc_netif_t *netif)
+{
+    switch (netif->device_type) {
+        #if defined(MODULE_NETDEV_IEEE802154)
+        case NETDEV_TYPE_IEEE802154:
+            return SIXLOWPAN_ND_REG_TRANSMIT_NUMOF;
+        #endif
+        #if defined(MODULE_NETDEV_ETH)
+        case NETDEV_TYPE_ETHERNET:
+            return NDP_DAD_TRANSMIT_NUMOF;
+        #endif
+        default:
+            return -ENOTSUP;
+    }
+}
+
 int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
                                   const uint8_t *addr, size_t addr_len,
                                   eui64_t *iid)

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -219,6 +219,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
     }
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 int gnrc_netif_ipv6_dad_transmits(const gnrc_netif_t *netif)
 {
     switch (netif->device_type) {
@@ -234,6 +235,7 @@ int gnrc_netif_ipv6_dad_transmits(const gnrc_netif_t *netif)
             return -ENOTSUP;
     }
 }
+#endif
 
 int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
                                   const uint8_t *addr, size_t addr_len,

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -24,6 +24,7 @@
 #include "net/eui48.h"
 #include "net/gnrc/netif.h"
 #include "net/ieee802154.h"
+#include "net/sixlowpan/nd.h"
 #include "net/l2util.h"
 
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -237,6 +237,7 @@ static void *_event_loop(void *args)
             case GNRC_IPV6_NIB_ADDR_REG_TIMEOUT:
             case GNRC_IPV6_NIB_ABR_TIMEOUT:
             case GNRC_IPV6_NIB_PFX_TIMEOUT:
+            case GNRC_IPV6_NIB_REGEN_TEMP_ADDR:
             case GNRC_IPV6_NIB_RTR_TIMEOUT:
             case GNRC_IPV6_NIB_RECALC_REACH_TIME:
             case GNRC_IPV6_NIB_REREG_ADDRESS:

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -237,7 +237,9 @@ static void *_event_loop(void *args)
             case GNRC_IPV6_NIB_ADDR_REG_TIMEOUT:
             case GNRC_IPV6_NIB_ABR_TIMEOUT:
             case GNRC_IPV6_NIB_PFX_TIMEOUT:
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
             case GNRC_IPV6_NIB_REGEN_TEMP_ADDR:
+#endif
             case GNRC_IPV6_NIB_RTR_TIMEOUT:
             case GNRC_IPV6_NIB_RECALC_REACH_TIME:
             case GNRC_IPV6_NIB_REREG_ADDRESS:

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -40,6 +40,10 @@ config GNRC_IPV6_NIB_SLAAC
     default n if USEMODULE_GNRC_IPV6_NIB_6LR || USEMODULE_GNRC_IPV6_NIB_6LN
     default y
 
+config GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES
+    bool "Use temporary addresses (rfc8981)"
+    depends on GNRC_IPV6_NIB_SLAAC
+
 config GNRC_IPV6_NIB_QUEUE_PKT
     bool "Use packet queue with address resolution"
     default n if USEMODULE_GNRC_IPV6_NIB_6LN || GNRC_IPV6_NIB_6LN

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -693,6 +693,15 @@ void _nib_offl_remove_prefix(_nib_offl_entry_t *pfx)
     netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
 
     if (netif != NULL) {
+        if (pfx->flags & _PFX_SLAAC) {
+            /* remove prefixes that manage a temporary address */
+            ipv6_addr_t temp_addr;
+            void *state = NULL;
+            while (iter_slaac_prefix_to_temp_addr(netif, &pfx->pfx, state, &temp_addr)) {
+                gnrc_ipv6_nib_pl_del(netif->pid, &temp_addr, IPV6_ADDR_BIT_LEN);
+            }
+        }
+
         uint8_t best_match_len = pfx->pfx_len;
         ipv6_addr_t *best_match = NULL;
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -29,7 +29,9 @@
 
 #include "_nib-internal.h"
 #include "_nib-router.h"
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 #include "_nib-slaac.h"
+#endif
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -692,13 +694,16 @@ void _nib_offl_remove_prefix(_nib_offl_entry_t *pfx)
 
     /* remove prefix timer */
     evtimer_del(&_nib_evtimer, &pfx->pfx_timeout.event);
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
     /* remove temporary address timer (not present if not a temporary address) */
     evtimer_del(&_nib_evtimer, &pfx->regen_temp_addr.event);
+#endif
 
     /* get interface associated with prefix */
     netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
 
     if (netif != NULL) {
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
         if (pfx->flags & _PFX_SLAAC) {
             /* remove prefixes that manage a temporary address */
             ipv6_addr_t temp_addr;
@@ -707,6 +712,7 @@ void _nib_offl_remove_prefix(_nib_offl_entry_t *pfx)
                 gnrc_ipv6_nib_pl_del(netif->pid, &temp_addr, IPV6_ADDR_BIT_LEN);
             }
         }
+#endif
 
         uint8_t best_match_len = pfx->pfx_len;
         ipv6_addr_t *best_match = NULL;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -708,7 +708,7 @@ void _nib_offl_remove_prefix(_nib_offl_entry_t *pfx)
             /* remove prefixes that manage a temporary address */
             ipv6_addr_t temp_addr;
             void *state = NULL;
-            while (iter_slaac_prefix_to_temp_addr(netif, &pfx->pfx, state, &temp_addr)) {
+            while (_iter_slaac_prefix_to_temp_addr(netif, &pfx->pfx, state, &temp_addr)) {
                 gnrc_ipv6_nib_pl_del(netif->pid, &temp_addr, IPV6_ADDR_BIT_LEN);
             }
         }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -29,6 +29,7 @@
 
 #include "_nib-internal.h"
 #include "_nib-router.h"
+#include "_nib-slaac.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -663,6 +663,10 @@ int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
 void _nib_pl_remove(_nib_offl_entry_t *nib_offl)
 {
     _evtimer_del(&nib_offl->pfx_timeout);
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
+    /* remove temporary address timer (not present if not a temporary address) */
+    _evtimer_del(&nib_offl->regen_temp_addr);
+#endif
     _nib_offl_remove(nib_offl, _PL);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
     unsigned idx = _idx_dsts(nib_offl);
@@ -688,6 +692,8 @@ void _nib_offl_remove_prefix(_nib_offl_entry_t *pfx)
 
     /* remove prefix timer */
     evtimer_del(&_nib_evtimer, &pfx->pfx_timeout.event);
+    /* remove temporary address timer (not present if not a temporary address) */
+    evtimer_del(&_nib_evtimer, &pfx->regen_temp_addr.event);
 
     /* get interface associated with prefix */
     netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -209,6 +209,12 @@ typedef struct {
      */
     evtimer_msg_event_t route_timeout;
 #endif
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
+    /**
+     * @brief   Event for @ref GNRC_IPV6_NIB_REGEN_TEMP_ADDR
+     */
+    evtimer_msg_event_t regen_temp_addr;
+#endif
     uint8_t mode;               /**< [mode](@ref net_gnrc_ipv6_nib_mode) of the
                                  *   off-link entry */
     uint8_t pfx_len;            /**< prefix-length in bits of

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -108,6 +108,13 @@ bool _iid_is_iana_reserved(const eui64_t *iid)
     || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
 }
 
+void _ipv6_get_random_iid(eui64_t *iid)
+{
+    do {
+        random_bytes(iid->uint8, 8);
+    } while (_iid_is_iana_reserved(iid));
+}
+
 uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif)
 {
     //https://datatracker.ietf.org/doc/html/rfc8981#section-3.8-3.2

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -277,7 +277,12 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
     if (is_temp_addr) {
         if (retries >= TEMP_IDGEN_RETRIES) {
+            //https://www.rfc-editor.org/rfc/rfc8981.html#section-3.4-3.7
             DEBUG("nib: Not regenerating temporary address, retried often enough.\n");
+            if (!gnrc_ipv6_nib_pl_reschedule_regen(netif->pid, &addr_backup, 0)) {
+                DEBUG("nib: Removing regen event timer failed\n");
+                assert(false);
+            }
             return;
         }
         retries++;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -97,6 +97,16 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 }
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
+uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif)
+{
+    //https://datatracker.ietf.org/doc/html/rfc8981#section-3.8-3.2
+    return 2 + (TEMP_IDGEN_RETRIES *
+    (gnrc_netif_ipv6_dad_transmits(netif) * (netif->ipv6.retrans_time / 1000))
+    );
+}
+#endif
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
 static bool _try_l2addr_reconfiguration(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -283,6 +283,19 @@ bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *a
     return false;
 }
 
+bool iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
+                                    ipv6_addr_t *next_temp_addr) {
+    gnrc_ipv6_nib_pl_t ple;
+    while (gnrc_ipv6_nib_pl_iter(netif->pid, &state, &ple)) {
+        if (ple.pfx_len == IPV6_ADDR_BIT_LEN /* is temp addr. prefix */
+            && ipv6_addr_match_prefix(&ple.pfx, slaac_pfx) >= SLAAC_PREFIX_LENGTH) {
+            *next_temp_addr = ple.pfx;
+            return true;
+        }
+    }
+    return false;
+}
+
 static int _get_netif_state(gnrc_netif_t **netif, const ipv6_addr_t *addr)
 {
     *netif = gnrc_netif_get_by_ipv6_addr(addr);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -120,7 +120,7 @@ int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, co
               TEMP_PREFERRED_LIFETIME, MAX_DESYNC_FACTOR);
 
         assert(MAX_DESYNC_FACTOR < TEMP_PREFERRED_LIFETIME - gnrc_netif_ipv6_regen_advance(netif));
-        //https://datatracker.ietf.org/doc/html/rfc8981#section-3.8-7.2
+        //https://www.rfc-editor.org/rfc/rfc8981.html#section-3.8-7.2
 
         return -1;
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -155,6 +155,14 @@ int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
         gnrc_ipv6_nib_pl_del(netif->pid, &addr, IPV6_ADDR_BIT_LEN);
         return -1;
     }
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
+    if (gnrc_netif_is_6ln(netif) &&
+        !gnrc_netif_is_6lbr(netif)) {
+        _handle_rereg_address(&netif->ipv6.addrs[index]);
+    }
+#endif
+
     return ta_max_pref_lft;
 }
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -101,7 +101,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
-int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime, uint8_t retries,
+int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, const uint32_t pfx_pref_ltime, const uint8_t retries,
                                  int *idx)
 {
     DEBUG("nib: add temporary address based on %s/%u automatically to interface %u\n",
@@ -148,15 +148,12 @@ int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, ui
     return ta_max_pref_lft;
 }
 
-bool is_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr) {
+bool is_temporary_addr(const gnrc_netif_t *netif, const ipv6_addr_t *addr) {
     return gnrc_ipv6_nib_pl_has_prefix(netif->pid, addr, IPV6_ADDR_BIT_LEN);
 }
 
 bool _iid_is_iana_reserved(const eui64_t *iid)
 {
-    //[RFC5453]
-    //https://www.iana.org/assignments/ipv6-interface-ids/ipv6-interface-ids.xhtml
-
     return (iid->uint64.u64 == htonll(0))
     || (iid->uint32[0].u32 == htonl(0x02005eff) && iid->uint8[4] == 0xfe)
     || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
@@ -171,7 +168,6 @@ void _ipv6_get_random_iid(eui64_t *iid)
 
 uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif)
 {
-    //https://datatracker.ietf.org/doc/html/rfc8981#section-3.8-3.2
     return 2 + (TEMP_IDGEN_RETRIES *
     (gnrc_netif_ipv6_dad_transmits(netif) * (netif->ipv6.retrans_time / 1000))
     );

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -21,6 +21,7 @@
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/netif/internal.h"
 
+#include "_nib-slaac.h"
 #include "_nib-6ln.h"
 #include "_nib-arsm.h"
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -173,7 +173,7 @@ uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif)
     );
 }
 
-bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until) {
+bool _get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until) {
     void *state = NULL;
     gnrc_ipv6_nib_pl_t ple;
     while (gnrc_ipv6_nib_pl_iter(netif->pid, &state, &ple)) {
@@ -290,7 +290,7 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
 
         //find associated prefix
         uint32_t slaac_prefix_pref_until;
-        if (!get_slaac_prefix_pref_until(netif, &addr_backup, &slaac_prefix_pref_until)) {
+        if (!_get_slaac_prefix_pref_until(netif, &addr_backup, &slaac_prefix_pref_until)) {
             // at least one match is expected,
             // the temporary address smh outlived the SLAAC prefix valid lft
             assert(false);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -186,8 +186,8 @@ bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *a
     return false;
 }
 
-bool iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
-                                    ipv6_addr_t *next_temp_addr) {
+bool _iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
+                                     ipv6_addr_t *next_temp_addr) {
     gnrc_ipv6_nib_pl_t ple;
     while (gnrc_ipv6_nib_pl_iter(netif->pid, &state, &ple)) {
         if (ple.pfx_len == IPV6_ADDR_BIT_LEN /* is temp addr. prefix */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -112,7 +112,7 @@ int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 
     if (pfx_pref_ltime <= _get_netif_regen_advance(netif)) {
         DEBUG("nib: Abort adding temporary address "
-              "because prefix's preferred lifetime too short (%u <= %u)\n",
+              "because prefix's preferred lifetime too short (%"PRIu32" <= %"PRIu32")\n",
               pfx_pref_ltime, _get_netif_regen_advance(netif));
         return -1;
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -330,7 +330,7 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
         uint32_t slaac_prefix_pref_until;
         if (!_get_slaac_prefix_pref_until(netif, addr, &slaac_prefix_pref_until)) {
             // at least one match is expected,
-            // the temporary address smh outlived the SLAAC prefix valid lft
+            LOG_WARNING("nib: The temporary address smh outlived the SLAAC prefix valid lft.");
             assert(false);
             return;
         }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -99,7 +99,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
-int _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime)
+int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime)
 {
     DEBUG("nib: add temporary address based on %s/%u automatically to interface %u\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)),
@@ -137,7 +137,7 @@ int _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32
         gnrc_ipv6_nib_pl_del(netif->pid, &addr, IPV6_ADDR_BIT_LEN); //remove the just created prefix again
         return -1;
     }
-    return 0;
+    return ta_max_pref_lft;
 }
 
 bool is_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -161,13 +161,13 @@ int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                                                    &addr,
                                                    IPV6_ADDR_BIT_LEN,
                                                    flags)) < 0) {
-        if (idx != NULL) {
-            *idx = index;
-        }
         LOG_WARNING("nib: Abort adding temporary address, adding address failed\n");
         //remove the just created prefix again
         gnrc_ipv6_nib_pl_del(netif->pid, &addr, IPV6_ADDR_BIT_LEN);
         return -1;
+    }
+    if (idx != NULL) {
+        *idx = index;
     }
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -267,7 +267,9 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
 
         uint32_t now = evtimer_now_msec();
         assert(now < slaac_prefix_pref_until); // else the temporary address smh outlived the SLAAC prefix preferred lft
-        int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &addr_backup, slaac_prefix_pref_until - now, retries);
+        int idx;
+        int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &addr_backup, slaac_prefix_pref_until - now, retries,
+                                                           &idx);
         if (ta_max_pref_lft < 0) {
             DEBUG("nib: Temporary address regeneration failed after DAD failure.\n");
             return;
@@ -276,7 +278,7 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
         //re-schedule regen event (incl. deleting old one)
         if (!gnrc_ipv6_nib_pl_reschedule_regen(netif->pid, &addr_backup, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif))) {
             DEBUG("nib: Temporary address regeneration failed after DAD failure, SLAAC prefix was not found to reschedule address regeneration timer.\n");
-            //TODO delete just created temp addr
+            gnrc_netif_ipv6_addr_remove_internal(netif, &netif->ipv6.addrs[idx]); //delete just created temp addr
             assert(false);
             return;
         }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -98,6 +98,16 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
+bool _iid_is_iana_reserved(const eui64_t *iid)
+{
+    //[RFC5453]
+    //https://www.iana.org/assignments/ipv6-interface-ids/ipv6-interface-ids.xhtml
+
+    return (iid->uint64.u64 == htonll(0))
+    || (iid->uint32[0].u32 == htonl(0x02005eff) && iid->uint8[4] == 0xfe)
+    || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
+}
+
 uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif)
 {
     //https://datatracker.ietf.org/doc/html/rfc8981#section-3.8-3.2

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -143,10 +143,12 @@ int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
         return -1;
     }
     int index;
-    if ((index = gnrc_netif_ipv6_addr_add_internal(netif, &addr, IPV6_ADDR_BIT_LEN,
-                                          GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE
-                                          | (retries << GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS)
-                                          )) < 0) {
+    uint8_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE
+            | (retries << GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS);
+    if ((index = gnrc_netif_ipv6_addr_add_internal(netif,
+                                                   &addr,
+                                                   IPV6_ADDR_BIT_LEN,
+                                                   flags)) < 0) {
         if (idx != NULL) {
             *idx = index;
         }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#define SLAAC_PREFIX_LENGTH (64U)
+
 /**
  * @name    Temporary address parameters
  * @see     [RFC 8981, section 3.8](https://tools.ietf.org/html/rfc8981#section-3.8)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -123,6 +123,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  * @param[in] retries Number of address generation retries
  * that is to be stored in the address flags.
  * @param[out] idx The index of the generated address.
+ * Optional, leave NULL if not needed.
  *
  * @return -1 on failure
  * @return ta_max_pref_lft on success

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -131,7 +131,7 @@ void _ipv6_get_random_iid(eui64_t *iid);
  * @param[in] netif The interface, as the value depends on this.
  * @return REGEN_ADVANCE [seconds]
  */
-uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
+uint32_t _get_netif_regen_advance(const gnrc_netif_t *netif);
 
 /**
  * @brief For an address, get the corresponding SLAAC prefix's preferred lifetime

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -84,6 +84,11 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #define _auto_configure_addr(netif, pfx, pfx_len) \
     (void)netif; (void)pfx; (void)pfx_len;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
+uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
+#endif
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**
  * @brief   Removes a tentative address from the interface and tries to

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -91,10 +91,11 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 /**
  * @param pfx_pref_ltime Lifetime of the prefix for which an address shall be created.
  *                       Needed to determine whether it is worth creating a temporary address.
+ * @param retries Number of address generation retries that is to be stored in the address flags.
  * @return -1 on failure
  * @return ta_max_pref_lft on success
  */
-int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime);
+int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime, uint8_t retries);
 
 /**
  * Assuming the provided address is a configured address,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -32,6 +32,15 @@
 extern "C" {
 #endif
 
+/**
+ * > An IPv6 address prefix used for stateless autoconfiguration [ACONF]
+ *   of an Ethernet interface must have a length of 64 bits.
+ * - https://datatracker.ietf.org/doc/html/rfc2464
+ *
+ * > An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
+ *   of an IEEE 802.15.4 interface MUST have a length of 64 bits.
+ * - https://datatracker.ietf.org/doc/html/rfc4944
+ */
 #define SLAAC_PREFIX_LENGTH (64U)
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -32,6 +32,42 @@
 extern "C" {
 #endif
 
+/**
+ * @name    Temporary address parameters
+ * @see     [RFC 8981, section 3.8](https://tools.ietf.org/html/rfc8981#section-3.8)
+ * @{
+ */
+/**
+ * @brief   Maximum valid lifetime [days] of a temporary address
+ */
+#ifndef TEMP_VALID_LIFETIME
+#define TEMP_VALID_LIFETIME            MS_PER_HOUR * HOURS_PER_DAY * (2U) /*default value*/
+#endif
+
+/**
+ * @brief   Maximum preferred lifetime [days] of a temporary address
+ * 
+ * @note    "MUST be smaller than the TEMP_VALID_LIFETIME value"
+ */
+#ifndef TEMP_PREFERRED_LIFETIME
+#define TEMP_PREFERRED_LIFETIME        MS_PER_HOUR * HOURS_PER_DAY * (1U) /*default value*/
+#endif
+
+/**
+ * @brief   Maximum time to randomly subtract from TEMP_PREFERRED_LIFETIME
+ *          for a temporary address
+ */
+#define MAX_DESYNC_FACTOR             (TEMP_PREFERRED_LIFETIME / 10 * 4)
+
+/**
+ * @brief   Maximum number of retries for generating a temporary address
+ *          in case a duplicate addresses was detected (DAD failure)
+ */
+#ifndef TEMP_IDGEN_RETRIES
+#define TEMP_IDGEN_RETRIES             (3U) /*default value*/
+#endif
+/** @} */
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**
  * @brief   Auto-configures an address from a given prefix

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -71,7 +71,7 @@ extern "C" {
 
 /**
  * @brief   Maximum preferred lifetime [days] of a temporary address
- * 
+ *
  * @note    "MUST be smaller than the TEMP_VALID_LIFETIME value"
  */
 #ifndef TEMP_PREFERRED_LIFETIME

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -86,6 +86,8 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
+bool _iid_is_iana_reserved(const eui64_t *iid);
+
 uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -127,6 +127,16 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr);
 bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until);
 
 /**
+ * @brief For a given SLAAC prefix, get the first-best temporary address prefix.
+ * @param[in] netif
+ * @param[in] slaac_pfx
+ * @param[out] next_temp_addr
+ * @return
+ */
+bool iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
+                                    ipv6_addr_t *next_temp_addr);
+
+/**
  * @brief   Handle @ref GNRC_IPV6_NIB_DAD event
  *
  * @param[in] addr  A TENTATIVE address.

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -94,6 +94,12 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  */
 int _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime);
 
+/**
+ * Assuming the provided address is a configured address,
+ * check if the address is a temporary address.
+ */
+bool is_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr);
+
 bool _iid_is_iana_reserved(const eui64_t *iid);
 
 void _ipv6_get_random_iid(eui64_t *iid);
@@ -110,6 +116,15 @@ uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
  * @param[in] addr  The address to remove.
  */
 void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr);
+
+/**
+ * @brief For an address, get the corresponding SLAAC prefix's preferred lifetime
+ * @param[in] netif The network interface the prefix is configured on.
+ * @param[in] addr An IP address in the SLAAC prefix
+ * @param[out] slaac_prefix_pref_until pref_until time of the SLAAC prefix
+ * @return
+ */
+bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until);
 
 /**
  * @brief   Handle @ref GNRC_IPV6_NIB_DAD event

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -114,27 +114,34 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 /**
  * @brief Create a temporary address for the given prefix.
  *
- * @param[in] netif The network interface on which to create the temporary address on. Untested behavior if not the same as for the prefix.
- * @param[in] pfx The prefix which is to be used in the temporary address. The prefix length is assumed to be @ref SLAAC_PREFIX_LENGTH
+ * @param[in] netif The network interface on which to create the temporary address on.
+ * Untested behavior if not the same as for the prefix.
+ * @param[in] pfx The prefix which is to be used in the temporary address.
+ * The prefix length is assumed to be @ref SLAAC_PREFIX_LENGTH
  * @param[in] pfx_pref_ltime Lifetime of the prefix for which an address shall be created.
  *                       Needed to determine whether it is worth creating a temporary address.
- * @param[in] retries Number of address generation retries that is to be stored in the address flags.
+ * @param[in] retries Number of address generation retries
+ * that is to be stored in the address flags.
  * @param[out] idx The index of the generated address.
  *
  * @return -1 on failure
  * @return ta_max_pref_lft on success
  */
-int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, const uint32_t pfx_pref_ltime, const uint8_t retries,
+int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                                 const uint32_t pfx_pref_ltime,
+                                 const uint8_t retries,
                                  int *idx);
 
 /**
  * @brief Check if the address is a temporary address.
- * (Assuming the provided address is a configured address. This function only checks for prefix existence.)
+ * (Assuming the provided address is a configured address.
+ * This function only checks for prefix existence.)
  */
 bool is_temporary_addr(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
 /**
- * @brief Check if an interface identifier of an IPv6 address is reserved by IANA, i.e. it shouldn't be used
+ * @brief Check if an interface identifier of an IPv6 address
+ * is reserved by IANA, i.e. it shouldn't be used
  * This is should be checked when the interface identifier is randomly generated.
  * @see [RFC5453], https://www.iana.org/assignments/ipv6-interface-ids/ipv6-interface-ids.xhtml
  * @param[in] iid The interface identifier to check for
@@ -143,13 +150,15 @@ bool is_temporary_addr(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 bool _iid_is_iana_reserved(const eui64_t *iid);
 
 /**
- * @brief Generate a random interface identifier that is not IANA reserved (@ref _iid_is_iana_reserved)
+ * @brief Generate a random interface identifier
+ * that is not IANA reserved (@ref _iid_is_iana_reserved)
  * @param[out] iid The interface identifier to write to.
  */
 void _ipv6_get_random_iid(eui64_t *iid);
 
 /**
- * @brief Get the duration in seconds at which regeneration of a temporary address should be started before deprecation of the current one.
+ * @brief Get the duration in seconds at which regeneration of a temporary address
+ * should be started before deprecation of the current one.
  * @see https://www.rfc-editor.org/rfc/rfc8981.html#section-3.8-3.2
  * @param[in] netif The interface, as the value depends on this.
  * @return REGEN_ADVANCE [seconds]
@@ -163,17 +172,23 @@ uint32_t _get_netif_regen_advance(const gnrc_netif_t *netif);
  * @param[out] slaac_prefix_pref_until pref_until time of the SLAAC prefix
  * @return true if a corresponding prefix was found, otherwise false
  */
-bool _get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until);
+bool _get_slaac_prefix_pref_until(const gnrc_netif_t *netif,
+                                  const ipv6_addr_t *addr,
+                                  uint32_t *slaac_prefix_pref_until);
 
 /**
  * @brief For a given SLAAC prefix, get the first-best temporary address prefix.
  * @param[in] netif The interface on which to find the @p slaac_pfc on (0 for any)
  * @param[in] slaac_pfx The SLAAC prefix to find a configured temporary address for.
- * @param[in, out] state Internal iteration state for the prefix list. Can be optionally provided to not start checking all prefixes from the beginning. Otherwise NULL.
+ * @param[in, out] state Internal iteration state for the prefix list.
+ * Can be optionally provided to not start checking all prefixes from the beginning.
+ * Otherwise NULL.
  * @param[out] next_temp_addr The temporary address that was configured from the given @p slaac_pfx.
  * @return true if a temporary address was found, false otherwise
  */
-bool _iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
+bool _iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif,
+                                     const ipv6_addr_t *slaac_pfx,
+                                     void *state,
                                      ipv6_addr_t *next_temp_addr);
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -92,10 +92,12 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  * @param pfx_pref_ltime Lifetime of the prefix for which an address shall be created.
  *                       Needed to determine whether it is worth creating a temporary address.
  * @param retries Number of address generation retries that is to be stored in the address flags.
+ * @param[out] idx The index of the generated address.
  * @return -1 on failure
  * @return ta_max_pref_lft on success
  */
-int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime, uint8_t retries);
+int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime, uint8_t retries,
+                                 int *idx);
 
 /**
  * Assuming the provided address is a configured address,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -150,8 +150,8 @@ bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *a
  * @param[out] next_temp_addr The temporary address that was configured from the given @p slaac_pfx.
  * @return true if a temporary address was found, false otherwise
  */
-bool iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
-                                    ipv6_addr_t *next_temp_addr);
+bool _iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
+                                     ipv6_addr_t *next_temp_addr);
 #endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -63,7 +63,7 @@ extern "C" {
  * @{
  */
 /**
- * @brief   Maximum valid lifetime [days] of a temporary address
+ * @brief   Maximum valid lifetime [ms] of a temporary address
  * @ref MAX_TEMP_ADDRESSES depends on this value
  */
 #ifndef TEMP_VALID_LIFETIME
@@ -71,7 +71,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Maximum preferred lifetime [days] of a temporary address
+ * @brief   Maximum preferred lifetime [ms] of a temporary address
  *
  * @note    "MUST be smaller than the TEMP_VALID_LIFETIME value"
  * @ref MAX_TEMP_ADDRESSES depends on this value

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 #define SLAAC_PREFIX_LENGTH (64U)
 
-/*
+/**
  * "the address architecture [RFC4291] also defines the length of the interface identifiers"
  * - https://datatracker.ietf.org/doc/html/rfc4862#section-2
  *

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -110,17 +110,6 @@ bool _iid_is_iana_reserved(const eui64_t *iid);
 void _ipv6_get_random_iid(eui64_t *iid);
 
 uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
-#endif
-
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
-/**
- * @brief   Removes a tentative address from the interface and tries to
- *          reconfigure a new address
- *
- * @param[in] netif The network interface the address is to be removed from.
- * @param[in] addr  The address to remove.
- */
-void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
 /**
  * @brief For an address, get the corresponding SLAAC prefix's preferred lifetime
@@ -140,6 +129,17 @@ bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *a
  */
 bool iter_slaac_prefix_to_temp_addr(const gnrc_netif_t *netif, const ipv6_addr_t *slaac_pfx, void *state,
                                     ipv6_addr_t *next_temp_addr);
+#endif
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
+/**
+ * @brief   Removes a tentative address from the interface and tries to
+ *          reconfigure a new address
+ *
+ * @param[in] netif The network interface the address is to be removed from.
+ * @param[in] addr  The address to remove.
+ */
+void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
 /**
  * @brief   Handle @ref GNRC_IPV6_NIB_DAD event

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -40,8 +40,22 @@ extern "C" {
  * > An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
  *   of an IEEE 802.15.4 interface MUST have a length of 64 bits.
  * - https://datatracker.ietf.org/doc/html/rfc4944
+ *
+ * Also see
+ * @ref INTERFACE_IDENTIFIER_LENGTH
+ * in combination with "sum" "does not equal 128 bits"
+ * from https://datatracker.ietf.org/doc/html/rfc4862#section-5.5.3 d)
  */
 #define SLAAC_PREFIX_LENGTH (64U)
+
+/*
+ * "the address architecture [RFC4291] also defines the length of the interface identifiers"
+ * - https://datatracker.ietf.org/doc/html/rfc4862#section-2
+ *
+ * "Interface IDs are required to be 64 bits long"
+ * - https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.1
+ */
+#define INTERFACE_IDENTIFIER_LENGTH (64U)
 
 /**
  * @name    Temporary address parameters

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -140,7 +140,7 @@ uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
  * @param[out] slaac_prefix_pref_until pref_until time of the SLAAC prefix
  * @return true if a corresponding prefix was found, otherwise false
  */
-bool get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until);
+bool _get_slaac_prefix_pref_until(const gnrc_netif_t *netif, const ipv6_addr_t *addr, uint32_t *slaac_prefix_pref_until);
 
 /**
  * @brief For a given SLAAC prefix, get the first-best temporary address prefix.

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -64,6 +64,8 @@ extern "C" {
 /**
  * @brief   Maximum number of retries for generating a temporary address
  *          in case a duplicate addresses was detected (DAD failure)
+ *
+ * @ref GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES must be able to store this number
  */
 #ifndef TEMP_IDGEN_RETRIES
 #define TEMP_IDGEN_RETRIES             (3U) /*default value*/

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -86,6 +86,14 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
+/**
+ * @param pfx_pref_ltime Lifetime of the prefix for which an address shall be created.
+ *                       Needed to determine whether it is worth creating a temporary address.
+ * @return -1 on failure
+ * @return 0 on success
+ */
+int _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime);
+
 bool _iid_is_iana_reserved(const eui64_t *iid);
 
 void _ipv6_get_random_iid(eui64_t *iid);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -36,7 +36,7 @@ extern "C" {
 
 /**
  * @name    Temporary address parameters
- * @see     [RFC 8981, section 3.8](https://tools.ietf.org/html/rfc8981#section-3.8)
+ * @see     [RFC 8981, section 3.8](https://www.rfc-editor.org/rfc/rfc8981.html#section-3.8)
  * @{
  */
 /**
@@ -127,7 +127,7 @@ void _ipv6_get_random_iid(eui64_t *iid);
 
 /**
  * @brief Get the duration in seconds at which regeneration of a temporary address should be started before deprecation of the current one.
- * @see https://datatracker.ietf.org/doc/html/rfc8981#section-3.8-3.2
+ * @see https://www.rfc-editor.org/rfc/rfc8981.html#section-3.8-3.2
  * @param[in] netif The interface, as the value depends on this.
  * @return REGEN_ADVANCE [seconds]
  */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -90,9 +90,9 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  * @param pfx_pref_ltime Lifetime of the prefix for which an address shall be created.
  *                       Needed to determine whether it is worth creating a temporary address.
  * @return -1 on failure
- * @return 0 on success
+ * @return ta_max_pref_lft on success
  */
-int _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime);
+int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint32_t pfx_pref_ltime);
 
 /**
  * Assuming the provided address is a configured address,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -130,6 +130,16 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  *
  * @return -1 on failure
  * @return ta_max_pref_lft on success
+ * This value should be used to (re)schedule
+ * the @ref GNRC_IPV6_NIB_REGEN_TEMP_ADDR event accordingly,
+ * i.e. if direct access to the @ref _nib_offl_entry_t is present,
+ * by its @ref regen_temp_addr event,
+ * otherwise through @ref gnrc_ipv6_nib_pl_reschedule_regen
+ * (This method does not do it by itself
+ * because it does not have direct access to the @ref _nib_offl_entry_t
+ * but the caller may have)
+ * The offset for the event SHOULD be
+ * the returned value minus @ref _get_netif_regen_advance(netif)
  */
 int32_t _generate_temporary_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                                  const uint32_t pfx_pref_ltime,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -88,6 +88,8 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 bool _iid_is_iana_reserved(const eui64_t *iid);
 
+void _ipv6_get_random_iid(eui64_t *iid);
+
 uint32_t gnrc_netif_ipv6_regen_advance(const gnrc_netif_t *netif);
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -64,6 +64,7 @@ extern "C" {
  */
 /**
  * @brief   Maximum valid lifetime [days] of a temporary address
+ * @ref MAX_TEMP_ADDRESSES depends on this value
  */
 #ifndef TEMP_VALID_LIFETIME
 #define TEMP_VALID_LIFETIME            MS_PER_HOUR * HOURS_PER_DAY * (2U) /*default value*/
@@ -73,6 +74,7 @@ extern "C" {
  * @brief   Maximum preferred lifetime [days] of a temporary address
  *
  * @note    "MUST be smaller than the TEMP_VALID_LIFETIME value"
+ * @ref MAX_TEMP_ADDRESSES depends on this value
  */
 #ifndef TEMP_PREFERRED_LIFETIME
 #define TEMP_PREFERRED_LIFETIME        MS_PER_HOUR * HOURS_PER_DAY * (1U) /*default value*/
@@ -81,6 +83,7 @@ extern "C" {
 /**
  * @brief   Maximum time to randomly subtract from TEMP_PREFERRED_LIFETIME
  *          for a temporary address
+ * @ref MAX_TEMP_ADDRESSES depends on this value
  */
 #define MAX_DESYNC_FACTOR             (TEMP_PREFERRED_LIFETIME / 10 * 4)
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1637,7 +1637,9 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     DEBUG("     - Preferred lifetime: %" PRIu32 "\n",
           byteorder_ntohl(pio->pref_ltime));
 
-    if (pio->flags & NDP_OPT_PI_FLAGS_A) {
+    if (pio->flags & NDP_OPT_PI_FLAGS_A
+        && pio->prefix_len == SLAAC_PREFIX_LENGTH
+        ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
     }
     if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1437,10 +1437,15 @@ static void _handle_snd_na(gnrc_pktsnip_t *pkt)
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
-    DEBUG("nib: Temporary address regeneration event for SLAAC prefix %s/%u\n", ipv6_addr_to_str(addr_str, &pfx->pfx, sizeof(addr_str)), pfx->pfx_len);
+    DEBUG("nib: Temporary address regeneration event for SLAAC prefix %s/%u\n",
+          ipv6_addr_to_str(addr_str, &pfx->pfx, sizeof(addr_str)),
+          pfx->pfx_len);
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
     assert(evtimer_now_msec() < pfx->pref_until);
-    int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx, pfx->pref_until - evtimer_now_msec(), 0, NULL);
+    int32_t ta_max_pref_lft;
+    ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx,
+                                               pfx->pref_until - evtimer_now_msec(),
+                                               0, NULL);
     if (ta_max_pref_lft < 0) {
         DEBUG("nib: Temporary address regeneration failed.\n");
         return;
@@ -1714,8 +1719,8 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
             if (ta_max_pref_lft > 0) {
                 // a temporary address was created
-                _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft -
-                        _get_netif_regen_advance(netif));
+                _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr,
+                             ta_max_pref_lft - _get_netif_regen_advance(netif));
             }
 #endif
             return _min(pref_ltime, valid_ltime);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1435,7 +1435,7 @@ static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
     DEBUG("nib: Temporary address regeneration event for SLAAC prefix %s/%u\n", ipv6_addr_to_str(addr_str, &pfx->pfx, sizeof(addr_str)), pfx->pfx_len);
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
     assert(evtimer_now_msec() < pfx->pref_until);
-    int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx, pfx->pref_until - evtimer_now_msec());
+    int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx, pfx->pref_until - evtimer_now_msec(), 0);
     if (ta_max_pref_lft < 0) {
         DEBUG("nib: Temporary address regeneration failed.\n");
         return;
@@ -1659,7 +1659,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
         && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
-        ta_max_pref_lft = _generate_temporary_addr(netif, &pio->prefix, pref_ltime);
+        ta_max_pref_lft = _generate_temporary_addr(netif, &pio->prefix, pref_ltime, 0);
     }
     if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {
         _nib_offl_entry_t *pfx;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -80,7 +80,9 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                           gnrc_pktsnip_t *pkt, gnrc_ipv6_nib_nc_t *nce,
                           _nib_onl_entry_t *entry);
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES) || defined(DOXYGEN)
 static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx);
+#endif
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx);
 static void _handle_rtr_timeout(_nib_dr_entry_t *router);
 static void _handle_snd_na(gnrc_pktsnip_t *pkt);
@@ -457,9 +459,11 @@ void gnrc_ipv6_nib_handle_timer_event(void *ctx, uint16_t type)
         case GNRC_IPV6_NIB_PFX_TIMEOUT:
             _handle_pfx_timeout(ctx);
             break;
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
         case GNRC_IPV6_NIB_REGEN_TEMP_ADDR:
             _handle_regen_temp_addr(ctx);
             break;
+#endif
         case GNRC_IPV6_NIB_RTR_TIMEOUT:
             _handle_rtr_timeout(ctx);
             break;
@@ -1431,6 +1435,7 @@ static void _handle_snd_na(gnrc_pktsnip_t *pkt)
 #endif  /* MODULE_GNRC_IPV6 */
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
     DEBUG("nib: Temporary address regeneration event for SLAAC prefix %s/%u\n", ipv6_addr_to_str(addr_str, &pfx->pfx, sizeof(addr_str)), pfx->pfx_len);
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
@@ -1442,6 +1447,7 @@ static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
     }
     _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif)); //add next regen timer
 }
+#endif
 
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx)
 {
@@ -1653,13 +1659,19 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     DEBUG("     - Preferred lifetime: %" PRIu32 "\n",
           byteorder_ntohl(pio->pref_ltime));
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
     int32_t ta_max_pref_lft = 0;
+#endif
     if (pio->flags & NDP_OPT_PI_FLAGS_A
         && pio->prefix_len == SLAAC_PREFIX_LENGTH
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
         && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
+#endif
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
         ta_max_pref_lft = _generate_temporary_addr(netif, &pio->prefix, pref_ltime, 0, NULL);
+#endif
     }
     if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {
         _nib_offl_entry_t *pfx;
@@ -1698,10 +1710,12 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
             if (pio->flags & NDP_OPT_PI_FLAGS_A) {
                 pfx->flags |= _PFX_SLAAC;
             }
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
             if (ta_max_pref_lft > 0) {
                 // a temporary address was created
                 _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif));
             }
+#endif
             return _min(pref_ltime, valid_ltime);
         }
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1671,7 +1671,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     if (pio->flags & NDP_OPT_PI_FLAGS_A
         && pio->prefix_len == SLAAC_PREFIX_LENGTH
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
-        && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
+        && (gnrc_netif_ipv6_addr_pfx_idx(netif, &pio->prefix, pio->prefix_len) < 0)
         /* do not cause generation of another temporary address
          * if the prefix is already known */
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -456,6 +456,9 @@ void gnrc_ipv6_nib_handle_timer_event(void *ctx, uint16_t type)
         case GNRC_IPV6_NIB_PFX_TIMEOUT:
             _handle_pfx_timeout(ctx);
             break;
+        case GNRC_IPV6_NIB_REGEN_TEMP_ADDR:
+            //TODO
+            break;
         case GNRC_IPV6_NIB_RTR_TIMEOUT:
             _handle_rtr_timeout(ctx);
             break;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1447,7 +1447,7 @@ static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
                                                pfx->pref_until - evtimer_now_msec(),
                                                0, NULL);
     if (ta_max_pref_lft < 0) {
-        DEBUG("nib: Temporary address regeneration failed.\n");
+        LOG_WARNING("nib: Temporary address regeneration failed.\n");
         return;
     }
     _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft -

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1642,6 +1642,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
         && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
+        _generate_temporary_addr(netif, &pio->prefix, pref_ltime);
     }
     if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {
         _nib_offl_entry_t *pfx;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1435,7 +1435,7 @@ static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
     DEBUG("nib: Temporary address regeneration event for SLAAC prefix %s/%u\n", ipv6_addr_to_str(addr_str, &pfx->pfx, sizeof(addr_str)), pfx->pfx_len);
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
     assert(evtimer_now_msec() < pfx->pref_until);
-    int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx, pfx->pref_until - evtimer_now_msec(), 0);
+    int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx, pfx->pref_until - evtimer_now_msec(), 0, NULL);
     if (ta_max_pref_lft < 0) {
         DEBUG("nib: Temporary address regeneration failed.\n");
         return;
@@ -1659,7 +1659,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
         && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
-        ta_max_pref_lft = _generate_temporary_addr(netif, &pio->prefix, pref_ltime, 0);
+        ta_max_pref_lft = _generate_temporary_addr(netif, &pio->prefix, pref_ltime, 0, NULL);
     }
     if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {
         _nib_offl_entry_t *pfx;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1445,7 +1445,8 @@ static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
         DEBUG("nib: Temporary address regeneration failed.\n");
         return;
     }
-    _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif)); //add next regen timer
+    _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft -
+            _get_netif_regen_advance(netif)); //add next regen timer
 }
 #endif
 
@@ -1713,7 +1714,8 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
             if (ta_max_pref_lft > 0) {
                 // a temporary address was created
-                _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif));
+                _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft -
+                        _get_netif_regen_advance(netif));
             }
 #endif
             return _min(pref_ltime, valid_ltime);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1639,6 +1639,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
 
     if (pio->flags & NDP_OPT_PI_FLAGS_A
         && pio->prefix_len == SLAAC_PREFIX_LENGTH
+        && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1640,12 +1640,13 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     DEBUG("     - Preferred lifetime: %" PRIu32 "\n",
           byteorder_ntohl(pio->pref_ltime));
 
+    int32_t ta_max_pref_lft = 0;
     if (pio->flags & NDP_OPT_PI_FLAGS_A
         && pio->prefix_len == SLAAC_PREFIX_LENGTH
         && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
-        _generate_temporary_addr(netif, &pio->prefix, pref_ltime);
+        ta_max_pref_lft = _generate_temporary_addr(netif, &pio->prefix, pref_ltime);
     }
     if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {
         _nib_offl_entry_t *pfx;
@@ -1683,6 +1684,10 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
             }
             if (pio->flags & NDP_OPT_PI_FLAGS_A) {
                 pfx->flags |= _PFX_SLAAC;
+            }
+            if (ta_max_pref_lft > 0) {
+                // a temporary address was created
+                _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif));
             }
             return _min(pref_ltime, valid_ltime);
         }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -80,6 +80,7 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                           gnrc_pktsnip_t *pkt, gnrc_ipv6_nib_nc_t *nce,
                           _nib_onl_entry_t *entry);
 
+static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx);
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx);
 static void _handle_rtr_timeout(_nib_dr_entry_t *router);
 static void _handle_snd_na(gnrc_pktsnip_t *pkt);
@@ -457,7 +458,7 @@ void gnrc_ipv6_nib_handle_timer_event(void *ctx, uint16_t type)
             _handle_pfx_timeout(ctx);
             break;
         case GNRC_IPV6_NIB_REGEN_TEMP_ADDR:
-            //TODO
+            _handle_regen_temp_addr(ctx);
             break;
         case GNRC_IPV6_NIB_RTR_TIMEOUT:
             _handle_rtr_timeout(ctx);
@@ -1428,6 +1429,18 @@ static void _handle_snd_na(gnrc_pktsnip_t *pkt)
     (void)pkt;
     DEBUG("nib: No IPv6 module to send delayed neighbor advertisement\n");
 #endif  /* MODULE_GNRC_IPV6 */
+}
+
+static void _handle_regen_temp_addr(_nib_offl_entry_t *pfx) {
+    DEBUG("nib: Temporary address regeneration event for SLAAC prefix %s/%u\n", ipv6_addr_to_str(addr_str, &pfx->pfx, sizeof(addr_str)), pfx->pfx_len);
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
+    assert(evtimer_now_msec() < pfx->pref_until);
+    int32_t ta_max_pref_lft = _generate_temporary_addr(netif, &pfx->pfx, pfx->pref_until - evtimer_now_msec());
+    if (ta_max_pref_lft < 0) {
+        DEBUG("nib: Temporary address regeneration failed.\n");
+        return;
+    }
+    _evtimer_add(pfx, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &pfx->regen_temp_addr, ta_max_pref_lft - gnrc_netif_ipv6_regen_advance(netif)); //add next regen timer
 }
 
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx)

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1672,6 +1672,8 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
         && pio->prefix_len == SLAAC_PREFIX_LENGTH
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
         && !gnrc_ipv6_nib_pl_has_prefix(netif->pid, &pio->prefix, pio->prefix_len)
+        /* do not cause generation of another temporary address
+         * if the prefix is already known */
 #endif
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -153,7 +153,9 @@ bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr
             && dst->pfx_len == SLAAC_PREFIX_LENGTH
             && ipv6_addr_match_prefix(&dst->pfx, pfx) >= dst->pfx_len) {
             evtimer_del(&_nib_evtimer, &dst->regen_temp_addr.event);
-            _evtimer_add(dst, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &dst->regen_temp_addr, offset);
+            if (offset != 0) {
+                _evtimer_add(dst, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &dst->regen_temp_addr, offset);
+            }
             result = true;
             break;
         }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -124,8 +124,8 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
 }
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
-bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx,
-                          uint8_t pfx_len)
+bool gnrc_ipv6_nib_pl_has_prefix(const unsigned int iface, const ipv6_addr_t *pfx,
+                                 const uint8_t pfx_len)
 {
     void *state = NULL;
     gnrc_ipv6_nib_pl_t ple;
@@ -139,7 +139,7 @@ bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx,
     return false;
 }
 
-bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, uint32_t offset)
+bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx, const uint32_t offset)
 {
     //adapted from gnrc_ipv6_nib_pl_iter
     _nib_offl_entry_t *dst = NULL;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -139,7 +139,8 @@ bool gnrc_ipv6_nib_pl_has_prefix(const unsigned int iface, const ipv6_addr_t *pf
     return false;
 }
 
-bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx, const uint32_t offset)
+bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr_t *pfx,
+                                       const uint32_t offset)
 {
     //adapted from gnrc_ipv6_nib_pl_iter
     _nib_offl_entry_t *dst = NULL;

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -120,6 +120,21 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
     _nib_release();
 }
 
+bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx,
+                          uint8_t pfx_len)
+{
+    void *state = NULL;
+    gnrc_ipv6_nib_pl_t ple;
+
+    while (gnrc_ipv6_nib_pl_iter(iface, &state, &ple)) {
+        if (ple.pfx_len == pfx_len
+            && ipv6_addr_match_prefix(&ple.pfx, pfx) >= pfx_len) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
                            gnrc_ipv6_nib_pl_t *entry)
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -25,7 +25,9 @@
 
 #include "_nib-internal.h"
 #include "_nib-router.h"
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 #include "_nib-slaac.h"
+#endif
 
 int gnrc_ipv6_nib_pl_set(unsigned iface,
                          const ipv6_addr_t *pfx, unsigned pfx_len,
@@ -121,6 +123,7 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
     _nib_release();
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
 bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx,
                           uint8_t pfx_len)
 {
@@ -159,6 +162,7 @@ bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, u
     
     return result;
 }
+#endif
 
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
                            gnrc_ipv6_nib_pl_t *entry)

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -161,7 +161,7 @@ bool gnrc_ipv6_nib_pl_reschedule_regen(const unsigned int iface, const ipv6_addr
         }
     }
     _nib_release();
-    
+
     return result;
 }
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -25,6 +25,7 @@
 
 #include "_nib-internal.h"
 #include "_nib-router.h"
+#include "_nib-slaac.h"
 
 int gnrc_ipv6_nib_pl_set(unsigned iface,
                          const ipv6_addr_t *pfx, unsigned pfx_len,
@@ -133,6 +134,30 @@ bool gnrc_ipv6_nib_pl_has_prefix(unsigned iface, const ipv6_addr_t *pfx,
         }
     }
     return false;
+}
+
+bool gnrc_ipv6_nib_pl_reschedule_regen(unsigned iface, const ipv6_addr_t *pfx, uint32_t offset)
+{
+    //adapted from gnrc_ipv6_nib_pl_iter
+    _nib_offl_entry_t *dst = NULL;
+    bool result = false;
+
+    _nib_acquire();
+    while ((dst = _nib_offl_iter(dst)) != NULL) {
+        const _nib_onl_entry_t *node = dst->next_hop;
+        if ((node != NULL) && (dst->mode & _PL) &&
+            ((iface == 0) || (_nib_onl_get_if(node) == iface))
+            && dst->pfx_len == SLAAC_PREFIX_LENGTH
+            && ipv6_addr_match_prefix(&dst->pfx, pfx) >= dst->pfx_len) {
+            evtimer_del(&_nib_evtimer, &dst->regen_temp_addr.event);
+            _evtimer_add(dst, GNRC_IPV6_NIB_REGEN_TEMP_ADDR, &dst->regen_temp_addr, offset);
+            result = true;
+            break;
+        }
+    }
+    _nib_release();
+    
+    return result;
 }
 
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -34,6 +34,9 @@
 #include "net/loramac.h"
 #include "net/netif.h"
 #include "shell.h"
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
+#include "../../net/gnrc/network_layer/ipv6/nib/_nib-slaac.h"
+#endif
 
 #ifdef MODULE_NETSTATS
 #include "net/netstats.h"
@@ -581,7 +584,7 @@ static unsigned _netif_list_flag(netif_t *iface, netopt_t opt, char *str,
 }
 
 #ifdef MODULE_IPV6
-static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
+static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags, netif_t *netif)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -621,6 +624,14 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
             break;
         }
     }
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES)
+    const gnrc_netif_t *gnrc_netif = container_of(netif, gnrc_netif_t, netif);
+    if (is_temporary_addr(gnrc_netif, addr)) {
+        printf(" TMP");
+    }
+#else
+    (void)netif;
+#endif
 #endif
     _newline(0U, _LINE_THRESHOLD);
 }
@@ -916,7 +927,7 @@ static void _netif_list(netif_t *iface)
                       sizeof(ipv6_addrs_flags));
         /* yes, the res of NETOPT_IPV6_ADDR is meant to be here ;-) */
         for (unsigned i = 0; i < (res / sizeof(ipv6_addr_t)); i++) {
-            _netif_list_ipv6(&ipv6_addrs[i], ipv6_addrs_flags[i]);
+            _netif_list_ipv6(&ipv6_addrs[i], ipv6_addrs_flags[i], iface);
         }
     }
     res = netif_get_opt(iface, NETOPT_IPV6_GROUP, 0, ipv6_groups,

--- a/tests/net/gnrc_ipv6_nib/main.c
+++ b/tests/net/gnrc_ipv6_nib/main.c
@@ -39,7 +39,7 @@
 #define _RTR_LTIME      (6612U)
 #define _REACH_TIME     (1210388825UL)
 #define _RETRANS_TIMER  (3691140UL)
-#define _LOC_GB_PFX_LEN (45U)
+#define _LOC_GB_PFX_LEN (64U)
 #define _REM_GB_PFX_LEN (37U)
 #define _PIO_PFX_LTIME  (0x8476fedf)
 

--- a/tests/net/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/net/gnrc_ipv6_nib_6ln/main.c
@@ -43,7 +43,7 @@
 #define _RTR_LTIME      (6612U)
 #define _REACH_TIME     (1210388825UL)
 #define _RETRANS_TIMER  (3691140UL)
-#define _LOC_GB_PFX_LEN (45U)
+#define _LOC_GB_PFX_LEN (64U)
 #define _REM_GB_PFX_LEN (37U)
 #define _PIO_PFX_LTIME  (0x8476fedf)
 #define _CTX_LTIME      (29169U)


### PR DESCRIPTION
### Contribution description

This implements RFC8981.

#### Design
The RFC describes an implementation where lifetimes are associated directly with an address. This is not the case in GNRC, where lifetimes are associated with a _prefix_ (prefix list  - https://datatracker.ietf.org/doc/html/rfc4861#section-5.1). This PR therefore adjusts the logic to be compatible with this design, while of course still following all the RFC requirements. (The adjusted logic may even be considered simpler than the one described in the RFC!)

In particular, the changes is in the logic used to implement coupling of temporary address to lifetimes of SLAAC prefix while still retaining maximum lifetimes for a temporary address:
- RFC: Initial and updated values for the lifetimes of the temporary address are always derived from both the prefix lifetime as well as the lifetime limits configured for temporary addresses.
- this PR: A temporary address is coupled to a new /128 (code keyword IPV6_ADDR_BIT_LEN=128) prefix to manage its maximum lifetime. (Coupling being that they are created and deleted at once.) Then, to couple the temporary address with the SLAAC prefix it was created from (so that the temporary address cannot possibly outlive the SLAAC prefix), the temporary address is deleted if the SLAAC prefix is deprecated or invalidated. (Note to code reviewer: For the case of deprecation of SLAAC prefix, no code had to be adjusted, all already covered by `_handle_pfx_timeout`.)

Therefore this PR considers an IP address to be temporary iff there exists a /128 prefix for it (i.e. with that address). This assumption is used throughout this implementation, in particular to determine whether an assigned address is a temporary address:
https://github.com/xnumad/RIOT/blob/15e8518d64f674d711f9e4d0fdd613617257a715/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c#L183
https://github.com/xnumad/RIOT/blob/15e8518d64f674d711f9e4d0fdd613617257a715/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c#L230
It is _theoretically possible_ for this circumstance to interfere with other /128 prefixes in the prefix list (e.g. a PIO for exactly that /128 prefix). This conflict could be detected by using a flag (to indicate relation to temporary address usage), but otherwise not avoided unless further changing the lifetime management, e.g. separating it from the NIB prefix list or even using the RFC logic that associates lifetimes directly to an address.

--

Design decision of where to store (temp addr) regeneration event:
The regen event timer is associated with the SLAAC prefix, not the address itself, because that's slightly more performant.

--

Other noteworthy **implications** of this PR:
- implements the `SLAAC_PREFIX_LENGTH=64` requirement of RFCs (see macro definition for RFC reference)
- adds a new address flag, `GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES`, as an easy way to associate the retry counter with the address, because the value is used again if DAD failures occur
These changes are also cherry-picked to the RFC7217 implementation

--

#### RFC compatibility
All but the following requirements of the RFC are implemented (https://datatracker.ietf.org/doc/html/rfc8981#section-3.3.2 is ignored because this PR uses the other algorithm, described in the previous subchapter):

  > implementations SHOULD provide a way to enable and disable generation of temporary addresses for specific prefix subranges

  Currently, no such subrange list is implemented. (Although comparatively low effort to implement.)
  Temporary addresses are generated for any "prefix advertised in a RA PIO with A flag set" and not for link-local addresses.
    
  > In addition, a site might wish to disable the use of temporary addresses in order to simplify network debugging and operations. Consequently, implementations SHOULD provide a way for trusted system administrators to enable or disable the use of temporary addresses.

Interpreting this as the need to ad-hoc disable temporary addresses. Not fulfilled; the setting is only set through a compile-time flag and cannot be changed at runtime.



--

Also I am not sure about the fulfillment of these link-related requirements:

- "when an interface connects to a new (different) link, existing temporary addresses for the corresponding interface MUST be removed"
        Should this be added to https://github.com/RIOT-OS/RIOT/blob/32d1cd93a169335e5629f63d55ccc11406009681/sys/net/gnrc/network_layer/ipv6/nib/nib.c#L173?
Currently, only _only link-local_ address seem to be removed at all. https://github.com/RIOT-OS/RIOT/blob/32d1cd93a169335e5629f63d55ccc11406009681/sys/net/gnrc/network_layer/ipv6/nib/nib.c#L196 I didn't find a way to test this.

#### Adaptability

This implementation supports Ethernet and 6loWPAN. Supporting a new link layer only requires its REGEN_ADVANCE value to be returned by
https://github.com/xnumad/RIOT/blob/15e8518d64f674d711f9e4d0fdd613617257a715/sys/net/gnrc/netif/gnrc_netif_device_type.c#L224

The usage of IIDs which do not match the link layer address causes LOWPAN_IPHC to not be able to statelessly compress the IP address anymore. An optimization to enable compression again could be to add compression contexts. I am looking into this.

### Testing procedure

Add `CFLAGS += -DCONFIG_GNRC_IPV6_NIB_SLAAC_TEMPORARY_ADDRESSES=1` at the appropriate position in the Makefile of `examples/gnrc_networking`. Tested on BOARD=nrf52840dk

Output of `ifconfig` command is expected to contain a line with a temporary address ("TMP"), like `inet6 addr: 2001:db8::6f04:c775:f9a9:dc48  scope: global  VAL TMP`
The temporary address is the preferred source address for the global address scope (can be tested by e.g. ping)

(And many more tests could be done)