### PR TITLE
tests/sys/psa_crypto: increase timeout

### DIFF
--- a/tests/sys/psa_crypto/tests/01-run.py
+++ b/tests/sys/psa_crypto/tests/01-run.py
@@ -11,4 +11,4 @@ from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run_check_unittests())
+    sys.exit(run_check_unittests(timeout=20))


### PR DESCRIPTION
### Contribution description

This should hopefully fix the failing nightly builds since https://github.com/RIOT-OS/RIOT/commit/ad9d50163e7b8c53e6c92016f3b3944adbb5023e

The test uses ed25519 in software and thereby takes some time to finish. Increasing the timeout to 20s fixed it locally with a samr21-xpro board.


### Testing procedure

Look at the minimal diff, merge and then hope for the next nightly.


### Issues/PRs references

thanks to @maribu for mentioning the failing builds