### PR TITLE
nanocoap_link_format: don't drop characters in fragmented entries

### DIFF
--- a/sys/net/application_layer/nanocoap/link_format.c
+++ b/sys/net/application_layer/nanocoap/link_format.c
@@ -58,16 +58,21 @@ static int _dirlist_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int m
             }
         }
 
-        if (*c == ',' || ctx->cur == ctx->end) {
-            int res;
+        bool found_end = false;
+        if (*c == ',') {
+            found_end = true;
+        }
+        else {
+            *ctx->cur++ = *c;
+        }
+
+        if (found_end || ctx->cur == ctx->end) {
             *ctx->cur = 0;
-            res = ctx->cb(ctx->buf, ctx->ctx);
+            int res = ctx->cb(ctx->buf, ctx->ctx);
             ctx->cur = ctx->buf;
             if (res < 0) {
                 return res;
             }
-        } else {
-            *ctx->cur++ = *c;
         }
     }
 
@@ -85,7 +90,7 @@ int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
     char buffer[CONFIG_NANOCOAP_QS_MAX];
     struct dir_list_ctx ctx = {
         .buf = buffer,
-        .end = buffer + sizeof(buffer) - 1,
+        .end = buffer + sizeof(buffer),
         .cur = buffer,
         .cb = cb,
         .ctx = arg,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If the directory entry returned by a CoAP server does not fit into `CONFIG_NANOCOAP_QS_MAX`, we get a call-back for the fragments.
Turns out this was not properly handled. 


### Testing procedure

I discovered this when running `aiocoap-fileserver` in `/tmp` where some very long directories live:

#### master

```
/test.sh
/.X11-unix/
/.font-unix/
/.com.google.Chrome.WsWxkT
/.ICE-unix/
/.XIM-unix/
[1]    52381 segmentation fault (core dumped)
```

#### this PR

```
> ncget coap://[fe80::607f:b1ff:fef7:689c]/
/test.sh
/.X11-unix/
/.font-unix/
/.com.google.Chrome.WsWxkT
/.ICE-unix/
/.XIM-unix/
/systemd-private-880118a9b51a45438f3c22d088d2e118-systemd-resolved.service-Jkz0l9/
/systemd-private-880118a9b51a45438f3c22d088d2e118-polkit.service-pHM9x2/
/snap-private-tmp/
/config-err-ErMZeV
/dock-replace.log
/systemd-private-880118a9b51a45438f3c22d088d2e118-fwupd.service-ygqHO4/
/systemd-private-880118a9b51a45438f3c22d088d2e118-bluetooth.service-p9wj7k/
/systemd-private-880118a9b51a45438f3c22d088d2e118-systemd-timesyncd.service-ULRs39/
/systemd-private-880118a9b51a45438f3c22d088d2e118-upower.service-D4dzsc/
/.com.google.Chrome.kk8kyD/
/systemd-private-880118a9b51a45438f3c22d088d2e118-colord.service-ChuMux/
/main.c
/systemd-private-880118a9b51a45438f3c22d088d2e118-ModemManager.service-aWDcAc/
/.X0-lock
/systemd-private-880118a9b51a45438f3c22d088d2e118-systemd-logind.service-HQ3Vxw/
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
