### PR TITLE
gnrc_ipv6_nib: Force unspecified next hop addresses

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -84,8 +84,11 @@ void _nib_release(void)
 static inline bool _addr_equals(const ipv6_addr_t *addr,
                                 const _nib_onl_entry_t *node)
 {
-    return (addr == NULL) || ipv6_addr_is_unspecified(&node->ipv6) ||
-           (ipv6_addr_equal(addr, &node->ipv6));
+    if (addr == NULL) {
+        return ipv6_addr_is_unspecified(&node->ipv6);
+    } else {
+        return ipv6_addr_equal(addr, &node->ipv6);
+    }
 }
 
 _nib_onl_entry_t *_nib_onl_alloc(const ipv6_addr_t *addr, unsigned iface)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

Reserve unspecified address in NCEs for on-link prefixes, to have
`_PFX_ON_LINK => ipv6_addr_is_unspecified(dst->next_hop)` be true

### Contribution description

In nib_[onl|offl]_entry_t,
a next_hop of NULL (as used by prefix list)
shouldn't be interpreted as "don't care"
but as an explicit "none, not applicable",
because the next_hop value is used for association with a router at
https://github.com/RIOT-OS/RIOT/blob/270aa7012fab0ceadeb0b82546ea06dbfe9c0902/sys/net/gnrc/network_layer/ipv6/nib/nib.c#L1469

The code intends to delete all off-link prefixes where next hop is the specified router [1], but (without this PR) it actually also deletes on-link prefixes on the same interface [2] because they falsely use the same next hop. (And are only distinguished as on-link through `_PFX_ON_LINK` flag, which however is not checked for in this place.)

(Note that on-link prefixes are added again when processing a RA Prefix Information Option, which can be in the same Router Advertisement that caused `_handle_rtr_timeout` and thereby their accidental deletion. This seems to be common and makes this deletion hard to notice.)

[1] which is the wrong thing to do in the first place, and was therefore removed in 96480008caaed8fa6af80a3afc1d6cb736287a42, thereby making this bug theoretical only
[2] such as "the /128 prefix used for managing a temporary address" in #20369 (affected)

### Testing procedure

Tests: #20372