### PR TITLE
.murdock: document TESTS_BOARDS_LLVM_COMPILE

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -37,8 +37,10 @@ esac
 
 #: ${EMULATED_BOARDS_AVAILABLE:="microbit"}
 
-# temporarily disabling llvm builds until https://github.com/RIOT-OS/RIOT/pull/15595
-# is in
+# Only a subset of boards are compiled on LLVM to not increase CI time by
+# factor 2, but still have a decent regression test coverage.
+# TODO: Consider reusing QUICKBUILD_BOARDS once all those boards are supported
+# on LLVM.
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native native64 nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
 : ${TEST_WITH_CONFIG_SUPPORTED:="examples/suit_update tests/drivers/at86rf2xx_aes"}


### PR DESCRIPTION
### Contribution description

The comment above TESTS_BOARDS_LLVM_COMPILE is misleading and outdated. This is due to an oversight in 52cf2b46c3ee607e43e824d0f9f8ef1a10a9c914 where tests on LLVM where re-enabled.

This drops the old comment and instead adds a comment why only a subset of boards are build on LLVM.

### Testing procedure

Read the comment added. This changes no code, so no breaking in the CI or on hardware is expected.

### Issues/PRs references

Reported in https://github.com/RIOT-OS/RIOT/pull/15595#issuecomment-2003129592