### PR TITLE
makefile: Don't $(info) when the output can break info-build-json

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -493,7 +493,7 @@ ifneq ($(RIOT_CI_BUILD),1)
   ifneq (iotlab,$(PROGRAMMER))
     ifneq (,$(PROGRAMMERS_SUPPORTED))
       ifeq (,$(filter $(PROGRAMMER),$(PROGRAMMERS_SUPPORTED)))
-        $(info '$(PROGRAMMER)' programmer is not supported by this board. \
+        $(warning '$(PROGRAMMER)' programmer is not supported by this board. \
                 Supported programmers: '$(PROGRAMMERS_SUPPORTED)')
       endif
     endif


### PR DESCRIPTION
### Contribution description

$(info ...) produces output to stdout, which in our makefiles is sometimes used to produce machine readable data, eg. in info-build-json; this fixes such a case.

### Testing procedure

```
$ cd tests/minimal
$ make BOARD=f4vi1 info-build-json | jq
```

Before, this erred due to non-JSON output in the text. After, it prettyprints.

### Issues/PRs references

Had something similar in https://github.com/RIOT-OS/RIOT/pull/20109