### PR TITLE
build system: drop bogus periph_init_gpio_ll* modules

### DIFF
--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -24,11 +24,7 @@ PERIPH_IGNORE_MODULES := \
   periph_flash \
   periph_flashpage_in_address_space \
   periph_flexcomm \
-  periph_gpio_ll \
-  periph_gpio_ll_irq \
-  periph_gpio_ll_irq_level_triggered_high \
-  periph_gpio_ll_irq_level_triggered_low \
-  periph_gpio_ll_irq_unmask \
+  periph_gpio_ll% \
   periph_gpio_mux \
   periph_hash_sha_1 \
   periph_hash_sha_224 \


### PR DESCRIPTION
### Contribution description

This does not change binaries, but it drops a lot of bogus modules that do not exist from `make info-modules`.

### Testing procedure

1. Run `make BOARD=<SOME_BOARD> -C tests/periph/gpio_ll info-modules` with `master` and this PR. Modules like `periph_init_gpio_ll_input_pull_down` should disappear.
2. Bun `make RIOT_CI_BUILD=1 BOARD=<SOME_BOARD> -C tests/periph/gpio_ll` in `master` and in this PR. The binaries should not differ.

### Issues/PRs references

None