### PR TITLE
cpu/stm32u5: Enable rtc support

### DIFF
--- a/boards/b-u585i-iot02a/Makefile.features
+++ b/boards/b-u585i-iot02a/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_rtc
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/nucleo-u575zi-q/Makefile.features
+++ b/boards/nucleo-u575zi-q/Makefile.features
@@ -7,6 +7,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_lpuart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_rtc
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features

--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -49,7 +49,7 @@
 #define EXTI_REG_FTSR       (EXTI->FTSR1)
 #define EXTI_REG_PR         (EXTI->PR1)
 #define EXTI_REG_IMR        (EXTI->IMR1)
-#elif defined(CPU_FAM_STM32G0)
+#elif defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32U5)
 #define EXTI_REG_RTSR       (EXTI->RTSR1)
 #define EXTI_REG_FTSR       (EXTI->FTSR1)
 #define EXTI_REG_PR         (EXTI->RPR1)
@@ -80,13 +80,21 @@
 #define RTC_ISR_RSF         RTC_ICSR_RSF
 #define RTC_ISR_INIT        RTC_ICSR_INIT
 #define RTC_ISR_INITF       RTC_ICSR_INITF
+#elif defined(CPU_FAM_STM32U5)
+#define RTC_REG_ISR         RTC->ICSR
+#define RTC_REG_SR          RTC->SR
+#define RTC_REG_SCR         RTC->SCR
+#define RTC_ISR_RSF         RTC_ICSR_RSF
+#define RTC_ISR_INIT        RTC_ICSR_INIT
+#define RTC_ISR_INITF       RTC_ICSR_INITF
+#define RTC_ISR_ALRAF       RTC_SR_ALRAF
 #else
 #define RTC_REG_ISR         RTC->ISR
 #endif
 
 /* interrupt line name mapping */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L5)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5)
 #define IRQN                (RTC_IRQn)
 #define ISR_NAME            isr_rtc
 #elif defined(CPU_FAM_STM32G0)
@@ -110,7 +118,7 @@
 #define EXTI_FTSR_BIT       (EXTI_FTSR1_FT17)
 #define EXTI_RTSR_BIT       (EXTI_RTSR1_RT17)
 #define EXTI_PR_BIT         (EXTI_PR1_PIF17)
-#elif defined(CPU_FAM_STM32G0)
+#elif defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32U5)
 #define EXTI_IMR_BIT        (EXTI_IMR1_IM11)
 #define EXTI_FTSR_BIT       (EXTI_FTSR1_FT11)
 #define EXTI_RTSR_BIT       (EXTI_RTSR1_RT11)
@@ -270,6 +278,8 @@ void rtc_init(void)
     periph_clk_en(APB1, RCC_APB1ENR1_RTCAPBEN);
 #elif defined(CPU_FAM_STM32G0)
     periph_clk_en(APB1, RCC_APBENR1_RTCAPBEN);
+#elif defined(CPU_FAM_STM32U5)
+    periph_clk_en(APB3, RCC_APB3ENR_RTCAPBEN);
 #endif
     EN_REG &= ~(CLKSEL_MASK);
 #if IS_ACTIVE(CONFIG_BOARD_HAS_LSE)
@@ -386,7 +396,7 @@ void rtc_clear_alarm(void)
 
     RTC->CR &= ~(RTC_CR_ALRAE | RTC_CR_ALRAIE);
 
-#if !defined(CPU_FAM_STM32L5)
+#if !defined(CPU_FAM_STM32L5) && !defined(CPU_FAM_STM32U5)
     while (!(RTC_REG_ISR & RTC_ISR_ALRAWF)) {}
 #else
     RTC_REG_SCR = RTC_SCR_CALRAF;
