### PR TITLE
core/thread: always use THREAD_CREATE_STACKTEST when DEVELHELP is enabled

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -47,7 +47,6 @@
  *  ----------------------------- | --------------------------------------------------
  *  @ref THREAD_CREATE_SLEEPING   | the thread will sleep until woken up manually
  *  @ref THREAD_CREATE_WOUT_YIELD | the thread might not run immediately after creation
- *  @ref THREAD_CREATE_STACKTEST  | measures the stack's memory usage
  *
  * Thread creation
  * ===============
@@ -83,7 +82,7 @@
  * int main(void)
  * {
  *     thread_create(rcv_thread_stack, sizeof(rcv_thread_stack),
- *                   THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+ *                   THREAD_PRIORITY_MAIN - 1, 0,
  *                   rcv_thread, NULL, "rcv_thread");
  * }
  * ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -231,10 +230,11 @@ struct _thread {
 #define THREAD_CREATE_WOUT_YIELD        (4)
 
 /**
- * @brief Write markers into the thread's stack to measure stack usage (for
- *        debugging and profiling purposes)
+ * @brief Legacy flag kept for compatibility.
+ *
+ * This is always enabled with `DEVELHELP=1` or `SCHED_TEST_STACK`.
  */
-#define THREAD_CREATE_STACKTEST         (8)
+#define THREAD_CREATE_STACKTEST         (0)
 /** @} */
 
 /**
@@ -452,7 +452,7 @@ static inline const char *thread_getname(kernel_pid_t pid)
 /**
  * @brief Measures the stack usage of a stack
  *
- * Only works if the thread was created with the flag THREAD_CREATE_STACKTEST.
+ * Only works if `DEVELHELP` or `SCHED_TEST_STACK` are enabled.
  *
  * @param[in] stack the stack you want to measure. Try `thread_get_stackstart(thread_get_active())`
  *

--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -113,13 +113,13 @@ void kernel_init(void)
     if (IS_USED(MODULE_CORE_IDLE_THREAD)) {
         thread_create(idle_stack, sizeof(idle_stack),
                       THREAD_PRIORITY_IDLE,
-                      THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                      THREAD_CREATE_WOUT_YIELD,
                       idle_thread, NULL, "idle");
     }
 
     thread_create(main_stack, sizeof(main_stack),
                   THREAD_PRIORITY_MAIN,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   main_trampoline, NULL, "main");
 
     cpu_switch_context_exit();

--- a/core/thread.c
+++ b/core/thread.c
@@ -244,21 +244,14 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
 
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_TEST_UTILS_PRINT_STACK_USAGE)
-    if (flags & THREAD_CREATE_STACKTEST) {
-        /* assign each int of the stack the value of it's address. Alignment
-         * has been handled above, so silence -Wcast-align */
-        uintptr_t *stackmax = (uintptr_t *)(uintptr_t)(stack + stacksize);
-        uintptr_t *stackp = (uintptr_t *)(uintptr_t)stack;
+    /* assign each int of the stack the value of it's address. Alignment
+     * has been handled above, so silence -Wcast-align */
+    uintptr_t *stackmax = (uintptr_t *)(uintptr_t)(stack + stacksize);
+    uintptr_t *stackp = (uintptr_t *)(uintptr_t)stack;
 
-        while (stackp < stackmax) {
-            *stackp = (uintptr_t)stackp;
-            stackp++;
-        }
-    }
-    else {
-        /* create stack guard. Alignment has been handled above, so silence
-         * -Wcast-align */
-        *(uintptr_t *)(uintptr_t)stack = (uintptr_t)stack;
+    while (stackp < stackmax) {
+        *stackp = (uintptr_t)stackp;
+        stackp++;
     }
 #endif
 

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -82,7 +82,7 @@ BaseType_t xTaskCreatePinnedToCore(TaskFunction_t pvTaskCode,
                                      usStackDepth + sizeof(thread_t),
                                      uxPriority,
                                      THREAD_CREATE_WOUT_YIELD |
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      (void *)pvTaskCode,
                                      pvParameters, pcName);
     DEBUG("pid=%d\n", pid);

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -379,7 +379,7 @@ static void start_server(void)
     _dtls_server_pid = thread_create(_dtls_server_stack,
                                      sizeof(_dtls_server_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      _dtls_server_wrapper, NULL, "DTLS_Server");
 
     /* Uncommon but better be sure */

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -218,7 +218,7 @@ static void start_server(void)
     _dtls_server_pid = thread_create(_dtls_server_stack,
                                      sizeof(_dtls_server_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      dtls_server_wrapper, NULL, "dtls_server");
 
     /* Uncommon but better be sure */

--- a/examples/ipc_pingpong/main.c
+++ b/examples/ipc_pingpong/main.c
@@ -51,7 +51,7 @@ int main(void)
     msg_t m;
 
     kernel_pid_t pid = thread_create(second_thread_stack, sizeof(second_thread_stack),
-                            THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                            THREAD_PRIORITY_MAIN - 1, 0,
                             second_thread, NULL, "pong");
 
     m.content.value = 1;

--- a/examples/posix_sockets/udp.c
+++ b/examples/posix_sockets/udp.c
@@ -154,7 +154,7 @@ static int udp_start_server(char *port_str)
     }
     /* start server (which means registering pktdump for the chosen port) */
     if (thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1,
-                      THREAD_CREATE_STACKTEST,
+                      0,
                       _server_thread, port_str, "UDP server") <= KERNEL_PID_UNDEF) {
         server_socket = -1;
         puts("error initializing thread");

--- a/examples/sniffer/main.c
+++ b/examples/sniffer/main.c
@@ -124,7 +124,7 @@ int main(void)
     /* start and register rawdump thread */
     puts("Run the rawdump thread and register it");
     dump.target.pid = thread_create(rawdmp_stack, sizeof(rawdmp_stack), RAWDUMP_PRIO,
-                                    THREAD_CREATE_STACKTEST, rawdump, NULL, "rawdump");
+                                    0, rawdump, NULL, "rawdump");
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 

--- a/examples/thread_duel/main.c
+++ b/examples/thread_duel/main.c
@@ -135,19 +135,19 @@ int main(void)
     {
         static char stack[WORKER_STACKSIZE];
         static struct worker_config wc = THREAD_1;   /* 0-10 workness */
-        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+        thread_create(stack, sizeof(stack), 7, 0,
                       thread_worker, &wc, "T1");
     }
     {
         static char stack[WORKER_STACKSIZE];
         static struct worker_config wc = THREAD_2;   /* 0-10 workness */
-        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+        thread_create(stack, sizeof(stack), 7, 0,
                       thread_worker, &wc, "T2");
     }
     {
         static char stack[WORKER_STACKSIZE];
         static struct worker_config wc = THREAD_3;   /* 0-10 workness */
-        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+        thread_create(stack, sizeof(stack), 7, 0,
                       thread_worker, &wc, "T3");
     }
 }

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -89,7 +89,7 @@ err_t lwip_netdev_init(struct netif *netif)
     /* start multiplexing thread (only one needed) */
     if (_pid <= KERNEL_PID_UNDEF) {
         _pid = thread_create(_stack, LWIP_NETDEV_STACKSIZE, LWIP_NETDEV_PRIO,
-                             THREAD_CREATE_STACKTEST, _event_loop, netif,
+                             0, _event_loop, netif,
                              LWIP_NETDEV_NAME);
         if (_pid <= 0) {
             return ERR_IF;

--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -213,7 +213,7 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg,
     if (stack == NULL) {
         return ERR_MEM;
     }
-    if ((res = thread_create(stack, stacksize, prio, THREAD_CREATE_STACKTEST,
+    if ((res = thread_create(stack, stacksize, prio, 0,
                              _lwip_thread_wrapper, &params,
                              name)) <= KERNEL_PID_UNDEF) {
         abort();

--- a/pkg/mynewt-core/contrib/task.c
+++ b/pkg/mynewt-core/contrib/task.c
@@ -36,7 +36,7 @@ int os_task_init(struct os_task *t, const char *name, os_task_func_t func,
     LOG_DEBUG("[mynewt-core]: starting thread %s\n", name);
 
     kernel_pid_t pid = thread_create(stack_bottom, (int) stack_size,
-                                     prio, THREAD_CREATE_STACKTEST,
+                                     prio, 0,
                                      func, arg, name);
 
     t->pid = pid;

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -89,7 +89,7 @@ static void *_host_thread(void *arg)
      */
     thread_create(_stack_controller, sizeof(_stack_controller),
                   NIMBLE_CONTROLLER_PRIO,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   (thread_task_func_t)nimble_port_ll_task_func, NULL,
                   "nimble_ctrl");
 
@@ -133,7 +133,7 @@ void nimble_riot_init(void)
     /* and finally initialize and run the host */
     thread_create(_stack_host, sizeof(_stack_host),
                   NIMBLE_HOST_PRIO,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _host_thread, NULL,
                   "nimble_host");
 

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -124,7 +124,7 @@ static void *_openthread_event_loop(void *arg)
 int openthread_netdev_init(char *stack, int stacksize, char priority,
                            const char *name, netdev_t *netdev) {
     if (thread_create(stack, stacksize,
-                         priority, THREAD_CREATE_STACKTEST,
+                         priority, 0,
                          _openthread_event_loop, netdev, name) < 0) {
         return -EINVAL;
     }

--- a/pkg/openwsn/contrib/openwsn.c
+++ b/pkg/openwsn/contrib/openwsn.c
@@ -107,7 +107,7 @@ int openwsn_bootstrap(void)
 
     LOG_DEBUG("[openwsn]: network thread\n");
     _pid = thread_create(_stack, OPENWSN_SCHED_STACKSIZE, OPENWSN_SCHED_PRIO,
-                         THREAD_CREATE_STACKTEST, _event_loop, NULL,
+                         0, _event_loop, NULL,
                          OPENWSN_SCHED_NAME);
     if (_pid <= 0) {
         LOG_ERROR("[openwsn]: couldn't create thread\n");

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -225,7 +225,7 @@ int ThreadStart(Thread *thread, void (*fn)(void *), void *arg)
     (void) fn;
     thread->pid = thread_create(thread->stack, sizeof(thread->stack),
                                 MQTT_THREAD_PRIORITY,
-                                THREAD_CREATE_STACKTEST, mqtt_riot_run, arg,
+                                0, mqtt_riot_run, arg,
                                 "paho_mqtt_riot");
     return thread->pid;
 }

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -834,7 +834,7 @@ int semtech_loramac_init(semtech_loramac_t *mac)
     semtech_loramac_pid = thread_create(_semtech_loramac_stack,
                                         sizeof(_semtech_loramac_stack),
                                         THREAD_PRIORITY_MAIN - 1,
-                                        THREAD_CREATE_STACKTEST,
+                                        0,
                                         _semtech_loramac_event_loop, mac,
                                         "recv_thread");
 

--- a/pkg/tinyusb/contrib/tinyusb.c
+++ b/pkg/tinyusb/contrib/tinyusb.c
@@ -77,9 +77,9 @@ int tinyusb_setup(void)
                              sizeof(_tinyusb_thread_stack),
                              TINYUSB_PRIORITY,
 #if MODULE_RIOTBOOT_TINYUSB_DFU
-                             THREAD_CREATE_STACKTEST,
+                             0,
 #else
-                             THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                             THREAD_CREATE_WOUT_YIELD,
 #endif
                              _tinyusb_thread_impl, NULL, "tinyusb")) < 0) {
         LOG_ERROR("tinyUSB thread couldn't be created, reason %d\n", res);

--- a/pkg/uwb-core/contrib/uwb_core.c
+++ b/pkg/uwb-core/contrib/uwb_core.c
@@ -48,7 +48,7 @@ void uwb_core_riot_init(void)
 #if !IS_USED(MODULE_UWB_CORE_EVENT_THREAD)
     thread_create(_stack_uwb_core, sizeof(_stack_uwb_core),
                   UWB_CORE_PRIO,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _uwb_core_thread, NULL,
                   "uwb_core_event");
 #endif

--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -95,7 +95,7 @@ lwm2m_context_t *lwm2m_client_run(lwm2m_client_data_t *client_data,
     _client_data->pid = thread_create(_lwm2m_client_stack,
                                      sizeof(_lwm2m_client_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      _lwm2m_client_run,
                                      NULL,
                                      "LwM2M client");

--- a/sys/auto_init/wdt_thread/wdt.c
+++ b/sys/auto_init/wdt_thread/wdt.c
@@ -52,7 +52,7 @@ static void *_wdt_thread(void *ctx)
 static void auto_init_wdt_thread(void)
 {
     thread_create(wdt_stack, sizeof(wdt_stack), THREAD_PRIORITY_MIN,
-                  THREAD_CREATE_STACKTEST, _wdt_thread, NULL, "watchdog");
+                  0, _wdt_thread, NULL, "watchdog");
 }
 
 AUTO_INIT(auto_init_wdt_thread, AUTO_INIT_PRIO_WDT_THREAD);

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -364,7 +364,7 @@ kernel_pid_t can_device_init(char *stack, int stacksize, char priority,
     }
 
     /* create new can device thread */
-    res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
+    res = thread_create(stack, stacksize, priority, 0,
                          _can_device_thread, (void *)params, name);
     if (res <= 0) {
         return -EINVAL;

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -732,7 +732,7 @@ kernel_pid_t isotp_init(char *stack, int stacksize, char priority, const char *n
     DEBUG("isotp_init\n");
 
     /* create new can device thread */
-    res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
+    res = thread_create(stack, stacksize, priority, 0,
                          _isotp_thread, NULL, name);
     if (res <= 0) {
         return -EINVAL;

--- a/sys/event/thread.c
+++ b/sys/event/thread.c
@@ -57,7 +57,7 @@ void event_thread_init_multi(event_queue_t *queues, size_t queues_numof,
 
     void *tagged_ptr = ptrtag(queues, queues_numof - 1);
 
-    thread_create(stack, stack_size, priority, THREAD_CREATE_STACKTEST,
+    thread_create(stack, stack_size, priority, 0,
                   _handler_thread, tagged_ptr, "event");
 }
 

--- a/sys/fido2/ctap/transport/ctap_transport.c
+++ b/sys/fido2/ctap/transport/ctap_transport.c
@@ -95,7 +95,7 @@ void fido2_ctap_transport_init(void)
 #endif
 
     int ret = thread_create(_ctap_stack, sizeof(_ctap_stack), CTAP_TRANSPORT_PRIO,
-                            THREAD_CREATE_STACKTEST, _event_loop, NULL,
+                            0, _event_loop, NULL,
                             "fido2_ctap_transport_loop");
 
     (void)ret;

--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -648,7 +648,7 @@ void _on_pkt(sock_udp_t *sock, sock_async_flags_t type, void *arg)
 void asymcute_handler_run(void)
 {
     thread_create(_stack, sizeof(_stack), ASYMCUTE_HANDLER_PRIO,
-                  THREAD_CREATE_STACKTEST, _eventloop, NULL, "asymcute_main");
+                  0, _eventloop, NULL, "asymcute_main");
 }
 
 int asymcute_topic_init(asymcute_topic_t *topic, const char *topic_name,

--- a/sys/net/application_layer/cord/ep/cord_ep_standalone.c
+++ b/sys/net/application_layer/cord/ep/cord_ep_standalone.c
@@ -87,7 +87,7 @@ static void *_reg_runner(void *arg)
 
 void cord_ep_standalone_run(void)
 {
-    thread_create(_stack, sizeof(_stack), PRIO, THREAD_CREATE_STACKTEST,
+    thread_create(_stack, sizeof(_stack), PRIO, 0,
                   _reg_runner, NULL, TNAME);
 }
 

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -136,7 +136,7 @@ void dhcpv6_client_auto_init(void)
     if (_thread_pid <= 0) {
         _thread_pid = thread_create(_thread_stack, DHCPV6_CLIENT_STACK_SIZE,
                                     DHCPV6_CLIENT_PRIORITY,
-                                    THREAD_CREATE_STACKTEST,
+                                    0,
                                     _thread, NULL, "dhcpv6-client");
     }
 }

--- a/sys/net/application_layer/dhcpv6/relay.c
+++ b/sys/net/application_layer/dhcpv6/relay.c
@@ -75,7 +75,7 @@ void dhcpv6_relay_auto_init(void)
             }
             else {
                 thread_create(_auto_init_stack, ARRAY_SIZE(_auto_init_stack),
-                              AUTO_INIT_PRIO, THREAD_CREATE_STACKTEST,
+                              AUTO_INIT_PRIO, 0,
                               _dhcpv6_relay_auto_init_thread,
                               (void *)(intptr_t)netif, "dhcpv6_relay");
             }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1496,7 +1496,7 @@ kernel_pid_t gcoap_init(void)
         return -EEXIST;
     }
     _pid = thread_create(_msg_stack, sizeof(_msg_stack), THREAD_PRIORITY_MAIN - 1,
-                            THREAD_CREATE_STACKTEST, _event_loop, NULL, "coap");
+                            0, _event_loop, NULL, "coap");
 
     mutex_init(&_coap_state.lock);
     /* Blank lists so we know if an entry is available. */

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -867,7 +867,7 @@ kernel_pid_t nanocoap_server_start(const sock_udp_ep_t *local)
         return _coap_server_pid;
     }
     _coap_server_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST, _nanocoap_server_thread,
+                                     0, _nanocoap_server_thread,
                                      (void *)local, "nanoCoAP server");
     return _coap_server_pid;
 }

--- a/sys/net/application_layer/telnet/telnet_server.c
+++ b/sys/net/application_layer/telnet/telnet_server.c
@@ -340,7 +340,7 @@ int telnet_server_start(void)
 
     /* initiate telnet server */
     thread_create(telnet_stack, sizeof(telnet_stack),
-                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 1, 0,
                   telnet_thread, NULL, "telnet");
 
     return 0;

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -154,7 +154,7 @@ void gnrc_dhcpv6_client_simple_pd_init(void)
     /* start DHCPv6 client thread to request prefix for WPAN */
     thread_create(_stack, DHCPV6_CLIENT_STACK_SIZE,
                   DHCPV6_CLIENT_PRIORITY,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _dhcpv6_cl_simple_pd_thread, NULL, "dhcpv6-client");
 }
 

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -111,6 +111,6 @@ void auto_init_gnrc_uhcpc(void)
 
     /* initiate uhcp client */
     thread_create(_uhcp_client_stack, sizeof(_uhcp_client_stack),
-            THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+            THREAD_PRIORITY_MAIN - 1, 0,
             uhcp_client_thread, NULL, "uhcp");
 }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -92,7 +92,7 @@ int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
     mutex_init(&ctx.init_done);
     mutex_lock(&ctx.init_done);
 
-    res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
+    res = thread_create(stack, stacksize, priority, 0,
                         _gnrc_netif_thread, &ctx, name);
     assert(res > 0);
     (void)res;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -85,7 +85,7 @@ kernel_pid_t gnrc_ipv6_init(void)
 {
     if (gnrc_ipv6_pid == KERNEL_PID_UNDEF) {
         gnrc_ipv6_pid = thread_create(_stack, sizeof(_stack), GNRC_IPV6_PRIO,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       _event_loop, NULL, "ipv6");
     }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -52,7 +52,7 @@ kernel_pid_t gnrc_sixlowpan_init(void)
     }
 
     _pid = thread_create(_stack, sizeof(_stack), GNRC_SIXLOWPAN_PRIO,
-                         THREAD_CREATE_STACKTEST, _event_loop, NULL, "6lo");
+                         0, _event_loop, NULL, "6lo");
 
     return _pid;
 }

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -204,7 +204,7 @@ kernel_pid_t gnrc_pktdump_init(void)
 {
     if (gnrc_pktdump_pid == KERNEL_PID_UNDEF) {
         gnrc_pktdump_pid = thread_create(_stack, sizeof(_stack), GNRC_PKTDUMP_PRIO,
-                             THREAD_CREATE_STACKTEST,
+                             0,
                              _eventloop, NULL, "pktdump");
     }
     return gnrc_pktdump_pid;

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -713,7 +713,7 @@ void gnrc_ipv6_auto_subnets_init(void)
 {
     /* initiate auto_subnets thread */
     _server_pid = thread_create(auto_subnets_stack, sizeof(auto_subnets_stack),
-                                THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                                THREAD_PRIORITY_MAIN - 1, 0,
                                 _eventloop, NULL, "auto_subnets");
 }
 #endif /* !IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_SIMPLE) */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -87,7 +87,7 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
         _instance_id = 0;
         /* start the event loop */
         gnrc_rpl_pid = thread_create(_stack, sizeof(_stack), GNRC_RPL_PRIO,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      _event_loop, (void*)&eventloop_startup,
                                      "RPL");
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -382,7 +382,7 @@ int _gnrc_tcp_eventloop_init(void)
     evtimer_init_msg(&_tcp_msg_timer);
 
     kernel_pid_t pid = thread_create(_stack, sizeof(_stack), TCP_EVENTLOOP_PRIO,
-                                     THREAD_CREATE_STACKTEST, _eventloop, NULL,
+                                     0, _eventloop, NULL,
                                      "gnrc_tcp");
     TCP_DEBUG_LEAVE;
     return pid;

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -303,7 +303,7 @@ int gnrc_udp_init(void)
     if (_pid == KERNEL_PID_UNDEF) {
         /* start UDP thread */
         _pid = thread_create(_stack, sizeof(_stack), GNRC_UDP_PRIO,
-                             THREAD_CREATE_STACKTEST, _event_loop, NULL, "udp");
+                             0, _event_loop, NULL, "udp");
     }
     return _pid;
 }

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -156,7 +156,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
             volatile kernel_pid_t pid = thread_create(pthread_reaper_stack,
                                              PTHREAD_REAPER_STACKSIZE,
                                              0,
-                                             THREAD_CREATE_STACKTEST,
+                                             0,
                                              pthread_reaper,
                                              NULL,
                                              "pthread-reaper");
