### PR TITLE
Fix stm32 periph headers

### DIFF
--- a/cpu/stm32/include/periph/cpu_spi.h
+++ b/cpu/stm32/include/periph/cpu_spi.h
@@ -81,6 +81,36 @@ typedef uint32_t spi_cs_t;
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+/* unify names across STM32 families */
+#ifdef SPI_CR1_CPHA_Msk
+#  define STM32_SPI_CPHA_Msk            SPI_CR1_CPHA_Msk
+#endif
+#ifdef SPI_CFG2_CPHA_Msk
+#  define STM32_SPI_CPHA_Msk            SPI_CFG2_CPHA_Msk
+#endif
+#ifdef SPI_CR1_CPOL_Msk
+#  define STM32_SPI_CPOL_Msk            SPI_CR1_CPOL_Msk
+#endif
+#ifdef SPI_CFG2_CPOL_Msk
+#  define STM32_SPI_CPOL_Msk            SPI_CFG2_CPOL_Msk
+#endif
+
+/**
+ * @name   Override the SPI mode values
+ *
+ * As the mode is set in bit 3 and 2 of the configuration register, we put the
+ * correct configuration there
+ * @{
+ */
+#define HAVE_SPI_MODE_T
+typedef enum {
+    SPI_MODE_0 = 0,                                         /**< CPOL=0, CPHA=0 */
+    SPI_MODE_1 = STM32_SPI_CPHA_Msk,                        /**< CPOL=0, CPHA=1 */
+    SPI_MODE_2 = STM32_SPI_CPOL_Msk,                        /**< CPOL=1, CPHA=0 */
+    SPI_MODE_3 = STM32_SPI_CPOL_Msk | STM32_SPI_CPHA_Msk,   /**< CPOL=1, CPHA=0 */
+} spi_mode_t;
+/** @} */
+
 /**
  * @brief   Override SPI clock speed values
  * @{

--- a/cpu/stm32/include/periph/cpu_usbdev.h
+++ b/cpu/stm32/include/periph/cpu_usbdev.h
@@ -39,6 +39,65 @@ extern "C" {
  */
 #define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
 
