### PR TITLE
cpu/samd5x/can: fix flag handling on receive

### DIFF
--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -412,6 +412,9 @@ static uint8_t _form_message_marker(can_mm_t *can_mm)
 
 static int _send(candev_t *candev, const struct can_frame *frame)
 {
+    /* this assertion ensures the EFF-FLAG is set or the id does not exceed the CAN_SFF_MASK*/
+    assert( (frame->can_id & CAN_EFF_FLAG)
+            || ((frame->can_id & CAN_SFF_MASK) == (frame->can_id & CAN_EFF_MASK)) );
     can_t *dev = container_of(candev, can_t, candev);
 
     if (frame->can_dlc > CAN_MAX_DLEN) {

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -716,7 +716,12 @@ static void _isr(candev_t *candev)
         else {
             DEBUG_PUTS("Received extended CAN frame");
             frame_received.can_id = dev->msg_ram_conf.rx_fifo_0[rx_get_idx].RXF0E_0.bit.ID;
+            frame_received.can_id |= CAN_EFF_FLAG;
         }
+        if (dev->msg_ram_conf.rx_fifo_0[rx_get_idx].RXF0E_0.bit.RTR) {
+            frame_received.can_id |= CAN_RTR_FLAG;
+        }
+
         frame_received.can_dlc = dev->msg_ram_conf.rx_fifo_0[rx_get_idx].RXF0E_1.bit.DLC;
         memcpy(frame_received.data, (uint32_t *)dev->msg_ram_conf.rx_fifo_0[rx_get_idx].RXF0E_DATA, frame_received.can_dlc);
 
@@ -747,7 +752,12 @@ static void _isr(candev_t *candev)
         else {
             DEBUG_PUTS("Received extended CAN frame");
             frame_received.can_id = dev->msg_ram_conf.rx_fifo_1[rx_get_idx].RXF1E_0.bit.ID;
+            frame_received.can_id |= CAN_EFF_FLAG;
         }
+        if (dev->msg_ram_conf.rx_fifo_1[rx_get_idx].RXF1E_0.bit.RTR) {
+            frame_received.can_id |= CAN_RTR_FLAG;
+        }
+
         frame_received.can_dlc = dev->msg_ram_conf.rx_fifo_1[rx_get_idx].RXF1E_1.bit.DLC;
         memcpy(frame_received.data, (uint32_t *)dev->msg_ram_conf.rx_fifo_1[rx_get_idx].RXF1E_DATA, frame_received.can_dlc);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

this sets the eff-flag and the rtr-flag on received frames as required by the can standard for reliable handling of can id

this also adds a helping assertion to the send 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

missing handling of eff /eid / xtd flag was identified by @firas-hamdi in #20640 