@@ -176,7 +176,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
                                    stack_size,
                                    THREAD_PRIORITY_MAIN,
                                    THREAD_CREATE_SLEEPING |
-                                   THREAD_CREATE_STACKTEST,
+                                   0,
                                    pthread_start_routine,
                                    pt,
                                    "pthread");

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -220,7 +220,7 @@ void suit_worker_trigger(const char *url, size_t len)
     _url[len] = '\0';
 
     _worker_pid = thread_create(_stack, SUIT_WORKER_STACKSIZE, SUIT_COAP_WORKER_PRIO,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _suit_worker_thread, NULL, "suit worker");
 }
 
@@ -245,7 +245,7 @@ void suit_worker_trigger_prepared(const uint8_t *buffer, size_t size)
     }
 
     _worker_pid = thread_create(_stack, SUIT_WORKER_STACKSIZE, SUIT_COAP_WORKER_PRIO,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _suit_worker_thread, NULL, "suit worker");
 }
 

--- a/sys/test_utils/benchmark_udp/benchmark_udp.c
+++ b/sys/test_utils/benchmark_udp/benchmark_udp.c
@@ -171,10 +171,10 @@ int benchmark_udp_start(const char *server, uint16_t port)
 
     running = true;
     thread_create(listen_thread_stack, sizeof(listen_thread_stack),
-                  THREAD_PRIORITY_MAIN - 2, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 2, 0,
                   _listen_thread, NULL, "UDP receiver");
     thread_create(send_thread_stack, sizeof(send_thread_stack),
-                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 1, 0,
                   _send_thread, &remote, "UDP sender");
     return 0;
 }

