### PR TITLE
ble/skald: Always enforce URL length check

### DIFF
--- a/sys/net/ble/skald/skald_eddystone.c
+++ b/sys/net/ble/skald/skald_eddystone.c
@@ -96,7 +96,10 @@ void skald_eddystone_url_adv(skald_ctx_t *ctx,
 {
     assert(url && ctx);
     size_t len = strlen(url);
-    assert(len <= (NETDEV_BLE_PDU_MAXLEN - (URL_HDR_LEN + PREAMBLE_LEN)));
+    if (len <= (NETDEV_BLE_PDU_MAXLEN - (URL_HDR_LEN + PREAMBLE_LEN))) {
+        assert(0);
+        return;
+    }
 
     eddy_url_t *pdu = (eddy_url_t *)ctx->pkt.pdu;
     _init_pre(&pdu->pre, EDDYSTONE_URL, (URL_HDR_LEN + len));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Call for feedback: Should we assume somebody builds an app where the URL parameter is not a compile time constant?
If so, we need to check the length even when assertions are disabled.

