### PR TITLE
sys/shell: add support for running a batch of commands from a file

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -237,6 +237,21 @@ static inline void shell_run(const shell_command_t *commands,
  */
 int shell_handle_input_line(const shell_command_t *commands, char *line);
 
+/**
+ * @brief           Read shell commands from a file and run them.
+ *
+ * @note            This requires the `vfs` module.
+ *
+ * @param[in]       commands    ptr to array of command structs
+ * @param[in]       filename    file to read shell commands from
+ * @param[out]      line_nr     line on which an error occurred, may be NULL
+ *
+ * @returns         0 if all commands were executed successful
+ *                  error return of failed command otherwise
+ */
+int shell_parse_file(const shell_command_t *commands,
+                     const char *filename, unsigned *line_nr);
+
 #ifndef __cplusplus
 /**
  * @brief   Define shell command

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -225,6 +225,18 @@ static inline void shell_run(const shell_command_t *commands,
     shell_run_forever(commands, line_buf, len);
 }
 
+/**
+ * @brief           Parse and run a line of text as a shell command with
+ *                  arguments.
+ *
+ * @param[in]       commands    ptr to array of command structs
+ * @param[in]       line        The input line to parse
+ *
+ * @returns         return value of the found command
+ * @returns         -ENOEXEC if no valid command could be found
+ */
+int shell_handle_input_line(const shell_command_t *commands, char *line);
+
 #ifndef __cplusplus
 /**
  * @brief   Define shell command

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -842,6 +842,20 @@ int vfs_open(const char *name, int flags, mode_t mode);
 ssize_t vfs_read(int fd, void *dest, size_t count);
 
 /**
+ * @brief Read a line from an open text file
+ *
+ * Reads from a file until a `\r` or `\n` character is found.
+ *
+ * @param[in]  fd       fd number obtained from vfs_open
+ * @param[out] dest     destination buffer to hold the line
+ * @param[in]  count    maximum number of characters to read
+ *
+ * @return number of bytes read on success
+ * @return <0 on error
+ */
+ssize_t vfs_readline(int fd, char *dest, size_t count);
+
+/**
  * @brief Write bytes to an open file
  *
  * @param[in]  fd       fd number obtained from vfs_open

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -20,6 +20,9 @@
 #ifndef VFS_UTIL_H
 #define VFS_UTIL_H
 
+#include <stdbool.h>
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -114,6 +117,15 @@ int vfs_file_sha256(const char* file, void *digest,
  * @return > 0 if @p path is a directory
  */
 int vfs_is_dir(const char *path);
+
+/**
+ @brief Checks if @p path is a file and can be read.
+ *
+ * @param[in]   path        Path to check
+ *
+ * @return true if the file exists, false otherwise
+ */
+bool vfs_file_exists(const char *path);
 
 /**
  * @brief    Behaves like `rm -r @p root`.

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -171,6 +171,17 @@ int vfs_is_dir(const char *path)
     return ((stat.st_mode & S_IFMT) == S_IFDIR);
 }
 
+bool vfs_file_exists(const char *path)
+{
+    int res = vfs_open(path, O_RDONLY, 0);
+    if (res < 0) {
+        return false;
+    }
+
+    vfs_close(res);
+    return true;
+}
+
 /**
  * @brief   Removes additional "/" slashes from @p path
  *

--- a/tests/sys/shell_scripting/Makefile
+++ b/tests/sys/shell_scripting/Makefile
@@ -1,0 +1,13 @@
+include ../Makefile.sys_common
+
+USEMODULE += shell
+USEMODULE += vfs_default
+USEMODULE += vfs_util
+USEMODULE += ztimer_msec
+
+DISABLE_MODULE += test_utils_interactive_sync
+
+# only boards with MTD are eligible
+TEST_ON_CI_WHITELIST += native native64
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/shell_scripting/Makefile.ci
+++ b/tests/sys/shell_scripting/Makefile.ci
@@ -1,0 +1,4 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    atmega8 \
+    nucleo-l011k4 \
+    #

--- a/tests/sys/shell_scripting/main.c
+++ b/tests/sys/shell_scripting/main.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   Shell Scripting Test Application
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <stdlib.h>
+
+#include "shell.h"
+#include "vfs_default.h"
+#include "vfs_util.h"
+#include "ztimer.h"
+
+#ifndef SCRIPT_FILE
+#define SCRIPT_FILE VFS_DEFAULT_DATA "/script.sh"
+#endif
+
+static int cmd_msleep(int argc, char **argv)
+{
+    if (argc != 2) {
+        return -1;
+    }
+
+    ztimer_sleep(ZTIMER_MSEC, atoi(argv[1]));
+    return 0;
+}
+
+static int cmd_echo(int argc, char **argv)
+{
+    for (int i = 1; i < argc; ++i) {
+        printf("%s ", argv[i]);
+    }
+    puts("");
+
+    return 0;
+}
+
+static int cmd_add(int argc, char **argv)
+{
+    int sum = 0;
+
+    for (int i = 1; i < argc; ++i) {
+        sum += atoi(argv[i]);
+    }
+
+    printf("%d\n", sum);
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "msleep", "sleep for a number of ms", cmd_msleep },
+    { "echo", "echo parameters to console", cmd_echo },
+    { "add", "add up a list of numbers", cmd_add },
+    { NULL, NULL, NULL }
+};
+
+static int _create_script(void)
+{
+    const char file[] = {
+        "# this is a comment\n"
+        "msleep 500\n"
+        "echo Hello RIOT!\n"
+        "\n"
+        "add 10 23 9\n"
+        "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+    };
+
+    return vfs_file_from_buffer(SCRIPT_FILE, file, sizeof(file) - 1);
+}
+
+int main(void)
+{
+    _create_script();
+
+    unsigned line;
+    int res = shell_parse_file(shell_commands, SCRIPT_FILE, &line);
+    if (res) {
+        fprintf(stderr, "%s:%u: error %d\n", SCRIPT_FILE, line, res);
+    }
+    return res;
+}

--- a/tests/sys/shell_scripting/tests/01-run.py
+++ b/tests/sys/shell_scripting/tests/01-run.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('Hello RIOT!')
+    child.expect_exact('42')
+    child.expect_exact('/nvm0/script.sh:6: error -7')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This was requested for easier integration testing: It allows to provide a fixed (`native`) binary that is able to execute shell commands provided by a file and terminate when it finished executing the commands (with an error code indicating success).

### Testing procedure

A simple test application is provided in `tests/sys/shell_scripting`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
