### PR TITLE
nanocoap_sock: add support for IPv4

### DIFF
--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -822,6 +822,26 @@ static inline bool sock_udp_ep_is_multicast(const sock_udp_ep_t *ep)
     return false;
 }
 
+/**
+ * @brief   Checks if the IP address of an endpoint is an IPv6 address
+ *
+ * @param[in] ep end point to check
+ *
+ * @returns true if end point is IPv6
+ */
+static inline bool sock_udp_ep_is_v6(const sock_udp_ep_t *ep)
+{
+#if !defined(SOCK_HAS_IPV6)
+    (void)ep;
+    return false;
+#elif !defined(SOCK_HAS_IPV4)
+    (void)ep;
+    return true;
+#else
+    return ep->family == AF_INET6;
+#endif
+}
+
 #include "sock_types.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

NanoCOAP is already agnostic towards the IP version, but there is one part where the code checks if the destination address is link-local, to see if an interface id is needed.
Since there are no link-local addresses with IPv4, we can simply not do that in the v4 only case.


### Testing procedure

Build an LWIP IPv4 application with the `nanocoap_vfs` module (and default shell commands)

```
2024-03-17 17:42:20,985 # > ifconfig
2024-03-17 17:42:20,990 # Iface ET0 HWaddr: 7c:df:a1:02:ec:d4 Link: up State: up
2024-03-17 17:42:20,991 #         Link type: wireless
2024-03-17 17:42:20,998 #         inet addr: 10.53.4.195 mask: 255.255.0.0 gw: 10.53.0.1

2024-03-17 17:42:22,763 # > ncget coap://134.102.218.18/
2024-03-17 17:42:22,791 # /test
2024-03-17 17:42:22,792 # /validate
2024-03-17 17:42:22,814 # /hello
2024-03-17 17:42:22,843 # /blåbærsyltetøy
2024-03-17 17:42:22,843 # /sink
2024-03-17 17:42:22,867 # /separate
2024-03-17 17:42:22,867 # /large
2024-03-17 17:42:22,916 # /secret
2024-03-17 17:42:22,960 # /broken
2024-03-17 17:42:22,960 # /weird33
2024-03-17 17:42:22,961 # /weird44
2024-03-17 17:42:22,990 # /weird55
2024-03-17 17:42:22,991 # /weird333
2024-03-17 17:42:23,023 # /weird3333
2024-03-17 17:42:23,023 # /weird33333
2024-03-17 17:42:23,079 # /123412341234123412341234
2024-03-17 17:42:23,107 # /location-query
2024-03-17 17:42:23,136 # /create1
2024-03-17 17:42:23,137 # /large-update
2024-03-17 17:42:23,161 # /large-create
2024-03-17 17:42:23,161 # /query
2024-03-17 17:42:23,190 # /seg1
2024-03-17 17:42:23,191 # /path
2024-03-17 17:42:23,191 # /location1
2024-03-17 17:42:23,214 # /multi-format
2024-03-17 17:42:23,214 # /3
2024-03-17 17:42:23,239 # /4
2024-03-17 17:42:23,239 # /5
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
