### PR TITLE
gnrc_ipv6_nib/SLAAC: rfc7217 stable privacy addresses

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -193,6 +193,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief Use stable privacy addresses (rfc7217)
+ */
+#ifndef CONFIG_GNRC_IPV6_STABLE_PRIVACY
+#define CONFIG_GNRC_IPV6_STABLE_PRIVACY 0
+#endif
+
+/**
  * @brief    handle Redirect Messages
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_REDIRECT

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -182,6 +182,7 @@ static inline uint8_t gnrc_netif_ipv6_addr_dad_trans(const gnrc_netif_t *netif,
     return netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE;
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
 /**
  * @brief   Gets number of address generation retries already performed for an address
  *
@@ -196,6 +197,7 @@ static inline uint8_t gnrc_netif_ipv6_addr_gen_retries(const gnrc_netif_t *netif
 {
     return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES) >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
 }
+#endif
 
 /**
  * @brief   Returns the index of an address in gnrc_netif_t::ipv6_addrs of @p

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -131,6 +131,28 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
                              const ipv6_addr_t *addr);
 
 /**
+ * @brief   Returns the index of the first pfx
+ *          in gnrc_netif_t::ipv6_addrs of @p netif
+ *          where the first @p pfx_len bits match with @p pfx
+ *
+ * @pre `(netif != NULL) && (pfx != NULL)`
+ *
+ * Can be used to check if an address is assigned to an interface.
+ *
+ * @param[in] netif the network interface
+ * @param[in] pfx  the address to check
+ * @param[in] pfx_len the amount of bits to compare
+ *
+ * @note    Only available with @ref net_gnrc_ipv6 "gnrc_ipv6".
+ *
+ * @return  index of the first matching address
+ *          in gnrc_netif_t::ipv6_addrs of @p netif
+ * @return  -1, if no matching address found for @p netif
+ */
+int gnrc_netif_ipv6_addr_pfx_idx(gnrc_netif_t *netif,
+                                 const ipv6_addr_t *pfx, uint8_t pfx_len);
+
+/**
  * @brief   Gets state from address flags
  *
  * @param[in] netif the network interface

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -195,7 +195,9 @@ static inline uint8_t gnrc_netif_ipv6_addr_dad_trans(const gnrc_netif_t *netif,
 static inline uint8_t gnrc_netif_ipv6_addr_gen_retries(const gnrc_netif_t *netif,
                                                      int idx)
 {
-    return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES) >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
+    return (netif->ipv6.addrs_flags[idx]
+    & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES)
+    >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
 }
 #endif
 

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -183,6 +183,21 @@ static inline uint8_t gnrc_netif_ipv6_addr_dad_trans(const gnrc_netif_t *netif,
 }
 
 /**
+ * @brief   Gets number of address generation retries already performed for an address
+ *
+ * @param[in] netif the network interface
+ * @param[in] idx   index of the address (and its flags)
+ *
+ * @return  the number of address generation retries already
+ *          performed
+ */
+static inline uint8_t gnrc_netif_ipv6_addr_gen_retries(const gnrc_netif_t *netif,
+                                                     int idx)
+{
+    return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES) >> GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS;
+}
+
+/**
  * @brief   Returns the index of an address in gnrc_netif_t::ipv6_addrs of @p
  *          netif that matches @p addr best
  *

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -69,6 +69,7 @@ extern "C" {
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST                (0x20U)
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
 /**
  * @brief Number of address generation retries
  * For addresses generated as per RFC7217, this stores the DAD_Counter value
@@ -79,6 +80,7 @@ extern "C" {
  * @brief Shift position of address generation retries
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS      (6)
+#endif
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -68,6 +68,17 @@ extern "C" {
  * @brief   Address is an anycast address
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST                (0x20U)
+
+/**
+ * @brief Number of address generation retries
+ * For addresses generated as per RFC7217, this stores the DAD_Counter value
+ * and the upper limit is defined by @ref STABLE_PRIVACY_IDGEN_RETRIES
+ */
+#define GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES          (0xC0U)
+/**
+ * @brief Shift position of address generation retries
+ */
+#define GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS      (6)
 /** @} */
 
 /**

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -24,6 +24,7 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <kernel_defines.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <net/ipv6/addr.h>
@@ -917,9 +918,12 @@ typedef enum {
  */
 enum {
     NETOPT_IPV6_IID_HWADDR = 0,
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
     NETOPT_IPV6_IID_RFC7217,
+#endif
 };
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
 /**
  * @brief       Data for @ref NETOPT_IPV6_IID when using RFC7217
  */
@@ -928,6 +932,7 @@ typedef struct {
     const ipv6_addr_t *pfx;
     uint8_t *dad_ctr;
 } netopt_ipv6_rfc7217_iid_data;
