### PR TITLE
drivers/periph_uart: document acquire/release semantic

### DIFF
--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -177,7 +177,7 @@ typedef enum {
 #endif
 
 /**
- * @brief   Initialize a given UART device
+ * @brief   Initialize and acquire a given UART device
  *
  * The UART device will be initialized with the following configuration:
  * - 8 data bits
@@ -187,6 +187,14 @@ typedef enum {
  *
  * If no callback parameter is given (rx_cb := NULL), the UART will be
  * initialized in TX only mode.
+ *
+ * @pre     The caller is not calling `uart_init()` twice without a call of
+ *          to @ref uart_poweroff in between.
+ *
+ * @note    This may block if the UART is already acquired until it is released.
+ *          This allows sharing the underlying peripheral to provide other
+ *          serial interfaces (e.g. if the peripheral can also provide SPI, I2C,
+ *          etc.)
  *
  * @param[in] uart          UART device to initialize
  * @param[in] baud          desired symbol rate in baud
@@ -401,14 +409,17 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
 void uart_write(uart_t uart, const uint8_t *data, size_t len);
 
 /**
- * @brief   Power on the given UART device
+ * @brief   Power on and acquire the given UART device
+ *
+ * The UART will resume with the configuration it was most recently configured
+ * with.
  *
  * @param[in] uart          the UART device to power on
  */
 void uart_poweron(uart_t uart);
 
 /**
- * @brief Power off the given UART device
+ * @brief Power off and release the given UART device
  *
  * @param[in] uart          the UART device to power off
  */

--- a/tests/periph/uart/Makefile
+++ b/tests/periph/uart/Makefile
@@ -6,6 +6,7 @@ FEATURES_OPTIONAL += periph_uart_collision
 FEATURES_OPTIONAL += periph_uart_modecfg
 FEATURES_OPTIONAL += periph_uart_rxstart_irq
 
+USEMODULE += bitfield
 USEMODULE += shell
 USEMODULE += ztimer_msec
 


### PR DESCRIPTION
### Contribution description

The UART API has not spelled out what happens when `uart_init()` is called twice. This adds precise language that states that acquire/release semantic is to be expected from the caller. Hence, a caller needs to call `uart_poweroff()` before reconfiguring the UART with a second call `uart_init()` for the same UART interface.

In practise, few apps will ever reconfigure the symbol rate. So the impact is rather low.

However: This API now allows drivers to implement sharing of a serial peripheral that can provide multiple interfaces (e.g. UART, SPI, I2C, etc.). It would require some cooperation from the code that does use the UART to actually release the UART again after each transaction; something that will only work when RX data is only expected at known points in time (e.g. in response to a request, or never in case of TX only stdio). But still, this can mean the difference between a use case becoming feasible on an MCU with a low number of serial peripherals or not.

### Testing procedure

- check the wording in the API
- the UART test should still work

### Issues/PRs references

None