--- a/sys/test_utils/dummy_thread/dummy_thread.c
+++ b/sys/test_utils/dummy_thread/dummy_thread.c
@@ -50,8 +50,6 @@ void dummy_thread_create(void)
 {
     thread_create(_dummy_stack, sizeof(_dummy_stack),
                   THREAD_PRIORITY_IDLE,
-                  THREAD_CREATE_WOUT_YIELD \
-                  | THREAD_CREATE_STACKTEST \
-                  | THREAD_CREATE_SLEEPING,
+                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_SLEEPING,
                   _dummy_thread, NULL, "dummy");
 }

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -61,7 +61,7 @@ void usbus_init(usbus_t *usbus, usbdev_t *usbdev)
 void usbus_create(char *stack, int stacksize, char priority,
                   const char *name, usbus_t *usbus)
 {
-    int res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
+    int res = thread_create(stack, stacksize, priority, 0,
                             _usbus_thread, (void *)usbus, name);
 
     (void)res;

--- a/tests/bench/msg_pingpong/main.c
+++ b/tests/bench/msg_pingpong/main.c
@@ -59,7 +59,7 @@ int main(void)
     kernel_pid_t other = thread_create(_stack,
                                        sizeof(_stack),
                                        (THREAD_PRIORITY_MAIN - 1),
-                                       THREAD_CREATE_STACKTEST,
+                                       0,
                                        _second_thread,
                                        NULL,
                                        "second_thread");

--- a/tests/bench/mutex_pingpong/main.c
+++ b/tests/bench/mutex_pingpong/main.c
@@ -59,7 +59,7 @@ int main(void)
     thread_create(_stack,
                   sizeof(_stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   _second_thread,
                   NULL,
                   "second_thread");

--- a/tests/bench/thread_flags_pingpong/main.c
+++ b/tests/bench/thread_flags_pingpong/main.c
@@ -58,7 +58,7 @@ int main(void)
     kernel_pid_t other = thread_create(_stack,
                                        sizeof(_stack),
                                        (THREAD_PRIORITY_MAIN - 1),
-                                       THREAD_CREATE_STACKTEST,
+                                       0,
                                        _second_thread,
                                        NULL,
                                        "second_thread");

--- a/tests/bench/thread_yield_pingpong/main.c
+++ b/tests/bench/thread_yield_pingpong/main.c
@@ -57,7 +57,7 @@ int main(void)
     thread_create(_stack,
                   sizeof(_stack),
                   THREAD_PRIORITY_MAIN,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _second_thread,
                   NULL,
                   "second_thread");

--- a/tests/bench/xtimer_load/main.c
+++ b/tests/bench/xtimer_load/main.c
@@ -160,7 +160,7 @@ int main(void)
     /* create and trigger first background thread */
     kernel_pid_t pid1 = thread_create(slacker_stack1, sizeof(slacker_stack1),
                                       THREAD_PRIORITY_MAIN - 1,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       slacker_thread, NULL, "slacker1");
 
     LOG_DEBUG("+ msg 1");
@@ -174,7 +174,7 @@ int main(void)
     /* create and trigger second background thread */
     kernel_pid_t pid2 = thread_create(slacker_stack2, sizeof(slacker_stack2),
                                       THREAD_PRIORITY_MAIN - 1,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       slacker_thread, NULL, "slacker2");
 
     LOG_DEBUG("+ msg 3");
@@ -188,7 +188,7 @@ int main(void)
     /* create and trigger worker thread */
     kernel_pid_t pid3 = thread_create(worker_stack, sizeof(worker_stack),
                                       THREAD_PRIORITY_MAIN - 2,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       worker_thread, NULL, "worker");
 
     printf("TEST_HZ=%lu\n", TEST_HZ);

--- a/tests/core/deferred_yield_higher/main.c
+++ b/tests/core/deferred_yield_higher/main.c
@@ -37,7 +37,7 @@ int main(void)
     thread_create(
         t2_stack, sizeof(t2_stack),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+        THREAD_CREATE_WOUT_YIELD,
         second_thread, NULL, "nr2");
 
     irq_disable();

--- a/tests/core/isr_yield_higher/main.c
+++ b/tests/core/isr_yield_higher/main.c
@@ -61,7 +61,7 @@ int main(void)
     (void)thread_create(
         t2_stack, sizeof(t2_stack),
         THREAD_PRIORITY_MAIN,
-        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+        THREAD_CREATE_WOUT_YIELD,
         second_thread, NULL, "nr2");
 
     while (xtimer_now_usec() < (TEST_TIME + start_time)) {}

--- a/tests/core/mutex_unlock_and_sleep/main.c
+++ b/tests/core/mutex_unlock_and_sleep/main.c
@@ -56,7 +56,7 @@ int main(void)
     kernel_pid_t second_pid = thread_create(stack,
                   sizeof(stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   second_thread,
                   NULL,
                   "second_thread");

--- a/tests/core/sched_change_priority/main.c
+++ b/tests/core/sched_change_priority/main.c
@@ -86,10 +86,10 @@ static void *t3_func(void *unused)
 int main(void)
 {
     thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1,
-                  THREAD_CREATE_STACKTEST, t2_func, NULL, "t2");
+                  0, t2_func, NULL, "t2");
 
     t3_pid = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
-                           THREAD_CREATE_STACKTEST, t3_func, NULL, "t3");
+                           0, t3_func, NULL, "t3");
 
     puts("[main] Use shell command \"nice\" to increase prio of t3.\n"
          "[main] If it works, it will run again. The \"hint\" cmd can be useful.");