+#endif
 
 /**
  * @brief   Option parameter to be used with @ref NETOPT_RF_TESTMODE

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -925,11 +925,22 @@ enum {
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
 /**
- * @brief       Data for @ref NETOPT_IPV6_IID when using RFC7217
+ * @brief       Data for @ref NETOPT_IPV6_IID when using RFC7217,
+ *              passed on to ipv6_get_rfc7217_iid,
+ *              from which the descriptions are also copied
  */
 typedef struct {
+    /**
+     * @param[out] where to store the generated interface identifier
+     */
     eui64_t *iid;
+    /**
+     * @param[in] pfx The prefix for which the IID is to be generated.
+     */
     const ipv6_addr_t *pfx;
+    /**
+     * @param[in,out] dad_ctr ("DAD_Counter" in rfc7217)
+     */
     uint8_t *dad_ctr;
 } netopt_ipv6_rfc7217_iid_data;
 #endif

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -26,6 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <net/ipv6/addr.h>
+#include "eui64.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -909,6 +911,23 @@ typedef enum {
                                  *   not listening to packets. */
     /* add other states if needed */
 } netopt_state_t;
+
+/**
+ * @brief   Option parameter to be used with @ref NETOPT_IPV6_IID
+ */
+enum {
+    NETOPT_IPV6_IID_HWADDR = 0,
+    NETOPT_IPV6_IID_RFC7217,
+};
+
+/**
+ * @brief       Data for @ref NETOPT_IPV6_IID when using RFC7217
+ */
+typedef struct {
+    eui64_t *iid;
+    const ipv6_addr_t *pfx;
+    uint8_t *dad_ctr;
+} netopt_ipv6_rfc7217_iid_data;
 
 /**
  * @brief   Option parameter to be used with @ref NETOPT_RF_TESTMODE

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -441,6 +441,21 @@ ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
   USEMODULE += random
 endif
 
+#This checks if the option is being set via Kconfig or CFLAGS
+ifneq (,$(or $(CONFIG_GNRC_IPV6_STABLE_PRIVACY),$(filter -DCONFIG_GNRC_IPV6_STABLE_PRIVACY=1,$(CFLAGS))))
+  # Set another macro that is needed for this option.
+
+  ##prepare value
+  stable_privacy_secret_key != python3 -c "import secrets; print(','.join([f'0x{byte:02x}' for byte in secrets.token_bytes(16)]))"
+
+  ##set macro
+  CFLAGS += -DSTABLE_PRIVACY_SECRET_KEY=$(stable_privacy_secret_key)
+
+  # dependencies
+  USEMODULE += hashes ##include "hashes/sha256.h"
+  USEMODULE += ztimer_msec
+endif
+
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_udp
   USEMODULE += gnrc_nettype_udp

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -985,7 +985,7 @@ static int _idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr, bool mcast)
 
 static int _pfx_idx(const gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint8_t pfx_len, bool mcast)
 {
-    //same as function @ref _idx above, but with generalized condition
+    /*same as function @ref _idx above, but with generalized condition*/
     if (!ipv6_addr_is_unspecified(pfx)) {
         const ipv6_addr_t *iplist = (mcast) ? netif->ipv6.groups :
                                     netif->ipv6.addrs;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1345,7 +1345,7 @@ int gnrc_netif_ipv6_add_prefix(gnrc_netif_t *netif,
     DEBUG("gnrc_netif: (re-)configure prefix %s/%d\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)), pfx_len);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
-    uint8_t dad_ctr;
+    uint8_t dad_ctr = 0;
     netopt_ipv6_rfc7217_iid_data data;
     data.iid = &iid;
     data.pfx = pfx;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -280,7 +280,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
                     assert(opt->data_len == sizeof(netopt_ipv6_rfc7217_iid_data));
                     netopt_ipv6_rfc7217_iid_data *data =
                             (netopt_ipv6_rfc7217_iid_data *) opt->data;
-                    res = _ipv6_get_rfc7217_iid(
+                    res = ipv6_get_rfc7217_iid(
                             data->iid, netif, data->pfx, data->dad_ctr);
                     break;
 #endif

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -502,6 +502,9 @@ void gnrc_netif_release(gnrc_netif_t *netif)
 
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
+static int _addr_pfx_idx(const gnrc_netif_t *netif,
+                                const ipv6_addr_t *pfx,
+                                uint8_t pfx_len);
 static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
@@ -730,6 +733,23 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
     return idx;
 }
 
+int gnrc_netif_ipv6_addr_pfx_idx(gnrc_netif_t *netif,
+                                 const ipv6_addr_t *pfx, uint8_t pfx_len)
+{
+    int idx;
+
+    assert((netif != NULL) && (pfx != NULL));
+    DEBUG("gnrc_netif: get index of first address matching %s/%u"
+          " from interface %" PRIkernel_pid "\n",
+          ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)),
+          pfx_len,
+          netif->pid);
+    gnrc_netif_acquire(netif);
+    idx = _addr_pfx_idx(netif, pfx, pfx_len);
+    gnrc_netif_release(netif);
+    return idx;
+}
+
 int gnrc_netif_ipv6_addr_match(gnrc_netif_t *netif,
                                const ipv6_addr_t *addr)
 {
@@ -947,9 +967,33 @@ static int _idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr, bool mcast)
     return -1;
 }
 
