### PR TITLE
cpu/cortexm: rework bkpt instruction call on panic

### DIFF
--- a/cpu/cortexm_common/panic.c
+++ b/cpu/cortexm_common/panic.c
@@ -27,7 +27,8 @@
 static void print_ipsr(void)
 {
     uint32_t ipsr = __get_IPSR() & IPSR_ISR_Msk;
-    if(ipsr) {
+
+    if (ipsr) {
         /* if you get here, you might have forgotten to implement the isr
          * for the printed interrupt number */
         LOG_ERROR("Inside isr %d\n", ((int)ipsr) - 16);

--- a/cpu/cortexm_common/panic.c
+++ b/cpu/cortexm_common/panic.c
@@ -39,7 +39,15 @@ void panic_arch(void)
 {
 #ifdef DEVELHELP
     print_ipsr();
-    /* The bkpt instruction will signal to the debugger to break here. */
-    __asm__("bkpt #0");
+    /* CM0+ has a C_DEBUGEN bit but it is NOT accessible by CPU (only by debugger) */
+#ifdef CoreDebug_DHCSR_C_DEBUGEN_Msk
+    if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) {
+        /* if Debug session is running, tell the debugger to break here.
+            Skip it otherwise as this instruction will cause either a fault
+            escalation to hardfault or a CPU lockup */
+        __asm__("bkpt #0");
+    }
+#endif /* CoreDebug_DHCSR_C_DEBUGEN_Msk */
+
 #endif
 }


### PR DESCRIPTION
### Contribution description

Rework the way `bkpt` instruction is call on panic for Cortex-M MCU.
Currently, this instruction is called everytime on panic. However, when a debug session is not active (no GDB running),  and if a panic occured, the `bkpt` instruction will either escalate the current fault to hardfault or the CPU will enter LOCKUP state (it may reset automatically depending on how vendors handle this signal internally).

To mitigate this issue, one can check the `C_DEBUGEN` in `CoreDebug->DHCSR`. If this bit is set, it means a debug session is running, thus `bkpt` instruction can be used safely. Otherwise, skip this instruction. The execution will then [continue until `pm_off()` or `while(1) {}` is called.](https://github.com/RIOT-OS/RIOT/blob/009d76e4fee66bc53c6b97aee02c831f164328d6/core/lib/panic.c#L91)

However, this bit is NOT accessible by the CPU on CortexM0+ (Only accessible by GDB). So the `bkpt` instruction is completely skip for this one.

### Testing procedure
Trigger a fault on any cortexm-based board 
for instance
```
volatile uint32_t *pointer = (uint32_t*) 0x60000001;
uint32_t val = *pointer; 
```
Such code will trigger a hardfault (technically a busfault for ARMv7-M or ARMv8-M Mainline, but it escalates to hardfault as the busfault is currently not enable).
On panic, if GDB is NOT used, the execution will 'stop' on the `bkpt` instruction. On nRF5340DK, a reset is issued (Probably because the processor enters LOCKUP state). Nevertheless, the execution should continue up to [here](https://github.com/RIOT-OS/RIOT/blob/009d76e4fee66bc53c6b97aee02c831f164328d6/core/lib/panic.c#L91).


### Issues/PRs references
None.
