### PR TITLE
boards/feather-nrf52840*: doc cleanup

### DIFF
--- a/boards/feather-nrf52840-sense/doc.txt
+++ b/boards/feather-nrf52840-sense/doc.txt
@@ -5,27 +5,32 @@
 
 ### General information
 
-[The Feather nRF52840 Sense][feather-nrf52840-sense] is a development board
-from Adafruits Feather board family. It is very similar to the [The Feather
+The [Feather nRF52840 Sense][feather-nrf52840-sense] is a development board
+from Adafruits Feather board family. It is very similar to the [Feather
 nRF52840 Express][feather-nrf52840] but comes with more sensors.
 
 It provides native USB support, Bluetooth
 Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
 
-![top-down view on feather-nrf52840-sense][top-down view]
+<img src="https://cdn-learn.adafruit.com/assets/assets/000/089/096/original/sensors_Feather_Sense_top.jpg"
+     alt="top-down view on feather-nrf52840-sense" width="50%"/>
 
 [feather-nrf52840]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/
 [feather-nrf52840-sense]: https://learn.adafruit.com/adafruit-feather-sense
-[top-down view]: https://cdn-learn.adafruit.com/assets/assets/000/089/096/original/sensors_Feather_Sense_top.jpg
 
 ### Flashing, Bootloader, and Terminal
 
-Refer to [The Feather nRF52840 Express
+Refer to the [Feather nRF52840 Express
 documentation](https://doc.riot-os.org/group__boards__feather-nrf52840.html) for further details.
 Both use the same flasher, bootloader, and terminal settings.
 
+Example with `hello-world` application:
+```
+     make BOARD=feather-nrf52840-sense -C examples/hello-world flash term
+```
+
 On "fresh" boards the
-[bootloader may need to be updated](https://learn.adafruit.com/adafruit-feather-sense/update-bootloader)
+[bootloader may need to be updated](https://learn.adafruit.com/adafruit-feather-sense/update-bootloader).
 
 #### Updating Old Bootloaders
 

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -5,14 +5,14 @@
 
 ### General information
 
-[The Feather nRF52840 Express][feather-nrf52840] is a development board
+The [Feather nRF52840 Express][feather-nrf52840] is a development board
 from Adafruits Feather board family. It provides native USB support, Bluetooth
 Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
 
-![top-down view on feather-nrf52840][top-down view]
+<img src="https://cdn-learn.adafruit.com/assets/assets/000/068/578/medium800/circuitpython_Screenshot_2019-01-02_at_12.04.27.png"
+     alt="top-down view on feather-nrf52840" width="50%"/>
 
 [feather-nrf52840]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/
-[top-down view]: https://cdn-learn.adafruit.com/assets/assets/000/068/578/medium800/circuitpython_Screenshot_2019-01-02_at_12.04.27.png
 
 ### Flash the board
 
@@ -20,22 +20,28 @@ The board is flashed using its on-board UF2 boot loader by default.
 The boot loader will present a mass storage device that has to be mounted to /media/MDK-DONGLE so
 `uf2conv.py` can find it. If you have an auto-mounter installed this will happen automatically.
 
-The rest of the process is automated in the usual `make flash` target.
+The rest of the process is automated in the usual way with `BOARD=feather-nrf52840`.
+
+Example with `hello-world` application:
+```
+     make BOARD=feather-nrf52840 -C examples/hello-world flash term
+```
 
 If RIOT is already running on the board, it will automatically reset the CPU and enter
 the bootloader.
 If some other firmware is running or RIOT crashed, you need to enter the bootloader
-manually by pressing the board's reset button while plugging the device into the
+manually by double-tapping the board's reset button while the device is connected.
 
-Otherwise See the **Flashing** section in @ref boards_common_nrf52. The easiest way is to
+Otherwise see the **Flashing** section in @ref boards_common_nrf52. The easiest way is to
 use an external Segger J-Link Programmer connected to the [SWD Connector].
 
 [SWD Connector]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/pinouts#swd-connector-3-12
 
 #### Flashing the uf2 bootloader
 
-To flash the uf2 bootloader (if its no longer present on your BOARD) then with
-a jlink attached to your BOARD and [`nrfjprog`][nrfjprog] installed:
+To flash the uf2 bootloader (if it is no longer present on your BOARD),
+you need to have [`nrfjprog`][nrfjprog] installed,
+connect a jlink to your BOARD and execute the following commands:
 
 ~~~~~~~~~~~~~{.sh}
 git clone git@github.com:adafruit/Adafruit_nRF52_Bootloader.git


### PR DESCRIPTION
### Contribution description

Make sure the board name (needed for `BOARD=`) is mentioned in the documentation.


### Testing procedure

Look at the CI-generated docs for [`boards/feather-nrf52840`](https://ci.riot-os.org/results/130163c049924aafb514f5d690466a9b/doc-preview/group__boards__feather-nrf52840.html) and [`boards/feather-nrf52840-sense`](https://ci.riot-os.org/results/130163c049924aafb514f5d690466a9b/doc-preview/group__boards__feather-nrf52840-sense.html).
