### PR TITLE
cpu/native: add gpio-mock

### DIFF
--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -96,6 +96,52 @@ typedef enum {
 } gpio_flank_t;
 
 /** @} */
+#elif defined(MODULE_PERIPH_GPIO_MOCK)
+
+/**
+ * @brief   Mocked GPIO
+ *
+ * Mocked GPIO representation for simulation.
+ * @{
+ */
+typedef struct {
+    int value;              /**< current value */
+    int mode;               /**< current mode */
+    int flank;              /**< flank to trigger interrupts */
+    void (*cb)(void *arg);  /**< ISR */
+    void *arg;              /**< ISR arg */
+} gpio_mock_t;
+/** @} */
+
+#define GPIO_UNDEF          0
+
+#ifndef GPIO_PORT_MAX
+#define GPIO_PORT_MAX       (16)
+#endif
+
+#ifndef GPIO_PIN_MAX
+#define GPIO_PIN_MAX        (32)
+#endif
+
+/**
+ * @brief Mocked GPIO array
+ */
+extern gpio_mock_t gpio_mock[GPIO_PORT_MAX][GPIO_PIN_MAX];
+
+#define HAVE_GPIO_T
+/**
+ * @brief   Pointer on a mocked GPIO
+ */
+typedef gpio_mock_t* gpio_t;
+
+/**
+ * @brief   Define a custom GPIO_PIN macro for native mocked GPIO framework.
+ *          Get the mocked GPIO object from mocked GPIO array.
+ */
+#define GPIO_PIN(port, pin) \
+    (((port >= 0) && (pin >= 0) && (port < GPIO_PORT_MAX) && (pin < GPIO_PIN_MAX)) \
+     ? &gpio_mock[port][pin] \
+     : GPIO_UNDEF)
 
 #endif /* MODULE_PERIPH_GPIO_LINUX | DOXYGEN */
 

--- a/cpu/native/periph/gpio_mock.c
+++ b/cpu/native/periph/gpio_mock.c
@@ -19,14 +19,14 @@
 
 #include "periph/gpio.h"
 
