### PR TITLE
tree wide: accomodate RISC-V toolchain update & boards/common/makefiles/stdio_cdc_acm.dep.mk: fix [backport 2024.01]

### DIFF
--- a/boards/common/makefiles/stdio_cdc_acm.dep.mk
+++ b/boards/common/makefiles/stdio_cdc_acm.dep.mk
@@ -1,5 +1,5 @@
 ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
-  ifneq (,$(filter tinyusb_device,$(USEMODULE)))
+  ifneq (,$(filter tinyusb_device,$(USEMODULE))$(filter tinyusb,$(USEPKG)))
     # Use stdio_tinyusb_cdc_acm only if no other stdio is requested explicitly
     # and tinyusb_device is used for any other reason
     USEMODULE += stdio_tinyusb_cdc_acm

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -128,7 +128,6 @@ for p in \
          msp430-elf \
          riscv-none-elf \
          riscv64-unknown-elf \
-         riscv-none-embed \
          riscv32-esp-elf \
          xtensa-esp32-elf \
          xtensa-esp32s2-elf \
@@ -147,7 +146,6 @@ for p in \
          msp430-elf \
          riscv-none-elf \
          riscv64-unknown-elf \
-         riscv-none-embed \
          riscv32-esp-elf \
          xtensa-esp32-elf \
          xtensa-esp32s2-elf \

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -12,8 +12,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     calliope-mini \
     derfmega128 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     microbit \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -10,8 +10,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     microduino-corerf \

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -8,8 +8,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     bluepill-stm32f030c8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -10,8 +10,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     chronos \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     msb-430 \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -10,8 +10,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     microduino-corerf \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -46,7 +46,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
-    seeedstudio-gd32 \
     sipeed-longan-nano \
     sipeed-longan-nano-tft \
     slstk3400a \

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -8,12 +8,9 @@
 # Ubuntu uses "riscv64-unknown-elf" despite being able to produce both 32 and
 # 64 bit binaries. We'll test all possible combinations from the most correct
 # triple to the least correct triple all that might be able to produce our
-# binaries. Finally, "riscv-none-embed" is also tested for compatibility with
-# an previously popular legacy toolchain.
-# For a CI transition period, it is tested first.
+# binaries.
 
 _TRIPLES_TO_TEST := \
-    riscv-none-embed \
     riscv32-none-elf \
     riscv32-unknown-elf \
     riscv32-elf \
@@ -27,7 +24,7 @@ _TRIPLES_TO_TEST := \
 # Do not test at run time if building with docker: The host may have no
 # RISC-V toolchain installed or a different one
 ifeq (1,$(BUILD_IN_DOCKER))
-  TARGET_ARCH_RISCV := riscv-none-embed
+  TARGET_ARCH_RISCV := riscv-none-elf
 endif
 
 TARGET_ARCH_RISCV ?= \

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -37,7 +37,6 @@ $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 	        -e 's/"riscv64-none-elf"/"riscv32"/g' \
 	        -e 's/"riscv64-unknown-elf"/"riscv32"/g' \
 	        -e 's/"riscv64-elf"/"riscv32"/g' \
-	        -e 's/"riscv-none-embed"/"riscv32"/g' \
 	  | $(LAZYSPONGE) $@
 
 

--- a/tests/bench/xtimer_load/Makefile
+++ b/tests/bench/xtimer_load/Makefile
@@ -9,4 +9,7 @@ CFLAGS += -DTEST_HZ=$(TEST_HZ)LU
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/core/thread_flags/Makefile
+++ b/tests/core/thread_flags/Makefile
@@ -6,4 +6,7 @@ USEMODULE += xtimer
 # microbit qemu timing is off
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/net/gcoap_dns/Makefile.ci
+++ b/tests/net/gcoap_dns/Makefile.ci
@@ -17,6 +17,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     calliope-mini \
     derfmega128 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     mega-xplained \

--- a/tests/net/gnrc_dhcpv6_relay/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_relay/Makefile.ci
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     msb-430 \

--- a/tests/net/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext/Makefile.ci
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     msb-430 \

--- a/tests/net/gnrc_netif_ipv6_wait_for_global_address/Makefile.ci
+++ b/tests/net/gnrc_netif_ipv6_wait_for_global_address/Makefile.ci
@@ -8,6 +8,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     bluepill-stm32f030c8 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/net/gnrc_rpl/Makefile
+++ b/tests/net/gnrc_rpl/Makefile
@@ -27,7 +27,7 @@ host-tools:
 
 TEST_DEPS += host-tools
 
