### PR TITLE
sys/vfs: use atomic_utils rather C11 atomics

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -54,14 +54,6 @@
 #define VFS_H
 
 #include <stdint.h>
-/* The stdatomic.h in GCC gives compilation errors with C++
- * see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932
- */
-#ifdef __cplusplus
-#include "c11_atomics_compat.hpp"
-#else
-#include <stdatomic.h> /* for atomic_int */
-#endif
 #include <sys/stat.h> /* for struct stat */
 #include <sys/types.h> /* for off_t etc. */
 #include <sys/statvfs.h> /* for struct statvfs */
@@ -383,7 +375,7 @@ struct vfs_mount_struct {
     const vfs_file_system_t *fs; /**< The file system driver for the mount point */
     const char *mount_point;     /**< Mount point, e.g. "/mnt/cdrom" */
     size_t mount_point_len;      /**< Length of mount_point string (set by vfs_mount) */
-    atomic_int open_files;       /**< Number of currently open files and directories */
+    uint16_t open_files;         /**< Number of currently open files and directories */
     void *private_data;          /**< File system driver private data, implementation defined */
 };
 


### PR DESCRIPTION
### Contribution description

This has the following advantages:

- faster and leaner when C11 atomics are not efficient (e.g. on LLVM this is almost always the case, as LLVM will only use efficient atomics if it doesn't has to bail out to library calls even for exotic things)
    - Even for GCC e.g. on the nucleo-f429zi this safes 72 B of .text for examples/filesystem despite runtime checks added for over- and underflow
- less pain in the ass for C++ and rust users, as both C++ and c2rust are incompatible with C11 atomics
- adds test for overflow of the open file counter for more robust operation
- adds `assumes()` so that underflows are detected in non-production code

### Testing procedure

No regressions in VFS operations.

**Beware:** I don't have the time to test this, so this is completely untested.

### Issues/PRs references

rust compatibility issues where reported in matrix