### PR TITLE
sys/usbus: answer get_status if request is standard type

### DIFF
--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -291,9 +291,11 @@ static int _recv_interface_setup(usbus_t *usbus, usb_setup_t *pkt)
     usbus_control_handler_t *ep0_handler =
         (usbus_control_handler_t *)usbus->control;
     uint16_t destination = pkt->index & 0x0f;
+    uint8_t type_mask = pkt->type & USB_SETUP_REQUEST_TYPE_MASK;
 
     /* Globally handle the iface get status request */
-    if (pkt->request == USB_SETUP_REQ_GET_STATUS) {
+    if (pkt->request == USB_SETUP_REQ_GET_STATUS &&
+        type_mask == USB_SETUP_REQUEST_TYPE_STANDARD) {
         return _req_iface_status(usbus);
     }
 


### PR DESCRIPTION
### Contribution description

this PR intends to fix #20474. In current master, a device doesn't behave properly when `dfu-util` is sending a detach request.
Once this request is sent, device must reboot into bootloader. However, it doesn't work in master since #17090.

#17090 introduces (among other things) a way for `USBUS` to answer standard requests (received on the control endpoints aka EP0).
However, DFU is an USB class which uses the same endpoints to operate. When `dfu-util` sends the detach request, `USBUS` wrongly interprets it as a standard `get_status` request so the stack answers it instead of the DFU interface.
Indeed, both the DFU detach request and the standard `get_status` have the same request number. `USB_SETUP_REQ_GET_STATUS` and `DFU_DETACH` are both 0x00.
Thus, this PR introduces a new check to ensure if the request should be processed by `USBUS` or by an interface.
The request type of a DFU detach request is 0x21 which correspond to `USB_SETUP_REQUEST_RECIPIENT_INTERFACE` | `USB_SETUP_REQUEST_TYPE_CLASS`.
This way, when `dfu-util` send a detach request, `USBUS` will now pass it to the interface and will only process `USB_SETUP_REQUEST_TYPE_STANDARD`, as it is suppose to do.

### Testing procedure
Flash `riotboot_dfu` bootloader into your board:
`make BOARD=same54-xpro -C bootloaders/riotboot_dfu flash`
Then flash a first app into your board through dfu;
`FEATURES_REQUIRED=riotboot PROGRAMMER=dfu-util USEMODULE=usbus_dfu make -j4 BOARD=same54-xpro -C tests/sys/shell riotboot/flash-slot0`
Finally, flash a second app while the first is running:
`DFU_USB_ID=1209:7d00 FEATURES_REQUIRED=riotboot PROGRAMMER=dfu-util USEMODULE=usbus_dfu make -j4 BOARD=same54-xpro -C tests/leds riotboot/flash-slot1`

On current master, the last step will fail, the device will never reboot into bootloader and stays in the first app.
With this PR, device will reboot, flash the second application then runs it.


### Issues/PRs references
Fixes #20474 