+static int _pfx_idx(const gnrc_netif_t *netif, const ipv6_addr_t *pfx, uint8_t pfx_len, bool mcast)
+{
+    //same as function @ref _idx above, but with generalized condition
+    if (!ipv6_addr_is_unspecified(pfx)) {
+        const ipv6_addr_t *iplist = (mcast) ? netif->ipv6.groups :
+                                    netif->ipv6.addrs;
+        unsigned ipmax = (mcast) ? GNRC_NETIF_IPV6_GROUPS_NUMOF :
+                         CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF;
+        for (unsigned i = 0; i < ipmax; i++) {
+            if (ipv6_addr_match_prefix(&iplist[i], pfx) >= pfx_len) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
 static inline int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
 {
     return _idx(netif, addr, false);
+}
+
+static inline int _addr_pfx_idx(const gnrc_netif_t *netif,
+                                const ipv6_addr_t *pfx,
+                                uint8_t pfx_len)
+{
+    return _pfx_idx(netif, pfx, pfx_len, false);
 }
 
 static inline int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -280,7 +280,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
                     assert(opt->data_len == sizeof(netopt_ipv6_rfc7217_iid_data));
                     netopt_ipv6_rfc7217_iid_data *data =
                             (netopt_ipv6_rfc7217_iid_data *) opt->data;
-                    res = ipv6_get_rfc7217_iid(
+                    res = ipv6_get_rfc7217_iid_idempotent(
                             data->iid, netif, data->pfx, data->dad_ctr);
                     break;
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -38,6 +38,14 @@ config GNRC_IPV6_NIB_SLAAC
     default n if USEMODULE_GNRC_IPV6_NIB_6LR || USEMODULE_GNRC_IPV6_NIB_6LN
     default y
 
+config GNRC_IPV6_STABLE_PRIVACY
+    bool "Use stable privacy addresses (rfc7217)"
+    depends on GNRC_IPV6_NIB_SLAAC
+    help
+        Generate semantically opaque interface identifiers
+        (i.e. L2ADDR is not embedded)
+        for SLAAC IPv6 addresses
+
 config GNRC_IPV6_NIB_QUEUE_PKT
     bool "Use packet queue with address resolution"
     default n if USEMODULE_GNRC_IPV6_NIB_6LN || GNRC_IPV6_NIB_6LN

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -181,7 +181,10 @@ int _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_ad
         sha256_final(&c, digest);
     }
 
-    assert(iid->uint64.u64 == 0);
+    iid->uint64.u64 = 0;
+    //uninitialized if called via gnrc_netapi_get (NETOPT_IPV6_IID_RFC7217)
+    //needs to be all zeros as precondition for the following copy operation
+
     assert(sizeof(digest) >= sizeof(*iid)); //as bits: 256 >= 64 //digest is large enough
 
     //copy digest into IID
@@ -190,7 +193,7 @@ int _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_ad
     for (uint8_t i = 0; i < sizeof(*iid); i++) { //for each of the 8 bytes
         for (int j = 0; j < 8; j++) { //for each of the 8 bits _within byte_
             if ((digest[(sizeof(digest)-1)-i])&(1<<j)) { //is 1 //reverse order
-                iid->uint8[i] |= 1 << ((8-1)-j); //set 1 //precondition: *iid = 0
+                iid->uint8[i] |= 1 << ((8-1)-j); //set 1 //precondition: iid->uint8[i] = 0
             }
         }
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -302,7 +302,8 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
 
         _auto_configure_addr_with_dad_ctr(netif, addr, SLAAC_PREFIX_LENGTH, dad_counter);
     } else {
-        //"hosts MUST NOT automatically fall back to employing other algorithms for generating Interface Identifiers"
+        //"hosts MUST NOT automatically fall back to employing other algorithms
+        // for generating Interface Identifiers"
         //- https://datatracker.ietf.org/doc/html/rfc7217#section-6
 
         //> If the address is a link-local address

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -15,8 +15,8 @@
 
 #include <kernel_defines.h>
 #include <stdbool.h>
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 #include "_nib-slaac.h"
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 #include <hashes/sha256.h>
 #include "ztimer.h"
 #include "random.h"
@@ -36,19 +36,23 @@
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
-#if !IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
-void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                          uint8_t pfx_len)
-#else
 inline void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len)
 {
+#if !IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
+    _auto_configure_addr_default(netif, pfx, pfx_len);
+#else
     _auto_configure_addr_with_dad_ctr(netif, pfx, pfx_len, 0);
+#endif
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
                                        const ipv6_addr_t *pfx, uint8_t pfx_len,
                                        uint8_t dad_ctr)
+#else
+void _auto_configure_addr_default(gnrc_netif_t *netif,
+                          const ipv6_addr_t *pfx, uint8_t pfx_len)
 #endif
 {
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -71,7 +71,7 @@ void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
     bool new_address = false;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
-    if (_ipv6_get_rfc7217_iid((eui64_t *) &addr.u64[1], netif, pfx, &dad_ctr) < 0) {
+    if (ipv6_get_rfc7217_iid((eui64_t *) &addr.u64[1], netif, pfx, &dad_ctr) < 0) {
         return;
     }
     flags |= (dad_ctr << GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS);
@@ -153,8 +153,8 @@ inline bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reas
     return false;
 }
 
-int _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                          uint8_t *dad_ctr)
+int ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                         uint8_t *dad_ctr)
 {
 #ifndef STABLE_PRIVACY_SECRET_KEY
 #error "Stable privacy requires a secret_key, this should have been configured by sys/net/gnrc/Makefile.dep"
@@ -207,7 +207,7 @@ int _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_ad
             return -1;
         }
         iid->uint64.u64 = 0; /* @pre for method call */
-        return _ipv6_get_rfc7217_iid(iid, netif, pfx, dad_ctr);
+        return ipv6_get_rfc7217_iid(iid, netif, pfx, dad_ctr);
     }
 
     return 0;
