### PR TITLE
drivers/periph/pdm: initial pdm implementation

### DIFF
--- a/boards/adafruit-clue/Makefile.features
+++ b/boards/adafruit-clue/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pdm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/adafruit-clue/include/periph_conf.h
+++ b/boards/adafruit-clue/include/periph_conf.h
@@ -115,6 +115,16 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name    PDM configuration
+ * @{
+ */
+static const pdm_conf_t pdm_config = {
+    .din_pin = GPIO_PIN(0, 0),
+    .clk_pin = GPIO_PIN(0, 1),
+};
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/feather-nrf52840-sense/Makefile.features
+++ b/boards/feather-nrf52840-sense/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pdm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/feather-nrf52840-sense/include/periph_conf.h
+++ b/boards/feather-nrf52840-sense/include/periph_conf.h
@@ -85,6 +85,16 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
+/**
+ * @name    PDM configuration
+ * @{
+ */
+static const pdm_conf_t pdm_config = {
+    .din_pin = GPIO_PIN(0, 0),
+    .clk_pin = GPIO_PIN(0, 1),
+};
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -155,7 +155,7 @@ typedef struct {
     uint8_t din_pin;         /**< DIN pin */
     uint8_t clk_pin;         /**< CLK pin */
 } pdm_conf_t;
-
+ 
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -116,6 +116,7 @@ void spi_twi_irq_register_i2c(NRF_TWIM_Type *bus,
                               spi_twi_irq_cb_t cb, void *arg);
 
 /**
+
  * @brief   Acquire the shared I2C/SPI peripheral in I2C mode
  *
  * @param   bus bus to acquire exclusive access on
@@ -146,6 +147,14 @@ void nrf5x_spi_acquire(NRF_SPIM_Type *bus, spi_twi_irq_cb_t cb, void *arg);
  * @param   bus bus to release exclusive access on
  */
 void nrf5x_spi_release(NRF_SPIM_Type *bus);
+ 
+ /**
+ * @brief   Structure for PDM configuration data
+ */
+typedef struct {
+    uint8_t din_pin;         /**< DIN pin */
+    uint8_t clk_pin;         /**< CLK pin */
+} pdm_conf_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/nrf52/periph/pdm.c
+++ b/cpu/nrf52/periph/pdm.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_nrf52
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the peripheral PDM interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+
+#include "cpu.h"
+#include "periph/gpio.h"
+#include "periph/pdm.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* The samples buffer is a double buffer */
+int16_t _pdm_buf[PDM_BUF_SIZE * 2] = { 0 };
+static uint8_t _pdm_current_buf = 0;
+static pdm_isr_ctx_t isr_ctx;
+
+int pdm_init(pdm_mode_t mode, pdm_sample_rate_t rate, int8_t gain,
+              pdm_data_cb_t cb, void *arg)
+{
+    if (NRF_CLOCK->EVENTS_HFCLKSTARTED == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        while (NRF_CLOCK->EVENTS_HFCLKSTARTED == 0) {}
+    }
+
+    /* Configure sampling rate */
+    switch (rate) {
+        case PDM_SAMPLE_RATE_16KHZ:
+#ifdef CPU_MODEL_NRF52840XXAA
+            NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio80 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+            NRF_PDM->PDMCLKCTRL = PDM_PDMCLKCTRL_FREQ_1280K;
+#else
+            NRF_PDM->PDMCLKCTRL = PDM_PDMCLKCTRL_FREQ_Default; /* 1.033MHz */
+#endif
+            break;
+        case PDM_SAMPLE_RATE_20KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x0A000000; /* CLK= 1.280 MHz (32 MHz / 25) => rate= 20000 Hz */
+            break;
+        case PDM_SAMPLE_RATE_41KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x15000000; /* CLK= 2.667 MHz (32 MHz / 12) => rate= 41667 Hz */
+            break;
+        case PDM_SAMPLE_RATE_50KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x19000000; /* CLK= 3.200 MHz (32 MHz / 10) => rate= 50000 Hz */
+            break;
+        case PDM_SAMPLE_RATE_60KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x20000000; /* CLK= 4.000 MHz (32 MHz / 8) => rate= 60000 Hz */
+            break;
+        default:
+            DEBUG("[pdm] init: sample rate not supported\n");
+            return -ENOTSUP;
+    }
+
+    /* Configure mode (Mono or Stereo) */
+    switch (mode) {
+        case PDM_MODE_MONO:
+            NRF_PDM->MODE = PDM_MODE_OPERATION_Mono;
+            break;
+        case PDM_MODE_STEREO:
+            NRF_PDM->MODE = PDM_MODE_OPERATION_Stereo;
+            break;
+        default:
+            DEBUG("[pdm] init: mode not supported\n");
+            return -ENOTSUP;
+    }
+
+    /* Configure gain */
+    if (gain > PDM_GAIN_MAX) {
+        gain = PDM_GAIN_MAX;
+    }
+
+    if (gain < PDM_GAIN_MIN) {
+        gain = PDM_GAIN_MIN;
+    }
+
+    NRF_PDM->GAINR = (gain << 1) + 40;
+    NRF_PDM->GAINL = (gain << 1) + 40;
+
+    /* Configure CLK and DIN pins */
+    gpio_init(pdm_config.clk_pin, GPIO_OUT);
+    gpio_clear(pdm_config.clk_pin);
+    gpio_init(pdm_config.din_pin, GPIO_IN);
+
+    NRF_PDM->PSEL.CLK = pdm_config.clk_pin;
+    NRF_PDM->PSEL.DIN = pdm_config.din_pin;
+
+    /* clear pending events */
+    NRF_PDM->EVENTS_STARTED = 0;
+    NRF_PDM->EVENTS_STOPPED = 0;
+    NRF_PDM->EVENTS_END = 0;
+
+    /* Enable end/started/stopped events */
+    NRF_PDM->INTENSET = ((PDM_INTEN_END_Enabled << PDM_INTEN_END_Pos) |
+                        (PDM_INTEN_STARTED_Enabled << PDM_INTEN_STARTED_Pos) |
+                        (PDM_INTEN_STOPPED_Enabled << PDM_INTEN_STOPPED_Pos));
+
+    /* Configure internal RAM buffer size, divide by 2 for stereo mode */
+    NRF_PDM->SAMPLE.MAXCNT = (PDM_BUF_SIZE >> mode);
+
+    isr_ctx.cb = cb;
+    isr_ctx.arg = arg;
+
+    /* enable interrupt */
+    NVIC_EnableIRQ(PDM_IRQn);
+
+    /* Enable PDM */
+    NRF_PDM->ENABLE = (PDM_ENABLE_ENABLE_Enabled << PDM_ENABLE_ENABLE_Pos);
+
+    return 0;
+}
+
+void pdm_start(void)
+{
+    NRF_PDM->SAMPLE.PTR = (uint32_t)_pdm_buf;
+    DEBUG("[PDM] MAXCNT: %lu\n", NRF_PDM->SAMPLE.MAXCNT);
+
+    NRF_PDM->TASKS_START = 1;
+}
+
+void pdm_stop(void)
+{
+    NRF_PDM->TASKS_STOP = 1;
+}
+
+void isr_pdm(void)
+{
+    if (NRF_PDM->EVENTS_STARTED == 1) {
+        NRF_PDM->EVENTS_STARTED = 0;
+        uint8_t next_buf_pos = (_pdm_current_buf + 1) & 0x1;
+        NRF_PDM->SAMPLE.PTR = (uint32_t)&_pdm_buf[next_buf_pos * (PDM_BUF_SIZE >> 1)];
+    }
+
+    if (NRF_PDM->EVENTS_STOPPED == 1) {
+        NRF_PDM->EVENTS_STOPPED = 0;
+        _pdm_current_buf = 0;
+    }
+
+    if (NRF_PDM->EVENTS_END == 1) {
+        NRF_PDM->EVENTS_END = 0;
+
+        /* Process received samples frame */
+        isr_ctx.cb(isr_ctx.arg, &_pdm_buf[_pdm_current_buf * (PDM_BUF_SIZE >> 1)]);
+
+        /* Set next buffer */
+        _pdm_current_buf = (_pdm_current_buf + 1) & 0x1;
+    }
+
+    cortexm_isr_end();
+}

--- a/drivers/include/periph/pdm.h
+++ b/drivers/include/periph/pdm.h
@@ -77,6 +77,9 @@ typedef enum {
 #define PDM_BUF_SIZE        (128U)
 #endif
 
+// Define the new buffer size
+#define NEW_BUF_SIZE    (PDM_BUF_SIZE * 5 * 16 * 16)
+
 /**
  * @brief   Signature for data received interrupt callback
  *
@@ -97,7 +100,7 @@ typedef struct {
 
 /**
  * @brief   Initialize the PDM peripheral
- *
+ * @param[in] mode      mode (Mono or Stereo)
  * @param[in] rate      sample rate
  * @param[in] gain      gain
  * @param[in] cb        data received callback function
@@ -106,8 +109,7 @@ typedef struct {
  * @return  0 on successful initialization
  * @return <0 on error
  */
-int pdm_init(pdm_mode_t mode, pdm_sample_rate_t rate, int8_t gain,
-             pdm_data_cb_t cb, void *arg);
+int pdm_init(pdm_mode_t mode, pdm_sample_rate_t rate, int8_t gain, pdm_data_cb_t cb, void *arg);
 
 /**
  * @brief   Start the PDM peripheral
@@ -120,7 +122,7 @@ void pdm_start(void);
 void pdm_stop(void);
 
 #ifdef __cplusplus
-}
+
 #endif
 
 #endif /* PERIPH_PDM_H */

--- a/drivers/include/periph/pdm.h
+++ b/drivers/include/periph/pdm.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_pdm Pulse Density Modulation (PDM) driver
+ * @ingroup     drivers_periph
+ * @brief       Low-level Pulse Density Modulation (PDM) driver
+ *
+ * @{
+ * @file
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_PDM_H
+#define PERIPH_PDM_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default PDM mode values
+ * @{
+ */
+#ifndef HAVE_PDM_MODE_T
+typedef enum {
+    PDM_MODE_MONO = 0,      /**< Mono mode */
+    PDM_MODE_STEREO,        /**< Stereo mode */
+} pdm_mode_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default PDM sampling rate values
+ * @{
+ */
+#ifndef HAVE_PDM_SAMPLE_RATE_T
+typedef enum {
+    PDM_SAMPLE_RATE_16KHZ = 0,      /**< 16kHz */
+    PDM_SAMPLE_RATE_20KHZ,          /**< 20kHz */
+    PDM_SAMPLE_RATE_41KHZ,          /**< 41.6kHz */
+    PDM_SAMPLE_RATE_50KHZ,          /**< 50kHz */
+    PDM_SAMPLE_RATE_60KHZ,          /**< 60kHz */
+} pdm_sample_rate_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default PDM min gain values (in dB)
+ */
+#ifndef PDM_GAIN_MIN
+#define PDM_GAIN_MIN        (-20)
+#endif
+
+/**
+ * @brief   Default PDM max gain values (in dB)
+ */
+#ifndef PDM_GAIN_MAX
+#define PDM_GAIN_MAX        (20)
+#endif
+
+/**
+ * @brief   Default PDM samples frame buffer size
+ */
+#ifndef PDM_BUF_SIZE
+#define PDM_BUF_SIZE        (128U)
+#endif
+
+/**
+ * @brief   Signature for data received interrupt callback
+ *
+ * @param[in] arg           context to the callback (optional)
+ * @param[in] buf           the buffer containing the current samples frame
+ */
+typedef void(*pdm_data_cb_t)(void *arg, int16_t *buf);
+
+/**
+ * @brief   Interrupt context for a PDM device
+ */
+#ifndef HAVE_PDM_ISR_CTX_T
+typedef struct {
+    pdm_data_cb_t cb;       /**< data received interrupt callback */
+    void *arg;              /**< argument to both callback routines */
+} pdm_isr_ctx_t;
+#endif
+
+/**
+ * @brief   Initialize the PDM peripheral
+ *
+ * @param[in] rate      sample rate
+ * @param[in] gain      gain
+ * @param[in] cb        data received callback function
+ * @param[in] arg       context passed to the callback function
+ *
+ * @return  0 on successful initialization
+ * @return <0 on error
+ */
+int pdm_init(pdm_mode_t mode, pdm_sample_rate_t rate, int8_t gain,
+             pdm_data_cb_t cb, void *arg);
+
+/**
+ * @brief   Start the PDM peripheral
+ */
+void pdm_start(void);
+
+/**
+ * @brief   Stop the PDM peripheral
+ */
+void pdm_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_PDM_H */
+/** @} */

--- a/tests/periph_pdm/Makefile
+++ b/tests/periph_pdm/Makefile
@@ -1,5 +1,21 @@
+# name of your application
+APPLICATION = shell
+
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
+CFLAGS +=-DPDM_BUF_SIZE=\(64\)
+
 FEATURES_REQUIRED = periph_pdm
+
+# use the shell module
+USEMODULE += shell
+
+USEMODULE += ztimer_msec
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pdm/Makefile
+++ b/tests/periph_pdm/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_pdm
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pdm/larger_buff_size.py
+++ b/tests/periph_pdm/larger_buff_size.py
@@ -1,0 +1,117 @@
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import re
+import numpy as np
+import os
+import csv
+from itertools import groupby
+from operator import itemgetter
+import serial
+import struct
+import wave
+import time
+
+str1 = "Start of the new buffer".encode('ascii')
+str2= "End of the new buffer".encode('ascii')
+
+start_index_buf = 0
+stop_index_buf = 0
+start_found = False
+buffer_number = 0
+start = True
+
+ser = serial.Serial('/dev/ttyACM0', 115200, timeout=1)
+data = {}
+key = 0
+
+ser.writelines(["start\n".encode('ascii')])
+while start:
+    line = ser.readline()
+    #print(line)
+    value = line.strip()
+    data[key] = value
+    if line.find(str1) != -1:
+        #print("Start Recording")
+        start_found = True
+        start_index_buf = key
+    if line.find(str2) != -1:
+
+        if start_found:
+            stop_index_buf = key
+            buffer_number = stop_index_buf - start_index_buf - 2
+            start = False
+            #print("Stop recording")
+            break
+    key +=1
+
+print(start_index_buf)
+print(stop_index_buf)
+print(buffer_number)
+ser.close()
+
+# Extract the data within the specified range
+data_to_plot = [int(data[i]) for i in range(start_index_buf+1, stop_index_buf)]
+data_to_bytes = [int(data[i]).to_bytes(2,byteorder="little",signed=True) for i in range(start_index_buf+1, stop_index_buf)]
+data_to_export = [(data[i]) for i in range(start_index_buf+1, stop_index_buf)]
+#print(data_to_bytes)
+
+# Save the data to 16-b file
+# Open a file in binary write mode
+with open("binary_data.bin", "wb") as f:
+    for binary_data in data_to_bytes:
+        # Write the binary data to the file
+        f.write(binary_data)
+
+# Sample rate (Hz)
+sample_rate = 16000
+
+# Open a new wave file
+with wave.open("output_wave.wav", "w") as output_wave:
+    # Set parameters for the wave file
+    output_wave.setnchannels(1)  # Mono
+    output_wave.setsampwidth(2)  # 2 bytes per sample for 16-bit audio
+    output_wave.setframerate(sample_rate)
+
+    # Convert data_to_plot to numpy array
+    data_np = np.array(data_to_bytes)
+
+    # Convert data to bytes and write to the wave file
+    output_wave.writeframes(data_np)
+
+# Sample rate (Hz)
+samplerate = 16000
+length = 1
+
+# The left channel for 1 second.
+t = np.linspace(0, length, samplerate)
+left_channel = 0.5 * np.sin(2 * np.pi * 440.0 * t)
+
+# Noise on the right channel.
+#right_channel = np.random.random(size=samplerate)
+left_channel = data_to_plot/np.max(np.abs(data_to_plot))
+audio = np.array([left_channel]).T
+
+# Convert to (little-endian) 16 bit integers.
+audio = (audio * (2 ** 15 - 1)).astype("<h")
+
+with wave.open("sound_new_buf.wav", "w") as f:
+    # Mono Channel
+    f.setnchannels(1)
+    # 2 bytes per sample.
+    f.setsampwidth(2)
+    f.setframerate(samplerate)
+    f.writeframes(audio.tobytes())
+
+print("WAV file successfully created.")
+
+# Plot the sliced data
+plt.plot(data_to_plot)
+
+plt.xlabel('Number of Sample')
+plt.ylabel('Signal Value', rotation=90)
+
+# Adjusting the limits of the axes for more detail
+plt.xlim(start_index_buf, len(data_to_plot))
+plt.ylim(min(data_to_plot), max(data_to_plot))
+plt.grid(True)
+plt.show()

--- a/tests/periph_pdm/main.c
+++ b/tests/periph_pdm/main.c
@@ -69,14 +69,8 @@ int start_recording_cmd(int argc, char **argv)
     (void)argv;
     _main_thread_pid = thread_getpid();
 #if !PDM_DATA_PRINT_BINARY
-    //puts("PDM peripheral driver test\n");
 #endif
 
-/*     msg_t temp;
-    for (unsigned i = 0; i<1; i++)
-    {
-        msg_receive(&temp);
-    }  */
     for (unsigned repeat = 0; repeat < NEW_BUF_SIZE / PDM_BUF_SIZE; repeat++) {
         msg_t msg;
         msg_receive(&msg);
@@ -84,14 +78,6 @@ int start_recording_cmd(int argc, char **argv)
 #if PDM_DATA_PRINT_BINARY
         stdio_write((uint8_t *)buf, PDM_BUF_SIZE >> 2);
 #else
-    /*      printf("Start of the buffer\n");
-        for (unsigned idx = 0; idx < PDM_BUF_SIZE; ++idx) {
-            printf("%i\n", buf[idx]);
-            buf_size = idx;
-        }
-        printf("End of the buffer\n");
-        printf("%d\n", buf_size); */
-
         // Copy PDM_BUF_SIZE to NEW_BUF_SIZE repeatedly
         for (unsigned idx = 0; idx < PDM_BUF_SIZE; idx++) {
             new_buf[repeat*PDM_BUF_SIZE+idx] = buf[idx];
@@ -99,7 +85,6 @@ int start_recording_cmd(int argc, char **argv)
 #endif
     }
     // Parse the new_buf
-    //pdm_stop();
     _main_thread_pid = KERNEL_PID_UNDEF;
     printf("Start of the new buffer\n");
     for (unsigned idx = 0; idx < NEW_BUF_SIZE ; idx++) {

--- a/tests/periph_pdm/main.c
+++ b/tests/periph_pdm/main.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Low-level PDM driver test
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "msg.h"
+#include "thread.h"
+#include "stdio_base.h"
+
+#include "periph/pdm.h"
+
+static kernel_pid_t _main_thread_pid;
+
+#ifndef PDM_DATA_PRINT_BINARY
+#define PDM_DATA_PRINT_BINARY   (0)
+#endif
+
+#ifndef PDM_TEST_MODE
+#define PDM_TEST_MODE           (PDM_MODE_MONO)
+#endif
+
+#ifndef PDM_TEST_SAMPLE_RATE
+#define PDM_TEST_SAMPLE_RATE    (PDM_SAMPLE_RATE_16KHZ)
+#endif
+
+#ifndef PDM_TEST_GAIN
+#define PDM_TEST_GAIN           (-10)
+#endif
+
+static void _pdm_cb(void *arg, int16_t *buf)
+{
+    (void)arg;
+    msg_t msg;
+    msg.content.ptr = buf;
+    msg_send(&msg, _main_thread_pid);
+}
+
+int main(void)
+{
+#if !PDM_DATA_PRINT_BINARY
+    puts("PDM peripheral driver test\n");
+#endif
+
+    if (pdm_init(PDM_TEST_MODE, PDM_TEST_SAMPLE_RATE, PDM_TEST_GAIN, _pdm_cb, NULL) < 0) {
+        puts("Failed to initialize PDM peripheral");
+        return 1;
+    }
+
+    pdm_start();
+
+    _main_thread_pid = thread_getpid();
+
+    while (1) {
+        msg_t msg;
+        msg_receive(&msg);
+        int16_t *buf = (int16_t *)msg.content.ptr;
+#if PDM_DATA_PRINT_BINARY
+        stdio_write((uint8_t *)buf, PDM_BUF_SIZE >> 2);
+#else
+        for (unsigned idx = 0; idx < PDM_BUF_SIZE; ++idx) {
+            printf("%i\n", buf[idx]);
+        }
+#endif
+    }
+
+    return 0;
+}

--- a/tests/periph_pdm/main.c
+++ b/tests/periph_pdm/main.c
@@ -20,14 +20,16 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "msg.h"
 #include "thread.h"
 #include "stdio_base.h"
-
+#include "shell.h"
 #include "periph/pdm.h"
+#include "ztimer.h"
 
-static kernel_pid_t _main_thread_pid;
+static kernel_pid_t _main_thread_pid = KERNEL_PID_UNDEF;
 
 #ifndef PDM_DATA_PRINT_BINARY
 #define PDM_DATA_PRINT_BINARY   (0)
@@ -45,41 +47,79 @@ static kernel_pid_t _main_thread_pid;
 #define PDM_TEST_GAIN           (-10)
 #endif
 
+int16_t new_buf[NEW_BUF_SIZE];
+
 static void _pdm_cb(void *arg, int16_t *buf)
 {
     (void)arg;
     msg_t msg;
     msg.content.ptr = buf;
-    msg_send(&msg, _main_thread_pid);
+    if (_main_thread_pid != KERNEL_PID_UNDEF)
+    {
+        msg_send(&msg, _main_thread_pid);
+    }
 }
 
-int main(void)
+int start_recording_cmd(int argc, char **argv)
 {
-#if !PDM_DATA_PRINT_BINARY
-    puts("PDM peripheral driver test\n");
-#endif
-
-    if (pdm_init(PDM_TEST_MODE, PDM_TEST_SAMPLE_RATE, PDM_TEST_GAIN, _pdm_cb, NULL) < 0) {
-        puts("Failed to initialize PDM peripheral");
+    if (argc != 1) {
+        puts("Note: Start Recording \n");
         return 1;
     }
-
-    pdm_start();
-
+    (void)argv;
     _main_thread_pid = thread_getpid();
+#if !PDM_DATA_PRINT_BINARY
+    //puts("PDM peripheral driver test\n");
+#endif
 
-    while (1) {
+/*     msg_t temp;
+    for (unsigned i = 0; i<1; i++)
+    {
+        msg_receive(&temp);
+    }  */
+    for (unsigned repeat = 0; repeat < NEW_BUF_SIZE / PDM_BUF_SIZE; repeat++) {
         msg_t msg;
         msg_receive(&msg);
         int16_t *buf = (int16_t *)msg.content.ptr;
 #if PDM_DATA_PRINT_BINARY
         stdio_write((uint8_t *)buf, PDM_BUF_SIZE >> 2);
 #else
+    /*      printf("Start of the buffer\n");
         for (unsigned idx = 0; idx < PDM_BUF_SIZE; ++idx) {
             printf("%i\n", buf[idx]);
+            buf_size = idx;
+        }
+        printf("End of the buffer\n");
+        printf("%d\n", buf_size); */
+
+        // Copy PDM_BUF_SIZE to NEW_BUF_SIZE repeatedly
+        for (unsigned idx = 0; idx < PDM_BUF_SIZE; idx++) {
+            new_buf[repeat*PDM_BUF_SIZE+idx] = buf[idx];
         }
 #endif
     }
-
+    // Parse the new_buf
+    //pdm_stop();
+    _main_thread_pid = KERNEL_PID_UNDEF;
+    printf("Start of the new buffer\n");
+    for (unsigned idx = 0; idx < NEW_BUF_SIZE ; idx++) {
+        printf("%i\n", new_buf[idx]);
+    }
+    printf("End of the new buffer\n");
+    printf("%d\n", NEW_BUF_SIZE);
     return 0;
+}
+
+SHELL_COMMAND(start,"Start Recording", start_recording_cmd);
+
+int main(void)
+{
+char line_buf[SHELL_DEFAULT_BUFSIZE];
+if (pdm_init(PDM_TEST_MODE, PDM_TEST_SAMPLE_RATE, PDM_TEST_GAIN, _pdm_cb, NULL) < 0) {
+        puts("Failed to initialize PDM peripheral");
+        return 1;
+    }
+    pdm_start();
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+return 0;
 }

--- a/tests/periph_pdm/testing_pdm_conversion.py
+++ b/tests/periph_pdm/testing_pdm_conversion.py
@@ -14,7 +14,7 @@ import time
 str1 = "Start of the new buffer".encode('ascii')
 str2= "End of the new buffer".encode('ascii')
 
-start_index_buf = 0
+start_index_buf = 0    
 stop_index_buf = 0
 start_found = False
 buffer_number = 0
@@ -31,20 +31,17 @@ while start:
     value = line.strip()
     data[key] = value
     if line.find(str1) != -1:
-        #print("Start Recording")
         start_found = True
         start_index_buf = key
     if line.find(str2) != -1:
-
         if start_found:
             stop_index_buf = key
             buffer_number = stop_index_buf - start_index_buf - 2
             start = False
-            #print("Stop recording")
             break
     key +=1
 
-print(start_index_buf)
+print(start_index_buf)     
 print(stop_index_buf)
 print(buffer_number)
 ser.close()
@@ -52,8 +49,6 @@ ser.close()
 # Extract the data within the specified range
 data_to_plot = [int(data[i]) for i in range(start_index_buf+1, stop_index_buf)]
 data_to_bytes = [int(data[i]).to_bytes(2,byteorder="little",signed=True) for i in range(start_index_buf+1, stop_index_buf)]
-data_to_export = [(data[i]) for i in range(start_index_buf+1, stop_index_buf)]
-#print(data_to_bytes)
 
 # Save the data to 16-b file
 # Open a file in binary write mode
@@ -61,22 +56,6 @@ with open("binary_data.bin", "wb") as f:
     for binary_data in data_to_bytes:
         # Write the binary data to the file
         f.write(binary_data)
-
-# Sample rate (Hz)
-sample_rate = 16000
-
-# Open a new wave file
-with wave.open("output_wave.wav", "w") as output_wave:
-    # Set parameters for the wave file
-    output_wave.setnchannels(1)  # Mono
-    output_wave.setsampwidth(2)  # 2 bytes per sample for 16-bit audio
-    output_wave.setframerate(sample_rate)
-
-    # Convert data_to_plot to numpy array
-    data_np = np.array(data_to_bytes)
-
-    # Convert data to bytes and write to the wave file
-    output_wave.writeframes(data_np)
 
 # Sample rate (Hz)
 samplerate = 16000
@@ -94,6 +73,7 @@ audio = np.array([left_channel]).T
 # Convert to (little-endian) 16 bit integers.
 audio = (audio * (2 ** 15 - 1)).astype("<h")
 
+# Save the data as a wave format
 with wave.open("sound_new_buf.wav", "w") as f:
     # Mono Channel
     f.setnchannels(1)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### PDM — Pulse density modulation interface

The pulse density modulation (PDM) module enables input of pulse density modulated signals from external audio frontends, for example, digital microphones. The PDM module generates the PDM clock and supports single-channel or dual-channel (left and right) data input. Data is transferred directly to RAM buffers using EasyDMA.




### Testing procedure

I utilized the PDM interface for Feather nRF52840 Sense board, conducting comprehensive some tests to validate its performance. after thorough examination, I successfully recorded from the PDM on the board and saw the result in the chart of python code and compared with Audacity application output.
- Synchronization PDM testing in different buffer size
- Record different frequencies and see the result in python chart
- The expected success test output in Audacity


### Issues/PRs references
based on #16125 
