### PR TITLE
Feat/implement at6561 can trx driver

### DIFF
--- a/drivers/at6561/Makefile
+++ b/drivers/at6561/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/at6561/Makefile.dep
+++ b/drivers/at6561/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += can_trx
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/at6561/at6561.c
+++ b/drivers/at6561/at6561.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         drivers_at6561
+ *
+ * @file
+ * @brief           Driver for AT6561 CAN transceiver
+ *
+ * @author          Firas Hamdi <firas.hamdi@ml-pa.com>
+ */
+
+#include "can/can_trx.h"
+#include "at6561.h"
+#include "periph/gpio.h"
+#include "assert.h"
+#include "container.h"
+
+static int _init(can_trx_t *can_trx);
+static int _set_mode(can_trx_t *can_trx, can_trx_mode_t mode);
+
+const trx_driver_t at6561_driver = {
+	.init = _init,
+	.set_mode = _set_mode,
+};
+
+static int _init(can_trx_t *can_trx)
+{
+	at6561_trx_t *dev = container_of(can_trx, at6561_trx_t, trx);
+
+	gpio_init(dev->stby_pin, GPIO_OUT);
+	/* A high level on the standby pin of the CAN transceiver will
+		select the standby mode. Check AT6560/1 datasheet, table 1-1 */
+	gpio_set(dev->stby_pin);
+
+	return 1;
+}
+
+/* Set the mode of the CAN transceiver */
+static int _set_mode(can_trx_t *can_trx, can_trx_mode_t mode)
+{
+	at6561_trx_t *dev = container_of(can_trx, at6561_trx_t, trx);
+
+	/* Check AT6560/1 datasheet, table 1-1 */
+	switch (mode) {
+		case TRX_NORMAL_MODE:
+			gpio_clear(dev->stby_pin);
+			break;
+		case TRX_SLEEP_MODE:
+			gpio_set(dev->stby_pin);
+			break;
+		default:
+			assert(0);
+	}
+
+	return 1;
+}

--- a/drivers/include/at6561.h
+++ b/drivers/include/at6561.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         drivers_at6561
+ *
+ * @file
+ * @brief           Driver for AT6561 CAN transceiver
+ *
+ * @author          Firas Hamdi <firas.hamdi@ml-pa.com>
+ */
+
+#include "periph/gpio.h"
+#include "can/can_trx.h"
+
+/**
+ * @brief AT6561 CAN transceiver descriptor
+ */
+typedef struct at6561_trx {
+	/* AT6561 standby pin */
+	gpio_t stby_pin;
+	/* AT6561 interface */
+	can_trx_t trx;
+} at6561_trx_t;
+
+/* AT6561 driver */
+extern const trx_driver_t at6561_driver;

--- a/tests/sys/can_trx/Makefile
+++ b/tests/sys/can_trx/Makefile
@@ -24,4 +24,11 @@ ifneq (,$(filter ncv7356,$(TRX_TO_BUILD)))
 	CFLAGS += -DNCV7356_MODE1_PIN=$(NCV7356_MODE1_PIN)
 endif
 
+ifneq (, $(filter at6561, $(TRX_TO_BUILD)))
+	USEMODULE += at6561
+	AT6561_STBY_PIN ?= GPIO_PIN\(0,0\)
+
+	CFLAGS += -DAT6561_STBY_PIN=$(AT6561_STBY_PIN)
+endif
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/can_trx/main.c
+++ b/tests/sys/can_trx/main.c
@@ -40,12 +40,22 @@ ncv7356_trx_t ncv7356 ={ .trx.driver = &ncv7356_driver,
 };
 #endif
 
+#ifdef MODULE_AT6561
+#include "at6561.h"
+at6561_trx_t at6561 = { .stby_pin = AT6561_STBY_PIN,
+                        .trx.driver = &at6561_driver
+};
+#endif
+
 static can_trx_t *devs[] = {
 #ifdef MODULE_TJA1042
     (can_trx_t *)&tja1042,
 #endif
 #ifdef MODULE_NCV7356
     (can_trx_t *)&ncv7356,
+#endif
+#ifdef MODULE_AT6561
+    &at6561.trx,
 #endif
     NULL,
 };


### PR DESCRIPTION
### Contribution description
Write a driver for the AT6561 CAN transceiver built on the CAN generic transceiver interface `can_trx`.

### Testing procedure
The driver is tested with `tests/sys/can_trx` application. Hardware used for testing is the same54-xpro devBoard.