### PR TITLE
cpu/msp430: implement get_caller_pc

### DIFF
--- a/cpu/msp430/include/cpu.h
+++ b/cpu/msp430/include/cpu.h
@@ -20,14 +20,12 @@
 #ifndef CPU_H
 #define CPU_H
 
-#include <stdio.h>
+#include <stdint.h>
 
 #include <msp430.h>
-#include "board.h"
 
 #include "sched.h"
 #include "thread.h"
-#include "cpu_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,12 +116,11 @@ static inline void __attribute__((always_inline)) __exit_isr(void)
 
 /**
  * @brief   Returns the last instruction's address
- *
- * @todo:   Not supported
  */
+__attribute__((always_inline))
 static inline uintptr_t cpu_get_caller_pc(void)
 {
-    return 0;
+    return (uintptr_t)__builtin_return_address(0);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description



### Testing procedure

Apply the following patch:

```diff
diff --git a/examples/default/main.c b/examples/default/main.c
index b847e0e5a1..b8c6856395 100644
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -32,6 +32,15 @@
 #include "net/gnrc.h"
 #endif
 
+static int _cmd_assert(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    assert(0);
+}
+
+SHELL_COMMAND(assert_fail, "trigger a blowing assertion", _cmd_assert);
+
 int main(void)
 {
 #ifdef MODULE_NETIF
```

Then run


```
make BOARD=olimex-msp430-h1611 flash term -C examples/default 
make: Entering directory '/home/maribu/Repos/software/RIOT/master/examples/default'
Building application "default" for "olimex-msp430-h1611" with CPU "msp430".

"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/olimex-msp430-h1611
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/msp430/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/saul
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/saul/init_devs
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/fmt
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/master/sys/phydat
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/ps
"make" -C /home/maribu/Repos/software/RIOT/master/sys/saul_reg
"make" -C /home/maribu/Repos/software/RIOT/master/sys/shell
"make" -C /home/maribu/Repos/software/RIOT/master/sys/shell/cmds
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  15950	   192	  1144	 17286	  4386	/home/maribu/Repos/software/RIOT/master/examples/default/bin/olimex-msp430-h1611/default.elf
[INFO] mspdebug binary not found - building it from source now
[INFO] mspdebug requires readline and libusb-compat headers to build
CC= CFLAGS= make -C /home/maribu/Repos/software/RIOT/master/dist/tools/mspdebug
[INFO] mspdebug binary successfully built!
/home/maribu/Repos/software/RIOT/master/dist/tools/mspdebug/mspdebug -j --expect-id "MSP430F1611" olimex "prog /home/maribu/Repos/software/RIOT/master/examples/default/bin/olimex-msp430-h1611/default.hex"
MSPDebug version 0.25 - debugging tool for MSP430 MCUs
Copyright (C) 2009-2017 Daniel Beer <dlbeer@gmail.com>
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Chip info database from MSP430.dll v3.15.0.1 Copyright (C) 2013 TI, Inc.

Resetting Olimex command processor...
Initializing FET...
FET protocol version is 20000007
Set Vcc: 3000 mV
Configured for JTAG (2)
Sending reset...
Using Olimex identification procedure
Device ID: 0xf16c
  Code start address: 0x4000
  Code size         : 49152 byte = 48 kb
  RAM  start address: 0x200
  RAM  end   address: 0x9ff
  RAM  size         : 2048 byte = 2 kb
Device: MSP430F1611
Number of breakpoints: 8
fet: FET returned error code 34 (Not supported by selected interface or interface is not initialized)
fet: warning: message C_IDENT3 failed
fet: FET returned NAK
warning: device does not support power profiling
Device: MSP430F1611
Erasing...
Programming...
Writing 4096 bytes at 4000...
Writing 4096 bytes at 5000...
Writing 4096 bytes at 6000...
Writing 3850 bytes at 7000...
Writing    2 bytes at ffe6...
Writing    2 bytes at fffe...
Done, 16142 bytes total
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "9600"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2024-04-19 21:24:29,607 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
2024-04-19 21:26:30,585 # 2024.07-devel-49-g024832-cpu/msp430/clock)
2024-04-19 21:26:30,585 # Welcome to RIOT!
> help
2024-04-19 21:26:34,783 # help
2024-04-19 21:26:34,819 # Command              Description
2024-04-19 21:26:34,855 # ---------------------------------------
2024-04-19 21:26:34,892 # assert_fail          trigger a blowing assertion
2024-04-19 21:26:34,964 # pm                   interact with layered PM subsystem
2024-04-19 21:26:35,036 # ps                   Prints information about running threads.
2024-04-19 21:26:35,072 # reboot               Reboot the node
2024-04-19 21:26:35,145 # saul                 interact with sensors and actuators using SAUL
2024-04-19 21:26:35,204 # version              Prints current RIOT_VERSION
> assert_fail
2024-04-19 21:26:37,909 # assert_fail
2024-04-19 21:26:37,910 # 4c22
2024-04-19 21:26:37,945 # *** RIOT kernel panic:
2024-04-19 21:26:37,945 # FAILED ASSERTION.
2024-04-19 21:26:37,946 # 
2024-04-19 21:26:38,054 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2024-04-19 21:26:38,198 # 	 - | isr_stack            | -        - |   - |    256 (   -1) (  257) |     0xffff |     0xffff
2024-04-19 21:26:38,306 # 	 1 | idle                 | pending  Q |  15 |     96 (   60) (   36) |     0x11b8 |     0x11de 
2024-04-19 21:26:38,415 # 	 2 | main                 | running  Q |   7 |    640 (  418) (  222) |     0x1218 |     0x137a 
2024-04-19 21:26:38,487 # 	   | SUM                  |            |     |    992 (  478) (  514)
2024-04-19 21:26:38,488 # 
2024-04-19 21:26:38,488 # *** halted.
```

```
msp430-elf-addr2line -e examples/default/bin/olimex-msp430-h1611/default.elf --address 0x4c22
0x00004c22
/home/maribu/Repos/software/RIOT/master/examples/default/main.c:45
```

### Issues/PRs references

None