### PR TITLE
always use nanocoap_resources instead of manually assembling coap_resources[]

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -38,6 +38,7 @@ QUIET ?= 1
 #
 
 USEMODULE += suit suit_transport_coap
+USEMODULE += nanocoap_resources
 
 # enable VFS transport (only works on boards with external storage)
 USEMODULE += suit_transport_vfs

--- a/examples/suit_update/coap_handler.c
+++ b/examples/suit_update/coap_handler.c
@@ -22,13 +22,8 @@ static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
             COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
 }
 
-/* must be sorted by path (ASCII order) */
-const coap_resource_t coap_resources[] = {
-    COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/riot/board", COAP_GET, _riot_board_handler, NULL },
-
-    /* this line adds the whole "/suit"-subtree */
-    SUIT_COAP_SUBTREE,
+NANOCOAP_RESOURCE(board) {
+    .path = "/riot/board", .methods = COAP_GET, .handler = _riot_board_handler,
 };
 
-const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);
+NANOCOAP_RESOURCE(suit) SUIT_COAP_SUBTREE;

--- a/tests/pkg/edhoc_c/Makefile
+++ b/tests/pkg/edhoc_c/Makefile
@@ -26,6 +26,7 @@ USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += nanocoap_sock
+USEMODULE += nanocoap_resources
 
 # include this for printing IP addresses
 USEMODULE += shell_cmds_default

--- a/tests/pkg/edhoc_c/responder.c
+++ b/tests/pkg/edhoc_c/responder.c
@@ -98,13 +98,9 @@ ssize_t _edhoc_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_c
     return msg_len;
 }
 
-/* must be sorted by path (ASCII order) */
-const coap_resource_t coap_resources[] = {
-    COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/.well-known/edhoc", COAP_POST, _edhoc_handler, NULL },
+NANOCOAP_RESOURCE(edhoc) {
+    .path = "/.well-known/edhoc", .methods = COAP_POST, .handler = _edhoc_handler
 };
-
-const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);
 
 int responder_cmd(int argc, char **argv)
 {

--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -13,6 +13,7 @@ USEMODULE += gnrc_icmpv6_echo
 
 # Required for nanocoap server
 USEMODULE += nanocoap_sock
+USEMODULE += nanocoap_resources
 
 # include this for printing IP addresses
 USEMODULE += shell_cmds_default

--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -78,10 +78,9 @@ ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_requ
     return pkt_pos - (uint8_t*)pkt->hdr;
 }
 
-/* must be sorted by path (ASCII order) */
-const coap_resource_t coap_resources[] = {
-    COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/flashwrite", COAP_POST, _flashwrite_handler, &_writer },
+NANOCOAP_RESOURCE(flashwrite) {
+    .path = "/flashwrite",
+    .methods = COAP_POST,
+    .handler = _flashwrite_handler,
+    .context = &_writer
 };
-
-const unsigned coap_resources_numof = ARRAY_SIZE(coap_resources);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We now have XFA helpers to assemble the `coap_resources[]` array, convert the legacy examples.


### Testing procedure

The same CoAP endpoints are still provided, but in a more user friendly way. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
