### PR TITLE
sys/psa_crypto: correct use of (ECDSA) key_bits

### DIFF
--- a/examples/psa_crypto/example_ecdsa_p256.c
+++ b/examples/psa_crypto/example_ecdsa_p256.c
@@ -88,7 +88,7 @@ psa_status_t example_ecdsa_p256(void)
     psa_set_key_usage_flags(&pubkey_attr, PSA_KEY_USAGE_VERIFY_MESSAGE);
 #endif
     psa_set_key_algorithm(&pubkey_attr, ECC_ALG);
-    psa_set_key_bits(&pubkey_attr, PSA_BYTES_TO_BITS(pubkey_length));
+    psa_set_key_bits(&pubkey_attr, ECC_KEY_SIZE);
     psa_set_key_type(&pubkey_attr, PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1));
 
     status = psa_import_key(&pubkey_attr, public_key, pubkey_length, &pubkey_id);

--- a/sys/include/psa_crypto/psa/crypto_sizes.h
+++ b/sys/include/psa_crypto/psa/crypto_sizes.h
@@ -894,30 +894,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Get curve size from ECC public key
- *
- * @details The representation of an ECC public key is dependent on the family:
- *          - for twisted Edwards curves: 32B
- *          - for Weierstrass curves:
- *            - The byte 0x04;
- *            - `x_P` as a `ceiling(m/8)`-byte string, big-endian;
- *            - `y_P` as a `ceiling(m/8)`-byte string, big-endian;
- *            - where m is the bit size associated with the curve.
- *            - 1 byte + 2 * point size.
- */
-#define PSA_ECC_KEY_GET_CURVE_FROM_PUBLIC_KEY(key_type, key_bits)                    \
-    (PSA_KEY_TYPE_ECC_GET_FAMILY(key_type) == PSA_ECC_FAMILY_TWISTED_EDWARDS ? 255 : \
-     ((size_t)((key_bits - 8) / 2)))
-
-/**
- * @brief   Get curve size from ECC key (public or private)
- */
-#define PSA_ECC_KEY_GET_CURVE(key_type, key_bits)                   \
-    (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) ?                     \
-        PSA_ECC_KEY_GET_CURVE_FROM_PUBLIC_KEY(key_type, key_bits) : \
-     (size_t)key_bits)
-
-/**
  * @brief   Maximum size of the export encoding of an ECC public key.
  *
  * @details The representation of an ECC public key is dependent on the family:
@@ -1059,7 +1035,7 @@ extern "C" {
  *          If the parameters are not valid, the return value is unspecified.
  */
 #define PSA_SIGN_OUTPUT_SIZE(key_type, key_bits, alg)        \
