### PR TITLE
cpu/cortexm: add stack limit support for Cortex-M33

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -285,7 +285,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
     thread->sp = thread_stack_init(function, arg, stack, stacksize);
 
 #if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) || \
-    defined(MODULE_MPU_STACK_GUARD)
+    defined(MODULE_MPU_STACK_GUARD) || defined(MODULE_CORTEXM_STACK_LIMIT)
     thread->stack_start = stack;
 #endif
 

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -36,6 +36,7 @@ else ifeq ($(CPU_CORE),cortex-m3)
   RUST_TARGET = thumbv7m-none-eabi
 else ifeq ($(CPU_CORE),cortex-m33)
   CPU_ARCH := armv8m
+  FEATURES_PROVIDED += cortexm_stack_limit
   #RUST_TARGET = thumbv8m.main-none-eabi
 else ifeq ($(CPU_CORE),cortex-m4)
   CPU_ARCH := armv7m

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -99,6 +99,11 @@ void reset_handler_default(void)
     uint32_t *dst;
     const uint32_t *src = &_etext;
 
+#ifdef __ARM_ARCH_8M_MAIN__
+    /* Set the lower limit of the exception stack into MSPLIM register */
+    __set_MSPLIM((uint32_t)&_sstack);
+#endif
+
     cortexm_init_fpu();
 
 #ifdef MODULE_PUF_SRAM

--- a/features.yaml
+++ b/features.yaml
@@ -79,6 +79,8 @@ groups:
       - name: cpu_check_address
         help: The @ref cpu_check_address can be used to check if
               accessing a given address would cause a bus fault.
+      - name: cortexm_stack_limit
+        help: ARM Cortex-M PSPLIM/MSPLIM registers are available.
       - name: cortexm_svc
         help: ARM Cortex-M Supervisor Calls are available.
       - name: cortexm_fpu

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -46,6 +46,7 @@ FEATURES_EXISTING := \
     can_rx_mailbox \
     cortexm_fpu \
     cortexm_mpu \
+    cortexm_stack_limit \
     cortexm_svc \
     cpp \
     cpu_arm7tdmi_gba \

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -78,6 +78,10 @@ ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += rtc_utils
 endif
 
+# select cortexm_stack_limit pseudomodule if the corresponding
+# feature is used
+USEMODULE += $(filter cortexm_stack_limit, $(FEATURES_USED))
+
 # select cortexm_svc pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cortexm_svc, $(FEATURES_USED))
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -35,6 +35,16 @@ PSEUDOMODULES += board_software_reset
 
 PSEUDOMODULES += arduino_pwm
 PSEUDOMODULES += arduino_serial_stdio
+## @defgroup pseudomodule_arm_stack_limit arm_stack_limit
+## @{
+## @brief Set MSP/PSP stack lower limit
+##
+## Use PSPLIM and MSPLIM ARM registers to set the lower limit of a stack
+## This is a protection mechanism to catch stack overflow early before it
+## can corrupt adjacent memory. Only available on ARMv8-M architecture.
+PSEUDOMODULES += cortexm_stack_limit
+## @}
+
 PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw

--- a/tests/cpu/cortexm_stack_limit/Makefile
+++ b/tests/cpu/cortexm_stack_limit/Makefile
@@ -1,0 +1,11 @@
+BOARD ?= nrf5340dk-app
+
+include ../Makefile.cpu_common
+
+FEATURES_REQUIRED += cortexm_stack_limit
+
+include $(RIOTBASE)/Makefile.include
+
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-infinite-recursion
+endif