@@ -286,7 +286,7 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
     gnrc_netif_ipv6_addr_remove_internal(netif, addr);
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
-    if (stable_privacy_should_retry_idgen(&dad_counter, "Duplicate address detected")) {
+    if (_stable_privacy_should_retry_idgen(&dad_counter, "Duplicate address detected")) {
 
         //> Hosts SHOULD introduce a random delay between 0 and IDGEN_DELAY seconds
         //- https://datatracker.ietf.org/doc/html/rfc7217#section-6

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -110,6 +110,18 @@ bool _iid_is_iana_reserved(const eui64_t *iid)
            || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
 }
 
+inline bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason) {
+    printf("%s", reason);
+    if (*dad_ctr < STABLE_PRIVACY_IDGEN_RETRIES) { //within retry limit
+        *dad_ctr += 1;
+        printf(", retrying IDGEN. (%u/%u)\n", *dad_ctr, STABLE_PRIVACY_IDGEN_RETRIES);
+        return true;
+    }
+    //retried often enough
+    printf(", not retrying: IDGEN_RETRIES limit reached\n");
+    return false;
+}
+
 uint8_t _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                               const uint8_t dad_ctr)
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -100,7 +100,7 @@ void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
         /*"the same network prefix" - https://datatracker.ietf.org/doc/html/rfc7217#section-5*/
         /*"unacceptable identifier" -> retry IDGEN (dad_ctr+1)*/
-        if (!stable_privacy_should_retry_idgen(&dad_ctr, "Generated address already exists")) {
+        if (!_stable_privacy_should_retry_idgen(&dad_ctr, "Generated address already exists")) {
             return;
         }
 
@@ -140,7 +140,7 @@ bool _iid_is_iana_reserved(const eui64_t *iid)
            || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
 }
 
-inline bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason) {
+inline bool _stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason) {
     if (*dad_ctr < STABLE_PRIVACY_IDGEN_RETRIES) { //within retry limit
         LOG_DEBUG("nib: %s", reason);
         *dad_ctr += 1;
@@ -202,8 +202,8 @@ int ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_add
      * the reserved IPv6 Interface Identifiers"
      * - https://datatracker.ietf.org/doc/html/rfc7217#section-5 */
     if (_iid_is_iana_reserved(iid)) {
-        if (!stable_privacy_should_retry_idgen(dad_ctr,
-                                               "IANA reserved IID generated")) {
+        if (!_stable_privacy_should_retry_idgen(dad_ctr,
+                                                "IANA reserved IID generated")) {
             return -1;
         }
         iid->uint64.u64 = 0; /* @pre for method call */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -96,6 +96,13 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 }
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
+bool _iid_is_iana_reserved(const eui64_t *iid)
+{
+    return (iid->uint64.u64 == htonll(0))
+           || (iid->uint32[0].u32 == htonl(0x02005eff) && iid->uint8[4] == 0xfe)
+           || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
+}
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
 static bool _try_l2addr_reconfiguration(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -36,8 +36,20 @@
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
+#if !IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len)
+#else
+inline void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                          uint8_t pfx_len)
+{
+    _auto_configure_addr_with_dad_ctr(netif, pfx, pfx_len, 0);
+}
+
+void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
+                                       const ipv6_addr_t *pfx, uint8_t pfx_len,
+                                       uint8_t dad_ctr)
+#endif
 {
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
     int idx;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -64,10 +64,6 @@ void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
         return;
     }
 #endif
-    if (!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR)) {
-        DEBUG("nib: interface %i has no link-layer addresses\n", netif->pid);
-        return;
-    }
     DEBUG("nib: add address based on %s/%u automatically to interface %u\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)),
           pfx_len, netif->pid);
@@ -80,6 +76,10 @@ void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
     }
     flags |= (dad_ctr << GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES_POS);
 #else
+    if (!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR)) {
+        DEBUG("nib: interface %i has no link-layer addresses\n", netif->pid);
+        return;
+    }
     if (gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]) < 0) {
         DEBUG("nib: Can't get IID on interface %u\n", netif->pid);
         return;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -209,6 +209,7 @@ uint8_t _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv
 #endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
+#if !IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 static bool _try_l2addr_reconfiguration(gnrc_netif_t *netif)
 {
     uint8_t hwaddr[GNRC_NETIF_L2ADDR_MAXLEN];
@@ -264,6 +265,7 @@ static bool _try_addr_reconfiguration(gnrc_netif_t *netif)
     }
     return hwaddr_reconf;
 }
