### PR TITLE
boards/feather-nrf52840-sense: Add WS281X_PARAM_PIN

### DIFF
--- a/boards/feather-nrf52840-sense/include/board.h
+++ b/boards/feather-nrf52840-sense/include/board.h
@@ -90,6 +90,15 @@ extern "C" {
 #define LSM6DSXX_PARAM_ADDR (0x6A)
 /** @} */
 
+/**
+ * @name    WS281x RGB LEDs configuration
+ * @{
+ */
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    GPIO_PIN(0, 16) /**< GPIO pin connected to the data pin of the first LED */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION

### Contribution description

Add the `WS281X_PARAM_PIN` for `feather-nrf52840-sense` so `tests/drivers/ws281x/` works out of the box.

### Testing procedure

```
BOARD=feather-nrf52840-sense make -C tests/drivers/ws281x/ flash
```
should flash :)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
