### PR TITLE
gnrc_mac / gnrc_lwmac / gnrc_gomach: Deprecate modules

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,4 +1,5 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
+DEPRECATED_MODULES += gnrc_mac
 DEPRECATED_MODULES += sema_deprecated
 DEPRECATED_MODULES += ztimer_now64

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,7 +1,9 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
+DEPRECATED_MODULES += gnrc_gomach
 DEPRECATED_MODULES += gnrc_lwmac
 DEPRECATED_MODULES += gnrc_mac
+DEPRECATED_MODULES += gnrc_nettype_gomach
 DEPRECATED_MODULES += gnrc_nettype_lwmac
 DEPRECATED_MODULES += sema_deprecated
 DEPRECATED_MODULES += ztimer_now64

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,5 +1,7 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
+DEPRECATED_MODULES += gnrc_lwmac
 DEPRECATED_MODULES += gnrc_mac
+DEPRECATED_MODULES += gnrc_nettype_lwmac
 DEPRECATED_MODULES += sema_deprecated
 DEPRECATED_MODULES += ztimer_now64

--- a/pkg/opendsme/include/opendsme/opendsme.h
+++ b/pkg/opendsme/include/opendsme/opendsme.h
@@ -40,14 +40,14 @@
  * of a series of superframes that repeat indefinitely. A superframe consists
  * of a Beacon Slot, a Contention Access Period and Contention Free Period.
  *
- *    BS                 CAP                      CFP        BS
- *   +------------------------------------------------------+----
- *   |   |                                |--|--|--|--|--|--|   | ...
- *   |   |                                |--|--|--|--|--|--|   |
- *   |   |                                |--|--|--|--|--|--|   | ...
- *   |   |                                |--|--|--|--|--|--|   |
- *   +---+--------------------------------+--+--+--+--+--+--+---+
- *   <------------------- Superframe ----------------------->
+ *      BS                 CAP                      CFP        BS
+ *     +------------------------------------------------------+----
+ *     |   |                                |--|--|--|--|--|--|   | ...
+ *     |   |                                |--|--|--|--|--|--|   |
+ *     |   |                                |--|--|--|--|--|--|   | ...
+ *     |   |                                |--|--|--|--|--|--|   |
+ *     +---+--------------------------------+--+--+--+--+--+--+---+
+ *     <------------------- Superframe ----------------------->
  *
  * Each period of the superframe serves a dedicated purpose:
  * - Beacon Slot: Used for beacon transmission. PAN Coordinators and Coordinators

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -10,6 +10,8 @@
  * @defgroup    net_gnrc_gomach GoMacH
  * @ingroup     net_gnrc
  * @brief       A traffic-adaptive multi-channel MAC
+ * @deprecated  This module is deprecated and will be removed after the 2024.10 release.
+ *              As an alternative MAC layer for IEEE 802.15.4, you can use @ref pkg_opendsme.
  *
  *
  * GoMacH is, "a General, nearly Optimal MAC protocol for multi-Hop communications",

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -11,6 +11,8 @@
  * @defgroup    net_gnrc_lwmac LWMAC
  * @ingroup     net_gnrc
  * @brief       A Lightweight duty-cycling 802.15.4 MAC protocol
+ * @deprecated  This module is deprecated and will be removed after the 2024.10 release.
+ *              As an alternative MAC layer for IEEE 802.15.4, you can use @ref pkg_opendsme.
  *
  *
  * ## LWMAC implementation

--- a/sys/include/net/gnrc/mac/mac.h
+++ b/sys/include/net/gnrc/mac/mac.h
@@ -11,6 +11,8 @@
  * @defgroup    net_gnrc_mac Common MAC module
  * @ingroup     net_gnrc
  * @brief       A MAC module for providing common MAC parameters and helper functions.
+ * @deprecated  This module is deprecated and will be removed after the 2024.10 release.
+ *              As an alternative, you can use @ref pkg_opendsme.
  *
  * @{
  *

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -66,7 +66,12 @@ typedef enum {
      * @name Link layer
      */
 #if IS_USED(MODULE_GNRC_NETTYPE_GOMACH) || defined(DOXYGEN)
-    GNRC_NETTYPE_GOMACH,         /**< Protocol is GoMacH */
+    /**
+     * @brief       Protocol is GoMacH
+     * @deprecated  @ref net_gnrc_gomach was deprecated and will be removed after
+     *              the 2024.10 release together with this protocol type.
+     */
+    GNRC_NETTYPE_GOMACH,
 #endif
 #if IS_USED(MODULE_GNRC_NETTYPE_LWMAC) || defined(DOXYGEN)
     /**

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -69,7 +69,12 @@ typedef enum {
     GNRC_NETTYPE_GOMACH,         /**< Protocol is GoMacH */
 #endif
 #if IS_USED(MODULE_GNRC_NETTYPE_LWMAC) || defined(DOXYGEN)
-    GNRC_NETTYPE_LWMAC,          /**< Protocol is lwMAC */
+    /**
+     * @brief       Protocol is lwMAC
+     * @deprecated  @ref net_gnrc_lwmac was deprecated and will be removed after
+     *              the 2024.10 release together with this protocol type.
+     */
+    GNRC_NETTYPE_LWMAC,
 #endif
 #if IS_USED(MODULE_GNRC_NETTYPE_CUSTOM) || defined(DOXYGEN)
     GNRC_NETTYPE_CUSTOM,         /**< Custom ethertype */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Both `gnrc_lwmac` and `gnrc_gomach` as well as their common module `gnrc_mac` are effectively unmaintained (the last commit to these modules that wasn't a cleanup or adoption for API change was in 2017). So let's deprecate them and later on remove them. People requiring a MAC protocols can use OpenDSME as an alternative.

Since I also had a look at the OpenDSME doc, I found a rendering issue there for which I piggybacked a fix.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make doc` should generate a documentation with those modules (and their `nettype` on the deprecated list. Building any application that uses those modules (e.g. `examples/gnrc_networking_mac`) should show a warning that deprecated modules are used.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
As discussed in #16502.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
