### PR TITLE
cpu/cortexm_common: make SVC call always available

### DIFF
--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -1,6 +1,5 @@
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_arm
-FEATURES_PROVIDED += cortexm_svc
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += cpu_check_address
 FEATURES_PROVIDED += cpu_core_cortexm

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -453,7 +453,6 @@ void __attribute__((naked)) __attribute__((used)) isr_pendsv(void) {
 }
 #endif
 
-#ifdef MODULE_CORTEXM_SVC
 void __attribute__((naked)) __attribute__((used)) isr_svc(void)
 {
     /* these two variants do exactly the same, but Cortex-M3 can use Thumb2
@@ -521,13 +520,6 @@ static void __attribute__((used)) _svc_dispatch(unsigned int *svc_args)
             break;
     }
 }
-
-#else /* MODULE_CORTEXM_SVC */
-void __attribute__((used)) isr_svc(void)
-{
-    SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
-}
-#endif /* MODULE_CORTEXM_SVC */
 
 void sched_arch_idle(void)
 {

--- a/features.yaml
+++ b/features.yaml
@@ -81,8 +81,6 @@ groups:
               accessing a given address would cause a bus fault.
       - name: cortexm_stack_limit
         help: ARM Cortex-M PSPLIM/MSPLIM registers are available.
-      - name: cortexm_svc
-        help: ARM Cortex-M Supervisor Calls are available.
       - name: cortexm_fpu
         help: A hardware floating point unit is available.
       - name: cortexm_mpu

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -47,7 +47,6 @@ FEATURES_EXISTING := \
     cortexm_fpu \
     cortexm_mpu \
     cortexm_stack_limit \
-    cortexm_svc \
     cpp \
     cpu_arm7tdmi_gba \
     cpu_atmega1281 \

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -82,9 +82,6 @@ endif
 # feature is used
 USEMODULE += $(filter cortexm_stack_limit, $(FEATURES_USED))
 
-# select cortexm_svc pseudomodule if the corresponding feature is used
-USEMODULE += $(filter cortexm_svc, $(FEATURES_USED))
-
 # select core_idle_thread if the feature no_idle_thread is *not* used
 ifeq (, $(filter no_idle_thread, $(FEATURES_USED)))
   ifneq (,$(filter core_thread, $(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -55,7 +55,6 @@ PSEUDOMODULES += conn_can_isotp_multi
 PSEUDOMODULES += cord_ep_standalone
 PSEUDOMODULES += core_%
 PSEUDOMODULES += cortexm_fpu
-PSEUDOMODULES += cortexm_svc
 PSEUDOMODULES += cpp
 PSEUDOMODULES += cpu_check_address
 PSEUDOMODULES += crc16_fast

--- a/pkg/wamr/Makefile.dep
+++ b/pkg/wamr/Makefile.dep
@@ -4,6 +4,7 @@ USEMODULE += ztimer_usec
 
 
 #WAMR supports "X86_32/64", "AARCH64", "ARM", "THUMB", "XTENSA" and RISCV
-FEATURES_REQUIRED_ANY += arch_native|arch_esp32|arch_riscv|cortexm_svc
+FEATURES_BLACKLIST += arch_arm7
+FEATURES_REQUIRED_ANY += arch_native|arch_esp32|arch_riscv|arch_arm
 #arch_arm|arch_esp need modified
 #  build/pkg/wamr/core/iwasm/common/arch/invokeNative_<arch>.s


### PR DESCRIPTION
### Contribution description
This PR proposes to make SVC call always available for user and thus removes the `cortexm_svc` pseudomodule.
SVCall is available on all ARMvx-M architecture. This exception was used before to trigger PendSV for the sheduler. Now PendSV is triggered manually and no longer require to use SVCall.
Since the feature was provided by default for all cortexm, I think it makes sense to remove the pseudomodule and to let it hardcoded in the code.


### Testing procedure
CI should be happy.

### Issues/PRs references
None.
