### PR TITLE
doc/doxygen: fix sidenav handling [backport 2024.04]

### DIFF
--- a/doc/doxygen/src/js/riot-doxy.js
+++ b/doc/doxygen/src/js/riot-doxy.js
@@ -46,14 +46,10 @@ function resize_content(sidenav)
 
 function resize_handler()
 {
-    if ($(window).width() == window_before) {return;}
-
     var sidenav = $("#side-nav");
-    if ($(window).width() < 750) {
+    const threshold = 750;
+    if ($(window).width() < threshold) {
         var toc = $(".toc");
-        if (window_before >= 750) {
-            original_sidenav_width = sidenav.width();
-        }
         sidenav.width("0px");
         sidenav.css("padding-right", "0px");
         sidenav.children(".ui-resizable-e").width("0px");
@@ -63,7 +59,9 @@ function resize_handler()
     }
     else {
         var toc = $(".toc-sm");
-        sidenav.width(parseInt(original_sidenav_width)+"px");
+        if (window_before < threshold) {
+            sidenav.width(parseInt(default_sidenav_width)+"px");
+        }
         sidenav.css("padding-right", original_padding);
         sidenav.children(".ui-resizable-e").width(original_padding);
         sidenav.show();
@@ -77,8 +75,8 @@ function resize_handler()
 $(document).ready(function() {
     var sidenav = $("#side-nav");
     original_padding = sidenav.css("padding-right")
-    window_before = $(window).width()
-    original_sidenav_width = (window_before >= 740) ? sidenav.width() : 275;
+    window_before = 0
+    default_sidenav_width = 300;
     resize_handler();
 });
 $(window).resize(resize_handler);


### PR DESCRIPTION
# Backport of #20631

### Contribution description

In https://github.com/RIOT-OS/RIOT/pull/20511/files a quick fix was added to allow resizing the sidenav. But this broke hiding the sidenav on mobile screen widths. This fixes the issue and also increase the default sidenav width a tad.

### Testing procedure

Check the generated doc preview also from a mobile device. It should no longer display the sidenav on small form factors (e.g. phones, or browsers resized to a narrow view) but still allow resizing the sidenav with the mouse on larger form factors.

### Issues/PRs references

Fixes regression from https://github.com/RIOT-OS/RIOT/pull/20511/files