### PR TITLE
boards/nucleo-u575zi-q: Add support

### DIFF
--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -26,8 +26,8 @@
 #ifndef BOARD_H
 #define BOARD_H
 
-#include "board_nucleo.h"
 #include "arduino_pinmap.h"
+#include "board_nucleo.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,24 +37,27 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#if defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI) || \
-    defined(CPU_MODEL_STM32L552ZE)
-#define LED0_PIN_NUM        7
-#define LED0_PORT_NUM       PORT_C
+#if defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI) ||        \
+    defined(CPU_MODEL_STM32L552ZE) || defined(CPU_MODEL_STM32U575ZI)
+#define LED0_PIN_NUM 7
+#define LED0_PORT_NUM PORT_C
 #else
-#define LED0_PIN_NUM        0
-#define LED0_PORT_NUM       PORT_B
+#define LED0_PIN_NUM 0
+#define LED0_PORT_NUM PORT_B
 #endif
 
-#define LED1_PIN_NUM        7
-#define LED1_PORT_NUM       PORT_B
+#define LED1_PIN_NUM 7
+#define LED1_PORT_NUM PORT_B
 
 #if defined(CPU_MODEL_STM32L552ZE)
-#define LED2_PIN_NUM        9
-#define LED2_PORT_NUM       PORT_A
+#define LED2_PIN_NUM 9
+#define LED2_PORT_NUM PORT_A
+#elif defined(CPU_MODEL_STM32U575ZI)
+#define LED2_PIN_NUM 2
+#define LED2_PORT_NUM PORT_G
 #else
-#define LED2_PIN_NUM        14
-#define LED2_PORT_NUM       PORT_B
+#define LED2_PIN_NUM 14
+#define LED2_PORT_NUM PORT_B
 #endif
 /** @} */
 
