### PR TITLE
pkg/lwext4: Minor string fixes

### DIFF
--- a/pkg/lwext4/fs/lwext4_fs.c
+++ b/pkg/lwext4/fs/lwext4_fs.c
@@ -111,7 +111,7 @@ static int prepare(lwext4_desc_t *fs, const char *mount_point)
     memset(&fs->bdev, 0, sizeof(fs->bdev));
     memset(&fs->iface, 0, sizeof(fs->iface));
 
-    strncpy(fs->mp.name, mount_point, CONFIG_EXT4_MAX_MP_NAME);
+    strncpy(fs->mp.name, mount_point, CONFIG_EXT4_MAX_MP_NAME - 1);
     strcat(fs->mp.name, "/");
 
     int res = mtd_init(dev);

--- a/pkg/lwext4/fs/lwext4_fs.c
+++ b/pkg/lwext4/fs/lwext4_fs.c
@@ -462,6 +462,7 @@ static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
     }
 
     strncpy(entry->d_name, (char *)dirent->name, sizeof(entry->d_name));
+    entry->d_name[sizeof(entry->d_name) - 1] = '\0';
 
     return 1;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello everyone 🐠

this fixes two minor bugs.
1. One off-by-one, where it was overlooked that `strcat` adds a null-terminator
2. That copying different string lengths into each other can mean missing the null-terminator


### Testing procedure

CI / good review

### Issues/PRs references

Reported by this advisory. Considered non-critical, as mount points in RIOT are usually configured statically.
[GHSA-2hx7-c324-3rxv](https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-2hx7-c324-3rxv)
