### PR TITLE
dist: tools: avoid hanging tapsetup in the absence of a DHCP server 

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -59,7 +59,7 @@ unsupported_platform() {
 
 update_uplink() {
     if command -v dhclient > /dev/null; then
-        dhclient $1
+        dhclient -nw $1
     else
         echo "DHCP client \`dhclient\` not found." >&2
         echo "Please reconfigure your DHCP client for interface $1" >&2


### PR DESCRIPTION
### Contribution description

"Become a daemon immediately (nowait) rather than waiting until an IP address has been acquired." Otherwise tapsetup may hang for a long time in the absence of a DHCP server.

### Testing procedure

Run `tapsetup -u <UPSTREAM-INTERFACE>` without a DHCP server ready on that link.