### PR TITLE
treewide: remove deprecated modules

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += nice # use shell_cmd_nice instead
 DEPRECATED_MODULES += random_cmd # use shell_cmd_random instead
 DEPRECATED_MODULES += sema_deprecated
 DEPRECATED_MODULES += sha1sum # use shell_cmd_sha1sum instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
 DEPRECATED_MODULES += sema_deprecated
-DEPRECATED_MODULES += sha256sum # use shell_cmd_sha256sum instead
 DEPRECATED_MODULES += shell_commands # use shell_cmds_default instead
 DEPRECATED_MODULES += ztimer_now64

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += gnrc_udp_cmd # use shell_cmd_gnrc_udp instead
 DEPRECATED_MODULES += heap_cmd # use shell_cmd_heap instead
 DEPRECATED_MODULES += i2c_scan # use shell_cmd_i2c_scan instead
 DEPRECATED_MODULES += md5sum # use shell_cmd_md5sum instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,7 +1,6 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
 DEPRECATED_MODULES += gnrc_netif_cmd_lora # use shell_cmd_gnrc_netif_lorawan instead
-DEPRECATED_MODULES += gnrc_pktbuf_cmd # use shell_cmd_gnrc_pktbuf instead
 DEPRECATED_MODULES += gnrc_udp_cmd # use shell_cmd_gnrc_udp instead
 DEPRECATED_MODULES += heap_cmd # use shell_cmd_heap instead
 DEPRECATED_MODULES += i2c_scan # use shell_cmd_i2c_scan instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += random_cmd # use shell_cmd_random instead
 DEPRECATED_MODULES += sema_deprecated
 DEPRECATED_MODULES += sha1sum # use shell_cmd_sha1sum instead
 DEPRECATED_MODULES += sha256sum # use shell_cmd_sha256sum instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += heap_cmd # use shell_cmd_heap instead
 DEPRECATED_MODULES += i2c_scan # use shell_cmd_i2c_scan instead
 DEPRECATED_MODULES += md5sum # use shell_cmd_md5sum instead
 DEPRECATED_MODULES += nice # use shell_cmd_nice instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,7 +1,6 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
 DEPRECATED_MODULES += sema_deprecated
-DEPRECATED_MODULES += sha1sum # use shell_cmd_sha1sum instead
 DEPRECATED_MODULES += sha256sum # use shell_cmd_sha256sum instead
 DEPRECATED_MODULES += shell_commands # use shell_cmds_default instead
 DEPRECATED_MODULES += ztimer_now64

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += gnrc_netif_cmd_lora # use shell_cmd_gnrc_netif_lorawan instead
 DEPRECATED_MODULES += gnrc_udp_cmd # use shell_cmd_gnrc_udp instead
 DEPRECATED_MODULES += heap_cmd # use shell_cmd_heap instead
 DEPRECATED_MODULES += i2c_scan # use shell_cmd_i2c_scan instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += i2c_scan # use shell_cmd_i2c_scan instead
 DEPRECATED_MODULES += md5sum # use shell_cmd_md5sum instead
 DEPRECATED_MODULES += nice # use shell_cmd_nice instead
 DEPRECATED_MODULES += random_cmd # use shell_cmd_random instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += gnrc_netdev_default
 DEPRECATED_MODULES += gnrc_netif_cmd_lora # use shell_cmd_gnrc_netif_lorawan instead
 DEPRECATED_MODULES += gnrc_pktbuf_cmd # use shell_cmd_gnrc_pktbuf instead
 DEPRECATED_MODULES += gnrc_udp_cmd # use shell_cmd_gnrc_udp instead

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,6 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
-DEPRECATED_MODULES += md5sum # use shell_cmd_md5sum instead
 DEPRECATED_MODULES += nice # use shell_cmd_nice instead
 DEPRECATED_MODULES += random_cmd # use shell_cmd_random instead
 DEPRECATED_MODULES += sema_deprecated

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -344,13 +344,6 @@ PSEUDOMODULES += psa_riot_hashes_sha_256
 PSEUDOMODULES += psa_riot_hashes_sha_512
 PSEUDOMODULES += psa_riot_hashes_hmac_sha256
 PSEUDOMODULES += fortuna_reseed
