### PR TITLE
Avoid using egrep

### DIFF
--- a/dist/tools/eclipsesym/cmdline2xml.sh
+++ b/dist/tools/eclipsesym/cmdline2xml.sh
@@ -55,7 +55,7 @@ ECLIPSE_PROJECT_NAME='RIOT'
 GCCCOMMANDLINE=$(cat)
 
 # Find all includes
-INCLUDES=$(${ECHO} "${GCCCOMMANDLINE}" | sed -e 's/ /\n/g' | egrep '^-I' | cut -c3-)
+INCLUDES=$(${ECHO} "${GCCCOMMANDLINE}" | sed -e 's/ /\n/g' | grep -E '^-I' | cut -c3-)
 
 # Parse and rewrite to project relative paths
 INCLUDES_REL=""
@@ -66,7 +66,7 @@ for p in ${INCLUDES}; do
 done
 
 # Grab macro definitions
-MACROS=$(${ECHO} "${GCCCOMMANDLINE}" | sed -e 's/ /\n/g' | egrep '^-D' | cut -c3-)
+MACROS=$(${ECHO} "${GCCCOMMANDLINE}" | sed -e 's/ /\n/g' | grep -E '^-D' | cut -c3-)
 
 # Output
 ${ECHO} "${XML_HEADER}"


### PR DESCRIPTION
This is a very simple change in `dist/tools/eclipsesym/cmdline2xml.sh`, just change `egrep` in `grep -E`.

The egrep and fgrep commands have been deprecated since 2007. Beginning with GNU Grep 3.8, calling these commands will now issue a warning to the user that instead they should use grep -E and grep -F, respectively.