### PR TITLE
sys/suit: Remove deprecated suit_coap_run function

### DIFF
--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -33,15 +33,6 @@ extern "C" {
 #endif
 
 /**
- * @brief    Start SUIT CoAP thread
- *
- * @deprecated This will be removed after after the 2023.01 release.
- */
-static inline void suit_coap_run(void)
-{
-}
-
-/**
  * @brief SUIT CoAP endpoint entry.
  *
  * In order to use, include this header, then add SUIT_COAP_SUBTREE to the nanocoap endpoint array.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hey hey 🐐

This removes a deprecated function `suit_coap_run`. I do not see any usage within RIOT so the removal should not have side effects. 

### Testing procedure

CI should be sufficient. 

### links

deprecated in #18551