### PR TITLE
tests/sys/shell: increase the stack size of periodic thread

### DIFF
--- a/tests/sys/shell/Makefile.ci
+++ b/tests/sys/shell/Makefile.ci
@@ -1,4 +1,9 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-uno \
+    arduino-nano \
+    atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
+    nucleo-l011k4 \
     #

--- a/tests/sys/shell/main.c
+++ b/tests/sys/shell/main.c
@@ -101,7 +101,7 @@ static int print_empty(int argc, char **argv)
     return 0;
 }
 
-static char _stack[THREAD_STACKSIZE_TINY];
+static char _stack[THREAD_STACKSIZE_SMALL];
 static struct {
     uint16_t period_ms;
     uint16_t reps;


### PR DESCRIPTION
### Contribution description
Increase the stack of the periodic thread which is started with the `periodic` command of `tests/sys/shell`.
On LLVM toolchain, the test fails as only one tick occurs. With this patch the test works as intended.

The behavior of the LLVM is unclear to me here, as it seems there is some data corruption occurring on the stack. 

### Testing procedure

CI catches this, so let's run the test on CI once again.


### Issues/PRs references
See [CI tests](https://ci.riot-os.org/details/branch/master/tests)
