### PR TITLE
tree wide: add `IWYU pragma: export` where needed

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -129,7 +129,7 @@
 #include "thread_flags.h"
 #endif
 
-#include "thread_arch.h"
+#include "thread_arch.h" /* IWYU pragma: export */
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/lib/include/irq.h
+++ b/core/lib/include/irq.h
@@ -91,7 +91,7 @@ MAYBE_INLINE bool irq_is_enabled(void);
 MAYBE_INLINE bool irq_is_in(void);
 
 #else
-#include "irq_arch.h"
+#include "irq_arch.h" /* IWYU pragma: export */
 #endif /* IRQ_API_INLINED */
 
 #ifdef __cplusplus

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -866,7 +866,7 @@ static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
 
 /* the hardware specific implementation relies on the types such as gpio_port_t
  * to be provided */
-#include "gpio_ll_arch.h"
+#include "gpio_ll_arch.h" /* IWYU pragma: export */
 
 #endif /* PERIPH_GPIO_LL_H */
 /** @} */

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -326,7 +326,7 @@ bool timer_poll_channel(tim_t dev, int channel);
 #endif
 
 #if defined(MODULE_PERIPH_TIMER_POLL)
-#include "timer_arch.h"
+#include "timer_arch.h" /* IWYU pragma: export */
 #endif
 
 #ifdef __cplusplus

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -28,7 +28,7 @@
 #include <inttypes.h>
 #include <limits.h>
 
-#include "architecture_arch.h"
+#include "architecture_arch.h" /* IWYU pragma: export */
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -142,7 +142,7 @@
 #include "macros/utils.h"
 #include "sched.h"
 
-#include "atomic_utils_arch.h"
+#include "atomic_utils_arch.h" /* IWYU pragma: export */
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/flash_utils.h
+++ b/sys/include/flash_utils.h
@@ -54,7 +54,7 @@
 #include "kernel_defines.h"
 
 #if IS_ACTIVE(HAS_FLASH_UTILS_ARCH)
-#include "flash_utils_arch.h"
+#include "flash_utils_arch.h" /* IWYU pragma: export */
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

We occasionally have some public `foo.h` header that includes a private `foo_arch.h` header. Users are expected to include the `foo.h` header and not the `foo_arch.h`. However, clangd will claim that the `#include` of `foo.h` is unused if only functions / macros/ types / ... from `foor_arch.h` is used and nothing from `foo.h`.

This adds the `IWYU pragma: export` comment to the include of `foo_arch.h` in `foo.h`, so that clangd treats functions / macros / types provided by `foo_arch.h` as if they were instead provided by `foo.h`, which fixes the false positives.

### Testing procedure

In `master`, the include of `irq.h` is often incorrectly labeled as unneeded by clangd (e.g. in VS code). This should get rid of these false positives.

### Issues/PRs references

See also: https://github.com/RIOT-OS/RIOT/pull/20570