### PR TITLE
gnrc, nanocoap: add optional work-arounds for buggy CoAP servers

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -176,6 +176,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Include a random token with block-wise transfers.
+ *
+ * This is a workaround for buggy CoPA implementations (e.g. go-coap) that expect
+ * to identify block-wise transfers based on the token.
+ *
+ * See https://github.com/plgd-dev/go-coap/issues/512
+ */
+#ifndef CONFIG_NANOCOAP_SOCK_BLOCK_TOKEN
+#define CONFIG_NANOCOAP_SOCK_BLOCK_TOKEN        (0)
+#endif
+
+/**
  * @brief   NanoCoAP socket types
  */
 typedef enum {

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -56,6 +56,14 @@ extern "C" {
 #define GNRC_SOCK_DYN_PORTRANGE_ERR (0)
 
 /**
+ * @brief   Check if remote address of a UDP packet matches the address the socket
+ *          is bound to.
+ */
+#ifndef CONFIG_GNRC_SOCK_UDP_CHECK_REMOTE_ADDR
+#define CONFIG_GNRC_SOCK_UDP_CHECK_REMOTE_ADDR (1)
+#endif
+
+/**
  * @brief   Structure to retrieve auxiliary data from @ref gnrc_sock_recv
  *
  * @details The members of this function depend on the modules used

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -231,7 +231,9 @@ static bool _accept_remote(const sock_udp_t *sock, const udp_hdr_t *hdr,
               ipv6_addr_to_str(addr_str, (ipv6_addr_t *)&sock->remote.addr, sizeof(addr_str)));
         DEBUG(", source (%s) does not match\n",
               ipv6_addr_to_str(addr_str, (ipv6_addr_t *)&remote->addr, sizeof(addr_str)));
-        return false;
+        if (CONFIG_GNRC_SOCK_UDP_CHECK_REMOTE_ADDR) {
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When working with go-coap we need to add several work-arounds:

 - If the server has multiple IPv6 addresses, it might respond with a different one that the one where it received the request on. We fixed this in our implementations (#19361, #18026) but obviously there is third-party software that does not have such fixes and we need to work with it. So add an option to disable the check.

 - go-coap expects to identify block-wise requests by token. This is against the spec, but since block-wise transfers don't work if there is no token, add an option to generate a random, per-transfer token to make the go-coap server happy.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/plgd-dev/go-coap/issues/512