-## @defgroup pseudomodule_random_cmd random_cmd
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_random` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += random_cmd
-## @}
 PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += rtt_cmd
 PSEUDOMODULES += saul_adc

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -380,13 +380,7 @@ PSEUDOMODULES += servo_timer
 ## @{
 PSEUDOMODULES += servo_saul
 ## @}
-## @defgroup pseudomodule_sha256sum sha256sum
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_sha256sum` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += sha256sum
-## @}
+
 PSEUDOMODULES += shell_cmd_app_metadata
 PSEUDOMODULES += shell_cmd_at30tse75x
 PSEUDOMODULES += shell_cmd_benchmark_udp

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -114,13 +114,6 @@ PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_bus
 PSEUDOMODULES += gnrc_netif_timestamp
-## @defgroup net_gnrc_pktbuf_cmd  gnrc_pktbuf_cmd
-## @ingroup net_gnrc_pktbuf
-## @{
-## @deprecated  Use module `shell_cmd_gnrc_pktbuf` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += gnrc_pktbuf_cmd
-## @}
 PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_ipv6
 PSEUDOMODULES += gnrc_netif_mac

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -286,13 +286,6 @@ PSEUDOMODULES += mpu_noexec_ram
 PSEUDOMODULES += pmp_noexec_ram
 ## @}
 
-## @defgroup pseudomodule_md5sum md5sum
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_md5sum` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += md5sum
-## @}
 PSEUDOMODULES += mtd_write_page
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += nanocoap_fileserver_callback

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -380,13 +380,6 @@ PSEUDOMODULES += servo_timer
 ## @{
 PSEUDOMODULES += servo_saul
 ## @}
-## @defgroup pseudomodule_sha1sum sha1sum
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_sha1sum` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += sha1sum
-## @}
 ## @defgroup pseudomodule_sha256sum sha256sum
 ## @ingroup sys_shell_commands
 ## @{

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -234,13 +234,6 @@ PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_congure_sfr
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc
 PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
-## @defgroup net_gnrc_udp_cmd  gnrc_udp_cmd
-## @ingroup net_gnrc_udp
-## @{
-## @deprecated  Use module `shell_cmd_gnrc_udp` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += gnrc_udp_cmd
-## @}
 PSEUDOMODULES += gnrc_sock_async
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -237,13 +237,6 @@ PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_async
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
-## @defgroup pseudomodule_i2c_scan i2c_scan
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_i2c_scan` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += i2c_scan
-## @}
 PSEUDOMODULES += ieee802154_security
 PSEUDOMODULES += ieee802154_submac
 PSEUDOMODULES += ipv4

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -237,13 +237,6 @@ PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_async
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
-## @defgroup pseudomodule_heap_cmd heap_cmd
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_heap` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += heap_cmd
-## @}
 ## @defgroup pseudomodule_i2c_scan i2c_scan
 ## @ingroup sys_shell_commands
 ## @{

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -109,13 +109,6 @@ PSEUDOMODULES += gnrc_ipv6_nib_rio
 PSEUDOMODULES += gnrc_ipv6_nib_router
 PSEUDOMODULES += gnrc_ipv6_nib_rtr_adv_pio_cb
 PSEUDOMODULES += gnrc_lorawan_1_1
-## @defgroup net_gnrc_netdev_default  gnrc_netdev_default
-## @ingroup net_gnrc_netif
-## @{
-## @deprecated  Use module `netdev_default` with `gnrc` or a `gnrc` submodule
-##              instead; will be removed after 2022.07 release.
-PSEUDOMODULES += gnrc_netdev_default
-## @}
 PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -322,13 +322,6 @@ PSEUDOMODULES += nrfx
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
-## @defgroup pseudomodule_nice nice
-## @ingroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmd_nice` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += nice
-## @}
 PSEUDOMODULES += nrf24l01p_ng_diagnostics
 PSEUDOMODULES += opendsme
 PSEUDOMODULES += openthread

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -118,14 +118,6 @@ PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_ipv6
 PSEUDOMODULES += gnrc_netif_mac
 PSEUDOMODULES += gnrc_netif_single
-## @defgroup net_gnrc_netif_cmd_lora  gnrc_netif_cmd_lora
-## @ingroup sys_shell_commands
-## @ingroup net_gnrc_netif
-## @{
-## @deprecated  Use module `shell_cmd_gnrc_netif_lorawan` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += gnrc_netif_cmd_lora
-## @}
 PSEUDOMODULES += gnrc_netif_dedup
 
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -259,10 +259,6 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += posix_headers
 endif
 
