### PR TITLE
rust: Update riot-wrappers

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -784,8 +784,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#f17d22a75f7494a39f5b5e8b02e3cddd3b86d3d4"
+version = "0.8.3"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -573,8 +573,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#f17d22a75f7494a39f5b5e8b02e3cddd3b86d3d4"
+version = "0.8.3"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -599,8 +599,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#f17d22a75f7494a39f5b5e8b02e3cddd3b86d3d4"
+version = "0.8.3"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -573,8 +573,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#f17d22a75f7494a39f5b5e8b02e3cddd3b86d3d4"
+version = "0.8.3"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",


### PR DESCRIPTION
### Contribution description

This pulls in https://github.com/RIOT-OS/rust-riot-wrappers/pull/87, unblocking https://github.com/RIOT-OS/RIOT/pull/20529.

### Testing procedure

CI should suffice.