### PR TITLE
doc/community-process: improve markdown style

### DIFF
--- a/doc/doxygen/src/community-processes.md
+++ b/doc/doxygen/src/community-processes.md
@@ -3,23 +3,23 @@
 The community around RIOT gathers many IoT developers and users from around
 the world, from the industry, from academia, and hobbyists. The RIOT
 community is open to everyone. To join and interact, you are invited to:
-* join and post to the [forum](https://forum.riot-os.org/),
-* post on [GitHub](https://github.com/RIOT-OS/RIOT/pulls),
-* connect and post to the [Matrix chat](https://matrix.to/#/#riot-os:matrix.org),
-* join virtual or f2f [meetings](https://forum.riot-os.org/c/community/events).
+* join and post to the [forum][riot-forum],
+* post on [GitHub][riot-pull-requests],
+* connect and post to the [Matrix chat][riot-matrix],
+* join virtual or f2f [meetings][riot-events].
 
 The community self-organizes using the open processes described below.
 
 ## Contributors
 
 Code contributions are very welcome. In order to streamline and harmonize code
-quality, contributors must follow the [contributing guidelines](https://github.com/RIOT-OS/RIOT/blob/master/CONTRIBUTING.md).
+quality, contributors must follow the [contributing guidelines][riot-contributing-guidelines].
 Aside of code contributions, you can also contribute to RIOT on other aspects,
 e.g. by actively participating in technical and non-technical discussions within
 the community. Regular and interim virtual meetings are announced on the
-[forum](https://forum.riot-os.org/c/community/events).
+[forum][riot-events].
 
-## Maintainers
+## Maintainers          {#community-process-maintainers}
 
 Among contributors, some have maintainer status, which consists in rights (merge rights)
 and duties (code review duties).
@@ -35,9 +35,9 @@ We are constantly looking for more maintainers. So if you are up for that,
 please start (or continue) contributing code and reviews!
 
 To contact maintainers, the best is to interact over actual RIOT code on
-[GitHub](https://github.com/RIOT-OS/RIOT/pulls).
+[GitHub][riot-pull-requests].
 
-## Coordinators
+## Coordinators         {#community-process-coordinators}
 
 Among contributors, some are also interested in discussing RIOT matters and
 perspectives, beyond coding RIOT. In short, maintainers focus on technical
@@ -59,7 +59,7 @@ then accept (or turn down).
 To contact coordinators, the best is to email the generic mailing list
 riot@riot-os.org
 
-## Task Forces
+## Task Forces          {#community-process-task-forces}
 
 Parts of the community are gathered in *Task Forces*, which provide a specific
 venue focusing on a particular technical topic.
@@ -72,19 +72,33 @@ Each Task Force consists of a small number of RIOT developers and has its own Wi
 page. One or two shepherds are identified per task force as the main contact(s)
 for this activity.
 
-**Creating a new Task Force**. If you wish to launch a new task force, go ahead,
+### Creating a new Task Force           {#community-process-task-force-creation}
+
+If you wish to launch a new task force, go ahead,
 create your wikipage, name your shepherd(s), and signal it on the forum. RIOT
 maintainers will contact you in the rare case where duplicate or very closely-related
 work has been detected elsewhere, and if joining forces might make sense.
 
-**Life of a Task Force**. Shepherds and/or participants in a Task Force are invited
+### Life of a Task Force                {#community-process-task-force-life}
+
+Shepherds and/or participants in a Task Force are invited
 to now and then update their wikipage, report progress or summarize the latest stand
 of your discussions on the forum. A shepherd-hood may be transferred from one person
 to another person if everyone is happy about that.
 
-**Dissolving an existing Task Force**. Dissolving an existing Task Force happens either
+## Dissolving an existing Task Force    {#community-process-task-force-dissolving}
+
+Dissolving an existing Task Force happens either
 (i) as the shepherd(s) declare the TF has concluded, or declare the TF is abandoned, or
 (ii) when the shepherds are unreachable, the TF has been dormant for a long time and
 RIOT maintainers declare the TF dissolved.
 
-More information about (active/concluded/archived) task forces can be found [here](https://github.com/RIOT-OS/RIOT/wiki/Task-Forces).
+More information about (active/concluded/archived) task forces can be found [here][riot-task-forces].
+
+<!-- Links, sorted alphabetically -->
+[riot-contributing-guidelines]: https://github.com/RIOT-OS/RIOT/blob/master/CONTRIBUTING.md
+[riot-events]: https://forum.riot-os.org/c/community/events
+[riot-forum]: https://forum.riot-os.org/
+[riot-matrix]: https://matrix.to/#/#riot-os:matrix.org
+[riot-pull-requests]: https://github.com/RIOT-OS/RIOT/pulls
+[riot-task-forces]: https://github.com/RIOT-OS/RIOT/wiki/Task-Forces


### PR DESCRIPTION
### Contribution description

This contains minor changes to ease maintaining the document (e.g. by using reference-style links so that an URL needs to be updated only in a single place) and adds explicit anchors to ease linking to a certain section.

### Testing procedure

This should not change the visible text generated in any way. In fact, other than the anchors now being named like `community-process-maintainers` instead of something like `autotoc_md2117` the generated HTML should be the same.

### Issues/PRs references

None