### PR TITLE
cpu/msp430/periph_timer: add a static_assert() for clear mask

### DIFF
--- a/cpu/msp430/periph/timer.c
+++ b/cpu/msp430/periph/timer.c
@@ -97,7 +97,12 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     assume((unsigned)dev < TIMER_NUMOF);
     msp430_timer_t *msptimer = timer_conf[dev].timer;
 
-    /* reset the timer A configuration */
+    static_assert(TACLR == TBCLR, "This driver assumes TIMER A and TIMER B "
+                                   "having the same register layout for the "
+                                   "features exposed by this driver. This "
+                                   "is backed by the datasheet for both "
+                                   "MSP430 x1xx and G2xx / F2xx MCUs.");
+    /* reset the timer configuration */
     msptimer->CTL = TACLR;
     /* save callback */
     isr_ctx[dev].cb = cb;


### PR DESCRIPTION
### Contribution description

The driver assumes that timer A and timer B have the same register layout regarding all the features exposed by the driver. This is backed by the MCU family datasheets for the MSP430 x1xx and the MSP430 G2xx / F2xx MCUs (and likely more families).

The assert() is pretty limited in coverage, but more to document why a "timer A clear" mask is used but still claiming the driver also works for timer B. It just looks too much like a bug otherwise.

### Testing procedure

Green CI.

### Issues/PRs references

None