### PR TITLE
dist/tools/insufficient_memory: add RISC-V failure mode

### DIFF
--- a/dist/tools/insufficient_memory/create_makefile.ci.sh
+++ b/dist/tools/insufficient_memory/create_makefile.ci.sh
@@ -56,6 +56,7 @@ for BOARD in $(EXTERNAL_BOARD_DIRS="" make  --no-print-directory info-boards-sup
         if grep -e overflowed \
                 -e "not within region" \
                 -e "wraps around address space" \
+                -e "overlaps section" \
                 "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
             BOARDS="${BOARDS} ${BOARD}"

--- a/dist/tools/insufficient_memory/update_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/update_insufficient_memory_board.sh
@@ -64,6 +64,7 @@ for application in ${APPLICATIONS}; do
         if grep -e overflowed \
                 -e "not within region" \
                 -e "wraps around address space" \
+                -e "overlaps section" \
                 "$TMPFILE" > /dev/null; then
             printf "${CBIG}%s${CRESET}\n" "too big"
             make -f "$(dirname "$0")"/Makefile.for_sh DIR="${RIOTBASE}/${application}" ADD_BOARDS="${BOARD}" Makefile.ci > /dev/null


### PR DESCRIPTION
### Contribution description

On RISC-V a RAM overlow is reported as:

    /opt/xpack-riscv-none-elf-gcc-13.2.0-2/bin/../lib/gcc/riscv-none-elf/13.2.0/../../../../riscv-none-elf/bin/ld: section .stack VMA [80003f00,80003fff] overlaps section .bss VMA [800000a8,80003fb7]

This extends the list of patters detecting RAM overflow.

### Testing procedure

The tool should now correctly classify RAM overflows of RISC-V boards.

### Issues/PRs references

None