### PR TITLE
boards/nucleo-f429zi & f439zi: documentation improvements 

### DIFF
--- a/boards/nucleo-f429zi/doc.txt
+++ b/boards/nucleo-f429zi/doc.txt
@@ -23,11 +23,13 @@ STM32F429ZI microcontroller with 256KiB of RAM and 2MiB of Flash.
 | Frequency    | up to 180 MHz       |
 | FPU          | yes                 |
 | Ethernet     | 10/100 Mbps         |
-| Timers       | 17                  |
+| Timers       | 17 (2x watchdog, 1 SysTick, 2x 32bit, 12x 16bit) |
+| ADCs         | 3x 12 bit (up to 24 channels) |
 | UARTs        | 4                   |
-| I2cs         | 3                   |
+| I2Cs         | 3                   |
 | SPIs         | 6                   |
 | CAN          | 2                   |
+| RTC          | 1                   |
 | Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f429zi.pdf)|
 | Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0090-stm32f405415-stm32f407417-stm32f427437-and-stm32f429439-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
 | Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|

--- a/boards/nucleo-f439zi/doc.txt
+++ b/boards/nucleo-f439zi/doc.txt
@@ -8,6 +8,29 @@
 The Nucleo-F439ZI is a board from ST's Nucleo family supporting ARM Cortex-M4
 STM32F439ZI microcontroller with, 256KiB of RAM and 2MiB of Flash.
 
+### MCU
+
+| MCU          | STM32F439ZI
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M4       |
+| Vendor       | ST Microelectronics |
+| RAM          | 256KiB              |
+| Flash        | 2MiB                |
+| Frequency    | up to 180 MHz       |
+| FPU          | yes                 |
+| Ethernet     | 10/100 Mbps         |
+| Timers       | 17 (2x watchdog, 1 SysTick, 2x 32bit, 12x 16bit) |
+| ADCs         | 3x 12 bit (up to 24 channels) |
+| UARTs        | 4                   |
+| I2Cs         | 3                   |
+| SPIs         | 6                   |
+| CAN          | 2                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f439zi.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0090-stm32f405415-stm32f407417-stm32f427437-and-stm32f429439-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00244518-stm32-nucleo-144-boards-stmicroelectronics.pdf)|
+
 ## Flashing the device
 
 ### Flashing the Board Using ST-LINK Removable Media
@@ -22,5 +45,13 @@ make BOARD=nucleo-f439zi PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
+## Accessing RIOT shell
+
+Default RIOT shell access utilize VCP (Virtual COM Port) via USB interface,
+provided by integrated ST-LINK programmer. ST-LINK is connected to the
+microcontroller USART3.
+
+The default baud rate is 115200.
 
  */


### PR DESCRIPTION
### Contribution description

This PR adds some improvements to the boards documentation pages.

Nucleo-f439zi
- addition of MCU table,
- addition of section concerning RIOT shell access (see PR #17453)

Nucleo-f429zi
- minor changes in the MCU table (typos, ADC, RTC, Timers, etc.)

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f429zi.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f439zi.html 
```

### Issues/PRs references

PR #17453