### PR TITLE
cpu/esp8266: Add missing MCU_ESP8266 define for vendor code

### DIFF
--- a/cpu/esp8266/vendor/esp-idf/Makefile
+++ b/cpu/esp8266/vendor/esp-idf/Makefile
@@ -11,3 +11,5 @@ ifneq (, $(filter esp_idf_heap, $(USEMODULE)))
 endif
 
 include $(RIOTBASE)/Makefile.base
+
+CFLAGS += -DMCU_ESP8266

--- a/cpu/esp_common/vendor/xtensa/Makefile
+++ b/cpu/esp_common/vendor/xtensa/Makefile
@@ -1,3 +1,7 @@
 MODULE=xtensa
 
 include $(RIOTBASE)/Makefile.base
+
+ifeq (esp8266,$(CPU))
+  CFLAGS += -DMCU_ESP8266
+endif


### PR DESCRIPTION
### Contribution description

Dropping the `MCU` variable in https://github.com/RIOT-OS/RIOT/pull/20397 resulted in breaking the compilation of the vendor code in a non-obvious way. Adding a `CFLAGS += -DMCU_ESP8266` specifically to the modules containing the vendor code that need this define fixes the issue.

### Testing procedure

ESP8266 should boot again

### Issues/PRs references

Follow up to https://github.com/RIOT-OS/RIOT/pull/20397

Alternative to https://github.com/RIOT-OS/RIOT/pull/20409