@@ -414,7 +424,7 @@ void rtc_poweroff(void)
 
 void ISR_NAME(void)
 {
-#if !defined(CPU_FAM_STM32L5) && !defined(CPU_FAM_STM32G0)
+#if !defined(CPU_FAM_STM32L5) && !defined(CPU_FAM_STM32G0) && !defined(CPU_FAM_STM32U5)
     if (RTC_REG_ISR & RTC_ISR_ALRAF) {
         if (isr_ctx.cb != NULL) {
             isr_ctx.cb(isr_ctx.arg);

--- a/cpu/stm32/periph/rtc_mem.c
+++ b/cpu/stm32/periph/rtc_mem.c
@@ -22,69 +22,69 @@
 #include "cpu.h"
 #include "periph/rtc_mem.h"
 
-#if defined(RTC_BKP31R)
+#if defined(RTC_BKP31R) || defined(TAMP_BKP31R)
 #define RTC_MEM_SIZE    32
-#elif defined(RTC_BKP30R)
+#elif defined(RTC_BKP30R) || defined(TAMP_BKP30R)
 #define RTC_MEM_SIZE    31
-#elif defined(RTC_BKP29R)
+#elif defined(RTC_BKP29R) || defined(TAMP_BKP29R)
 #define RTC_MEM_SIZE    30
-#elif defined(RTC_BKP28R)
+#elif defined(RTC_BKP28R) || defined(TAMP_BKP28R)
 #define RTC_MEM_SIZE    29
-#elif defined(RTC_BKP27R)
+#elif defined(RTC_BKP27R) || defined(TAMP_BKP27R)
 #define RTC_MEM_SIZE    28
-#elif defined(RTC_BKP26R)
+#elif defined(RTC_BKP26R) || defined(TAMP_BKP26R)
 #define RTC_MEM_SIZE    27
-#elif defined(RTC_BKP25R)
+#elif defined(RTC_BKP25R) || defined(TAMP_BKP25R)
 #define RTC_MEM_SIZE    26
-#elif defined(RTC_BKP24R)
+#elif defined(RTC_BKP24R) || defined(TAMP_BKP24R)
 #define RTC_MEM_SIZE    25
-#elif defined(RTC_BKP23R)
+#elif defined(RTC_BKP23R) || defined(TAMP_BKP23R)
 #define RTC_MEM_SIZE    24
-#elif defined(RTC_BKP22R)
+#elif defined(RTC_BKP22R) || defined(TAMP_BKP22R)
 #define RTC_MEM_SIZE    23
-#elif defined(RTC_BKP21R)
+#elif defined(RTC_BKP21R) || defined(TAMP_BKP21R)
 #define RTC_MEM_SIZE    22
-#elif defined(RTC_BKP20R)
+#elif defined(RTC_BKP20R) || defined(TAMP_BKP20R)
 #define RTC_MEM_SIZE    21
-#elif defined(RTC_BKP19R)
+#elif defined(RTC_BKP19R) || defined(TAMP_BKP19R)
 #define RTC_MEM_SIZE    20
-#elif defined(RTC_BKP18R)
+#elif defined(RTC_BKP18R) || defined(TAMP_BKP18R)
 #define RTC_MEM_SIZE    19
-#elif defined(RTC_BKP17R)
+#elif defined(RTC_BKP17R) || defined(TAMP_BKP17R)
 #define RTC_MEM_SIZE    18
-#elif defined(RTC_BKP16R)
+#elif defined(RTC_BKP16R) || defined(TAMP_BKP16R)
 #define RTC_MEM_SIZE    17
-#elif defined(RTC_BKP15R)
+#elif defined(RTC_BKP15R) || defined(TAMP_BKP15R)
 #define RTC_MEM_SIZE    16
-#elif defined(RTC_BKP14R)
+#elif defined(RTC_BKP14R) || defined(TAMP_BKP14R)
 #define RTC_MEM_SIZE    15
-#elif defined(RTC_BKP13R)
+#elif defined(RTC_BKP13R) || defined(TAMP_BKP13R)
 #define RTC_MEM_SIZE    14
-#elif defined(RTC_BKP12R)
+#elif defined(RTC_BKP12R) || defined(TAMP_BKP12R)
 #define RTC_MEM_SIZE    13
-#elif defined(RTC_BKP11R)
+#elif defined(RTC_BKP11R) || defined(TAMP_BKP11R)
 #define RTC_MEM_SIZE    12
-#elif defined(RTC_BKP10R)
+#elif defined(RTC_BKP10R) || defined(TAMP_BKP10R)
 #define RTC_MEM_SIZE    11
-#elif defined(RTC_BKP9R)
+#elif defined(RTC_BKP9R) || defined(TAMP_BKP9R)
 #define RTC_MEM_SIZE    10
-#elif defined(RTC_BKP8R)
+#elif defined(RTC_BKP8R) || defined(TAMP_BKP8R)
 #define RTC_MEM_SIZE    9
-#elif defined(RTC_BKP7R)
+#elif defined(RTC_BKP7R) || defined(TAMP_BKP7R)
 #define RTC_MEM_SIZE    8
-#elif defined(RTC_BKP6R)
+#elif defined(RTC_BKP6R) || defined(TAMP_BKP6R)
 #define RTC_MEM_SIZE    8
-#elif defined(RTC_BKP5R)
+#elif defined(RTC_BKP5R) || defined(TAMP_BKP5R)
 #define RTC_MEM_SIZE    6
-#elif defined(RTC_BKP4R)
+#elif defined(RTC_BKP4R) || defined(TAMP_BKP4R)
 #define RTC_MEM_SIZE    5
-#elif defined(RTC_BKP3R)
+#elif defined(RTC_BKP3R) || defined(TAMP_BKP3R)
 #define RTC_MEM_SIZE    4
-#elif defined(RTC_BKP2R)
+#elif defined(RTC_BKP2R) || defined(TAMP_BKP2R)
 #define RTC_MEM_SIZE    3
-#elif defined(RTC_BKP1R)
+#elif defined(RTC_BKP1R) || defined(TAMP_BKP1R)
 #define RTC_MEM_SIZE    2
-#elif defined(RTC_BKP0R)
+#elif defined(RTC_BKP0R) || defined(TAMP_BKP0R)
 #define RTC_MEM_SIZE    1
 #else
 #define RTC_MEM_SIZE    0
@@ -106,7 +106,12 @@ void rtc_mem_write(unsigned offset, const void *data, size_t len)
 
     const uint8_t *in = data;
 
+#if defined(TAMP_BKP0R)
+    volatile uint32_t *rtc_regs = &TAMP->BKP0R + (offset / __SIZEOF_POINTER__);
+#else
     volatile uint32_t *rtc_regs = &RTC->BKP0R + (offset / __SIZEOF_POINTER__);
+#endif
+
     offset %= __SIZEOF_POINTER__;
 
     rtc_unlock();
@@ -133,7 +138,12 @@ void rtc_mem_read(unsigned offset, void *data, size_t len)
 
     uint8_t *out = (uint8_t *)data;
 
+#if defined(TAMP_BKP0R)
+    volatile uint32_t *rtc_regs = &TAMP->BKP0R + (offset / __SIZEOF_POINTER__);
+#else
     volatile uint32_t *rtc_regs = &RTC->BKP0R + (offset / __SIZEOF_POINTER__);
+#endif
+
     offset %= __SIZEOF_POINTER__;
 
     while (len) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds support for the real-time clock on the stm32u5 series devices.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tested with `tests/periph/rtc` with the following output:

![rtc-test](https://github.com/RIOT-OS/RIOT/assets/20866465/e4f87cf7-62b2-4e3d-9212-95711aebf441)

Which indicates that everything works I think 


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->



<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
