### PR TITLE
tests/rsut_libs: add missing dependency

### DIFF
--- a/tests/rust_libs/Makefile
+++ b/tests/rust_libs/Makefile
@@ -2,6 +2,7 @@ include ../Makefile.tests_common
 
 USEMODULE += shell
 USEMODULE += shell_democommands
+USEMODULE += ztimer_msec
 
 FEATURES_REQUIRED += rust_target
 


### PR DESCRIPTION
### Contribution description

In `main.c:115` the call
`ztimer_sleep(ZTIMER_MSEC, _periodic_ctx.period.ms);` depends on the module `ztimer_msec`. Apparently, this was previously pulled in indirectly and the missing dep has gone unnoticed. This adds the dep explicitly to fix compilation issues that now have surfaced in the CI.

### Testing procedure

Green CI

### Issues/PRs references

None