### PR TITLE
boards/olimex-msp430-h2618: fix ztimer config [backport 2024.04]

### DIFF
--- a/boards/olimex-msp430-h2618/include/board.h
+++ b/boards/olimex-msp430-h2618/include/board.h
@@ -22,6 +22,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,11 +36,12 @@ extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  * @{
  */
-#define XTIMER_WIDTH                (16)
-#define XTIMER_BACKOFF              (40)
+#define CONFIG_ZTIMER_USEC_WIDTH        16      /**< running on a 16-bit timer */
+#define CONFIG_ZTIMER_USEC_BASE_FREQ    MHZ(2)  /**< Cannot divide 16 MHz clock
+                                                     to 1 MHz, go for 2 MHz instead */
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Backport of #20575

### Contribution description

The MSP430 timer prescaler can device the 16 MHz clock down to (16 / 2^x) MHz, with 0 <= x < 4. So no slower than 2 MHz.

With the current ztimer config the clock would run at twice the speed.

### Testing procedure

The tests wouldn't really catch this, but the datasheet and the test in `tests/periph/timer` can confirm that it gets no slower than 2 MHz with a 16 MHz subsystem main clock.

### Issues/PRs references

None