### PR TITLE
drivers/mtd: Add check for interger overflow

### DIFF
--- a/tests/pkg/littlefs/Makefile.ci
+++ b/tests/pkg/littlefs/Makefile.ci
@@ -11,7 +11,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \
+    olimex-msp430-h1611 \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
+    telosb \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hei 🦫

Fixes a minor potential for integer overflow.

### Testing procedure

CI / good review
Maybe `make -C tests/unittests tests-mtd test`

