### PR TITLE
net/gcoap: Fix typo, replacing _uri with _proxy

### DIFF
--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -30,6 +30,7 @@
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
 #include "random.h"
+#include "string_utils.h"
 #include "uri_parser.h"
 #include "ut_process.h"
 
@@ -316,13 +317,9 @@ ssize_t gcoap_dns_server_proxy_get(char *proxy, size_t proxy_len)
     ssize_t res = 0;
     mutex_lock(&_client_mutex);
     if (_dns_server_uri_isset()) {
-        res = strlen(_uri);
-        if (((size_t)res + 1) > proxy_len) {
-            /* account for trailing \0 */
+        res = strscpy(proxy, _proxy, proxy_len);
+        if (res == -E2BIG) {
             res = -ENOBUFS;
-        }
-        else {
-            strcpy(proxy, _proxy);
         }
     }
     mutex_unlock(&_client_mutex);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🦇

this fixes a small typo, ensuring the correct buffer is checked.


### Testing procedure

`make -C tests/net/gcoap_dns all test` should be enough, I do not see other use cases of this function.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
