### PR TITLE
sys/suit: return error when URL buffer is too small [backport 2024.01]

### DIFF
--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -424,7 +424,10 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
         return err;
     }
 
-    assert(manifest->urlbuf && url_len < manifest->urlbuf_len);
+    if (!manifest->urlbuf || url_len >= manifest->urlbuf_len) {
+        assert(0);
+        return SUIT_ERR_NO_MEM;
+    }
     memcpy(manifest->urlbuf, url, url_len);
     manifest->urlbuf[url_len] = '\0';
 


### PR DESCRIPTION
# Backport of #20559

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If we run production firmware and provide a manifest with a too large URL, don't crash with a hard to debug error, but return an error value instead.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-c4p4-vv7v-3hx8
