### PR TITLE
doc/terminals: add putty and sort terminals

### DIFF
--- a/doc/doxygen/src/terminal-programs.md
+++ b/doc/doxygen/src/terminal-programs.md
@@ -16,13 +16,6 @@ character (0xD, 0xA). See https://en.wikipedia.org/wiki/Newline for background.
 This page tries to collect needed settings for common terminal programs that
 will make them correctly display newlines.
 
-picocom                                                               {#picocom}
-=======
-- Generic method:
-    - Start with `--imap lfcrlf` parameter.
-- Via RIOT build system:
-    - `RIOT_TERMINAL=picocom make term`
-
 gtkterm                                                               {#gtkterm}
 ======
 - Graphical method:
@@ -47,6 +40,13 @@ miniterm                                                             {#miniterm}
     - Start with `--eol CR`parameter.
 - Via RIOT build system:
     - `RIOT_TERMINAL=miniterm make term`
+
+picocom                                                               {#picocom}
+=======
+- Generic method:
+    - Start with `--imap lfcrlf` parameter.
+- Via RIOT build system:
+    - `RIOT_TERMINAL=picocom make term`
 
 putty
 =====

--- a/doc/doxygen/src/terminal-programs.md
+++ b/doc/doxygen/src/terminal-programs.md
@@ -47,3 +47,9 @@ miniterm                                                             {#miniterm}
     - Start with `--eol CR`parameter.
 - Via RIOT build system:
     - `RIOT_TERMINAL=miniterm make term`
+
+putty
+=====
+- Graphical method:
+    - Go to configuration tree and choose `Terminal` branch.
+    - Enable option `Implicit CR in every LF`.

--- a/doc/doxygen/src/terminal-programs.md
+++ b/doc/doxygen/src/terminal-programs.md
@@ -48,7 +48,7 @@ picocom                                                               {#picocom}
 - Via RIOT build system:
     - `RIOT_TERMINAL=picocom make term`
 
-putty
+putty                                                                   {#putty}
 =====
 - Graphical method:
     - Go to configuration tree and choose `Terminal` branch.


### PR DESCRIPTION
### Contribution description

This PR adds `putty` terminal to the list (very convenient in the Windows ;) ) and sort all terminal programs alphabetically.

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/terminal-programs.html 
```

### Issues/PRs references

PR #20493
