### PR TITLE
cpu/same5x: correct extended CAN msg send api

### DIFF
--- a/tests/drivers/candev/main.c
+++ b/tests/drivers/candev/main.c
@@ -68,7 +68,7 @@ static int _send(int argc, char **argv)
     int ret = 0;
 
     struct can_frame frame = {
-        .can_id = 1,
+        .can_id = 0x0CABCDEF,
         .can_dlc = 3,
         .data[0] = 0xAB,
         .data[1] = 0xCD,


### PR DESCRIPTION
### Contribution description

The SAMD5x does send correctly the extended frames only when the user inputs a CAN ID in which the extended flag bit is set. To avoid this error, this PR sets the extended flag bit automatically by the driver when an extended frame ID (superior to the standard ID mask) is detected


### Testing procedure

Testing steps:

1.  the test app is tests/drivers/candev, target hardware same54-xpro, tool to analyse the CAN bus is PCAN_USB adapter
2. With master, try to send a message with ID 0x0CABCDEF by starting shell command send.
3. Using the candump command, you will see that the message was sent as a standard frame and not an extended one.
![image](https://github.com/RIOT-OS/RIOT/assets/53952217/901a01ec-c967-46b5-9cc4-99c18d5f3a05)
4. With this PR, reproduce step 2 and 3. You'll notice that extended frame was sent correctly.
![image](https://github.com/RIOT-OS/RIOT/assets/53952217/012cd60d-7b4c-4e97-96cd-9dbc884f49f4) 
