### PR TITLE
doc/CONTRIBUTION.md: document mediation process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ of this document using the following links:
 * [Contributing code][contributing-code]
 * [Writing Documentation][writing-documentation]
 * [Working with Git][working with git]
+* [Mediate Conflicts][mediate-conflicts]
 
 If you have questions, please write a post over at our [forum] or chat on
 `#riot-os:matrix.org` on [Matrix].
@@ -356,3 +357,45 @@ PR:
 ```console
 $ git push --force-with-lease
 ```
+
+## Mediating Conflicts
+[mediate-conflicts]: #mediate-conflicts
+
+A diverse community such as the RIOT community has inherently a diverse set of
+views and opinions. Occasionally those may clash, even with all parties adhering
+to our [code of conduct][code-of-conduct]. In case you seek out help to resolve
+it you may send an email to [mediator email list][email-mediator]. The email
+will be forwarded to a panel of mediators consisting of trusted RIOT
+community members including both maintainers and non-maintainers.
+
+We see the mediation as a tool to solve conflicts, not as a way to sanction
+people. Hence, do not be afraid to contact our mediators and equally do not
+feel denounced or punished if someone invokes mediation.
+
+This is a (non-exhaustive) list of reasons you can ask for mediation:
+
+- You are a contributor and feel being treated unfairly by another contributor
+  or maintainer
+    - Your PR is rejected/blocked for unjust or non-technical reasons.
+    - A PR is rejected/blocked for valid technical reasons, but without due
+      consideration of your arguments
+    - A maintainer is asking for disproportionate changes to your PR in order
+      to get it upstream, e.g. fixing issues unrelated to your PR
+- You disagree with other contributors/maintainers on how RIOT should evolve
+    - E.g. there are competing pull requests that cover highly related use
+      cases and there is a disagreement which should be preferred
+    - A pull requests results (or resulted) deliberately in a regression for a
+      particular use case, e.g. by doing a different trade-off that benefits
+      another use case
+    - A feature relevant for your use case has been deprecated/removed
+      (e.g. to reduce maintenance burden, reduce (perceived) duplication of
+      features, etc.) but your use case relies on the feature or implementation
+      details of the feature
+
+Note: Violations of our [code of conduct][code-of-conduct] should be reported
+      to [email-coc]. See our [code of conduct][code-of-conduct] for more
+      details.
+
+[code-of-conduct]: CODE_OF_CONDUCT.md
+[email-mediator]: mailto:mediation@riot-os.org
+[email-coc]: mailto:conduct@riot-os.org


### PR DESCRIPTION
### Contribution description

As agreed upon in the weekly coordination meeting we want to set up a channel / tool / process to aid contributors to solve conflicts.

This is especially aimed to empower contributors to solve conflicts with maintainers, as we were unsure that the existing code of conduct violation mechanism is sufficient to address conflicts that do not involve a CoC violation.

### Testing procedure

- [ ] Wait for the infrastructure to contact mediators to be in place and check if the address matches
- [ ] Check if the wording is clear
- [ ] Check if the doc is easy to find
- [ ] Check if it is made clear that the mechanism is intended to be a constructive tool aimed at solving the conflict
    - specifically: it should be clear to all parties than invoking the mediation should be seen as "blame game"

### Issues/PRs references

None