### PR TITLE
doc/CoC: Remove references to communication tools

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -16,9 +16,8 @@ the technical community in general with new knowledge and perspectives by
 allowing everyone to participate.
 
 This code of conduct applies to all spaces managed by the RIOT community. This
-includes IRC, the mailing lists, our GitHub projects, face to face events, and
-any other forums created by the community for communication within the
-community. In addition, violations of this code outside these spaces may also
+includes any communication within the RIOT community, both online and face to
+face. In addition, violations of this code outside these spaces may also
 affect a person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you report


### PR DESCRIPTION
### Contribution description

The list of communication tools has been outdated. Rather than keeping this list up to date, the list was dropped and the wording changed so that we refer to communication within the community.

### Testing procedure

Read the CoC and confirm that this:

1. Does not change the meaning of the CoC. Especially: It should still be obvious that it applies to communication via all the channels and tools we use
2. It does no longer contain references to specific channels or tools, so that we can evolve them without having to keep the CoC in sync

### Issues/PRs references

None