### PR TITLE
boards/common/stm32: simplify ifdef logic

### DIFF
--- a/boards/common/stm32/include/cfg_timer_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim2.h
@@ -37,10 +37,9 @@ static const timer_conf_t timer_config[] = {
 #else
         .max      = 0xffffffff,
 #endif
-#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32G4)
+#if defined(RCC_APB1ENR1_TIM2EN)
         .rcc_mask = RCC_APB1ENR1_TIM2EN,
-#elif CPU_FAM_STM32MP1
+#elif defined(RCC_MC_APB1ENSETR_TIM2EN)
         .rcc_mask = RCC_MC_APB1ENSETR_TIM2EN,
 #else
         .rcc_mask = RCC_APB1ENR_TIM2EN,

--- a/boards/common/stm32/include/cfg_timer_tim5.h
+++ b/boards/common/stm32/include/cfg_timer_tim5.h
@@ -33,8 +33,7 @@ static const timer_conf_t timer_config[] = {
     {
         .dev      = TIM5,
         .max      = 0xffffffff,
-#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5)
+#if defined(RCC_APB1ENR1_TIM5EN)
         .rcc_mask = RCC_APB1ENR1_TIM5EN,
 #else
         .rcc_mask = RCC_APB1ENR_TIM5EN,

--- a/boards/common/stm32/include/cfg_timer_tim5_and_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim5_and_tim2.h
@@ -37,8 +37,7 @@ static const timer_conf_t timer_config[] = {
     {
         .dev      = TIM5,
         .max      = 0xffffffff,
-#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5)
+#if defined(RCC_APB1ENR1_TIM5EN)
         .rcc_mask = RCC_APB1ENR1_TIM5EN,
 #else
         .rcc_mask = RCC_APB1ENR_TIM5EN,
@@ -53,10 +52,9 @@ static const timer_conf_t timer_config[] = {
 #else
         .max      = 0xffffffff,
 #endif
-#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32G4)
+#if defined(RCC_APB1ENR1_TIM2EN)
         .rcc_mask = RCC_APB1ENR1_TIM2EN,
-#elif CPU_FAM_STM32MP1
+#elif defined(RCC_MC_APB1ENSETR_TIM2EN)
         .rcc_mask = RCC_MC_APB1ENSETR_TIM2EN,
 #else
         .rcc_mask = RCC_APB1ENR_TIM2EN,


### PR DESCRIPTION
### Contribution description

This patch just simplifies the the ifedef logic in a few shared stm32 headers, in support of the STM32H7 port.


### Testing procedure

try running:

``` sh
#! /bin/sh -e

boards=""
boards="$boards `ls -1 boards/ | grep stm32`"
boards="$boards `ls -1 boards/ | grep nucleo`"

for board in $boards
do
	make -C examples/blinky BOARD=$board
done
```


### Issues/PRs references

none known
