### PR TITLE
tests/periph/spi_dma: fix Makefile.ci

### DIFF
--- a/tests/periph/spi_dma/Makefile.ci
+++ b/tests/periph/spi_dma/Makefile.ci
@@ -1,6 +1,0 @@
-# Boards not able to accomodate the regular SPI test will not be able to link
-# this test.
-include ../spi/Makefile.ci
-BOARD_INSUFFICIENT_MEMORY += \
-    samd10-xmini \
-    #


### PR DESCRIPTION
### Contribution description

The `Makefile.ci` was intended to be read and generated by command line utilities and the contents should look exactly like this:

```
BOARD_INSUFFICIENT_MEMORY += \
    board_a \
    board_b \
    ... \
    #
```

No fancy schmancy, no `include`, no nothing. This fixes the format.

### Testing procedure

The tools in `dist/tools/insufficient_memory` should work again.

### Issues/PRs references

None