### PR TITLE
boards/nRF52xx: correctly set JLINK_DEVICE

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -18,8 +18,6 @@ else
   PROGRAMMER ?= openocd
 endif
 
-# setup JLink for flashing
-JLINK_DEVICE = nrf52
 # setup OpenOCD for flashing. Version 0.10 of OpenOCD doesn't contain support
 # for nrf52dk and nrf52840dk boards. To use OpenOCD with these a version
 # build from source (master > 2018, August the 13rd) is required.

--- a/cpu/nrf52/Makefile.include
+++ b/cpu/nrf52/Makefile.include
@@ -35,6 +35,11 @@ ifneq (,$(filter nrf52840xxaa,$(CPU_MODEL)))
   RAM_LEN ?= 0x40000
 endif
 
+# Set the target for the JLink programmer for flashing, JLINK expects an
+# underscore in the target, like "nrf52832_xxaa".
+# Boards that do not use a JLink ignore the flag.
+JLINK_DEVICE = $(subst xx,_xx,$(CPU_MODEL))
+
 VECTORS_O ?= $(BINDIR)/nrf52_vectors/vectors_$(CPU_MODEL).o
 
 include $(RIOTCPU)/nrf5x_common/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Since a version update of JLinkExe about four years ago, it performs a check of the Flash memory range, which depends on the JLINK_DEVICE selected. Currently, the JLINK_DEVICE variable is set in the boards/common/nrf52/Makefile.include file, which sets it to "NRF52". This seems to default to the nRF52832 chip, which is incorrect for all boards not using this chip.
The issue is described in #14576 and it seems to trigger (mostly? only?) when flashing images that are close to the maximum flash size of the nRF52832 or when specifying explicit memory addresses. Therefore the bug has been mostly unnoticed in normal operation and is triggered when trying to flash a bootloader to the nRF52840 chip.

This PR removes the JLINK_DEVICE variable from the common Makefile.include, because the boards including this file have various Nordic nRF52 processors. The declaration of the JLINK_DEVICE variable is therefore moved to the various Makefile.include files of the relevant targets which actually use the JLink programmer (or do not have a built in programmer in which case RIOT assumes a JLink will be used).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run the following command with an arbitrary nRF52 development board connected and observe the console output:
```
BOARD=nrf52dk make -C tests/riotboot/ riotboot/flash-slot1
```

You should be able to see the right processor being selected for the BOARD specified in the command. The relevant line is **'Device "NRF52832_XXAA" selected.'**
You can skip the programming process when JLinkExe asks you to unsecure the device (we don't actually want to program incorrect code into the microcontroller :eyes: )
```
chris@ThinkPias:~/flashdev-riot/RIOT$ BOARD=nrf52dk make -C tests/riotboot/ riotboot/flash-slot1
make: Verzeichnis „/home/chris/flashdev-riot/RIOT/tests/riotboot“ wird betreten
compiling /home/chris/flashdev-riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
make -C ...
creating /home/chris/flashdev-riot/RIOT/tests/riotboot/bin/nrf52dk/riotboot_files/slot1.1713533231.bin...
/home/chris/flashdev-riot/RIOT/dist/tools/jlink/jlink.sh flash /home/chris/flashdev-riot/RIOT/tests/riotboot/bin/nrf52dk/riotboot_files/slot1.1713533231.bin
### Flashing Target ###
### Flashing bin file at base address 0x0 with offset 0x41000 ###
SEGGER J-Link Commander V7.96e (Compiled Apr 17 2024 16:28:22)
DLL version V7.96e, compiled Apr 17 2024 16:27:56

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...
J-Link>loadbin /home/chris/flashdev-riot/RIOT/tests/riotboot/bin/nrf52dk/riotboot_files/slot1.1713533231.bin 0x00041000
J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-nRF5340-NordicSemi compiled Apr 11 2024 17:44:26
Hardware version: V1.00
J-Link uptime (since boot): 0d 00h 00m 05s
S/N: 1050208458
License(s): RDI, FlashBP, FlashDL, JFlash, GDB
USB speed mode: Full speed (12 MBit/s)
VTref=3.300V
Target connection not established yet but required for command.
Device "NRF52832_XXAA" selected.


Connecting to target via SWD
InitTarget() start
Skipping unsecure.
InitTarget() end - Took 7.61s
Connect failed. Resetting via Reset pin and trying again.
InitTarget() start
Skipping unsecure.
InitTarget() end - Took 1.17s
Error occurred: Could not connect to the target device.
For troubleshooting steps visit: https://wiki.segger.com/J-Link_Troubleshooting

Script processing completed.

make: *** [/home/chris/flashdev-riot/RIOT/makefiles/boot/riotboot.mk:148: riotboot/flash-slot1] Fehler 1
make: Verzeichnis „/home/chris/flashdev-riot/RIOT/tests/riotboot“ wird verlassen
```

Repeat for the following targets:
 -  nrf52dk
 -  nrf52840dk
 -  ruuvitag
 -  waveshare-nrf52840-eval-kit
 -  acd52832 (although it is obsolete now)
 -  dwm1001
 -  e104-bt50xxa-tb
      - e104-bt5010a-tb with nRF52810 (now obsolete)
      - e104-bt5011a-tb with nRF52811 (now obsolete)



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This PR fixes #14576.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
