### PR TITLE
boards/mulle: fix flashing

### DIFF
--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -26,3 +26,4 @@ DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
 # Define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+TTY_BOARD_FILTER := --model 'Mulle Programmer' --iface-num 0

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -8,6 +8,8 @@ PROGRAMMER ?= openocd
 PROGRAMMERS_SUPPORTED += openocd
 OPENOCD_TRANSPORT := jtag
 
+JLINK_DEVICE := MK60DN512XXX10
+
 # Default debug adapter choice is to use the Mulle programmer board
 OPENOCD_DEBUG_ADAPTER ?= mulle
 

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -6,6 +6,7 @@ endif
 # this board uses openocd
 PROGRAMMER ?= openocd
 PROGRAMMERS_SUPPORTED += openocd
+OPENOCD_TRANSPORT := jtag
 
 # Default debug adapter choice is to use the Mulle programmer board
 OPENOCD_DEBUG_ADAPTER ?= mulle

--- a/boards/mulle/dist/openocd/mulle-programmer-0.60.cfg
+++ b/boards/mulle/dist/openocd/mulle-programmer-0.60.cfg
@@ -6,23 +6,23 @@
 #
 
 # Reduce this if you are having problems with losing connection to the Mulle
-adapter_khz 1000
+adapter speed 1000
 
 # JTAG interface configuration
 
-interface ftdi
+adapter driver ftdi
 ftdi_device_desc "Mulle Programmer v0.60"
 ftdi_vid_pid 0x0403 0x6010
 
-ftdi_channel 1
-ftdi_layout_init 0x0008 0x005b
+ftdi channel 1
+ftdi layout_init 0x0008 0x005b
 
 # These are the pins that are used for SRST and TRST. Note that the Mulle
 # programming board inverts the reset signal between the FTDI chip and the MCU,
 # so we need to use -ndata here to tell OpenOCD that the signals are active HIGH.
-ftdi_layout_signal nTRST -ndata 0x0010
-ftdi_layout_signal nSRST -ndata 0x0040
+ftdi layout_signal nTRST -ndata 0x0010
+ftdi layout_signal nSRST -ndata 0x0040
 
 # In the eyes of OpenOCD, the reset signal is push-pull, because of the hardware
 # design however, it is actually open drain.
-reset_config srst_push_pull
+reset_config srst_push_pull srst_gates_jtag

--- a/boards/mulle/dist/openocd/mulle-programmer-0.70.cfg
+++ b/boards/mulle/dist/openocd/mulle-programmer-0.70.cfg
@@ -6,22 +6,22 @@
 #
 
 # Reduce this if you are having problems with losing connection to the Mulle
-adapter_khz 1000
+adapter speed 1000
 
 # JTAG interface configuration
 
-interface ftdi
-ftdi_device_desc "Mulle Programmer v0.70"
-ftdi_vid_pid 0x0403 0x6010
+adapter driver ftdi
+ftdi device_desc "Mulle Programmer v0.70"
+ftdi vid_pid 0x0403 0x6010
 
-ftdi_channel 1
-ftdi_layout_init 0x0008 0x005b
+ftdi channel 1
+ftdi layout_init 0x0008 0x005b
 
 # These are the pins that are used for SRST and TRST. Active low on programmer
 # boards v0.70 and up (used to be active high on v0.60)
-ftdi_layout_signal nTRST -data 0x0010
-ftdi_layout_signal nSRST -data 0x0040
+ftdi layout_signal nTRST -data 0x0010
+ftdi layout_signal nSRST -data 0x0040
 
 # In the eyes of OpenOCD, the reset signal is push-pull, because of the hardware
 # design however, it is actually open drain.
-reset_config srst_push_pull
+reset_config srst_push_pull srst_gates_jtag

--- a/cpu/kinetis/dist/check-fcfield.sh
+++ b/cpu/kinetis/dist/check-fcfield.sh
@@ -12,7 +12,8 @@
 # @author       Joakim Nohlgård <joakim.nohlgard@eistec.se>
 # @author       Francisco Molina <francisco.molina@inria.fr>
 