--- a/tests/core/thread_basic/main.c
+++ b/tests/core/thread_basic/main.c
@@ -35,7 +35,7 @@ int main(void)
     (void) thread_create(
             t2_stack, sizeof(t2_stack),
             THREAD_PRIORITY_MAIN - 1,
-            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+            THREAD_CREATE_WOUT_YIELD,
             second_thread, NULL, "nr2");
     puts("first thread\n");
     return 0;

--- a/tests/core/thread_cooperation/main.c
+++ b/tests/core/thread_cooperation/main.c
@@ -78,7 +78,7 @@ int main(void)
         printf("MAIN: create thread, arg: %d\n", arg);
         ths = thread_create(stacks[i], sizeof(stacks[i]),
                             THREAD_PRIORITY_MAIN - 1,
-                            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                            THREAD_CREATE_WOUT_YIELD,
                             run, NULL, "thread");
 
         if (ths < 0)  {

--- a/tests/core/thread_exit/main.c
+++ b/tests/core/thread_exit/main.c
@@ -50,7 +50,7 @@ void *second_thread(void *arg)
              third_thread_stack,
              sizeof(third_thread_stack),
              THREAD_PRIORITY_MAIN - 2,
-             THREAD_CREATE_STACKTEST,
+             0,
              third_thread,
              NULL,
              "nr3")
@@ -64,7 +64,7 @@ void *second_thread(void *arg)
              third_thread_stack,
              sizeof(third_thread_stack),
              THREAD_PRIORITY_MAIN - 1,
-             THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+             THREAD_CREATE_WOUT_YIELD,
              fourth_thread,
              NULL,
              "nr4")
@@ -84,7 +84,7 @@ int main(void)
              second_thread_stack,
              sizeof(second_thread_stack),
              THREAD_PRIORITY_MAIN - 1,
-             THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+             THREAD_CREATE_WOUT_YIELD,
              second_thread,
              NULL,
              "nr2")

--- a/tests/core/thread_flags/main.c
+++ b/tests/core/thread_flags/main.c
@@ -74,7 +74,7 @@ int main(void)
     kernel_pid_t pid = thread_create(stack,
                   sizeof(stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _thread,
                   NULL,
                   "second_thread");

--- a/tests/core/thread_float/main.c
+++ b/tests/core/thread_float/main.c
@@ -94,13 +94,13 @@ int main(void)
     timeout = 50000000000U / coreclk();
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN + 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread_1_2_3, (void *)t1_name, t1_name);
     p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread_1_2_3, (void *)t2_name, t2_name);
     p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN + 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread_1_2_3, (void *)t3_name, t3_name);
     puts("THREADS CREATED\n");
 

