### PR TITLE
sys/ztimer: make use of periph_timer_query_freqs

### DIFF
--- a/boards/olimex-msp430-h1611/include/board.h
+++ b/boards/olimex-msp430-h1611/include/board.h
@@ -36,6 +36,26 @@ extern "C" {
 #endif
 
 /**
+ * @name    ztimer configuration
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_WIDTH        16      /**< running on a 16-bit timer */
+/**
+ * @brief   Configure clock to 1 MHz.
+ */
+#define CONFIG_ZTIMER_USEC_BASE_FREQ    MHZ(1)
+/**
+ * @brief   Force frequency conversion to be used
+ *
+ * Otherwise ztimer would assume that it can run the 1 MHz clock from the timer
+ * configured at 1 MHz without conversion. But the actual frequency the timer
+ * will run at will be detected at runtime and, due to inaccuracy of the
+ * internal oscillator, will indeed require frequency conversion.
+ */
+#define CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION     1
+/** @} */
+
+/**
  * @name    Xtimer configuration
  * @{
  */

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -49,6 +49,26 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    ztimer configuration
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_WIDTH        16      /**< running on a 16-bit timer */
+/**
+ * @brief   Configure clock to 1 MHz.
+ */
+#define CONFIG_ZTIMER_USEC_BASE_FREQ    MHZ(1)
+/**
+ * @brief   Force frequency conversion to be used
+ *
+ * Otherwise ztimer would assume that it can run the 1 MHz clock from the timer
+ * configured at 1 MHz without conversion. But the actual frequency the timer
+ * will run at will be detected at runtime and, due to inaccuracy of the
+ * internal oscillator, will indeed require frequency conversion.
+ */
+#define CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION     1
+/** @} */
+
+/**
  * @name    Xtimer configuration
  * @{
  */

--- a/examples/advanced/suit_update/Makefile.ci
+++ b/examples/advanced/suit_update/Makefile.ci
@@ -9,9 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     gd32vf103c-start \
     lsn50 \
     nucleo-c031c6 \
-    nucleo-f030r8 \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \

--- a/examples/basic/ipc_pingpong/Makefile.ci
+++ b/examples/basic/ipc_pingpong/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/examples/lang_support/official/riot_and_cpp/Makefile.ci
+++ b/examples/lang_support/official/riot_and_cpp/Makefile.ci
@@ -1,6 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/examples/networking/cord/cord_epsim/Makefile.ci
+++ b/examples/networking/cord/cord_epsim/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     olimex-msp430-h1611 \
+    olimex-msp430-h2618 \
     samd10-xmini \
     slstk3400a \
     stk3200 \

--- a/examples/networking/gnrc/gnrc_lorawan/Makefile.ci
+++ b/examples/networking/gnrc/gnrc_lorawan/Makefile.ci
@@ -8,7 +8,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-c031c6 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     samd10-xmini \

--- a/sys/include/ztimer/periph_timer.h
+++ b/sys/include/ztimer/periph_timer.h
@@ -52,9 +52,11 @@ typedef struct {
  * @param[in]   dev     periph timer to use
  * @param[in]   freq    frequency to configure
  * @param[in]   max_val maximum value this timer supports
+ *
+ * @return  The actual frequency the timer has been configured to
  */
-void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
-                              uint32_t freq, uint32_t max_val);
+uint32_t ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
+                                  uint32_t freq, uint32_t max_val);
 
 #ifdef __cplusplus
 }

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -39,6 +39,7 @@ endif
 
 ifneq (,$(filter ztimer_periph_timer,$(USEMODULE)))
   FEATURES_REQUIRED += periph_timer
+  FEATURES_OPTIONAL += periph_timer_query_freqs
 endif
 
 ifneq (,$(filter ztimer_periph_rtc,$(USEMODULE)))

--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -39,7 +39,9 @@
 
 #include "kernel_defines.h"
 
+#include "assert.h"
 #include "board.h"