-: ${OBJDUMP:=arm-none-eabi-objdump}
+: "${OBJDUMP:=arm-none-eabi-objdump}"
+: "${IMAGE_OFFSET:=0}"
 
 # elf, hex or bin file to flash
 FLASHFILE="$1"
@@ -28,12 +29,12 @@ EXPECTED_FCFIELD="^fffffffffffffffffffffffffe..ffff$"
 
 get_fc_field()
 {
-    if [ ${1##*.} = elf ]; then
+    if [ "${1##*.}" = elf ]; then
         "${OBJDUMP}" -j.fcfield -s "${1}"
-    elif [ ${1##*.} = bin ]; then
-        "${OBJDUMP}" --start-address=${FCFIELD_START} --stop-address=${FCFIELD_END} -bbinary -marm ${1} -s
-    elif [ ${1##*.} = hex ]; then
-        "${OBJDUMP}" --start-address=${FCFIELD_START} --stop-address=${FCFIELD_END} ${1} -s
+    elif [ "${1##*.}" = bin ]; then
+        "${OBJDUMP}" --start-address=${FCFIELD_START} --stop-address=${FCFIELD_END} -bbinary -marm "${1}" -s
+    elif [ "${1##*.}" = hex ]; then
+        "${OBJDUMP}" --start-address=${FCFIELD_START} --stop-address=${FCFIELD_END} "${1}" -s
     else
         echo "Unknown file extension: ${1##*.}"
         exit 1
@@ -51,16 +52,16 @@ if [ $# -ne 1 ]; then
     exit 2
 fi
 
-if [ $(printf '%d' "${IMAGE_OFFSET}") -ge $(printf '%d' "${FCFIELD_END}") ]; then
+if [ "$(printf '%d' "${IMAGE_OFFSET}")" -ge "$(printf '%d' "${FCFIELD_END}")" ]; then
     echo "Value in fcfield is not checked when flashing at \$IMAGE_OFFSET >= 0x410"
     exit 0
-elif [ 0 -lt $(printf '%d' "${IMAGE_OFFSET}") ] && [ $(printf '%d' "${IMAGE_OFFSET}") -lt $(printf '%d' "${FCFIELD_END}") ]; then
+elif [ 0 -lt "$(printf '%d' "${IMAGE_OFFSET}")" ] && [ "$(printf '%d' "${IMAGE_OFFSET}")" -lt "$(printf '%d' "${FCFIELD_END}")" ]; then
     echo "Error: flashing with 0 < \$IMAGE_OFFSET < 0x410 is currently not handled"
     exit 1
-elif ! filter_fc_field ${FLASHFILE} ${FCFIELD_AWK_REGEX} | grep -q "${EXPECTED_FCFIELD}"; then
+elif ! filter_fc_field "${FLASHFILE}" "${FCFIELD_AWK_REGEX}" | grep -q "${EXPECTED_FCFIELD}"; then
     echo "Danger of bricking the device during flash!"
     echo "Flash configuration field of ${FLASHFILE}:"
-    get_fc_field ${FLASHFILE}
+    get_fc_field "${FLASHFILE}"
     echo "Abort flash procedure!"
     exit 1
 fi


### PR DESCRIPTION
### Contribution description

This does some minor clean up and updates:

- minor fixes to a shell script testing kinetis firmwares prior flashing
    - this should now be POSIX shell compliant
- fix and update mulle's OpenOCD config
    - previously JTAG was the defaul. The MCU needs special magic to switch into SWD mode, which is not implemented
    - set JTAG as transport explicitly to get programming working again
- add a TTY_BOARD_FILTER

### Testing procedure

`make flash` does now work. Fast verification with CRC fails with:

```
Error: [kx.cpu] not halted (start target algo)
Error: error executing cortex_m crc algorithm
```

But OpenOCD gracefully handles this and falls back to slow verification by reading back what was written.

Sadly, `board_init` runs into a failing assertion when mounting the SPI flash as `/mtd0`. But the way the mulle integrates the SPI is suboptimal and inconsistent with other boards anyway.

With this PR, at least flashing and debugging the board works again as before.

### Issues/PRs references

None