-include $(RIOTBASE)/Makefile.include
-
 # Test is flaky and regularly derails unrelated merge trains
-TEST_ON_CI_BLACKLIST += native
+TEST_ON_CI_BLACKLIST += native native64
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/net/gnrc_rpl_srh/Makefile.ci
+++ b/tests/net/gnrc_rpl_srh/Makefile.ci
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     msb-430 \

--- a/tests/net/gnrc_sock_dns/Makefile.ci
+++ b/tests/net/gnrc_sock_dns/Makefile.ci
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/pkg/edhoc_c/Makefile.ci
+++ b/tests/pkg/edhoc_c/Makefile.ci
@@ -12,8 +12,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc2650stk \
     e104-bt5010a-tb \
     e104-bt5011a-tb \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     lsn50 \

--- a/tests/pkg/lwip/Makefile.ci
+++ b/tests/pkg/lwip/Makefile.ci
@@ -3,8 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-stm32f103c8 \
     bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     nrf6310 \
     nucleo-f030r8 \

--- a/tests/sys/conn_can/Makefile.ci
+++ b/tests/sys/conn_can/Makefile.ci
@@ -1,8 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
     calliope-mini \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     microbit \

--- a/tests/sys/evtimer_underflow/Makefile
+++ b/tests/sys/evtimer_underflow/Makefile
@@ -6,4 +6,7 @@ USEMODULE += ztimer_msec
 # microbit qemu lacks rtt
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/pthread_cooperation/Makefile.ci
+++ b/tests/sys/pthread_cooperation/Makefile.ci
@@ -1,7 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    hifive1 \
-    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     nucleo-f031k6 \

--- a/tests/sys/xtimer_hang/Makefile
+++ b/tests/sys/xtimer_hang/Makefile
@@ -21,4 +21,7 @@ DISABLE_MODULE := core_msg
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/ztimer_msg/Makefile
+++ b/tests/sys/ztimer_msg/Makefile
@@ -8,4 +8,8 @@ USEMODULE += ztimer_usec
 # uncomment this to test using ztimer sec
 #USEMODULE += ztimer_sec
 
+# The test is sensitive to background CPU load. On the CI workers a lot of
+# compilation tasks are run in parallel, making this test randomly fail.
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/ztimer_overhead/Makefile
+++ b/tests/sys/ztimer_overhead/Makefile
@@ -9,4 +9,8 @@ USEMODULE += ztimer_usec
 # microbit qemu timing is off
 TEST_ON_CI_BLACKLIST += microbit
 
+# The test is sensitive to background CPU load. On the CI workers a lot of
+# compilation tasks are run in parallel, making this test randomly fail.
+TEST_ON_CI_BLACKLIST += native
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/ztimer_underflow/Makefile
+++ b/tests/sys/ztimer_underflow/Makefile
@@ -20,4 +20,7 @@ CFLAGS += -DTEST_ZTIMER_CLOCK=$(TEST_ZTIMER_CLOCK)
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
# Backport of #20379, #20380, #20382, #20358, #20324

## 20378
### Contribution description

This fixes compilation issues in `tests/pkg/tinyusb_netdev` with newer versions of the RISC-V toolchain due to two competing USB stacks being pulled in. With the older toolchain the build system warns:

    The following features may conflict: periph_usbdev tinyusb_device

But builds fine (even though surprises at runtime are likely). The newer toolchain takes an issue with the same symbol being linked in more than once (and more than one instance not being `weak`).

### Testing procedure

` make BOARD=seeedstudio-gd32 -C tests/pkg/tinyusb_netdev` should no longer pull in two USB stacks.

### Issues/PRs references

None

## 20380

### Contribution description

This contains fixed needed after updating the RISC-V toolchain in the CI

### Testing procedure

Build `riotbuild` from https://github.com/RIOT-OS/riotdocker/pull/248 locally, then run

```
env DOCKER_IMAGE=<LOCAL_BUILD_ID> ./dist/tools/insufficient_memory/update_insufficient_memory_board.sh hifive1b
```

This should fail for each and every build in `master`, but work for each and every build with this PR

### Issues/PRs references

Depends on:

- [x] https://github.com/RIOT-OS/riotdocker/pull/248
- [x] https://github.com/RIOT-OS/RIOT/pull/20379

## 20382, 20358, 20324

Disabling flaky native tests...