### PR TITLE
pkg/uwb-dw1000: fix README include

### DIFF
--- a/pkg/uwb-dw1000/doc.txt
+++ b/pkg/uwb-dw1000/doc.txt
@@ -4,5 +4,5 @@
  * @brief    uwb-core driver for Decawave DW1000 transceiver
  * @see      https://github.com/Decawave/uwb-dw1000
  *
- * @include pkg/ucglib/README.md
+ * @include pkg/uwb-dw1000/README.md
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The doc.txt file of the uwb-dw1000 package included to the incorrect README.md file (from pkg/ucglib) instead of pkg/uwb-dw1000, which led to the generation of incorrect Doxygen documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

With the change applied, the Doxygen documentation should still successfully build and now have the correct description of the UWB-DW1000 package.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

No separate issue opened.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
