### PR TITLE
drivers/led: add LEDX_IS_PRESENT defines

### DIFF
--- a/drivers/include/led.h
+++ b/drivers/include/led.h
@@ -46,49 +46,66 @@ extern "C" {
 #define LED0_ON             /**< defined empty */
 #define LED0_OFF            /**< defined empty */
 #define LED0_TOGGLE         /**< defined empty */
+#else
+#define LED0_IS_PRESENT     /**< indicate that LED0 is present */
 #endif
 
 #ifndef LED1_ON
 #define LED1_ON             /**< defined empty */
 #define LED1_OFF            /**< defined empty */
 #define LED1_TOGGLE         /**< defined empty */
+#else
+#define LED1_IS_PRESENT     /**< indicate that LED1 is present */
 #endif
 
 #ifndef LED2_ON
 #define LED2_ON             /**< defined empty */
 #define LED2_OFF            /**< defined empty */
 #define LED2_TOGGLE         /**< defined empty */
+#else
+#define LED2_IS_PRESENT     /**< indicate that LED2 is present */
 #endif
 
 #ifndef LED3_ON
 #define LED3_ON             /**< defined empty */
 #define LED3_OFF            /**< defined empty */
 #define LED3_TOGGLE         /**< defined empty */
+#else
+#define LED3_IS_PRESENT     /**< indicate that LED3 is present */
 #endif
 
 #ifndef LED4_ON
 #define LED4_ON             /**< defined empty */
 #define LED4_OFF            /**< defined empty */
 #define LED4_TOGGLE         /**< defined empty */
+#else
+#define LED4_IS_PRESENT     /**< indicate that LED4 is present */
 #endif
 
 #ifndef LED5_ON
 #define LED5_ON             /**< defined empty */
 #define LED5_OFF            /**< defined empty */
 #define LED5_TOGGLE         /**< defined empty */
+#else
+#define LED5_IS_PRESENT     /**< indicate that LED5 is present */
 #endif
 
 #ifndef LED6_ON
 #define LED6_ON             /**< defined empty */
 #define LED6_OFF            /**< defined empty */
 #define LED6_TOGGLE         /**< defined empty */
+#else
+#define LED6_IS_PRESENT     /**< indicate that LED6 is present */
 #endif
 
 #ifndef LED7_ON
 #define LED7_ON             /**< defined empty */
 #define LED7_OFF            /**< defined empty */
 #define LED7_TOGGLE         /**< defined empty */
+#else
+#define LED7_IS_PRESENT     /**< indicate that LED7 is present */
 #endif
+
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Currently `LEDX_ON`, `LEDX_OFF`, etc. are defined in the `board.h` (or `board_common.h` or similar) files. However, various boards could have from 0 to 8 internal LEDs and to write portable code each call of `LEDX_...` should be protected by `#ifdef LEDX_...` . Including `led.h` header file resolve this issue and defines empty `LEDX_...` if LED is not present for given board. However, after including `led.h` there is no possibility to check if given board, really posses particular LED.

This PR adds `LEDX_IS_PRESENT` define for each presented LED at given board.

### Testing procedure

This code snippet:

```
#if defined LED0_IS_PRESENT
 printf("LED0_IS_PRESENT defined.\n");
#endif

#if defined LED1_IS_PRESENT
 printf("LED1_IS_PRESENT defined.\n");
#endif

#if defined LED2_IS_PRESENT
 printf("LED2_IS_PRESENT defined.\n");
#endif
```

Should show real number of first three LEDs, for example:

```
LED0_IS_PRESENT defined.
LED1_IS_PRESENT defined.
``` 
in native board.

### Issues/PRs references

None