### PR TITLE
doc/doxygen: fix name and intro of "Modules" section

### DIFF
--- a/doc/doxygen/RIOTDoxygenLayout.xml
+++ b/doc/doxygen/RIOTDoxygenLayout.xml
@@ -5,8 +5,8 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
     <tab type="user" url="@ref boards" title="Supported Boards"/>
-    <tab type="topics" visible="yes" title="" intro=""/>
-    <tab type="modules" visible="yes" title="" intro=""/>
+    <tab type="topics" visible="yes" title="Modules" intro="This is the list of modules in RIOT"/>
+    <tab type="modules" visible="yes" title="Modules" intro="This is the list of modules in RIOT"/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>
       <tab type="namespacemembers" visible="yes" title="" intro=""/>


### PR DESCRIPTION
### Contribution description

This fixes a regression from https://github.com/RIOT-OS/RIOT/pull/20443 which does cause the modules to re-appear in the side panel, but under the name "Topics" rather than "Modules".

### Testing procedure

Check the generated doc with a modern version of Doxygen. The module section should be named "Modules" again.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/20443