--- a/tests/core/thread_flood/main.c
+++ b/tests/core/thread_flood/main.c
@@ -46,7 +46,7 @@ int main(void)
         thr_id = thread_create(
             dummy_stack, sizeof(dummy_stack),
             THREAD_PRIORITY_MAIN - 1,
-            THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+            THREAD_CREATE_SLEEPING,
             thread_func, NULL, "dummy");
             ++thr_cnt;
             printf(".");

--- a/tests/core/thread_msg/main.c
+++ b/tests/core/thread_msg/main.c
@@ -87,13 +87,13 @@ int main(void)
 {
     p_main = thread_getpid();
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread1, NULL, "nr1");
     p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread2, NULL, "nr2");
     p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread3, NULL, "nr3");
     puts("THREADS CREATED\n");
 

--- a/tests/core/thread_msg_block_race/main.c
+++ b/tests/core/thread_msg_block_race/main.c
@@ -94,7 +94,7 @@ int main(void)
          "sched_run() which was the cause of the bug tested here");
     _sched_next();
     pid = thread_create(_stack, sizeof(_stack), THREAD_PRIORITY_MAIN + 1,
-                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                        THREAD_CREATE_WOUT_YIELD,
                         _thread, NULL, "nr2");
     expect(pid != KERNEL_PID_UNDEF);
 

--- a/tests/core/thread_msg_block_w_queue/main.c
+++ b/tests/core/thread_msg_block_w_queue/main.c
@@ -62,7 +62,7 @@ int main(void)
     msg_init_queue(_msg_q, 1);
 
     p_send = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        sender_thread, NULL, "nr1");
 
     /* step 3: receive first msg from sender_thread*/

--- a/tests/core/thread_msg_block_wo_queue/main.c
+++ b/tests/core/thread_msg_block_wo_queue/main.c
@@ -58,7 +58,7 @@ int main(void)
     p_recv = thread_getpid();
 
     p_send = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       THREAD_CREATE_WOUT_YIELD,
                        thread1, NULL, "nr1");
 
     /* step 3: receive first msg from sender_thread*/

--- a/tests/core/thread_msg_bus/main.c
+++ b/tests/core/thread_msg_bus/main.c
@@ -108,11 +108,11 @@ int main(void)
 
     p_main = thread_getpid();
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 3,
-                       THREAD_CREATE_STACKTEST, thread1, &my_bus, "nr1");
+                       0, thread1, &my_bus, "nr1");
     p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 2,
-                       THREAD_CREATE_STACKTEST, thread2, &my_bus, "nr2");
+                       0, thread2, &my_bus, "nr2");
     p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_STACKTEST, thread3, &my_bus, "nr3");
+                       0, thread3, &my_bus, "nr3");
     puts("THREADS CREATED");
 
     const char hello[] = "Hello Threads!";

--- a/tests/core/thread_msg_seq/main.c
+++ b/tests/core/thread_msg_seq/main.c
@@ -56,13 +56,13 @@ int main(void)
     p_main = thread_getpid();
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_STACKTEST, sub_thread, "nr1", "nr1");
+                       0, sub_thread, "nr1", "nr1");
 
     p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_STACKTEST, sub_thread, "nr2", "nr2");
+                       0, sub_thread, "nr2", "nr2");
 
     p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_STACKTEST, sub_thread, "nr3", "nr3");
+                       0, sub_thread, "nr3", "nr3");
     puts("THREADS CREATED\n");
 
     for (int i = 0; i < 3; i++) {

--- a/tests/core/thread_priority_inversion/main.c
+++ b/tests/core/thread_priority_inversion/main.c
@@ -150,15 +150,15 @@ static void *high_handler(void *arg)
 int main(void)
 {
     thread_create(stack_low, sizeof(stack_low),
-                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 1, 0,
                   low_handler, NULL, "low");
 
     thread_create(stack_mid, sizeof(stack_mid),
-                  THREAD_PRIORITY_MAIN - 2, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 2, 0,
                   mid_handler, NULL, "mid");
 
     thread_create(stack_high, sizeof(stack_high),
-                  THREAD_PRIORITY_MAIN - 3, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 3, 0,
                   high_handler, NULL, "high");
 
     /* Start low priority thread first, which will start high and mid priority ones after the

--- a/tests/core/thread_stack_alignment/main.c
+++ b/tests/core/thread_stack_alignment/main.c
@@ -83,7 +83,7 @@ int main(void)
         printf("Testing for alignment %" PRIuSIZE ": ", i);
         kernel_pid_t p;
         p = thread_create(stack + i, STACKSIZE, THREAD_PRIORITY_MAIN - 1,
-                          THREAD_CREATE_STACKTEST,
+                          0,
                           thread_func, NULL, "test");
         /* we expect that the new thread is scheduled to directly after it is
          * created and this will only continue one the thread has terminated.

--- a/tests/core/thread_zombie/main.c
+++ b/tests/core/thread_zombie/main.c
@@ -55,7 +55,7 @@ int main(void)
     kernel_pid_t first_pid =  thread_create(
         t2_stack, sizeof(t2_stack),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        THREAD_CREATE_SLEEPING,
         second_thread, (void *)1, "nr1");
 
     #ifdef MODULE_PS
@@ -67,7 +67,7 @@ int main(void)
     kernel_pid_t second_pid =  thread_create(
         t3_stack, sizeof(t3_stack),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        THREAD_CREATE_SLEEPING,
         second_thread, (void *)2, "nr2");
     #ifdef MODULE_PS
     ps();
@@ -78,7 +78,7 @@ int main(void)
     kernel_pid_t third_pid =  thread_create(
         t4_stack, sizeof(t4_stack),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        THREAD_CREATE_SLEEPING,
         second_thread, (void *)3, "nr3");
     #ifdef MODULE_PS
     ps();
@@ -217,7 +217,7 @@ int main(void)
     kernel_pid_t last_pid =  thread_create(
         t2_stack, sizeof(t2_stack),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+        THREAD_CREATE_SLEEPING,
         second_thread, (void *)4, "nr4");
 
     #ifdef MODULE_PS

--- a/tests/drivers/at86rf215/main.c
+++ b/tests/drivers/at86rf215/main.c
@@ -169,7 +169,7 @@ int test_init(void)
 {
     /* create battery monitor thread */
     thread_create(batmon_stack, sizeof(batmon_stack), THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST, batmon_thread, NULL, "batmon");
+                  0, batmon_thread, NULL, "batmon");
     return 0;
 }
 
@@ -247,7 +247,7 @@ int main(void)
 
     /* create battery monitor thread */
     thread_create(batmon_stack, sizeof(batmon_stack), THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST, batmon_thread, NULL, "batmon");
+                  0, batmon_thread, NULL, "batmon");
 
     /* start the shell */
     puts("Initialization successful - starting the shell now");

--- a/tests/drivers/lis2dh12/main.c
+++ b/tests/drivers/lis2dh12/main.c
@@ -367,7 +367,7 @@ int main(void)
 
     /* processing lis2dh12 acceleration data */
     thread_create(lis2dh12_process_stack, sizeof(lis2dh12_process_stack),
-                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 1, 0,
                   lis2dh12_test_process, NULL, "lis2dh12_process");
 #endif /* MODULE_LIS2DH12_INT */
 

