### PR TITLE
pkg/nanopb: allow multiple proto locations

### DIFF
--- a/pkg/nanopb/Makefile.gensrc
+++ b/pkg/nanopb/Makefile.gensrc
@@ -1,7 +1,7 @@
 PROTOC ?= protoc
 PROTOC_GEN_NANOPB ?= $(PKGDIRBASE)/nanopb/generator/protoc-gen-nanopb
 
-PROTOBUF_FILES ?= $(wildcard *.proto)
+PROTOBUF_FILES += $(wildcard *.proto)
 
 # remove duplicates
 PROTOBUF_FILES := $(sort $(PROTOBUF_FILES))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Our app has proto files in multiple locations, so allow to add them instead of overwriting them.


### Testing procedure

`tests/pkg/nanopb` still works
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/20400/files#r1553568720
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
