### PR TITLE
cpu/stm32/periph/usbdev_fs: avoid using ztimer when not needed

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -7,20 +7,26 @@ ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
   ifneq (,$(filter f2 f4 f7 h7 u5,$(CPU_FAM)))
     # Whole STM32 families F2, F4, F7, H7 and U5 use the Synopsys DWC2 USB OTG core
     USEMODULE += usbdev_synopsys_dwc2
+    USEMODULE += ztimer
+    USEMODULE += ztimer_msec
   else ifneq (,$(filter stm32f105% stm32f107%,$(CPU_MODEL)))
     # STM32F105xx and STM32F107xx also use the Synopsys DWC2 USB OTG core
     USEMODULE += usbdev_synopsys_dwc2
+    USEMODULE += ztimer
+    USEMODULE += ztimer_msec
   else ifneq (,$(filter stm32l47% stm32l48% stm32l49%,$(CPU_MODEL)))
     # STM32L475xx, STM32L476xx, STM32L485xx, STM32L486xx and STM32L496xx
     # also use the Synopsys DWC2 USB OTG core
     USEMODULE += usbdev_synopsys_dwc2
+    USEMODULE += ztimer
+    USEMODULE += ztimer_msec
   else ifneq (,$(filter stm32l4a% stm32l4p% stm32l4q% stm32l4r% stm32l4s%,$(CPU_MODEL)))
     # STM32L4Axxx, STM32L4Pxxx, STM32L4Qxxx, STM32L4Rxxx and STM32L4Sxxx
     # also use the Synopsys DWC2 USB OTG core
     USEMODULE += usbdev_synopsys_dwc2
+    USEMODULE += ztimer
+    USEMODULE += ztimer_msec
   endif
-  USEMODULE += ztimer
-  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -32,6 +32,7 @@
 #include "usbdev_stm32.h"
 #include "pm_layered.h"
 #include "ztimer.h"
+#include "busy_wait.h"
 
 #include <string.h>
 /**
@@ -218,7 +219,15 @@ static void _enable_gpio(const stm32_usbdev_fs_config_t *conf)
         gpio_init(conf->dp, GPIO_OUT);
         gpio_clear(conf->dp);
         /* wait a 1 ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
+        if (IS_USED(MODULE_ZTIMER_MSEC)) {
+            ztimer_sleep(ZTIMER_MSEC, 1);
+        }
+        else if(IS_USED(MODULE_ZTIMER_USEC)) {
+            ztimer_sleep(ZTIMER_USEC, 1 * US_PER_MS);
+        }
+        else {
+            busy_wait_us(1 * US_PER_MS);
+        }
         gpio_init(conf->dp, GPIO_IN);
     }
     if (conf->af != GPIO_AF_UNDEF) {


### PR DESCRIPTION
### Contribution description
Avoid pulling `ztimer` and `ztimer_msec` dependencies by default when using `usbdev_fs` peripheral driver.
If another module needs `ztimer`, then we can keep using it but otherwise use `busy_wait()` to perform the small delay needed by the driver.
My main idea is to avoid pulling `ztimer` when it is possible, to save ROM for `riotboot_dfu` bootloader application.

### Testing procedure
`make BOARD=bluepill-stm32f103c8 -C tests/sys/usbus_cdc_acm_stdio` must compile (and `ztimer` should not appear if you use `info-build`)

`make BOARD=bluepill-stm32f103c8 -C tests/sys/usbus_cdc_ecm` must compile (and `ztimer` should appear if you use `info-build` because `ztimer` dependency is pulled by another module


### Issues/PRs references
None.
