### PR TITLE
drivers/periph_timer: add `timer_get_closest_freq()`

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -267,7 +267,7 @@ uword_t timer_query_channel_numof(tim_t dev);
 /**
  * @brief   Iterate over supported frequencies
  *
- * @param   dev     Timer to get the next supported frequency of
+ * @param   dev     The timer to get the next supported frequency of
  * @param   index   Index of the frequency to get
  * @return          The @p index highest frequency supported by the timer
  * @retval  0       @p index is too high
@@ -295,6 +295,24 @@ uword_t timer_query_channel_numof(tim_t dev);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 uint32_t timer_query_freqs(tim_t dev, uword_t index);
+
+/**
+ * @brief   Search the frequency supported by the timer that is closest to
+ *          a given target frequency, efficiently
+ *
+ * @param   dev     The timer to get the closest supported frequency for
+ * @param   target  Ideal frequency to match
+ * @return          The frequency supported by the timer @p dev that is
+ *                  closest to @p target
+ *
+ * @details This will use binary search internally to have an O(log(n))
+ *          runtime. This can be relevant on hardware with 16 bit or 32 bit
+ *          prescaler registers.
+ *
+ * @note    Add `FEATURES_REQUIRED += periph_timer_query_freqs` to your
+ *          `Makefile`.
+ */
+uint32_t timer_get_closest_freq(tim_t dev, uint32_t target);
 
 #if defined(DOXYGEN)
 /**

--- a/drivers/periph_common/timer.c
+++ b/drivers/periph_common/timer.c
@@ -38,4 +38,53 @@ uword_t timer_query_channel_numof(tim_t dev)
     (void)dev;
     return TIMER_CHANNEL_NUMOF;
 }
+
+uint32_t timer_get_closest_freq(tim_t dev, uint32_t target)
+{
+    uint32_t freq;
+    uword_t idx_max = timer_query_freqs_numof(dev) - 1;
+
+    /* use binary search to find one of the three possibilities:
+     * 1. If an exact match is possible: The exact match is found
+     * 2. Otherwise the closest frequency is found, which might be either
+     *      a) the highest frequency below the target, or
+     *      b) the lowest frequency above the target
+     */
+    uword_t idx_lower = 0;
+    uword_t idx_upper = idx_max;
+    while (idx_lower != idx_upper) {
+        uword_t idx_mid = (idx_lower + idx_upper) >> 1;
+        freq = timer_query_freqs(dev, idx_mid);
+        if (freq > target) {
+            idx_lower = idx_mid + 1;
+        }
+        else {
+            idx_upper = idx_mid;
+        }
+    }
+
+    freq = timer_query_freqs(dev, idx_lower);
+    if ((freq < target) && (idx_lower > 0)) {
+        /* binary search yielded the closest frequency below the target. But
+         * maybe the closest frequency above the target is actually better. */
+        uint32_t diff = target - freq;
+        uint32_t alternative = timer_query_freqs(dev, idx_lower - 1);
+        if (target + diff > alternative) {
+            /* the alternative is better */
+            return alternative;
+        }
+    }
+    else if ((freq > target) && (idx_lower < idx_max)) {
+        /* Got a frequency above the target, maybe the one below would be
+         * a closer match */
+        uint32_t diff = freq - target;
+        uint32_t alternative = timer_query_freqs(dev, idx_lower + 1);
+        if (target < alternative + diff) {
+            return alternative;
+        }
+    }
+
+    /* either we got an exact match, or the other candidate was no closer */
+    return freq;
+}
 #endif

--- a/tests/periph/timer/main.c
+++ b/tests/periph/timer/main.c
@@ -202,7 +202,7 @@ static int test_timer(unsigned num, uint32_t timer_freq)
         return 0;
     }
 
-    printf("    OK (no spurious IRQs)\n");
+    printf("    [OK] (no spurious IRQs)\n");
 
     return 1;
 }
@@ -249,8 +249,47 @@ static void print_supported_frequencies(tim_t dev)
                "    %u: %" PRIu32 "\n",
                (unsigned)(end - 1), timer_query_freqs(dev, end - 1));
     }
+}
 
