### PR TITLE
drivers/periph_gpio_ll: change API to access GPIO ports

### DIFF
--- a/boards/alientek-pandora/include/board.h
+++ b/boards/alientek-pandora/include/board.h
@@ -32,12 +32,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        7
+#define LED0_PORT           GPIO_PORT_E /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_E
 
 #define LED1_PIN_NUM        8
+#define LED1_PORT           GPIO_PORT_E /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_E
 
 #define LED2_PIN_NUM        9
+#define LED2_PORT           GPIO_PORT_E /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_E
 
 /** @} */

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -55,15 +55,19 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        5
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        5
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 
 #define LED2_PIN_NUM        6
+#define LED2_PORT           GPIO_PORT_B /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_B
 
 #define LED3_PIN_NUM        7
+#define LED3_PORT           GPIO_PORT_B /**< GPIO port of LED 3 */
 #define LED3_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -32,9 +32,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        5
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        14
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/b-u585i-iot02a/include/board.h
+++ b/boards/b-u585i-iot02a/include/board.h
@@ -32,12 +32,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_E /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_E
 
 #define LED1_PIN_NUM        6
+#define LED1_PORT           GPIO_PORT_H /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_H
 
 #define LED2_PIN_NUM        7
+#define LED2_PORT           GPIO_PORT_H /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_H
 /** @} */
 

