### PR TITLE
doc/roadmap: update contacts

### DIFF
--- a/doc/doxygen/src/roadmap.md
+++ b/doc/doxygen/src/roadmap.md
@@ -30,7 +30,7 @@ The text and items below are tentative, up for discussion, to be updated by regu
 - [Home-Assistant](https://www.home-assistant.io/) integration via [MQTT Discovery](https://www.home-assistant.io/integrations/mqtt#mqtt-discovery)
 
 # Power Modes
-(contact/steering: [Hauke](https://github.com/haukepetersen))
+(contact/steering: [benpicco](https://github.com/benpicco))
 
 - concept to fix shell usage issue while LPM activated
 - integrate generic power management functions in device driver APIs (netdev, SAUL, ...)
@@ -40,7 +40,7 @@ The text and items below are tentative, up for discussion, to be updated by regu
 
 
 # Peripheral drivers
-(contact/steering: [Hauke](https://github.com/haukepetersen))
+(contact/steering: [maribu](https://github.com/maribu))
 
 ## Timers
 


### PR DESCRIPTION
### Contribution description

Hauke has stopped working on RIOT for some time now and other maintainers agreed to step up to take over the steering / contact job during the VMA. This change replaces Hauke by benpicco and maribu as contact as agreed upon.

### Testing procedure

Check the [notes of the VMA](https://forum.riot-os.org/t/notes-virtual-maintainer-assembly-vma-2024-02/4118) to confirm that the change is as agreed upon.

### Issues/PRs references

None