--- a/tests/drivers/ltc4150/main.c
+++ b/tests/drivers/ltc4150/main.c
@@ -180,7 +180,7 @@ int main(void)
 
     /* Start the thread that will keep the MCU busy */
     thread_create(busy_thread_stack, sizeof(busy_thread_stack),
-                  THREAD_PRIORITY_MAIN + 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN + 1, 0,
                   busy_thread, NULL, "busy_thread");
 
     print_str("This test will put three levels of load on the MCU:\n"

--- a/tests/drivers/pir/main.c
+++ b/tests/drivers/pir/main.c
@@ -82,7 +82,7 @@ int main(void)
 #else
    thread_create(
            pir_handler_stack, sizeof(pir_handler_stack), THREAD_PRIORITY_MAIN - 1,
-           THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+           THREAD_CREATE_WOUT_YIELD,
            pir_handler, NULL, "pir_handler");
 #endif
     return 0;

--- a/tests/drivers/sx126x/main.c
+++ b/tests/drivers/sx126x/main.c
@@ -334,7 +334,7 @@ int main(void)
     }
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
-                              THREAD_CREATE_STACKTEST, _recv_thread, netdev,
+                              0, _recv_thread, netdev,
                               "recv_thread");
 
     if (_recv_pid <= KERNEL_PID_UNDEF) {

--- a/tests/drivers/sx127x/main.c
+++ b/tests/drivers/sx127x/main.c
@@ -553,7 +553,7 @@ int main(void)
     }
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
-                              THREAD_CREATE_STACKTEST, _recv_thread, NULL,
+                              0, _recv_thread, NULL,
                               "recv_thread");
 
     if (_recv_pid <= KERNEL_PID_UNDEF) {

--- a/tests/drivers/sx1280/main.c
+++ b/tests/drivers/sx1280/main.c
@@ -364,7 +364,7 @@ int main(void)
     }
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
-                              THREAD_CREATE_STACKTEST, _recv_thread, netdev,
+                              0, _recv_thread, netdev,
                               "recv_thread");
 
     if (_recv_pid <= KERNEL_PID_UNDEF) {

--- a/tests/net/gnrc_dhcpv6_client/main.c
+++ b/tests/net/gnrc_dhcpv6_client/main.c
@@ -59,7 +59,7 @@ int main(void)
 
     _gnrc_netif_config(0, NULL);
     thread_create(_dhcpv6_client_stack, DHCPV6_CLIENT_STACK_SIZE,
-                  DHCPV6_CLIENT_PRIORITY, THREAD_CREATE_STACKTEST,
+                  DHCPV6_CLIENT_PRIORITY, 0,
                   _dhcpv6_client_thread, NULL, "dhcpv6-client");
     xtimer_sleep(5);
     /* global address should now be configured */

--- a/tests/net/gnrc_mac_timeout/main.c
+++ b/tests/net/gnrc_mac_timeout/main.c
@@ -95,7 +95,7 @@ int main(void)
     /* create worker thread */
     kernel_pid_t pid = thread_create(worker_stack, sizeof(worker_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      worker_thread, NULL, "worker");
 
     timeout_1 = -1;

--- a/tests/net/gnrc_netif_ipv6_wait_for_global_address/main.c
+++ b/tests/net/gnrc_netif_ipv6_wait_for_global_address/main.c
@@ -66,7 +66,7 @@ static void _add_delayed_addr(gnrc_netif_t *netif)
     memset(adder_stack, 0, sizeof(adder_stack));
     thread_create(adder_stack, sizeof(adder_stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   _adder_thread, netif, "add_addr");
 }
 

--- a/tests/net/gnrc_udp/udp.c
+++ b/tests/net/gnrc_udp/udp.c
@@ -183,7 +183,7 @@ static void start_server(char *port_str)
     if (server_pid <= KERNEL_PID_UNDEF) {
         /* start server */
         server_pid = thread_create(server_stack, sizeof(server_stack), SERVER_PRIO,
-                                   THREAD_CREATE_STACKTEST, _eventloop, NULL, "UDP server");
+                                   0, _eventloop, NULL, "UDP server");
         if (server_pid <= KERNEL_PID_UNDEF) {
             puts("Error: can not start server thread");
             return;

--- a/tests/net/sock_udp_aux/main.c
+++ b/tests/net/sock_udp_aux/main.c
@@ -115,7 +115,7 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     thread_create(server_thread_stack, sizeof(server_thread_stack),
-                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 1, 0,
                   server_thread, NULL, "UDP echo server");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/tests/pkg/lwip/ip.c
+++ b/tests/pkg/lwip/ip.c
@@ -167,7 +167,7 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
 static int ip_start_server(char *port_str)
 {
     if (thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1,
-                      THREAD_CREATE_STACKTEST, _server_thread, port_str,
+                      0, _server_thread, port_str,
                       "IP server") <= KERNEL_PID_UNDEF) {
         return 1;
     }

--- a/tests/pkg/lwip/tcp.c
+++ b/tests/pkg/lwip/tcp.c
@@ -182,7 +182,7 @@ static int tcp_send(char *data, unsigned int num, unsigned int delay)
 static int tcp_start_server(char *port_str)
 {
     if (thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1,
-                      THREAD_CREATE_STACKTEST, _server_thread, port_str,
+                      0, _server_thread, port_str,
                       "TCP server") <= KERNEL_PID_UNDEF) {
         return 1;
     }

--- a/tests/pkg/lwip/udp.c
+++ b/tests/pkg/lwip/udp.c
@@ -129,7 +129,7 @@ static int udp_send(char *addr_str, char *data, unsigned int num,
 static int udp_start_server(char *port_str)
 {
     if (thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1,
-                      THREAD_CREATE_STACKTEST, _server_thread, port_str,
+                      0, _server_thread, port_str,
                       "UDP server") <= KERNEL_PID_UNDEF) {
         return 1;
     }

--- a/tests/pkg/lwip_sock_tcp/main.c
+++ b/tests/pkg/lwip_sock_tcp/main.c
@@ -968,10 +968,10 @@ int main(void)
     printf("code 0x%02x\n", code);
     _net_init();
     expect(0 < thread_create(_client_stack, sizeof(_client_stack),
-                             THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                             THREAD_PRIORITY_MAIN - 1, 0,
                              _client_func, NULL, "tcp_client"));
     expect(0 < thread_create(_server_stack, sizeof(_server_stack),
-                             THREAD_PRIORITY_MAIN - 2, THREAD_CREATE_STACKTEST,
+                             THREAD_PRIORITY_MAIN - 2, 0,
                              _server_func, NULL, "tcp_server"));
     tear_down();
 #ifdef MODULE_LWIP_IPV4

--- a/tests/pkg/tinyusb_cdc_msc/main.c
+++ b/tests/pkg/tinyusb_cdc_msc/main.c
@@ -85,7 +85,7 @@ int main(void)
 
     thread_create(led_thread_stack, sizeof(led_thread_stack),
                   THREAD_PRIORITY_MAIN + 1,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   led_thread_impl, NULL, "led");
 
     if (!IS_USED(MODULE_AUTO_INIT)) {

--- a/tests/sys/atomic_utils/main.c
+++ b/tests/sys/atomic_utils/main.c
@@ -1322,13 +1322,13 @@ static int sc_list(int argc, char **argv)
 int main(void)
 {
     thread_create(thread_worker_stack, sizeof(thread_worker_stack),
-                  THREAD_PRIORITY_MAIN + 2, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN + 2, 0,
                   thread_worker_func, NULL, "worker");
     thread_create(thread_checker_stack, sizeof(thread_checker_stack),
-                  THREAD_PRIORITY_MAIN + 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN + 1, 0,
                   thread_checker_func, NULL, "checker");
     thread_create(thread_timeout_stack, sizeof(thread_timeout_stack),
-                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                  THREAD_PRIORITY_MAIN - 1, 0,
                   thread_timeout_func, NULL, "timeout");
 
     print_str(

--- a/tests/sys/conn_can/main.c
+++ b/tests/sys/conn_can/main.c
@@ -732,7 +732,7 @@ int main(void)
     for (intptr_t i = 0; i < RCV_THREAD_NUMOF; i++) {
         receive_pid[i] = thread_create(thread_stack[i], THREAD_STACKSIZE,
                                        THREAD_PRIORITY_MAIN - 1,
-                                       THREAD_CREATE_STACKTEST, _receive_thread,
+                                       0, _receive_thread,
                                        (void*)i, "receive_thread");
     }
 

--- a/tests/sys/evtimer_msg/main.c
+++ b/tests/sys/evtimer_msg/main.c
@@ -69,7 +69,7 @@ int main(void)
     /* create worker thread */
     kernel_pid_t pid = thread_create(worker_stack, sizeof(worker_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      worker_thread, NULL, "worker");
 
     printf("Testing generic evtimer\n");

--- a/tests/sys/evtimer_underflow/main.c
+++ b/tests/sys/evtimer_underflow/main.c
@@ -71,7 +71,7 @@ int main(void)
     /* create worker thread */
     kernel_pid_t pid = thread_create(worker_stack, sizeof(worker_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      worker_thread, NULL, "worker");
 
     while (1) {

--- a/tests/sys/malloc_thread_safety/main.c
+++ b/tests/sys/malloc_thread_safety/main.c
@@ -112,9 +112,9 @@ int main(void)
     for (size_t i = 0; i < ARRAY_SIZE(funcs); i++) {
         printf("Testing: %s\n", tests[i]);
         t1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN + 1,
-                           THREAD_CREATE_STACKTEST, funcs[i], NULL, "t1");
+                           0, funcs[i], NULL, "t1");
         t2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1,
-                           THREAD_CREATE_STACKTEST, funcs[i], NULL, "t2");
+                           0, funcs[i], NULL, "t2");
         expect((t1 != KERNEL_PID_UNDEF) && (t2 != KERNEL_PID_UNDEF));
 
         for (uint16_t i = 0; i < 2 * MS_PER_SEC; i++) {

--- a/tests/sys/pipe/main.c
+++ b/tests/sys/pipe/main.c
@@ -101,11 +101,11 @@ int main(void)
 
     thread_create(stacks[0], sizeof (stacks[0]),
                   THREAD_PRIORITY_MAIN,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   run_middle, NULL, "middle");
     thread_create(stacks[1], sizeof (stacks[1]),
                   THREAD_PRIORITY_MAIN,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   run_end, NULL, "end");
 
     unsigned total = 0;

--- a/tests/sys/posix_semaphore/main.c
+++ b/tests/sys/posix_semaphore/main.c
@@ -78,7 +78,7 @@ static void test1(void)
     kernel_pid_t pid = thread_create(test1_thread_stack,
                                      sizeof(test1_thread_stack),
                                      THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_STACKTEST,
+                                     0,
                                      test1_second_thread,
                                      NULL,
                                      "second");
@@ -156,7 +156,7 @@ void test2(void)
         kernel_pid_t pid = thread_create(test2_thread_stack[i],
                                          sizeof(test2_thread_stack[i]),
                                          priority,
-                                         THREAD_CREATE_STACKTEST,
+                                         0,
                                          priority_sema_thread,
                                          names[i],
                                          names[i]);
@@ -215,14 +215,14 @@ void test3(void)
     }
     puts("first: create thread 1");
     if (thread_create(test2_thread_stack[0], sizeof(test2_thread_stack[0]),
-                      THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                      THREAD_PRIORITY_MAIN - 1, 0,
                       test3_one_two_thread, NULL, "thread 1") < 0) {
         puts("first: thread create FAILED");
         return;
     }
     puts("first: create thread 2");
     if (thread_create(test2_thread_stack[1], sizeof(test2_thread_stack[1]),
-                      THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,
+                      THREAD_PRIORITY_MAIN - 1, 0,
                       test3_two_one_thread, NULL, "thread 2") < 0) {
         puts("first: thread create FAILED");
         return;

--- a/tests/sys/ps_schedstatistics/main.c
+++ b/tests/sys/ps_schedstatistics/main.c
@@ -62,7 +62,7 @@ int main(void)
     for (uintptr_t i = 0; i < NB_THREADS; ++i) {
         pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
                                 THREAD_PRIORITY_MAIN - 1,
-                                THREAD_CREATE_STACKTEST,
+                                0,
                                 _thread_fn, (void *)i, "thread");
     }
     /* sleep for a second, so that `ps` shows some % on idle at the beginning */

--- a/tests/sys/pthread_condition_variable/main.c
+++ b/tests/sys/pthread_condition_variable/main.c
@@ -63,7 +63,7 @@ int main(void)
     pthread_cond_init(&cv, NULL);
 
     kernel_pid_t pid = thread_create(stack,sizeof(stack), THREAD_PRIORITY_MAIN - 1,
-                                     THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                                     THREAD_CREATE_WOUT_YIELD,
                                      second_thread, NULL, "second_thread");
 
     while (1) {

--- a/tests/sys/pthread_rwlock/main.c
+++ b/tests/sys/pthread_rwlock/main.c
@@ -159,7 +159,7 @@ int main(void)
         }
 
         thread_create(stacks[i], sizeof(stacks[i]),
-                      prio, THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                      prio, THREAD_CREATE_WOUT_YIELD,
                       fun, NULL, name);
     }
 

--- a/tests/sys/sched_round_robin/main.c
+++ b/tests/sys/sched_round_robin/main.c
@@ -53,9 +53,9 @@ int main(void)
 {
     puts("starting threads");
     main_pid = thread_getpid();
-    thread_create(stack[0], sizeof(stack[0]), shared_prio, THREAD_CREATE_STACKTEST,
+    thread_create(stack[0], sizeof(stack[0]), shared_prio, 0,
                   thread_wakeup_main, NULL, "TWakeup");
-    thread_create(stack[1], sizeof(stack[1]), shared_prio, THREAD_CREATE_STACKTEST,
+    thread_create(stack[1], sizeof(stack[1]), shared_prio, 0,
                   thread_bad, NULL, "TBad");
     puts("main is going to sleep");
     thread_sleep();

--- a/tests/sys/sema/main.c
+++ b/tests/sys/sema/main.c
@@ -86,7 +86,7 @@ int main(void)
     thread_create(stack,
                   sizeof(stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                  THREAD_CREATE_WOUT_YIELD,
                   second_thread,
                   &thread_success,
                   "second_thread");

--- a/tests/sys/sema_inv/main.c
+++ b/tests/sys/sema_inv/main.c
@@ -76,11 +76,11 @@ static void test_counter_mode(void)
     sema_inv_init(&sync, 3);
 
     thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST, thread_count, &ctx[0], "nr1");
+                  0, thread_count, &ctx[0], "nr1");
     thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1,
-                  THREAD_CREATE_STACKTEST, thread_count, &ctx[1], "nr2");
+                  0, thread_count, &ctx[1], "nr2");
     thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN + 1,
-                  THREAD_CREATE_STACKTEST, thread_count, &ctx[2], "nr3");
+                  0, thread_count, &ctx[2], "nr3");
 
     sema_inv_wait(&sync);
     puts("thread synced");
@@ -103,11 +103,11 @@ static void test_mask_mode(void)
     sema_inv_init(&sync, 0xE);
 
     thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST, thread_bit, &ctx[0], "nr1");
+                  0, thread_bit, &ctx[0], "nr1");
     thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1,
-                  THREAD_CREATE_STACKTEST, thread_bit, &ctx[1], "nr2");
+                  0, thread_bit, &ctx[1], "nr2");
     thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN + 1,
