### PR TITLE
drivers/pcf857x: fix missing include kernel_defines.h

### DIFF
--- a/drivers/include/pcf857x.h
+++ b/drivers/include/pcf857x.h
@@ -249,6 +249,8 @@ extern "C"
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "kernel_defines.h"
+
 #include "periph/gpio.h"
 #include "periph/i2c.h"
 


### PR DESCRIPTION
### Contribution description
If not included before, IS_USED macro from modules.h is undefined, leading to such errors:
  error: missing binary operator before token "("


### Testing procedure

```shell
make -C tests/drivers/pcf857x/ BOARD=native
```

Depends on https://github.com/RIOT-OS/RIOT/pull/20430
Depends on https://github.com/RIOT-OS/RIOT/pull/20431