### PR TITLE
doc: doxygen: add "Topics" to menus

### DIFF
--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -8423,3 +8423,4 @@ warning: Member LSM6DSXX_PARAM_ACC_FIFO_DEC (macro definition) of file lsm6dsxx_
 warning: Member LSM6DSXX_PARAM_GYRO_FIFO_DEC (macro definition) of file lsm6dsxx_params.h is not documented.
 warning: Member LSM6DSXX_PARAMS (macro definition) of file lsm6dsxx_params.h is not documented.
 warning: Member LSM6DSXX_SAUL_INFO (macro definition) of file lsm6dsxx_params.h is not documented.
+RIOTDoxygenLayout.xml:8: warning: the type 'topics' is not supported for the entry tag within a navindex! Check your layout file!

--- a/doc/doxygen/RIOTDoxygenLayout.xml
+++ b/doc/doxygen/RIOTDoxygenLayout.xml
@@ -5,6 +5,7 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
     <tab type="user" url="@ref boards" title="Supported Boards"/>
+    <tab type="topics" visible="yes" title="" intro=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>


### PR DESCRIPTION
### Contribution description

Beginning with doxygen 1.9.8 "Modules" are renamed to "Topics" (see [here](https://github.com/doxygen/doxygen/issues/10562) and [here](https://github.com/doxygen/doxygen/issues/3319#issuecomment-1720923984)). This patch adds the new entry to the layout file. Having both, "Modules" and "Topics" in the layout file should generate similar output for older and newer doxygen versions.

### Testing procedure

Run `make doc` and check the output. Verify whether the menus (navigation bars) on the left and on top contain either "Modules" or "Topics". Should work with all known doxygen versions.