-                  THREAD_CREATE_STACKTEST, thread_bit, &ctx[2], "nr3");
+                  0, thread_bit, &ctx[2], "nr3");
 
     sema_inv_wait(&sync);
     puts("thread synced");

--- a/tests/sys/xtimer_drift/main.c
+++ b/tests/sys/xtimer_drift/main.c
@@ -138,7 +138,7 @@ int main(void)
     /* create and trigger first background thread */
     kernel_pid_t pid1 = thread_create(slacker_stack1, sizeof(slacker_stack1),
                                       THREAD_PRIORITY_MAIN - 1,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       slacker_thread, NULL, "slacker1");
 
     LOG_DEBUG("+ msg 1");
@@ -152,7 +152,7 @@ int main(void)
     /* create and trigger second background thread */
     kernel_pid_t pid2 = thread_create(slacker_stack2, sizeof(slacker_stack2),
                                       THREAD_PRIORITY_MAIN - 1,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       slacker_thread, NULL, "slacker2");
 
     LOG_DEBUG("+ msg 3");
@@ -166,7 +166,7 @@ int main(void)
     /* create and trigger worker thread */
     kernel_pid_t pid3 = thread_create(worker_stack, sizeof(worker_stack),
                                       THREAD_PRIORITY_MAIN - 2,
-                                      THREAD_CREATE_STACKTEST,
+                                      0,
                                       worker_thread, NULL, "worker");
 
     puts("[START]\n");

