### PR TITLE
doc: Link OpenThread primer, cleanup

### DIFF
--- a/pkg/openthread/doc.txt
+++ b/pkg/openthread/doc.txt
@@ -4,9 +4,6 @@
  * @ingroup  net
  * @brief    Provides a RIOT adaption of the OpenThread network stack
  * @see      https://github.com/openthread/openthread
- * @note     Currently there's only support for @ref drivers_at86rf2xx.
- *           There's a work in progress to support more radio drivers
- *           (see [this issue](https://github.com/RIOT-OS/RIOT/issues/10045))
  * @note     A good technical introduction to how Thread works is available in
  *           the [thread primer] of OpenThread.
  *

--- a/pkg/openthread/doc.txt
+++ b/pkg/openthread/doc.txt
@@ -7,4 +7,8 @@
  * @note     Currently there's only support for @ref drivers_at86rf2xx.
  *           There's a work in progress to support more radio drivers
  *           (see [this issue](https://github.com/RIOT-OS/RIOT/issues/10045))
+ * @note     A good technical introduction to how Thread works is available in
+ *           the [thread primer] of OpenThread.
+ *
+ * [thread primer]: https://openthread.io/guides/thread-primer
  */

--- a/sys/net/ieee802154.txt
+++ b/sys/net/ieee802154.txt
@@ -66,8 +66,10 @@
  * protocols used on top of it, applications always need to pick their
  * components; that selection is often guided by standards or organizations
  * that pick an interoperable set of components (higher-level protocol, MAC,
- * band and others), like Thread (6LoWPAN, nonbeacon-enabled, 2.4GHz),
+ * band and others), like [Thread] \(6LoWPAN, nonbeacon-enabled, 2.4GHz),
  * WirelessHART (HART, TSCH, 2.4GHz) or 6TiSCH (6LoWPAN, TSCH).
+ *
+ * [Thread]: https://openthread.io/guides/thread-primer
  *
  * Availability in RIOT
  * --------------------


### PR DESCRIPTION
### Contribution description

The Thread protocol is not easily accessible because its specs are behind EULAs, and many intro articles are super vague.

I've found a good one at https://openthread.io/guides/thread-primer, linking it where relevant, and removed

### Testing procedure

* Look at the generated docs.

### State

<del>This is a draft PR until I've verified that the generated help looks nice.</del>

[edit] Docs look good now after two rounds through markdown, ready for review.