### PR TITLE
cpu/nrf5x: implement pm_off() for nRF53/9160

### DIFF
--- a/cpu/nrf5x_common/periph/pm.c
+++ b/cpu/nrf5x_common/periph/pm.c
@@ -27,19 +27,22 @@
 #define NRF_POWER NRF_POWER_S
 #endif
 
-/* TODO: implement proper pm_off for nRF9160 */
+/* Workaround inconsistency between nRF9160 / nRF53 headers */
+#ifdef REGULATORS_SYSTEMOFF_SYSTEMOFF_Enable
+#define REGULATORS_SYSTEMOFF_SYSTEMOFF_Enter REGULATORS_SYSTEMOFF_SYSTEMOFF_Enable
+#endif
+
 void pm_off(void)
 {
-#if (!defined(CPU_FAM_NRF9160) && !defined(CPU_FAM_NRF53))
-#ifdef CPU_FAM_NRF51
+#if defined(REGULATORS_SYSTEMOFF_SYSTEMOFF_Enter)
+    NRF_REGULATORS_S->SYSTEMOFF = REGULATORS_SYSTEMOFF_SYSTEMOFF_Enter;
+#elif defined(CPU_FAM_NRF51)
     NRF_POWER->RAMON = 0;
 #else
-    for (int i = 0; i < 8; i++) {
+    for (unsigned int i = 0; i < ARRAY_SIZE(NRF_POWER->RAM); i++) {
         NRF_POWER->RAM[i].POWERCLR = (POWER_RAM_POWERCLR_S1RETENTION_Msk |
                                       POWER_RAM_POWERCLR_S0RETENTION_Msk);
     }
 #endif
-    NRF_POWER->SYSTEMOFF = 1;
     while (1) {}
-#endif /* ndef CPU_FAM_NRF9160 */
 }


### PR DESCRIPTION
### Contribution description

This PR implements `pm_off()` support for nRF9160 and nRF53.
The register moved to the regulator peripheral compared to nRF52.
Nordic also have two different names for the same bit of this register, so I add a small workaround. (Could have use '1' instead but I prefer to clearly identify bits within registers).
### Testing procedure

Run `tests/periph/pm` on `nrf9160dk` or `nrf5340dk-app`
and use `pm off` command


### Issues/PRs references
None.
