### PR TITLE
sys/psa_crypto: use SHA256 CSPRNG as default

### DIFF
--- a/sys/psa_crypto/Makefile.dep
+++ b/sys/psa_crypto/Makefile.dep
@@ -1,6 +1,6 @@
 ifneq (,$(filter psa_crypto,$(USEMODULE)))
   USEMODULE += random
-  USEMODULE += prng_musl_lcg
+  USEMODULE += prng_sha256prng
 endif
 
 # Asymmetric

--- a/tests/sys/psa_crypto_hashes/Makefile.ci
+++ b/tests/sys/psa_crypto_hashes/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
+    nucleo-l011k4 \
     #


### PR DESCRIPTION
### Contribution description
So far the PSA Crypto implementation used MUSL C PRNG as the default random number generator, which is not cryptographically secure.
This PR uses the SHA256 RNG instead, which is a CSPRNG.

### Testing procedure
When building `examples/psa_crypto`: `make info-modules` should list `prng_sha256prng`