### PR TITLE
vscode: Add hard-coded path to compile_commands.json

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,11 @@
+{
+    "configurations": [
+        {
+            "name": "RIOT",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "compileCommands": "${workspaceFolder}/compile_commands.json"
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
### Contribution description

When run from Windows via WSL, VS Code just won't find the `compile_commands.json` otherwise.

### Testing procedure

1. Install VS Code in Windows (not in WSL)
2. Install WSL + Ubuntu
3. Install clang, clang, gcc-multilib, python3-serial, etc. in Ubuntin in WSL on Windows
4. Clone RIOT in Ubuntu in WSL on Windows, run `make compile-commands` in `examples/hello-world`
5. Install the WSL extension in VS Code in Windows (not in WSL)
6. Reboot WSL so that the WSL extensions gets automagically installed on the next run
7. Within Ubuntu/WSL inside the RIOT Repo run `code .` to launch VS Code in Windows, connected to WSL
8. Open `examples/hello-world/main.c`
9. Check if the `RIOT_BOARD` and the `RIOT_CPU` macros are defined an the value is presented as `"native"` when hovering with the mouse

In `master`, this doesn't work. With this PR, it should work.

### Issues/PRs references

None