### PR TITLE
makefiles/docker.inc.mk: always pull to keep image up-to-date

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -121,12 +121,13 @@ DOCKER ?= docker
 _docker_is_podman = $(shell $(DOCKER) --version | grep podman 2>/dev/null)
 
 # Set default run flags:
-# - allocate a pseudo-tty
+# - always pull to have riot/riotbuild:latest up-to-date
 # - remove container on exit
+# - allocate a pseudo-tty
 # - set username/UID to executor
 DOCKER_USER ?= $$(id -u)
 DOCKER_USER_OPT = $(if $(_docker_is_podman),--userns keep-id,--user $(DOCKER_USER))
-DOCKER_RUN_FLAGS ?= --rm --tty $(DOCKER_USER_OPT)
+DOCKER_RUN_FLAGS ?= --pull=always --rm --tty $(DOCKER_USER_OPT)
 
 # allow setting make args from command line like '-j'
 DOCKER_MAKE_ARGS ?=


### PR DESCRIPTION
### Contribution description

On current master, `BUILD_IN_DOCKER` might fail just because the local docker image is outdated. Since the image is automatically pulled upon the first build with docker, users (including me) probably would expect RIOT to keep the image updated automatically.

This PR changes the [`docker run --pull` argument](https://docs.docker.com/reference/cli/docker/container/run/#pull) from the default `missing` to `always`.

### Testing procedure

- Have an outdated version of riot/riotbuild locally (in my case it was ~5 months old).
- `BUILD_IN_DOCKER=1 make -C examples/hello-world all`
- see how the docker image gets updated automatically

---

- Have an up-to-date version of riot/riotbuild locally.
- `BUILD_IN_DOCKER=1 make -C examples/hello-world all`
- see that the image is only updated if it was outdated:
  ```
  latest: Pulling from riot/riotbuild
  Digest: sha256:66d026e6f33763b8e016354853b15f4a71ffdd62a3c92fbd0f5e9eb8166ef87f
  Status: Image is up to date for riot/riotbuild:latest 
  ```


### Issues/PRs references

Issue was discussed on matrix, where @maribu proposed to automatically pull on each build.
