### PR TITLE
pkg/nimble: Ignore bogus adv. during scan

### DIFF
--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -71,7 +71,12 @@ void nimble_scanlist_update(uint8_t type, const ble_addr_t *addr,
                             const uint8_t *ad, size_t len)
 {
     assert(addr);
-    assert(len <= BLE_ADV_PDU_LEN);
+
+    /* Ignore bogus advertisements */
+    if (len > BLE_ADV_PDU_LEN) {
+        assert(0);
+        return;
+    }
 
     uint32_t now = (uint32_t)ztimer_now(ZTIMER_USEC);
     nimble_scanlist_entry_t *e = _find(addr);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🪰

this ensures that bogus advertisements are always ignored.
The behavior of a failing assertion during debug builds is kept.

### Testing procedure

One option is to build & run the scanner example:
`make -C examples/nimble_scanner/ flash term`