--- a/tests/cpu/cortexm_stack_limit/main.c
+++ b/tests/cpu/cortexm_stack_limit/main.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief Test application for the cortexm_stack_limit pseudo-module
+ *
+ * @author Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "cpu.h"
+#include "thread.h"
+#include "board.h"
+
+#define CANARY_VALUE 0xdeadbeef
+
+static struct {
+    unsigned int canary;
+    char stack[THREAD_STACKSIZE_MAIN];
+} buf;
+
+/* Tell modern GCC (12.x) to not complain that this infinite recursion is
+ * bound to overflow the stack - this is exactly what this test wants to do :)
+ *
+ * Also, tell older versions of GCC that do not know about -Winfinit-recursion
+ * that it is safe to ignore `GCC diagnostics ignored "-Winfinit-recursion"`.
+ * They behave as intended in this case :)
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
+static int recurse(int counter)
+{
+    if (buf.canary != CANARY_VALUE) {
+#ifdef LED0_ON
+        LED0_ON;
+#endif
+#ifdef LED1_ON
+        LED1_ON;
+#endif
+#ifdef LED2_ON
+        LED2_ON;
+#endif
+#ifdef LED3_ON
+        LED3_ON;
+#endif
+
+        for (;;) {
+            thread_sleep();
+        }
+    }
+
+    counter++;
+    /* Recursing twice here prevents the compiler from optimizing-out the recursion. */
+    return recurse(counter) + recurse(counter);
+}
+#pragma GCC diagnostic pop
+
+static void *thread(void *arg)
+{
+    (void) arg;
+
+    recurse(0);
+
+    return NULL;
+}
+
+int main(void)
+{
+    puts("\nCortex-M Stack limit test\n");
+
+    puts("If the test fails, all onboard LEDs will be on");
+
+#ifdef MODULE_CORTEXM_STACK_LIMIT
+    puts("The cortexm_stack_limit module is present. Expect the board to crash"\
+         " without onboard LEDs on.\n");
+#else
+    puts("The cortexm_stack_limit module is missing! Expect the test to crash"\
+         " with all onboard LEDs on\n");
+#endif
+
+    buf.canary = CANARY_VALUE;
+    thread_create(buf.stack, sizeof(buf.stack), THREAD_PRIORITY_MAIN + 1,
+                  0, thread, NULL, "thread");
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description
ARMv8-M architecture introduces `PSPLIM` and `MSPLIM` as CPU registers to be used alongside with `PSP` and `MSP`.
The idea of these registers is to define the lower limit of a stack. If the stack pointer reaches this limit, a fault is generated before the adjacent memory of the stack can be corrupted.

This module is not enabled by default as it introduces a bit of overhead per context switch (We need to update `PSPLIM` every time we also change PSP).

I didn't add Cortex-M23 here on purpose. It seems to be a little be different because of
```
  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
  Stack Pointer Limit register hence zero is returned always in non-secure
  mode.
 ```


### Testing procedure
This PR also introduces a basic test application. I don't know if it's relevant enough to be merged.
I took inspiration from `tests/cpu/mpu_stack_guard` except that I remove all the `printf` as they eat too much stack.
Here, the stack overflows at some point, but a fault is generated before the canary word is modified.
If you remove the feature from the makefile, the stack will also overflows but the canary word will be modified, then all onboard LEDs will be switch on.
All of this can also be checked with GDB.

Regarding the overhead introduces in the context switching
Here are the result from `tests/bench/thread_yield_pingpong`
On current master:
```
2024-04-27 19:09:09,063 # main(): This is RIOT! (Version: 2024.07-devel-101-g89a74-pr/cpu/cortexm33/add_splim_support)
2024-04-27 19:09:09,065 # main starting
2024-04-27 19:09:10,068 # { "result" : 386706, "ticks" : 331 }
2024-04-27 19:09:10,074 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 268 }]}
```
With this PR and `FEATURES_REQUIRED+="cortexm_stack_limit"`:
```
2024-04-27 19:11:15,783 # main(): This is RIOT! (Version: 2024.07-devel-101-g89a74-pr/cpu/cortexm33/add_splim_support)
2024-04-27 19:11:15,784 # main starting
2024-04-27 19:11:16,787 # { "result" : 371014, "ticks" : 345 }
2024-04-27 19:11:16,793 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 268 }]}

```


### Issues/PRs references
None.