### PR TITLE
sys/shell/cmds: Guard periph_pm calls

### DIFF
--- a/sys/shell/cmds/sys.c
+++ b/sys/shell/cmds/sys.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 
+#ifdef MODULE_PERIPH_PM
 #include "periph/pm.h"
+#endif
 #include "shell.h"
 
 #ifdef MODULE_USB_BOARD_RESET
@@ -30,6 +32,7 @@
 #include "riotboot/slot.h"
 #endif
 
+#ifdef MODULE_PERIPH_PM
 static int _reboot_handler(int argc, char **argv)
 {
     (void) argc;
@@ -41,6 +44,7 @@ static int _reboot_handler(int argc, char **argv)
 }
 
 SHELL_COMMAND(reboot, "Reboot the node", _reboot_handler);
+#endif /* MODULE_PERIPH_PM */
 
 #ifdef MODULE_USB_BOARD_RESET
 static int _bootloader_handler(int argc, char **argv)


### PR DESCRIPTION
### Contribution description

It would seem that either we need to require the periph_pm module in shell or make it optional... since we have many other optional modules here and we still may want the RIOT_VERSION command, lets make it optional for now.


### Testing procedure

Remove the `periph_pm` feature from a board and try to `examples/saul` such as on this [PR](https://ci.riot-os.org/details/3de5effb982a48d7be27140b2ec1c52b) and you should not get a linking error that looks like:

```
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /data/riotbuild/riotbase/examples/saul/bin/gba_cartridge/shell_cmds/sys.o: in function `_reboot_handler':
/data/riotbuild/riotbase/sys/shell/cmds/sys.c:38: undefined reference to `pm_reboot'
collect2: error: ld returned 1 exit status
```
### Issues/PRs references

discovered while testing #19519