+#include "compiler_hints.h"
 #include "ztimer.h"
 #include "ztimer/convert_frac.h"
 #include "ztimer/convert_shift.h"
@@ -72,6 +74,9 @@
 #  define ZTIMER_TIMER      _ztimer_periph_timer
 #  define ZTIMER_TIMER_CLK  _ztimer_periph_timer.super
 #  define ZTIMER_TIMER_FREQ CONFIG_ZTIMER_USEC_BASE_FREQ
+#  ifndef CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION
+#    define CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION 0
+#  endif
 #endif
 
 #if MODULE_ZTIMER_PERIPH_LPTIMER
@@ -209,9 +214,9 @@ ztimer_clock_t *const ZTIMER_USEC_BASE = &ZTIMER_TIMER_CLK;
 #  else
 #    error No suitable ZTIMER_USEC config. Basic timer configuration missing?
 #  endif
-#  if ZTIMER_TIMER_FREQ == FREQ_1MHZ
+#  if (ZTIMER_TIMER_FREQ == FREQ_1MHZ) && !(CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION)
 ztimer_clock_t *const ZTIMER_USEC = &ZTIMER_TIMER_CLK;
-#  elif ZTIMER_TIMER_FREQ == 250000LU
+#  elif (ZTIMER_TIMER_FREQ == 250000LU) && !(CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION)
 static ztimer_convert_shift_t _ztimer_convert_shift_usec;
 ztimer_clock_t *const ZTIMER_USEC = &_ztimer_convert_shift_usec.super.super;
 #  else
@@ -290,8 +295,11 @@ void ztimer_init(void)
         "ztimer_init(): ZTIMER_TIMER using periph timer %u, freq %lu, width %u\n",
         CONFIG_ZTIMER_USEC_DEV, ZTIMER_TIMER_FREQ,
         CONFIG_ZTIMER_USEC_WIDTH);
-    ztimer_periph_timer_init(&ZTIMER_TIMER, CONFIG_ZTIMER_USEC_DEV,
-                             ZTIMER_TIMER_FREQ, WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
+    MAYBE_UNUSED
+    uint32_t periph_timer_freq =
+        ztimer_periph_timer_init(&ZTIMER_TIMER, CONFIG_ZTIMER_USEC_DEV,
+                                 ZTIMER_TIMER_FREQ,
+                                 WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
 #  if MODULE_PM_LAYERED && !MODULE_ZTIMER_ONDEMAND
     LOG_DEBUG("ztimer_init(): ZTIMER_TIMER setting block_pm_mode to %i\n",
               CONFIG_ZTIMER_TIMER_BLOCK_PM_MODE);
@@ -335,19 +343,27 @@ void ztimer_init(void)
 
 /* Step 5: initialize ztimers requested */
 #if MODULE_ZTIMER_USEC
-#  if ZTIMER_TIMER_FREQ != FREQ_1MHZ
-#    if ZTIMER_TIMER_FREQ == FREQ_250KHZ
+#  if (ZTIMER_TIMER_FREQ != FREQ_1MHZ) || CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION
+#    if (ZTIMER_TIMER_FREQ == FREQ_250KHZ) && !(CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION)
+    if (IS_ACTIVE(DEVELHELP) && ((periph_timer_freq < 237500) || (periph_timer_freq > 262500))) {
+        LOG_WARNING("ZTIMER_USEC from %" PRIu32 " Hz clock with \"left-shift by 2\" frequency conversion\n",
+                    periph_timer_freq);
+    }
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %lu to 1000000\n",
-              ZTIMER_TIMER_FREQ);
+              periph_timer_freq);
     ztimer_convert_shift_up_init(&_ztimer_convert_shift_usec,
                                  ZTIMER_USEC_BASE, 2);
 #    else
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_frac %lu to 1000000\n",
               ZTIMER_TIMER_FREQ);
     ztimer_convert_frac_init(&_ztimer_convert_frac_usec, ZTIMER_USEC_BASE,
-                             FREQ_1MHZ, ZTIMER_TIMER_FREQ);
+                             FREQ_1MHZ, periph_timer_freq);
 #    endif
 #  else
