### PR TITLE
tests: disable flaky tests on `native` in the CI

### DIFF
--- a/tests/net/gnrc_rpl/Makefile
+++ b/tests/net/gnrc_rpl/Makefile
@@ -27,7 +27,7 @@ host-tools:
 
 TEST_DEPS += host-tools
 
-include $(RIOTBASE)/Makefile.include
-
 # Test is flaky and regularly derails unrelated merge trains
 TEST_ON_CI_BLACKLIST += native native64
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/ztimer_msg/Makefile
+++ b/tests/sys/ztimer_msg/Makefile
@@ -8,4 +8,8 @@ USEMODULE += ztimer_usec
 # uncomment this to test using ztimer sec
 #USEMODULE += ztimer_sec
 
+# The test is sensitive to background CPU load. On the CI workers a lot of
+# compilation tasks are run in parallel, making this test randomly fail.
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

As the title says, this disables `tests/sys/ztimer_msg` ([example flaky failure](https://ci.riot-os.org/details/c25e00f3fb704a148d452199a190d1cc/tests)) and tries to disable `tests/net/gnrc_rpl` for good, which was already marked as disabled.

I theorize that the reason the RPL test was still run in the order of evaluation. Due to the default recursive definitions of variables in Makefile often the order of definition can change while still achieving the same result, except when the order does matter. This is a bit of an unfortunate default.

### Testing procedure

In the CI the RPL test should not be run on native. (This has `CI: full build` set so that we can observe this even without hitting merge.)

### Issues/PRs references

None