### PR TITLE
sam0_eth: wait until the current tx buffer is no longer in use

### DIFF
--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -185,6 +185,7 @@ static void _init_desc_buf(void)
     /* Initialize TX buffer descriptors */
     for (i=0; i < ETH_TX_BUFFER_COUNT; i++) {
         tx_desc[i].address = (uint32_t) tx_buf[i];
+        tx_desc[i].status = DESC_TX_STATUS_USED;
     }
     /* Set WRAP flag to indicate last buffer */
     tx_desc[i-1].status |= DESC_TX_STATUS_WRAP;
@@ -223,6 +224,11 @@ int sam0_eth_send(const struct iolist *iolist)
 
     if (_is_sleeping) {
         return -ENOTSUP;
+    }
+
+    /* wait until the current buffer is no longer in use */
+    while (!(tx_curr->status & DESC_TX_STATUS_USED)) {
+        thread_yield();
     }
 
     /* load packet data into TX buffer */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When many (>4) packets are sent in rapid succession, the 5th packet will overwrite the first packet in the transmit buffer before it can be sent out.

This happens e.g. when sending large (> 4500 byte) fragmented packets.

As a solution, always set the USED bit:

> must be zero for the GMAC to read data to the transmit buffer. The GMAC sets this to one for the
first buffer of a frame once it has been successfully transmitted. Software must clear this bit before the buffer
can be used again.

This however is an incomplete fix: We clear the bit on each frame to be sent, if we sent the fifth frame before any of the frames has been sent, we still overwrite the first frame.

Strangely this instead disrupts transmission of non-fragmented packets afterwards, they are stuck in the tx queue.

### Testing procedure

<details><summary>UDP Command</summary>

```C
#include "net/sock/udp.h"

static void _fill_buffer(void *buffer, size_t len)
{
    void *end = (char *)buffer + len;
    uint16_t *b16 = buffer;
    uint16_t count = 0;
    while ((void *)b16 < end) {
        *b16++ = count++;
    }
}

static int _udp_cmd(int argc, char **argv)
{
    if (argc < 2) {
        goto usage;
    }

    int len = atoi(argv[1]);
    if (!len) {
        goto usage;
    }

    if (len & 1) {
        ++len;
    }

    static uint8_t _buf[65536];
    if (len > (int)sizeof(_buf)) {
        puts("too big");
        return -ENOBUFS;
    }

    const sock_udp_ep_t remote = {
         .family = AF_INET6,
         .addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL,
         .port = 1234,
    };

    _fill_buffer(_buf, len);
    int res = sock_udp_send(NULL, _buf, len, &remote);
    if (res > 0) {
        printf("%d bytes sent\n", res);
    } else {
        printf("error: %d\n", -res);
    }

    return 0;

usage:
    printf("usage: %s <bytes>\n", argv[0]);
    return 1;
}

SHELL_COMMAND(udp2, "send large UDP packets", _udp_cmd);
```
</details>

<details><summary>Compile Flags</summary>

```make
USEMODULE += sock_udp
USEMODULE += gnrc_ipv6_ext_frag
USEMODULE += gnrc_netif_single
CFLAGS += -DCONFIG_GNRC_PKTBUF_SIZE=65536
```
</details>

<details><summary>Receiver App (Linux)</summary>

```C
#include <stdio.h>
#include <string.h>
#include <unistd.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <netdb.h>
#include <stdlib.h>

#define MAXBUF 65536

struct adc_val {
    uint16_t u;
    uint16_t i;
};

int main()
{
    struct sockaddr_in6 sin6 = {
        .sin6_port = htons(1234),
        .sin6_family = AF_INET6,
        .sin6_addr = in6addr_any,
    };

    static char buffer[MAXBUF];
    int sock = socket(PF_INET6, SOCK_DGRAM,0);

    if (bind(sock, (struct sockaddr *)&sin6, sizeof(struct sockaddr_in6)) < 0) {
        perror("bind");
        exit(1);
    }

    int len;
    do {
        len = recv(sock, buffer, sizeof(buffer), 0);
        printf("got %d bytes\n", len);
    } while (len > 0);

    close(sock);
    return 0;
}
```
</details>

#### normal operation before fragmented packet
```
2024-04-02 23:10:10,929 # > ping 2001:9e8:1414:3e00:1ded:24db:24f:c127
2024-04-02 23:10:10,938 # 12 bytes from 2001:9e8:1414:3e00:1ded:24db:24f:c127: icmp_seq=0 ttl=255 time=1.082 ms
2024-04-02 23:10:11,937 # 12 bytes from 2001:9e8:1414:3e00:1ded:24db:24f:c127: icmp_seq=1 ttl=255 time=0.357 ms
2024-04-02 23:10:12,937 # 12 bytes from 2001:9e8:1414:3e00:1ded:24db:24f:c127: icmp_seq=2 ttl=255 time=0.375 ms
2024-04-02 23:10:12,937 # 
2024-04-02 23:10:12,942 # --- 2001:9e8:1414:3e00:1ded:24db:24f:c127 PING statistics ---
2024-04-02 23:10:12,947 # 3 packets transmitted, 3 packets received, 0% packet loss
2024-04-02 23:10:12,951 # round-trip min/avg/max = 0.357/0.604/1.082 ms
```

#### fragmented packet is transmitted

```
2024-04-02 23:10:15,070 # > udp 16384
2024-04-02 23:10:15,074 # 16384 bytes sent
```

##### sending is disrupted afterwards

```
2024-04-02 23:10:17,433 # > ping 2001:9e8:1414:3e00:1ded:24db:24f:c127
2024-04-02 23:10:18,175 # 12 bytes from 2001:9e8:1414:3e00:1ded:24db:24f:c127: icmp_seq=0 ttl=255 time=734.203 ms
2024-04-02 23:10:18,183 # 12 bytes from 2001:9e8:1414:3e00:1ded:24db:24f:c127: icmp_seq=0 ttl=255 time=742.017 ms (DUP!)
2024-04-02 23:10:18,192 # 12 bytes from 2001:9e8:1414:3e00:1ded:24db:24f:c127: icmp_seq=0 ttl=255 time=750.437 ms (DUP!)
2024-04-02 23:10:20,433 # 
2024-04-02 23:10:20,438 # --- 2001:9e8:1414:3e00:1ded:24db:24f:c127 PING statistics ---
2024-04-02 23:10:20,444 # 3 packets transmitted, 1 packets received, 2 duplicates, 66% packet loss
2024-04-02 23:10:20,449 # round-trip min/avg/max = 734.203/742.219/750.437 ms
```

This is still an improvement over `master` where the fragmented packet is never received on the destination.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
