### PR TITLE
sys/net/grnc: fix NULL ptr dereferencing

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -244,7 +244,8 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
         ext_opts = rdnsso;
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_DNS */
-    if (gnrc_netif_is_6ln(netif)) {
+    if (gnrc_netif_is_6lr(netif)) {
+        assert(abr != NULL);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
         uint16_t ltime_min;
         gnrc_pktsnip_t *abro;
@@ -293,7 +294,7 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
         ext_opts = abro;
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
     }
-    else {
+    else if (!gnrc_netif_is_6ln(netif)) {
         (void)abr;
         while ((pfx = _nib_offl_iter(pfx))) {
             if ((pfx->mode & _PL) && (_nib_onl_get_if(pfx->next_hop) == id)) {


### PR DESCRIPTION
### Contribution description

This bug was spotted by GCC 14.1.0:

    In file included from /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h:27,
                     from /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h:33,
                     from /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h:30,
                     from /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c:28:
    In function 'bf_isset',
        inlined from '_build_ext_opts' at /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c:256:17,
        inlined from '_snd_ra' at /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c:368:20,
        inlined from '_snd_rtr_advs' at /home/maribu/Repos/software/RIOT/master/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c:99:9:
    /home/maribu/Repos/software/RIOT/master/sys/include/bitfield.h:130:18: error: array subscript 0 is outside array bounds of 'uint8_t[0]' {aka 'unsigned char[]'} [-Werror=array-bounds=]
      130 |     return (field[idx / 8] & (1u << (7 - (idx % 8))));
          |             ~~~~~^~~~~~~~~
    In function '_snd_rtr_advs':
    cc1: note: source object is likely at address zero
    cc1: all warnings being treated as errors

### Testing procedure

Apps that use GNRC and send router advertisements should still work.

### Issues/PRs references

None