### PR TITLE
cpu/msp430/periph_uart: Fix uart_write() for USCI peripheral

### DIFF
--- a/cpu/msp430/periph/uart_usci.c
+++ b/cpu/msp430/periph/uart_usci.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2024 Marian Buschsieweke
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @brief       Low-level UART driver implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
  *
  * @}
  */
@@ -128,6 +130,11 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     while (len--) {
         while (!(*usci->interrupt_flag & usci->tx_irq_mask)) { }
         usci->dev->TXBUF = *data++;
+    }
+
+    while (usci->dev->STAT & UCBUSY) {
+        /* busy wait for completion, e.g. to avoid losing chars/bits
+         * before releasing the USCI in TX only mode. */
     }
 
     if (tx_only) {


### PR DESCRIPTION
### Contribution description

In TX-only mode the UART was previously release before all bits of the last byte were shifted out. This adds a busy loop waiting while the peripheral is still busy, fixing the issue.

### Testing procedure

`make BOARD=olimex-msp430-h2618 flash term -C tests/sys/busy_wait` now gives:

```
[...]
2024-04-14 16:05:16,734 # main(): This is RIOT! (Version: 2024.04-devel-652-g3cdc43)
2024-04-14 16:05:16,734 # waiting for 10 µs…
2024-04-14 16:05:16,735 # took 427 µs (diff: 417 µs)
2024-04-14 16:05:16,735 # waiting for 100 µs…
2024-04-14 16:05:16,735 # took 848 µs (diff: 748 µs)
2024-04-14 16:05:16,735 # waiting for 1000 µs…
2024-04-14 16:05:16,735 # took 4508 µs (diff: 3508 µs)
2024-04-14 16:05:16,735 # waiting for 10000 µs…
2024-04-14 16:05:16,736 # took 40651 µs (diff: 30651 µs)
2024-04-14 16:13:23,451 # Exiting Pyterm
```

With `master`, there is no output shown because pyterm is waiting for the `\n` to complete the line. But since `\n` is incidentally the last char in all strings send (and, therefore, corrupted), it will never show any output.

### Issues/PRs references

Regression introduced by https://github.com/RIOT-OS/RIOT/pull/20357