### PR TITLE
Makefile.{include,base},pkg/nanopb: fix target deps & code generation

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -97,9 +97,6 @@ compile-commands: | $(DIRS:%=COMPILE-COMMANDS--%)
 	$(file >>$(BINDIR)/$(MODULE)/compile_cmds.txt,TARGET_ARCH: $(TARGET_ARCH))
 	$(file >>$(BINDIR)/$(MODULE)/compile_cmds.txt,TARGET_ARCH_LLVM: $(TARGET_ARCH_LLVM))
 
-# include makefile snippets for packages in $(PKG_PATHS) that modify GENSRC:
--include $(PKG_PATHS:%=%Makefile.gensrc)
-
 GENOBJC     := $(GENSRC:%.c=%.o)
 OBJC_LTO    := $(SRC:%.c=$(BINDIR)/$(MODULE)/%.o)
 OBJC_NOLTO  := $(SRC_NOLTO:%.c=$(BINDIR)/$(MODULE)/%.o)

--- a/Makefile.include
+++ b/Makefile.include
@@ -709,6 +709,12 @@ BUILDDEPS += $(BUILD_DIR)/CACHEDIR.TAG
 # clean removing dependencies that make previously considered as up to date.
 $(BUILDDEPS): $(CLEAN)
 
+# include makefile snippets for packages in $(PKG_PATHS) that modify GENSRC:
+-include $(PKG_PATHS:%=%Makefile.gensrc)
+# remove duplicates & make accessible to subprocesses
+GENSRC := $(sort $(GENSRC))
+export GENSRC
+
 # Save value to verify it is not modified later
 _BASELIBS_VALUE_BEFORE_USAGE := $(BASELIBS)
 
@@ -757,7 +763,7 @@ $(APPLICATION_MODULE).module: FORCE
 
 # Other modules are built by application.inc.mk and packages building
 _SUBMAKE_LIBS = $(filter-out $(APPLICATION_MODULE).module $(APPDEPS), $(BASELIBS) $(ARCHIVES))
-$(_SUBMAKE_LIBS): $(APPLICATION_MODULE).module pkg-build
+$(_SUBMAKE_LIBS): $(APPLICATION_MODULE).module pkg-build $(GENSRC)
 
 # 'print-size' triggers a rebuild. Use 'info-buildsize' if you do not need to rebuild.
 print-size: $(ELFFILE)
@@ -810,13 +816,15 @@ endif
 	@$(COLOR_ECHO)
 
 # The `clean` needs to be serialized before everything else.
-all $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) ..in-docker-container: | $(CLEAN)
+all $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) $(GENSRC) ..in-docker-container: | $(CLEAN)
 
 .PHONY: pkg-prepare pkg-build
 pkg-prepare:
 	-@$(foreach dir,$(PKG_PATHS),"$(MAKE)" -C $(dir) prepare $(NEWLINE))
 
-pkg-build: $(BUILDDEPS)
+$(GENSRC): pkg-prepare
+
+pkg-build: $(BUILDDEPS) | $(GENSRC)
 	$(foreach dir,$(PKG_PATHS),$(QQ)"$(MAKE)" -C $(dir) $(NEWLINE))
 
 clean:

--- a/pkg/nanopb/Makefile.gensrc
+++ b/pkg/nanopb/Makefile.gensrc
@@ -2,29 +2,40 @@ PROTOC ?= protoc
 PROTOC_GEN_NANOPB ?= $(PKGDIRBASE)/nanopb/generator/protoc-gen-nanopb
 
 PROTOBUF_FILES ?= $(wildcard *.proto)
-PROTOBUF_PATH  ?= $(CURDIR)
-GENSRC   += $(PROTOBUF_FILES:%.proto=$(BINDIR)/$(MODULE)/%.pb.c)
-GENOBJC  := $(GENSRC:%.c=%.o)
+
+# remove duplicates
+PROTOBUF_FILES := $(sort $(PROTOBUF_FILES))
+
+NANOPB_OUT_DIR := $(BINDIR)/nanopb
 
 ifneq (,$(PROTOBUF_FILES))
-  INCLUDES += -I$(BINDIR)/$(MODULE)
+  INCLUDES += -I$(NANOPB_OUT_DIR)
 endif
+
+PROTOBUF_FILES_BASENAMES = $(notdir $(PROTOBUF_FILES))
+
+GENSRC   += $(PROTOBUF_FILES_BASENAMES:%.proto=$(NANOPB_OUT_DIR)/%.pb.c)
 
 # workaround for old protoc
 PROTO_INCLUDES += -I.
 # add nanopb specific includes
 PROTO_INCLUDES += -I$(PKGDIRBASE)/nanopb/generator/proto
-PROTO_INCLUDES += -I$(PROTOBUF_PATH)
 
-$(SRC) $(SRCXX): $(GENSRC)
+# We need to filter all protobuf files for source generation as pattern
+# matching won't work due to the potentially different directory
+# prefixes.
 
-$(GENSRC): $(PROTOBUF_FILES)
-	$(Q)D=$(BINDIR)/$(MODULE) && \
-	  mkdir -p "$$D" && \
-		cd $(CURDIR) && \
-		$(MAKE) -C $(PKGDIRBASE)/nanopb/generator/proto && \
-		for protofile in $(PROTOBUF_FILES); do \
-			protoc --plugin=protoc-gen-nanopb=$(PROTOC_GEN_NANOPB) \
-				--nanopb_out="$$D" $(PROTO_INCLUDES) \
-				$^ \
-				; done
+nanopb_select_proto_from_target = $(firstword $(filter %$(notdir $(basename $(basename $(1)))).proto,$(PROTOBUF_FILES)))
+
+$(NANOPB_OUT_DIR)/%.pb.c: $(PROTOBUF_FILES)
+# We have to create the output directory here because properly chaining
+# with the clean target is currently not possible.
+	-$(Q)mkdir -p $(NANOPB_OUT_DIR)
+# Change of directory is required here because of protoc shortcomings.
+# Setting --proto_path to the same value will fail under certain
+# conditions.
+	$(Q)cd "$(dir $(call nanopb_select_proto_from_target,$@))" \
+	&& protoc --plugin=protoc-gen-nanopb=$(PROTOC_GEN_NANOPB) \
+	    --proto_path=. \
+	    --nanopb_out="$(NANOPB_OUT_DIR)" $(PROTO_INCLUDES) \
+	    $(notdir $(call nanopb_select_proto_from_target,$@))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR aims to

- make the results of GENSRC available to all modules (and be robust against multiple dependencies against the same protobuf schema)
- compile protobuf schema outside the current directory without caring much about the shortcomings of protoc

To achieve that

- The GENSRC target is moved into a more central place. Before, it did run on every module build. GENSRC is known already much earlier and can be run once for all modules. This PR suggests to run it once after pkg-prepare.
- The output of nanopb is put into a central place in $(BINDIR)/nanopb to make it accessible to all modules which depend on nanopb. While not normally required, this allows for multiple modules using the generated sources. Without the changes of this PR the options for usage by multiple modules was to live with a race condition during build because one module (the application) would generate sources which another one then wanted to use for compiling. Naming of the same protobuf dependency by multiple modules would lead to multiple definitions of the same symbols.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

none

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

none

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
