### PR TITLE
doc: replace obsolete xitter link with mastodon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![API docs][api-badge]][api-link]
 [![Wiki][wiki-badge]][wiki-link]
 [![Stack Overflow questions][stackoverflow-badge]][stackoverflow-link]
-[![Twitter][twitter-badge]][twitter-link]
+[![Mastodon][mastodon-badge]][mastodon-link]
 [![Matrix][matrix-badge]][matrix-link]
 
 <p align="center"><img src="doc/doxygen/src/riot-logo.svg" width="66%"><!--
@@ -165,7 +165,7 @@ https://www.riot-os.org
 [release-link]: https://github.com/RIOT-OS/RIOT/releases/latest
 [stackoverflow-badge]: https://img.shields.io/badge/stackoverflow-%5Briot--os%5D-yellow
 [stackoverflow-link]: https://stackoverflow.com/questions/tagged/riot-os
-[twitter-badge]: https://img.shields.io/badge/social-Twitter-informational.svg
-[twitter-link]: https://twitter.com/RIOT_OS
+[mastodon-badge]: https://img.shields.io/badge/social-Mastodon-informational.svg
+[mastodon-link]: https://fosstodon.org/@RIOT_OS
 [wiki-badge]: https://img.shields.io/badge/docs-Wiki-informational.svg
 [wiki-link]: https://github.com/RIOT-OS/RIOT/wiki

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -38,7 +38,7 @@ RIOT is developed by an open community that anyone is welcome to join:
  - Sign-up to our [forum](https://forum.riot-os.org/) to ask for help using RIOT
    or writing an application for RIOT, discuss kernel and network stack
    development as well as hardware support, or to show-case your latest project.
- - Follow us on [Twitter](https://twitter.com/RIOT_OS) for news from the RIOT
+ - Follow us on [Mastodon][mastodon-link] for news from the RIOT
    community.
  - Regarding critical vulnerabilities we would appreciate if you give us a
    90-days head-start by reporting to security@riot-os.org, before making your
@@ -46,6 +46,7 @@ RIOT is developed by an open community that anyone is welcome to join:
  - Contact us on Matrix for live support and discussions:
    [riot-os:matrix.org](https://matrix.to/#/#riot-os:matrix.org)
 
+[mastodon-link]: https://fosstodon.org/@RIOT_OS
 
 The quickest start                                        {#the-quickest-start}
 ==================


### PR DESCRIPTION
### Contribution description

During the [last VMA](https://forum.riot-os.org/t/notes-virtual-maintainer-assembly-vma-2024-02/4118#twitterx-freeze-5min-emmanuel-11) we decided to abandon Xitter. So let's replace also the link to the now obsolete account with a link to our mastodon account.

### Testing procedure

- Check the [VMA notes](https://forum.riot-os.org/t/notes-virtual-maintainer-assembly-vma-2024-02/4118#twitterx-freeze-5min-emmanuel-11) that we indeed agreed upon dropping Xitter
- Check the generated doc

### Issues/PRs references

None