--- a/tests/sys/xtimer_hang/main.c
+++ b/tests/sys/xtimer_hang/main.c
@@ -84,10 +84,10 @@ int main(void)
     LOG_DEBUG("[INIT]\n");
 
     thread_create(stack_timer1, TEST_TIMER_STACKSIZE,
-                  2, THREAD_CREATE_STACKTEST,
+                  2, 0,
                   timer_func, &sleep_timer1, "timer1");
     thread_create(stack_timer2, TEST_TIMER_STACKSIZE,
-                  3, THREAD_CREATE_STACKTEST,
+                  3, 0,
                   timer_func, &sleep_timer2, "timer2");
 
     uint32_t now = 0;

--- a/tests/sys/xtimer_msg/main.c
+++ b/tests/sys/xtimer_msg/main.c
@@ -100,7 +100,7 @@ int main(void)
                   timer_stack,
                   sizeof(timer_stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   timer_thread,
                   NULL,
                   "timer");
@@ -119,7 +119,7 @@ int main(void)
                    timer_stack_local,
                    sizeof(timer_stack_local),
                    THREAD_PRIORITY_MAIN - 1,
-                   THREAD_CREATE_STACKTEST,
+                   0,
                    timer_thread_local,
                    NULL,
                    "timer local");

--- a/tests/sys/xtimer_mutex_lock_timeout/main.c
+++ b/tests/sys/xtimer_mutex_lock_timeout/main.c
@@ -225,7 +225,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
     printf("threads = %d\n", current_thread_count);
     kernel_pid_t test_thread = thread_create(t_stack, sizeof(t_stack),
                                              THREAD_PRIORITY_MAIN + 1,
-                                             THREAD_CREATE_STACKTEST,
+                                             0,
                                              thread_low_prio_test,
                                              (void *)&test_mutex,
                                              "thread_low_prio_test");

--- a/tests/sys/xtimer_rmutex_lock_timeout/main.c
+++ b/tests/sys/xtimer_rmutex_lock_timeout/main.c
@@ -200,7 +200,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
     /* lock rmutex from different thread */
     kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
                                                THREAD_PRIORITY_MAIN - 1,
-                                               THREAD_CREATE_STACKTEST,
+                                               0,
                                                lock_rmutex_thread,
                                                (void *)&test_rmutex,
                                                "lock_thread");
@@ -252,7 +252,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
 
     kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
                                                THREAD_PRIORITY_MAIN + 1,
-                                               THREAD_CREATE_STACKTEST,
+                                               0,
                                                test_thread,
                                                (void *)&test_rmutex,
                                                "test_thread");
@@ -306,7 +306,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
 
     kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
                                                THREAD_PRIORITY_MAIN - 1,
-                                               THREAD_CREATE_STACKTEST,
+                                               0,
                                                lock_rmutex_thread,
                                                (void *)&test_rmutex,
                                                "lock_thread");

--- a/tests/sys/ztimer64_msg/main.c
+++ b/tests/sys/ztimer64_msg/main.c
@@ -119,7 +119,7 @@ int main(void)
         timer_stack,
         sizeof(timer_stack),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_STACKTEST,
+        0,
         timer_thread,
         NULL,
         "timer");
@@ -138,7 +138,7 @@ int main(void)
         timer_stack_local,
         sizeof(timer_stack_local),
         THREAD_PRIORITY_MAIN - 1,
-        THREAD_CREATE_STACKTEST,
+        0,
         timer_thread_local,
         NULL,
         "timer local");

--- a/tests/sys/ztimer_msg/main.c
+++ b/tests/sys/ztimer_msg/main.c
@@ -115,7 +115,7 @@ int main(void)
                   timer_stack,
                   sizeof(timer_stack),
                   THREAD_PRIORITY_MAIN - 1,
-                  THREAD_CREATE_STACKTEST,
+                  0,
                   timer_thread,
                   NULL,
                   "timer");
@@ -134,7 +134,7 @@ int main(void)
                    timer_stack_local,
                    sizeof(timer_stack_local),
                    THREAD_PRIORITY_MAIN - 1,
-                   THREAD_CREATE_STACKTEST,
+                   0,
                    timer_thread_local,
                    NULL,
                    "timer local");

--- a/tests/sys/ztimer_rmutex_lock_timeout/main.c
+++ b/tests/sys/ztimer_rmutex_lock_timeout/main.c
@@ -193,7 +193,7 @@ static int cmd_test_ztimer_rmutex_lock_timeout_long_locked(int argc,
     /* lock rmutex from different thread */
     kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
                                                THREAD_PRIORITY_MAIN - 1,
-                                               THREAD_CREATE_STACKTEST,
+                                               0,
                                                lock_rmutex_thread,
                                                (void *)&test_rmutex,
                                                "lock_thread");
@@ -245,7 +245,7 @@ static int cmd_test_ztimer_rmutex_lock_timeout_low_prio_thread(
 
     kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
                                                THREAD_PRIORITY_MAIN + 1,
-                                               THREAD_CREATE_STACKTEST,
+                                               0,
                                                test_thread,
                                                (void *)&test_rmutex,
                                                "test_thread");
@@ -299,7 +299,7 @@ static int cmd_test_ztimer_rmutex_lock_timeout_short_locked(int argc,
 
     kernel_pid_t second_t_pid = thread_create( t_stack, sizeof(t_stack),
                                                THREAD_PRIORITY_MAIN - 1,
-                                               THREAD_CREATE_STACKTEST,
+                                               0,
                                                lock_rmutex_thread,
                                                (void *)&test_rmutex,
                                                "lock_thread");

--- a/tests/unittests/tests-bhp_msg/tests-bhp_msg.c
+++ b/tests/unittests/tests-bhp_msg/tests-bhp_msg.c
@@ -72,7 +72,7 @@ static void test_bhp_msg__claim(void)
 static void test_bhp_msg__cb(void)
 {
     kernel_pid_t pid = thread_create(_stack, sizeof(_stack), THREAD_PRIORITY_MAIN - 1,
-                             THREAD_CREATE_STACKTEST, _event_loop, NULL,
+                             0, _event_loop, NULL,
                              "bhp_msg");
 
     bhp_msg_claim_thread(&bhp_msg, pid);

--- a/tests/unittests/tests-core/tests-core-ringbuffer.c
+++ b/tests/unittests/tests-core/tests-core-ringbuffer.c
@@ -109,7 +109,7 @@ static void tests_core_ringbuffer(void)
     pid_add = thread_getpid();
     pid_get = thread_create(stack_get, sizeof (stack_get),
                             THREAD_PRIORITY_MAIN,
-                            THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
+                            THREAD_CREATE_SLEEPING,
                             run_get, NULL, "get");
     run_add();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We already create every thread with `THREAD_CREATE_STACKTEST`.
If someone creates a thread without it, `ps` output is weird (all stack is marked as used) and the overhead is only at thread creation and only when `DEVELHELP` is set.

Remove the flag (but keep the define to not break apps) since in all those years, not a single use-case has been found for creating a thread without `THREAD_CREATE_STACKTEST`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
