### PR TITLE
cpu/msp430: clean up and fix clock driver

### DIFF
--- a/cpu/msp430/Makefile.include
+++ b/cpu/msp430/Makefile.include
@@ -2,6 +2,7 @@ INCLUDES += -I$(RIOTCPU)/msp430/include/
 INCLUDES += -I$(RIOTCPU)/msp430/include/$(subst msp430_,,$(CPU_FAM))
 
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
+CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
 # include the msp430 common Makefile
 include $(RIOTMAKE)/arch/msp430.inc.mk


### PR DESCRIPTION
### Contribution description
- The validity test for the high frequency crystal did not take into account the higher range supported by the MSP430 F2xx / G2xx family. This fixes the issue.
    - The CPU family used is exposed to C as `CPU_FAM_<NAME>` macro
- Unused headers where dropped
- The status register is aliased `SR`, so let's use that more readable name.

### Testing procedure

This does not change any binaries. It would allow boards using an MSP430 F2xx/G2xx MCU to configure a CPU frequency of 16 MHz from a crystal without a compile time check triggering. (Both upstream boards use 16 MHz, but from a DCO instead of a crystal.)

One could test this with the following patch:


```
diff --git a/boards/olimex-msp430-h2618/include/periph_conf.h b/boards/olimex-msp430-h2618/include/periph_conf.h
index 23d223a40b..20b981a6f7 100644
--- a/boards/olimex-msp430-h2618/include/periph_conf.h
+++ b/boards/olimex-msp430-h2618/include/periph_conf.h
@@ -28,19 +28,21 @@
 extern "C" {
 #endif
 
-#define CLOCK_CORECLOCK     msp430_dco_freq
+#define CLOCK_CORECLOCK     MHZ(16)
 
 /**
  * @brief   Clock configuration
  */
 static const msp430_clock_params_t clock_params = {
-    .target_dco_frequency = MHZ(16),
+    .target_dco_frequency = 0,
     .lfxt1_frequency = 32768,
-    .main_clock_source = MAIN_CLOCK_SOURCE_DCOCLK,
-    .submain_clock_source = SUBMAIN_CLOCK_SOURCE_DCOCLK,
+    .main_clock_source = MAIN_CLOCK_SOURCE_XT2CLK,
+    .submain_clock_source = SUBMAIN_CLOCK_SOURCE_XT2CLK,
     .main_clock_divier = MAIN_CLOCK_DIVIDE_BY_1,
     .submain_clock_divier = SUBMAIN_CLOCK_DIVIDE_BY_1,
     .auxiliary_clock_divier = AUXILIARY_CLOCK_DIVIDE_BY_1,
+    .xt2_frequency = CLOCK_CORECLOCK,
+    .has_xt2 = true,
 };
 
 /**
```

`make BOARD=olimex-msp430-h2618 -C examples/default `

yields `undefined reference to `xt2_frequency_invalid'` in `master`, but works with this PR.

### Issues/PRs references

None