### PR TITLE
cpu/esp: Use CPU_ESP8266 define instead of the removed MCU_ESP8266

### DIFF
--- a/cpu/esp8266/vendor/esp-idf/esp8266/source/startup.c
+++ b/cpu/esp8266/vendor/esp-idf/esp8266/source/startup.c
@@ -53,7 +53,7 @@ static void user_init_entry(void *param)
 
     phy_get_bb_evm();
 
-#ifdef MCU_ESP8266
+#ifdef CPU_ESP8266
     /* initialize newlib system calls */
     extern void syscalls_init (void);
     syscalls_init ();

--- a/cpu/esp_common/vendor/xtensa/xtensa_vectors.S
+++ b/cpu/esp_common/vendor/xtensa/xtensa_vectors.S
@@ -493,7 +493,7 @@ User Exception (including Level 1 Interrupt from user mode).
 
 _UserExceptionVector:
 
-#ifdef MCU_ESP8266
+#ifdef CPU_ESP8266
     wsr     a0, EXCSAVE_1                   /* preserve a0 */
     j       _UserExceptionTrampoline        /* jump to handler trampoline */
 #else
@@ -504,7 +504,7 @@ _UserExceptionVector:
 
     .end        literal_prefix
 
-#ifdef MCU_ESP8266
+#ifdef CPU_ESP8266
 /*************************** LoadStoreError Handler BEGIN ********************/
 /*
  * PLEASE NOTE: The code between "LoadStoreError Handler BEGIN" and
@@ -549,7 +549,7 @@ _LoadStoreErrorHandlerStack:
 _UserExceptionTrampoline:
 
     wsr     a1, EXCSAVE_2                   /* preserve a1 */
-#ifdef MCU_ESP8266
+#ifdef CPU_ESP8266
     rsr     a1, exccause
     beqi    a1, CAUSE_LOADSTORE, _LoadStoreErrorHandler
 #endif
@@ -2010,7 +2010,7 @@ _xt_nmi:
     /* USER_EDIT:
     ADD HIGH PRIORITY NON-MASKABLE INTERRUPT (NMI) HANDLER CODE HERE.
     */
-    #if defined(RIOT_VERSION) && defined(MCU_ESP8266)
+    #if defined(RIOT_VERSION) && defined(CPU_ESP8266)
 
     rsr     a0, EXCSAVE + XCHAL_NMILEVEL /* restore a0 as saved in _NMIExceptionHandler */
 
@@ -2116,7 +2116,7 @@ _xt_nmi:
 
     /*************************** NMI Handler END ****************************/
 
-    #endif  /* defined(RIOT_VERSION) && defined(MCU_ESP8266) */
+    #endif  /* defined(RIOT_VERSION) && defined(CPU_ESP8266) */
 
     .align  4
 .L_xt_nmi_exit:


### PR DESCRIPTION
### Contribution description

Some vendor files we have in the ESP CPU area were modified to pick up our defines, in particular MCU_ESP8266. Our MCU went away in #20397, this fixes things by doing a change in the style of what was already done there for the ESP CPUs. (My original checks left those out because those were vendor files, and most other vendors have all kinds of MCU_SOMETHING_INTERNAL defines that are unrelated to our MCU defines).

### Testing procedure

* ESP8266 comes up with any applicaiton (I don't have one, reviewers please check)

### Issues/PRs references

Follow-up-for: https://github.com/RIOT-OS/RIOT/pull/20397 (where I broke this)
Closes: https://github.com/RIOT-OS/RIOT/pull/20409 (which inspired this)
Closes: https://github.com/RIOT-OS/RIOT/pull/20415 (which would also solve the issue but also keep the MCU_ variable mess)

### Acknowledgements

Thanks @maribu for finding in #20498 the precise cause, I'm just offering a different solution.