### PR TITLE
cpu/stm32: Fix ifdefs in periph_gpio_ll

### DIFF
--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -85,12 +85,8 @@
 #  define SYSFG_CLOCK           APB2
 #  define SYSFG_ENABLE_MASK     RCC_APB2ENR_SYSCFGCOMPEN
 #elif defined(RCC_APB2ENR_SYSCFGEN)
+#  define SYSFG_CLOCK           APB2
 #  define SYSFG_ENABLE_MASK     RCC_APB2ENR_SYSCFGEN
-#  ifdef APB12
-#    define SYSFG_CLOCK         APB12
-#  else
-#    define SYSFG_CLOCK         APB2
-#  endif
 #endif
 
 #ifdef RCC_APB3ENR_SYSCFGEN

--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -42,25 +42,19 @@
 
 #if defined(EXTI_SWIER_SWI0) || defined(EXTI_SWIER_SWIER0)
 #  define EXTI_REG_SWIER        (EXTI->SWIER)
-#endif
-
-#if defined(EXTI_SWIER1_SWI0) || defined(EXTI_SWIER1_SWIER0)
+#elif defined(EXTI_SWIER1_SWI0) || defined(EXTI_SWIER1_SWIER0)
 #  define EXTI_REG_SWIER        (EXTI->SWIER1)
 #endif
 
 #if defined(EXTI_RTSR_RT0) || defined(EXTI_RTSR_TR0)
 #  define EXTI_REG_RTSR         (EXTI->RTSR)
-#endif
-
-#if defined(EXTI_RTSR1_RT0) || defined(EXTI_RTSR1_TR0)
+#elif defined(EXTI_RTSR1_RT0) || defined(EXTI_RTSR1_TR0)
 #  define EXTI_REG_RTSR         (EXTI->RTSR1)
 #endif
 
 #if defined(EXTI_FTSR_FT0) || defined(EXTI_FTSR_TR0)
 #  define EXTI_REG_FTSR         (EXTI->FTSR)
-#endif
-
-#if defined(EXTI_FTSR1_FT0) || defined (EXTI_FTSR1_TR0)
+#elif defined(EXTI_FTSR1_FT0) || defined (EXTI_FTSR1_TR0)
 #  define EXTI_REG_FTSR         (EXTI->FTSR1)
 #endif
 
@@ -81,40 +75,30 @@
 #  define EXTI_REG_IMR          (EXTI->IMR1)
 #endif
 
-#ifdef RCC_APB2ENR_SYSCFGCOMPEN
+#if defined(RCC_APB2ENR_SYSCFGCOMPEN)
 #  define SYSFG_CLOCK           APB2
 #  define SYSFG_ENABLE_MASK     RCC_APB2ENR_SYSCFGCOMPEN
 #elif defined(RCC_APB2ENR_SYSCFGEN)
 #  define SYSFG_CLOCK           APB2
 #  define SYSFG_ENABLE_MASK     RCC_APB2ENR_SYSCFGEN
-#endif
-
-#ifdef RCC_APB3ENR_SYSCFGEN
+#elif defined(RCC_APB3ENR_SYSCFGEN)
 #  define SYSFG_CLOCK           APB3
 #  define SYSFG_ENABLE_MASK     RCC_APB3ENR_SYSCFGEN
 #endif
 
-#ifdef EXTI_EXTICR1_EXTI0
+#if defined(EXTI_EXTICR1_EXTI0)
 #  define EXTICR_REG(num)       (EXTI->EXTICR[(num) >> 2])
-#endif
-
-#ifdef SYSCFG_EXTICR1_EXTI0
+#elif defined(SYSCFG_EXTICR1_EXTI0)
 #  define EXTICR_REG(num)       (SYSCFG->EXTICR[(num) >> 2])
-#endif
-
-#ifdef AFIO_EXTICR1_EXTI0
+#elif defined(AFIO_EXTICR1_EXTI0)
 #  define EXTICR_REG(num)       (AFIO->EXTICR[(num) >> 2])
 #endif
 
-#ifdef SYSCFG_EXTICR1_EXTI1_Pos
+#if defined(SYSCFG_EXTICR1_EXTI1_Pos)
 #  define EXTICR_FIELD_SIZE     SYSCFG_EXTICR1_EXTI1_Pos
-#endif
-
-#ifdef EXTI_EXTICR1_EXTI1_Pos
+#elif defined(EXTI_EXTICR1_EXTI1_Pos)
 #  define EXTICR_FIELD_SIZE     EXTI_EXTICR1_EXTI1_Pos
-#endif
-
-#ifdef AFIO_EXTICR1_EXTI1_Pos
+#elif defined(AFIO_EXTICR1_EXTI1_Pos)
 #  define EXTICR_FIELD_SIZE     AFIO_EXTICR1_EXTI1_Pos
 #endif
 


### PR DESCRIPTION
### Contribution description

From the commit msgs:
 ```
    cpu/stm32/gpio_ll: make style consistent

    This block of code inconsistently made use of else-if statments. The
    patch makes the use consistent. The change also makes the code a bit
    simpler to read.
```

```
    cpu/stm32/gpio_ll: fix ifdef
    
    APB12 is never defined as a macro. It is an element in the bus_t enum.
    Therefore, the test to check if it is defined will always fail.
    
    APB12 is not a real bus. It is the second register of the APB1 bus. I am
    not aware of any STM32 family where the ABP2 bus is implmented (ie
    RCC_APB2ENR_SYSCFGEN is defined) and devices attached to said bus are
    enabled via the APB1 second register. For this reason, the fix is to
    simply remove the check.
```

### Testing procedure

I ensured I did not break the build by doing `make -C tests/periph/gpio_ll/ BOARD=nucleo-f767zi`. I did not actually run the test, as am not very familiar with the actual driver.


### Issues/PRs references

none known