@@ -62,8 +65,8 @@ extern "C" {
  * @name    User button
  * @{
  */
-#define BTN0_PIN            GPIO_PIN(PORT_C, 13)
-#define BTN0_MODE           GPIO_IN_PD
+#define BTN0_PIN GPIO_PIN(PORT_C, 13)
+#define BTN0_MODE GPIO_IN_PD
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-u575zi-q/Makefile
+++ b/boards/nucleo-u575zi-q/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-u575zi-q/Makefile.dep
+++ b/boards/nucleo-u575zi-q/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-u575zi-q/Makefile.features
+++ b/boards/nucleo-u575zi-q/Makefile.features
@@ -1,0 +1,12 @@
+CPU = stm32
+CPU_MODEL = stm32u575zi
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart periph_lpuart
+FEATURES_PROVIDED += periph_usbdev
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo144/Makefile.features

--- a/boards/nucleo-u575zi-q/Makefile.include
+++ b/boards/nucleo-u575zi-q/Makefile.include
@@ -1,0 +1,2 @@
+# load the common Makefile.include for Nucleo boards
+include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-u575zi-q/doc.txt
+++ b/boards/nucleo-u575zi-q/doc.txt
@@ -1,0 +1,63 @@
+/**
+@defgroup    boards_nucleo-u575zi-q STM32 Nucleo-U575ZI-Q
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-U575ZI-Q
+
+## Overview
+
+The Nucleo-L552ZE-Q is a board from ST's Nucleo family supporting the ARM Cortex-M33
+STM32U575ZIT6Q ultra-low-power microcontroller with TrustZone, 768KiB of RAM and 2MiB
+of Flash.
+
+## Hardware
+
+![Nucleo144 L552ZE-Q](https://www.st.com/bin/ecommerce/api/image.PF271812.en.feature-description-include-personalized-no-cpn-medium.jpg)
+
+### MCU
+
+| MCU          | STM32U575ZIT6Q               |
+|:-------------|:-----------------------------|
+| Family       | ARM Cortex-M33               |
+| Vendor       | ST Microelectronics          |
+| RAM          | 786KiB                       |
+| Flash        | 2MiB                         |
+| Frequency    | up tp 160MHz                 |
+| FPU          | yes                          |
+| TrustZone    | yes                          |
+| Timers       | 17                           |
+| UARTs        | 6 (3xUSART, 2xUART, 1xLPUART)|
+| I2cs         | 4                            |
+| SPIs         | 3                            |
+| CAN          | 1                            |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32u575zi.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0264-stm32-cortexm33-mcus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2861-stm32u5-nucleo144-board-mb1549-stmicroelectronics.pdf)|
+
+## Flashing the device
+
+### Flashing the Board Using OpenOCD
+
+The ST Nucleo-L552ZE-Q board includes an on-board ST-LINK programmer and can be
+flashed using OpenOCD.
+
+Once OpenOCD is installed, you can flash the board simply by typing
+
+```
+make BOARD=nucleo-u575zi-q flash
+```
+
+and debug via GDB by simply typing
+```
+make BOARD=nucleo-u575zi-q debug
+```
+
+## Accessing RIOT shell
+
+Default RIOT shell access utilize VCP (Virtual COM Port) via USB interface,
+provided by integrated ST-LINK programmer. ST-LINK is connected to the
+microcontroller USART1.
+
+The default baud rate is 115 200.
+
+If a physical connection to USART1 is needed, connect UART interface to pins PA9 (USART1 TX) and PA10 (USART1 RX).
+*/

--- a/boards/nucleo-u575zi-q/include/periph_conf.h
+++ b/boards/nucleo-u575zi-q/include/periph_conf.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-u575zi-q
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the nucleo-u575zi-q board
+ *
+ * @author      Nils Ollrogge <nils.ollrogge@mailbox.tu-dresden.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE 1
+#endif
+
+#include "cfg_timer_tim5.h"
+#include "cfg_usb_otg_fs_u5.h"
+#include "clk_conf.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = USART1,
+        .rcc_mask = RCC_APB2ENR_USART1EN,
+        .rx_pin = GPIO_PIN(PORT_A, 10),
+        .tx_pin = GPIO_PIN(PORT_A, 9),
+        .rx_af = GPIO_AF7,
+        .tx_af = GPIO_AF7,
+        .bus = APB2,
+        .irqn = USART1_IRQn,
+        .type = STM32_USART,
+        .clk_src = 0, /* Use APB clock */
+    },
+    {
+        .dev = LPUART1,
+        .rcc_mask = RCC_APB3ENR_LPUART1EN,
+        .rx_pin = GPIO_PIN(PORT_G, 8),
+        .tx_pin = GPIO_PIN(PORT_G, 7),
+        .rx_af = GPIO_AF8,
+        .tx_af = GPIO_AF8,
+        .bus = APB3,
+        .irqn = LPUART1_IRQn,
+        .type = STM32_LPUART,
+        .clk_src = 0, /* Use APB clock */
+    },
+};
+
+#define UART_0_ISR (isr_usart1)
+#define UART_1_ISR (isr_lpuart1)
+
+#define UART_NUMOF ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),    /* Arduino D11 */
+        .miso_pin = GPIO_PIN(PORT_A, 6),    /* Arduino D12 */
+        .sclk_pin = GPIO_PIN(PORT_A, 5),    /* Arduino D13 */
+        .cs_pin = GPIO_UNDEF,
+        .mosi_af = GPIO_AF5,
+        .miso_af = GPIO_AF5,
+        .sclk_af = GPIO_AF5,
+        .cs_af = GPIO_AF5,
+        .rccmask = RCC_APB2ENR_SPI1EN,
+        .apbbus = APB2,
+    },
+};
+
+#define SPI_NUMOF ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = I2C1,
+        .speed = I2C_SPEED_NORMAL,
+        .scl_pin = GPIO_PIN(PORT_B, 8),
+        .sda_pin = GPIO_PIN(PORT_B, 9),
+        .scl_af = GPIO_AF4,
+        .sda_af = GPIO_AF4,
+        .bus = APB1,
+        .rcc_mask = RCC_APB1ENR1_I2C1EN,
+        .rcc_sw_mask = RCC_CCIPR1_I2C1SEL_1,
+        .irqn = I2C1_ER_IRQn,
+    },
+    {
+        .dev = I2C2,
+        .speed = I2C_SPEED_NORMAL,
+        .scl_pin = GPIO_PIN(PORT_F, 1),
+        .sda_pin = GPIO_PIN(PORT_F, 0),
+        .scl_af = GPIO_AF4,
+        .sda_af = GPIO_AF4,
+        .bus = APB1,
+        .rcc_mask = RCC_APB1ENR1_I2C2EN,
+        .rcc_sw_mask = RCC_CCIPR1_I2C2SEL_1,
+        .irqn = I2C2_ER_IRQn,
+    },
+};
+
+#define I2C_0_ISR isr_i2c1_er
+#define I2C_1_ISR isr_i2c2_er
+#define I2C_NUMOF ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ *
+ * To find appriopate device and channel find in the MCU datasheet table
+ * concerning "Alternate function AF0 to AF7" a text similar to TIM[X]_CH[Y],
+ * where:
+ * TIM[X] - is device,
+ * [Y] - describes used channel (indexed from 0), for example TIM2_CH1 is
+ * channel 0 in configuration structure (cc_chan - field),
+ * Port column in the table describes connected port.
+ *
+ * For Nucleo-U575ZI-Q this information is in the datasheet, Table 27, page 127.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    { .dev = TIM2,
+      .rcc_mask = RCC_APB1ENR1_TIM2EN,
+      .chan = { { .pin = GPIO_PIN(PORT_A, 0) /* CN10 D32 */, .cc_chan = 0 },
+          { .pin = GPIO_PIN(PORT_A, 1) /* CN10  A8 */, .cc_chan = 1 },
+          { .pin = GPIO_PIN(PORT_A, 2) /*  CN9  A1 */, .cc_chan = 2 },
+          { .pin = GPIO_PIN(PORT_A, 3) /*  CN9  A0 */, .cc_chan = 3 } },
+      .af = GPIO_AF1,
+      .bus = APB1 },
+    { .dev = TIM3,
+      .rcc_mask = RCC_APB1ENR1_TIM3EN,
+      .chan = { { .pin = GPIO_PIN(PORT_B, 4) /*  CN7 D25 */, .cc_chan = 0 },
+          { .pin = GPIO_PIN(PORT_B, 5) /*  CN7 D22 */, .cc_chan = 1 },
+          { .pin = GPIO_PIN(PORT_B, 0) /*  CN9  A3 */, .cc_chan = 2 },
+          { .pin = GPIO_PIN(PORT_B, 1) /* CN10  A6 */, .cc_chan = 3 } },
+      .af = GPIO_AF2,
+      .bus = APB1 },
+    { .dev = TIM4,
+      .rcc_mask = RCC_APB1ENR1_TIM4EN,
+      .chan = { { .pin = GPIO_PIN(PORT_D, 12) /*  CN7 D19 */, .cc_chan = 0 },
+          { .pin = GPIO_PIN(PORT_B, 7) /* Blue LD2 */, .cc_chan = 1 },
+          { .pin = GPIO_PIN(PORT_D, 14) /*  CN7 D10 */, .cc_chan = 2 },
+          { .pin = GPIO_PIN(PORT_D, 15) /*  CN7  D9 */, .cc_chan = 3 } },
+      .af = GPIO_AF2,
+      .bus = APB1 },
+};
+
+#define PWM_NUMOF ARRAY_SIZE(pwm_config)
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -332,6 +332,10 @@ static inline void uart_init_usart(uart_t uart, uint32_t baudrate)
 #define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR1_LPUART1SEL_0
 #define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR1_LPUART1SEL_1
 #define CCIPR                   CCIPR1
+#elif CPU_FAM_STM32U5
+#define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR3_LPUART1SEL_0
+#define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR3_LPUART1SEL_1
+#define CCIPR                   CCIPR3
 #endif
 #ifdef MODULE_PERIPH_LPUART
 static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds support for the NUCLEO-U575ZI-Q board.

### Testing procedure
+ Tested UART based on RIOT shell
+ Tested pwm via `tests/periph/pwm`
+ LEDs work
+ Tested USB via `usbus_minimal` & `usbus_hid`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


