### PR TITLE
drivers/ws281x: Add saul support

### DIFF
--- a/boards/feather-nrf52840-sense/Makefile.dep
+++ b/boards/feather-nrf52840-sense/Makefile.dep
@@ -5,6 +5,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lsm6dsxx
   USEMODULE += saul_gpio
   USEMODULE += sht3x
+  USEMODULE += ws281x
 endif
 
 # include common nrf52 dependencies

--- a/boards/feather-nrf52840-sense/include/board.h
+++ b/boards/feather-nrf52840-sense/include/board.h
@@ -97,6 +97,9 @@ extern "C" {
 #ifndef WS281X_PARAM_PIN
 #define WS281X_PARAM_PIN    GPIO_PIN(0, 16) /**< GPIO pin connected to the data pin of the first LED */
 #endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)      /**< Number of LEDs chained */
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/saul/init_devs/auto_init_ws281x.c
+++ b/drivers/saul/init_devs/auto_init_ws281x.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of ws281x RGB LED devices
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+
+#include "ws281x.h"
+#include "ws281x_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define WS281X_NUM     ARRAY_SIZE(ws281x_params)
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static ws281x_t ws281x_devs[WS281X_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[WS281X_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define WS281X_INFO_NUM ARRAY_SIZE(ws281x_saul_info)
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern const saul_driver_t ws281x_saul_driver;
+
+void auto_init_ws281x(void)
+{
+    assert(WS281X_NUM == WS281X_INFO_NUM);
+
+    for (unsigned i = 0; i < WS281X_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing WS281x #%u: ", i);
+
+        if (ws281x_init(&ws281x_devs[i], &ws281x_params[i]) != 0) {
+            LOG_ERROR("ERROR\n");
+            continue;
+        }
+        LOG_DEBUG("SUCCESS\n");
+        saul_entries[i].dev = &(ws281x_devs[i]);
+        saul_entries[i].name = ws281x_saul_info[i].name;
+        saul_entries[i].driver = &ws281x_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
+    }
+}

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -343,4 +343,8 @@ void saul_init_devs(void)
         extern void auto_init_servo(void);
         auto_init_servo();
     }
+    if (IS_USED(MODULE_WS281X)) {
+        extern void auto_init_ws281x(void);
+        auto_init_ws281x();
+    }
 }

--- a/drivers/ws281x/Makefile
+++ b/drivers/ws281x/Makefile
@@ -1,3 +1,14 @@
 SRC := ws281x.c # All other sources files provide ws281x_write as submodule
 SUBMODULES := 1
+
+# Since we have submodules we need to manually handle saul instead of
+# including driver_with_saul.mk
+MODULE ?= $(shell basename $(CURDIR))
+SAUL_INTERFACE ?= $(MODULE)_saul.c
+
+# only include <module>_saul.c if saul module is used
+ifneq (,$(filter saul,$(USEMODULE)))
+  SRC += $(SAUL_INTERFACE)
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/drivers/ws281x/Makefile.dep
+++ b/drivers/ws281x/Makefile.dep
@@ -37,3 +37,6 @@ endif
 ifneq (,$(filter ws281x_timer_gpio_ll,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio_ll periph_timer periph_timer_poll
 endif
+
+# It would seem xtimer is always required as it is used in the header...
+USEMODULE += xtimer

--- a/drivers/ws281x/include/ws281x_params.h
+++ b/drivers/ws281x/include/ws281x_params.h
@@ -20,6 +20,8 @@
 #define WS281X_PARAMS_H
 
 #include "board.h"
+#include "saul_reg.h"
+
 #include "ws281x.h"
 
 #ifdef __cplusplus
@@ -104,6 +106,21 @@ static const ws281x_params_t ws281x_params[] =
 #ifndef WS281X_TIMER_FREQ
 #define WS281X_TIMER_FREQ 16000000
 #endif
+
+/**
+ * @brief   SAUL info
+ */
+#ifndef WS281X_SAUL_INFO
+#define WS281X_SAUL_INFO  { .name = "WS281X RGB LED" }
+#endif
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t ws281x_saul_info[] =
+{
+    WS281X_SAUL_INFO
+};
 
 #ifdef __cplusplus
 }

--- a/drivers/ws281x/ws281x_saul.c
+++ b/drivers/ws281x/ws281x_saul.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ws281x
+ * @{
+ *
+ * @file
+ * @brief       NEOPixel/ws281x adaption to SAUL
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "saul.h"
+#include "ws281x.h"
+
+static int set_rgb_led(const void *dev, const phydat_t *res)
+{
+    ws281x_t *ws281x = (ws281x_t *)dev;
+    color_rgb_t color = {
+        .r = res->val[0],
+        .g = res->val[1],
+        .b = res->val[2]
+    };
+    for (unsigned idx = 0; idx < ws281x->params.numof; idx++) {
+        puts("Setting LED");
+        ws281x_set(ws281x, idx, color);
+    }
+    ws281x_write(ws281x);
+    return 1;
+}
+
+const saul_driver_t ws281x_saul_driver = {
+    .read = saul_read_notsup,
+    .write = set_rgb_led,
+    .type = SAUL_ACT_LED_RGB,
+};

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#de348dce223543babe4763dda39196bd5f881c8d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#ea8d7fad95c8cb256ba9bc178f7779d266cc0def"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",


### PR DESCRIPTION
### Contribution description

Support the ws281x driver on saul... starting with :drum: the `feather-nrf52840-sense` .

Note that this only allows control of all LEDs at once since saul does not really have a way to handle subindex or array control (for example LED array). For our use case we would like to keep it simple now but if we did want to allow saul to control individual LEDs in the future here are some considerations:
- `saul_entries` would be of size `WS281X_NUM * WS281X_PARAM_NUMOF` and one could iterate over this matrix, though there would still be no mechanism to address each one...
- The `ws281x_t` should change to be for each LED and not an array (likely a bit of rework) but then each `dev` could be for each LED
- Add a mechanism in saul to not only interact with an object, but an array of objects.

All of this is out of scope of this PR, but if people need individual control with saul, these issues must be considered.

### Testing procedure

Play around with:
```
BOARD=feather-nrf52840-sense make -C examples/saul flash term
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
