### PR TITLE
boards/waspmote-pro: deprecate board

### DIFF
--- a/boards/waspmote-pro/doc.txt
+++ b/boards/waspmote-pro/doc.txt
@@ -3,6 +3,18 @@
 @ingroup     boards
 @brief       Support for the Waspmote PRO v1.2 board.
 
+## End of Life
+
+@deprecated     Support for the Waspmote Pro is scheduled for removal after the
+                2024-07 release.
+
+This board is sold only B2B, so that our community members from the DIY/hobbyist
+community and academia do not have access to the board. Our community members
+from the industry mostly develop their own hardware and, therefore, have no
+interest in supporting this board. As result, none of the RIOT core contributors
+has access to the hardware, preventing us from doing the necessary testing
+for maintaining this board.
+
 ## Pin Change Interrupts
 
 More pins can be used for hardware interrupts using the Pin Change


### PR DESCRIPTION
### Contribution description

The board has history of bugs that (such as broken timer configuration) that would directly bite any users, but still have gone unnoticed for significant time periods due to lack of testing. It appears, that none of the core contributors has access to the boards and the number of users is limited.

### Testing procedure

Check the generated doc

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/5301#issuecomment-2092766969