### PR TITLE
tests/periph/uart: clean up and add power off cmd

### DIFF
--- a/tests/periph/uart/Makefile
+++ b/tests/periph/uart/Makefile
@@ -7,7 +7,7 @@ FEATURES_OPTIONAL += periph_uart_modecfg
 FEATURES_OPTIONAL += periph_uart_rxstart_irq
 
 USEMODULE += shell
-USEMODULE += xtimer
+USEMODULE += ztimer_msec
 
 # avoid running Kconfig by default
 SHOULD_RUN_KCONFIG ?=

--- a/tests/periph/uart/main.c
+++ b/tests/periph/uart/main.c
@@ -22,13 +22,12 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "board.h"
 #include "shell.h"
 #include "thread.h"
 #include "msg.h"
 #include "ringbuffer.h"
 #include "periph/uart.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_STDIO_UART
 #include "stdio_uart.h"
@@ -44,7 +43,7 @@
 #define PRINTER_PRIO        (THREAD_PRIORITY_MAIN - 1)
 #define PRINTER_TYPE        (0xabcd)
 
-#define POWEROFF_DELAY      (250U * US_PER_MS)      /* quarter of a second */
+#define POWEROFF_DELAY_MS   (250U)
 
 /* if stdio is not done via UART, allow to use the stdio UART for the test */
 #ifndef MODULE_STDIO_UART
@@ -215,7 +214,7 @@ static void sleep_test(int num, uart_t uart)
 {
     printf("UARD_DEV(%i): test uart_poweron() and uart_poweroff()  ->  ", num);
     uart_poweroff(uart);
-    xtimer_usleep(POWEROFF_DELAY);
+    ztimer_sleep(ZTIMER_MSEC, POWEROFF_DELAY_MS);
     uart_poweron(uart);
     puts("[OK]");
 }
@@ -254,6 +253,27 @@ static int cmd_init(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(init, "Initialize a UART device with a given baudrate", cmd_init);
+
+static int cmd_off(int argc, char **argv)
+{
+    if (argc != 2) {
+        printf("usage: %s <dev>\n", argv[0]);
+        return 1;
+    }
+
+    int dev = parse_dev(argv[1]);
+    if (dev < 0) {
+        return 1;
+    }
+
+    uart_poweroff(UART_DEV(dev));
+
+    return 0;
+}
+
+SHELL_COMMAND(off, "Power off the given UART device", cmd_off);
 
 #ifdef MODULE_PERIPH_UART_MODECFG
 static int cmd_mode(int argc, char **argv)
@@ -321,6 +341,8 @@ static int cmd_mode(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(mode, "Setup data bits, stop bits and parity for a given UART device", cmd_mode);
 #endif /* MODULE_PERIPH_UART_MODECFG */
 
 static int cmd_send(int argc, char **argv)
@@ -342,6 +364,8 @@ static int cmd_send(int argc, char **argv)
     _write_newline(UART_DEV(dev));
     return 0;
 }
+
+SHELL_COMMAND(send, "Send a string through given UART device", cmd_send);
 
 static int cmd_test(int argc, char **argv)
 {
@@ -371,6 +395,8 @@ static int cmd_test(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(test, "Run an automated test on a UART with RX and TX connected", cmd_test);
+
 static int cmd_eol_cr(int argc, char **argv)
 {
     (void)argc;
@@ -378,6 +404,8 @@ static int cmd_eol_cr(int argc, char **argv)
     _endline = "\r";
     return 0;
 }
+
+SHELL_COMMAND(eol_cr, "Set CR as the end-of-line for send", cmd_eol_cr);
 
 static int cmd_eol_lf(int argc, char **argv)
 {
@@ -387,6 +415,8 @@ static int cmd_eol_lf(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(eol_lf, "Set LF as the end-of-line for send (default)", cmd_eol_lf);
+
 static int cmd_eol_crlf(int argc, char **argv)
 {
     (void)argc;
@@ -395,18 +425,7 @@ static int cmd_eol_crlf(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "init", "Initialize a UART device with a given baudrate", cmd_init },
-#ifdef MODULE_PERIPH_UART_MODECFG
-    { "mode", "Setup data bits, stop bits and parity for a given UART device", cmd_mode },
-#endif
-    { "send", "Send a string through given UART device", cmd_send },
-    { "test", "Run an automated test on a UART with RX and TX connected", cmd_test },
-    { "eol_cr", "Set CR as the end-of-line for send", cmd_eol_cr },
-    { "eol_crlf", "Set CRLF as the end-of-line for send", cmd_eol_crlf },
-    { "eol_lf", "Set LF as the end-of-line for send (default)", cmd_eol_lf },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(eol_crlf, "Set CRLF as the end-of-line for send", cmd_eol_crlf);
 
 int main(void)
 {
@@ -447,6 +466,6 @@ int main(void)
 
     /* run the shell */
     char line_buf[SHELL_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_BUFSIZE);
     return 0;
 }


### PR DESCRIPTION
### Contribution description

This updates the test app to use the XFA shell interface and ztimer. In addition, a shell command to power off the UART interface is added to e.g. confirm that power consumption indeed goes down.

### Testing procedure

The test should work as before, except for one shell command to power down the UART being added.

### Issues/PRs references

None