### PR TITLE
treewide: remove deprecated shell_commands module

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -4,12 +4,12 @@ This application is a showcase for RIOT's hardware support. Using it
 for your board, you should be able to interactively use any hardware
 that is supported.
 
-To do this, the application uses the `shell` and `shell_commands`
+To do this, the application uses the `shell` and `shell_cmds_default`
 modules and all the driver modules each board supports.
 
 `shell` is a very simple interactive command interpreter that can be
 used to call functions.  Many of RIOT's modules define some generic
-shell commands. These are included via the `shell_commands` module.
+shell commands. These are included via the `shell_cmds_default` module.
 
 Additionally, the `ps` module which provides the `ps` shell command is
 included.

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,5 +1,4 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
 DEPRECATED_MODULES += sema_deprecated
-DEPRECATED_MODULES += shell_commands # use shell_cmds_default instead
 DEPRECATED_MODULES += ztimer_now64

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -435,12 +435,6 @@ PSEUDOMODULES += shell_cmd_sys
 PSEUDOMODULES += shell_cmd_udptty
 PSEUDOMODULES += shell_cmd_vfs
 PSEUDOMODULES += shell_cmds_default
-## @addtogroup sys_shell_commands
-## @{
-## @deprecated  Use module `shell_cmds_default` instead;
-##              will be removed after 2023.07 release.
-PSEUDOMODULES += shell_commands
-## @}
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += shell_lock_auto_locking
 PSEUDOMODULES += shield_w5100

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -70,7 +70,7 @@ endif
 ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
   USEMODULE += bluetil_ad
   USEMODULE += bluetil_addr
-  ifneq (,$(filter shell_commands,$(USEMODULE)))
+  ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
     DEFAULT_MODULE += nimble_autoadv_shell
   endif
 endif

--- a/pkg/openwsn/Makefile.dep
+++ b/pkg/openwsn/Makefile.dep
@@ -112,7 +112,7 @@ ifneq (,$(filter openwsn_sock_async,$(USEMODULE)))
   USEMODULE += sock_async
 endif
 
-ifneq (,$(filter shell_commands,$(USEMODULE)))
+ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   USEMODULE += l2util
 endif
 # This port currently requires setting ISR_STACKSIZE

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -259,12 +259,6 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += posix_headers
 endif
 
-ifneq (,$(filter shell_commands,$(USEMODULE)))
-  # shell_commands has been renamed to shell_cmds_default, but let's keep this
-  # for backward compatibility
-  USEMODULE += shell_cmds_default
-endif
-
 ifneq (,$(filter shell_cmd%,$(USEMODULE)))
   # each and every command is a submodule of shell_cmds
   USEMODULE += shell_cmds

--- a/sys/shell/cmds/nice.c
+++ b/sys/shell/cmds/nice.c
@@ -13,7 +13,8 @@
  * @file
  * @brief       A shell command to change the niceness (inverse priority) of a thread
  *
- * @note        Enable this by using the modules shell_commands and nice
+ * @note        Enable this by using the modules shell_cmds_default and
+ *              shell_cmd_nice
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  *

--- a/sys/shell/doc.txt
+++ b/sys/shell/doc.txt
@@ -15,11 +15,11 @@ Shell Commands
 
 Certain modules such as `ps`, `saul_reg`, or `gnrc_icmpv6_echo` can expose
 (some of) their functionality not only as C-API, but also as shell command.
-Using the module `shell_commands` will enable the shell integration of the used
+Using the module `shell_cmds_default` will enable the shell integration of the used
 modules, if it exists.
 
 A few rarely needed shell commands that needs to be used in addition to the
-`shell_commands` and the module providing the C-API. Examples include
+`shell_cmds_default` and the module providing the C-API. Examples include
 `shell_cmd_nice`, `shell_cmd_gnrc_udp`, or `shell_random_cmd`.
 Consult the documentation of the modules to find out whether they have a
 shell integration and how to enable it.

--- a/tests/sys/shell/ReadMe.txt
+++ b/tests/sys/shell/ReadMe.txt
@@ -1,7 +1,7 @@
 This application shows how to use own or the system shell commands. In order to use
 the system shell commands:
 
-1. Additionally to the module: shell, shell_commands,
+1. Additionally to the module: shell, shell_cmds_default,
    the module for the corresponding system command is to include, e.g.
    module ps for the ps command (cf. the Makefile in the application root
    directory).


### PR DESCRIPTION
### Contribution description

This PR removes a deprecated module that should have been removed a few release ago.
I've replaced it by `shell_cmds_default` where needed.

### Testing procedure

CI should be enough to catch up any miss.

### Issues/PRs references
None.
