### PR TITLE
cpu/nrf9160: fix GPIOTE ISR

### DIFF
--- a/boards/nrf9160dk/include/board.h
+++ b/boards/nrf9160dk/include/board.h
@@ -78,13 +78,13 @@ extern "C" {
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(0, 6)  /**< BTN0 pin definition */
-#define BTN0_MODE           GPIO_IN         /**< BTN0 default mode */
+#define BTN0_MODE           GPIO_IN_PU      /**< BTN0 default mode */
 #define BTN1_PIN            GPIO_PIN(0, 7)  /**< BTN1 pin definition */
-#define BTN1_MODE           GPIO_IN         /**< BTN1 default mode */
+#define BTN1_MODE           GPIO_IN_PU      /**< BTN1 default mode */
 #define BTN2_PIN            GPIO_PIN(0, 8)  /**< BTN2 pin definition */
-#define BTN2_MODE           GPIO_IN         /**< BTN2 default mode */
+#define BTN2_MODE           GPIO_IN_PU      /**< BTN2 default mode */
 #define BTN3_PIN            GPIO_PIN(0, 9)  /**< BTN3 pin definition */
-#define BTN3_MODE           GPIO_IN         /**< BTN3 default mode */
+#define BTN3_MODE           GPIO_IN_PU      /**< BTN3 default mode */
 /** @} */
 
 /**

--- a/cpu/nrf9160/vectors/vectors_nrf9160.c
+++ b/cpu/nrf9160/vectors/vectors_nrf9160.c
@@ -36,7 +36,7 @@ WEAK_DEFAULT void isr_uarte0_spim0_spis0_twim0_twis0(void);
 WEAK_DEFAULT void isr_uarte1_spim1_spis1_twim1_twis1(void);
 WEAK_DEFAULT void isr_uarte2_spim2_spis2_twim2_twis2(void);
 WEAK_DEFAULT void isr_uarte3_spim3_spis3_twim3_twis3(void);
-WEAK_DEFAULT void isr_gpiote(void);
+WEAK_DEFAULT void isr_gpiote0(void);
 WEAK_DEFAULT void isr_saadc(void);
 WEAK_DEFAULT void isr_timer0(void);
 WEAK_DEFAULT void isr_timer1(void);
@@ -70,7 +70,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [9] = isr_uarte1_spim1_spis1_twim1_twis1,
     [10] = isr_uarte2_spim2_spis2_twim2_twis2,
     [11] = isr_uarte3_spim3_spis3_twim3_twis3,
-    [13] = isr_gpiote,             /* gpiote0 */
+    [13] = isr_gpiote0,             /* gpiote0 */
     [14] = isr_saadc,
     [15] = isr_timer0,
     [16] = isr_timer1,


### PR DESCRIPTION
### Contribution description

On master, GPIO interrupts are broken for nRF9160 MCU. (Dummy handler is called and thus hardfault).
This PR renames the gpiote isr to matches the behavior of nRF53. With this, the GPIO ISR works as expected.

The second commit also enables internal pullups on all nRF9160DK boards buttons as they are required for the hardware to work.

### Testing procedure

Flash  `tests/buttons` on `nrf9160dk` board and play with the onboard buttons.

### Issues/PRs references
None.