### PR TITLE
boards/feather-nrf52840-sense: declare lsm6ds33 accelerometer

### DIFF
--- a/boards/feather-nrf52840-sense/Makefile.dep
+++ b/boards/feather-nrf52840-sense/Makefile.dep
@@ -2,6 +2,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += apds9960
   USEMODULE += bmp280_i2c
   USEMODULE += lis3mdl
+  USEMODULE += lsm6ds33
   USEMODULE += saul_gpio
   USEMODULE += sht3x
 endif


### PR DESCRIPTION
### Contribution description

Declare that the accelerometer/gyroscope/temperature sensor `lsm6ds33` is available on the `feather-nrf52840-sense` so it is recognized by SAUL.


### Testing procedure

`make -C tests/drivers/saul BOARD=feather-nrf52840-sense term`

this adds the following to the output compared to `master` (example values):

```
2024-02-27 19:41:53,945 # Dev: lsm6dsxx Type: SENSE_ACCEL
2024-02-27 19:41:53,946 # Data: [0]           0 mgₙ
2024-02-27 19:41:53,946 #       [1]          37 mgₙ
2024-02-27 19:41:53,947 #       [2]        1030 mgₙ
2024-02-27 19:41:53,948 # 
2024-02-27 19:41:53,949 # Dev: lsm6dsxx Type: SENSE_GYRO
2024-02-27 19:41:53,949 # Data: [0]         3.2 dps
2024-02-27 19:41:53,950 #       [1]        -5.5 dps
2024-02-27 19:41:53,950 #       [2]        -1.6 dps
2024-02-27 19:41:53,950 # 
2024-02-27 19:41:53,951 # Dev: lsm6dsxx Type: SENSE_TEMP
2024-02-27 19:41:53,952 # Data:           24.66 °C
```

### Issues/PRs references

see #20027 for the initial port and #20170 for the (later merged) driver support in RIOT
