### PR TITLE
cpu/esp: Handle format print errors

### DIFF
--- a/cpu/esp_common/lib_printf.c
+++ b/cpu/esp_common/lib_printf.c
@@ -46,6 +46,16 @@ static int _lib_printf(int level, const char* tag, const char* format, va_list a
 
     int len = vsnprintf(_printf_buf, PRINTF_BUFSIZ - 1, format, arg);
 
+    if (len < 0) {
+        ESP_EARLY_LOGI(tag, "Failed to format print");
+        return 0;
+    }
+
+    /* Did the output get truncated? */
+    if ((unsigned) len > PRINTF_BUFSIZ - 1) {
+        len = PRINTF_BUFSIZ - 1;
+    }
+
     /*
      * Since ESP_EARLY_LOG macros add a line break at the end, a terminating
      * line break in the output must be removed if there is one.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hi 🦋

`vsnprintf` is not easy to use. This catches the error return and the truncation.
Not sure if my approach is good as I am lacking context knowledge for that function.


### Testing procedure

I don't know. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
