### PR TITLE
cpu/stm32: remove redundant conditional compile block

### DIFF
--- a/cpu/stm32/include/clk/c0/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/c0/cfg_clock_default.h
@@ -20,6 +20,8 @@
 #define CLK_C0_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32/include/clk/c0/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/c0/cfg_clock_default.h
@@ -19,6 +19,8 @@
 #ifndef CLK_C0_CFG_CLOCK_DEFAULT_H
 #define CLK_C0_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_fx_gx_mp1_c0.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/cfg_clock_common_fx_gx_mp1_c0.h
+++ b/cpu/stm32/include/clk/cfg_clock_common_fx_gx_mp1_c0.h
@@ -23,6 +23,8 @@
 #ifndef CLK_CFG_CLOCK_COMMON_FX_GX_MP1_C0_H
 #define CLK_CFG_CLOCK_COMMON_FX_GX_MP1_C0_H
 
+#include "kernel_defines.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/cfg_clock_common_lx_u5_wx.h
+++ b/cpu/stm32/include/clk/cfg_clock_common_lx_u5_wx.h
@@ -23,6 +23,8 @@
 #ifndef CLK_CFG_CLOCK_COMMON_LX_U5_WX_H
 #define CLK_CFG_CLOCK_COMMON_LX_U5_WX_H
 
+#include "kernel_defines.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/clk_conf.h
+++ b/cpu/stm32/include/clk/clk_conf.h
@@ -23,17 +23,6 @@
 #include "macros/units.h"
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
-    defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F3) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7) || \
-    defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32MP1) || defined(CPU_FAM_STM32C0)
-#include "cfg_clock_common_fx_gx_mp1_c0.h"
-#else /* CPU_FAM_STM32L0 || CPU_FAM_STM32L1 || CPU_FAM_STM32L4 ||
-       * CPU_FAM_STM32L5 || CPU_FAM_STM32U5 || CPU_FAM_STM32WB */
-#include "cfg_clock_common_lx_u5_wx.h"
-#endif
-
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3)
 #include "f0f1f3/cfg_clock_default.h"
 #elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \

--- a/cpu/stm32/include/clk/clk_conf.h
+++ b/cpu/stm32/include/clk/clk_conf.h
@@ -19,9 +19,6 @@
 #ifndef CLK_CLK_CONF_H
 #define CLK_CLK_CONF_H
 
-#include "kernel_defines.h"
-#include "macros/units.h"
-
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3)
 #include "f0f1f3/cfg_clock_default.h"

--- a/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
@@ -27,6 +27,8 @@
 #define CLK_F0F1F3_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
@@ -26,6 +26,8 @@
 #ifndef CLK_F0F1F3_CFG_CLOCK_DEFAULT_H
 #define CLK_F0F1F3_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_fx_gx_mp1_c0.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
@@ -19,6 +19,8 @@
 #ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_H
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_fx_gx_mp1_c0.h"
+
 #if defined(CPU_FAM_STM32F2)
 #include "f2f4f7/cfg_clock_default_120.h"
 #elif defined(CPU_FAM_STM32F4)

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
@@ -20,6 +20,7 @@
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
+#include "kernel_defines.h"
 
 #if defined(CPU_FAM_STM32F2)
 #include "f2f4f7/cfg_clock_default_120.h"

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_100.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_100.h
@@ -23,6 +23,9 @@
 #ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_100_H
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_100_H
 
+#include "kernel_defines.h"
+#include "macros/units.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_120.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_120.h
@@ -23,6 +23,9 @@
 #ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_120_H
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_120_H
 
+#include "kernel_defines.h"
+#include "macros/units.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_180.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_180.h
@@ -23,6 +23,9 @@
 #ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_180_H
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_180_H
 
+#include "kernel_defines.h"
+#include "macros/units.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_216.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_216.h
@@ -23,6 +23,9 @@
 #ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_216_H
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_216_H
 
+#include "kernel_defines.h"
+#include "macros/units.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_84.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_84.h
@@ -23,6 +23,9 @@
 #ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_84_H
 #define CLK_F2F4F7_CFG_CLOCK_DEFAULT_84_H
 
+#include "kernel_defines.h"
+#include "macros/units.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
@@ -24,6 +24,8 @@
 #define CLK_G0G4_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
@@ -23,6 +23,8 @@
 #ifndef CLK_G0G4_CFG_CLOCK_DEFAULT_H
 #define CLK_G0G4_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_fx_gx_mp1_c0.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
@@ -19,6 +19,7 @@
 #ifndef CLK_L0L1_CFG_CLOCK_DEFAULT_H
 #define CLK_L0L1_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_lx_u5_wx.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus

--- a/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
@@ -20,6 +20,8 @@
 #define CLK_L0L1_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_lx_u5_wx.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus

--- a/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
@@ -21,6 +21,8 @@
 #ifndef CLK_L4L5WX_CFG_CLOCK_DEFAULT_H
 #define CLK_L4L5WX_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_lx_u5_wx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
@@ -22,6 +22,8 @@
 #define CLK_L4L5WX_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_lx_u5_wx.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32/include/clk/mp1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/mp1/cfg_clock_default.h
@@ -19,6 +19,8 @@
 #ifndef CLK_MP1_CFG_CLOCK_DEFAULT_H
 #define CLK_MP1_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_fx_gx_mp1_c0.h"
+
 /**
  * @name    MP1 clock PLL settings (208MHz)
  * @{

--- a/cpu/stm32/include/clk/mp1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/mp1/cfg_clock_default.h
@@ -20,6 +20,8 @@
 #define CLK_MP1_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 
 /**
  * @name    MP1 clock PLL settings (208MHz)

--- a/cpu/stm32/include/clk/u5/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/u5/cfg_clock_default.h
@@ -20,6 +20,8 @@
 #define CLK_U5_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_lx_u5_wx.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32/include/clk/u5/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/u5/cfg_clock_default.h
@@ -19,6 +19,8 @@
 #ifndef CLK_U5_CFG_CLOCK_DEFAULT_H
 #define CLK_U5_CFG_CLOCK_DEFAULT_H
 
+#include "cfg_clock_common_lx_u5_wx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description

This patch removes a largely redundant block of conditional includes.

The removed includes are moved into the family specific headers so that the more specific headers may override defaults defined in the shared headers.


### Testing procedure

The changes are paternalistic enough that it should be obvious in review if this breaks anything.

I did do:

``` bash
$ make -C examples/blinky BOARD=nucleo-f303ze
```

and 

``` bash
$ make -C examples/blinky BOARD=nucleo-f767zi
```

### Issues/PRs references

This relates to the work I am doing to port RIOT to the STM32H7 family.
