### PR TITLE
README: Rephrase forum into more generic help

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,27 @@ Using Windows? Use [this guide][dev-setup-windows] to
 
 [dev-setup-windows]: doc/guides/setup-windows
 
-## Forum
-Do you have a question, want to discuss a new feature, or just want to present
-your latest project using RIOT? Come over to our [forum] and post to your hearts
-content.
+## Community
 
-[forum]: https://forum.riot-os.org
+You can ask for help on the Forum or on Matrix. Please send bug reports and
+feature requests to our [GitHub issue tracker](https://github.com/RIOT-OS/RIOT/issues)
+
+- [forum](https://forum.riot-os.org) is the default place to start asking for
+help. Our Forum provides an archive of prior questions and answers.
+- For chat, we use
+  [#riot-os:matrix.org](https://matrix.to/#/#riot-os:matrix.org) on the
+  [Matrix](https://matrix.org/) chat network.
+- [GitHub Issue tracker](https://github.com/RIOT-OS/RIOT/issues) for issues
+with the code and documentation.
+
+### How to Ask
+
+Please include as much detail as you can that is relevant to your question, not
+only "this isn't working". These details include:
+
+1. What you want to achieve.
+2. What have you tried so far (for example the commands you typed).
+3. What happened so far.
 
 ## Contribute
 


### PR DESCRIPTION
### Contribution description

This PR replaces the section called 'Forum' with a more generic section on 'asking for help'. I couldn't find something similar at first glance in our documentation so it is likely helpful for newcomers to explicitly add this.

### Testing procedure

Read the update to the readme and check whether all the links added work.


### Issues/PRs references

None