### PR TITLE
periph/adc: add adc_continuous_sample_multi()

### DIFF
--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -43,9 +43,9 @@
 
 /* Prototypes */
 static void _adc_poweroff(Adc *dev);
-static void _setup_clock(Adc *dev);
+static void _setup_clock(Adc *dev, uint32_t f_tgt);
 static void _setup_calibration(Adc *dev);
-static int _adc_configure(Adc *dev, adc_res_t res);
+static int _adc_configure(Adc *dev, adc_res_t res, uint32_t f_tgt);
 
 static mutex_t _lock = MUTEX_INIT;
 
@@ -67,7 +67,7 @@ static void _adc_poweroff(Adc *dev)
     _wait_syncbusy(dev);
 
     /* Disable */
-    dev->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
+    dev->CTRLA.reg = 0;
     _wait_syncbusy(dev);
 
     /* Disable bandgap */
@@ -82,7 +82,41 @@ static void _adc_poweroff(Adc *dev)
 #endif
 }
 
-static void _setup_clock(Adc *dev)
+static uint32_t _absdiff(uint32_t a, uint32_t b)
+{
+    return a > b ? a - b : b - a;
+}
+
+static void _find_presc(uint32_t f_src, uint32_t f_tgt,
+                        uint8_t *prescale, uint8_t *samplen)
+{
+    uint32_t _best_match = UINT32_MAX;
+
+#if defined(ADC_CTRLB_PRESCALER_DIV2) || defined(ADC_CTRLB_PRESCALER_DIV2)
+    uint8_t start = 1;
+#else
+    uint8_t start = 2;
+#endif
+    uint8_t end = start + 8;
+    for (uint8_t i = start; i < end; ++i) {
+        for (uint8_t _samplen = 32; _samplen > 0; --_samplen) {
+            unsigned diff = _absdiff((f_src >> i) / _samplen, f_tgt);
+            if (diff < _best_match) {
+                _best_match = diff;
+                *samplen  = _samplen;
+                *prescale = i;
+            }
+        }
+    }
+}
+
+#ifdef ADC_CTRLB_PRESCALER_Pos
+#define ADC_PRESCALER_Pos   ADC_CTRLB_PRESCALER_Pos
+#else
+#define ADC_PRESCALER_Pos   ADC_CTRLA_PRESCALER_Pos
+#endif
+
+static void _setup_clock(Adc *dev, uint32_t f_tgt)
 {
     /* Enable gclk in case we are the only user */
     sam0_gclk_enable(ADC_GCLK_SRC);
@@ -94,8 +128,6 @@ static void _setup_clock(Adc *dev)
     GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN
                       | GCLK_CLKCTRL_GEN(ADC_GCLK_SRC)
                       | GCLK_CLKCTRL_ID(ADC_GCLK_ID);
-    /* Configure prescaler */
-    dev->CTRLB.reg = ADC_PRESCALER;
 #else
     /* Power on */
     #ifdef MCLK_APBCMASK_ADC
@@ -122,16 +154,28 @@ static void _setup_clock(Adc *dev)
             GCLK->PCHCTRL[ADC1_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
                     | GCLK_PCHCTRL_GEN(ADC_GCLK_SRC);
         }
-        /* Configure prescaler */
-        dev->CTRLA.reg = ADC_PRESCALER;
     #else
         /* GCLK Setup */
         GCLK->PCHCTRL[ADC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
                 | GCLK_PCHCTRL_GEN(ADC_GCLK_SRC);
-        /* Configure prescaler */
-        dev->CTRLB.reg = ADC_PRESCALER;
     #endif
 #endif
+
+    uint8_t prescaler = ADC_PRESCALER >> ADC_PRESCALER_Pos;
+    uint8_t sampllen  = 0;
+
+    if (f_tgt) {
+        _find_presc(sam0_gclk_freq(ADC_GCLK_SRC), f_tgt,
+                    &prescaler, &sampllen);
+    }
+
+    /* Configure prescaler */
+#ifdef ADC_CTRLB_PRESCALER
+    dev->CTRLB.reg = prescaler << ADC_CTRLB_PRESCALER_Pos;
+#else
+    dev->CTRLA.reg = prescaler << ADC_CTRLA_PRESCALER_Pos;
+#endif
+    dev->SAMPCTRL.reg = sampllen;
 }
 
 static void _setup_calibration(Adc *dev)
@@ -170,21 +214,21 @@ static void _setup_calibration(Adc *dev)
 #endif
 }
 
