### PR TITLE
cpu/msp430: implement power management

### DIFF
--- a/cpu/msp430/include/cpu.h
+++ b/cpu/msp430/include/cpu.h
@@ -37,6 +37,11 @@ extern "C" {
 #define WORDSIZE 16
 
 /**
+ * @brief   MSP430 has power management support
+ */
+#define PROVIDES_PM_SET_LOWEST
+
+/**
  * @brief   Macro for defining interrupt service routines
  */
 #define ISR(a,b)        void __attribute__((naked, interrupt (a))) b(void)
@@ -94,6 +99,14 @@ static inline void __attribute__((always_inline)) __restore_context(void)
  */
 static inline void __attribute__((always_inline)) __enter_isr(void)
 {
+    /* modify state register pushed to stack to not got to power saving
+     * mode right again */
+    __asm__ volatile(
+        "bic %[mask], 0(SP)"            "\n\t"
+        : /* no outputs */
+        : [mask]    "i"(CPUOFF | SCG0 | SCG1 | OSCOFF)
+        : "memory"
+    );
     extern char __stack;    /* defined by linker script to end of RAM */
     __save_context();
     __asm__("mov.w %0,r1" : : "i"(&__stack));

--- a/cpu/msp430/include/irq_arch.h
+++ b/cpu/msp430/include/irq_arch.h
@@ -44,8 +44,8 @@ __attribute__((always_inline)) static inline unsigned int irq_disable(void)
 {
     unsigned int state;
     __asm__ volatile(
-        "mov.w r2, %[state]"                "\n\t"
-        "bic %[gie], r2"                    "\n\t"
+        "mov.w SR, %[state]"                "\n\t"
+        "bic %[gie], SR"                    "\n\t"
         "nop"                               "\n\t"
         "and %[gie], %[state]"              "\n\t"
         : [state]   "=r"(state)
@@ -60,9 +60,9 @@ __attribute__((always_inline)) static inline unsigned int irq_enable(void)
 {
     unsigned int state;
     __asm__ volatile(
-        "mov.w r2, %[state]"                "\n\t"
+        "mov.w SR, %[state]"                "\n\t"
         "nop"                               "\n\t"
-        "bis %[gie], r2"                    "\n\t"
+        "bis %[gie], SR"                    "\n\t"
         "nop"                               "\n\t"
         "and %[gie], %[state]"              "\n\t"
         : [state]   "=r"(state)
@@ -76,7 +76,7 @@ __attribute__((always_inline)) static inline unsigned int irq_enable(void)
 __attribute__((always_inline)) static inline void irq_restore(unsigned int state)
 {
     __asm__ volatile(
-        "bis %[state], r2"                    "\n\t"
+        "bis %[state], SR"                    "\n\t"
         "nop"                                 "\n\t"
         : /* no outputs */
         : [state]   "r"(state)
@@ -93,7 +93,7 @@ __attribute__((always_inline)) static inline bool irq_is_enabled(void)
 {
     unsigned int state;
     __asm__ volatile(
-        "mov.w r2,%[state]"                   "\n\t"
+        "mov.w SR,%[state]"                   "\n\t"
         : [state]   "=r"(state)
         : /* no inputs */
         : "memory"

--- a/cpu/msp430/include/periph_cpu_common.h
+++ b/cpu/msp430/include/periph_cpu_common.h
@@ -312,6 +312,17 @@ typedef enum {
 } msp430_timer_clock_source_t;
 
 /**
+ * @brief   IDs of the different clock domains on the MSP430
+ *
+ * These can be used as internal clock sources for peripherals
+ */
+typedef enum {
+    MSP430_CLOCK_SUBMAIN,                               /**< Subsystem main clock */
+    MSP430_CLOCK_AUXILIARY,                             /**< Auxiliary clock */
+    MSP430_CLOCK_NUMOF,                                 /**< Number of clock domains */
+} msp430_clock_t;
+
+/**
  * @brief   Timer configuration on an MSP430 timer
  */
 typedef struct {
@@ -366,6 +377,28 @@ uint32_t PURE msp430_submain_clock_freq(void);
  * @note    This is only useful when implementing MSP430 peripheral drivers
  */
 uint32_t PURE msp430_auxiliary_clock_freq(void);
+
+/**
+ * @brief   Increase the refcount of the given clock
+ *
+ * @param[in]   clock       clock domain to acquire
+ *
+ * @warning This is an internal function and must only be called from
+ *          peripheral drivers
+ * @note    An assertion will blow when the count exceeds capacity
+ */
+void msp430_clock_acquire(msp430_clock_t clock);
+
+/**
+ * @brief   Decrease the refcount of the subsystem main clock
+ *
+ * @param[in]   clock       clock domain to acquire
+ *
+ * @warning This is an internal function and must only be called from
+ *          peripheral drivers
+ * @note    An assertion will blow when the count drops below zero
+ */
+void msp430_clock_release(msp430_clock_t clock);
 
 #ifdef __cplusplus
 }

--- a/examples/gnrc_lorawan/Makefile.ci
+++ b/examples/gnrc_lorawan/Makefile.ci
@@ -6,8 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f031k6 \
     nucleo-f042k6 \
@@ -17,6 +15,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
-    telosb \
     weact-g030f6 \
     #

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -8,8 +8,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     e104-bt5011a-tb \
     gd32vf103c-start \
     lsn50 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \
@@ -32,5 +30,4 @@ BOARD_INSUFFICIENT_MEMORY := \
     slstk3400a \
     stk3200 \
     stm32f0discovery \
-    telosb \
     #

--- a/tests/drivers/atwinc15x0/Makefile.ci
+++ b/tests/drivers/atwinc15x0/Makefile.ci
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/drivers/bme680/Makefile.ci
+++ b/tests/drivers/bme680/Makefile.ci
@@ -1,8 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     chronos \
-    msb-430 \
-    msb-430h \
     nucleo-f031k6 \
-    telosb \
     #

--- a/tests/drivers/nrf24l01p_ng/Makefile.ci
+++ b/tests/drivers/nrf24l01p_ng/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
+    msb-430 \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/drivers/w5100/Makefile.ci
+++ b/tests/drivers/w5100/Makefile.ci
@@ -8,8 +8,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/net/gnrc_ndp/Makefile.ci
+++ b/tests/net/gnrc_ndp/Makefile.ci
@@ -8,8 +8,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/net/netstats_neighbor/Makefile.ci
+++ b/tests/net/netstats_neighbor/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    telosb \
     waspmote-pro \
     weact-g030f6 \
     #

--- a/tests/pkg/emlearn/Makefile.ci
+++ b/tests/pkg/emlearn/Makefile.ci
@@ -9,8 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-stm32f103c8 \
     bluepill-stm32f103c8 \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg/fatfs_vfs/Makefile.ci
+++ b/tests/pkg/fatfs_vfs/Makefile.ci
@@ -6,8 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/pkg/u8g2/Makefile.ci
+++ b/tests/pkg/u8g2/Makefile.ci
@@ -11,5 +11,4 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
-    telosb \
     #

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -5,8 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f103cb \
     gd32vf103c-start \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \
@@ -28,5 +26,4 @@ BOARD_INSUFFICIENT_MEMORY := \
     slstk3400a \
     stk3200 \
     stm32f0discovery \
-    telosb \
     #

--- a/tests/sys/bloom_bytes/Makefile.ci
+++ b/tests/sys/bloom_bytes/Makefile.ci
@@ -7,5 +7,4 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
     stm32f030f4-demo \
-    telosb \
     #

--- a/tests/sys/conn_can/Makefile.ci
+++ b/tests/sys/conn_can/Makefile.ci
@@ -4,8 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     im880b \
     microbit \
-    msb-430 \
-    msb-430h \
     nrf51dongle \
     nrf6310 \
     nucleo-f030r8 \
@@ -24,6 +22,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
-    telosb \
     yunjia-nrf51822 \
     #

--- a/tests/sys/ps_schedstatistics/Makefile.ci
+++ b/tests/sys/ps_schedstatistics/Makefile.ci
@@ -22,6 +22,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
-    telosb \
     weact-g030f6 \
     #

--- a/tests/sys/shell/Makefile.ci
+++ b/tests/sys/shell/Makefile.ci
@@ -1,7 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-uno \
     arduino-nano \
+    arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \

--- a/tests/sys/suit_manifest/Makefile.ci
+++ b/tests/sys/suit_manifest/Makefile.ci
@@ -2,8 +2,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     chronos \
     i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/sys/trace/Makefile.ci
+++ b/tests/sys/trace/Makefile.ci
@@ -1,8 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     chronos \
-    msb-430 \
-    msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \


### PR DESCRIPTION
### Contribution description

This implements power management for the MSP430.

### Testing procedure

Flash this on any MSP430 board. No regressions should occur, but power consumption should drop. Your mileage may wary, though:

- There will be zero power safe while the CPU is still in use
- There will be more power saving when clock domains can be disabled

#### Benchmarks

I attached a power monitor in-between the USB connection to our [Olimex MSP430Hxxx breakout board](https://github.com/RIOT-OS/RIOT-Open-Hardware/tree/main/olimex-msp430-arduino-uno) and monitored the power consumption in the following scenarios:

1. Nothing connected to the USB (e.g. Noise of the monitor)
2. The breakout board without the header board connected and the USB2UART adapter in use (`/dev/ttyUSB0` open). This is the baseline, as this power is used even without the MCU actually attached
3. The breakout + header board plugged in, `exmaples/default` from `master` flashed, and first `help` then `ps` run
4. The breakout + header board plugged in, `exmaples/default` from this PR flashed, and first `help` then `ps` run

##### Benchmark on the `olimex-msp430h1611`

![olimex-msp430h1611](https://github.com/RIOT-OS/RIOT/assets/2041729/cbb3e49e-2d75-4bd7-943e-ba0c248bf96d)

##### Benchmark on the `olimex-msp430h2618`

![olimex-msp430h2618](https://github.com/RIOT-OS/RIOT/assets/2041729/73d90641-6532-4442-9c5e-bb00d2c26517)

##### Conclusion

The power consumption goes down pretty much to the base line for each MCU family while the MCU is not in use, but spikes when there is activity. It looks pretty much like one would expect.

### Issues/PRs references

- [x] Depends on and includes https://github.com/RIOT-OS/RIOT/pull/20623