+#endif
 
 void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -96,12 +96,14 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 }
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 bool _iid_is_iana_reserved(const eui64_t *iid)
 {
     return (iid->uint64.u64 == htonll(0))
            || (iid->uint32[0].u32 == htonl(0x02005eff) && iid->uint8[4] == 0xfe)
            || (iid->uint32[0].u32 == htonl(0xfdffffff) && iid->uint16[2].u16 == htons(0xffff) && iid->uint8[6] == 0xff && (iid->uint8[7] & 0x80));
 }
+#endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
 static bool _try_l2addr_reconfiguration(gnrc_netif_t *netif)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -36,11 +36,11 @@
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
-inline void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                          uint8_t pfx_len)
+inline void auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                                uint8_t pfx_len)
 {
 #if !IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
-    _auto_configure_addr_default(netif, pfx, pfx_len);
+    _auto_configure_addr(netif, pfx, pfx_len);
 #else
     _auto_configure_addr_with_dad_ctr(netif, pfx, pfx_len, 0);
 #endif
@@ -51,7 +51,7 @@ void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif,
                                        const ipv6_addr_t *pfx, uint8_t pfx_len,
                                        uint8_t dad_ctr)
 #else
-void _auto_configure_addr_default(gnrc_netif_t *netif,
+void _auto_configure_addr(gnrc_netif_t *netif,
                           const ipv6_addr_t *pfx, uint8_t pfx_len)
 #endif
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -15,6 +15,12 @@
 
 #include <kernel_defines.h>
 #include <stdbool.h>
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
+#include "_nib-slaac.h"
+#include <hashes/sha256.h>
+#include "ztimer.h"
+#include "random.h"
+#endif
 
 #include "log.h"
 #include "luid.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -130,6 +130,7 @@ bool _stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
  * Value may increase and is to be stored associated with the address by caller
  * @return 0 on success
  * @return -1 if failed, because retry limit reached
+ * @return  `-ENOTSUP`, if interface has no link-layer address.
  */
 int ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                          uint8_t *dad_ctr);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -105,6 +105,12 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 bool _iid_is_iana_reserved(const eui64_t *iid);
 
 /**
+ * @param[in,out] dad_ctr
+ * @param[in] reason
+ */
+bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
+
+/**
  * @brief
  * @pre @p iid is all 0 bits (iid->uint64.u64 == 0)
  * @param[out] iid

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -91,13 +91,17 @@ extern "C" {
  */
 void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len);
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 /**
  * @brief Overload of @ref _auto_configure_addr
  * @param dad_ctr rfc7217 DAD_Counter
  */
 void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len, uint8_t dad_ctr);
+#else
+void _auto_configure_addr_default(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                                       uint8_t pfx_len);
 #endif
 
 #else   /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -140,13 +140,14 @@ bool _stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
  * ("Net_iface" in rfc7217)
  * @param[in] pfx The prefix for which the IID is to be generated.
  * ("Prefix" in rfc7217)
+ * It is assumed to be of length @ref SLAAC_PREFIX_LENGTH
  * @param[in,out] dad_ctr ("DAD_Counter" in rfc7217)
  * Value may increase and is to be stored associated with the address by caller
  * @return 0 on success
  * @return -1 if failed, because retry limit reached
  * @return  `-ENOTSUP`, if interface has no link-layer address.
  */
-int ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+int ipv6_get_rfc7217_iid(eui64_t *iid, gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                          uint8_t *dad_ctr);
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -82,6 +82,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  * @return whether the IID is IANA reserved
  */
 bool _iid_is_iana_reserved(const eui64_t *iid);
+#endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -116,7 +116,7 @@ bool _iid_is_iana_reserved(const eui64_t *iid);
  * @param[in,out] dad_ctr
  * @param[in] reason
  */
-bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
+bool _stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
 
 /**
  * @brief

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -149,6 +149,13 @@ bool _stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
  */
 int ipv6_get_rfc7217_iid(eui64_t *iid, gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                          uint8_t *dad_ctr);
+
+/**
+ * @brief @ref ipv6_get_rfc7217_iid for those callers which assume idempotency.
+ * @return 1 if ignored for idempotency, else @ref ipv6_get_rfc7217_iid
+ */
+int ipv6_get_rfc7217_iid_idempotent(eui64_t *iid, gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                                    uint8_t *dad_ctr);
 #endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -89,8 +89,8 @@ extern "C" {
  * @param[in] pfx       The prefix for the address.
  * @param[in] pfx_len   Length of @p pfx in bits.
  */
-void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                          uint8_t pfx_len);
+void auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                         uint8_t pfx_len);
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
 /**
@@ -100,12 +100,18 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len, uint8_t dad_ctr);
 #else
-void _auto_configure_addr_default(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                                       uint8_t pfx_len);
+/**
+ * @brief   Auto-configures an address from a given prefix.
+ * Internal method without a DAD_Counter.
+ * Use auto_configure_addr() instead
+ * to automatically use the appropriate function.
+ */
+void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                          uint8_t pfx_len);
 #endif
 
 #else   /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
