### PR TITLE
dist/tools/bmp: fix target parsing

### DIFF
--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -85,7 +85,7 @@ def detect_targets(gdbmi, res):
     while True:
         for msg in res:
             if msg['type'] == 'target':
-                m = re.fullmatch(pattern=r"\s*(\d)+\s*(.*)\\n", string=msg['payload'])
+                m = re.fullmatch(pattern=r"\s*(\d+)\s*(.*)\s*", string=msg['payload'])
                 if m:
                     targets.append(m.group(2))
             elif msg['type'] == 'result':


### PR DESCRIPTION
### Contribution description

Either GDB or pygdbmi changed behavior to trim off whitespace following the message, resulting in the `\\n` at the end of the regex no longer matching. This replaces the `\\n` with `\s*` to match both old and new output.

Fixes: https://github.com/RIOT-OS/RIOT/issues/20604

### Testing procedure

Run `make BOARD=nrf52840dk PROGRAMMER=bmp flash` with a [black magic probe](https://black-magic.org/hardware.html), a cheaper [Jeff Probe](https://flirc.tv/products/flirc-jeffprobe), or an even cheaper ST-Link V2 clone with BMP firmware flashed used as debugger.

In `master` this yields (with recent version of GDB and `pygdbmi` installed):

```
found following Black Magic GDB servers:
	[/dev/ttyACM0] Serial: 3D8E4CC3 <- default 
connecting to [/dev/ttyACM0]...
connecting successful.
scanning using SWD...
res = [{'type': 'log', 'message': None, 'payload': 'monitor swdp_scan\n', 'stream': 'stdout'}, {'type': 'target', 'message': None, 'payload': 'Target voltage: 3.0V\n', 'stream': 'stdout'}]
targets = []
Traceback (most recent call last):
  File "/home/maribu/Repos/software/RIOT/master/dist/tools/bmp/bmp.py", line 272, in <module>
    gdbmi = connect_to_target(port)
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/maribu/Repos/software/RIOT/master/dist/tools/bmp/bmp.py", line 245, in connect_to_target
    assert len(targets) > 0, "no targets found"
           ^^^^^^^^^^^^^^^^
AssertionError: no targets found
make: *** [/home/maribu/Repos/software/RIOT/master/examples/hello-world/../../Makefile.include:849: flash] Error 1
```

With this PR, this yields:

```
found following Black Magic GDB servers:
	[/dev/ttyACM0] Serial: 3D8E4CC3 <- default 
connecting to [/dev/ttyACM0]...
connecting successful.
scanning using SWD...
found following targets:
	Nordic nRF52 M4
	Nordic nRF52 Access Port 

attaching to target successful.
downloading... total size: 1.2M
downloading section [.text] (8.4K)
100%|###################################################################################################################################################################|
downloading section [.ARM.exidx] (8B)
100%|###################################################################################################################################################################|
downloading section [.eh_frame] (80B)
100%|###################################################################################################################################################################|
downloading section [.relocate] (100B)
100%|###################################################################################################################################################################|
downloading finished
checking successful
killing successful.
- |#                                                                                                                                            | 0 Elapsed Time: 0:00:00
```

### Issues/PRs references

Fixes: https://github.com/RIOT-OS/RIOT/issues/20604