### PR TITLE
cpu/msp430/periph_timer: fix timer_query_freqs()

### DIFF
--- a/cpu/msp430/periph/timer.c
+++ b/cpu/msp430/periph/timer.c
@@ -188,6 +188,10 @@ uint32_t timer_query_freqs(tim_t dev, uword_t index)
     assume((clock_source == TIMER_CLOCK_SOURCE_AUXILIARY_CLOCK) ||
            (clock_source == TIMER_CLOCK_SOURCE_SUBMAIN_CLOCK));
 
+    if (index > TXID_DIV_MAX) {
+        return 0;
+    }
+
     uint32_t clock_freq;
     switch (clock_source) {
     default:

--- a/tests/periph/timer/main.c
+++ b/tests/periph/timer/main.c
@@ -249,6 +249,8 @@ static void print_supported_frequencies(tim_t dev)
                "    %u: %" PRIu32 "\n",
                (unsigned)(end - 1), timer_query_freqs(dev, end - 1));
     }
+
+    expect(timer_query_freqs(dev, end) == 0);
 }
 
 int main(void)


### PR DESCRIPTION
### Contribution description

The API doc for `timer_query_freqs()` says it should return 0 Hz as frequency when the prescaler index is out of range. This changes the MSP430 timer driver to live up to the spec.

It also sneaks in an extension to the test app, so that in the future offending code is more easily detected.

### Testing procedure

Run the new test. It should pass with this PR, but would fail on master (when the next test is backported).

### Issues/PRs references

None