### PR TITLE
shell/doc: Point users who run into shell buffer issues to the stdin buffer

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -75,6 +75,19 @@ extern "C" {
 
 /**
  * @brief Default shell buffer size (maximum line length shell can handle)
+ *
+ * @warning When terminals that buffer input and send the full command line in
+ *   one go are used on stdin implementations with fast bursts of data,
+ *   it may be necessary to increase the @ref STDIO_RX_BUFSIZE to make
+ *   practical use of this buffer, especially because the current mechanism of
+ *   passing stdin (`isrpipe_t stdin_isrpipe`) does not support backpressure
+ *   and overflows silently. As a consequence, commands through such terminals
+ *   appear to be truncated at @ref STDIO_RX_BUFSIZE bytes (defaulting to 64)
+ *   unless the command is sent in parts (on many terminals, by presing Ctrl-D
+ *   half way through the command).
+ *
+ *   For example, this affects systems with direct USB stdio (@ref
+ *   usbus_cdc_acm_stdio) with the default terminal `pyterm`.
  */
 #define SHELL_DEFAULT_BUFSIZE   (128)
 


### PR DESCRIPTION
### Contribution description

Trouble with stdin and the shell can be hard to debug, and may send people off to a wild goose chase:

```
> coap get 2001:db8:8000:0:acf7:8017:ce77:b42a 5683 /.well-known/core
```

Is that an issue with CoAP? No. The shell? No. Let's ask on matrix... 🪿🪿🪿

This PR cuts the chase short when looking at the shell documentation and its buffer length.

### Testing procedure

Please don't, it's annoying to forget everything written above and go through the debug steps once more with the updated documentation. Instead, just look at the documentation and ponder whether it'd have cut the chase short.

### Further processing

The warning can go away once the ISR queue mechanism for stdin is replaced with something that has backpressure, so that (in the concrete case where it was discovered) the USB CDC-ACM can start sending NACKs until the stdin buffer has been read into the command line buffer (or we switch completely to something where stdin either has a configured receive buffer that is switched around fast enough, and the interrupts write into that directly).