-#define _auto_configure_addr(netif, pfx, pfx_len) \
+#define auto_configure_addr(netif, pfx, pfx_len) \
     (void)netif; (void)pfx; (void)pfx_len;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -32,6 +32,15 @@
 extern "C" {
 #endif
 
+/**
+ * > An IPv6 address prefix used for stateless autoconfiguration [ACONF]
+ *   of an Ethernet interface must have a length of 64 bits.
+ * - https://datatracker.ietf.org/doc/html/rfc2464
+ *
+ * > An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
+ *   of an IEEE 802.15.4 interface MUST have a length of 64 bits.
+ * - https://datatracker.ietf.org/doc/html/rfc4944
+ */
 #define SLAAC_PREFIX_LENGTH (64U)
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -88,6 +88,14 @@ extern "C" {
  */
 void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len);
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
+/**
+ * @param dad_ctr rfc7217 DAD_Counter
+ */
+void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                          uint8_t pfx_len, uint8_t dad_ctr);
+#endif
+
 #else   /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
 #define _auto_configure_addr(netif, pfx, pfx_len) \
     (void)netif; (void)pfx; (void)pfx_len;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -40,8 +40,22 @@ extern "C" {
  * > An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
  *   of an IEEE 802.15.4 interface MUST have a length of 64 bits.
  * - https://datatracker.ietf.org/doc/html/rfc4944
+ *
+ * Also see
+ * @ref INTERFACE_IDENTIFIER_LENGTH
+ * in combination with "sum" "does not equal 128 bits"
+ * from https://datatracker.ietf.org/doc/html/rfc4862#section-5.5.3 d)
  */
 #define SLAAC_PREFIX_LENGTH (64U)
+
+/*
+ * "the address architecture [RFC4291] also defines the length of the interface identifiers"
+ * - https://datatracker.ietf.org/doc/html/rfc4862#section-2
+ *
+ * "Interface IDs are required to be 64 bits long"
+ * - https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.1
+ */
+#define INTERFACE_IDENTIFIER_LENGTH (64U)
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -57,6 +57,27 @@ extern "C" {
  */
 #define INTERFACE_IDENTIFIER_LENGTH (64U)
 
+/**
+ * @name    Stable privacy host constants
+ * @see     [RFC 7217, section 7](https://tools.ietf.org/html/rfc7217#section-7)
+ * @{
+ */
+/**
+ * @brief   Limit for stable privacy (IDGEN) addr. generation retries for subsequent DAD failures
+ *
+ * @note    Must not be greater than 3 for @ref net_gnrc since
+ *          @ref GNRC_NETIF_IPV6_ADDRS_FLAGS_IDGEN_RETRIES restricts it to
+ *          that number.
+ */
+#ifndef STABLE_PRIVACY_IDGEN_RETRIES
+#define STABLE_PRIVACY_IDGEN_RETRIES            (3U) /*default value*/
+#endif
+
+#ifndef STABLE_PRIVACY_IDGEN_DELAY_MS
+#define STABLE_PRIVACY_IDGEN_DELAY_MS 1000 /*default value*/
+#endif
+/** @} */
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**
  * @brief   Auto-configures an address from a given prefix

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -71,6 +71,18 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #define _auto_configure_addr(netif, pfx, pfx_len) \
     (void)netif; (void)pfx; (void)pfx_len;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN || CONFIG_GNRC_IPV6_NIB_SLAAC */
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
+/**
+ * @brief Check if an interface identifier of an IPv6 address
+ * is reserved by IANA, i.e. it shouldn't be used
+ * This is should be checked when the interface identifier is randomly generated.
+ * @see [RFC5453], https://www.iana.org/assignments/ipv6-interface-ids/ipv6-interface-ids.xhtml
+ * @param[in] iid The interface identifier to check for
+ * @return whether the IID is IANA reserved
+ */
+bool _iid_is_iana_reserved(const eui64_t *iid);
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**
  * @brief   Removes a tentative address from the interface and tries to

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -131,8 +131,8 @@ bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
  * @return 0 on success
  * @return -1 if failed, because retry limit reached
  */
-int _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                              uint8_t *dad_ctr);
+int ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                         uint8_t *dad_ctr);
 #endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 #define SLAAC_PREFIX_LENGTH (64U)
 
-/*
+/**
  * "the address architecture [RFC4291] also defines the length of the interface identifiers"
  * - https://datatracker.ietf.org/doc/html/rfc4862#section-2
  *
@@ -73,6 +73,9 @@ extern "C" {
 #define STABLE_PRIVACY_IDGEN_RETRIES            (3U) /*default value*/
 #endif
 
+/**
+ * @brief Upper limit for random time to wait between IDGEN retries
+ */
 #ifndef STABLE_PRIVACY_IDGEN_DELAY_MS
 #define STABLE_PRIVACY_IDGEN_DELAY_MS 1000 /*default value*/
 #endif
@@ -90,6 +93,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
                           uint8_t pfx_len);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY) || defined(DOXYGEN)
 /**
+ * @brief Overload of @ref _auto_configure_addr
  * @param dad_ctr rfc7217 DAD_Counter
  */
 void _auto_configure_addr_with_dad_ctr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
