### PR TITLE
pkg/wamr: Added support for THUMB_VFP in wamr Makefile

### DIFF
--- a/pkg/wamr/Makefile
+++ b/pkg/wamr/Makefile
@@ -44,7 +44,11 @@ ifeq ($(findstring aarch,$(OS_ARCH)),aarch)
   WAMR_BUILD_TARGET = ARM
 endif
 else ifeq ($(findstring arm,$(CPU_ARCH)),arm)
-  WAMR_BUILD_TARGET = THUMB
+  ifeq ($(findstring cortexm_fpu,$(FEATURES_PROVIDED)),cortexm_fpu)
+    WAMR_BUILD_TARGET = THUMB_VFP
+  else
+    WAMR_BUILD_TARGET = THUMB
+  endif
 else ifeq ($(CPU_ARCH),xtensa)
   WAMR_BUILD_TARGET = XTENSA
 else ifeq ($(CPU_ARCH),rv32)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Edited wamr Makefile to support THUMB_VFP

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Build and test with arduino-nano-33-ble (nrf52840 cpu) for THUMB_VFP mode and built with nrf51dk for THUMB mode.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
