### PR TITLE
tests/pkg/flashdb_fal_cfg: abort test if no MTD device is configured

### DIFF
--- a/pkg/flashdb/mtd/fal_mtd_port.c
+++ b/pkg/flashdb/mtd/fal_mtd_port.c
@@ -74,6 +74,8 @@ struct fal_flash_dev mtd_flash0 = {
 
 void fdb_mtd_init(mtd_dev_t *mtd)
 {
+    assert(mtd);
+
     unsigned sector_size;
     if (_mtd) {
         return;

--- a/tests/pkg/flashdb_fal_cfg/main.c
+++ b/tests/pkg/flashdb_fal_cfg/main.c
@@ -103,6 +103,11 @@ static fdb_time_t _get_time(void)
 
 int main(void)
 {
+    if (FDB_MTD == NULL) {
+        puts("No MTD device configured for test, abort.");
+        return -1;
+    }
+
     int init_failed;
     fdb_mtd_init(FDB_MTD);
     size_t size = FDB_MTD->pages_per_sector * FDB_MTD->page_size;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Instead of doing random things with uninitialized data, abort the test if there is no MTD device.


### Testing procedure

Now a clear error message is printed in absence of a MTD device instead of a random failure. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
