### PR TITLE
tests: Add cases to the scn_u32_hex unittest

### DIFF
--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -254,7 +254,6 @@ static void test_fmt_u16_hex(void)
     TEST_ASSERT_EQUAL_INT(4, fmt_u16_hex(out, 0));
     TEST_ASSERT(memcmp(out, "0000zzzz", 8) == 0);
 
-
     TEST_ASSERT_EQUAL_INT(4, fmt_u16_hex(out, 0xBEEF));
     TEST_ASSERT(memcmp(out, "BEEFzzzz", 8) == 0);
 }
@@ -859,11 +858,15 @@ static void test_scn_u32_hex(void)
     TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9-ABCD", 4));
     TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9+ABCD", 4));
     TEST_ASSERT_EQUAL_INT(0xab, scn_u32_hex("AB_CD", 4));
+    TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9:3kCD", 4));
+    TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9}3kCD", 4));
+    TEST_ASSERT_EQUAL_INT(0x9, scn_u32_hex("9?3kCD", 4));
 
     /* Stop on the length argument or on the null terminator */
     TEST_ASSERT_EQUAL_INT(0xab12ce4f, scn_u32_hex("aB12cE4F", 8));
     TEST_ASSERT_EQUAL_INT(0xab1, scn_u32_hex("aB12cE4F", 3));
     TEST_ASSERT_EQUAL_INT(0xab12ce4f, scn_u32_hex("aB12cE4F", 9));
+    TEST_ASSERT_EQUAL_INT(0xab, scn_u32_hex("aB", 9));
 }
 
 static void test_fmt_lpad(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Follow-up to #20458 
@kfessel discovered that the tests were still insufficient. This adds the missing cases.
Technically, all ascii characters could be tested separately...

### Testing procedure

`make -C tests/unittests/ tests-fmt term`

### Issues/PRs references

#19894
