### PR TITLE
doc: Allow resizing of doxygen side-nav

### DIFF
--- a/doc/doxygen/src/js/riot-doxy.js
+++ b/doc/doxygen/src/js/riot-doxy.js
@@ -46,6 +46,8 @@ function resize_content(sidenav)
 
 function resize_handler()
 {
+    if ($(window).width() == window_before) {return;}
+
     var sidenav = $("#side-nav");
     if ($(window).width() < 750) {
         var toc = $(".toc");


### PR DESCRIPTION
### Contribution description

Fixes the bug that the side-nav on RIOT-doxygen website can not be resized (in Firefox) (See https://github.com/RIOT-OS/RIOT/issues/20414). 

### Testing procedure

Open <https://doc.riot-os.org/> and try to resize the side-nav on the left (using Firefox).

### Issues/PRs references

Closes https://github.com/RIOT-OS/RIOT/issues/20414

