### PR TITLE
cpu/esp8266: allow arbitrary SPI clocks

### DIFF
--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -24,6 +24,7 @@
 
 #include "eagle_soc.h"
 #include "cpu_conf.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -263,6 +264,19 @@ typedef struct {
 typedef enum {
     HSPI = 1,         /**< HSPI interface controller */
 } spi_ctrl_t;
+
+/**
+ * @brief   Override SPI clock speed values
+ * @{
+ */
+#define HAVE_SPI_CLK_T
+typedef enum {
+    SPI_CLK_100KHZ = KHZ(100), /**< drive the SPI bus with 100KHz */
+    SPI_CLK_400KHZ = KHZ(400), /**< drive the SPI bus with 400KHz */
+    SPI_CLK_1MHZ   = MHZ(1),   /**< drive the SPI bus with 1MHz */
+    SPI_CLK_5MHZ   = MHZ(5),   /**< drive the SPI bus with 5MHz */
+    SPI_CLK_10MHZ  = MHZ(10),  /**< drive the SPI bus with 10MHz */
+} spi_clk_t;
 
 /**
  * @brief   SPI configuration structure type

--- a/cpu/esp8266/periph/spi.c
+++ b/cpu/esp8266/periph/spi.c
@@ -262,28 +262,11 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
      * https://www.espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf
      */
 
-    uint32_t spi_clkdiv_pre;
-    uint32_t spi_clkcnt_N;
+    uint32_t spi_clkdiv_pre;    /* 13 bit */
+    uint32_t spi_clkcnt_N;      /*  6 bit */
 
-    switch (clk) {
-        case SPI_CLK_10MHZ:  spi_clkdiv_pre = 2;    /* predivides 80 MHz to 40 MHz */
-                             spi_clkcnt_N = 4;      /* 4 cycles results into 10 MHz */
-                             break;
-        case SPI_CLK_5MHZ:   spi_clkdiv_pre = 2;    /* predivides 80 MHz to 40 MHz */
-                             spi_clkcnt_N = 8;      /* 8 cycles results into 5 MHz */
-                             break;
-        case SPI_CLK_1MHZ:   spi_clkdiv_pre = 2;    /* predivides 80 MHz to 40 MHz */
-                             spi_clkcnt_N = 40;     /* 40 cycles results into 1 MHz */
-                             break;
-        case SPI_CLK_400KHZ: spi_clkdiv_pre = 20;   /* predivides 80 MHz to 4 MHz */
-                             spi_clkcnt_N = 10;     /* 10 cycles results into 400 kHz */
-                             break;
-        case SPI_CLK_100KHZ: spi_clkdiv_pre = 20;   /* predivides 80 MHz to 4 MHz */
-                             spi_clkcnt_N = 40;     /* 20 cycles results into 100 kHz */
-                             break;
-        default: spi_clkdiv_pre = 20;   /* predivides 80 MHz to 4 MHz */
-                 spi_clkcnt_N = 40;     /* 20 cycles results into 100 kHz */
-    }
+    spi_clkcnt_N = 2;
+    spi_clkdiv_pre = (MHZ(80)/spi_clkcnt_N) / clk;
 
     /* register values are set to deviders-1 */
     spi_clkdiv_pre--;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The formula for the ESP8266 SPI clock is `clk_spi = clk_src / ((prediv + 1) * (N + 1))` where N has to be at least 1.

Since `prediv` is 13 bit, this gets us down to 4882 Hz without further touching N, so just use that.


### Testing procedure

I connected an oscilloscope to the clock pin of `esp8266-esp-12x` and tried out all pre-defined SPI clocks with `tests/periph/spi`:

```
2024-02-21 23:17:44,351 # Sent bytes
2024-02-21 23:17:44,359 #    0    1    2    3    4    5    6    7    8    9   10   11   12   13 
2024-02-21 23:17:44,365 #   0x74 0x68 0x69 0x73 0x20 0x69 0x73 0x20 0x61 0x20 0x74 0x65 0x73 0x74
2024-02-21 23:17:44,370 #     t    h    i    s         i    s         a         t    e    s    t 
2024-02-21 23:17:44,371 # 
2024-02-21 23:17:44,373 # Received bytes
2024-02-21 23:17:44,379 #    0    1    2    3    4    5    6    7    8    9   10   11   12   13 
2024-02-21 23:17:44,384 #   0x74 0x68 0x69 0x73 0x20 0x69 0x73 0x20 0x61 0x20 0x74 0x65 0x73 0x74
2024-02-21 23:17:44,392 #     t    h    i    s         i    s         a         t    e    s    t 
```

#### 100 kHz
![bmp_27_001](https://github.com/RIOT-OS/RIOT/assets/1301112/740d4b27-34a4-4b83-ae14-a3e95659de66)

#### 400 kHz
![bmp_27_002](https://github.com/RIOT-OS/RIOT/assets/1301112/c485c0fb-dcb0-4115-912f-b06cbbfcf5a5)

#### 1 MHz
![bmp_27_003](https://github.com/RIOT-OS/RIOT/assets/1301112/7aa66918-e627-4fe1-ad46-f49808a34cf5)

#### 5 MHz
![bmp_27_004](https://github.com/RIOT-OS/RIOT/assets/1301112/254d0cbd-d40e-43ce-9b1e-81b3e229f78f)

#### 10 MHz
![bmp_27_005](https://github.com/RIOT-OS/RIOT/assets/1301112/cf259e60-1a5b-487c-935b-4707fa9d4e37)



### Issues/PRs references

useful for #20218