-ifneq (,$(filter sha1sum,$(USEMODULE)))
-  USEMODULE += shell_cmd_sha1sum
-endif
-
 ifneq (,$(filter sha256sum,$(USEMODULE)))
   USEMODULE += shell_cmd_sha256sum
 endif
@@ -290,7 +286,7 @@ ifneq (,$(filter isrpipe_read_timeout,$(USEMODULE)))
   USEMODULE += ztimer_usec
 endif
 
-ifneq (,$(filter sha1sum sha256sum,$(USEMODULE)))
+ifneq (,$(filter sha256sum,$(USEMODULE)))
   USEMODULE += vfs_util
   USEMODULE += hashes
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -267,10 +267,6 @@ ifneq (,$(filter sha256sum,$(USEMODULE)))
   USEMODULE += shell_cmd_sha256sum
 endif
 
-ifneq (,$(filter random_cmd,$(USEMODULE)))
-  USEMODULE += shell_cmd_random
-endif
-
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   # shell_commands has been renamed to shell_cmds_default, but let's keep this
   # for backward compatibility

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -259,10 +259,6 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += posix_headers
 endif
 
-ifneq (,$(filter sha256sum,$(USEMODULE)))
-  USEMODULE += shell_cmd_sha256sum
-endif
-
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   # shell_commands has been renamed to shell_cmds_default, but let's keep this
   # for backward compatibility
@@ -284,11 +280,6 @@ include $(RIOTBASE)/makefiles/stdio.inc.mk
 ifneq (,$(filter isrpipe_read_timeout,$(USEMODULE)))
   USEMODULE += isrpipe
   USEMODULE += ztimer_usec
-endif
-
-ifneq (,$(filter sha256sum,$(USEMODULE)))
-  USEMODULE += vfs_util
-  USEMODULE += hashes
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -259,10 +259,6 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += posix_headers
 endif
 
-ifneq (,$(filter md5sum ,$(USEMODULE)))
-  USEMODULE += shell_cmd_md5sum
-endif
-
 ifneq (,$(filter sha1sum,$(USEMODULE)))
   USEMODULE += shell_cmd_sha1sum
 endif
@@ -298,7 +294,7 @@ ifneq (,$(filter isrpipe_read_timeout,$(USEMODULE)))
   USEMODULE += ztimer_usec
 endif
 
-ifneq (,$(filter md5sum sha1sum sha256sum,$(USEMODULE)))
+ifneq (,$(filter sha1sum sha256sum,$(USEMODULE)))
   USEMODULE += vfs_util
   USEMODULE += hashes
 endif

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -46,11 +46,6 @@ ifneq (,$(filter gnrc_lorawan_1_1,$(USEMODULE)))
   FEATURES_REQUIRED += periph_flashpage
 endif
 
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  # enable default network devices on the platform
-  USEMODULE += netdev_default
-endif
-
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += netdev
   USEMODULE += gnrc_netif

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -71,10 +71,6 @@ ifneq (,$(filter gnrc_dhcpv6_client_simple_pd,$(USEMODULE)))
   USEMODULE += dhcpv6_client_ia_pd
 endif
 
-ifneq (,$(filter gnrc_netif_cmd_lora,$(USEMODULE)))
-  USEMODULE += shell_cmd_gnrc_netif_lorawan
-endif
-
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_uhcpc
   USEMODULE += uhcpc

--- a/sys/net/gnrc/pktbuf/Makefile.include
+++ b/sys/net/gnrc/pktbuf/Makefile.include
@@ -1,5 +1,5 @@
 # Check that only one implementation of pktbuf is used
-USED_PKTBUF_IMPLEMENTATIONS := $(filter-out gnrc_pktbuf_cmd,$(filter gnrc_pktbuf_%,$(USEMODULE)))
+USED_PKTBUF_IMPLEMENTATIONS := $(filter gnrc_pktbuf_%,$(USEMODULE))
 ifneq (1,$(words $(USED_PKTBUF_IMPLEMENTATIONS)))
   $(error Only one implementation of gnrc_pktbuf should be used. Currently using: $(USED_PKTBUF_IMPLEMENTATIONS))
 endif

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -69,9 +69,6 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
     USEMODULE += shell_cmd_gnrc_sixlowpan_frag_stats
   endif
