### PR TITLE
tests/drivers/at_unit: fix unit tests on native

### DIFF
--- a/tests/drivers/at_unit/test_all_configs.sh
+++ b/tests/drivers/at_unit/test_all_configs.sh
@@ -7,6 +7,7 @@ rcv_eol_2=""
 send_eol=""
 
 run_test() {
+	echo "================================="
 	echo "Running test with:"
 	echo "  URC handling = $handle_urc"
 	echo "  echo         = $echo"
@@ -14,12 +15,12 @@ run_test() {
 	echo "  rcv EOL 1    = $rcv_eol_1"
 	echo "  rcv EOL 2    = $rcv_eol_2"
 
-	make -j --silent BOARD=native "HANDLE_URC=$handle_urc" "ECHO_ON=$echo" "SEND_EOL=\"$send_eol\"" "RECV_EOL_1=\"$rcv_eol_1\"" "RECV_EOL_2=\"$rcv_eol_2\"" tests-at
+	make -j --silent BOARD=native "HANDLE_URC=$handle_urc" "ECHO_ON=$echo" "SEND_EOL=\"$send_eol\"" "RECV_EOL_1=\"$rcv_eol_1\"" "RECV_EOL_2=\"$rcv_eol_2\""
 
 	# take /dev/ttyS0 as serial interface. It is only required s.t. UART
 	# initialization succeeds and it gets turned off right away.
 	set +e
-	if ! ./bin/native/tests_unittests.elf -c /dev/ttyS0 <<< "s\n";
+	if ! ./bin/native/tests_at_unit.elf -c /dev/ttyS0 <<< "s\n";
 	then
 		echo "================================================================================"
 		echo "Test failed! Generating compile-commands.json of the last build configuration..."
@@ -32,11 +33,6 @@ run_test() {
 
 # set -x
 set -e
-
-SCRIPT=$(readlink -f "$0")
-BASEDIR=$(dirname "$SCRIPT")/../../../unittests
-
-cd "$BASEDIR"
 
 for urc_i in 0 1; do
 	handle_urc=$urc_i

--- a/tests/drivers/at_unit/tests-at.c
+++ b/tests/drivers/at_unit/tests-at.c
@@ -50,6 +50,13 @@ at_urc_t urc_short = {
 };
 #endif
 
+#ifdef BOARD_NATIVE
+#define AT_UNIT_UART_DEV 0
+#else
+/* Most non-native boards have stdout mapped to device 0 */
+#define AT_UNIT_UART_DEV 1
+#endif
+
 static void set_up(void)
 {
     at_dev_init_t at_init_params = {
@@ -58,7 +65,7 @@ static void set_up(void)
         .rp_buf_size = sizeof(rp_buf),
         .rx_buf = buf,
         .rx_buf_size = sizeof(buf),
-        .uart = UART_DEV(1),
+        .uart = UART_DEV(AT_UNIT_UART_DEV),
     };
     int res = at_dev_init(&at_dev, &at_init_params);
     /* check the UART initialization return value and respond as needed */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
#20540 breaks two things:
 - `tests/drivers/at/tests-with-config/test_all_configs.sh` can not find the AT unit tests anymore
 - afaik there is no UART dev 1 on native, so the unit tests segfault
 
This PR fixes these issues.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/drivers/at_unit/test_all_configs.sh` should finish successfully.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#20540

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
