### PR TITLE
drivers/pcf857x: stop (ab)using gpio_t

### DIFF
--- a/drivers/include/pcf857x.h
+++ b/drivers/include/pcf857x.h
@@ -297,7 +297,7 @@ extern "C"
 /** @} */
 
 /** conversion of (port x : pin y) to a pin number */
-#define PCF857X_GPIO_PIN(x,y)  ((gpio_t)((x << 3) | y))
+#define PCF857X_GPIO_PIN(x,y)  (y)
 
 /**
  * @name   Module dependent definitions and declarations
@@ -484,7 +484,7 @@ int pcf857x_init(pcf857x_t *dev, const pcf857x_params_t *params);
  * @retval  0                   on success
  * @retval  <0                  a negative errno error code on error
  */
-int pcf857x_gpio_init(pcf857x_t *dev, gpio_t pin, gpio_mode_t mode);
+int pcf857x_gpio_init(pcf857x_t *dev, uint8_t pin, gpio_mode_t mode);
 
 #if IS_USED(MODULE_PCF857X_IRQ) || DOXYGEN
 /**
@@ -522,7 +522,7 @@ int pcf857x_gpio_init(pcf857x_t *dev, gpio_t pin, gpio_mode_t mode);
  * @retval  0                   on success
  * @retval  <0                  a negative errno error code on error
  */
