### PR TITLE
cpu/native: return error code on failed assertion

### DIFF
--- a/cpu/native/panic.c
+++ b/cpu/native/panic.c
@@ -18,6 +18,7 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
+#include <errno.h>
 #include <unistd.h>
 #include <signal.h>
 
@@ -25,6 +26,9 @@
 
 void panic_arch(void)
 {
+    extern unsigned _native_retval;
+    _native_retval = EINVAL;
+
 #ifdef DEVELHELP
     /* since we're atop an Unix-like platform,
        just use the (developer-)friendly core-dump feature */

--- a/cpu/native/periph/pm.c
+++ b/cpu/native/periph/pm.c
@@ -36,6 +36,8 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+unsigned _native_retval = EXIT_SUCCESS;
+
 static void _native_sleep(void)
 {
     _native_in_syscall++; /* no switching here */
@@ -75,7 +77,7 @@ void pm_off(void)
     extern void auto_unmount_vfs(void);
     auto_unmount_vfs();
 #endif
-    real_exit(EXIT_SUCCESS);
+    real_exit(_native_retval);
 }
 
 void pm_reboot(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When `native` hits a failed assertion, it will exit but the exit code will still be `EXIT_SUCCESS`.

Fix this by setting an error exit code in the `panic_arch()` handler.


### Testing procedure

I added an `assert(0)` in `examples/hello-world`:

```
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2024.04-devel-291-gd83ec)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native CPU.
examples/hello-world/main.c:32 => *** RIOT kernel panic:
FAILED ASSERTION.

*** halted.


native: exiting
22 benpicco@T430s ~/dev/RIOT/examples/hello-world (git)-[cpu/native_assert-reval] %
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