-int gpio_init(gpio_t pin, gpio_mode_t mode) {
+__attribute__((weak)) int gpio_init(gpio_t pin, gpio_mode_t mode) {
     (void) pin;
     (void) mode;
 
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+__attribute__((weak)) int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                   gpio_cb_t cb, void *arg)
 {
     (void) pin;
@@ -38,35 +38,35 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+__attribute__((weak)) void gpio_irq_enable(gpio_t pin)
 {
     (void) pin;
 }
 
-void gpio_irq_disable(gpio_t pin)
+__attribute__((weak)) void gpio_irq_disable(gpio_t pin)
 {
     (void) pin;
 }
 
-int gpio_read(gpio_t pin) {
+__attribute__((weak)) int gpio_read(gpio_t pin) {
   (void) pin;
 
   return 0;
 }
 
-void gpio_set(gpio_t pin) {
+__attribute__((weak)) void gpio_set(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_clear(gpio_t pin) {
+__attribute__((weak)) void gpio_clear(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_toggle(gpio_t pin) {
+__attribute__((weak)) void gpio_toggle(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_write(gpio_t pin, int value) {
+__attribute__((weak)) void gpio_write(gpio_t pin, int value) {
   (void) pin;
   (void) value;
 }

--- a/cpu/native/periph/gpio_mock.c
+++ b/cpu/native/periph/gpio_mock.c
@@ -19,23 +19,41 @@
 
 #include "periph/gpio.h"
 
+/**
+ * @brief Mocked GPIO array
+ */
+gpio_mock_t gpio_mock[GPIO_PORT_MAX][GPIO_PIN_MAX];
+
 __attribute__((weak)) int gpio_init(gpio_t pin, gpio_mode_t mode) {
     (void) pin;
     (void) mode;
 
-    return 0;
+    if (pin) {
+        pin->mode = mode;
+        pin->value = 0;
+        return 0;
+    }
+
+    return -1;
 }
 
 __attribute__((weak)) int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                   gpio_cb_t cb, void *arg)
 {
-    (void) pin;
-    (void) mode;
-    (void) flank;
     (void) cb;
     (void) arg;
 
-    return 0;
+    if (pin) {
+        pin->mode = mode;
+        pin->flank = flank;
+        pin->value = 0;
+        pin->cb = cb;
+        pin->arg = arg;
+
+        return 0;
+    }
+
+    return -1;
 }
 
 __attribute__((weak)) void gpio_irq_enable(gpio_t pin)
@@ -49,26 +67,35 @@ __attribute__((weak)) void gpio_irq_disable(gpio_t pin)
 }
 
 __attribute__((weak)) int gpio_read(gpio_t pin) {
-  (void) pin;
+  if (pin) {
+    return pin->value;
+  }
 
-  return 0;
+  return -1;
 }
 
 __attribute__((weak)) void gpio_set(gpio_t pin) {
-  (void) pin;
+  if (pin) {
+    pin->value = 1;
+  }
 }
 
 __attribute__((weak)) void gpio_clear(gpio_t pin) {
-  (void) pin;
+  if (pin) {
+    pin->value = 0;
+  }
 }
 
 __attribute__((weak)) void gpio_toggle(gpio_t pin) {
-  (void) pin;
+  if (pin) {
+    pin->value ^= 1;
+  }
 }
 
 __attribute__((weak)) void gpio_write(gpio_t pin, int value) {
-  (void) pin;
-  (void) value;
+  if (pin) {
+    pin->value = value;
+  }
 }
 
 /** @} */

--- a/cpu/native/periph/gpio_mock.c
+++ b/cpu/native/periph/gpio_mock.c
@@ -20,13 +20,10 @@
 #include "periph/gpio.h"
 
 int gpio_init(gpio_t pin, gpio_mode_t mode) {
-  (void) pin;
-  (void) mode;
+    (void) pin;
+    (void) mode;
 
-  if (mode >= GPIO_OUT)
     return 0;
-  else
-    return -1;
 }
 
 int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
@@ -38,7 +35,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     (void) cb;
     (void) arg;
 
-    return -1;
+    return 0;
 }
 
 void gpio_irq_enable(gpio_t pin)

--- a/cpu/native/periph/qdec.c
+++ b/cpu/native/periph/qdec.c
@@ -71,9 +71,7 @@ int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
     }
 
     /* Initialize qdec channels */
-    for (uint8_t i = 0; i < QDEC_NUMOF; i++) {
-        qdecs[qdec] = 0;
-    }
+    qdecs[qdec] = 0;
 
     /* Reset counter and start qdec */
     qdec_start(qdec);


### PR DESCRIPTION
### Contribution description

Modify gpio-mock to allow arbitrary GPIO emulation.

### Testing procedure

Build:
```shell
$ make -C tests/periph/gpio BOARD=native -j
make : on entre dans le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/periph/gpio »
Building application "tests_gpio" for "native" with CPU "native".

"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/common/init
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/core
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/core/lib
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/drivers
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/native/drivers
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/drivers/periph_common
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/auto_init
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/benchmark
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/frac
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/isrpipe
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/libc
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/preprocessor
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/shell
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/shell/cmds
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/test_utils/interactive_sync
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/test_utils/print_stack_usage
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/tsrb
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/ztimer
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native/periph
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native/stdio_native
   text	   data	    bss	    dec	    hex	filename
  49771	    844	  58120	 108735	  1a8bf	/home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/periph/gpio/bin/native/tests_gpio.elf
make : on quitte le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/periph/gpio »
```

Test:
```shell
$ tests/periph/gpio/bin/native/tests_gpio.elf
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2024.04-devel-390-gebf95d-native_fixes)
GPIO peripheral driver test

In this test, pins are specified by integer port and pin numbers.
So if your platform has a pin PA01, it will be port=0 and pin=1,
PC14 would be port=2 and pin=14 etc.

NOTE: make sure the values you use exist on your platform! The
      behavior for not existing ports/pins is not defined!
> init_in 0 10
init_in 0 10
> read 0 10
read 0 10
GPIO_PIN(0.10) is LOW
> set 0 10
set 0 10
> read 0 10
read 0 10
GPIO_PIN(0.10) is HIGH
> bench 0 10
bench 0 10

GPIO driver run-time performance benchmark

                 nop loop:        46us  ---   0.000us per call  ---  2173913043 calls per sec
                 gpio_set:       346us  ---   0.003us per call  ---  289017341 calls per sec
               gpio_clear:       346us  ---   0.003us per call  ---  289017341 calls per sec
              gpio_toggle:       387us  ---   0.003us per call  ---  258397932 calls per sec
                gpio_read:       329us  ---   0.003us per call  ---  303951367 calls per sec
               gpio_write:       382us  ---   0.003us per call  ---  261780104 calls per sec

 --- DONE ---
> clear 0 10
clear 0 10
> read 0 10
read 0 10
GPIO_PIN(0.10) is LOW
> init_out 0 10
init_out 0 10
> read 0 10
read 0 10
GPIO_PIN(0.10) is LOW
> set 0 10
set 0 10
> read 0 10
read 0 10
GPIO_PIN(0.10) is HIGH
> 
```