### PR TITLE
make use of nanocoap_server_auto_init

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -38,7 +38,7 @@ QUIET ?= 1
 #
 
 USEMODULE += suit suit_transport_coap
-USEMODULE += nanocoap_resources
+USEMODULE += nanocoap_server_auto_init
 
 # enable VFS transport (only works on boards with external storage)
 USEMODULE += suit_transport_vfs

--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -44,13 +44,6 @@
 #include "periph/gpio.h"
 #endif
 
-#define COAP_INBUF_SIZE (256U)
-
-/* Extend stacksize of nanocoap server thread */
-static char _nanocoap_server_stack[THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF];
-#define NANOCOAP_SERVER_QUEUE_SIZE     (8)
-static msg_t _nanocoap_server_msg_queue[NANOCOAP_SERVER_QUEUE_SIZE];
-
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
@@ -62,21 +55,6 @@ XFA(suit_storage_files_reg, 0) char* _slot0 = VFS_DEFAULT_DATA "/SLOT0.txt";
 XFA(suit_storage_files_reg, 1) char* _slot1 = VFS_DEFAULT_DATA "/SLOT1.txt";
 #endif
 #endif
-
-static void *_nanocoap_server_thread(void *arg)
-{
-    (void)arg;
-
-    /* nanocoap_server uses gnrc sock which uses gnrc which needs a msg queue */
-    msg_init_queue(_nanocoap_server_msg_queue, NANOCOAP_SERVER_QUEUE_SIZE);
-
-    /* initialize nanocoap server instance */
-    uint8_t buf[COAP_INBUF_SIZE];
-    sock_udp_ep_t local = { .port=COAP_PORT, .family=AF_INET6 };
-    nanocoap_server(&local, buf, sizeof(buf));
-
-    return NULL;
-}
 
 /* assuming that first button is always BTN0 */
 #if defined(MODULE_PERIPH_GPIO_IRQ) && defined(BTN0_PIN)
@@ -212,12 +190,6 @@ int main(void)
 #endif
     /* initialize suit storage */
     suit_storage_init_all();
-
-    /* start nanocoap server thread */
-    thread_create(_nanocoap_server_stack, sizeof(_nanocoap_server_stack),
-                  THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST,
-                  _nanocoap_server_thread, NULL, "nanocoap server");
 
     /* the shell contains commands that receive packets via GNRC and thus
        needs a msg queue */

--- a/tests/pkg/edhoc_c/Makefile
+++ b/tests/pkg/edhoc_c/Makefile
@@ -26,7 +26,6 @@ USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += nanocoap_sock
-USEMODULE += nanocoap_resources
 
 # include this for printing IP addresses
 USEMODULE += shell_cmds_default
@@ -43,6 +42,12 @@ CFLAGS += -DCONFIG_INITIATOR=$(CONFIG_INITIATOR)
 # Include responder code
 CONFIG_RESPONDER ?= 1
 CFLAGS += -DCONFIG_RESPONDER=$(CONFIG_RESPONDER)
+
+
+ifeq (1, $(CONFIG_RESPONDER))
+  USEMODULE += nanocoap_server_auto_init
+  CFLAGS += -DCONFIG_NANOCOAP_SERVER_BUF_SIZE=512
+endif
 
 include $(RIOTBASE)/Makefile.include
 include $(RIOTMAKE)/default-radio-settings.inc.mk

--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -11,9 +11,8 @@ USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 
-# Required for nanocoap server
-USEMODULE += nanocoap_sock
-USEMODULE += nanocoap_resources
+# Enable nanocoap server
+USEMODULE += nanocoap_server_auto_init
 
 # include this for printing IP addresses
 USEMODULE += shell_cmds_default


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Apps don't need to create the nanoCoAP server thread manually, they can just pull in `nanocoap_server_auto_init`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
