### PR TITLE
core/panic: make reboot on panic configurable

### DIFF
--- a/core/lib/include/panic.h
+++ b/core/lib/include/panic.h
@@ -29,6 +29,19 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Automatically reboot the system on panic()
+ *
+ * By default this is on when @ref DEVELHELP is disabled.
+ */
+#ifndef CONFIG_CORE_REBOOT_ON_PANIC
+#ifdef DEVELHELP
+#define CONFIG_CORE_REBOOT_ON_PANIC (0)
+#else
+#define CONFIG_CORE_REBOOT_ON_PANIC (1)
+#endif
+#endif
+
+/**
  * @brief Definition of available panic modes
  */
 typedef enum {

--- a/core/lib/panic.c
+++ b/core/lib/panic.c
@@ -79,7 +79,7 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
     /* disable watchdog and all possible sources of interrupts */
     irq_disable();
     panic_arch();
-#if !defined(DEVELHELP) && defined(MODULE_PERIPH_PM)
+#if CONFIG_CORE_REBOOT_ON_PANIC && defined(MODULE_PERIPH_PM)
     /* DEVELHELP not set => reboot system */
     pm_reboot();
 #else


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently a `core_panic()` will reboot the system with `DEVELHELP=0` and print a crash trace and lock up the system with `DEVELHELP=1`.

There can be situations where this is not what's wanted, e.g. we might want to make a crash that only happens with `DEVELHELP=0` more visible or we want to run with `DEVELHELP=1` and still auto reboot on a crash because we want to debug something unrelated.

So add a config variable to toggle the behavior - the current configuration is kept as the default.


### Testing procedure

The system should now auto-restart with `DEVELHELP=1` and `CFLAGS += -DCONFIG_CORE_REBOOT_ON_PANIC=1`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
