### PR TITLE
tests/pkg/edhoc_c: bump CoAP thread stack size

### DIFF
--- a/tests/pkg/edhoc_c/Makefile
+++ b/tests/pkg/edhoc_c/Makefile
@@ -35,6 +35,7 @@ USEMODULE += xtimer
 # This is an optimized stack value based on testing, if you observe
 # a segmentation fault please increase this stack size.
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=3*THREAD_STACKSIZE_LARGE
+CFLAGS += -DCONFIG_NANOCOAP_SERVER_STACK_SIZE=3*THREAD_STACKSIZE_LARGE
 
 # Include responder code
 CONFIG_INITIATOR ?= 1


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The CoAP thread stack size needs to be the same as the main thread stack size to accommodate the EDHOC stack requirements. This was lost when moving to the common CoAP server code.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Lo longer crashes on hardware, e.g. `nrf52840dk`:

<details><summary>test output</summary>

```
> ifconfig
ifconfig
Iface  6  HWaddr: 3A:F1  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: AA:CC:F4:7B:67:C4:BA:F1 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::a8cc:f47b:67c4:baf1  scope: link  VAL
init handshake fe80::a8cc:f47b:67c4:baf1%6 5683
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffc4:baf1
          
> init handshake fe80::a8cc:f47b:67c4:baf1%6 5683
[initiator]: sending msg1 (37 bytes):
0x0d 0x00 0x58 0x20 0x8d 0x3e 0xf5 0x6d 
0x1b 0x75 0x0a 0x43 0x51 0xd6 0x8a 0xc2 
0x50 0xa0 0xe8 0x83 0x79 0x0e 0xfc 0x80 
0xa5 0x38 0xa4 0x44 0xee 0x9e 0x2b 0x57 
0xe2 0x44 0x1a 0x7c 0x21 
[responder]: received an EDHOC message (len 37):
0x0d 0x00 0x58 0x20 0x8d 0x3e 0xf5 0x6d 
0x1b 0x75 0x0a 0x43 0x51 0xd6 0x8a 0xc2 
0x50 0xa0 0xe8 0x83 0x79 0x0e 0xfc 0x80 
0xa5 0x38 0xa4 0x44 0xee 0x9e 0x2b 0x57 
0xe2 0x44 0x1a 0x7c 0x21 
[responder]: sending msg2 (46 bytes):
0x58 0x20 0x52 0xfb 0xa0 0xbd 0xc8 0xd9 
0x53 0xdd 0x86 0xce 0x1a 0xb2 0xfd 0x7c 
0x05 0xa4 0x65 0x8c 0x7c 0x30 0xaf 0xdb 
0xfc 0x33 0x01 0x04 0x70 0x69 0x45 0x1b 
0xaf 0x35 0x37 0x4a 0xa3 0xf1 0xbd 0x5d 
0x02 0x8d 0x19 0xcf 0x3c 0x99 
[initiator]: received a message (46 bytes):
0x58 0x20 0x52 0xfb 0xa0 0xbd 0xc8 0xd9 
0x53 0xdd 0x86 0xce 0x1a 0xb2 0xfd 0x7c 
0x05 0xa4 0x65 0x8c 0x7c 0x30 0xaf 0xdb 
0xfc 0x33 0x01 0x04 0x70 0x69 0x45 0x1b 
0xaf 0x35 0x37 0x4a 0xa3 0xf1 0xbd 0x5d 
0x02 0x8d 0x19 0xcf 0x3c 0x99 
[initiator]: sending msg3 (20 bytes):
0x37 0x52 0xd5 0x53 0x5f 0x31 0x47 0xe8 
0x5f 0x1c 0xfa 0xcd 0x9e 0x78 0xab 0xf9 
0xe0 0xa8 0x1b 0xbf 
[responder]: received an EDHOC message (len 20):
0x37 0x52 0xd5 0x53 0x5f 0x31 0x47 0xe8 
0x5f 0x1c 0xfa 0xcd 0x9e 0x78 0xab 0xf9 
0xe0 0xa8 0x1b 0xbf 
[responder]: finalize exchange
[responder]: handshake successfully completed
[initiator]: handshake successfully completed
[initiator]: Transcript hash 4 (32 bytes):
0x7c 0xcf 0xde 0xdc 0x2c 0x10 0xca 0x03 
0x56 0xe9 0x57 0xb9 0xf6 0xa5 0x92 0xe0 
0xfa 0x74 0xdb 0x2a 0xb5 0x4f 0x59 0x24 
0x40 0x96 0xf9 0xa2 0xac 0x56 0xd2 0x07 
init oscore

> init oscore
OSCORE secret:
0x5b 0xb2 0xae 0xe2 0x5b 0x16 0x0e 0x7c 
0x6d 0x26 0x12 0xb0 0xa6 0x01 0x09 0x16 

OSCORE salt:
0x8e 0x44 0x92 0x10 0xe0 0x3b 0xc2 0x9d 

resp oscore
> resp oscore
OSCORE secret:
0x5b 0xb2 0xae 0xe2 0x5b 0x16 0x0e 0x7c 
0x6d 0x26 0x12 0xb0 0xa6 0x01 0x09 0x16 

OSCORE salt:
0x8e 0x44 0x92 0x10 0xe0 0x3b 0xc2 0x9d 

make BOARD=nrf52840dk flash test  33,55s user 6,05s system 69% cpu 56,615 total
```
</details>


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
