### PR TITLE
periph/eeprom: fix off-by-one error in debug statement

### DIFF
--- a/cpu/stm32/periph/eeprom.c
+++ b/cpu/stm32/periph/eeprom.c
@@ -95,7 +95,7 @@ size_t eeprom_read(uint32_t pos, void *data, size_t len)
     for (size_t i = 0; i < len; i++) {
         _wait_for_pending_operations();
         *p++ = *(__IO uint8_t *)(EEPROM_START_ADDR + pos++);
-        DEBUG("0x%02X ", *p);
+        DEBUG("0x%02X ", *(p-1));
     }
     DEBUG("\n");
 
@@ -110,8 +110,10 @@ size_t eeprom_write(uint32_t pos, const void *data, size_t len)
 
     _unlock();
 
+    DEBUG("Writing data to EEPROM at pos %" PRIu32 ": ", pos);
     for (size_t i = 0; i < len; i++) {
         _write_byte((EEPROM_START_ADDR + pos++), *p++);
+        DEBUG("0x%02X ", *(p-1));
     }
 
     _lock();


### PR DESCRIPTION
### Contribution description
While looking through the `eeprom.c` code, I discovered an off-by-one error in the `DEBUG` statements. This fixes that by subtracting 1 from the pointer before we dereference. I also add debug statements to the `eeprom_write` with the same fix


### Testing procedure
run the code with `ENABLE_DEBUG 1` and see it prints correct values

### Issues/PRs references