+    if (IS_ACTIVE(DEVELHELP) && ((periph_timer_freq < 950000) || (periph_timer_freq > 1050000))) {
+        LOG_WARNING("ZTIMER_USEC from %" PRIu32 " Hz clock without frequency conversion\n",
+                    periph_timer_freq);
+    }
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC without conversion\n");
 #  endif
 

--- a/tests/bench/msg_pingpong/Makefile.ci
+++ b/tests/bench/msg_pingpong/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench/mutex_pingpong/Makefile.ci
+++ b/tests/bench/mutex_pingpong/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench/thread_flags_pingpong/Makefile.ci
+++ b/tests/bench/thread_flags_pingpong/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench/thread_yield_pingpong/Makefile.ci
+++ b/tests/bench/thread_yield_pingpong/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/build_system/cpp_exclude/Makefile.ci
+++ b/tests/build_system/cpp_exclude/Makefile.ci
@@ -1,6 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/build_system/cpp_ext/Makefile.ci
+++ b/tests/build_system/cpp_ext/Makefile.ci
@@ -1,6 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/core/irq/Makefile.ci
+++ b/tests/core/irq/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/isr_yield_higher/Makefile.ci
+++ b/tests/core/isr_yield_higher/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/msg_try_receive/Makefile.ci
+++ b/tests/core/msg_try_receive/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/sched_testing/Makefile.ci
+++ b/tests/core/sched_testing/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/thread_basic/Makefile.ci
+++ b/tests/core/thread_basic/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/thread_flags/Makefile.ci
+++ b/tests/core/thread_flags/Makefile.ci
@@ -5,7 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/thread_msg_block_race/Makefile.ci
+++ b/tests/core/thread_msg_block_race/Makefile.ci
@@ -5,6 +5,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     #

--- a/tests/core/thread_msg_block_w_queue/Makefile.ci
+++ b/tests/core/thread_msg_block_w_queue/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/core/thread_msg_block_wo_queue/Makefile.ci
+++ b/tests/core/thread_msg_block_wo_queue/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/drivers/at_unit/Makefile.ci
+++ b/tests/drivers/at_unit/Makefile.ci
@@ -7,4 +7,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-l011k4 \
+    samd10-xmini \
     #

--- a/tests/drivers/bme680/Makefile.ci
+++ b/tests/drivers/bme680/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     chronos \
-    nucleo-f031k6 \
     #

--- a/tests/drivers/bmx055/Makefile.ci
+++ b/tests/drivers/bmx055/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
-    samd10-xmini \
     stk3200 \
     #

--- a/tests/drivers/candev/Makefile.ci
+++ b/tests/drivers/candev/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
+    samd10-xmini \
     #

--- a/tests/drivers/cc110x/Makefile.ci
+++ b/tests/drivers/cc110x/Makefile.ci
@@ -19,7 +19,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     im880b \
     mega-xplained \
     microduino-corerf \
-    msb-430 \
     msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \

--- a/tests/drivers/ds18/Makefile.ci
+++ b/tests/drivers/ds18/Makefile.ci
@@ -1,4 +1,3 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/drivers/ds3231/Makefile.ci
+++ b/tests/drivers/ds3231/Makefile.ci
@@ -6,8 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-c031c6 \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stk3200 \

--- a/tests/drivers/epd_bw_spi_disp_dev/Makefile.ci
+++ b/tests/drivers/epd_bw_spi_disp_dev/Makefile.ci
@@ -7,6 +7,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-l011k4 \
-    samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/drivers/kw2xrf/Makefile.ci
+++ b/tests/drivers/kw2xrf/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l011k4 \
-    samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/drivers/mpu9x50/Makefile.ci
+++ b/tests/drivers/mpu9x50/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
-    samd10-xmini \
     #

