### PR TITLE
examples/gcoap: pass through variables to docker

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -73,6 +73,13 @@ ifeq (1,$(USE_ZEP))
   USEMODULE += socket_zep
 endif
 
+# Pass through application configuration to the docker container, if
+# BUILD_IN_DOCKER=1 is used:
+DOCKER_ENV_VARS += LWIP_IPV4
+DOCKER_ENV_VARS += LWIP_IPV6
+DOCKER_ENV_VARS += USE_ZEP
+DOCKER_ENV_VARS += ZEP_PORT_BASE
+
 include $(RIOTBASE)/Makefile.include
 
 # For now this goes after the inclusion of Makefile.include so Kconfig symbols


### PR DESCRIPTION
### Contribution description

Pass through application configuration environment variables to docker, so that one can use e.g. `make LWIP_IPV4=1 BUILD_IN_DOCKER=1`.

### Testing procedure

```
make LWIP_IPV4=1 BUILD_IN_DOCKER=1 -C examples/gcoap
```

should now work.

### Issues/PRs references

Used to test https://github.com/RIOT-OS/RIOT/pull/18359