### PR TITLE
tests/unittests/README: link to Supported Boards updated (wiki -> site)

### DIFF
--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -22,7 +22,7 @@ You then can run the tests by calling
 make term
 ```
 
-or flash them to your board as you would flash any RIOT application to the board (see [board documentation|RIOT-Platforms](https://github.com/RIOT-OS/RIOT/wiki/RIOT-Platforms)).
+or flash them to your board as you would flash any RIOT application to the board (see [Supported Boards](https://www.riot-os.org/boards.html)).
 
 You can debug your tests by running
 


### PR DESCRIPTION
### Contribution description

This commit changes the link about supported boards in the README from the wiki page to the RIOT-OS website. Since the wiki is not up to date.


### Testing procedure

Read the text, test the links. 

### Issues/PRs references

See also https://github.com/RIOT-OS/riot-os.org/pull/109 that fixed the same link on the website.