### PR TITLE
cpu/native/panic.c: exit with -1

### DIFF
--- a/cpu/native/panic.c
+++ b/cpu/native/panic.c
@@ -30,4 +30,5 @@ void panic_arch(void)
        just use the (developer-)friendly core-dump feature */
     kill(_native_pid, SIGTRAP);
 #endif
+    real_exit(-1);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
On native, exit with -1 on panic. It makes e.g. a failed `assert` to end the program with an error result code. This is useful e.g. for test scripts to determine whether the program ended successfully or not.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
An `assert(0)` should make the native program return `255`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
