### PR TITLE
ipv6/nib: do not allocate an NCE for a prefix

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -90,21 +90,23 @@ static inline bool _addr_equals(const ipv6_addr_t *addr,
 
 _nib_onl_entry_t *_nib_onl_alloc(const ipv6_addr_t *addr, unsigned iface)
 {
+    assert(addr);
     _nib_onl_entry_t *node = NULL;
-
     DEBUG("nib: Allocating on-link node entry (addr = %s, iface = %u)\n",
-          (addr == NULL) ? "NULL" : ipv6_addr_to_str(addr_str, addr,
-                                                     sizeof(addr_str)), iface);
+          ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)), iface);
+
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_NUMOF; i++) {
         _nib_onl_entry_t *tmp = &_nodes[i];
 
-        if ((_nib_onl_get_if(tmp) == iface) && _addr_equals(addr, tmp)) {
-            /* exact match */
-            DEBUG("  %p is an exact match\n", (void *)tmp);
-            node = tmp;
-            break;
+        if (tmp->mode != _EMPTY) {
+            if (_nib_onl_get_if(tmp) == iface && _addr_equals(addr, tmp)) {
+                /* exact match */
+                DEBUG("  %p is an exact match\n", (void *)tmp);
+                node = tmp;
+                break;
+            }
         }
-        if ((node == NULL) && (tmp->mode == _EMPTY)) {
+        else if (node == NULL) {
             DEBUG("  using %p\n", (void *)node);
             node = tmp;
         }
@@ -487,12 +489,18 @@ _nib_offl_entry_t *_nib_offl_alloc(const ipv6_addr_t *next_hop, unsigned iface,
         _nib_offl_entry_t *tmp = &_dsts[i];
         _nib_onl_entry_t *tmp_node = tmp->next_hop;
 
-        if ((tmp->pfx_len == pfx_len) &&                /* prefix length matches and */
-            (tmp_node != NULL) &&                       /* there is a next hop that */
-            (_nib_onl_get_if(tmp_node) == iface) &&     /* has a matching interface and */
-            _addr_equals(next_hop, tmp_node) &&         /* equal address to next_hop, also */
-            (ipv6_addr_match_prefix(&tmp->pfx, pfx) >= pfx_len)) {  /* the prefix matches */
-            /* exact match (or next hop address was previously unset) */
+        bool match = false;
+        if (tmp->mode != _EMPTY) {
+            /* match onlink entry by interface and address for DC and FT */
+            bool match = !tmp_node || (_nib_onl_get_if(tmp_node) == iface &&
+                                       _addr_equals(next_hop, tmp_node));
+            /* match offlink entry for PFX, DC and FT */
+            match = match && tmp->pfx_len == pfx_len &&
+                             _nib_offl_get_if(tmp) == iface &&
+                             ipv6_addr_match_prefix(&tmp->pfx, pfx) >= pfx_len;
+
+        }
+        if (match) {
             DEBUG("  %p is an exact match\n", (void *)tmp);
             if (next_hop != NULL) {
                 memcpy(&tmp_node->ipv6, next_hop, sizeof(tmp_node->ipv6));
@@ -506,14 +514,16 @@ _nib_offl_entry_t *_nib_offl_alloc(const ipv6_addr_t *next_hop, unsigned iface,
     }
     if (dst != NULL) {
         DEBUG("  using %p\n", (void *)dst);
-        dst->next_hop = _nib_onl_alloc(next_hop, iface);
-
-        if (dst->next_hop == NULL) {
-            memset(dst, 0, sizeof(_nib_offl_entry_t));
-            return NULL;
+        if (next_hop) {
+            /* PFX do not require an NCE, but DC and FT do */
+            if (!(dst->next_hop = _nib_onl_alloc(next_hop, iface))) {
+                memset(dst, 0, sizeof(_nib_offl_entry_t));
+                return NULL;
+            }
+            _override_node(next_hop, iface, dst->next_hop);
+            dst->next_hop->mode |= _DST;
         }
-        _override_node(next_hop, iface, dst->next_hop);
-        dst->next_hop->mode |= _DST;
+        _nib_offl_set_if(dst, iface);
         ipv6_addr_init_prefix(&dst->pfx, pfx, pfx_len);
         dst->pfx_len = pfx_len;
     }
@@ -593,7 +603,7 @@ static _nib_offl_entry_t *_nib_offl_get_match(const ipv6_addr_t *dst)
                   (entry->mode == _PL) ? "(nil)" :
                   ipv6_addr_to_str(addr_str, &entry->next_hop->ipv6,
                                    sizeof(addr_str)),
-                  _nib_onl_get_if(entry->next_hop), match);
+                  _nib_offl_get_if(entry), match);
             if ((match > best_match) && (match >= entry->pfx_len)) {
                 DEBUG("nib: best match (%u bits)\n", match);
                 res = entry;
@@ -610,7 +620,7 @@ void _nib_ft_get(const _nib_offl_entry_t *dst, gnrc_ipv6_nib_ft_t *fte)
     memcpy(&fte->dst, &dst->pfx, sizeof(dst->pfx));
     fte->dst_len = dst->pfx_len;
     fte->primary = 0;
-    fte->iface = _nib_onl_get_if(dst->next_hop);
+    fte->iface = _nib_offl_get_if(dst);
     if (dst->mode == _PL) { /* entry is only in prefix list */
         ipv6_addr_set_unspecified(&fte->next_hop);
     }
@@ -690,7 +700,7 @@ void _nib_offl_remove_prefix(_nib_offl_entry_t *pfx)
     evtimer_del(&_nib_evtimer, &pfx->pfx_timeout.event);
 
     /* get interface associated with prefix */
-    netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
+    netif = gnrc_netif_get_by_pid(_nib_offl_get_if(pfx));
 
     if (netif != NULL) {
         uint8_t best_match_len = pfx->pfx_len;
@@ -859,10 +869,9 @@ _nib_offl_entry_t *_nib_pl_add(unsigned iface,
 static void _override_node(const ipv6_addr_t *addr, unsigned iface,
                            _nib_onl_entry_t *node)
 {
+    assert(addr);
     _nib_onl_clear(node);
-    if (addr != NULL) {
-        memcpy(&node->ipv6, addr, sizeof(node->ipv6));
-    }
+    memcpy(&node->ipv6, addr, sizeof(node->ipv6));
     _nib_onl_set_if(node, iface);
 }
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -70,6 +70,9 @@ extern "C" {
  */
 #define _PFX_ON_LINK    (0x0001)
 #define _PFX_SLAAC      (0x0002)
+#define _PFX_IF_MASK    (GNRC_IPV6_NIB_NC_INFO_IFACE_MASK)
+#define _PFX_IF_POS     (GNRC_IPV6_NIB_NC_INFO_IFACE_POS)
+#define _PFX_IF_MAX     (_PFX_IF_MASK >> _PFX_IF_POS)
 /** @} */
 
 /**
@@ -327,7 +330,20 @@ void _nib_release(void);
  */
 static inline unsigned _nib_onl_get_if(const _nib_onl_entry_t *node)
 {
+    assert(node);
     return (node->info & _NIB_IF_MASK) >> _NIB_IF_POS;
+}
+
+/**
+ * @brief   Gets the interface identifier towards an NIB offlink entry
+ *
+ * @param[in] node  An NIB offlink entry.
+ *
+ * @return  The NIB entry's interface identifier.
+ */
+static inline unsigned _nib_offl_get_if(const _nib_offl_entry_t *node)
+{
+    return (node->flags & _PFX_IF_MASK) >> _PFX_IF_POS;
 }
 
 /**
@@ -341,6 +357,19 @@ static inline void _nib_onl_set_if(_nib_onl_entry_t *node, unsigned iface)
     assert(iface <= _NIB_IF_MAX);
     node->info &= ~(_NIB_IF_MASK);
     node->info |= ((iface << _NIB_IF_POS) & _NIB_IF_MASK);
+}
+
+/**
+ * @brief   Sets the interface identifier towards an NIB offlink entry
+ *
+ * @param[in,out] node  An NIB offlink entry.
+ * @param[in] iface     An interface identifier.
+ */
+static inline void _nib_offl_set_if(_nib_offl_entry_t *node, unsigned iface)
+{
+    assert(iface <= _PFX_IF_MASK);
+    node->flags &= ~(_PFX_IF_MASK);
+    node->flags |= ((iface << _PFX_IF_POS) & _PFX_IF_MASK);
 }
 
 /**
@@ -764,6 +793,7 @@ static inline _nib_offl_entry_t *_nib_ft_add(const ipv6_addr_t *next_hop,
                                              const ipv6_addr_t *pfx,
                                              unsigned pfx_len)
 {
+    assert((next_hop != NULL) && (pfx != NULL));
     return _nib_offl_add(next_hop, iface, pfx, pfx_len, _FT);
 }
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -105,9 +105,7 @@ static gnrc_pktsnip_t *_offl_to_pio(_nib_offl_entry_t *offl,
 {
     uint32_t now = evtimer_now_msec();
     gnrc_pktsnip_t *pio;
-    gnrc_netif_t *netif = gnrc_netif_get_by_pid(
-            _nib_onl_get_if(offl->next_hop)
-        );
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_offl_get_if(offl));
     uint8_t flags = 0;
     uint32_t valid_ltime = (offl->valid_until == UINT32_MAX) ? UINT32_MAX :
                            ((offl->valid_until - now) / MS_PER_SEC);
@@ -179,7 +177,7 @@ static gnrc_pktsnip_t *_add_rio(gnrc_netif_t *netif, gnrc_pktsnip_t *ext_opts, b
     while ((entry = _nib_offl_iter(entry))) {
 
         unsigned id = netif->pid;
-        if (_nib_onl_get_if(entry->next_hop) == id) {
+        if (_nib_offl_get_if(entry) == id) {
             continue;
         }
 
@@ -266,7 +264,7 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
         }
 #endif  /* MODULE_GNRC_SIXLOWPAN_CTX */
         while ((pfx = _nib_abr_iter_pfx(abr, pfx))) {
-            if (_nib_onl_get_if(pfx->next_hop) == id) {
+            if (_nib_offl_get_if(pfx) == id) {
                 if ((ext_opts = _offl_to_pio(pfx, ext_opts)) == NULL) {
                     return NULL;
                 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -241,7 +241,7 @@ static bool _on_link(const ipv6_addr_t *dst, unsigned *iface)
     }
 
     if (match) {
-        *iface = _nib_onl_get_if(match->next_hop);
+        *iface = _nib_offl_get_if(match);
         /* check if prefix is on-link */
         return (match->mode & _PL) && (match->flags & _PFX_ON_LINK);
     }
@@ -1429,7 +1429,7 @@ static void _handle_snd_na(gnrc_pktsnip_t *pkt)
 
 static void _handle_pfx_timeout(_nib_offl_entry_t *pfx)
 {
-    gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(pfx->next_hop));
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_offl_get_if(pfx));
     if (netif == NULL) {
         return;
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -46,8 +46,7 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr)
      * Option (ABRO) in a respective Prefix Information Option (PIO)
      * (see https://tools.ietf.org/html/rfc6775#section-8.1.1). */
     while ((offl = _nib_offl_iter(offl))) {
-        if ((offl->mode & _PL) &&
-            (_nib_onl_get_if(offl->next_hop) == (unsigned)netif->pid)) {
+        if ((offl->mode & _PL) && (_nib_offl_get_if(offl) == (unsigned)netif->pid)) {
             _nib_abr_add_pfx(abr, offl);
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Motivated by the findings in #20371 I would propose this, to not allocate a dummy NCE without an IPv6 for a prefix in the prefix list. Previously the NCE was allocated to store the interface on which the prefix was received, but having an NCE without an address seems weird as NCEs are keyed by their IPv6 address.
If an NCE is only matched by interface, this creates ambiguity as you can imagine multiple neighbors can be present on the same interface.

The implemented approach here is to use the already present `flags` member in `_nib_offl_entry_t` to encode the interface.
It is the same as the `info` member in `_nib_onl_entry_t`.

CON: The interface information is duplicated for FT and DC entries as they require a real NCE which also stores the interface number.

Having a separate PL data structure would require bigger refactoring, I guess.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Not really tested in a setup yet.
But at least the test which failed in #20371 with the provided fix to not treat `NULL` as "don't care" now succeeds.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#20371