+#if !DOXYGEN    /* hide implementation details */
+
+/**
+ * @name    USB device definitions
+ * @{
+ */
+/* Detect the IP version based on the available register define */
+#if defined(USB_OTG_GCCFG_NOVBUSSENS)
+#define STM32_USB_OTG_CID_1x        /**< USB OTG FS version 0x00001200 */
+#elif defined(USB_OTG_GCCFG_VBDEN)
+#define STM32_USB_OTG_CID_2x        /**< USB OTG FS version 0x00002000 */
+#elif defined(USB)
+#define STM32_USB_FS_CID_1x         /**< USB FS version 0x00001200 */
+#endif
+
+/**
+ * @brief Number of endpoints available with the OTG FS peripheral
+ *        including the control endpoint
+ */
+#if defined(USB_OTG_FS_MAX_IN_ENDPOINTS)
+#define STM32_USB_OTG_FS_NUM_EP     (USB_OTG_FS_MAX_IN_ENDPOINTS)
+#elif defined(STM32_USB_OTG_CID_1x)
+#define STM32_USB_OTG_FS_NUM_EP     (4)    /**< OTG FS with 4 endpoints */
+#elif defined(STM32_USB_OTG_CID_2x)
+#define STM32_USB_OTG_FS_NUM_EP     (6)    /**< OTG FS with 6 endpoints */
+#endif
+
+/**
+ * @brief Number of endpoints available with the OTG HS peripheral
+ *        including the control endpoint
+ */
+#if defined(USB_OTG_HS_MAX_IN_ENDPOINTS)
+#define STM32_USB_OTG_HS_NUM_EP     (USB_OTG_HS_MAX_IN_ENDPOINTS)
+#elif defined(STM32_USB_OTG_CID_1x)
+#define STM32_USB_OTG_HS_NUM_EP     (6)     /**< OTG HS with 6 endpoints */
+#elif defined(STM32_USB_OTG_CID_2x)
+#define STM32_USB_OTG_HS_NUM_EP     (9)     /**< OTG HS with 9 endpoints */
+#endif
+
+/**
+ * @brief Number of IN/OUT endpoints including EP0 as used by USBUS
+ *
+ * @note USBUS allows only one definition of the number of available EPs, which
+ *       is then used for all devices. To be able to use all EPs for devices
+ *       with more EPs, the largest possible number of available EPs for
+ *       several USB devices is defined here. The driver has to ensure that the
+ *       number of allocated EPs does not exceed the number of available EPs if
+ *       a device has less EPs.
+ */
+#if defined(MODULE_PERIPH_USBDEV_HS) && defined(STM32_USB_OTG_HS_NUM_EP)
+#define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_HS_NUM_EP
+#elif defined(STM32_USB_OTG_FS_NUM_EP)
+#define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_FS_NUM_EP
+#else
+#define USBDEV_NUM_ENDPOINTS            8
+#endif
+
+#endif /* !DOXYGEN */
+
 /**
  * @brief stm32 USB device FS configuration
  */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -117,64 +117,6 @@ typedef struct {
 #define HAVE_PTP_TIMER_SET_ABSOLUTE 1   /**< Native implementation available */
 /** @} */
 
-#if !DOXYGEN    /* hide implementation details */
-/**
- * @name    USB device definitions
- * @{
- */
-/* Detect the IP version based on the available register define */
-#if defined(USB_OTG_GCCFG_NOVBUSSENS)
-#define STM32_USB_OTG_CID_1x        /**< USB OTG FS version 0x00001200 */
-#elif defined(USB_OTG_GCCFG_VBDEN)
-#define STM32_USB_OTG_CID_2x        /**< USB OTG FS version 0x00002000 */
-#elif defined(USB)
-#define STM32_USB_FS_CID_1x         /**< USB FS version 0x00001200 */
-#endif
-
-/**
- * @brief Number of endpoints available with the OTG FS peripheral
- *        including the control endpoint
- */
-#if defined(USB_OTG_FS_MAX_IN_ENDPOINTS)
-#define STM32_USB_OTG_FS_NUM_EP     (USB_OTG_FS_MAX_IN_ENDPOINTS)
-#elif defined(STM32_USB_OTG_CID_1x)
-#define STM32_USB_OTG_FS_NUM_EP     (4)    /**< OTG FS with 4 endpoints */
-#elif defined(STM32_USB_OTG_CID_2x)
-#define STM32_USB_OTG_FS_NUM_EP     (6)    /**< OTG FS with 6 endpoints */
-#endif
-
-/**
- * @brief Number of endpoints available with the OTG HS peripheral
- *        including the control endpoint
- */
-#if defined(USB_OTG_HS_MAX_IN_ENDPOINTS)
-#define STM32_USB_OTG_HS_NUM_EP     (USB_OTG_HS_MAX_IN_ENDPOINTS)
-#elif defined(STM32_USB_OTG_CID_1x)
-#define STM32_USB_OTG_HS_NUM_EP     (6)     /**< OTG HS with 6 endpoints */
-#elif defined(STM32_USB_OTG_CID_2x)
-#define STM32_USB_OTG_HS_NUM_EP     (9)     /**< OTG HS with 9 endpoints */
-#endif
-
-/**
- * @brief Number of IN/OUT endpoints including EP0 as used by USBUS
- *
- * @note USBUS allows only one definition of the number of available EPs, which
- *       is then used for all devices. To be able to use all EPs for devices
- *       with more EPs, the largest possible number of available EPs for
- *       several USB devices is defined here. The driver has to ensure that the
- *       number of allocated EPs does not exceed the number of available EPs if
- *       a device has less EPs.
- */
-#if defined(MODULE_PERIPH_USBDEV_HS) && defined(STM32_USB_OTG_HS_NUM_EP)
-#define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_HS_NUM_EP
-#elif defined(STM32_USB_OTG_FS_NUM_EP)
-#define USBDEV_NUM_ENDPOINTS            STM32_USB_OTG_FS_NUM_EP
-#else
-#define USBDEV_NUM_ENDPOINTS            8
-#endif
-
-#endif /* !DOXYGEN */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -173,36 +173,6 @@ typedef struct {
 #define USBDEV_NUM_ENDPOINTS            8
 #endif
 
-/* unify names across STM32 families */
-#ifdef SPI_CR1_CPHA_Msk
-#  define STM32_SPI_CPHA_Msk            SPI_CR1_CPHA_Msk
-#endif
-#ifdef SPI_CFG2_CPHA_Msk
-#  define STM32_SPI_CPHA_Msk            SPI_CFG2_CPHA_Msk
-#endif
-#ifdef SPI_CR1_CPOL_Msk
-#  define STM32_SPI_CPOL_Msk            SPI_CR1_CPOL_Msk
-#endif
-#ifdef SPI_CFG2_CPOL_Msk
-#  define STM32_SPI_CPOL_Msk            SPI_CFG2_CPOL_Msk
-#endif
-
-/**
- * @name   Override the SPI mode values
- *
- * As the mode is set in bit 3 and 2 of the configuration register, we put the
- * correct configuration there
- * @{
- */
-#define HAVE_SPI_MODE_T
-typedef enum {
-    SPI_MODE_0 = 0,                                         /**< CPOL=0, CPHA=0 */
-    SPI_MODE_1 = STM32_SPI_CPHA_Msk,                        /**< CPOL=0, CPHA=1 */
-    SPI_MODE_2 = STM32_SPI_CPOL_Msk,                        /**< CPOL=1, CPHA=0 */
-    SPI_MODE_3 = STM32_SPI_CPOL_Msk | STM32_SPI_CPHA_Msk,   /**< CPOL=1, CPHA=0 */
-} spi_mode_t;
-/** @} */
-
 #endif /* !DOXYGEN */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

This PR should not change what is built. It just moves some things out of shared headers into peripheral specific headers that already existed.


### Testing procedure

I checked that it still builds by running `make -C ../../tests/periph/uart BOARD=nucleo-f767zi`. I could not find a similar test for usbdev.


### Issues/PRs references

none known