-    expect(timer_query_freqs(dev, end) == 0);
+static void test_querying(tim_t dev)
+{
+    uword_t last = query_freq_numof(dev) - 1;
+
+    puts("Testing timer_get_closest_freq()...");
+    for (uword_t i = 0; i <= MIN(last, 255); i++) {
+        uint32_t closest;
+        uint32_t freq = timer_query_freqs(dev, i);
+
+        /* Searching for a supported freq should yield the supported freq: */
+        expect(freq == timer_get_closest_freq(dev, freq));
+
+        /* Assuming that no other frequency close to `freq` are supported,
+         * we would assume that asking for `freq - 1` and for `freq + 1` would
+         * also return `freq`. There are some corner cases, though. Let's look
+         * at asking for `freq - 1` here first:
+         *
+         * - `freq - 1` is actually also supported. In that case
+         *   `timer_get_closest_freq(dev, freq - 1)` should actually return
+         *   `freq - 1`
+         * - `freq - 2` is also supported (but not `freq - 1`). In this case
+         *   returning either `freq - 2` or `freq` would be valid for
+         *   `timer_get_closest_freq(dev, freq - 1)`.
+         *
+         * Therefore, we just except `freq - 2`, `freq - 1`, and `freq` as
+         * results for `timer_get_closest_freq(dev, freq - 1)`. */
+        closest = timer_get_closest_freq(dev, freq - 1);
+        expect((freq >= closest) && closest >= freq - 2);
+
+        /* Now same with `freq + 1` as target. Due to the same corner cases,
+         * we accept `freq`, `freq + 1`, and `freq + 2` here. */
+        closest = timer_get_closest_freq(dev, freq + 1);
+        expect((freq <= closest) && closest <= freq + 2);
+    }
+
+    puts("[OK]\n"
+         "Testing timer_query_freqs() for out of bound index...");
+    expect(timer_query_freqs(dev, last + 1) == 0);
+    puts("[OK]");
 }
 
 int main(void)
@@ -265,6 +304,12 @@ int main(void)
         printf("\nTIMER %u\n"
                  "=======\n\n", i);
         print_supported_frequencies(TIMER_DEV(i));