-int pcf857x_gpio_init_int(pcf857x_t *dev, gpio_t pin,
+int pcf857x_gpio_init_int(pcf857x_t *dev, uint8_t pin,
                                           gpio_mode_t mode,
                                           gpio_flank_t flank,
                                           gpio_cb_t isr,
@@ -538,7 +538,7 @@ int pcf857x_gpio_init_int(pcf857x_t *dev, gpio_t pin,
  * @param[in]   dev     descriptor of PCF857X I/O expander device
  * @param[in]   pin     pin to read, use PCF857X_GPIO_PIN(x,y) to specify
  */
-int pcf857x_gpio_read(pcf857x_t *dev, gpio_t pin);
+int pcf857x_gpio_read(pcf857x_t *dev, uint8_t pin);
 
 /**
  * @brief   Write the value to PCF857X input pin
@@ -547,7 +547,7 @@ int pcf857x_gpio_read(pcf857x_t *dev, gpio_t pin);
  * @param[in]   pin     pin to write, use PCF857X_GPIO_PIN(x,y) to specify
  * @param[in]   value   value to write
  */
-void pcf857x_gpio_write(pcf857x_t *dev, gpio_t pin, int value);
+void pcf857x_gpio_write(pcf857x_t *dev, uint8_t pin, int value);
 
 /**
  * @brief   Clear the PCF857X output pin
@@ -555,7 +555,7 @@ void pcf857x_gpio_write(pcf857x_t *dev, gpio_t pin, int value);
  * @param[in]   dev     descriptor of PCF857X I/O expander device
  * @param[in]   pin     pin to clear, use PCF857X_GPIO_PIN(x,y) to specify
  */
-void pcf857x_gpio_clear(pcf857x_t *dev, gpio_t pin);
+void pcf857x_gpio_clear(pcf857x_t *dev, uint8_t pin);
 
 /**
  * @brief   Set the PCF857X output pin
@@ -563,7 +563,7 @@ void pcf857x_gpio_clear(pcf857x_t *dev, gpio_t pin);
  * @param[in]   dev     descriptor of PCF857X I/O expander device
  * @param[in]   pin     pin to set, use PCF857X_GPIO_PIN(x,y) to specify
  */
-void pcf857x_gpio_set(pcf857x_t *dev, gpio_t pin);
+void pcf857x_gpio_set(pcf857x_t *dev, uint8_t pin);
 
 /**
  * @brief   Toggle the value of the PCF857X output pin
@@ -571,7 +571,7 @@ void pcf857x_gpio_set(pcf857x_t *dev, gpio_t pin);
  * @param[in]   dev     descriptor of PCF857X I/O expander device
  * @param[in]   pin     pin to toggle, use PCF857X_GPIO_PIN(x,y) to specify
  */
-void pcf857x_gpio_toggle(pcf857x_t *dev, gpio_t pin);
+void pcf857x_gpio_toggle(pcf857x_t *dev, uint8_t pin);
 
 #if IS_USED(MODULE_PCF857X_IRQ) || DOXYGEN
 /**
@@ -583,7 +583,7 @@ void pcf857x_gpio_toggle(pcf857x_t *dev, gpio_t pin);
  * @param[in]   dev     descriptor of PCF857X I/O expander device
  * @param[in]   pin     pin to enable the interrupt for
  */
-void pcf857x_gpio_irq_enable(pcf857x_t *dev, gpio_t pin);
+void pcf857x_gpio_irq_enable(pcf857x_t *dev, uint8_t pin);
 
 /**
  * @brief   Disable pin interrupt
@@ -594,7 +594,7 @@ void pcf857x_gpio_irq_enable(pcf857x_t *dev, gpio_t pin);
  * @param[in]   dev     descriptor of PCF857X I/O expander device
  * @param[in]   pin     pin to enable the interrupt for
  */
-void pcf857x_gpio_irq_disable(pcf857x_t *dev, gpio_t pin);
+void pcf857x_gpio_irq_disable(pcf857x_t *dev, uint8_t pin);
 #endif /* MODULE_PCF857X_IRQ || DOXYGEN */
 
 #ifdef __cplusplus

--- a/drivers/pcf857x/pcf857x.c
+++ b/drivers/pcf857x/pcf857x.c
@@ -147,13 +147,13 @@ int pcf857x_init(pcf857x_t *dev, const pcf857x_params_t *params)
     return res;
 }
 
-int pcf857x_gpio_init(pcf857x_t *dev, gpio_t pin, gpio_mode_t mode)
+int pcf857x_gpio_init(pcf857x_t *dev, uint8_t pin, gpio_mode_t mode)
 {
     /* some parameter sanity checks */
     assert(dev != NULL);
     assert(pin < dev->pin_num);
 
-    DEBUG_DEV("pin=%u mode=%u", dev, (unsigned)pin, (unsigned)mode);
+    DEBUG_DEV("pin=%u mode=%u", dev, pin, (unsigned)mode);
 
     /*
      * Since the LOW output is the only actively driven level possible with
@@ -209,7 +209,7 @@ int pcf857x_gpio_init(pcf857x_t *dev, gpio_t pin, gpio_mode_t mode)
 }
 
 #if IS_USED(MODULE_PCF857X_IRQ)
-int pcf857x_gpio_init_int(pcf857x_t *dev, gpio_t pin,
+int pcf857x_gpio_init_int(pcf857x_t *dev, uint8_t pin,
                                           gpio_mode_t mode,
                                           gpio_flank_t flank,
                                           gpio_cb_t isr,
@@ -237,7 +237,7 @@ int pcf857x_gpio_init_int(pcf857x_t *dev, gpio_t pin,
     return PCF857X_OK;
 }
 
-void pcf857x_gpio_irq_enable(pcf857x_t *dev, gpio_t pin)
+void pcf857x_gpio_irq_enable(pcf857x_t *dev, uint8_t pin)
 {
     /* some parameter sanity checks */
     assert(dev != NULL);
@@ -247,7 +247,7 @@ void pcf857x_gpio_irq_enable(pcf857x_t *dev, gpio_t pin)
     dev->enabled[pin] = true;
 }
 
-void pcf857x_gpio_irq_disable(pcf857x_t *dev, gpio_t pin)
+void pcf857x_gpio_irq_disable(pcf857x_t *dev, uint8_t pin)
 {
     /* some parameter sanity checks */
     assert(dev != NULL);
@@ -258,13 +258,13 @@ void pcf857x_gpio_irq_disable(pcf857x_t *dev, gpio_t pin)
 }
 #endif
 
-int pcf857x_gpio_read(pcf857x_t *dev, gpio_t pin)
+int pcf857x_gpio_read(pcf857x_t *dev, uint8_t pin)
 {
     /* some parameter sanity checks */
     assert(dev != NULL);
     assert(pin < dev->pin_num);
 
-    DEBUG_DEV("pin=%u", dev, (unsigned)pin);
+    DEBUG_DEV("pin=%u", dev, pin);
 
     /*
      * If we use the interrupt, we always have an up-to-date input snapshot
@@ -279,13 +279,13 @@ int pcf857x_gpio_read(pcf857x_t *dev, gpio_t pin)
     return (dev->in &(1 << pin)) ? 1 : 0;
 }
 
-void pcf857x_gpio_write(pcf857x_t *dev, gpio_t pin, int value)
+void pcf857x_gpio_write(pcf857x_t *dev, uint8_t pin, int value)
 {
     /* some parameter sanity checks */
     assert(dev != NULL);
     assert(pin < dev->pin_num);
 
-    DEBUG_DEV("pin=%u value=%d", dev, (unsigned)pin, value);
+    DEBUG_DEV("pin=%u value=%d", dev, pin, value);
 
     /* set pin bit value */
     if (value) {
@@ -316,21 +316,21 @@ void pcf857x_gpio_write(pcf857x_t *dev, gpio_t pin, int value)
 #endif
 }
 
-void pcf857x_gpio_clear(pcf857x_t *dev, gpio_t pin)
+void pcf857x_gpio_clear(pcf857x_t *dev, uint8_t pin)
 {
-    DEBUG_DEV("pin=%u", dev, (unsigned)pin);
+    DEBUG_DEV("pin=%u", dev, pin);
     return pcf857x_gpio_write(dev, pin, 0);
 }
 
-void pcf857x_gpio_set(pcf857x_t *dev, gpio_t pin)
+void pcf857x_gpio_set(pcf857x_t *dev, uint8_t pin)
 {
-    DEBUG_DEV("pin=%u", dev, (unsigned)pin);
+    DEBUG_DEV("pin=%u", dev, pin);
     return pcf857x_gpio_write(dev, pin, 1);
 }
 
-void pcf857x_gpio_toggle(pcf857x_t *dev, gpio_t pin)
+void pcf857x_gpio_toggle(pcf857x_t *dev, uint8_t pin)
 {
-    DEBUG_DEV("pin=%u", dev, (unsigned)pin);
+    DEBUG_DEV("pin=%u", dev, pin);
     return pcf857x_gpio_write(dev, pin, (dev->out & (1 << pin)) ? 0 : 1);
 }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The driver only supports addressing GPIOs by their index, (ab)using `gpio_t` for that will break on platforms that encode GPIO values differently.


### Testing procedure

I don't have the hardware to test this, but this should be a simple conversion as the driver expects that `gpio_t` just encodes the pin number in lower 3 bits of `gpio_t`.

It never accesses the 'port' bits (which would be implementation defined anyway).


### Issues/PRs references

triggered some unnecessary workarounds in #20431 