--- a/boards/blackpill-stm32f103c8/include/board.h
+++ b/boards/blackpill-stm32f103c8/include/board.h
@@ -35,6 +35,7 @@ extern "C" {
  * @name   Macros for controlling the on-board LED.
  * @{
  */
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B  /**< GPIO Port number the LED is connected to */
 #define LED0_PIN_NUM        12      /**< Pin number the LED is connected to */
 /** @} */

--- a/boards/blackpill-stm32f103cb/include/board.h
+++ b/boards/blackpill-stm32f103cb/include/board.h
@@ -35,6 +35,7 @@ extern "C" {
  * @name   Macros for controlling the on-board LED.
  * @{
  */
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B  /**< GPIO Port number the LED is connected to */
 #define LED0_PIN_NUM        (12)    /**< Pin number the LED is connected to */
 /** @} */

--- a/boards/bluepill-stm32f030c8/include/board.h
+++ b/boards/bluepill-stm32f030c8/include/board.h
@@ -40,6 +40,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_C
 #define LED0_IS_INVERTED    1
 /** @} */

--- a/boards/common/blxxxpill/include/board_common.h
+++ b/boards/common/blxxxpill/include/board_common.h
@@ -33,6 +33,7 @@ extern "C" {
  * @{
  */
 #ifndef LED0_PORT_NUM
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_C                                  /**< GPIO Port number the LED is connected to */
 #endif
 #ifndef LED0_PIN_NUM

--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -78,12 +78,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        2
+#define LED0_PORT           GPIO_PORT_D /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_D
 
 #define LED1_PIN_NUM        5
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 
 #define LED2_PIN_NUM        10
+#define LED2_PORT           GPIO_PORT_C /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_C
 /** @} */
 

--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -40,23 +40,29 @@ extern "C" {
 #if defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI) || \
     defined(CPU_MODEL_STM32L552ZE) || defined(CPU_MODEL_STM32U575ZI)
 #define LED0_PIN_NUM        7
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_C
 #else
 #define LED0_PIN_NUM        0
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 #endif
 
 #define LED1_PIN_NUM        7
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 
 #if defined(CPU_MODEL_STM32L552ZE)
 #define LED2_PIN_NUM        9
+#define LED2_PORT           GPIO_PORT_A /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_A
 #elif defined(CPU_MODEL_STM32U575ZI)
 #define LED2_PIN_NUM        2
+#define LED2_PORT           GPIO_PORT_G /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_G
 #else
 #define LED2_PIN_NUM        14
+#define LED2_PORT           GPIO_PORT_B /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_B
 #endif
 /** @} */

--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -34,6 +34,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        3
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -36,9 +36,11 @@ extern "C" {
  */
 #if defined(CPU_MODEL_STM32F302R8) || defined(CPU_MODEL_STM32L433RC)
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 #else
 #define LED0_PIN_NUM        5
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 #endif
 /** @} */

--- a/boards/common/stm32/include/stm32_leds.h
+++ b/boards/common/stm32/include/stm32_leds.h
@@ -16,16 +16,17 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  *
- * This idea is that STM32 boards only define the pin and port number of LEDs
- * and this header provides the rest of the defines
+ * The idea is that STM32 boards only define the pin number, port number and
+ * port of LEDs and this header provides the rest of the defines
  */
 
 #ifndef STM32_LEDS_H
 #define STM32_LEDS_H
 
-/* Using gpio_ll_arch for the gpio_port() function. This even works when
- * GPIO LL is not in used */
-#include "gpio_ll_arch.h"
+/* Using gpio_ll_arch for GPIO access. On STM32, accessing the GPIO output
+ * buffer via GPIO LL even works when the GPIO LL feature/module is not in
+ * use */
+#include "periph/gpio_ll.h"
 #include "kernel_defines.h"
 
 #ifdef __cplusplus
@@ -37,115 +38,107 @@ extern "C" {
  * @{
  */
 #if defined(LED0_PORT_NUM) && defined (LED0_PIN_NUM)
-#  define LED0_PORT           ((GPIO_TypeDef *)gpio_port(LED0_PORT_NUM))
-#  define LED0_PIN            GPIO_PIN(LED0_PORT_NUM, LED0_PIN_NUM)
-#  define LED0_MASK           (1 << LED0_PIN_NUM)
+#  define LED0_PIN              GPIO_PIN(LED0_PORT_NUM, LED0_PIN_NUM)
+#  define LED0_MASK             (1 << LED0_PIN_NUM)
 #  if IS_ACTIVE(LED0_IS_INVERTED)
-#    define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
-#    define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)
+#    define LED0_ON             gpio_ll_clear(LED0_PORT, LED0_MASK)
+#    define LED0_OFF            gpio_ll_set(LED0_PORT, LED0_MASK)
 #  else
-#    define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
-#    define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
+#    define LED0_ON             gpio_ll_set(LED0_PORT, LED0_MASK)
+#    define LED0_OFF            gpio_ll_clear(LED0_PORT, LED0_MASK)
 #  endif
-#  define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+#  define LED0_TOGGLE           gpio_ll_toggle(LED0_PORT, LED0_MASK)
 #endif
 
 #if defined(LED1_PORT_NUM) && defined (LED1_PIN_NUM)
-#  define LED1_PORT           ((GPIO_TypeDef *)gpio_port(LED1_PORT_NUM))
-#  define LED1_PIN            GPIO_PIN(LED1_PORT_NUM, LED1_PIN_NUM)
-#  define LED1_MASK           (1 << LED1_PIN_NUM)
+#  define LED1_PIN              GPIO_PIN(LED1_PORT_NUM, LED1_PIN_NUM)
+#  define LED1_MASK             (1 << LED1_PIN_NUM)
 #  if IS_ACTIVE(LED1_IS_INVERTED)
-#    define LED1_ON             (LED1_PORT->BSRR = (LED1_MASK << 16))
-#    define LED1_OFF            (LED1_PORT->BSRR = LED1_MASK)
+#    define LED1_ON             gpio_ll_clear(LED1_PORT, LED1_MASK)
+#    define LED1_OFF            gpio_ll_set(LED1_PORT, LED1_MASK)
 #  else
-#    define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
-#    define LED1_OFF            (LED1_PORT->BSRR = (LED1_MASK << 16))
+#    define LED1_ON             gpio_ll_set(LED1_PORT, LED1_MASK)
+#    define LED1_OFF            gpio_ll_clear(LED1_PORT, LED1_MASK)
 #  endif
-#  define LED1_TOGGLE         (LED1_PORT->ODR  ^= LED1_MASK)
+#  define LED1_TOGGLE           gpio_ll_toggle(LED1_PORT, LED1_MASK)
 #endif
 
 #if defined(LED2_PORT_NUM) && defined (LED2_PIN_NUM)
-#  define LED2_PORT           ((GPIO_TypeDef *)gpio_port(LED2_PORT_NUM))
-#  define LED2_PIN            GPIO_PIN(LED2_PORT_NUM, LED2_PIN_NUM)
-#  define LED2_MASK           (1 << LED2_PIN_NUM)
+#  define LED2_PIN              GPIO_PIN(LED2_PORT_NUM, LED2_PIN_NUM)
+#  define LED2_MASK             (1 << LED2_PIN_NUM)
 #  if IS_ACTIVE(LED2_IS_INVERTED)
-#    define LED2_ON             (LED2_PORT->BSRR = (LED2_MASK << 16))
-#    define LED2_OFF            (LED2_PORT->BSRR = LED2_MASK)
+#    define LED2_ON             gpio_ll_clear(LED2_PORT, LED2_MASK)
+#    define LED2_OFF            gpio_ll_set(LED2_PORT, LED2_MASK)
 #  else
-#    define LED2_ON             (LED2_PORT->BSRR = LED2_MASK)
-#    define LED2_OFF            (LED2_PORT->BSRR = (LED2_MASK << 16))
+#    define LED2_ON             gpio_ll_set(LED2_PORT, LED2_MASK)
+#    define LED2_OFF            gpio_ll_clear(LED2_PORT, LED2_MASK)
 #  endif
-#  define LED2_TOGGLE         (LED2_PORT->ODR  ^= LED2_MASK)
+#  define LED2_TOGGLE           gpio_ll_toggle(LED2_PORT, LED2_MASK)
 #endif
 
 #if defined(LED3_PORT_NUM) && defined (LED3_PIN_NUM)
-#  define LED3_PORT           ((GPIO_TypeDef *)gpio_port(LED3_PORT_NUM))
-#  define LED3_PIN            GPIO_PIN(LED3_PORT_NUM, LED3_PIN_NUM)
-#  define LED3_MASK           (1 << LED3_PIN_NUM)
+#  define LED3_PIN              GPIO_PIN(LED3_PORT_NUM, LED3_PIN_NUM)
+#  define LED3_MASK             (1 << LED3_PIN_NUM)
 #  if IS_ACTIVE(LED3_IS_INVERTED)
-#    define LED3_ON             (LED3_PORT->BSRR = (LED3_MASK << 16))
-#    define LED3_OFF            (LED3_PORT->BSRR = LED3_MASK)
+#    define LED3_ON             gpio_ll_clear(LED3_PORT, LED3_MASK)
+#    define LED3_OFF            gpio_ll_set(LED3_PORT, LED3_MASK)
 #  else
-#    define LED3_ON             (LED3_PORT->BSRR = LED3_MASK)
-#    define LED3_OFF            (LED3_PORT->BSRR = (LED3_MASK << 16))
+#    define LED3_ON             gpio_ll_set(LED3_PORT, LED3_MASK)
+#    define LED3_OFF            gpio_ll_clear(LED3_PORT, LED3_MASK)
 #  endif
-#  define LED3_TOGGLE         (LED3_PORT->ODR  ^= LED3_MASK)
+#  define LED3_TOGGLE           gpio_ll_toggle(LED3_PORT, LED3_MASK)
 #endif
 
 #if defined(LED4_PORT_NUM) && defined (LED4_PIN_NUM)
-#  define LED4_PORT           ((GPIO_TypeDef *)gpio_port(LED4_PORT_NUM))
-#  define LED4_PIN            GPIO_PIN(LED4_PORT_NUM, LED4_PIN_NUM)
-#  define LED4_MASK           (1 << LED4_PIN_NUM)
+#  define LED4_PIN              GPIO_PIN(LED4_PORT_NUM, LED4_PIN_NUM)
+#  define LED4_MASK             (1 << LED4_PIN_NUM)
 #  if IS_ACTIVE(LED4_IS_INVERTED)
-#    define LED4_ON             (LED4_PORT->BSRR = (LED4_MASK << 16))
-#    define LED4_OFF            (LED4_PORT->BSRR = LED4_MASK)
+#    define LED4_ON             gpio_ll_clear(LED4_PORT, LED4_MASK)
+#    define LED4_OFF            gpio_ll_set(LED4_PORT, LED4_MASK)
 #  else
-#    define LED4_ON             (LED4_PORT->BSRR = LED4_MASK)
-#    define LED4_OFF            (LED4_PORT->BSRR = (LED4_MASK << 16))
+#    define LED4_ON             gpio_ll_set(LED4_PORT, LED4_MASK)
+#    define LED4_OFF            gpio_ll_clear(LED4_PORT, LED4_MASK)
 #  endif
-#  define LED4_TOGGLE         (LED4_PORT->ODR  ^= LED4_MASK)
+#  define LED4_TOGGLE           gpio_ll_toggle(LED4_PORT, LED4_MASK)
 #endif
 
 #if defined(LED5_PORT_NUM) && defined (LED5_PIN_NUM)
-#  define LED5_PORT           ((GPIO_TypeDef *)gpio_port(LED5_PORT_NUM))
-#  define LED5_PIN            GPIO_PIN(LED5_PORT_NUM, LED5_PIN_NUM)
-#  define LED5_MASK           (1 << LED5_PIN_NUM)
+#  define LED5_PIN              GPIO_PIN(LED5_PORT_NUM, LED5_PIN_NUM)
+#  define LED5_MASK             (1 << LED5_PIN_NUM)
 #  if IS_ACTIVE(LED5_IS_INVERTED)
-#    define LED5_ON             (LED5_PORT->BSRR = (LED5_MASK << 16))
-#    define LED5_OFF            (LED5_PORT->BSRR = LED5_MASK)
+#    define LED5_ON             gpio_ll_clear(LED5_PORT, LED5_MASK)
+#    define LED5_OFF            gpio_ll_set(LED5_PORT, LED5_MASK)
 #  else
-#    define LED5_ON             (LED5_PORT->BSRR = LED5_MASK)
-#    define LED5_OFF            (LED5_PORT->BSRR = (LED5_MASK << 16))
+#    define LED5_ON             gpio_ll_set(LED5_PORT, LED5_MASK)
+#    define LED5_OFF            gpio_ll_clear(LED5_PORT, LED5_MASK)
 #  endif
-#  define LED5_TOGGLE         (LED5_PORT->ODR  ^= LED5_MASK)
+#  define LED5_TOGGLE           gpio_ll_toggle(LED5_PORT, LED5_MASK)
 #endif
 
 #if defined(LED6_PORT_NUM) && defined (LED6_PIN_NUM)
-#  define LED6_PORT           ((GPIO_TypeDef *)gpio_port(LED6_PORT_NUM))
-#  define LED6_PIN            GPIO_PIN(LED6_PORT_NUM, LED6_PIN_NUM)
-#  define LED6_MASK           (1 << LED6_PIN_NUM)
+#  define LED6_PIN              GPIO_PIN(LED6_PORT_NUM, LED6_PIN_NUM)
+#  define LED6_MASK             (1 << LED6_PIN_NUM)
 #  if IS_ACTIVE(LED6_IS_INVERTED)
-#    define LED6_ON             (LED6_PORT->BSRR = (LED6_MASK << 16))
-#    define LED6_OFF            (LED6_PORT->BSRR = LED6_MASK)
+#    define LED6_ON             gpio_ll_clear(LED6_PORT, LED6_MASK)
+#    define LED6_OFF            gpio_ll_set(LED6_PORT, LED6_MASK)
 #  else
-#    define LED6_ON             (LED6_PORT->BSRR = LED6_MASK)
-#    define LED6_OFF            (LED6_PORT->BSRR = (LED6_MASK << 16))
+#    define LED6_ON             gpio_ll_set(LED6_PORT, LED6_MASK)
+#    define LED6_OFF            gpio_ll_clear(LED6_PORT, LED6_MASK)
 #  endif
-#  define LED6_TOGGLE         (LED6_PORT->ODR  ^= LED6_MASK)
+#  define LED6_TOGGLE           gpio_ll_toggle(LED6_PORT, LED6_MASK)
 #endif
 
 #if defined(LED7_PORT_NUM) && defined (LED7_PIN_NUM)
-#  define LED7_PORT           ((GPIO_TypeDef *)gpio_port(LED7_PORT_NUM))
-#  define LED7_PIN            GPIO_PIN(LED7_PORT_NUM, LED7_PIN_NUM)
-#  define LED7_MASK           (1 << LED7_PIN_NUM)
+#  define LED7_PIN              GPIO_PIN(LED7_PORT_NUM, LED7_PIN_NUM)
+#  define LED7_MASK             (1 << LED7_PIN_NUM)
 #  if IS_ACTIVE(LED7_IS_INVERTED)
-#    define LED7_ON             (LED7_PORT->BSRR = (LED7_MASK << 16))
-#    define LED7_OFF            (LED7_PORT->BSRR = LED7_MASK)
+#    define LED7_ON             gpio_ll_clear(LED7_PORT, LED7_MASK)
+#    define LED7_OFF            gpio_ll_set(LED7_PORT, LED7_MASK)
 #  else
-#    define LED7_ON             (LED7_PORT->BSRR = LED7_MASK)
-#    define LED7_OFF            (LED7_PORT->BSRR = (LED7_MASK << 16))
+#    define LED7_ON             gpio_ll_set(LED7_PORT, LED7_MASK)
+#    define LED7_OFF            gpio_ll_clear(LED7_PORT, LED7_MASK)
 #  endif
-#  define LED7_TOGGLE         (LED7_PORT->ODR  ^= LED7_MASK)
+#  define LED7_TOGGLE           gpio_ll_toggle(LED7_PORT, LED7_MASK)
 #endif
 
 /** @} */

--- a/boards/common/stm32/include/stm32_leds.h
+++ b/boards/common/stm32/include/stm32_leds.h
@@ -23,7 +23,8 @@
 #ifndef STM32_LEDS_H
 #define STM32_LEDS_H
 
-/* GPIO_PORT() macro. This define even works when GPIO LL is not in used */
+/* Using gpio_ll_arch for the gpio_port() function. This even works when
+ * GPIO LL is not in used */
 #include "gpio_ll_arch.h"
 #include "kernel_defines.h"
 
@@ -36,7 +37,7 @@ extern "C" {
  * @{
  */
 #if defined(LED0_PORT_NUM) && defined (LED0_PIN_NUM)
-#  define LED0_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED0_PORT_NUM))
+#  define LED0_PORT           ((GPIO_TypeDef *)gpio_port(LED0_PORT_NUM))
 #  define LED0_PIN            GPIO_PIN(LED0_PORT_NUM, LED0_PIN_NUM)
 #  define LED0_MASK           (1 << LED0_PIN_NUM)
 #  if IS_ACTIVE(LED0_IS_INVERTED)
@@ -50,7 +51,7 @@ extern "C" {
 #endif
 
 #if defined(LED1_PORT_NUM) && defined (LED1_PIN_NUM)
-#  define LED1_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED1_PORT_NUM))
+#  define LED1_PORT           ((GPIO_TypeDef *)gpio_port(LED1_PORT_NUM))
 #  define LED1_PIN            GPIO_PIN(LED1_PORT_NUM, LED1_PIN_NUM)
 #  define LED1_MASK           (1 << LED1_PIN_NUM)
 #  if IS_ACTIVE(LED1_IS_INVERTED)
@@ -64,7 +65,7 @@ extern "C" {
 #endif
 
 #if defined(LED2_PORT_NUM) && defined (LED2_PIN_NUM)
-#  define LED2_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED2_PORT_NUM))
+#  define LED2_PORT           ((GPIO_TypeDef *)gpio_port(LED2_PORT_NUM))
 #  define LED2_PIN            GPIO_PIN(LED2_PORT_NUM, LED2_PIN_NUM)
 #  define LED2_MASK           (1 << LED2_PIN_NUM)
 #  if IS_ACTIVE(LED2_IS_INVERTED)
@@ -78,7 +79,7 @@ extern "C" {
 #endif
 
 #if defined(LED3_PORT_NUM) && defined (LED3_PIN_NUM)
-#  define LED3_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED3_PORT_NUM))
+#  define LED3_PORT           ((GPIO_TypeDef *)gpio_port(LED3_PORT_NUM))
 #  define LED3_PIN            GPIO_PIN(LED3_PORT_NUM, LED3_PIN_NUM)
 #  define LED3_MASK           (1 << LED3_PIN_NUM)
 #  if IS_ACTIVE(LED3_IS_INVERTED)
@@ -92,7 +93,7 @@ extern "C" {
 #endif
 
 #if defined(LED4_PORT_NUM) && defined (LED4_PIN_NUM)
-#  define LED4_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED4_PORT_NUM))
+#  define LED4_PORT           ((GPIO_TypeDef *)gpio_port(LED4_PORT_NUM))
 #  define LED4_PIN            GPIO_PIN(LED4_PORT_NUM, LED4_PIN_NUM)
 #  define LED4_MASK           (1 << LED4_PIN_NUM)
 #  if IS_ACTIVE(LED4_IS_INVERTED)
@@ -106,7 +107,7 @@ extern "C" {
 #endif
 
 #if defined(LED5_PORT_NUM) && defined (LED5_PIN_NUM)
-#  define LED5_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED5_PORT_NUM))
+#  define LED5_PORT           ((GPIO_TypeDef *)gpio_port(LED5_PORT_NUM))
 #  define LED5_PIN            GPIO_PIN(LED5_PORT_NUM, LED5_PIN_NUM)
 #  define LED5_MASK           (1 << LED5_PIN_NUM)
 #  if IS_ACTIVE(LED5_IS_INVERTED)
@@ -120,7 +121,7 @@ extern "C" {
 #endif
 
 #if defined(LED6_PORT_NUM) && defined (LED6_PIN_NUM)
-#  define LED6_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED6_PORT_NUM))
+#  define LED6_PORT           ((GPIO_TypeDef *)gpio_port(LED6_PORT_NUM))
 #  define LED6_PIN            GPIO_PIN(LED6_PORT_NUM, LED6_PIN_NUM)
 #  define LED6_MASK           (1 << LED6_PIN_NUM)
 #  if IS_ACTIVE(LED6_IS_INVERTED)
@@ -134,7 +135,7 @@ extern "C" {
 #endif
 
 #if defined(LED7_PORT_NUM) && defined (LED7_PIN_NUM)
-#  define LED7_PORT           ((GPIO_TypeDef *)GPIO_PORT(LED7_PORT_NUM))
+#  define LED7_PORT           ((GPIO_TypeDef *)gpio_port(LED7_PORT_NUM))
 #  define LED7_PIN            GPIO_PIN(LED7_PORT_NUM, LED7_PIN_NUM)
 #  define LED7_MASK           (1 << LED7_PIN_NUM)
 #  if IS_ACTIVE(LED7_IS_INVERTED)

--- a/boards/common/weact-f4x1cx/include/board.h
+++ b/boards/common/weact-f4x1cx/include/board.h
@@ -40,6 +40,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_C
 #define LED0_IS_INVERTED    1
 /** @} */

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -32,12 +32,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        1
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        3
+#define LED1_PORT           GPIO_PORT_A /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_A
 
 #define LED2_PIN_NUM        2
+#define LED2_PORT           GPIO_PORT_A /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_A
 /** @} */
 

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -33,6 +33,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        3
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_C
  /** @} */
 

--- a/boards/lobaro-lorabox/include/board.h
+++ b/boards/lobaro-lorabox/include/board.h
@@ -38,6 +38,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        1
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 #define LED0_IS_INVERTED    1
 

--- a/boards/lora-e5-dev/include/board.h
+++ b/boards/lora-e5-dev/include/board.h
@@ -46,6 +46,7 @@ extern void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mo
  * @name    LED pin definitions and handlers
  * @{
  */
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 #define LED0_PIN_NUM        5
 /** @} */

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -37,6 +37,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        1
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -49,12 +49,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        8       /**< Pin number of red LED */
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B  /**< Port number of red LED */
 
 #define LED1_PIN_NUM        14      /**< Pin number of yellow LED */
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B  /**< Port number of yellow LED */
 
 #define LED2_PIN_NUM        15      /**< Pin number of green LED */
+#define LED2_PORT           GPIO_PORT_B /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_B  /**< Port number of green LED */
 /** @} */
 

--- a/boards/nucleo-wl55jc/include/board.h
+++ b/boards/nucleo-wl55jc/include/board.h
@@ -49,12 +49,15 @@ extern void nucleo_wl55jc_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_
  * @{
  */
 #define LED0_PIN_NUM        15
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 
 #define LED1_PIN_NUM        9
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 
 #define LED2_PIN_NUM        11
+#define LED2_PORT           GPIO_PORT_B /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/nz32-sc151/include/board.h
+++ b/boards/nz32-sc151/include/board.h
@@ -33,6 +33,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        2
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
  /** @} */
 

--- a/boards/olimexino-stm32/include/board.h
+++ b/boards/olimexino-stm32/include/board.h
@@ -39,9 +39,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        1
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        5
+#define LED1_PORT           GPIO_PORT_A /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_A
 
 #define LED_PANIC           LED0_ON

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -37,6 +37,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        9
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/p-l496g-cell02/include/board.h
+++ b/boards/p-l496g-cell02/include/board.h
@@ -32,9 +32,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        5
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        13
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/p-nucleo-wb55/include/board.h
+++ b/boards/p-nucleo-wb55/include/board.h
@@ -30,12 +30,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        5
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 
 #define LED1_PIN_NUM        0
+#define LED1_PORT           GPIO_PORT_B /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_B
 
 #define LED2_PIN_NUM        1
+#define LED2_PORT           GPIO_PORT_B /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/pyboard/include/board.h
+++ b/boards/pyboard/include/board.h
@@ -34,6 +34,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        4
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -38,15 +38,19 @@
  * @{
  */
 #define LED0_PIN_NUM        9
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        10
+#define LED1_PORT           GPIO_PORT_A /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_A
 
 #define LED2_PIN_NUM        8
+#define LED2_PORT           GPIO_PORT_A /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_A
 
 #define LED3_PIN_NUM        13
+#define LED3_PORT           GPIO_PORT_A /**< GPIO port of LED 3 */
 #define LED3_PORT_NUM       PORT_A
 /** @} */
 

--- a/boards/stm32f030f4-demo/include/board.h
+++ b/boards/stm32f030f4-demo/include/board.h
@@ -40,6 +40,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        4
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 #define LED0_IS_INVERTED    1
 /** @} */

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -31,9 +31,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        9
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_C
 
 #define LED1_PIN_NUM        8
+#define LED1_PORT           GPIO_PORT_C /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_C
 /** @} */
 

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -31,27 +31,35 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        9
+#define LED0_PORT           GPIO_PORT_E /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_E
 
 #define LED1_PIN_NUM        8
+#define LED1_PORT           GPIO_PORT_E /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_E
 
 #define LED2_PIN_NUM        10
+#define LED2_PORT           GPIO_PORT_E /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_E
 
 #define LED3_PIN_NUM        15
+#define LED3_PORT           GPIO_PORT_E /**< GPIO port of LED 3 */
 #define LED3_PORT_NUM       PORT_E
 
 #define LED4_PIN_NUM        11
+#define LED4_PORT           GPIO_PORT_E /**< GPIO port of LED 4 */
 #define LED4_PORT_NUM       PORT_E
 
 #define LED5_PIN_NUM        14
+#define LED5_PORT           GPIO_PORT_E /**< GPIO port of LED 5 */
 #define LED5_PORT_NUM       PORT_E
 
 #define LED6_PIN_NUM        12
+#define LED6_PORT           GPIO_PORT_E /**< GPIO port of LED 6 */
 #define LED6_PORT_NUM       PORT_E
 
 #define LED7_PIN_NUM        13
+#define LED7_PORT           GPIO_PORT_E /**< GPIO port of LED 7 */
 #define LED7_PORT_NUM       PORT_E
 /** @} */
 

--- a/boards/stm32f429i-disc1/include/board.h
+++ b/boards/stm32f429i-disc1/include/board.h
@@ -31,9 +31,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_G /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_G
 
 #define LED1_PIN_NUM        14
+#define LED1_PORT           GPIO_PORT_G /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_G
 /** @} */
 

--- a/boards/stm32f469i-disco/include/board.h
+++ b/boards/stm32f469i-disco/include/board.h
@@ -30,21 +30,25 @@ extern "C"
  * @name Macros for controlling the on-board LEDs
  * @{
  */
-#define LED0_PIN_NUM    6
-#define LED0_PORT_NUM   PORT_G
-#define LED0_IS_INVERTED    1
+#define LED0_PIN_NUM        6               /**< pin number of LED 0*/
+#define LED0_PORT           GPIO_PORT_G     /**< GPIO port of LED 0 */
+#define LED0_PORT_NUM       PORT_G          /**< GPIO port number of LED 0 */
+#define LED0_IS_INVERTED    1               /**< LED 0 is active-low */
 
-#define LED1_PIN_NUM    4
-#define LED1_PORT_NUM   PORT_D
-#define LED1_IS_INVERTED    1
+#define LED1_PIN_NUM        4               /**< pin number of LED 1*/
+#define LED1_PORT           GPIO_PORT_D     /**< GPIO port of LED 1 */
+#define LED1_PORT_NUM       PORT_D          /**< GPIO port number of LED 0 */
+#define LED1_IS_INVERTED    1               /**< LED 1 is active-low */
 
-#define LED2_PIN_NUM    5
-#define LED2_PORT_NUM   PORT_D
-#define LED2_IS_INVERTED    1
+#define LED2_PIN_NUM        5               /**< pin number of LED 2*/
+#define LED2_PORT           GPIO_PORT_D     /**< GPIO port of LED 2 */
+#define LED2_PORT_NUM       PORT_D          /**< GPIO port number of LED 0 */
+#define LED2_IS_INVERTED    1               /**< LED 2 is active-low */
 
-#define LED3_PIN_NUM    3
-#define LED3_PORT_NUM   PORT_K
-#define LED3_IS_INVERTED    1
+#define LED3_PIN_NUM        3               /**< pin number of LED 3*/
+#define LED3_PORT           GPIO_PORT_K     /**< GPIO port of LED 3 */
+#define LED3_PORT_NUM       PORT_K          /**< GPIO port number of LED 0 */
+#define LED3_IS_INVERTED    1               /**< LED 3 is active-low */
 /** @} */
 
 /**

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -39,15 +39,19 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_D /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_D
 
 #define LED1_PIN_NUM        12
+#define LED1_PORT           GPIO_PORT_D /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_D
 
 #define LED2_PIN_NUM        14
+#define LED2_PORT           GPIO_PORT_D /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_D
 
 #define LED3_PIN_NUM        15
+#define LED3_PORT           GPIO_PORT_D /**< GPIO port of LED 3 */
 #define LED3_PORT_NUM       PORT_D
 /** @} */
 

--- a/boards/stm32f723e-disco/include/board.h
+++ b/boards/stm32f723e-disco/include/board.h
@@ -117,12 +117,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        5
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define LED1_PIN_NUM        7
+#define LED1_PORT           GPIO_PORT_A /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_A
 
 #define LED2_PIN_NUM        1
+#define LED2_PORT           GPIO_PORT_B /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_B
 /** @} */
 

--- a/boards/stm32f746g-disco/include/board.h
+++ b/boards/stm32f746g-disco/include/board.h
@@ -62,6 +62,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        1           /**< LD1 pin number */
+#define LED0_PORT           GPIO_PORT_I /**< GPIO port of LD1 */
 #define LED0_PORT_NUM       PORT_I      /**< LD1 port */
 /** @} */
 

--- a/boards/stm32f769i-disco/include/board.h
+++ b/boards/stm32f769i-disco/include/board.h
@@ -32,15 +32,19 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        13
+#define LED0_PORT           GPIO_PORT_J /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_J
 
 #define LED1_PIN_NUM        5
+#define LED1_PORT           GPIO_PORT_J /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_J
 
 #define LED2_PIN_NUM        12
+#define LED2_PORT           GPIO_PORT_A /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_A
 
 #define LED3_PIN_NUM        4
+#define LED3_PORT           GPIO_PORT_D /**< GPIO port of LED 3 */
 #define LED3_PORT_NUM       PORT_D
 /** @} */
 

--- a/boards/stm32g0316-disco/include/board.h
+++ b/boards/stm32g0316-disco/include/board.h
@@ -29,6 +29,7 @@ extern "C" {
 
 
 #define LED0_PIN_NUM        12
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)

--- a/boards/stm32l0538-disco/include/board.h
+++ b/boards/stm32l0538-disco/include/board.h
@@ -37,9 +37,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        4
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 
 #define LED1_PIN_NUM        5
+#define LED1_PORT           GPIO_PORT_A /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_A
 /** @} */
 

--- a/boards/stm32l476g-disco/include/board.h
+++ b/boards/stm32l476g-disco/include/board.h
@@ -33,9 +33,11 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        2
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_B
 
 #define LED1_PIN_NUM        8
+#define LED1_PORT           GPIO_PORT_E /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_E
 /** @} */
 

--- a/boards/stm32l496g-disco/include/board.h
+++ b/boards/stm32l496g-disco/include/board.h
@@ -148,12 +148,14 @@ extern "C" {
  * - LD3 green, active LOW (connected to PA5)
  * @{
  */
-#define LED0_PIN_NUM        13      /**< green LED (LD2) pin */
-#define LED0_PORT_NUM       PORT_B  /**< green LED (LD2) port */
+#define LED0_PIN_NUM        13          /**< green LED (LD2) pin */
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of green LED (LD2) */
+#define LED0_PORT_NUM       PORT_B      /**< green LED (LD2) port */
 
-#define LED1_PIN_NUM        5       /**< green LED (LD3) pin */
-#define LED1_PORT_NUM       PORT_A  /**< green LED (LD3) port */
-#define LED1_IS_INVERTED    1       /**< green LED (LD3) is LOW active */
+#define LED1_PIN_NUM        5           /**< green LED (LD3) pin */
+#define LED1_PORT           GPIO_PORT_A /**< GPIO port of green LED (LD3) */
+#define LED1_PORT_NUM       PORT_A      /**< green LED (LD3) port */
+#define LED1_IS_INVERTED    1           /**< green LED (LD3) is LOW active */
 /** @} */
 
 /**

--- a/boards/ublox-c030-u201/include/board.h
+++ b/boards/ublox-c030-u201/include/board.h
@@ -34,12 +34,15 @@ extern "C" {
  * @{
  */
 #define LED0_PIN_NUM        3
+#define LED0_PORT           GPIO_PORT_E /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_E
 
 #define LED1_PIN_NUM        4
+#define LED1_PORT           GPIO_PORT_E /**< GPIO port of LED 1 */
 #define LED1_PORT_NUM       PORT_E
 
 #define LED2_PIN_NUM        1
+#define LED2_PORT           GPIO_PORT_E /**< GPIO port of LED 2 */
 #define LED2_PORT_NUM       PORT_E
 /** @} */
 

--- a/boards/weact-g030f6/include/board.h
+++ b/boards/weact-g030f6/include/board.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #define LED0_PIN_NUM        4
+#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
 #define LED0_PORT_NUM       PORT_A
 
 #define BTN0_PIN            GPIO_PIN(PORT_A, 14)

--- a/cpu/atmega_common/include/gpio_ll_arch.h
+++ b/cpu/atmega_common/include/gpio_ll_arch.h
@@ -57,19 +57,85 @@ extern "C" {
  * whenever the port number is known at compile time.
  */
 
-#ifdef PORTH
-#define GPIO_PORT(num) \
-    ((num >= PORT_H) ? \
-     (ATMEGA_GPIO_BASE_H + ((num) - PORT_H) * ATMEGA_GPIO_SIZE) : \
-     (ATMEGA_GPIO_BASE_A + (num) * ATMEGA_GPIO_SIZE))
-#define GPIO_PORT_NUM(port) \
-    (((port) >= ATMEGA_GPIO_BASE_H) ? \
-     (((port) - ATMEGA_GPIO_BASE_H) / ATMEGA_GPIO_SIZE + PORT_H) : \
-     (((port) - ATMEGA_GPIO_BASE_A) / ATMEGA_GPIO_SIZE))
-#else
-#define GPIO_PORT(num) (ATMEGA_GPIO_BASE_A + (num) * ATMEGA_GPIO_SIZE)
-#define GPIO_PORT_NUM(port) (((port) - ATMEGA_GPIO_BASE_A) / ATMEGA_GPIO_SIZE)
+#define GPIO_PORT_NUMBERING_ALPHABETIC  1
+
+#ifdef PINA
+/* We sadly cannot use PINA, as PINA is technically (in terms of C spec lingo)
+ * not constant and would trigger:
+ *      initializer element is not constant
+ * Hence, the defines are a bit more involved to yield proper constants
+ * suitable for initializers.
+ */
+#  define GPIO_PORT_0   (ATMEGA_GPIO_BASE_A)
 #endif
+
+#ifdef PINB
+#  define GPIO_PORT_1   (ATMEGA_GPIO_BASE_A + 1 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PINC
+#  define GPIO_PORT_2   (ATMEGA_GPIO_BASE_A + 2 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PIND
+#  define GPIO_PORT_3   (ATMEGA_GPIO_BASE_A + 3 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PINE
+#  define GPIO_PORT_4   (ATMEGA_GPIO_BASE_A + 4 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PINF
+#  define GPIO_PORT_5   (ATMEGA_GPIO_BASE_A + 5 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PING
+#  define GPIO_PORT_6   (ATMEGA_GPIO_BASE_A + 6 * ATMEGA_GPIO_SIZE)
+#endif
+
+/* There is a larger gap between PING and PINH to allow other peripherals to
+ * also be mapped into the fast I/O memory area. */
+#ifdef PINH
+#  define GPIO_PORT_7   (ATMEGA_GPIO_BASE_H)
+#endif
+
+#ifdef PINI
+#  define GPIO_PORT_8   (ATMEGA_GPIO_BASE_H + 1 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PINJ
+#  define GPIO_PORT_9   (ATMEGA_GPIO_BASE_H + 2 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PINK
+#  define GPIO_PORT_10  (ATMEGA_GPIO_BASE_H + 3 * ATMEGA_GPIO_SIZE)
+#endif
+
+#ifdef PINL
+#  define GPIO_PORT_11  (ATMEGA_GPIO_BASE_H + 4 * ATMEGA_GPIO_SIZE)
+#endif
+
+static inline gpio_port_t gpio_port(uword_t num)
+{
+#ifdef PINH
+    if (num >= PORT_H) {
+        return ATMEGA_GPIO_BASE_H + ((num - PORT_H) * ATMEGA_GPIO_SIZE);
+    }
+#endif
+
+    return ATMEGA_GPIO_BASE_A + (num * ATMEGA_GPIO_SIZE);
+}
+
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+#ifdef PINH
+    if ((port) >= ATMEGA_GPIO_BASE_H) {
+        return (port - ATMEGA_GPIO_BASE_H) / ATMEGA_GPIO_SIZE + PORT_H;
+    }
+#endif
+
+     return (port - ATMEGA_GPIO_BASE_A) / ATMEGA_GPIO_SIZE;
+}
 
 static inline uword_t gpio_ll_read(gpio_port_t port)
 {
@@ -158,7 +224,7 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t value)
 
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
-    return GPIO_PORT(pin >> 4);
+    return gpio_port(pin >> 4);
 }
 
 static inline uint8_t gpio_get_pin_num(gpio_t pin)

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -73,16 +73,16 @@ typedef uint8_t gpio_t;
 #ifdef GPIO_PORT_DESCENDENT
 #ifdef      _AVR_ATTINY1634_H_INCLUDED
 /*          the only one that requires particular treatment! */
-#define     ATMEGA_GPIO_BASE_A  (0x2F)
+#define     ATMEGA_GPIO_BASE_A  0x2F
 #else
 /*          all other port descendent, including :
              - _AVR_IO8534_ (only have port A but with 0x1B address) ;
              - _AVR_IOAT94K_H_ (only have ports D and E) ;
              - _AVR_IOTN28_H_ (only have ports A and D). */
-#define     ATMEGA_GPIO_BASE_A  (0x39)
+#define     ATMEGA_GPIO_BASE_A  0x39
 #endif /*   _AVR_ATTINY1634_H_INCLUDED */
 #else /* !GPIO_PORT_DESCENDENT */
-#define     ATMEGA_GPIO_BASE_A  (0x20)
+#define     ATMEGA_GPIO_BASE_A  0x20
 #endif /* GPIO_PORT_DESCENDENT */
 /**
  * @brief   Base of the GPIO port G register as memory address

--- a/cpu/atmega_common/periph/gpio_ll_irq.c
+++ b/cpu/atmega_common/periph/gpio_ll_irq.c
@@ -62,7 +62,7 @@ static void clear_pending_irqs(uint8_t exti)
 
 void gpio_ll_irq_mask(gpio_port_t port, uint8_t pin)
 {
-    uint8_t exti = atmega_pin2exti(GPIO_PORT_NUM(port), pin);
+    uint8_t exti = atmega_pin2exti(gpio_port_num(port), pin);
 #if defined(EIMSK)
     EIMSK &= ~(1 << exti);
 #elif defined(GICR)
@@ -72,7 +72,7 @@ void gpio_ll_irq_mask(gpio_port_t port, uint8_t pin)
 
 void gpio_ll_irq_unmask(gpio_port_t port, uint8_t pin)
 {
-    uint8_t exti = atmega_pin2exti(GPIO_PORT_NUM(port), pin);
+    uint8_t exti = atmega_pin2exti(gpio_port_num(port), pin);
 #if defined(EIMSK)
     EIMSK |= 1 << exti;
 #elif defined(GICR)
@@ -82,7 +82,7 @@ void gpio_ll_irq_unmask(gpio_port_t port, uint8_t pin)
 
 void gpio_ll_irq_unmask_and_clear(gpio_port_t port, uint8_t pin)
 {
-    uint8_t exti = atmega_pin2exti(GPIO_PORT_NUM(port), pin);
+    uint8_t exti = atmega_pin2exti(gpio_port_num(port), pin);
     clear_pending_irqs(exti);
 #if defined(EIMSK)
     EIMSK |= 1 << exti;
@@ -118,7 +118,7 @@ static void set_trigger(uint8_t exti, gpio_irq_trig_t trig)
 int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig,
                 gpio_ll_cb_t cb, void *arg)
 {
-    int port_num = GPIO_PORT_NUM(port);
+    int port_num = gpio_port_num(port);
     assert((trig != GPIO_TRIGGER_LEVEL_HIGH) && cb);
     if (!atmega_has_pin_exti(port_num, pin)) {
         return -ENOTSUP;

--- a/cpu/efm32/include/gpio_ll_arch.h
+++ b/cpu/efm32/include/gpio_ll_arch.h
@@ -48,12 +48,63 @@ extern "C" {
 
 #ifndef DOXYGEN /* hide implementation specific details from Doxygen */
 
+#define GPIO_PORT_NUMBERING_ALPHABETIC  1
+
+/* Note: The pin count may be defined as zero to indicate the port not existing.
+ * Hence, don't to `#if defined(foo)` but only `#if foo`
+ */
+#if _GPIO_PORT_A_PIN_COUNT
+#  define GPIO_PORT_0   0
+#endif
+
+#if _GPIO_PORT_B_PIN_COUNT
+#  define GPIO_PORT_1   1
+#endif
+
+#if _GPIO_PORT_C_PIN_COUNT
+#  define GPIO_PORT_2   2
+#endif
+
+#if _GPIO_PORT_D_PIN_COUNT
+#  define GPIO_PORT_3   3
+#endif
+
+#if _GPIO_PORT_E_PIN_COUNT
+#  define GPIO_PORT_4   4
+#endif
+
+#if _GPIO_PORT_F_PIN_COUNT
+#  define GPIO_PORT_6   6
+#endif
+
+#if _GPIO_PORT_G_PIN_COUNT
+#  define GPIO_PORT_7   7
+#endif
+
+#if _GPIO_PORT_H_PIN_COUNT
+#  define GPIO_PORT_8   8
+#endif
+
+#if _GPIO_PORT_I_PIN_COUNT
+#  define GPIO_PORT_9   9
+#endif
+
+#if _GPIO_PORT_J_PIN_COUNT
+#  define GPIO_PORT_10  10
+#endif
+
+#if _GPIO_PORT_K_PIN_COUNT
+#  define GPIO_PORT_11  11
+#endif
+
 /* We could do
  *
-#define GPIO_PORT(num) (GPIO->P[num])
-#define GPIO_PORT_NUM(port) ((port - &GPIO->P))
+ * static inline gpio_port_t gpio_port(uword_t num)
+ * {
+ *     return GPIO->P[num];
+ * }
  *
- * which forks for some operations, but at latest when _ll_set needs to fan out
+ * which works for some operations, but at latest when _ll_set needs to fan out
  * for some EFM32 families to
  *
 #if defined(_GPIO_P_DOUTSET_MASK)
@@ -78,9 +129,15 @@ extern "C" {
  * an implementation for other EFM32 families. For the time being, the
  * suboptimal-but-works-for-all version is the best we have.
  */
+static inline gpio_port_t gpio_port(uword_t num)
+{
+    return num;
+}
 
-#define GPIO_PORT(num) (num)
-#define GPIO_PORT_NUM(port) (port)
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+    return port;
+}
 
 static inline uword_t gpio_ll_read(gpio_port_t port)
 {

--- a/cpu/esp32/include/gpio_ll_arch.h
+++ b/cpu/esp32/include/gpio_ll_arch.h
@@ -32,12 +32,19 @@ extern "C" {
 
 #ifndef DOXYGEN /* hide implementation specific details from Doxygen */
 
-#define GPIO_PORT(num)          (num)
-#if GPIO_PORT_NUMOF > 1
-#  define GPIO_PORT_NUM(port)   (port)
-#else
-#  define GPIO_PORT_NUM(port)   0
-#endif
+static inline gpio_port_t gpio_port(uword_t num)
+{
+    return num;
+}
+
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+    if (GPIO_PORT_NUMOF == 1) {
+        return 0;
+    }
+
+    return port;
+}
 
 static inline uword_t gpio_ll_read(gpio_port_t port)
 {
@@ -45,7 +52,7 @@ static inline uword_t gpio_ll_read(gpio_port_t port)
     volatile uword_t *in = (uint32_t *)GPIO_IN_REG;
     /* return 0 for unconfigured pins, the current level at the pin otherwise */
 #if GPIO_PORT_NUM > 1
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
         in = (uint32_t *)GPIO_IN1_REG;
     }
 #endif
@@ -58,7 +65,7 @@ static inline uword_t gpio_ll_read_output(gpio_port_t port)
     static_assert(GPIO_PORT_NUMOF < 3);
     volatile uword_t *out = (uint32_t *)GPIO_OUT_REG;
 #if GPIO_PORT_NUM > 1
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
         out = (uint32_t *)GPIO_OUT1_REG;
     }
 #endif
@@ -70,7 +77,7 @@ static inline void gpio_ll_set(gpio_port_t port, uword_t mask)
 {
     static_assert(GPIO_PORT_NUMOF < 3);
     volatile uword_t *out_w1ts = (uint32_t *)GPIO_OUT_W1TS_REG;
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
 #if GPIO_PORT_NUM > 1
         out_w1ts = (uint32_t)GPIO_OUT1_W1TS;
 #endif
@@ -83,7 +90,7 @@ static inline void gpio_ll_clear(gpio_port_t port, uword_t mask)
 {
     static_assert(GPIO_PORT_NUMOF < 3);
     volatile uword_t *out_w1tc = (uint32_t *)GPIO_OUT_W1TC_REG;
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
 #if GPIO_PORT_NUM > 1
         out_w1tc = (uint32_t)GPIO_OUT1_W1TC;
 #endif
@@ -97,7 +104,7 @@ static inline void gpio_ll_toggle(gpio_port_t port, uword_t mask)
     static_assert(GPIO_PORT_NUMOF < 3);
     volatile uword_t *out = (uint32_t *)GPIO_OUT_REG;
 #if GPIO_PORT_NUM > 1
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
         out = (uint32_t *)GPIO_OUT1_REG;
     }
 #endif
@@ -111,7 +118,7 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t value)
     static_assert(GPIO_PORT_NUMOF < 3);
     volatile uword_t *out = (uint32_t *)GPIO_OUT_REG;
 #if GPIO_PORT_NUM > 1
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
         out = (uint32_t *)GPIO_OUT1_REG;
     }
 #endif
@@ -120,7 +127,7 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t value)
 
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
-    return GPIO_PORT(pin >> 5);
+    return gpio_port(pin >> 5);
 }
 
 static inline uint8_t gpio_get_pin_num(gpio_t pin)

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -151,8 +151,8 @@ typedef enum {
 #if SOC_GPIO_PIN_COUNT > 32
 
 #define GPIO_PORT_NUMOF         2
-#define GPIO_PORT_0             GPIO_PORT(0)
-#define GPIO_PORT_1             GPIO_PORT(1)
+#define GPIO_PORT_0             0
+#define GPIO_PORT_1             1
 #define GPIO_PORT_0_PIN_NUMOF   (32)
 #define GPIO_PORT_1_PIN_NUMOF   (SOC_GPIO_PIN_COUNT - 32)
 #define GPIO_PORT_PIN_NUMOF(p)  ((p == GPIO_PORT_0) ? GPIO_PORT_0_PIN_NUMOF \
@@ -160,7 +160,7 @@ typedef enum {
 #else
 
 #define GPIO_PORT_NUMOF         1
-#define GPIO_PORT_0             GPIO_PORT(0)
+#define GPIO_PORT_0             0
 #define GPIO_PORT_0_PIN_NUMOF   (SOC_GPIO_PIN_COUNT)
 #define GPIO_PORT_PIN_NUMOF(p)  ((p == GPIO_PORT_0) ? GPIO_PORT_0_PIN_NUMOF : 0)
 

--- a/cpu/esp32/periph/gpio_ll.c
+++ b/cpu/esp32/periph/gpio_ll.c
@@ -60,7 +60,7 @@ int gpio_ll_init(gpio_port_t port, uint8_t pin, gpio_conf_t conf)
     assert(is_gpio_port_num_valid(port));
     assert(pin < GPIO_PORT_PIN_NUMOF(port));
 
-    gpio_t gpio = GPIO_PIN(GPIO_PORT_NUM(port), pin);
+    gpio_t gpio = GPIO_PIN(gpio_port_num(port), pin);
 
     gpio_config_t cfg = {
         .pin_bit_mask = (1ULL << gpio),
@@ -168,7 +168,7 @@ gpio_conf_t gpio_ll_query_conf(gpio_port_t port, uint8_t pin)
 
     unsigned state = irq_disable();
 
-    result = _gpio_conf[GPIO_PIN(GPIO_PORT_NUM(port), pin)];
+    result = _gpio_conf[GPIO_PIN(gpio_port_num(port), pin)];
     if (result.state == GPIO_INPUT) {
         result.initial_value = (gpio_ll_read(port) >> pin) & 1UL;
     }

--- a/cpu/esp32/periph/gpio_ll_irq.c
+++ b/cpu/esp32/periph/gpio_ll_irq.c
@@ -61,10 +61,10 @@ int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig,
 
     unsigned state = irq_disable();
 
-    gpio_t gpio = GPIO_PIN(GPIO_PORT_NUM(port), pin);
+    gpio_t gpio = GPIO_PIN(gpio_port_num(port), pin);
 
     DEBUG("%s gpio=%u port=%u pin=%u trig=%d cb=%p arg=%p\n",
-          __func__, gpio, GPIO_PORT_NUM(port), pin, trig, cb, arg);
+          __func__, gpio, (unsigned)gpio_port_num(port), pin, trig, cb, arg);
 
     /* install GPIO ISR of ESP-IDF if not yet done */
     if (!gpio_isr_service_installed &&
@@ -113,10 +113,10 @@ int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig,
 
 void gpio_ll_irq_mask(gpio_port_t port, uint8_t pin)
 {
-    gpio_t gpio = GPIO_PIN(GPIO_PORT_NUM(port), pin);
+    gpio_t gpio = GPIO_PIN(gpio_port_num(port), pin);
 
     DEBUG("%s gpio=%u port=%u pin=%u\n",
-          __func__, gpio, GPIO_PORT_NUM(port), pin);
+          __func__, gpio, (unsigned)gpio_port_num(port), pin);
 
     if (esp_idf_gpio_intr_disable(gpio) == ESP_OK) {
         gpio_int_enabled_table[gpio] = false;
@@ -125,7 +125,7 @@ void gpio_ll_irq_mask(gpio_port_t port, uint8_t pin)
 
 void gpio_ll_irq_unmask(gpio_port_t port, uint8_t pin)
 {
-    gpio_t gpio = GPIO_PIN(GPIO_PORT_NUM(port), pin);
+    gpio_t gpio = GPIO_PIN(gpio_port_num(port), pin);
 
     DEBUG("%s gpio=%u port=%u pin=%u\n",
           __func__, gpio, port, pin);
@@ -137,14 +137,14 @@ void gpio_ll_irq_unmask(gpio_port_t port, uint8_t pin)
 
 void gpio_ll_irq_unmask_and_clear(gpio_port_t port, uint8_t pin)
 {
-    gpio_t gpio = GPIO_PIN(GPIO_PORT_NUM(port), pin);
+    gpio_t gpio = GPIO_PIN(gpio_port_num(port), pin);
 
     DEBUG("%s gpio=%u port=%u pin=%u\n",
-          __func__, gpio, GPIO_PORT_NUM(port), pin);
+          __func__, gpio, (unsigned)gpio_port_num(port), pin);
 
     volatile uint32_t *status_w1tc = (uint32_t *)GPIO_STATUS_W1TC_REG;
 #if GPIO_PORT_NUMOF > 1
-    if (GPIO_PORT_NUM(port) != 0) {
+    if (gpio_port_num(port) != 0) {
         status_w1tc = (uint32_t *)GPIO_STATUS1_W1TC_REG;
     }
 #endif

--- a/cpu/gd32v/include/gpio_ll_arch.h
+++ b/cpu/gd32v/include/gpio_ll_arch.h
@@ -21,7 +21,6 @@
 #define GPIO_LL_ARCH_H
 
 #include "architecture.h"
-#include "periph/gpio_ll.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
@@ -35,15 +34,69 @@ extern "C" {
  */
 #define GPIO_PORT_NUMOF 5
 
-/**
- * @brief   Get a GPIO port by number
- */
-#define GPIO_PORT(num)      (GPIOA_BASE + ((num) << 10))
+#define GPIO_PORT_NUMBERING_ALPHABETIC  1
 
-/**
- * @brief   Get a GPIO port number by gpio_t value
- */
-#define GPIO_PORT_NUM(port) (((port) - GPIOA_BASE) >> 10)
+#ifdef GPIOA_BASE
+#  define GPIO_PORT_0       GPIOA_BASE
+#endif
+
+#ifdef GPIOB_BASE
+#  define GPIO_PORT_1       GPIOB_BASE
+#endif
+
+#ifdef GPIOC_BASE
+#  define GPIO_PORT_2       GPIOC_BASE
+#endif
+
+#ifdef GPIOD_BASE
+#  define GPIO_PORT_3       GPIOD_BASE
+#endif
+
+#ifdef GPIOE_BASE
+#  define GPIO_PORT_4       GPIOE_BASE
+#endif
+
+#ifdef GPIOF_BASE
+#  define GPIO_PORT_5       GPIOF_BASE
+#endif
+
+#ifdef GPIOG_BASE
+#  define GPIO_PORT_6       GPIOG_BASE
+#endif
+
+#ifdef GPIOH_BASE
+#  define GPIO_PORT_7       GPIOH_BASE
+#endif
+
+#ifdef GPIOI_BASE
+#  define GPIO_PORT_8       GPIOI_BASE
+#endif
+
+#ifdef GPIOJ_BASE
+#  define GPIO_PORT_9       GPIOJ_BASE
+#endif
+
+#ifdef GPIOK_BASE
+#  define GPIO_PORT_10      GPIOK_BASE
+#endif
+
+static inline gpio_port_t gpio_port(uword_t num)
+{
+#if defined(CPU_FAM_STM32MP1)
+    return GPIOA_BASE + (num << 12);
+#else
+    return GPIOA_BASE + (num << 10);
+#endif
+}
+
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+#if defined(CPU_FAM_STM32MP1)
+    return (port - GPIOA_BASE) >> 12;
+#else
+    return (port - GPIOA_BASE) >> 10;
+#endif
+}
 
 static inline uword_t gpio_ll_read(gpio_port_t port)
 {

--- a/cpu/gd32v/periph/gpio_ll.c
+++ b/cpu/gd32v/periph/gpio_ll.c
@@ -48,7 +48,7 @@ int gpio_ll_init(gpio_port_t port, uint8_t pin, gpio_conf_t conf)
 
     unsigned state = irq_disable();
 
-    periph_clk_en(APB2, (RCU_APB2EN_PAEN_Msk << GPIO_PORT_NUM(port)));
+    periph_clk_en(APB2, (RCU_APB2EN_PAEN_Msk << gpio_port_num(port)));
 
     volatile uint32_t *ctrl = (pin < 8) ? &((GPIO_Type *)port)->CTL0
                                         : &((GPIO_Type *)port)->CTL1;
@@ -60,13 +60,13 @@ int gpio_ll_init(gpio_port_t port, uint8_t pin, gpio_conf_t conf)
 
     switch (conf.state) {
     case GPIO_DISCONNECT:
-        pin_used[GPIO_PORT_NUM(port)] &= ~(1 << pin);
-        if (pin_used[GPIO_PORT_NUM(port)] == 0) {
-            periph_clk_dis(APB2, (RCU_APB2EN_PAEN_Msk << GPIO_PORT_NUM(port)));
+        pin_used[gpio_port_num(port)] &= ~(1 << pin);
+        if (pin_used[gpio_port_num(port)] == 0) {
+            periph_clk_dis(APB2, (RCU_APB2EN_PAEN_Msk << gpio_port_num(port)));
         }
         break;
     case GPIO_INPUT:
-        pin_used[GPIO_PORT_NUM(port)] |= 1 << pin;
+        pin_used[gpio_port_num(port)] |= 1 << pin;
         if (conf.pull == GPIO_FLOATING) {
             *ctrl |= 0x1 << (pos + 2);
         }
@@ -82,7 +82,7 @@ int gpio_ll_init(gpio_port_t port, uint8_t pin, gpio_conf_t conf)
         break;
     case GPIO_OUTPUT_PUSH_PULL:
     case GPIO_OUTPUT_OPEN_DRAIN:
-        pin_used[GPIO_PORT_NUM(port)] |= 1 << pin;
+        pin_used[gpio_port_num(port)] |= 1 << pin;
         *ctrl |= (conf.slew_rate + 1) << pos;
         *ctrl |= (conf.state == GPIO_OUTPUT_OPEN_DRAIN ? 0x1 : 0x0) << (pos + 2);
         if (conf.initial_value) {

--- a/cpu/gd32v/periph/gpio_ll_irq.c
+++ b/cpu/gd32v/periph/gpio_ll_irq.c
@@ -78,7 +78,7 @@ static void _gpio_isr(unsigned irqn);
 int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig, gpio_ll_cb_t cb, void *arg)
 {
     unsigned irq_state = irq_disable();
-    int port_num = GPIO_PORT_NUM(port);
+    int port_num = gpio_port_num(port);
 
     /* set callback */
     _exti_ctx[pin].cb = cb;
@@ -177,7 +177,7 @@ static void _gpio_isr(unsigned irqn)
         if ((_h_level_triggered & pin_mask) || (_l_level_triggered & pin_mask)) {
             /* determine the port of triggered interrupt */
             volatile uint32_t *afio_exti_ss = &AFIO->EXTISS0 + (pin >> 2);
-            gpio_port_t port = GPIO_PORT(((*afio_exti_ss >> ((pin & 0x03) * 4)) & 0xfUL));
+            gpio_port_t port = gpio_port(((*afio_exti_ss >> ((pin & 0x03) * 4)) & 0xfUL));
 
             /* trigger software interrupt if the pin has the according level */
             uint32_t level = gpio_ll_read(port) & pin_mask;

--- a/cpu/nrf5x_common/include/gpio_ll_arch.h
+++ b/cpu/nrf5x_common/include/gpio_ll_arch.h
@@ -51,15 +51,36 @@ extern "C" {
 #endif
 
 #if defined(CPU_FAM_NRF51)
-#define GPIO_PORT(num)      ((gpio_port_t)NRF_GPIO)
-#define GPIO_PORT_NUM(port) 0
-#elif defined(NRF_P1)
-#define GPIO_PORT(num)      ((num) ? (gpio_port_t)NRF_P1 : (gpio_port_t)NRF_P0)
-#define GPIO_PORT_NUM(port) ((port == (gpio_port_t)NRF_P1) ? 1 : 0)
+#  define GPIO_PORT_0       ((gpio_port_t)NRF_GPIO)
 #else
-#define GPIO_PORT(num)      ((gpio_port_t)NRF_P0)
-#define GPIO_PORT_NUM(port) 0
+#  if defined(NRF_P1)
+#    define GPIO_PORT_1     ((gpio_port_t)NRF_P1)
+#  endif
+#  define GPIO_PORT_0       ((gpio_port_t)NRF_P0)
 #endif
+
+static inline gpio_port_t gpio_port(uword_t num)
+{
+    (void)num;
+#ifdef GPIO_PORT_1
+    if (num == 1) {
+        return GPIO_PORT_1;
+    }
+#endif
+
+    return GPIO_PORT_0;
+}
+
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+    (void)port;
+#ifdef GPIO_PORT_1
+    if (port == GPIO_PORT_1) {
+        return 1;
+    }
+#endif
+    return 0;
+}
 
 static inline uword_t gpio_ll_read(gpio_port_t port)
 {
@@ -102,10 +123,10 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t value)
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
 #if defined(NRF_P1)
-    return GPIO_PORT(pin >> 5);
+    return gpio_port(pin >> 5);
 #else
     (void)pin;
-    return GPIO_PORT(0);
+    return GPIO_PORT_0;
 #endif
 }
 

--- a/cpu/nrf5x_common/periph/gpio_ll_irq.c
+++ b/cpu/nrf5x_common/periph/gpio_ll_irq.c
@@ -128,7 +128,7 @@ int gpio_ll_irq(gpio_port_t port, uint8_t pin,
 {
     /* param port is not used on nRF5x variants with only one GPIO port */
     (void)port;
-    uint8_t port_num = GPIO_PORT_NUM(port);
+    uint8_t port_num = gpio_port_num(port);
     uint8_t channel = get_channel_for_pin(port_num, pin);
     assert((trig != GPIO_TRIGGER_LEVEL_HIGH) && (trig != GPIO_TRIGGER_LEVEL_LOW));
 
@@ -167,7 +167,7 @@ void gpio_ll_irq_mask(gpio_port_t port, uint8_t pin)
 {
     /* param port is not used on nRF5x variants with only one GPIO port */
     (void)port;
-    uint8_t port_num = GPIO_PORT_NUM(port);
+    uint8_t port_num = gpio_port_num(port);
     unsigned channel = get_channel_of_pin(port_num, pin);
     assert(channel != GPIOTE_CHAN_NUMOF);
     if (channel != GPIOTE_CHAN_NUMOF) {
@@ -179,7 +179,7 @@ void gpio_ll_irq_unmask(gpio_port_t port, uint8_t pin)
 {
     /* param port is not used on nRF5x variants with only one GPIO port */
     (void)port;
-    uint8_t port_num = GPIO_PORT_NUM(port);
+    uint8_t port_num = gpio_port_num(port);
     unsigned channel = get_channel_of_pin(port_num, pin);
     assert(channel != GPIOTE_CHAN_NUMOF);
     if (channel != GPIOTE_CHAN_NUMOF) {
@@ -191,7 +191,7 @@ void gpio_ll_irq_unmask_and_clear(gpio_port_t port, uint8_t pin)
 {
     /* param port is not used on nRF5x variants with only one GPIO port */
     (void)port;
-    uint8_t port_num = GPIO_PORT_NUM(port);
+    uint8_t port_num = gpio_port_num(port);
     unsigned channel = get_channel_of_pin(port_num, pin);
     assert(channel != GPIOTE_CHAN_NUMOF);
     if (channel != GPIOTE_CHAN_NUMOF) {
@@ -204,7 +204,7 @@ void gpio_ll_irq_off(gpio_port_t port, uint8_t pin)
 {
     /* param port is not used on nRF5x variants with only one GPIO port */
     (void)port;
-    uint8_t port_num = GPIO_PORT_NUM(port);
+    uint8_t port_num = gpio_port_num(port);
     unsigned channel = get_channel_of_pin(port_num, pin);
     assert(channel != GPIOTE_CHAN_NUMOF);
     if (channel != GPIOTE_CHAN_NUMOF) {

--- a/cpu/sam0_common/include/gpio_ll_arch.h
+++ b/cpu/sam0_common/include/gpio_ll_arch.h
@@ -23,7 +23,6 @@
 #define GPIO_LL_ARCH_H
 
 #include "architecture.h"
-#include "periph/gpio_ll.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
@@ -48,6 +47,36 @@ extern "C" {
 #  define GPIO_IOBUS_BASE GPIO_APB_BASE /* no IOBUS present, fall back to APB */
 #endif
 
+#define GPIO_PORT_NUMBERING_ALPHABETIC  1
+
+#if PORT_GROUPS >= 1
+#  define GPIO_PORT_0   ((uintptr_t)&GPIO_IOBUS_BASE->Group[0])
+#endif
+#if PORT_GROUPS >= 2
+#  define GPIO_PORT_1   ((uintptr_t)&GPIO_IOBUS_BASE->Group[1])
+#endif
+#if PORT_GROUPS >= 3
+#  define GPIO_PORT_2   ((uintptr_t)&GPIO_IOBUS_BASE->Group[2])
+#endif
+#if PORT_GROUPS >= 4
+#  define GPIO_PORT_3   ((uintptr_t)&GPIO_IOBUS_BASE->Group[3])
+#endif
+#if PORT_GROUPS >= 5
+#  define GPIO_PORT_4   ((uintptr_t)&GPIO_IOBUS_BASE->Group[4])
+#endif
+#if PORT_GROUPS >= 5
+#  define GPIO_PORT_4   ((uintptr_t)&GPIO_IOBUS_BASE->Group[4])
+#endif
+#if PORT_GROUPS >= 6
+#  define GPIO_PORT_5   ((uintptr_t)&GPIO_IOBUS_BASE->Group[5])
+#endif
+#if PORT_GROUPS >= 7
+#  define GPIO_PORT_6   ((uintptr_t)&GPIO_IOBUS_BASE->Group[6])
+#endif
+#if PORT_GROUPS >= 8
+#  define GPIO_PORT_7   ((uintptr_t)&GPIO_IOBUS_BASE->Group[7])
+#endif
+
 /**
  * @brief   Get a GPIO port by number
  */
@@ -58,6 +87,16 @@ extern "C" {
  */
 #define GPIO_PORT_NUM(port) \
     (((port) - (uintptr_t)&GPIO_IOBUS_BASE->Group[0]) / sizeof(GPIO_IOBUS_BASE->Group[0]))
+
+static inline gpio_port_t gpio_port(uword_t num)
+{
+    return (uintptr_t)&GPIO_IOBUS_BASE->Group[num];
+}
+
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+    return (port - (uintptr_t)&GPIO_IOBUS_BASE->Group[0]) / sizeof(GPIO_IOBUS_BASE->Group[0]);
+}
 
 static inline PortGroup *sam0_gpio_iobus2ap(PortGroup *iobus)
 {

--- a/cpu/stm32/include/gpio_ll_arch.h
+++ b/cpu/stm32/include/gpio_ll_arch.h
@@ -23,7 +23,6 @@
 #define GPIO_LL_ARCH_H
 
 #include "architecture.h"
-#include "periph/gpio_ll.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
@@ -32,23 +31,69 @@ extern "C" {
 
 #ifndef DOXYGEN /* hide implementation specific details from Doxygen */
 
-/**
- * @brief   Get a GPIO port by number
- */
-#if defined(CPU_FAM_STM32MP1)
-#define GPIO_PORT(num)      (GPIOA_BASE + ((num) << 12))
-#else
-#define GPIO_PORT(num)      (GPIOA_BASE + ((num) << 10))
+#define GPIO_PORT_NUMBERING_ALPHABETIC  1
+
+#ifdef GPIOA_BASE
+#  define GPIO_PORT_0       GPIOA_BASE
 #endif
 
-/**
- * @brief   Get a GPIO port number by gpio_t value
- */
-#if defined(CPU_FAM_STM32MP1)
-#define GPIO_PORT_NUM(port) (((port) - GPIOA_BASE) >> 12)
-#else
-#define GPIO_PORT_NUM(port) (((port) - GPIOA_BASE) >> 10)
+#ifdef GPIOB_BASE
+#  define GPIO_PORT_1       GPIOB_BASE
 #endif
+
+#ifdef GPIOC_BASE
+#  define GPIO_PORT_2       GPIOC_BASE
+#endif
+
+#ifdef GPIOD_BASE
+#  define GPIO_PORT_3       GPIOD_BASE
+#endif
+
+#ifdef GPIOE_BASE
+#  define GPIO_PORT_4       GPIOE_BASE
+#endif
+
+#ifdef GPIOF_BASE
+#  define GPIO_PORT_5       GPIOF_BASE
+#endif
+
+#ifdef GPIOG_BASE
+#  define GPIO_PORT_6       GPIOG_BASE
+#endif
+
+#ifdef GPIOH_BASE
+#  define GPIO_PORT_7       GPIOH_BASE
+#endif
+
+#ifdef GPIOI_BASE
+#  define GPIO_PORT_8       GPIOI_BASE
+#endif
+
+#ifdef GPIOJ_BASE
+#  define GPIO_PORT_9       GPIOJ_BASE
+#endif
+
+#ifdef GPIOK_BASE
+#  define GPIO_PORT_10      GPIOK_BASE
+#endif
+
+static inline gpio_port_t gpio_port(uword_t num)
+{
+#if defined(CPU_FAM_STM32MP1)
+    return GPIOA_BASE + (num << 12);
+#else
+    return GPIOA_BASE + (num << 10);
+#endif
+}
+
+static inline uword_t gpio_port_num(gpio_port_t port)
+{
+#if defined(CPU_FAM_STM32MP1)
+    return (port - GPIOA_BASE) >> 12;
+#else
+    return (port - GPIOA_BASE) >> 10;
+#endif
+}
 
 static inline uword_t gpio_ll_read(gpio_port_t port)
 {

--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -108,14 +108,14 @@ static ztimer_t _link_status_timer;
 #  endif
 #endif
 
-#ifndef STM32_ETH_TRACING_TX_PORT_NUM
-#  if defined(LED1_PORT_NUM) || defined(DOXYGEN)
+#ifndef STM32_ETH_TRACING_TX_PORT
+#  if defined(LED1_PORT) || defined(DOXYGEN)
 /**
  * @brief   port to trace TX events
  */
-#    define STM32_ETH_TRACING_TX_PORT_NUM LED1_PORT_NUM
+#    define STM32_ETH_TRACING_TX_PORT   LED1_PORT
 #  else
-#    define STM32_ETH_TRACING_TX_PORT_NUM 0
+#    define STM32_ETH_TRACING_TX_PORT   GPIO_PORT_0
 #  endif
 #endif
 
@@ -130,14 +130,14 @@ static ztimer_t _link_status_timer;
 #  endif
 #endif
 
-#ifndef STM32_ETH_TRACING_RX_PORT_NUM
-#  if defined(LED2_PORT_NUM) || defined(DOXYGEN)
+#ifndef STM32_ETH_TRACING_RX_PORT
+#  if defined(LED2_PORT) || defined(DOXYGEN)
 /**
  * @brief   port to trace RX events
  */
-#    define STM32_ETH_TRACING_RX_PORT_NUM LED2_PORT_NUM
+#    define STM32_ETH_TRACING_RX_PORT   LED2_PORT
 #  else
-#    define STM32_ETH_TRACING_RX_PORT_NUM 0
+#    define STM32_ETH_TRACING_RX_PORT   GPIO_PORT_0
 #  endif
 #endif
 /** @} */
@@ -480,10 +480,10 @@ static int stm32_eth_init(netdev_t *netdev)
 {
     (void)netdev;
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_init(GPIO_PORT(STM32_ETH_TRACING_TX_PORT_NUM),
+        gpio_ll_init(STM32_ETH_TRACING_TX_PORT,
                      STM32_ETH_TRACING_TX_PIN_NUM,
                      gpio_ll_out);
-        gpio_ll_init(GPIO_PORT(STM32_ETH_TRACING_RX_PORT_NUM),
+        gpio_ll_init(STM32_ETH_TRACING_RX_PORT,
                      STM32_ETH_TRACING_RX_PIN_NUM,
                      gpio_ll_out);
     }
@@ -578,7 +578,7 @@ static int stm32_eth_send(netdev_t *netdev, const struct iolist *iolist)
     }
 
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_set(GPIO_PORT(STM32_ETH_TRACING_TX_PORT_NUM),
+        gpio_ll_set(STM32_ETH_TRACING_TX_PORT,
                     (1U << STM32_ETH_TRACING_TX_PIN_NUM));
     }
     /* start TX */
@@ -595,7 +595,7 @@ static int stm32_eth_confirm_send(netdev_t *netdev, void *info)
     (void)info;
     (void)netdev;
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_clear(GPIO_PORT(STM32_ETH_TRACING_TX_PORT_NUM),
+        gpio_ll_clear(STM32_ETH_TRACING_TX_PORT,
                       (1U << STM32_ETH_TRACING_TX_PIN_NUM));
     }
     DEBUG("[stm32_eth] TX completed\n");
@@ -768,7 +768,7 @@ static int stm32_eth_recv(netdev_t *netdev, void *_buf, size_t max_len,
     }
 
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_clear(GPIO_PORT(STM32_ETH_TRACING_RX_PORT_NUM),
+        gpio_ll_clear(STM32_ETH_TRACING_RX_PORT,
                       (1U << STM32_ETH_TRACING_RX_PIN_NUM));
     }
 
@@ -806,7 +806,7 @@ static void stm32_eth_isr(netdev_t *netdev)
     }
 
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_set(GPIO_PORT(STM32_ETH_TRACING_RX_PORT_NUM),
+        gpio_ll_set(STM32_ETH_TRACING_RX_PORT,
                     (1U << STM32_ETH_TRACING_RX_PIN_NUM));
     }
     netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -52,14 +52,14 @@
 #  endif
 #endif
 
-#ifndef STM32_ETH_TRACING_IRQ_PORT_NUM
+#ifndef STM32_ETH_TRACING_IRQ_PORT
 #  if defined(LED0_PORT_NUM) || defined(DOXYGEN)
 /**
  * @brief   port to trace IRQs
  */
-#    define STM32_ETH_TRACING_IRQ_PORT_NUM LED0_PORT_NUM
+#    define STM32_ETH_TRACING_IRQ_PORT  LED0_PORT
 #  else
-#    define STM32_ETH_TRACING_IRQ_PORT_NUM 0
+#    define STM32_ETH_TRACING_IRQ_PORT  GPIO_PORT_0
 #  endif
 #endif
 /** @} */
@@ -93,7 +93,7 @@ void stm32_eth_common_init(void)
     while (ETH->DMABMR & ETH_DMABMR_SR) {}
 
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_init(GPIO_PORT(STM32_ETH_TRACING_IRQ_PORT_NUM),
+        gpio_ll_init(STM32_ETH_TRACING_IRQ_PORT,
                      STM32_ETH_TRACING_IRQ_PIN_NUM,
                      gpio_ll_out);
     }
@@ -108,7 +108,7 @@ void isr_eth(void)
 {
     DEBUG("[periph_eth_common] isr_eth()\n");
     if (IS_USED(MODULE_STM32_ETH_TRACING)) {
-        gpio_ll_toggle(GPIO_PORT(STM32_ETH_TRACING_IRQ_PORT_NUM),
+        gpio_ll_toggle(STM32_ETH_TRACING_IRQ_PORT,
                        (1U << STM32_ETH_TRACING_IRQ_PIN_NUM));
     }
 

--- a/cpu/stm32/periph/gpio_ll.c
+++ b/cpu/stm32/periph/gpio_ll.c
@@ -95,7 +95,7 @@ static inline void print_str(const char *str)
 
 static void _init_clock(gpio_port_t port)
 {
-    periph_clk_en(GPIO_BUS, (GPIOAEN << GPIO_PORT_NUM(port)));
+    periph_clk_en(GPIO_BUS, (GPIOAEN << gpio_port_num(port)));
 #ifdef PORTG_REQUIRES_EXTERNAL_POWER
     if (port == (uintptr_t)GPIOG) {
         /* Port G requires external power supply */

--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -207,7 +207,7 @@ static uint8_t get_exti_port(uint8_t exti_num)
 int gpio_ll_irq(gpio_port_t port, uint8_t pin, gpio_irq_trig_t trig, gpio_ll_cb_t cb, void *arg)
 {
     unsigned irq_state = irq_disable();
-    int port_num = GPIO_PORT_NUM(port);
+    int port_num = gpio_port_num(port);
 
     /* set callback */
     isr_ctx[pin].cb = cb;
@@ -297,7 +297,7 @@ void isr_exti(void)
         if (level_triggered & (1UL << pin)) {
             /* Trading a couple of CPU cycles to not having to store port connected to EXTI in RAM.
              * A simple look up table would save ~6 instructions for the cost 64 bytes of RAM. */
-            gpio_port_t port = GPIO_PORT(get_exti_port(pin));
+            gpio_port_t port = gpio_port(get_exti_port(pin));
             uint32_t actual_level = gpio_ll_read(port) & (1UL << pin);
             uint32_t trigger_level = EXTI_REG_RTSR & (1UL << pin);
             if (actual_level == trigger_level) {

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -93,38 +93,63 @@ typedef uintptr_t gpio_port_t;
 #define GPIO_PORT_UNDEF         UINTPTR_MAX
 #endif
 
-#ifdef DOXYGEN
+#if defined(DOXYGEN)
 /**
- * @brief   Get the @ref gpio_port_t value of the port identified by @p num
+ * @brief   Indicates whether GPIO ports are enumerated alphabetically (`1`)
+ *          or numerically (`0`).
  *
- * @note    If @p num is a compile time constant, this is guaranteed to be
- *          suitable for a constant initializer.
- *
- * Typically this will be something like `(GPIO_BASE_ADDR + num * sizeof(struct
- * vendor_gpio_reg))`
+ * @note    You can use both @ref GPIO_PORT_A and @ref GPIO_PORT_0 to refer
+ *          to the first GPIO port in RIOT, regardless of the naming scheme
+ *          used by the MCU the app is compiled for. This macro is useful
+ *          e.g. for pretty-printing.
  */
-#define GPIO_PORT(num)  implementation_specific
+#  define GPIO_PORT_NUMBERING_ALPHABETIC    implementation_specific
 #endif
+
 
 #ifdef DOXYGEN
 /**
- * @brief   Get the number of the GPIO port belonging to the given @ref
- *          gpio_port_t value
+ * @brief   Get the @ref gpio_port_t value of the port labeled 0.
  *
- * @note    If @p port is a compile time constant, this is guaranteed to be
- *          suitable for a constant initializer.
- *
- * @pre     @p port is the return value of @ref GPIO_PORT
- *
- * For every supported port number *n* the following `assert()` must not blow
- * up:
- *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
- * assert(n == GPIO_PORT_NUM(GPIO_PORT(n)));
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * @note    For MCUs that use letters instead of numbers, this will be an alias
+ *          for @ref GPIO_PORT_A
+ * @note    Some MCUs will not start with Port 0 / Port A, but rather with
+ *          Port 1 (e.g. MSP430) or Port B (e.g. ATmega328P). It will be
+ *          undefined when unavailable
+ * @note    There will also be `GPIO_PORT_1`, `GPIO_PORT_2`, etc. when there
+ *          are corresponding GPIO ports in hardware.
  */
-#define GPIO_PORT_NUM(port) implementation_specific
-#endif
+#define GPIO_PORT_0     implementation_specific
+
+/**
+ * @brief       Get the @ref gpio_port_t value of the port number @p num
+ * @param[in]   num     The number of the port to get
+ * @pre         @p num is a valid GPIO port number. An implementation may
+ *              follow the "garbage in, garbage out" philosophy.
+ *
+ * @note        If the MCU uses an alphabetic naming scheme, number 0 refers
+ *              to port A.
+ * @warning     This may involve accessing a lookup table, prefer e.g. using
+ *              `GPIO_PORT_0` over `gpio_port(0)` if the port number is known
+ *              at compile time.
+ */
+gpio_port_t gpio_port(uword_t num);
+
+/**
+ * @brief       Get the number of the GPIO port @p port refers to
+ * @param[in]   port    The port to get the number of
+ *
+ * @pre         @p port is a valid GPIO port. An implementation may follow the
+ *              "garbage in, garbage out" philosophy.
+ * @warning     This may involve iterating over a lookup table, prefer using
+ *              e.g. `0` instead of `gpio_port_num(GPIO_PORT_0)` if the port
+ *              number is known at compile time.
+ *
+ * In other words `n == gpio_port_num(gpio_port(n))` for every `n` that is
+ * a valid port number.
+ */
+uword_t gpio_port_num(gpio_port_t port);
+#endif /* DOXYGEN */
 
 #if !defined(HAVE_GPIO_STATE_T) || defined(DOXYGEN)
 /**
@@ -490,7 +515,7 @@ static const gpio_conf_t gpio_ll_od_pu = {
 #endif
 
 /**
- * @brief   Check if the given number is a valid argument for @ref GPIO_PORT
+ * @brief   Check if the given number is a valid argument for @ref gpio_port
  *
  * @param[in]       num     port number to check
  * @retval          true    the MCU used has a GPIO port with that number
@@ -867,6 +892,112 @@ static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
 /* the hardware specific implementation relies on the types such as gpio_port_t
  * to be provided */
 #include "gpio_ll_arch.h" /* IWYU pragma: export */
+
+#if !defined(DOXYGEN) && !defined(GPIO_PORT_NUMBERING_ALPHABETIC)
+#  define GPIO_PORT_NUMBERING_ALPHABETIC    0
+#endif
+
+/**
+ * @name    GPIO port aliases for alphabetic enumeration
+ * @{
+ */
+#if defined(GPIO_PORT_0) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_0`
+ */
+#  define GPIO_PORT_A   GPIO_PORT_0
+#endif
+#if defined(GPIO_PORT_1) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_1`
+ */
+#  define GPIO_PORT_B   GPIO_PORT_1
+#endif
+#if defined(GPIO_PORT_2) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_2`
+ */
+#  define GPIO_PORT_C   GPIO_PORT_2
+#endif
+#if defined(GPIO_PORT_3) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_3`
+ */
+#  define GPIO_PORT_D   GPIO_PORT_3
+#endif
+#if defined(GPIO_PORT_4) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_4`
+ */
+#  define GPIO_PORT_E   GPIO_PORT_4
+#endif
+#if defined(GPIO_PORT_5) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_5`
+ */
+#  define GPIO_PORT_F   GPIO_PORT_5
+#endif
+#if defined(GPIO_PORT_6) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_6`
+ */
+#  define GPIO_PORT_G   GPIO_PORT_6
+#endif
+#if defined(GPIO_PORT_7) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_7`
+ */
+#  define GPIO_PORT_H   GPIO_PORT_7
+#endif
+#if defined(GPIO_PORT_8) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_8`
+ */
+#  define GPIO_PORT_I   GPIO_PORT_8
+#endif
+#if defined(GPIO_PORT_9) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_9`
+ */
+#  define GPIO_PORT_J   GPIO_PORT_9
+#endif
+#if defined(GPIO_PORT_10) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_10`
+ */
+#  define GPIO_PORT_K   GPIO_PORT_10
+#endif
+#if defined(GPIO_PORT_11) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_11`
+ */
+#  define GPIO_PORT_L   GPIO_PORT_11
+#endif
+#if defined(GPIO_PORT_12) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_12`
+ */
+#  define GPIO_PORT_M   GPIO_PORT_12
+#endif
+#if defined(GPIO_PORT_13) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_13`
+ */
+#  define GPIO_PORT_N   GPIO_PORT_13
+#endif
+#if defined(GPIO_PORT_14) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_14`
+ */
+#  define GPIO_PORT_O   GPIO_PORT_14
+#endif
+#if defined(GPIO_PORT_15) || defined(DOXYGEN)
+/**
+ * @brief   Alias of `ref GPIO_PORT_15`
+ */
+#  define GPIO_PORT_P   GPIO_PORT_15
+#endif
+/** @} */
 
 #endif /* PERIPH_GPIO_LL_H */
 /** @} */

--- a/tests/bench/periph_gpio_ll/Makefile
+++ b/tests/bench/periph_gpio_ll/Makefile
@@ -9,7 +9,7 @@ BOARD ?= nucleo-f767zi
 #
 # Beware: If other pins on the output port are configured as output GPIOs, they
 #         might be written to during this test.
-PORT_OUT ?= 0
+#PORT_OUT := 0
 PIN_OUT_0 ?= 0
 PIN_OUT_1 ?= 1
 
@@ -36,7 +36,10 @@ endif
 
 COMPENSATE_OVERHEAD ?= 1
 
-CFLAGS += -DPORT_OUT=$(PORT_OUT)
+ifneq (,$(PORT_OUT))
+  CFLAGS += -DPORT_OUT=GPIO_PORT_$(PORT_OUT)
+  CFLAGS += -DPORT_OUT_NUM=$(PORT_OUT)
+endif
 CFLAGS += -DPIN_OUT_0=$(PIN_OUT_0)
 CFLAGS += -DPIN_OUT_1=$(PIN_OUT_1)
 CFLAGS += -DCOMPENSATE_OVERHEAD=$(COMPENSATE_OVERHEAD)

--- a/tests/bench/periph_gpio_ll/main.c
+++ b/tests/bench/periph_gpio_ll/main.c
@@ -30,7 +30,20 @@
 #define COMPENSATE_OVERHEAD 1
 #endif
 
-static gpio_port_t port_out = GPIO_PORT(PORT_OUT);
+#ifndef PORT_OUT
+#  if defined(GPIO_PORT_0)
+#    define PORT_OUT        GPIO_PORT_0
+#    define PORT_OUT_NUM    0
+#  elif defined(GPIO_PORT_1)
+#    define PORT_OUT        GPIO_PORT_1
+#    define PORT_OUT_NUM    1
+#  elif defined(GPIO_PORT_2)
+#    define PORT_OUT        GPIO_PORT_2
+#    define PORT_OUT_NUM    2
+#  endif
+#endif
+
+static gpio_port_t port_out = PORT_OUT;
 
 static void print_summary_compensated(uint_fast16_t loops, uint32_t duration,
                                       uint32_t duration_uncompensated)
@@ -124,8 +137,8 @@ int main(void)
         puts("\n"
              "periph/gpio: Using 2x gpio_set() and 2x gpio_clear()\n"
              "---------------------------------------------------");
-        gpio_t p0 = GPIO_PIN(PORT_OUT, PIN_OUT_0);
-        gpio_t p1 = GPIO_PIN(PORT_OUT, PIN_OUT_1);
+        gpio_t p0 = GPIO_PIN(PORT_OUT_NUM, PIN_OUT_0);
+        gpio_t p1 = GPIO_PIN(PORT_OUT_NUM, PIN_OUT_1);
         gpio_init(p0, GPIO_OUT);
         gpio_init(p1, GPIO_OUT);
 
@@ -177,8 +190,8 @@ int main(void)
         puts("\n"
              "periph/gpio: Using 4x gpio_toggle()\n"
              "-----------------------------------");
-        gpio_t p0 = GPIO_PIN(PORT_OUT, PIN_OUT_0);
-        gpio_t p1 = GPIO_PIN(PORT_OUT, PIN_OUT_1);
+        gpio_t p0 = GPIO_PIN(PORT_OUT_NUM, PIN_OUT_0);
+        gpio_t p1 = GPIO_PIN(PORT_OUT_NUM, PIN_OUT_1);
         gpio_init(p0, GPIO_OUT);
         gpio_init(p1, GPIO_OUT);
 
@@ -230,8 +243,8 @@ int main(void)
         puts("\n"
              "periph/gpio: Using 4x gpio_write()\n"
              "----------------------------------");
-        gpio_t p0 = GPIO_PIN(PORT_OUT, PIN_OUT_0);
-        gpio_t p1 = GPIO_PIN(PORT_OUT, PIN_OUT_1);
+        gpio_t p0 = GPIO_PIN(PORT_OUT_NUM, PIN_OUT_0);
+        gpio_t p1 = GPIO_PIN(PORT_OUT_NUM, PIN_OUT_1);
         gpio_init(p0, GPIO_OUT);
         gpio_init(p1, GPIO_OUT);
 

--- a/tests/periph/gpio_ll/Makefile
+++ b/tests/periph/gpio_ll/Makefile
@@ -9,8 +9,8 @@ BOARD ?= nucleo-f767zi
 # pins *must* be on the same port, respectively. Connect the first input to the
 # first output pin and the second input pin to the second output pin, e.g. using
 # jumper wires.
-PORT_IN ?= 1
-PORT_OUT ?= 1
+PORT_IN ?=
+PORT_OUT ?=
 PIN_IN_0 ?= 0
 PIN_IN_1 ?= 1
 PIN_OUT_0 ?= 2
@@ -38,8 +38,14 @@ USEMODULE += ztimer_usec
 
 include $(RIOTBASE)/Makefile.include
 
-CFLAGS += -DPORT_OUT=$(PORT_OUT)
-CFLAGS += -DPORT_IN=$(PORT_IN)
+ifneq (,$(PORT_OUT))
+  CFLAGS += -DPORT_OUT=GPIO_PORT_$(PORT_OUT)
+  CFLAGS += -DPORT_OUT_NUM=$(PORT_OUT)
+endif
+ifneq (,$(PORT_IN))
+  CFLAGS += -DPORT_IN=GPIO_PORT_$(PORT_IN)
+  CFLAGS += -DPORT_IN_NUM=$(PORT_IN)
+endif
 CFLAGS += -DPIN_IN_0=$(PIN_IN_0)
 CFLAGS += -DPIN_IN_1=$(PIN_IN_1)
 CFLAGS += -DPIN_OUT_0=$(PIN_OUT_0)

--- a/tests/periph/gpio_ll/Makefile.ci
+++ b/tests/periph/gpio_ll/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
+    samd10-xmini \
     #

--- a/tests/periph/gpio_ll/main.c
+++ b/tests/periph/gpio_ll/main.c
@@ -909,6 +909,11 @@ static void test_switch_dir(void)
     expect(conf.state == GPIO_INPUT);
     gpio_conf_t conf_orig = conf;
 
+    /* conf_orig.initial_value contains the current value in query_conf.
+     * Since this is a floating input connected to a floating input, it is
+     * random here. ==> Clear it. */
+    conf_orig.initial_value = false;
+
     /* capture output state before switching from input mode to output mode, so
      * that it can be restored when switching back to input mode */
     uword_t out_state = gpio_ll_read_output(port_out);
@@ -935,6 +940,8 @@ static void test_switch_dir(void)
     gpio_ll_write(port_out, out_state);
     /* verify we are back at the old config */
     conf = gpio_ll_query_conf(port_out, PIN_OUT_0);
+    /* again, initial_value is random due to floating input ==> clear it */
+    conf.initial_value = false;
     test_passed = (conf.bits == conf_orig.bits);
     printf_optional("Returning back to input had no side effects on config: %s\n",
                     noyes[test_passed]);


### PR DESCRIPTION
### Contribution description

The API was based on the assumption that GPIO ports are mapped in memory sanely, so that a `GPIO_PORT(num)` macro would work allow for constant folding when `num` is known and still be efficient when it is not.

Some MCUs, however, will need a look up tables to efficiently translate GPIO port numbers to the port's base address. This will prevent the use of such a `GPIO_PORT(num)` macro in constant initializers.

As a result, we rather provide `GPIO_PORT_0`, `GPIO_PORT_1`, etc. macros for each GPIO port present (regardless of MCU naming scheme), as well as `GPIO_PORT_A`, `GPIO_PORT_B`, etc. macros if (and only if) the MCU port naming scheme uses letters rather than numbers.

These can be defined as macros to the peripheral base address even when those are randomly mapped into the address space. In addition, a C function `gpio_port()` replaces the role of the `GPIO_PORT()` and `gpio_port_num()` the `GPIO_PORT_NUM()` macro. Those functions will still be implemented as efficient as possible and will allow constant folding where it was formerly possible. Hence, there is no downside
for MCUs with sane peripheral memory mapping, but it is highly beneficial for the crazy ones.

There are also two benefits for the non-crazy MCUs:
1. We can now test for valid port numbers with `#ifdef GPIO_PORT_<NUM>`
    - This directly benefits the test in `tests/periph/gpio_ll`, which can now provide a valid GPIO port for each and every board
    - Writing to invalid memory mapped I/O addresses was treated as triggering undefined behavior by the compiler and used as a optimization opportunity
2. We can now detect at compile time if the naming scheme of the MCU uses letters or numbers, and produce more user friendly output.
    - This is directly applied in the test app

### Testing procedure

The test app in `tests/periph/gpio_ll` should still work.

### Issues/PRs references

- [x] depends on and includes https://github.com/RIOT-OS/RIOT/pull/20635