### PR TITLE
tests: exit `native` with error value on failure

### DIFF
--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -74,6 +74,17 @@ static void *main_trampoline(void *arg)
     }
 #endif
 
+#ifdef CPU_NATIVE
+    extern unsigned _native_retval;
+    if (!_native_retval) {
+        _native_retval = res;
+    }
+#endif
+
+    if (IS_ACTIVE(CONFIG_CORE_EXIT_WITH_MAIN)) {
+        pm_off();
+    }
+
     return NULL;
 }
 

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -184,8 +184,9 @@ void cpu_switch_context_exit(void)
 {
 #ifdef NATIVE_AUTO_EXIT
     if (sched_num_threads <= 1) {
+        extern unsigned _native_retval;
         DEBUG("cpu_switch_context_exit: last task has ended. exiting.\n");
-        real_exit(EXIT_SUCCESS);
+        real_exit(_native_retval);
     }
 #endif
 

--- a/sys/embunit/TestRunner.c
+++ b/sys/embunit/TestRunner.c
@@ -99,7 +99,7 @@ void TestRunner_runTest(Test* test)
     Test_run(test, &result_);
 }
 
-void TestRunner_end(void)
+int TestRunner_end(void)
 {
     char buf[16];
     if (result_.failureCount) {
@@ -118,4 +118,6 @@ void TestRunner_end(void)
         stdimpl_print(buf);
         stdimpl_print(" tests)\n");
     }
+
+    return TestRunnerHadErrors;
 }

--- a/sys/include/embUnit/TestRunner.h
+++ b/sys/include/embUnit/TestRunner.h
@@ -41,7 +41,7 @@ extern "C" {
 
 void TestRunner_start(void);
 void TestRunner_runTest(Test* test);
-void TestRunner_end(void);
+int TestRunner_end(void);
 
 extern int TestRunnerHadErrors;
 

--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -12,6 +12,9 @@ ifneq (,$(wildcard $(CURDIR)/tests*/.))
   endif
 endif
 
+# terminate native when the test is complete
+CFLAGS += -DNATIVE_AUTO_EXIT=1
+
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 QUIET ?= 1

--- a/tests/sys/pthread_condition_variable/Makefile
+++ b/tests/sys/pthread_condition_variable/Makefile
@@ -4,6 +4,4 @@ USEMODULE += posix_headers
 USEMODULE += pthread
 USEMODULE += xtimer
 
-CFLAGS += -DNATIVE_AUTO_EXIT
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -35,6 +35,7 @@ INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 
 # some tests need more stack
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
+CFLAGS += -DCONFIG_CORE_EXIT_WITH_MAIN=1
 
 # for these boards, enable asan (Address Sanitizer)
 ASAN_BOARDS ?= native native64

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -49,7 +49,5 @@ int main(void)
 #ifndef NO_TEST_SUITES
     UNCURRY(RUN_TEST_SUITES, TEST_SUITES)
 #endif
-    TESTS_END();
-
-    return 0;
+    return TESTS_END();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When no more threads are running, we can exit `native` for all tests.
In this case, also return `_native_retval` instead of `EXIT_SUCCESS`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
