### PR TITLE
tests/sys/posix_semaphore: disable native,native64 on CI

### DIFF
--- a/tests/sys/posix_semaphore/Makefile
+++ b/tests/sys/posix_semaphore/Makefile
@@ -7,4 +7,8 @@ USEMODULE += ztimer64_usec
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 
+# native / native64 may fail under load with:
+#    first: waited too long <NUM> usec => FAILED
+TEST_ON_CI_BLACKLIST += native native64
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The CI tests may fail under load with:

    first: waited too long 1001711 usec => FAILED

### Testing procedure

The test should no longer be run in the CI

### Issues/PRs references

None