### PR TITLE
tests/sys/psa_crypto: test interleaved hash operations

### DIFF
--- a/tests/sys/psa_crypto/Makefile
+++ b/tests/sys/psa_crypto/Makefile
@@ -12,4 +12,7 @@ CFLAGS += -DCONFIG_PSA_SINGLE_KEY_COUNT=1
 USEMODULE += psa_asymmetric
 USEMODULE += psa_asymmetric_ecc_ed25519
 
+USEMODULE += psa_hash
+USEMODULE += psa_hash_sha_256
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/psa_crypto/Makefile.ci
+++ b/tests/sys/psa_crypto/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
+    arduino-mega2560 \
     arduino-nano \
     arduino-uno \
     atmega328p \

--- a/tests/sys/psa_crypto/main.c
+++ b/tests/sys/psa_crypto/main.c
@@ -66,6 +66,51 @@ cleanup:
     TEST_ASSERT_PSA_CONTINUE(psa_destroy_key(key_id));
 }
 
+/*
+ * Several interleaved hash operations shouldn't collide.
+ */
+static void test_hash_interleaved(void)
+{
+    const psa_algorithm_t alg = PSA_ALG_SHA_256;
+
+    const uint8_t in1[1] = "a";
+    const uint8_t in2[1] = "b";
+
+    const uint8_t exp1[] = {
+        0xca, 0x97, 0x81, 0x12, 0xca, 0x1b, 0xbd, 0xca, 0xfa, 0xc2, 0x31, 0xb3,
+        0x9a, 0x23, 0xdc, 0x4d, 0xa7, 0x86, 0xef, 0xf8, 0x14, 0x7c, 0x4e, 0x72,
+        0xb9, 0x80, 0x77, 0x85, 0xaf, 0xee, 0x48, 0xbb
+    };
+    const uint8_t exp2[] = {
+        0x3e, 0x23, 0xe8, 0x16, 0x00, 0x39, 0x59, 0x4a, 0x33, 0x89, 0x4f, 0x65,
+        0x64, 0xe1, 0xb1, 0x34, 0x8b, 0xbd, 0x7a, 0x00, 0x88, 0xd4, 0x2c, 0x4a,
+        0xcb, 0x73, 0xee, 0xae, 0xd5, 0x9c, 0x00, 0x9d
+    };
+
+    uint8_t out[PSA_HASH_LENGTH(alg)];
+    size_t out_len;
+
+    psa_hash_operation_t op1 = PSA_HASH_OPERATION_INIT;
+    psa_hash_operation_t op2 = PSA_HASH_OPERATION_INIT;
+
+    TEST_ASSERT_PSA_CLEANUP(psa_hash_setup(&op1, alg));
+    TEST_ASSERT_PSA_CLEANUP(psa_hash_setup(&op2, alg));
+
+    TEST_ASSERT_PSA_CLEANUP(psa_hash_update(&op1, in1, sizeof(in1)));
+    TEST_ASSERT_PSA_CLEANUP(psa_hash_update(&op2, in2, sizeof(in2)));
+
+    TEST_ASSERT_PSA_CLEANUP(psa_hash_finish(&op1, out, sizeof(out), &out_len));
+    TEST_ASSERT_EQUAL_INT(sizeof(out), out_len);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(out, exp1, sizeof(out)));
+    TEST_ASSERT_PSA_CLEANUP(psa_hash_finish(&op2, out, sizeof(out), &out_len));
+    TEST_ASSERT_EQUAL_INT(sizeof(out), out_len);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(out, exp2, sizeof(out)));
+
+cleanup:
+    TEST_ASSERT_PSA_CONTINUE(psa_hash_abort(&op1));
+    TEST_ASSERT_PSA_CONTINUE(psa_hash_abort(&op2));
+}
+
 /**
  * Exporting and re-importing a private Ed25519 key should result in the same public key and signature.
  */
@@ -181,6 +226,7 @@ static Test *tests_psa_crypto(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_init_twice),
+        new_TestFixture(test_hash_interleaved),
         new_TestFixture(test_exported_key_is_identical_when_imported_again_ed25519),
         new_TestFixture(test_export_public_key_ed25519),
     };


### PR DESCRIPTION
### Contribution description

Wrote this test while debugging some code, just to make sure the PSA Crypto API behaves as expected when using different hash operations in an interleaved form. It does, but I think it doesn't harm to expand the test coverage.

### Testing procedure

CI should confirm it's working.