### PR TITLE
tests: Use ASAN for all (native) tests

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,5 +1,12 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
 
+# for these boards, enable asan (Address Sanitizer)
+ASAN_BOARDS ?= native native64
+ifneq (, $(filter $(ASAN_BOARDS), $(BOARD)))
+  CFLAGS += $(CFLAGS_ASAN)
+  LINKFLAGS += $(LINKFLAGS_ASAN)
+endif
+
 ifneq (,$(wildcard $(CURDIR)/tests*/.))
   # add interactive test configuration when testing Kconfig
   DEFAULT_MODULE += test_utils_interactive_sync

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -37,13 +37,6 @@ INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
 CFLAGS += -DCONFIG_CORE_EXIT_WITH_MAIN=1
 
-# for these boards, enable asan (Address Sanitizer)
-ASAN_BOARDS ?= native native64
-ifneq (, $(filter $(ASAN_BOARDS), $(BOARD)))
-  CFLAGS += $(CFLAGS_ASAN)
-  LINKFLAGS += $(LINKFLAGS_ASAN)
-endif
-
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: $(UNIT_TESTS)

--- a/tests/unittests/tests-asan_canary/Makefile
+++ b/tests/unittests/tests-asan_canary/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-asan_canary/tests-asan.c
+++ b/tests/unittests/tests-asan_canary/tests-asan.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Christian Amsüss
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "tests-asan.h"
+
+static void __attribute__ ((noinline)) read_10(uint8_t *source)
+{
+    printf("Read %d\n", source[10]);
+}
+
+static void tests_read_beyond_buf(void)
+{
+    uint8_t source[5] = {0, };
+    read_10(&source[0]);
+
+}
+Test *tests_asan_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(tests_read_beyond_buf),
+    };
+
+    EMB_UNIT_TESTCALLER(asan_tests, NULL, NULL, fixtures);
+
+    return (Test *)&asan_tests;
+}
+
+void tests_asan_canary(void)
+{
+    TESTS_RUN(tests_asan_tests());
+}

--- a/tests/unittests/tests-asan_canary/tests-asan.h
+++ b/tests/unittests/tests-asan_canary/tests-asan.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Christian Amsüss
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief   Unittests canary for address sanitizer violations
+ *
+ * @author  Christian Amsüss <chrysn@fsfe.org>
+ */
+#ifndef TESTS_ASAN_H
+#define TESTS_ASAN_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ *
+ * If this test passes, the address sanitizer was not active.
+ */
+void tests_asan(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_ASAN_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

So far, ASAN has only been used in unit tests for native, but not in general tests.

ASAN would have spotted issues like https://github.com/RIOT-OS/RIOT/pull/20549, and may spot security issues as well -- but only wen turned on.

There is a trade-off: Enabling ASAN pulls in the NATIVE_MEMORY define that disables TLSF. I think it's worth it: It's more likely we make bugs anywhere in the tested code base that are spotted this way than to overlook TLSF bugs that only occur on native (because it's still tested on other boards), and memory properties are different on native already anyway.

(FWIW I'd advocate enabling ASAN for developers all the time, but let's take it one step at a time.)

### Testing procedure

* Look at what CI does.