### PR TITLE
doc: add terminal program configuration

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -767,6 +767,7 @@ INPUT                  = ../../doc.txt \
                          src/driver-guide.md \
                          src/getting-started.md \
                          src/flashing.md \
+                         src/terminal-programs.md \
                          src/build-in-docker.md \
                          ../../tests/README.md \
                          src/build-system-basics.md \

--- a/doc/doxygen/src/terminal-programs.md
+++ b/doc/doxygen/src/terminal-programs.md
@@ -1,0 +1,49 @@
+Terminal programs configuration                             {#terminal-programs}
+===========================================================
+
+[TOC]
+
+Background                                                         {#background}
+==========
+This page explains how to configure some popular terminal programs for correct
+display of newlines when using the serial interface of a RIOT powered device.
+When printing something using *stdio* (e.g., `printf("Hello World!\n");`, RIOT
+sends a line feed character (`0xA`) as `\n` (newline).
+
+Some terminals need more, for example, a carriage return and a line feed
+character (0xD, 0xA). See https://en.wikipedia.org/wiki/Newline for background.
+
+This page tries to collect needed settings for common terminal programs that
+will make them correctly display newlines.
+
+picocom                                                               {#picocom}
+=======
+- Generic method:
+    - Start with `--imap lfcrlf` parameter.
+- Via RIOT build system:
+    - `RIOT_TERMINAL=picocom make term`
+
+gtkterm                                                               {#gtkterm}
+======
+- Graphical method:
+    - Open the configuration menu.
+    - Click on ***CR LF auto***.
+- Manual method:
+    - Edit the file `~/.gtktermrc`.
+    - Change value of ***crlfauto*** option to `True`.
+
+minicom                                                               {#minicom}
+=======
+- Interactive method:
+    - Press ***Ctrl+A u***.
+- Manual method:
+    - Edit the configuration file (`~/.minirc.dfl` per default).
+    - Add the following line:
+    pu addcarreturn     Yes
+
+miniterm                                                             {#miniterm}
+========
+- Generic method:
+    - Start with `--eol CR`parameter.
+- Via RIOT build system:
+    - `RIOT_TERMINAL=miniterm make term`


### PR DESCRIPTION
### Contribution description

This is mostly an import from https://github.com/RIOT-OS/RIOT/wiki/Configure-terminal-programs-for-correct-display-of-newlines.

### Testing procedure

Checkout this branch, run `make doc` and check the link "Terminal programs configuration" in the navigation menu.