### PR TITLE
cpu/stm32/periph/adc: improve adc wait

### DIFF
--- a/cpu/stm32/periph/adc_f3.c
+++ b/cpu/stm32/periph/adc_f3.c
@@ -20,6 +20,7 @@
  */
 
 #include "cpu.h"
+#include "macros/math.h"
 #include "mutex.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
@@ -146,9 +147,9 @@ int adc_init(adc_t line)
 #if IS_USED(MODULE_ZTIMER_USEC)
         ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
 #else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
+        /* to avoid using ZTIMER_USEC, unless already included, round up the
+           internal voltage regulator start up time to milliseconds */
+        ztimer_sleep(ZTIMER_MSEC, DIV_ROUND_UP(ADC_T_ADCVREG_STUP_US, 1000));
 #endif
 
         if (dev(line)->DIFSEL & (1 << adc_config[line].chan)) {

--- a/cpu/stm32/periph/adc_l4.c
+++ b/cpu/stm32/periph/adc_l4.c
@@ -22,6 +22,7 @@
  */
 
 #include "cpu.h"
+#include "macros/math.h"
 #include "mutex.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
@@ -176,9 +177,9 @@ int adc_init(adc_t line)
 #if IS_USED(MODULE_ZTIMER_USEC)
         ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
 #else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
+        /* to avoid using ZTIMER_USEC, unless already included, round up the
+           internal voltage regulator start up time to milliseconds */
+        ztimer_sleep(ZTIMER_MSEC, DIV_ROUND_UP(ADC_T_ADCVREG_STUP_US, 1000));
 #endif
 
         /* configure calibration for single ended input */

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -24,6 +24,7 @@
  */
 
 #include "cpu.h"
+#include "macros/math.h"
 #include "mutex.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
@@ -86,9 +87,9 @@ int adc_init(adc_t line)
 #if IS_USED(MODULE_ZTIMER_USEC)
         ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
 #else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
+        /* to avoid using ZTIMER_USEC, unless already included, round up the
+           internal voltage regulator start up time to milliseconds */
+        ztimer_sleep(ZTIMER_MSEC, DIV_ROUND_UP(ADC_T_ADCVREG_STUP_US, 1000));
 #endif
 
         /* ´start automatic calibration and wait for it to complete */


### PR DESCRIPTION
### Contribution description

This patch just makes the use of ztimer_sleep() inside the ADC driver for certain STM32 MCUs just a little bit more safe.


### Testing procedure

I did not run this code, but I did ensure that there was already a unit test test in place for `DIV_ROUND_UP()`. So we can trust it will do its job here. I did do `make -C tests/periph/adc BOARD=nucleo-f303ze` just to ensure it does compiles for the STM32F3.


### Issues/PRs references

none known
