### PR TITLE
boards/common/makefiles/stdio_cdc_acm.dep.mk: fix

### DIFF
--- a/boards/common/makefiles/stdio_cdc_acm.dep.mk
+++ b/boards/common/makefiles/stdio_cdc_acm.dep.mk
@@ -1,5 +1,5 @@
 ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
-  ifneq (,$(filter tinyusb_device,$(USEMODULE)))
+  ifneq (,$(filter tinyusb_device,$(USEMODULE))$(filter tinyusb,$(USEPKG)))
     # Use stdio_tinyusb_cdc_acm only if no other stdio is requested explicitly
     # and tinyusb_device is used for any other reason
     USEMODULE += stdio_tinyusb_cdc_acm


### PR DESCRIPTION
### Contribution description

This fixes compilation issues in `tests/pkg/tinyusb_netdev` with newer versions of the RISC-V toolchain due to two competing USB stacks being pulled in. With the older toolchain the build system warns:

    The following features may conflict: periph_usbdev tinyusb_device

But builds fine (even though surprises at runtime are likely). The newer toolchain takes an issue with the same symbol being linked in more than once (and more than one instance not being `weak`).

### Testing procedure

` make BOARD=seeedstudio-gd32 -C tests/pkg/tinyusb_netdev` should no longer pull in two USB stacks.

### Issues/PRs references

None