### PR TITLE
core: Guard pm_set_lowest with module_periph_pm

### DIFF
--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -93,7 +93,9 @@ static void *idle_thread(void *arg)
     (void)arg;
 
     while (1) {
-        pm_set_lowest();
+        if (IS_USED(MODULE_PERIPH_PM)) {
+            pm_set_lowest();
+        }
     }
 
     return NULL;


### PR DESCRIPTION
### Contribution description

🙃
 I think `pm_set_lowest()` needs to be guarded against the module `periph_pm`. Otherwise you can not build RIOT if `periph_pm` is not provided by the target board.

I wasn't super sure if it needs to be `periph_pm` maybe it should be `pm_layered` instead?

### Testing procedure

CI, I guess? Very unsure here!