--- a/tests/drivers/nrf24l01p_ng/Makefile.ci
+++ b/tests/drivers/nrf24l01p_ng/Makefile.ci
@@ -11,7 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
-    msb-430 \
+    msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/drivers/st77xx/Makefile.ci
+++ b/tests/drivers/st77xx/Makefile.ci
@@ -1,6 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-c031c6 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     samd10-xmini \

--- a/tests/drivers/w5100/Makefile.ci
+++ b/tests/drivers/w5100/Makefile.ci
@@ -8,9 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
-    nucleo-f030r8 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \

--- a/tests/drivers/w5500/Makefile.ci
+++ b/tests/drivers/w5500/Makefile.ci
@@ -9,11 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
-    nucleo-f030r8 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \

--- a/tests/drivers/xbee/Makefile.ci
+++ b/tests/drivers/xbee/Makefile.ci
@@ -7,7 +7,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-c031c6 \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f334r8 \

--- a/tests/net/gnrc_ndp/Makefile.ci
+++ b/tests/net/gnrc_ndp/Makefile.ci
@@ -9,7 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     i-nucleo-lrwan1 \
     nucleo-c031c6 \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/net/gnrc_sock_async_event/Makefile.ci
+++ b/tests/net/gnrc_sock_async_event/Makefile.ci
@@ -7,7 +7,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stk3200 \

--- a/tests/net/gnrc_sock_ip/Makefile.ci
+++ b/tests/net/gnrc_sock_ip/Makefile.ci
@@ -6,11 +6,13 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
+    msb-430 \
     nucleo-c031c6 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \
     nucleo-l031k6 \
+    msb-430h \
     olimex-msp430-h1611 \
     samd10-xmini \
     stk3200 \

--- a/tests/pkg/edhoc_c/Makefile.ci
+++ b/tests/pkg/edhoc_c/Makefile.ci
@@ -19,9 +19,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     microbit \
     nrf51dk \
     nrf51dongle \
-    nucleo-f030r8 \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-f070rb \
     nucleo-f072rb \
     nucleo-f103rb \
@@ -34,7 +31,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l073rz \
     olimexino-stm32 \
     opencm904 \
-    samd10-xmini \
     saml10-xpro \
     saml11-xpro \
     slstk3400a \

--- a/tests/pkg/emlearn/Makefile.ci
+++ b/tests/pkg/emlearn/Makefile.ci
@@ -10,7 +10,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     i-nucleo-lrwan1 \
     nucleo-c031c6 \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f302r8 \

--- a/tests/pkg/libcose_encrypt/Makefile.ci
+++ b/tests/pkg/libcose_encrypt/Makefile.ci
@@ -10,7 +10,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/pkg/libfixmath_unittests/Makefile.ci
+++ b/tests/pkg/libfixmath_unittests/Makefile.ci
@@ -4,7 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103c8 \
     i-nucleo-lrwan1 \
     nucleo-c031c6 \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f302r8 \

--- a/tests/pkg/minmea/Makefile.ci
+++ b/tests/pkg/minmea/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
-    samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/pkg/yxml/Makefile.ci
+++ b/tests/pkg/yxml/Makefile.ci
@@ -1,6 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -6,9 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     gd32vf103c-start \
     i-nucleo-lrwan1 \
     nucleo-c031c6 \
-    nucleo-f030r8 \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \

--- a/tests/rust_libs/Makefile.ci
+++ b/tests/rust_libs/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     nucleo-l031k6 \
-    samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \

--- a/tests/sys/arduino_lib/Makefile.ci
+++ b/tests/sys/arduino_lib/Makefile.ci
@@ -1,4 +1,3 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     #

--- a/tests/sys/cpp11_thread/Makefile.ci
+++ b/tests/sys/cpp11_thread/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-c031c6 \
-    nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \
     nucleo-l031k6 \

