### PR TITLE
cpu/msp430/perriph_usci: fix prescaler values for ACLK

### DIFF
--- a/cpu/msp430/periph/usci.c
+++ b/cpu/msp430/periph/usci.c
@@ -162,19 +162,19 @@ msp430_usci_prescaler_t msp430_usci_prescale(uint32_t target_hz)
          * be needed. Otherwise the estimation will be good enough.
          */
         switch (target_hz) {
-        case 9600:
+        case 1200:
             result.mctl = 2U << UCBRS_Pos;
             result.br0 = 27;
             return result;
-        case 4800:
+        case 2400:
             result.mctl = 6U << UCBRS_Pos;
             result.br0 = 13;
             return result;
-        case 2400:
+        case 4800:
             result.mctl = 7U << UCBRS_Pos;
             result.br0 = 6;
             return result;
-        case 1200:
+        case 9600:
             result.mctl = 3U << UCBRS_Pos;
             result.br0 = 3;
             return result;


### PR DESCRIPTION
### Contribution description

For super low symbol rates the auxiliary clock (ACLK) is used to conserve power. But with only 32,678 Hz clock just prescaling will result in poor bit timing, hence correct modulation control settings to compensate are needed. Since computing this is too expensive, a look-up table (as switch statement) for the four most common symbol rates was used.

The datasheet gave the prescaler values ordered by ascending symbol rate, the switch statement was ordered descending. This changes the order to match the datasheets order and matches the correct prescaler setting to the corresponding symbol rate.

### Testing procedure

UART on MSP430F2xx is now working for symbol rates of 9600 Bd.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/20620