### PR TITLE
sys/shell/doc: Shell access is root access

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -11,6 +11,14 @@
  * @ingroup     sys
  * @brief       Simple shell interpreter
  *
+ * ## Security expectations
+ *
+ * Access to the shell grants access to the system that may exercise any power
+ * the firmware can exercise. While some commands only provide limited access
+ * to the system, and it is best practice for commands to validate their input,
+ * there is no expectation of security of the system when an attacker gains
+ * access to the shell.
+ *
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

To my understanding it is widely understood in the community that shell access is equivalent to root access on the device -- a) because modules are additive and shell commands are easily pulled in that allow all kinds of access, and b) because string parsing is hard.

This states this plainly in the documentation.