### PR TITLE
sys/embunit: return failure state in TextUIRunner_end()

### DIFF
--- a/sys/embunit/TextUIRunner.c
+++ b/sys/embunit/TextUIRunner.c
@@ -101,7 +101,8 @@ void TextUIRunner_runTest(TestRef test)
     Outputter_printEndTest(outputterRef_,test);
 }
 
-void TextUIRunner_end(void)
+int TextUIRunner_end(void)
 {
     Outputter_printStatistics(outputterRef_,&result_);
+    return wasfailure_;
 }

--- a/sys/include/embUnit/TextUIRunner.h
+++ b/sys/include/embUnit/TextUIRunner.h
@@ -47,7 +47,7 @@ void TextUIRunner_setOutputter(OutputterRef outputter);
 void TextUIRunner_startWithOutputter(OutputterRef outputter);
 void TextUIRunner_start(void);
 void TextUIRunner_runTest(TestRef test);
-void TextUIRunner_end(void);
+int TextUIRunner_end(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`OUTPUT="TEXT" make -C tests/unittest` should work again


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
