### PR TITLE
boards/doc: Explicitly warn when nRF chips are advertised as NFC supporting

### DIFF
--- a/boards/nrf5340dk-app/doc.txt
+++ b/boards/nrf5340dk-app/doc.txt
@@ -7,7 +7,7 @@
 
 The nRF5340DK is a devboard based on nRF5340 MCU which offers a dual core
 Cortex-M33 with one application core and one network core.
-The network core is able to handle Bluetooth 5.3, BLE, mesh, NFC, Thread and
+The network core is able to handle Bluetooth 5.3, BLE, mesh, NFC (only tag emulation, no reader support), Thread and
 Zigbee connectivity.
 Currently only the application core can be used with RIOT-OS.
 

--- a/boards/thingy52/doc.txt
+++ b/boards/thingy52/doc.txt
@@ -4,12 +4,12 @@
 @brief       Support for the Nordic Thingy:52 board
 
 ## Overview
-The Nordic Thingy:52 is a battery powered platform with Bluetooth and NFC
+The Nordic Thingy:52 is a battery powered platform with Bluetooth and NFC (only tag emulation, no reader support)
 radio, a wide range of sensors and some output capabilities.
 
 Components:
 
-- nRF52832 main controller (providing Bluetooth and NFC)
+- nRF52832 main controller (providing Bluetooth and NFC tag emulation)
 - an LIS2DH12 low-power three-axis linear accelerometer
 - an MPU-9250 nine-axis motion sensor
 - an LPS22HB air pressure and temperature sensor


### PR DESCRIPTION
### Contribution description

The nRF family's NFC radio part implements only the tag emulation, and can neither access other tags nor do peer-to-peer mode.

### Testing procedure

Look at the changed documentation.

### Issues/PRs references

I'd rather not rant on about how much time I've sunk without this warning. (Yes I wrote the thingy:52 documentation myself).