### PR TITLE
doc/getting-started: add hint for correct access rights on serial device

### DIFF
--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -239,6 +239,16 @@ serial interface:
 make term BOARD=samr21-xpro PORT=/dev/ttyACM1
 ~~~~~~~~
 
+For flashing and accessing the board via the serial interface, the current user
+needs to have the correct access rights on the serial device.
+The easiest way to ensure this is to add the current user to the group that is
+owning the serial device. For example, this can be achieved on Linux by issuing
+the following line, logging out and logging in again:
+
+~~~~~~~~ {.sh}
+sudo usermod -aG $(stat --format="%G" /dev/ttyACM0) $USER
+~~~~~~~~
+
 Note that the `PORT` macro has a slightly different semantic in `native`. Here
 it is used to provide the name of the TAP interface you want to use for the
 virtualized networking capabilities of RIOT.


### PR DESCRIPTION
### Contribution description

The problem of missing access rights to the serial device has come up for one of our students while trying to setup their RIOT development environment.
I would have liked to point them to a sentence in the RIOT documentation, preferably in one of the first documents that a new user would read.

This PR adds two sentences and an example command line to fix this to the "getting started" page.

### Testing procedure

Check the generated docs.


### Issues/PRs references

None
