### PR TITLE
doc/boards: fix minor editorial mistakes

### DIFF
--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -24,7 +24,7 @@ STM32F767ZI microcontroller with 512KiB of RAM and 2 MiB of Flash.
 | FPU          | yes                 |
 | Ethernet     | 10/100 Mbps         |
 | Timers       | 18 (2x watchdog, 1 SysTick, 2x 32-bit, 13x 16-bit) |
-| ADCs         | 3x 12 bit (up to 24 channels |
+| ADCs         | 3x 12 bit (up to 24 channels) |
 | UARTs        | 4                   |
 | I2cs         | 4                   |
 | SPIs         | 6                   |

--- a/boards/nucleo-u575zi-q/doc.txt
+++ b/boards/nucleo-u575zi-q/doc.txt
@@ -5,13 +5,14 @@
 
 ## Overview
 
-The Nucleo-L552ZE-Q is a board from ST's Nucleo family supporting the ARM Cortex-M33
+The Nucleo-U575ZI-Q is a board from ST's Nucleo family supporting the ARM Cortex-M33
 STM32U575ZIT6Q ultra-low-power microcontroller with TrustZone, 768KiB of RAM and 2MiB
 of Flash.
 
 ## Hardware
 
-![Nucleo144 L552ZE-Q](https://www.st.com/bin/ecommerce/api/image.PF271812.en.feature-description-include-personalized-no-cpn-medium.jpg)
+![Nucleo144 U575ZI-Q](https://www.st.com/bin/ecommerce/api/image.PF271812.en.fea
+ture-description-include-personalized-no-cpn-medium.jpg)
 
 ### MCU
 
@@ -37,7 +38,7 @@ of Flash.
 
 ### Flashing the Board Using OpenOCD
 
-The ST Nucleo-L552ZE-Q board includes an on-board ST-LINK programmer and can be
+The ST Nucleo-U575ZI-Q board includes an on-board ST-LINK programmer and can be
 flashed using OpenOCD.
 
 Once OpenOCD is installed, you can flash the board simply by typing

--- a/boards/stm32f469i-disco/doc.txt
+++ b/boards/stm32f469i-disco/doc.txt
@@ -81,7 +81,7 @@ Also provides some system signals and power.
 - 1 User button.
 - 4 LEDs.
 - 3 Digital microphones
-- 1 LCD Color 4"
+- 1 LCD Color 4''
 
 ## Working with this Dev-Kit
 

--- a/boards/stm32f469i-disco/doc.txt
+++ b/boards/stm32f469i-disco/doc.txt
@@ -68,7 +68,7 @@ This extension connector gives access to:
 - USART6 (Tx, Rx)
 - I2S2
 - SPI1
-- 7 timers channels.
+- 7 timers channels
 - Speaker output (1W)
 
 Also provides some system signals and power.
@@ -77,11 +77,11 @@ Also provides some system signals and power.
 
 ## Buttons, LEDS and other devices
 
-- 1 Button for reset.
-- 1 User button.
-- 4 LEDs.
+- 1 Button for reset
+- 1 User button
+- 4 LEDs
 - 3 Digital microphones
-- 1 LCD Color 4''
+- 1 LCD Color 4 inches
 
 ## Working with this Dev-Kit
 


### PR DESCRIPTION
### Contribution description

This PR fix some minor editorial mistakes:
- nucleo-f767 - add ending bracket in ADCs details,
- nucleo-u575zi-q - fix wrong board name - change nucleo-l552ze-q to u575zi-q,
- stmf469i-disco - change inch sign (`"`) which corrupt bottom of the doc page to (`''`).

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f767zi.html 
xdg-open doc/doxygen/html/group__boards__nucleo-u575zi-q.html 
xdg-open doc/doxygen/html/group__boards__nucleo-stm32f469i-disco.html 
```

### Issues/PRs references

None