### PR TITLE
cpu/sam0_common: RTC: avoid negative month after POR

### DIFF
--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -330,6 +330,13 @@ static void _rtc_init(void)
     RTC->MODE2.CTRLA.reg = RTC_MODE2_CTRLA_PRESCALER_DIV1024   /* CLK_RTC_CNT = 1KHz / 1024 -> 1Hz */
                          | RTC_MODE2_CTRLA_CLOCKSYNC           /* Clock Read Synchronization Enable */
                          | RTC_MODE2_CTRLA_MODE_CLOCK;
+
+    /* RTC is all 0 after POR, avoid reading invalid date right after boot */
+    if (RTC->MODE2.CLOCK.bit.MONTH == 0) {
+        RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_MONTH(1)
+                             | RTC_MODE2_CLOCK_DAY(1);
+    }
+
 #ifdef RTC_MODE2_CTRLB_GP2EN
     /* RTC driver does not use COMP[1] or ALARM[1] */
     /* Use second set of Compare registers as general purpose register */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

On power-on reset, all RTC register values are 0, but January is expected to be month 1.
Since `struct tm` expects January to be 0, we subtract 1 from the month, leading to a negative month after POR.

This of course causes all kinds of trouble, so only subtract 1 if the month will not turn out negative. 

### Testing procedure

The issue occurs when reading the RTC before the first second has ticked:

```C
 int main(void)
 {
    struct tm now;
    rtc_get_time(&now);
    _print_time(&now);
    return 0;
}
```

on `master` this will print

```
2024-03-07 11:24:16,694 # main(): This is RIOT! (Version: 2024.04-devel-361-g31d23)
2024-03-07 11:24:16,694 # 2020-00-00 00:00:00
```

With this patch, we get a valid date

```
2024-03-07 11:29:32,008 # main(): This is RIOT! (Version: 2024.04-devel-363-ge3708-cpu/sam0_common-rtc-0)
2024-03-07 11:29:32,009 # 2020-01-01 00:00:00
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
