### PR TITLE
tests: Cover API of scn_u32_hex in the unittest

### DIFF
--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -852,13 +852,18 @@ static void test_scn_u32_dec(void)
 
 static void test_scn_u32_hex(void)
 {
-    const char *string1 = "aB12cE4F";
-    uint32_t val1 = 0xab12ce4f;
-    uint32_t val2 = 0xab1;
+    /* ´x´ is not a valid hexadecimal character */
+    TEST_ASSERT_EQUAL_INT(0x0, scn_u32_hex("0xABCD", 4));
+    /* so are these: */
+    TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9 ABCD", 4));
+    TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9-ABCD", 4));
+    TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9+ABCD", 4));
+    TEST_ASSERT_EQUAL_INT(0xab, scn_u32_hex("AB_CD", 4));
 
-    TEST_ASSERT_EQUAL_INT(val1, scn_u32_hex(string1, 8));
-    TEST_ASSERT_EQUAL_INT(val2, scn_u32_hex(string1, 3));
-    TEST_ASSERT_EQUAL_INT(val1, scn_u32_hex(string1, 9));
+    /* Stop on the length argument or on the null terminator */
+    TEST_ASSERT_EQUAL_INT(0xab12ce4f, scn_u32_hex("aB12cE4F", 8));
+    TEST_ASSERT_EQUAL_INT(0xab1, scn_u32_hex("aB12cE4F", 3));
+    TEST_ASSERT_EQUAL_INT(0xab12ce4f, scn_u32_hex("aB12cE4F", 9));
 }
 
 static void test_fmt_lpad(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hej :shark: 

This adds the test case to the unit-tests of `scn_u32_hex()` in which parsing is aborted on non hex characters.

### Testing procedure

`make -C tests/unittests/ tests-fmt term`

### Issues/PRs references

 This lacking coverage was brought up twice! In #19894 and #19027

There are still test holes remaining in that unittest...