@@ -121,7 +125,7 @@ bool _stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
 /**
  * @brief
  * @pre @p iid is all 0 bits (iid->uint64.u64 == 0)
- * @param[out] iid
+ * @param[out] iid where to store the generated interface identifier
  * @param[in] netif The network interface to use as source for IID generation.
  * ("Net_iface" in rfc7217)
  * @param[in] pfx The prefix for which the IID is to be generated.

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -103,6 +103,21 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
  * @return whether the IID is IANA reserved
  */
 bool _iid_is_iana_reserved(const eui64_t *iid);
+
+/**
+ * @brief
+ * @pre @p iid is all 0 bits (iid->uint64.u64 == 0)
+ * @param[out] iid
+ * @param[in] netif The network interface to use as source for IID generation.
+ * ("Net_iface" in rfc7217)
+ * @param[in] pfx The prefix for which the IID is to be generated.
+ * ("Prefix" in rfc7217)
+ * @param[in] dad_ctr ("DAD_Counter" in rfc7217)
+ * @return new value of DAD_Counter, to be stored associated with the address
+ * @return -1 if failed, because retry limit reached
+ */
+uint8_t _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                              uint8_t dad_ctr);
 #endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#define SLAAC_PREFIX_LENGTH (64U)
+
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)
 /**
  * @brief   Auto-configures an address from a given prefix

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.h
@@ -126,12 +126,13 @@ bool stable_privacy_should_retry_idgen(uint8_t *dad_ctr, const char *reason);
  * ("Net_iface" in rfc7217)
  * @param[in] pfx The prefix for which the IID is to be generated.
  * ("Prefix" in rfc7217)
- * @param[in] dad_ctr ("DAD_Counter" in rfc7217)
- * @return new value of DAD_Counter, to be stored associated with the address
+ * @param[in,out] dad_ctr ("DAD_Counter" in rfc7217)
+ * Value may increase and is to be stored associated with the address by caller
+ * @return 0 on success
  * @return -1 if failed, because retry limit reached
  */
-uint8_t _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
-                              uint8_t dad_ctr);
+int _ipv6_get_rfc7217_iid(eui64_t *iid, const gnrc_netif_t *netif, const ipv6_addr_t *pfx,
+                              uint8_t *dad_ctr);
 #endif
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || defined(DOXYGEN)

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -190,7 +190,7 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
         DEBUG("nib: Can't join link-local all-nodes on interface %u\n", netif->pid);
     }
     _add_static_lladdr(netif);
-    _auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
+    auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
     if (_should_search_rtr(netif)) {
         uint32_t next_rs_time = random_uint32_range(0, NDP_MAX_RS_MS_DELAY);
 
@@ -1742,7 +1742,7 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
          * */
 #endif
         ) {
-        _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
+        auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
     }
     if ((pio->flags & (NDP_OPT_PI_FLAGS_A | NDP_OPT_PI_FLAGS_L))
         || _multihop_p6c(netif, abr)) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1731,7 +1731,9 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     DEBUG("     - Preferred lifetime: %" PRIu32 "\n",
           byteorder_ntohl(pio->pref_ltime));
 
-    if (pio->flags & NDP_OPT_PI_FLAGS_A) {
+    if (pio->flags & NDP_OPT_PI_FLAGS_A
+        && pio->prefix_len == SLAAC_PREFIX_LENGTH
+        ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
     }
     if ((pio->flags & (NDP_OPT_PI_FLAGS_A | NDP_OPT_PI_FLAGS_L))

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1733,6 +1733,14 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
 
     if (pio->flags & NDP_OPT_PI_FLAGS_A
         && pio->prefix_len == SLAAC_PREFIX_LENGTH
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_STABLE_PRIVACY)
+        && (gnrc_netif_ipv6_addr_pfx_idx(netif, &pio->prefix, pio->prefix_len) < 0)
+        /* if the prefix is already known,
+         * do not cause generation of a potentially different
+         * stable privacy address (keyword DAD_Counter).
+         * refer to https://datatracker.ietf.org/doc/html/rfc4862#section-5.5.3 d)
+         * */
+#endif
         ) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
     }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -50,6 +50,7 @@
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+#include "../../network_layer/ipv6/nib/_nib-slaac.h"
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -585,10 +586,8 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
                 && !(pi->LAR_flags & GNRC_RPL_PREFIX_AUTO_ADDRESS_BIT)) {
                 break;
             }
