### PR TITLE
makefiles/docker: prevent recursive docker invocation

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -278,6 +278,10 @@ DOCKER_VOLUMES_AND_ENV += -e 'CCACHE_BASEDIR=$(DOCKER_RIOTBASE)'
 
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,BUILD_DIR,,build)
 
+# Prevent recursive invocation of docker by explicitely disabling docker via env variable,
+# overwriting potential default in application Makefile
+DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,BUILD_IN_DOCKER,,0)
+
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,RIOTPROJECT,,riotproject)
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,RIOTCPU,,riotcpu)
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,RIOTBOARD,,riotboard)


### PR DESCRIPTION
### Contribution description

When `BUILD_IN_DOCKER ?= 1` is set as default in an application Makefile, the build system currently tries to invoke docker recursively from within docker.

This PR adds `BUILD_IN_DOCKER=0` as environment variable to the docker invocation to explicitly disable recursive docker.

Note that this approach still fails if the application Makefile contains an unconditional `BUILD_IN_DOCKER = 1`.

### Testing procedure

Apply the following patch and run `make -C examples/hello-world all`:

```diff
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9baf..a05360cfd5 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -7,6 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+BUILD_IN_DOCKER ?= 1
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
```

On `master`, this fails with a recursive invocation of docker
```sh
make: Entering directory '/home/mikolai/TUD/Code/RIOT/examples/hello-world'
Launching build container using image "docker.io/riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/mikolai/TUD/Code/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/mikolai/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/mikolai/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -v '/home/mikolai/.riot:/data/riotbuild/build:delegated' -e 'BUILD_DIR=/data/riotbuild/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'       -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/hello-world/' 'docker.io/riot/riotbuild:latest' make     all
/bin/sh: 1: docker: not found
Launching build container using image "docker.io/riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Etc/UTC:/etc/localtime:ro' -v '/data/riotbuild/riotbase:/data/riotbuild/riotbase:delegated' -v '/data/riotbuild/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/data/riotbuild/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -v '/data/riotbuild/build:/data/riotbuild/build:delegated' -e 'BUILD_DIR=/data/riotbuild/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'       -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/hello-world/' 'docker.io/riot/riotbuild:latest' make     all
/bin/sh: 1: docker: not found
make: *** [/data/riotbuild/riotbase/makefiles/docker.inc.mk:350: ..in-docker-container] Error 127
make: *** [/home/mikolai/TUD/Code/RIOT/makefiles/docker.inc.mk:350: ..in-docker-container] Error 2
make: Leaving directory '/home/mikolai/TUD/Code/RIOT/examples/hello-world'
```

With this change, it builds successfully.

### Issues/PRs references

Fixes #20636 
