### PR TITLE
tests/sys/psa_crypto_se*: add arduino leonardo to board insufficient memory list

### DIFF
--- a/tests/sys/psa_crypto_se_ecdsa/Makefile.ci
+++ b/tests/sys/psa_crypto_se_ecdsa/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
+    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \

--- a/tests/sys/psa_crypto_se_mac/Makefile.ci
+++ b/tests/sys/psa_crypto_se_mac/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
+    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \


### PR DESCRIPTION
### Contribution description
My last two PRs (#20460 and #20461) slightly increased the memory sizes, which makes two tests too large for the Arduino Leonardo.

I added it to the list of boards with insufficient memory.
