### PR TITLE
examples/psa_crypto: Fix modules to run ECDSA on SEs

### DIFF
--- a/examples/psa_crypto/main.c
+++ b/examples/psa_crypto/main.c
@@ -27,7 +27,8 @@ extern psa_status_t example_cipher_aes_128(void);
 #if IS_USED(MODULE_PSA_MAC)
 extern psa_status_t example_hmac_sha256(void);
 #endif
-#if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1)
+#if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1) || \
+    IS_USED(MODULE_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256)
 extern psa_status_t example_ecdsa_p256(void);
 #endif
 #if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_ED25519)
@@ -43,7 +44,7 @@ extern psa_status_t example_cipher_aes_128_sec_se(void);
 #if IS_USED(MODULE_PSA_MAC)
 extern psa_status_t example_hmac_sha256_sec_se(void);
 #endif /* MODULE_PSA_MAC */
-#if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1)
+#if IS_USED(MODULE_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256)
 extern psa_status_t example_ecdsa_p256_sec_se(void);
 #endif /* MODULE_PSA_ASYMMETRIC_ECC_P256R1 */
 #endif /* MULTIPLE_SE */
@@ -81,7 +82,8 @@ int main(void)
     }
 #endif
 
-#if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1)
+#if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1) || \
+    IS_USED(MODULE_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256)
     start = ztimer_now(ZTIMER_USEC);
     status = example_ecdsa_p256();
     printf("ECDSA took %d us\n", (int)(ztimer_now(ZTIMER_USEC) - start));
@@ -122,7 +124,7 @@ int main(void)
     }
 #endif /* MODULE_PSA_CIPHER */
 
-#if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1)
+#if IS_USED(MODULE_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256)
     start = ztimer_now(ZTIMER_USEC);
     status = example_ecdsa_p256_sec_se();
     printf("ECDSA took %d us\n", (int)(ztimer_now(ZTIMER_USEC) - start));
@@ -130,7 +132,7 @@ int main(void)
         failed = true;
         printf("ECDSA failed: %s\n", psa_status_to_humanly_readable(status));
     }
-#endif /* MODULE_PSA_ASYMMETRIC_ECC_P256R1 */
+#endif /* MODULE_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256 */
 #endif /* MULTIPLE_SE */
 
     ztimer_release(ZTIMER_USEC);


### PR DESCRIPTION
### Contribution description
There was an error in the compile time conditionals that did not consider secure elements.
This means that when running the example with a secure element, the ECDSA functions were not executed anymore. 

This provides a fix for that. 

### Testing procedure
When running `SECURE_ELEMENT=1 BOARD=nrf52840dk make flash term` on master

```
2024-03-12 14:23:31,097 # main(): This is RIOT! (Version: 2024.01-devel-1054-g03c05f-pr/run-ecdsa-functions-with-secure-elements)
2024-03-12 14:23:31,098 # HMAC SHA256 took 56402 us
2024-03-12 14:23:31,098 # Cipher AES 128 took 68853 us
2024-03-12 14:23:31,099 # All Done
2024-03-12 14:25:03,072 # Exiting Pyterm
```

After applying these changes:

```
2024-03-12 14:41:09,059 # main(): This is RIOT! (Version: 2024.01-devel-1054-g03c05f-pr/run-ecdsa-functions-with-secure-elements)
2024-03-12 14:41:09,060 # HMAC SHA256 took 56535 us
2024-03-12 14:41:09,060 # Cipher AES 128 took 68973 us
2024-03-12 14:41:09,061 # ECDSA took 282086 us
2024-03-12 14:41:09,061 # All Done
2024-03-12 14:41:17,151 # Exiting Pyterm
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