-static int _adc_configure(Adc *dev, adc_res_t res)
+static int _adc_configure(Adc *dev, adc_res_t res, uint32_t f_tgt)
 {
     if ((res == ADC_RES_6BIT) || (res == ADC_RES_14BIT)) {
         return -1;
     }
 
-    _adc_poweroff(dev);
+    dev->CTRLA.reg = 0;
+    _wait_syncbusy(dev);
 
-    if (dev->CTRLA.reg & ADC_CTRLA_SWRST ||
-        dev->CTRLA.reg & ADC_CTRLA_ENABLE ) {
+    while (dev->CTRLA.reg & ADC_CTRLA_SWRST ||
+           dev->CTRLA.reg & ADC_CTRLA_ENABLE) {
         DEBUG("adc: not ready\n");
-        return -1;
     }
 
-    _setup_clock(dev);
+    _setup_clock(dev, f_tgt);
     _setup_calibration(dev);
 
     /* Set ADC resolution */
@@ -308,25 +352,30 @@ static Adc *_adc(uint8_t dev)
 #endif
 }
 
-static int32_t _sample(adc_t line)
+static inline void _config_line(Adc *dev, adc_t line, bool diffmode, bool freerun)
 {
-    Adc *dev = _dev(line);
-    bool diffmode = adc_channels[line].inputctrl & ADC_INPUTCTRL_DIFFMODE;
-
     dev->INPUTCTRL.reg = ADC_GAIN_FACTOR_DEFAULT
                        | adc_channels[line].inputctrl
                        | (diffmode ? 0 : ADC_NEG_INPUT);
-#ifdef ADC_CTRLB_DIFFMODE
+#if defined(ADC_CTRLB_DIFFMODE)
     dev->CTRLB.bit.DIFFMODE = diffmode;
+#elif defined(ADC_CTRLC_DIFFMODE)
+    dev->CTRLC.bit.DIFFMODE = diffmode;
+#endif
+
+#if defined(ADC_CTRLB_FREERUN)
+    dev->CTRLB.bit.FREERUN = freerun;
+#else
+    dev->CTRLC.bit.FREERUN = freerun;
 #endif
     _wait_syncbusy(dev);
 
-    /* Start the conversion */
-    dev->SWTRIG.reg = ADC_SWTRIG_START;
+    /* clear stale flag */
+    dev->INTFLAG.reg = ADC_INTFLAG_RESRDY;
+}
 
-    /* Wait for the result */
-    while (!(dev->INTFLAG.reg & ADC_INTFLAG_RESRDY)) {}
-
+static int32_t _sample_dev(Adc *dev, bool diffmode)
+{
     uint16_t sample = dev->RESULT.reg;
     int result;
 
@@ -340,7 +389,24 @@ static int32_t _sample(adc_t line)
     return result;
 }
 
-static uint8_t _shift_from_res(adc_res_t res)
+static int32_t _sample(adc_t line)
+{
+    Adc *dev = _dev(line);
+    bool diffmode = adc_channels[line].inputctrl & ADC_INPUTCTRL_DIFFMODE;
+
+    /* configure ADC line */
+    _config_line(dev, line, diffmode, 0);
+
+    /* Start the conversion */
+    dev->SWTRIG.reg = ADC_SWTRIG_START;
+
+    /* Wait for the result */
+    while (!(dev->INTFLAG.reg & ADC_INTFLAG_RESRDY)) {}
+
+    return _sample_dev(dev, diffmode);
+}
+
+static int8_t _shift_from_res(adc_res_t res)
 {
     /* 16 bit mode is implemented as oversampling */
     if ((res & 0x3) == 1) {
@@ -370,7 +436,7 @@ static void _get_adcs(bool *adc0, bool *adc1)
 }
 
 static uint8_t _shift;
-void adc_continuous_begin(adc_res_t res)
+void adc_continuous_begin(adc_res_t res, uint32_t f_adc)
 {
     bool adc0, adc1;
     _get_adcs(&adc0, &adc1);
@@ -378,10 +444,10 @@ void adc_continuous_begin(adc_res_t res)
     mutex_lock(&_lock);
 
     if (adc0) {
-        _adc_configure(_adc(0), res);
+        _adc_configure(_adc(0), res, f_adc);
     }
     if (adc1) {
-        _adc_configure(_adc(1), res);
+        _adc_configure(_adc(1), res, f_adc);
     }
 
     _shift = _shift_from_res(res);
@@ -421,7 +487,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
 
     Adc *dev = _dev(line);
 
-    if (_adc_configure(dev, res) != 0) {
+    if (_adc_configure(dev, res, 0) != 0) {
         DEBUG("adc: configuration failed\n");
         mutex_unlock(&_lock);
         return -1;

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -134,15 +134,16 @@ int32_t adc_sample(adc_t line, adc_res_t res);
  * @note requires the `periph_adc_continuous` feature
  *
  * @param[in] res           resolution to use for conversion
+ * @param[in] adc           frequency to use for conversion, leave 0 for default
  */
-void adc_continuous_begin(adc_res_t res);
+void adc_continuous_begin(adc_res_t res, uint32_t f_adc);
 
 /**
- * @brief   Sample an ADC line without powering off the ADC afterward
+ * @brief   Sample an ADC line without powering off the ADC afterwards
  *
  * @note requires the `periph_adc_continuous` feature
  *
- * @brief   Sample a value from the given ADC line
+ * @param[in] line          line to sample
  *
  * @return                  the sampled value on success
  */

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -161,6 +161,31 @@ int32_t adc_continuous_sample(adc_t line);
 void adc_continuous_sample_multi(adc_t line, uint16_t *buf, size_t len);
 
 /**
+ * @brief   Configure the ADC with a given resolution for continuous sampling
+ *          on two lines.
+ *
+ * @note requires the `periph_adc_continuous` feature
+ *
+ * @param[in] res           resolution to use for conversion
+ * @param[in] f_adc         frequency to use for conversion, leave 0 for default
+ */
+void adc_dual_continuous_begin(adc_res_t res, uint32_t f_adc);
+
+/**
+ * @brief   Capture multiple ADC samples from two ADC lines at the same time
+ *
+ * @note The hardware needs to be capable of sampling two lines at the same time,
+ *       e.g. they need to be configured to two separate ADC instances.
+ *
+ * @note requires the `periph_adc_continuous` feature
+ *
+ * @param[in]  line         lines to sample
+ * @param[out] buf          target buffers
+ * @param[in]  len          number of samples to sample
+ */
+void adc_dual_continuous_sample_multi(adc_t line[2], uint16_t *buf[2], size_t len);
+
+/**
  * @brief   Disable the ADC to save power
  *
  * @note requires the `periph_adc_continuous` feature

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -134,7 +134,7 @@ int32_t adc_sample(adc_t line, adc_res_t res);
  * @note requires the `periph_adc_continuous` feature
  *
  * @param[in] res           resolution to use for conversion
- * @param[in] adc           frequency to use for conversion, leave 0 for default
+ * @param[in] f_adc         frequency to use for conversion, leave 0 for default
  */
 void adc_continuous_begin(adc_res_t res, uint32_t f_adc);
 
@@ -148,6 +148,17 @@ void adc_continuous_begin(adc_res_t res, uint32_t f_adc);
  * @return                  the sampled value on success
  */
 int32_t adc_continuous_sample(adc_t line);
+
+/**
+ * @brief   Capture multiple ADC samples from an ADC line
+ *
+ * @note requires the `periph_adc_continuous` feature
+ *
+ * @param[in]  line         line to sample
+ * @param[out] buf          target buffer
+ * @param[in]  len          number of samples to sample
+ */
+void adc_continuous_sample_multi(adc_t line, uint16_t *buf, size_t len);
 
 /**
  * @brief   Disable the ADC to save power

--- a/tests/periph/adc_continuous/main.c
+++ b/tests/periph/adc_continuous/main.c
@@ -44,7 +44,7 @@ int main(void)
         }
     }
 
-    adc_continuous_begin(RES);
+    adc_continuous_begin(RES, 0);
     while (1) {
         for (unsigned i = 0; i < ADC_NUMOF; i++) {
             sample = adc_continuous_sample(ADC_LINE(i));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When collecting multiple samples, re-configuring the ADC lines is still too slow to keep up with the ADC sampling frequency.

Instead, add a new API function that allows to supply a buffer in which the samples from a single ADC line will be stored. This would be used with DMA in the future too.

In our application, we want to sample two ADC lines for Maximum Power Point Tracking of a solar cell. Here we set a voltage level to which the solar cell will be discharged, depending on the solar intensity the time until the solar cell recharged will vary. If we discharge it too deep, there is a lot of dead time before until the next discharge period starts.
If we discharge it too lightly, we leave power on the table.

So the idea is to measure both solar current and solar voltage to integrate the power level at different discharge voltage points to find the optimum.

This is still not possible with just sampling a single ADC line to a buffer, but SAM D5x/E5x has two ADC instances, so if the lines are on two instance we can sample them at the same time.

The hardware provides a host/client mode where ADC1 can be controlled in lockstep with ADC0 so both collect a sample at the same time.

I added an API for that too.

### Testing procedure

No integration in the test app yet, but I can produce some nice graphs of the sample data with Gnuplot:

### too much discharge
![5800 dat](https://github.com/RIOT-OS/RIOT/assets/1301112/54160bc6-4ca3-4f08-b6e3-41e4dc3910c9)

### max power point
![5c00 dat](https://github.com/RIOT-OS/RIOT/assets/1301112/2e13dd07-4868-499b-a097-3a8f4b317806)



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
