### PR TITLE
cpu/esp8266: fix doxygen unbalanced grouping

### DIFF
--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -91,7 +91,6 @@ typedef enum {
 } gpio_flank_t;
 /** @} */
 #endif /* ndef DOXYGEN */
-/** @} */
 
 /**
  * @name   Predefined GPIO names
@@ -115,6 +114,9 @@ typedef enum {
 #define GPIO15      (GPIO_PIN(PORT_GPIO,15))
 #define GPIO16      (GPIO_PIN(PORT_GPIO,16))
 /** @} */
+
+/** @} */
+
 
 /**
  * @name   I2C configuration
@@ -297,6 +299,8 @@ typedef struct {
 #define PERIPH_SPI_NEEDS_TRANSFER_BYTE  /**< requires function spi_transfer_byte */
 #define PERIPH_SPI_NEEDS_TRANSFER_REG   /**< requires function spi_transfer_reg */
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS  /**< requires function spi_transfer_regs */
+/** @} */
+
 /** @} */
 
 /**

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -96,27 +96,26 @@ typedef enum {
  * @name   Predefined GPIO names
  * @{
  */
-#define GPIO0       (GPIO_PIN(PORT_GPIO,0))
-#define GPIO1       (GPIO_PIN(PORT_GPIO,1))
-#define GPIO2       (GPIO_PIN(PORT_GPIO,2))
-#define GPIO3       (GPIO_PIN(PORT_GPIO,3))
-#define GPIO4       (GPIO_PIN(PORT_GPIO,4))
-#define GPIO5       (GPIO_PIN(PORT_GPIO,5))
-#define GPIO6       (GPIO_PIN(PORT_GPIO,6))
-#define GPIO7       (GPIO_PIN(PORT_GPIO,7))
-#define GPIO8       (GPIO_PIN(PORT_GPIO,8))
-#define GPIO9       (GPIO_PIN(PORT_GPIO,9))
-#define GPIO10      (GPIO_PIN(PORT_GPIO,10))
-#define GPIO11      (GPIO_PIN(PORT_GPIO,11))
-#define GPIO12      (GPIO_PIN(PORT_GPIO,12))
-#define GPIO13      (GPIO_PIN(PORT_GPIO,13))
-#define GPIO14      (GPIO_PIN(PORT_GPIO,14))
-#define GPIO15      (GPIO_PIN(PORT_GPIO,15))
-#define GPIO16      (GPIO_PIN(PORT_GPIO,16))
+#define GPIO0       (GPIO_PIN(PORT_GPIO, 0))
+#define GPIO1       (GPIO_PIN(PORT_GPIO, 1))
+#define GPIO2       (GPIO_PIN(PORT_GPIO, 2))
+#define GPIO3       (GPIO_PIN(PORT_GPIO, 3))
+#define GPIO4       (GPIO_PIN(PORT_GPIO, 4))
+#define GPIO5       (GPIO_PIN(PORT_GPIO, 5))
+#define GPIO6       (GPIO_PIN(PORT_GPIO, 6))
+#define GPIO7       (GPIO_PIN(PORT_GPIO, 7))
+#define GPIO8       (GPIO_PIN(PORT_GPIO, 8))
+#define GPIO9       (GPIO_PIN(PORT_GPIO, 9))
+#define GPIO10      (GPIO_PIN(PORT_GPIO, 10))
+#define GPIO11      (GPIO_PIN(PORT_GPIO, 11))
+#define GPIO12      (GPIO_PIN(PORT_GPIO, 12))
+#define GPIO13      (GPIO_PIN(PORT_GPIO, 13))
+#define GPIO14      (GPIO_PIN(PORT_GPIO, 14))
+#define GPIO15      (GPIO_PIN(PORT_GPIO, 15))
+#define GPIO16      (GPIO_PIN(PORT_GPIO, 16))
 /** @} */
 
 /** @} */
-
 
 /**
  * @name   I2C configuration

--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -1,4 +1,3 @@
-warning: end of file with unbalanced grouping commands
 warning: explicit link request to 'esp32_application_specific_board_configuration' could not be resolved
 warning: explicit link request to 'esp32_application_specific_configurations' could not be resolved
 warning: explicit link request to 'esp32_heltec_lora32_v2_optional_hardware' could not be resolved


### PR DESCRIPTION
### Contribution description

During working on PR #20556 I observe in the `make doc` output error:

```
.../RIOT/cpu/esp8266/include/periph_cpu.h:335: warning: end of file with unbalanced grouping commands

```

This PR fix it.

### Testing procedure

Execute `make doc` and observe output - with this PR mentioned error did not appear.

### Issues/PRs references

None