### PR TITLE
doc/doxygen/src/getting-started.md: fix broken link

### DIFF
--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -37,7 +37,7 @@ feature freeze period, if you develop on macOS or BSD.
 Windows users can refer to [this guide][dev-setup-windows] to
 [setup the development environment][dev-setup-windows] on Windows.
 
-[dev-setup-windows]: doc/guides/setup-windows
+[dev-setup-windows]: https://github.com/RIOT-OS/RIOT/tree/master/doc/guides/setup-windows
 
 Native development on macOS machines is not officially supported. What works well is using Linux
 in a virtual machine, but at much lower performance than running Linux natively. We also offer Docker images.


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

Check if the links in "Windows users can refer to this guide to setup the development environment on Windows." work in the doc preview generated by the CI.

### Issues/PRs references

Reported in https://matrix.to/#/!pqHdpanAvkJvlCwUDE:matrix.org/$BijYISxb1sS2ObDdd7P1ox9Vbz8PYTR4R0CvIHMD_aQ?via=matrix.org&via=utwente.io&via=tu-dresden.de