### PR TITLE
build sytem: add `--no-warn-rwx-segments` to linker

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -506,6 +506,15 @@ TOOLCHAINS_SUPPORTED ?= gnu
 # Import all toolchain settings
 include $(RIOTMAKE)/toolchain/$(TOOLCHAIN).inc.mk
 
+# Other than on native, RWX segments in ROM are not actually RWX, as regular
+# store instructions won't write to flash.
+ifeq (,$(filter native native64,$(BOARD)))
+  LINKER_SUPPORTS_NOWARNRWX ?= $(shell LC_ALL=C $(LINK) $(RIOTTOOLS)/testprogs/minimal_linkable.c -o /dev/null -lc -Wall -Wextra -pedantic -Wl,--no-warn-rwx-segments 2> /dev/null && echo 1 || echo 0)
+  ifeq (1,$(LINKER_SUPPORTS_NOWARNRWX))
+    LINKFLAGS += -Wl,--no-warn-rwx-segments
+  endif
+endif
+
 # Append ldscript path after importing CPU and board makefiles to allow
 # overriding the core ldscripts
 LINKFLAGS += -L$(RIOTBASE)/core/ldscripts

--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -27,14 +27,6 @@ ifeq (1,$(USE_PICOLIBC))
     CFLAGS += -DPICOLIBC_INTEGER_PRINTF_SCANF
     LINKFLAGS += -DPICOLIBC_INTEGER_PRINTF_SCANF
   endif
-  # For some reason segments with RWX permissions will be created with
-  # picolibc. But since (as of now) RIOT only supports disabling the execute of
-  # all RAM via the `mpu_noexec_ram` module, permissions of the segments are
-  # ignored anyway. So for now, we just simply disable the warning.
-  LINKER_SUPPORTS_NOWARNRWX ?= $(shell LC_ALL=C $(LINK) $(RIOTTOOLS)/testprogs/minimal_linkable.c -o /dev/null -lc -Wall -Wextra -pedantic -Wl,--no-warn-rwx-segments 2> /dev/null && echo 1 || echo 0)
-  ifeq (1,$(LINKER_SUPPORTS_NOWARNRWX))
-    LINKFLAGS += -Wl,--no-warn-rwx-segments
-  endif
 endif
 
 LINKFLAGS += -lc


### PR DESCRIPTION
### Contribution description

Before we disabled the warning about RWX segments only for picolibc, but this issue is popping up on more and more toolchains (looking at MSP430 and RISC-V). Other than on `native`/`native64`, there is no MMU to enforce whatever permissions the segments contain anyway. (And writing to ROM with regular store instructions will not be possible even without the need for an MMU.)

So let's just globally disable this warning, unless building for `native` and `native64`.

### Testing procedure

Building in `master` with https://github.com/RIOT-OS/riotdocker/pull/248 will issue the RWX warning for every app now. And so does building on Alpine for MSP430.

With this PR the in our context not helpful warning is disabled.

### Issues/PRs references

Not necessary, but useful for https://github.com/RIOT-OS/riotdocker/pull/248