### PR TITLE
tools/openocd: define SWD_EN signal for tigard

### DIFF
--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -11,3 +11,10 @@ OPENOCD_TRANSPORT ?= swd
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
 endif
+
+ifeq (swd, $(OPENOCD_TRANSPORT))
+  ifeq (tigard, $(OPENOCD_FTDI_ADAPTER))
+    # Add dummy SWD_EN signal
+    OPENOCD_ADAPTER_INIT += -c 'ftdi layout_signal SWD_EN -data 0'
+  endif
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The upstream OpenOCD config for Tigard does not define SWD_EN, as it can also be used in JTAG mode.
However, OpenOCD will complain when the signal is not set. A quick and dirty solution is directly editing `/usr/share/openocd/scripts/interface/ftdi/tigard.cfg`, but this is of course not a great user experience. 

To solve this, add the [line from the example config](https://github.com/tigard-tools/tigard?tab=readme-ov-file#swd-on-cortex-header) to our OpenOCD command line if tigard is used in SWD mode.

### Testing procedure

In `master` interacting with OpenOCD and Tigard either requires editing `tigard.cfg` or you'll get

```
/home/benpicco/dev/RIOT/dist/tools/openocd/openocd.sh reset
### Resetting Target ###
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
none separate

Info : FTDI SWD mode enabled
swd
Error: SWD mode is active but SWD_EN signal is not defined
```

With this patch, everything works out of the box with the default `tigard.cfg`.

```
/home/benpicco/dev/RIOT/dist/tools/openocd/openocd.sh reset
### Resetting Target ###
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
none separate

Info : FTDI SWD mode enabled
swd
Info : clock speed 2000 kHz
Info : SWD DPIDR 0x2ba01477
Info : [atsame5.cpu] Cortex-M4 r0p1 processor detected
Info : [atsame5.cpu] target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for atsame5.cpu on 0
Info : Listening on port 39161 for gdb connections
Error: [atsame5.cpu] DP initialisation failed
Info : SWD DPIDR 0x2ba01477
shutdown command invoked
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
