### PR TITLE
shell/vfs: Handle print failure in genfile cmd gracefully

### DIFF
--- a/sys/shell/cmds/vfs.c
+++ b/sys/shell/cmds/vfs.c
@@ -742,11 +742,19 @@ static char _get_char(unsigned i)
 static void _write_block(int fd, unsigned bs, unsigned i)
 {
     char block[bs];
-    char *buf = block;
 
-    buf += snprintf(buf, bs, "|%03u|", i);
+    int size_wanted = snprintf(block, bs, "|%03u|", i);
 
-    memset(buf, _get_char(i), &block[bs] - buf);
+    if (size_wanted < 0) {
+        assert(0);
+        return;
+    }
+
+    /* Only memset the buffer, if there is space left in the buffer */
+    if ((unsigned) size_wanted < bs) {
+        memset(&block[size_wanted], _get_char(i), bs - size_wanted);
+    }
+
     block[bs - 1] = '\n';
 
     vfs_write(fd, block, bs);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hey 🐡

`snprintf` turned out to be difficult to get right.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Try `make -C tests/sys/vfs_default/ all-asan term` and play with `genfile

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
