### PR TITLE
boards/nucleo-f767zi: doc update

### DIFF
--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -8,6 +8,29 @@
 The Nucleo-F767ZI is a board from ST's Nucleo family supporting ARM Cortex-M7
 STM32F767ZI microcontroller with 512KiB of RAM and 2 MiB of Flash.
 
+### MCU
+
+| MCU          | STM32F767ZI
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M7       |
+| Vendor       | ST Microelectronics |
+| RAM          | 512KiB              |
+| Flash        | 2MiB                |
+| Frequency    | up to 216 MHz       |
+| FPU          | yes                 |
+| Ethernet     | 10/100 Mbps         |
+| Timers       | 18 (2x watchdog, 1 SysTick, 2x 32-bit, 13x 16-bit) |
+| ADCs         | 3x 12 bit (up to 24 channels |
+| UARTs        | 4                   |
+| I2cs         | 4                   |
+| SPIs         | 6                   |
+| CAN          | 3                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f767zi.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0410-stm32f76xxx-and-stm32f77xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0253-stm32f7-series-and-stm32h7-series-cortexm7-processor-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00244518-stm32-nucleo-144-boards-stmicroelectronics.pdf)|
+
 ## Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.


### PR DESCRIPTION
### Contribution description

This PR adds to the `nucleo-f767zi` board documentation page MCU table with links to datasheets.

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f767zi.html 
```
### Issues/PRs references

None
