### PR TITLE
coap: ensure DTLS buffer is at least 200 bytes

### DIFF
--- a/sys/net/application_layer/gcoap/Makefile.include
+++ b/sys/net/application_layer/gcoap/Makefile.include
@@ -4,4 +4,5 @@ ifeq (2, $(words $(filter ipv4 ipv6, $(USEMODULE))))
 endif
 
 CONFIG_GCOAP_PDU_BUF_SIZE := $(or $(CONFIG_GCOAP_PDU_BUF_SIZE),128)
-DTLS_MAX_BUF ?= ($(CONFIG_GCOAP_PDU_BUF_SIZE) + 36)
+# the initial DTLS handshake may exceed the block size
+DTLS_MAX_BUF ?= $(shell echo $$(((${CONFIG_GCOAP_PDU_BUF_SIZE} + 36) > 200 ? (${CONFIG_GCOAP_PDU_BUF_SIZE} + 36) : 200 )))

--- a/sys/net/application_layer/nanocoap/Makefile.include
+++ b/sys/net/application_layer/nanocoap/Makefile.include
@@ -1,4 +1,7 @@
 ifneq (,$(filter nanocoap_dtls,$(USEMODULE)))
   CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT := $(or $(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT),2)
-  DTLS_MAX_BUF ?= ((1 << ($(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT) + 3)) + 36)
+  NANOCOAP_BLOCK_FRAME := (1 << ($(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT) + 4)) + 36
+  NANOCOAP_BLOCK_FRAME := $(shell echo $$((${NANOCOAP_BLOCK_FRAME})))
+  # the initial DTLS handshake may exceed the block size
+  DTLS_MAX_BUF ?= $(shell echo $$((${NANOCOAP_BLOCK_FRAME} > 200 ? ${NANOCOAP_BLOCK_FRAME} : 200 )))
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The initial DTLS handshake can be larger than a block in CoAP block-wise.
#19892 reduced the DTLS buffer to a CoAP block size + 36 bytes.
This has proven to be too little, breaking DTLS clients.

Bump `DTLS_MAX_BUF` to be at least 200 bytes as this has proven to work well in the past.


### Testing procedure

First, create the tap interfaces by running `sudo dist/tools/tapsetup/tapsetup`.

In one terminal, run the GCoAP DTSL server:

`make -C examples/gcoap_dtls PORT=tap1 all term`
```
2024-02-26 20:18:43,184 # main(): This is RIOT! (Version: 2024.04-devel-327-gb8d58-DTLS_MAX_BUF-fix)
2024-02-26 20:18:43,184 # gcoap example app
2024-02-26 20:18:43,185 # All up, running the shell now

2024-02-26 20:22:23,060 # > ifconfig
2024-02-26 20:22:23,060 # Iface  7  HWaddr: 5A:1A:98:23:2D:6C 
2024-02-26 20:22:23,061 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2024-02-26 20:22:23,061 #           Link type: wired
2024-02-26 20:22:23,062 #           inet6 addr: fe80::581a:98ff:fe23:2d6c  scope: link  VAL
2024-02-26 20:22:23,063 #           inet6 group: ff02::1
2024-02-26 20:22:23,063 #           inet6 group: ff02::1:ff23:2d6c
```

In another terminal, run the nanoCoAP DTLS client:

`make -C tests/net/nanocoap_cli PORT=tap0 all term`
```
2024-02-26 20:23:47,051 # main(): This is RIOT! (Version: 2024.04-devel-326-gf04871)
2024-02-26 20:23:47,052 # nanocoap test app
2024-02-26 20:23:47,052 # All up, running the shell now

2024-02-26 20:23:52,901 # > ncget coaps://[fe80::581a:98ff:fe23:2d6c]/.well-known/core -
2024-02-26 20:23:52,905 # </cli/stats>;ct=0;rt="count";obs,</riot/board>
```

In `master` this would yield

```
2024-02-26 20:25:18,617 # main(): This is RIOT! (Version: 2024.04-devel-326-gf04871)
2024-02-26 20:25:18,618 # nanocoap test app
2024-02-26 20:25:18,618 # All up, running the shell now

2024-02-26 20:25:19,605 # > ncget coaps://[fe80::581a:98ff:fe23:2d6c]/.well-known/core -
2024-02-26 20:25:19,606 # cannot send ClientHello
2024-02-26 20:25:20,606 # cannot send ClientHello
2024-02-26 20:25:22,607 # cannot send ClientHello
```


### Issues/PRs references

follow-up to #19892