-    (PSA_KEY_TYPE_IS_ECC(key_type) ? PSA_ECDSA_SIGNATURE_SIZE(PSA_ECC_KEY_GET_CURVE(key_type, key_bits)) : \
+    (PSA_KEY_TYPE_IS_ECC(key_type) ? PSA_ECDSA_SIGNATURE_SIZE(key_bits) : \
      ((void)alg, 0))
 
 #ifdef __cplusplus

--- a/sys/psa_crypto/psa_crypto.c
+++ b/sys/psa_crypto/psa_crypto.c
@@ -1551,6 +1551,12 @@ psa_status_t psa_builtin_import_key(const psa_key_attributes_t *attributes,
         return PSA_SUCCESS;
     }
     else if (PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(type)) {
+        /* key material does not match expected size */
+        if (data_length != PSA_EXPORT_KEY_OUTPUT_SIZE(type, attributes->bits)) {
+            return PSA_ERROR_INVALID_ARGUMENT;
+        }
+
+        /* key material too large to be represented */
         if (data_length > PSA_EXPORT_PUBLIC_KEY_MAX_SIZE) {
             return PSA_ERROR_NOT_SUPPORTED;
         }
@@ -1944,7 +1950,7 @@ psa_status_t psa_sign_hash(psa_key_id_t key,
         return status;
     }
 
-    if (signature_size < PSA_ECDSA_SIGNATURE_SIZE(PSA_ECC_KEY_GET_CURVE(slot->attr.type, slot->attr.bits))) {
+    if (signature_size < PSA_ECDSA_SIGNATURE_SIZE(slot->attr.bits)) {
         return PSA_ERROR_BUFFER_TOO_SMALL;
     }
 
@@ -1997,7 +2003,7 @@ psa_status_t psa_sign_message(psa_key_id_t key,
         return status;
     }
 
-    if (signature_size < PSA_ECDSA_SIGNATURE_SIZE(PSA_ECC_KEY_GET_CURVE(slot->attr.type, slot->attr.bits))) {
+    if (signature_size < PSA_ECDSA_SIGNATURE_SIZE(slot->attr.bits)) {
         return PSA_ERROR_BUFFER_TOO_SMALL;
     }
 
@@ -2048,7 +2054,7 @@ psa_status_t psa_verify_hash(psa_key_id_t key,
         return status;
     }
 
-    if (signature_length != PSA_ECDSA_SIGNATURE_SIZE(PSA_ECC_KEY_GET_CURVE(slot->attr.type, slot->attr.bits))) {
+    if (signature_length != PSA_ECDSA_SIGNATURE_SIZE(slot->attr.bits)) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
@@ -2105,7 +2111,7 @@ psa_status_t psa_verify_message(psa_key_id_t key,
         return status;
     }
 
-    if (signature_length != PSA_ECDSA_SIGNATURE_SIZE(PSA_ECC_KEY_GET_CURVE(slot->attr.type, slot->attr.bits))) {
+    if (signature_length != PSA_ECDSA_SIGNATURE_SIZE(slot->attr.bits)) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 

--- a/tests/sys/psa_crypto_ecdsa/example_ecdsa_p256.c
+++ b/tests/sys/psa_crypto_ecdsa/example_ecdsa_p256.c
@@ -78,7 +78,7 @@ psa_status_t example_ecdsa_p256(void)
 
     psa_set_key_usage_flags(&pubkey_attr, PSA_KEY_USAGE_VERIFY_MESSAGE);
     psa_set_key_algorithm(&pubkey_attr, ECC_ALG);
-    psa_set_key_bits(&pubkey_attr, PSA_BYTES_TO_BITS(pubkey_length));
+    psa_set_key_bits(&pubkey_attr, ECC_KEY_SIZE);
     psa_set_key_type(&pubkey_attr, PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1));
 
     status = psa_import_key(&pubkey_attr, public_key, pubkey_length, &pubkey_id);

--- a/tests/sys/psa_crypto_se_ecdsa/example_ecdsa_p256.c
+++ b/tests/sys/psa_crypto_se_ecdsa/example_ecdsa_p256.c
@@ -84,7 +84,7 @@ psa_status_t example_ecdsa_p256(void)
     psa_set_key_lifetime(&pubkey_attr, lifetime);
     psa_set_key_usage_flags(&pubkey_attr, PSA_KEY_USAGE_VERIFY_HASH);
     psa_set_key_algorithm(&pubkey_attr, ECC_ALG);
-    psa_set_key_bits(&pubkey_attr, PSA_BYTES_TO_BITS(pubkey_length));
+    psa_set_key_bits(&pubkey_attr, ECC_KEY_SIZE);
     psa_set_key_type(&pubkey_attr, PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1));
 
     status = psa_import_key(&pubkey_attr, public_key, pubkey_length, &pubkey_id);


### PR DESCRIPTION
### Contribution description

The `key_bits` that are part of the `psa_key_attributes_t` are restricted to certain values in the PSA specification. An example is [PSA_ECC_FAMILY_SECP_R1](https://arm-software.github.io/psa-api/crypto/1.1/api/keys/types.html#c.PSA_ECC_FAMILY_SECP_R1), which allows for `key_bits = 256`, among others.

However, in https://github.com/RIOT-OS/RIOT/blob/master/examples/psa_crypto/example_ecdsa_p256.c#L91, `key_bits` was set to the size of the exported key, which at least for PSA_ECC_FAMILY_SECP_R1 doesn't match the expected `key_bits` (as it is defined [here](https://arm-software.github.io/psa-api/crypto/1.1/api/keys/management.html#key-formats) to be `1+2*key_bits`).

Fixing this revealed a unnecessary computation of the `curve_bits`, which actually match the `key_bits` according to the specification. Removed the respective macros and adapted all their usage.


### Testing procedure

CI should suffice to see that compilation and the tests succeed.


### Issues/PRs references

Fixes #20468.

~~Draft since blocked by #20545: the change in `examples/psa_crypto/example_ecdsa_p256.c` needs to be copied to `tests/sys/psa_crypto_ecdsa*/example_ecdsa_p256.c`~~ Done :heavy_check_mark: 
