### PR TITLE
codeowners: Notify chrysn on Rust PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,9 @@
 
 *.md                                        @jia200x
 
+Cargo.*                                     @chrysn
+*.rs                                        @chrysn
+
 /.murdock                                   @kaspar030
 
 /boards/common/atxmega/                     @nandojve


### PR DESCRIPTION
### Contribution description

This creates a section in CODEOWNERS for Rust files unless they are part of a concrete module further down. (In particular, examples and sys/rust_riotmodules* are not "taken", so these will also notify me).