--- a/tests/sys/event_threads/Makefile.ci
+++ b/tests/sys/event_threads/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/sys/evtimer_msg/Makefile.ci
+++ b/tests/sys/evtimer_msg/Makefile.ci
@@ -6,7 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/sys/evtimer_underflow/Makefile.ci
+++ b/tests/sys/evtimer_underflow/Makefile.ci
@@ -6,7 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/sys/psa_crypto_hashes/Makefile.ci
+++ b/tests/sys/psa_crypto_hashes/Makefile.ci
@@ -8,4 +8,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
     samd10-xmini \
+    stm32f030f4-demo \
     #

--- a/tests/sys/pthread_barrier/Makefile.ci
+++ b/tests/sys/pthread_barrier/Makefile.ci
@@ -1,7 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     i-nucleo-lrwan1 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32l0538-disco \
     #

--- a/tests/sys/pthread_cooperation/Makefile.ci
+++ b/tests/sys/pthread_cooperation/Makefile.ci
@@ -2,7 +2,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     i-nucleo-lrwan1 \
     im880b \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32l0538-disco \
     #

--- a/tests/sys/rng/Makefile.ci
+++ b/tests/sys/rng/Makefile.ci
@@ -5,8 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     samd10-xmini \

--- a/tests/sys/sched_round_robin/Makefile.ci
+++ b/tests/sys/sched_round_robin/Makefile.ci
@@ -6,7 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
     stk3200 \

--- a/tests/sys/senml_cbor/Makefile.ci
+++ b/tests/sys/senml_cbor/Makefile.ci
@@ -6,6 +6,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     #

--- a/tests/sys/senml_saul/Makefile.ci
+++ b/tests/sys/senml_saul/Makefile.ci
@@ -5,8 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
-    samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/sys/trace/Makefile.ci
+++ b/tests/sys/trace/Makefile.ci
@@ -1,8 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     chronos \
-    nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/sys/usbus_cdc_ecm/Makefile.ci
+++ b/tests/sys/usbus_cdc_ecm/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
+    stm32f7508-dk \
     #

--- a/tests/sys/ztimer_underflow/Makefile.ci
+++ b/tests/sys/ztimer_underflow/Makefile.ci
@@ -1,5 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/sys/ztimer_xsec/Makefile.ci
+++ b/tests/sys/ztimer_xsec/Makefile.ci
@@ -1,6 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
-    nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #


### PR DESCRIPTION
### Contribution description

This makes use of the `periph_timer_query_freqs` feature:

1. It does choose the closest frequency supported before calling timer_init() in the ztimer_periph_timer backend.
2. It does make use of the actually chosen frequency when using `ztimer_convert_frac`.
3. It does `assert()` the frequency is within 5% of the specified when no frequency conversion is performed or `ztimer_convert_shift_up` is used.


#### Motivation

We have a number of MCUs that can run from internal oscillators (without using external crystal for accuracy):

- ATmega MCUs
- STM32 MCUs
- MSP430 MCUs
- RP2040
- FE310 (but it doesn't have a proper `periph_timer`, so not relevant here)
- ...

If those MCUs are used without external crystal, the actual CPU frequency may be off from what the the board config aims for significantly due to large production variance and temperature and supply voltage dependence. As a result, all `periph_timer` instances driven by the same clock will also be off significantly, which can hinder accuracy in time keeping significantly.

This adds the support to ztimer to react on the actual frequency information provided by `periph_timer_query_freqs` and adjust the time keeping accordingly.

### Testing procedure

As of now, only the MSP430 (and the FE310) will measure the actual CPU frequency at runtime, and only the MSP430 timer will compensate frequencies exposed via `timer_query_freqs()`. So only on MSP430 this can really be tested now, e.g. with `tests/sys/ztimer_msg`.

In `master` this test sadly fails because of `timer_set()` not yet working correctly on small timeouts (and waiting one period longer than needed).

With this PR the test passes and the messages at second 30 is indeed about thirty seconds after the start message received. (It would be off by 40 % without compensation.)

### Issues/PRs references

- [x] Depends on and includes https://github.com/RIOT-OS/RIOT/pull/20581

Fixes https://github.com/RIOT-OS/RIOT/issues/8251