+
+        /* test querying of frequencies, but only if supported by the driver */
+        if (IS_USED(MODULE_PERIPH_TIMER_QUERY_FREQS)) {
+            test_querying(TIMER_DEV(i));
+        }
+
         uword_t end = query_freq_numof(TIMER_DEV(i));
 
         /* Test only up to three frequencies and only the fastest once.


### PR DESCRIPTION
### Contribution description

This provides a helper function that builds upon the `periph_timer_query_freqs` feature to find the frequency supported by a given timer that is closest to a given target frequency.

This functionality isn't as straight forward to implement, as a naive implementation iterating over all supported pre-scalers will be prohibitively expensive when the pre-scaler register is 16 bit or even 32 bit wide.

Instead, a binary search is performed plus some corner case handling in case the target frequency cannot exactly be met, in which it is checked if the highest frequency below the target or the smallest above the target is closer.

### Testing procedure

The test app was extended:

```
git:(timer_get_closest_freq) ~/Repos/software/RIOT/master/tests/periph/timer ➜ make BOARD=nucleo-f429zi flash test
Building application "tests_timer" for "nucleo-f429zi" with CPU "stm32".

"make" -C /home/maribu/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/nucleo-f429zi
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/nucleo
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/cortexm_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32/stmclk
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/stm32/vectors
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  13972	   128	  2752	 16852	  41d4	/home/maribu/Repos/software/RIOT/master/tests/periph/timer/bin/nucleo-f429zi/tests_timer.elf
/home/maribu/Repos/software/RIOT/master/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/master/tests/periph/timer/bin/nucleo-f429zi/tests_timer.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-snapshot (2024-01-17-08:38)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
DEPRECATED! use 'adapter serial' not 'hla_serial'
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : clock speed 2000 kHz
Info : STLINK V2J29M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.260526
Info : [stm32f4x.cpu] Cortex-M4 r0p1 processor detected
Info : [stm32f4x.cpu] target has 6 breakpoints, 4 watchpoints
Info : [stm32f4x.cpu] Examination succeed
Info : starting gdb server for stm32f4x.cpu on 0
Info : Listening on port 33673 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f4x.cpu       hla_target little stm32f4x.cpu       unknown
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[stm32f4x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000cc8 msp: 0x20000200
Info : device id = 0x20016419
Info : flash size = 2048 KiB
Info : Dual Bank 2048 kiB STM32F42x/43x/469/479 found
auto erase enabled
wrote 16384 bytes from file /home/maribu/Repos/software/RIOT/master/tests/periph/timer/bin/nucleo-f429zi/tests_timer.elf in 0.659411s (24.264 KiB/s)
verified 14100 bytes in 0.161758s (85.124 KiB/s)
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2024.07-devel-12-ga63d0-timer_get_closest_freq)

Test for peripheral TIMERs

Available timers: 2

TIMER 0
=======

  - supported frequencies:
    0: 90000000
    1: 45000000
    2: 30000000
    ....
    65535: 1373
Testing timer_get_closest_freq()...
[OK]
Testing timer_query_freqs() for out of bound index...
[OK]
  - Calling timer_init(0, 90000000)
    initialization successful
  - timer_stop(0): stopped
  - timer_set(0, 0, 450000)
    Successfully set timeout 450000 for channel 0
  - timer_set(0, 1, 900000)
    Successfully set timeout 900000 for channel 1
  - timer_set(0, 2, 1350000)
    Successfully set timeout 1350000 for channel 2
  - timer_set(0, 3, 1800000)
    Successfully set timeout 1800000 for channel 3
  - timer_start(0)
  - Results:
    - channel 0 fired at SW count    52941      - init:    52941
    - channel 1 fired at SW count   105867      - diff:    52926
    - channel 2 fired at SW count   158798      - diff:    52931
    - channel 3 fired at SW count   211728      - diff:    52930
  - Validating no spurious IRQs are triggered:
    [OK] (no spurious IRQs)
  - Calling timer_init(0, 45000000)
    initialization successful
  - timer_stop(0): stopped
  - timer_set(0, 0, 225000)
    Successfully set timeout 225000 for channel 0
  - timer_set(0, 1, 450000)
    Successfully set timeout 450000 for channel 1
  - timer_set(0, 2, 675000)
    Successfully set timeout 675000 for channel 2
  - timer_set(0, 3, 900000)
    Successfully set timeout 900000 for channel 3
  - timer_start(0)
  - Results:
    - channel 0 fired at SW count    52941      - init:    52941
    - channel 1 fired at SW count   105867      - diff:    52926
    - channel 2 fired at SW count   158798      - diff:    52931
    - channel 3 fired at SW count   211728      - diff:    52930
  - Validating no spurious IRQs are triggered:
    [OK] (no spurious IRQs)
  - Calling timer_init(0, 30000000)
    initialization successful
  - timer_stop(0): stopped
  - timer_set(0, 0, 150000)
    Successfully set timeout 150000 for channel 0
  - timer_set(0, 1, 300000)
    Successfully set timeout 300000 for channel 1
  - timer_set(0, 2, 450000)
    Successfully set timeout 450000 for channel 2
  - timer_set(0, 3, 600000)
    Successfully set timeout 600000 for channel 3
  - timer_start(0)
  - Results:
    - channel 0 fired at SW count    52941      - init:    52941
    - channel 1 fired at SW count   105868      - diff:    52927
    - channel 2 fired at SW count   158798      - diff:    52930
    - channel 3 fired at SW count   211728      - diff:    52930
  - Validating no spurious IRQs are triggered:
    [OK] (no spurious IRQs)

TIMER 1
=======

  - supported frequencies:
    0: 90000000
    1: 45000000
    2: 30000000
    ....
    65535: 1373
Testing timer_get_closest_freq()...
[OK]
Testing timer_query_freqs() for out of bound index...
[OK]
  - Calling timer_init(1, 90000000)
    initialization successful
  - timer_stop(1): stopped
  - timer_set(1, 0, 450000)
    Successfully set timeout 450000 for channel 0
  - timer_set(1, 1, 900000)
    Successfully set timeout 900000 for channel 1
  - timer_set(1, 2, 1350000)
    Successfully set timeout 1350000 for channel 2
  - timer_set(1, 3, 1800000)
    Successfully set timeout 1800000 for channel 3
  - timer_start(1)
  - Results:
    - channel 0 fired at SW count    52941      - init:    52941
    - channel 1 fired at SW count   105868      - diff:    52927
    - channel 2 fired at SW count   158799      - diff:    52931
    - channel 3 fired at SW count   211729      - diff:    52930
  - Validating no spurious IRQs are triggered:
    [OK] (no spurious IRQs)
  - Calling timer_init(1, 45000000)
    initialization successful
  - timer_stop(1): stopped
  - timer_set(1, 0, 225000)
    Successfully set timeout 225000 for channel 0
  - timer_set(1, 1, 450000)
    Successfully set timeout 450000 for channel 1
  - timer_set(1, 2, 675000)
    Successfully set timeout 675000 for channel 2
  - timer_set(1, 3, 900000)
    Successfully set timeout 900000 for channel 3
  - timer_start(1)
  - Results:
    - channel 0 fired at SW count    52941      - init:    52941
    - channel 1 fired at SW count   105868      - diff:    52927
    - channel 2 fired at SW count   158799      - diff:    52931
    - channel 3 fired at SW count   211729      - diff:    52930
  - Validating no spurious IRQs are triggered:
    [OK] (no spurious IRQs)
  - Calling timer_init(1, 30000000)
    initialization successful
  - timer_stop(1): stopped
  - timer_set(1, 0, 150000)
    Successfully set timeout 150000 for channel 0
  - timer_set(1, 1, 300000)
    Successfully set timeout 300000 for channel 1
  - timer_set(1, 2, 450000)
    Successfully set timeout 450000 for channel 2
  - timer_set(1, 3, 600000)
    Successfully set timeout 600000 for channel 3
  - timer_start(1)
  - Results:
    - channel 0 fired at SW count    52941      - init:    52941
    - channel 1 fired at SW count   105868      - diff:    52927
    - channel 2 fired at SW count   158799      - diff:    52931
    - channel 3 fired at SW count   211729      - diff:    52930
  - Validating no spurious IRQs are triggered:
    [OK] (no spurious IRQs)

TEST SUCCEEDED
```

### Issues/PRs references

None