### PR TITLE
examples/gnrc_border_router: pass variables to docker

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -123,6 +123,14 @@ endif
 # the variable to empty
 SHOULD_RUN_KCONFIG ?=
 
+# Pass through application configuration to the docker container, if
+# BUILD_IN_DOCKER=1 is used:
+DOCKER_ENV_VARS += IPV6_ADDR
+DOCKER_ENV_VARS += IPV6_DEFAULT_ROUTER
+DOCKER_ENV_VARS += IPV6_PREFIX IPV6_DEFAULT_ROUTER
+DOCKER_ENV_VARS += PREFIX_CONF
+DOCKER_ENV_VARS += UPLINK
+
 include $(RIOTBASE)/Makefile.include
 
 # Compile-time configuration for DHCPv6 client (needs to come after

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -70,6 +70,8 @@ export DOCKER_ENV_VARS += \
   TOOLCHAIN \
   UNDEF \
   WERROR \
+  WIFI_PASS \
+  WIFI_SSID \
   #
 
 # List of all exported environment variables that shall be passed on to the


### PR DESCRIPTION
### Contribution description

This passes environment variables used to configure e.g. the uplink of the border router to the docker container, so that configuration works with `BUILD_IN_DOCKER=1`.

### Testing procedure

Run:

```
USEMODULE="sock_dns gnrc_ipv6_nib_dns" make -C examples/gnrc_border_router BOARD=esp32-mh-et-live-minikit BUILD_IN_DOCKER=1 UPLINK=wifi WIFI_SSID=foobar WIFI_PASS=foobar1337 flash term
make: Entering directory '/home/maribu/Repos/software/RIOT/master/examples/gnrc_border_router'
```

In `master`, you'll see "crazy" serial output, as the build system on the host expects normal stdio and WiFi as uplink, but the build system in the docker container expected slip as uplink and multiplexes the uplink with stdio.

With this PR, the serial is no longer multiplexed with the uplink, but WiFi is used as configured.

### Issues/PRs references

None