### PR TITLE
dist/tools/dhcpv6-pd_ia: recognize Debian correctly

### DIFF
--- a/dist/tools/dhcpv6-pd_ia/pkg/__init__.py
+++ b/dist/tools/dhcpv6-pd_ia/pkg/__init__.py
@@ -27,9 +27,7 @@ __email__ = "m.lenders@fu-berlin.de"
 class PackageManagerFactory(object):
     @staticmethod
     def _get_linux_distro():
-        if hasattr(platform, "linux_distribution"):
-            return platform.linux_distribution()[0]
-        elif os.path.exists("/etc/os-release"):
+        if os.path.exists("/etc/os-release"):
             with open("/etc/os-release") as f:
                 for line in f:
                     m = re.match(r"^NAME=\"(.+)\"$", line)
@@ -42,7 +40,7 @@ class PackageManagerFactory(object):
         system = platform.system()
         if system == "Linux":
             system = cls._get_linux_distro()
-        if system in ["Debian", "Ubuntu", "Linux Mint"]:
+        if system.startswith(("Debian", "Ubuntu", "Linux Mint")):
             return Apt("Debian")
         if system in ["Arch Linux"]:
             return PacMan("Arch")


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

At least on my system, `cat /etc/os-release` contains `NAME="Debian GNU/Linux"` and not just `NAME="Debian"`. This fixes the recognition logic to work in this case, too.

Also removing the `platform.linux_distribution()` part since that is deprecated since python 3.5 and removed since 3.7: https://docs.python.org/3.5/library/platform.html#platform.linux_distribution

### Testing procedure

on Debian without keas installed, compile on `master` for a board with usb-cdc-ecm:

```
$ make -C examples/gnrc_border_router BOARD=feather-nrf52840-sense UPLINK=cdc-ecm term
...
Traceback (most recent call last):
  File ".../RIOT/dist/tools/dhcpv6-pd_ia/dhcpv6-pd_ia.py", line 72, in <module>
    main()
  File ".../RIOT/dist/tools/dhcpv6-pd_ia/dhcpv6-pd_ia.py", line 68, in main
    server.run()
  File ".../RIOT/dist/tools/dhcpv6-pd_ia/kea.py", line 110, in run
    self.install()
  File ".../RIOT/dist/tools/dhcpv6-pd_ia/base.py", line 92, in install
    self.installer = pkg.PackageManagerFactory.get_installer()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../RIOT/dist/tools/dhcpv6-pd_ia/pkg/__init__.py", line 50, in get_installer
    return AskToInstall()
           ^^^^^^^^^^^^^^
TypeError: Can't instantiate abstract class AskToInstall with abstract method _install
```

with this PR:
```
make -C examples/gnrc_border_router BOARD=feather-nrf52840-sense UPLINK=cdc-ecm term
...
Install package kea-dhcp6? [Y/n] 
```


### Issues/PRs references

Encountered while working on #20192 
