### PR TITLE
gcoap: make gcoap_req_send_tl() an alias of gcoap_req_send()

### DIFF
--- a/examples/gcoap/client.c
+++ b/examples/gcoap/client.c
@@ -146,7 +146,8 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
 
             int len = coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
             gcoap_req_send((uint8_t *)pdu->hdr, len, remote,
-                           _resp_handler, memo->context);
+                           _resp_handler, memo->context,
+                           GCOAP_SOCKET_TYPE_UNDEF);
         }
         else {
             puts("--- blockwise complete ---");
@@ -158,7 +159,8 @@ static size_t _send(uint8_t *buf, size_t len, sock_udp_ep_t *remote)
 {
     size_t bytes_sent;
 
-    bytes_sent = gcoap_req_send(buf, len, remote, _resp_handler, NULL);
+    bytes_sent = gcoap_req_send(buf, len, remote, _resp_handler, NULL,
+                                GCOAP_SOCKET_TYPE_UNDEF);
     if (bytes_sent > 0) {
         req_count++;
     }

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -330,7 +330,8 @@
  * coap_opt_add_proxy_uri(&pdu, uri);
  * unsigned len = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
  *
- * gcoap_req_send((uint8_t *) pdu->hdr, len, proxy_remote, _resp_handler, NULL);
+ * gcoap_req_send((uint8_t *) pdu->hdr, len, proxy_remote, _resp_handler, NULL,
+ *                GCOAP_SOCKET_TYPE_UNDEF);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * See the gcoap example for a sample implementation.
@@ -960,8 +961,33 @@ static inline ssize_t gcoap_request(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 /**
  * @brief   Sends a buffer containing a CoAP request to the provided endpoint
  *
- * @deprecated Will be an alias for @ref gcoap_req_send after the 2022.01
- *             release. Will be removed after the 2022.04 release.
+ * @param[in] buf           Buffer containing the PDU
+ * @param[in] len           Length of the buffer
+ * @param[in] remote        Destination for the packet
+ * @param[in] resp_handler  Callback when response received, may be NULL
+ * @param[in] context       User defined context passed to the response handler
+ * @param[in] tl_type       The transport type to use for send. When
+ *                          @ref GCOAP_SOCKET_TYPE_UNDEF is selected, the highest
+ *                          available (by value) will be selected. Only single
+ *                          types are allowed, not a combination of them.
+ *
+ * @note The highest supported (by value) gcoap_socket_type_t will be selected
+ *       as transport type.
+ *
+ * @return  length of the packet
+ * @return -ENOTCONN, if DTLS was used and session establishment failed
+ * @return -EINVAL, if @p tl_type is is not supported
+ * @return  0 if cannot send
+ */
+ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
+                                     const sock_udp_ep_t *remote,
+                                     gcoap_resp_handler_t resp_handler, void *context,
+                                     gcoap_socket_type_t tl_type);
+
+/**
+ * @brief   Sends a buffer containing a CoAP request to the provided endpoint
+ *
+ * @deprecated Will be removed after the 2023.10 release. Use alias @ref gcoap_req_send() instead.
  *
  * @param[in] buf           Buffer containing the PDU
  * @param[in] len           Length of the buffer
@@ -978,34 +1004,12 @@ static inline ssize_t gcoap_request(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  * @return -EINVAL, if @p tl_type is is not supported
  * @return  0 if cannot send
  */
-ssize_t gcoap_req_send_tl(const uint8_t *buf, size_t len,
+static inline ssize_t gcoap_req_send_tl(const uint8_t *buf, size_t len,
                           const sock_udp_ep_t *remote,
                           gcoap_resp_handler_t resp_handler, void *context,
-                          gcoap_socket_type_t tl_type);
-
-/**
- * @brief   Sends a buffer containing a CoAP request to the provided endpoint
- *
- * @param[in] buf           Buffer containing the PDU
- * @param[in] len           Length of the buffer
- * @param[in] remote        Destination for the packet
- * @param[in] resp_handler  Callback when response received, may be NULL
- * @param[in] context       User defined context passed to the response handler
- *
- * @note The highest supported (by value) gcoap_socket_type_t will be selected
- *       as transport type.
- *
- * @return  length of the packet
- * @return -ENOTCONN, if DTLS was used and session establishment failed
- * @return  0 if cannot send
- */
-static inline ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
-                                     const sock_udp_ep_t *remote,
-                                     gcoap_resp_handler_t resp_handler,
-                                     void *context)
+                          gcoap_socket_type_t tl_type)
 {
-    return gcoap_req_send_tl(buf, len, remote, resp_handler, context,
-                             GCOAP_SOCKET_TYPE_UNDEF);
+    return gcoap_req_send(buf, len, remote, resp_handler, context, tl_type);
 }
 
 /**

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -151,7 +151,7 @@ static int _update_remove(unsigned code, gcoap_resp_handler_t handle)
     ssize_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
 
     /* send request */
-    ssize_t send_len = gcoap_req_send(buf, pkt_len, &_rd_remote, handle, NULL);
+    ssize_t send_len = gcoap_req_send(buf, pkt_len, &_rd_remote, handle, NULL, GCOAP_SOCKET_TYPE_UNDEF);
     if (send_len <= 0) {
         return CORD_EP_ERR;
     }
@@ -225,7 +225,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
     coap_opt_add_uri_query(&pkt, "rt", "core.rd");
     size_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
-    res = gcoap_req_send(buf, pkt_len, remote, _on_discover, NULL);
+    res = gcoap_req_send(buf, pkt_len, remote, _on_discover, NULL, GCOAP_SOCKET_TYPE_UNDEF);
     if (res <= 0) {
         return CORD_EP_ERR;
     }
@@ -296,7 +296,7 @@ int cord_ep_register(const sock_udp_ep_t *remote, const char *regif)
     pkt_len += res;
 
     /* send out the request */
-    res = gcoap_req_send(buf, pkt_len, remote, _on_register, NULL);
+    res = gcoap_req_send(buf, pkt_len, remote, _on_register, NULL, GCOAP_SOCKET_TYPE_UNDEF);
     if (res <= 0) {
         retval = CORD_EP_ERR;
         goto end;

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -67,7 +67,7 @@ int cord_epsim_register(const sock_udp_ep_t *rd_ep)
     /* finish, we don't have any payload */
     ssize_t len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
     _state = CORD_EPSIM_BUSY;
-    if (gcoap_req_send(buf, len, rd_ep, _req_handler, NULL) == 0) {
+    if (gcoap_req_send(buf, len, rd_ep, _req_handler, NULL, GCOAP_SOCKET_TYPE_UNDEF) == 0) {
         return CORD_EPSIM_ERROR;
     }
 

--- a/sys/net/application_layer/cord/lc/cord_lc.c
+++ b/sys/net/application_layer/cord/lc/cord_lc.c
@@ -190,7 +190,7 @@ static ssize_t _lookup_raw(const cord_lc_rd_t *rd, unsigned content_format,
     if (pkt_len < 0) {
         return CORD_LC_ERR;
     }
-    res = gcoap_req_send(reqbuf, pkt_len, rd->remote, _on_lookup, NULL);
+    res = gcoap_req_send(reqbuf, pkt_len, rd->remote, _on_lookup, NULL, GCOAP_SOCKET_TYPE_UNDEF);
     if (res < 0) {
         return CORD_LC_ERR;
     }
@@ -250,7 +250,7 @@ static int _send_rd_init_req(coap_pkt_t *pkt, const sock_udp_ep_t *remote,
         return CORD_LC_ERR;
     }
 
-    if (!gcoap_req_send(buf, pkt_len, remote, _on_rd_init, NULL)) {
+    if (!gcoap_req_send(buf, pkt_len, remote, _on_rd_init, NULL, GCOAP_SOCKET_TYPE_UNDEF)) {
         DEBUG("cord_lc: error gcoap_req_send()\n");
         return CORD_LC_ERR;
     }

--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -765,6 +765,6 @@ static ssize_t _send(const void *buf, size_t len, const sock_udp_ep_t *remote,
     if (lock_resp_wait) {
         mutex_lock(&context->resp_wait);
     }
-    return gcoap_req_send_tl(buf, len, remote, _resp_handler, context, tl_type);
+    return gcoap_req_send(buf, len, remote, _resp_handler, context, tl_type);
 }
 /** @} */

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -208,10 +208,10 @@ static bool _parse_endpoint(sock_udp_ep_t *remote,
 static ssize_t _dispatch_msg(const void *buf, size_t len, sock_udp_ep_t *remote)
 {
     /* Yes it's not a request -- but turns out there is nothing in
-     * gcoap_req_send_tl that is actually request specific, especially if we
+     * gcoap_req_send that is actually request specific, especially if we
      * don't assign a callback. */
-    ssize_t res = gcoap_req_send_tl(buf, len, remote, NULL, NULL,
-                                    GCOAP_SOCKET_TYPE_UDP);
+    ssize_t res = gcoap_req_send(buf, len, remote, NULL, NULL,
+                                 GCOAP_SOCKET_TYPE_UDP);
     if (res <= 0) {
         DEBUG("gcoap_forward_proxy: unable to dispatch message: %d\n", -res);
     }
@@ -440,7 +440,8 @@ static int _gcoap_forward_proxy_via_coap(coap_pkt_t *client_pkt,
 
     len = gcoap_req_send((uint8_t *)pkt.hdr, len,
                          &origin_server_ep,
-                         _forward_resp_handler, (void *)client_ep);
+                         _forward_resp_handler, (void *)client_ep,
+                         GCOAP_SOCKET_TYPE_UNDEF);
     return len;
 }
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1612,10 +1612,10 @@ int gcoap_obs_req_forget(const sock_udp_ep_t *remote, const uint8_t *token,
     return res;
 }
 
-ssize_t gcoap_req_send_tl(const uint8_t *buf, size_t len,
-                          const sock_udp_ep_t *remote,
-                          gcoap_resp_handler_t resp_handler, void *context,
-                          gcoap_socket_type_t tl_type)
+ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
+                       const sock_udp_ep_t *remote,
+                       gcoap_resp_handler_t resp_handler, void *context,
+                       gcoap_socket_type_t tl_type)
 {
     gcoap_socket_t socket = { 0 };
     gcoap_request_memo_t *memo = NULL;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The deprecation notice for `gcoap_req_send_tl()` says, it was supposed to be made an alias for `gcoap_req_send()` after the 2022.01 release. This never happened, so let's do that 2 years after ;-). As a consequence I bumped up the actual removal of `gcoap_req_send_tl()` to after the 2024.10 release.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Should be straight forward, as `gcoap_req_send()` was a wrapper around `gcoap_req_send_tl()` with the default parameter `GCOAP_SOCKET_TYPE_UNDEF` already. As this adds that default parameter to all calls of `gcoap_req_send()`, nothing should change. So compilation should catch any issues.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
