### PR TITLE
boards/feather-nrf52840-sense: use generic lsm6dsxx

### DIFF
--- a/boards/feather-nrf52840-sense/Makefile.dep
+++ b/boards/feather-nrf52840-sense/Makefile.dep
@@ -2,7 +2,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += apds9960
   USEMODULE += bmp280_i2c
   USEMODULE += lis3mdl
-  USEMODULE += lsm6ds33
+  USEMODULE += lsm6dsxx
   USEMODULE += saul_gpio
   USEMODULE += sht3x
 endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This will help handle multiple board variants such as rev B and C.

### Testing procedure

Test on both variants with SAUL.

I ran on both the blue and black boards:
<details>

```
$ BOARD=feather-nrf52840-sense make -C examples/saul flash-only term
make: Entering directory '/home/weiss/repos/RIOT/examples/saul'
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 3
[INFO] uf2conv.py not found - fetching it from GitHub now
CC= CFLAGS= make -C /home/weiss/repos/RIOT/dist/tools/uf2
[INFO] uf2conv.py successfully fetched!
/home/weiss/repos/RIOT/dist/tools/uf2/uf2conv.py -f 0xADA52840 /home/weiss/repos/RIOT/examples/saul/bin/feather-nrf52840-sense/saul_example.hex --base 0x1000
Converted to uf2, output size: 66560, start address: 0x1000
Flashing /media/weiss/FTHRSNSBOOT (nRF52840-Feather-Sense)
Wrote 66560 bytes to /media/weiss/FTHRSNSBOOT/NEW.UF2
sleep 2
/home/weiss/repos/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2024-04-02 11:19:13,689 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2024-04-02 11:19:14,695 # ersion: 2024.04-devel-589-g99daa-pr/feathersaul)
2024-04-02 11:19:14,696 # Welcome to RIOT!
2024-04-02 11:19:14,697 # 
2024-04-02 11:19:14,699 # Type `help` for help, type `saul` to see all SAUL devices
2024-04-02 11:19:14,700 # 
> saul read 12
2024-04-02 11:19:16,471 # saul read 12
2024-04-02 11:19:16,474 # Reading from #12 (lsm6dsxx|SENSE_TEMP)
2024-04-02 11:19:16,475 # Data:           19.62 °C
> 2024-04-02 11:19:18,190 # Exiting Pyterm
make: *** [/home/weiss/repos/RIOT/examples/saul/../../Makefile.include:873: term] Interrupt

weiss@mobiweiss:~/repos/RIOT$ BOARD=feather-nrf52840-sense make -C examples/saul flash-only term
make: Entering directory '/home/weiss/repos/RIOT/examples/saul'
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 3
[INFO] uf2conv.py not found - fetching it from GitHub now
CC= CFLAGS= make -C /home/weiss/repos/RIOT/dist/tools/uf2
[INFO] uf2conv.py successfully fetched!
/home/weiss/repos/RIOT/dist/tools/uf2/uf2conv.py -f 0xADA52840 /home/weiss/repos/RIOT/examples/saul/bin/feather-nrf52840-sense/saul_example.hex --base 0x1000
Converted to uf2, output size: 66560, start address: 0x1000
Flashing /media/weiss/FTHRSNSBOOT (nRF52840-Feather-Sense)
Wrote 66560 bytes to /media/weiss/FTHRSNSBOOT/NEW.UF2
sleep 2
/home/weiss/repos/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2024-04-02 11:19:32,438 # Connect to serial port /dev/ttyACM0
^[[AWelcome to pyterm!
Type '/exit' to exit.
saul read 122024-04-02 11:19:33,443 # ersion: 2024.04-devel-589-g99daa-pr/feathersaul)
2024-04-02 11:19:33,444 # Welcome to RIOT!
2024-04-02 11:19:33,444 # 
2024-04-02 11:19:33,446 # Type `help` for help, type `saul` to see all SAUL devices
2024-04-02 11:19:33,447 # 
saul read 12
2024-04-02 11:19:37,639 # saul read 12
2024-04-02 11:19:37,642 # Reading from #12 (lsm6dsxx|SENSE_TEMP)
2024-04-02 11:19:37,643 # Data:           19.79 °C
```
</details>


### Issues/PRs references

Follow-up of #20504