-            ipv6_addr_set_aiid(&pi->prefix, iid.uint8);
-            /* TODO: find a way to do this with DAD (i.e. state != VALID) */
-            gnrc_netif_ipv6_addr_add_internal(netif, &pi->prefix, pi->prefix_len,
-                                              GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
+            _auto_configure_addr(netif, &pi->prefix, pi->prefix_len);
+
             /* set lifetimes */
             gnrc_ipv6_nib_pl_set(netif->pid, &pi->prefix, pi->prefix_len,
                                  _sec_to_ms(byteorder_ntohl(pi->valid_lifetime)),

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -586,7 +586,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
                 && !(pi->LAR_flags & GNRC_RPL_PREFIX_AUTO_ADDRESS_BIT)) {
                 break;
             }
-            _auto_configure_addr(netif, &pi->prefix, pi->prefix_len);
+            auto_configure_addr(netif, &pi->prefix, pi->prefix_len);
 
             /* set lifetimes */
             gnrc_ipv6_nib_pl_set(netif->pid, &pi->prefix, pi->prefix_len,

--- a/tests/net/gnrc_ipv6_nib/main.c
+++ b/tests/net/gnrc_ipv6_nib/main.c
@@ -39,7 +39,7 @@
 #define _RTR_LTIME      (6612U)
 #define _REACH_TIME     (1210388825UL)
 #define _RETRANS_TIMER  (3691140UL)
-#define _LOC_GB_PFX_LEN (45U)
+#define _LOC_GB_PFX_LEN (64U)
 #define _REM_GB_PFX_LEN (37U)
 #define _PIO_PFX_LTIME  (0x8476fedf)
 

--- a/tests/net/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/net/gnrc_ipv6_nib_6ln/main.c
@@ -43,7 +43,7 @@
 #define _RTR_LTIME      (6612U)
 #define _REACH_TIME     (1210388825UL)
 #define _RETRANS_TIMER  (3691140UL)
-#define _LOC_GB_PFX_LEN (45U)
+#define _LOC_GB_PFX_LEN (64U)
 #define _REM_GB_PFX_LEN (37U)
 #define _PIO_PFX_LTIME  (0x8476fedf)
 #define _CTX_LTIME      (29169U)

--- a/tests/net/gnrc_netif/main.c
+++ b/tests/net/gnrc_netif/main.c
@@ -805,12 +805,12 @@ static void test_netapi_get__IPV6_IID(void)
 
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ethernet_netif.pid,
                 NETOPT_IPV6_IID,
-                0, &value, sizeof(value)));
+                NETOPT_IPV6_IID_HWADDR, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ethernet_ipv6_ll.u64[1],
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif.pid,
                 NETOPT_IPV6_IID,
-                0, &value, sizeof(value)));
+                NETOPT_IPV6_IID_HWADDR, &value, sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ieee802154_ipv6_ll_long.u64[1],
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
@@ -820,7 +820,7 @@ static void test_netapi_get__IPV6_IID(void)
                 sizeof(ieee802154_l2addr_len)));
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif.pid,
                 NETOPT_IPV6_IID,
-                0, &value,
+                NETOPT_IPV6_IID_HWADDR, &value,
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ieee802154_eui64_short,
                 sizeof(value)));
@@ -833,7 +833,7 @@ static void test_netapi_get__IPV6_IID(void)
                 sizeof(ieee802154_l2addr_len)));
     TEST_ASSERT_EQUAL_INT(-ENOTSUP, gnrc_netapi_get(netifs[0].pid,
                 NETOPT_IPV6_IID,
-                0, &value, sizeof(value)));
+                NETOPT_IPV6_IID_HWADDR, &value, sizeof(value)));
 }
 
 static void test_netapi_get__MAX_PACKET_SIZE(void)


### PR DESCRIPTION
### Contribution description

Implementation of RFC7217 ("stable privacy") means that for addresses generated by SLAAC, their IID (interface identifier) is
- semantically opaque, i.e. cannot derive hwaddr from it
- random but with such parameters that it is stable within a subnet (i.e. for the same prefix on the same interface)
- derived from a randomly generated key (secret_key) that shouldn't be shared across devices.
RIOT-specific: The implementation in this PR compiles the secret_key into the elffile, therefore the same elffile shouldn't be flashed onto multiple devices - in order to fulfill the RFC requirements.

Notes about implementation:
- uses tail recursion (i.e. optimizable by compiler, or manually replacable by a loop) (affects stack size)

RFC compatibility: Requirement levels: (implemented: MUST, SHOULD. not implemented: MAY, OPTIONAL.)

--

#### Adaptability

Supports any link layer that has a hardware address:
https://github.com/xnumad/RIOT/blob/88363f3cde7175691fe27399d73a54e08934e6c7/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c#L168-L169

The usage of IIDs which do not match the link layer address causes LOWPAN_IPHC to not be able to statelessly compress the IP address anymore. An optimization to enable compression again could be to add compression contexts (feature branch for opportunistic compression contexts: https://github.com/xnumad/RIOT/tree/feature%2Fopportunistic-compression-contexts).

##### 6LoWPAN specifics
They do not affect this PRs current functionality but are worth noting.

For link-local addresses on a 6LN iface, this PR does not use the IDGEN (interface identifier generation) mechanism described by rfc7217.
- This is because of incompatibility with 6LoWPAN-ND (RFC6775) (and RFC8505, which would allow it, is not implemented).
- → Not fulfilling RFC7217 requirement "MUST be employed for [...] link-local"

### Testing procedure

Add `CFLAGS += -DCONFIG_GNRC_IPV6_STABLE_PRIVACY=1` at the appropriate position in the Makefile of `examples/gnrc_networking`. Tested on BOARD=nrf52840dk

Output of `ifconfig` command shows that SLAAC addresses have random differing IIDs (except for link-local address on a 6LoWPAN iface, see above). The IID is stable within a subnet, i.e. it also persists across reboots.

### Issues/PRs references

Commits marked with 🍒 (cherry-picked) are largely derived from the RFC8981 implementation at #20369 