-  ifneq (,$(filter i2c_scan,$(USEMODULE)))
-    USEMODULE += shell_cmd_i2c_scan
-  endif
   ifneq (,$(filter lpc2387,$(USEMODULE)))
     USEMODULE += shell_cmd_heap
   endif

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -84,9 +84,6 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter netstats_neighbor,$(USEMODULE)))
     USEMODULE += shell_cmd_netstats_neighbor
   endif
-  ifneq (,$(filter nice,$(USEMODULE)))
-    USEMODULE += shell_cmd_nice
-  endif
   ifneq (,$(filter nimble_netif,$(USEMODULE)))
     USEMODULE += shell_cmd_nimble_netif
   endif

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -69,9 +69,6 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
     USEMODULE += shell_cmd_gnrc_sixlowpan_frag_stats
   endif
-  ifneq (,$(filter gnrc_udp_cmd,$(USEMODULE)))
-    USEMODULE += shell_cmd_gnrc_udp
-  endif
   ifneq (,$(filter heap_cmd,$(USEMODULE)))
     USEMODULE += shell_cmd_heap
   endif

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -60,9 +60,6 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter gnrc_netif_lorawan,$(USEMODULE)))
     USEMODULE += shell_cmd_gnrc_netif_lorawan
   endif
-  ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
-      USEMODULE += shell_cmd_gnrc_pktbuf
-  endif
   ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
       USEMODULE += shell_cmd_gnrc_rpl
   endif

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -69,9 +69,6 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
     USEMODULE += shell_cmd_gnrc_sixlowpan_frag_stats
   endif
-  ifneq (,$(filter heap_cmd,$(USEMODULE)))
-    USEMODULE += shell_cmd_heap
-  endif
   ifneq (,$(filter i2c_scan,$(USEMODULE)))
     USEMODULE += shell_cmd_i2c_scan
   endif

--- a/sys/shell/doc.txt
+++ b/sys/shell/doc.txt
@@ -20,7 +20,7 @@ modules, if it exists.
 
 A few rarely needed shell commands that needs to be used in addition to the
 `shell_commands` and the module providing the C-API. Examples include
-`shell_cmd_nice`, `shell_cmd_gnrc_udp`, or `random_cmd`.
+`shell_cmd_nice`, `shell_cmd_gnrc_udp`, or `shell_random_cmd`.
 Consult the documentation of the modules to find out whether they have a
 shell integration and how to enable it.
  */

--- a/sys/shell/doc.txt
+++ b/sys/shell/doc.txt
@@ -20,6 +20,6 @@ modules, if it exists.
 
 A few rarely needed shell commands that needs to be used in addition to the
 `shell_commands` and the module providing the C-API. Examples include `nice`,
-`gnrc_udp_cmd`, or `random_cmd`. Consult the documentation of the modules to
+`shell_cmd_gnrc_udp`, or `random_cmd`. Consult the documentation of the modules to
 find out whether they have a shell integration and how to enable it.
  */

--- a/sys/shell/doc.txt
+++ b/sys/shell/doc.txt
@@ -19,7 +19,8 @@ Using the module `shell_commands` will enable the shell integration of the used
 modules, if it exists.
 
 A few rarely needed shell commands that needs to be used in addition to the
-`shell_commands` and the module providing the C-API. Examples include `nice`,
-`shell_cmd_gnrc_udp`, or `random_cmd`. Consult the documentation of the modules to
-find out whether they have a shell integration and how to enable it.
+`shell_commands` and the module providing the C-API. Examples include
+`shell_cmd_nice`, `shell_cmd_gnrc_udp`, or `random_cmd`.
+Consult the documentation of the modules to find out whether they have a
+shell integration and how to enable it.
  */

--- a/tests/core/sched_change_priority/Makefile
+++ b/tests/core/sched_change_priority/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.core_common
 
-USEMODULE += nice
+USEMODULE += shell_cmd_nice
 USEMODULE += ps
 USEMODULE += shell_cmds_default
 


### PR DESCRIPTION
### Contribution description
This PR removes a bunch of deprecated modules that I found while looking at the `makefiles/pseudomodules.inc.mk` so I guess it is time to do some cleanup.

There are still some deprecated modules in the wild, but they will need a little bit more attention so I think it is better if this is done in another PR.

### Testing procedure
I think CI should be enough but you could run a quick `grep` to ensure I didn't forget something.

### Issues/PRs references
None.
