### PR TITLE
examples/psa_crypto: pass environment variable down to docker

### DIFF
--- a/examples/psa_crypto/Makefile
+++ b/examples/psa_crypto/Makefile
@@ -5,6 +5,8 @@ APPLICATION = example_psa_crypto
 
 BOARD ?= native
 
+DOCKER_ENV_VARS += SECURE_ELEMENT
+
 ifeq (2, $(SECURE_ELEMENT))
   CFLAGS += -DSECURE_ELEMENT # Application specific (not needed by PSA)
   CFLAGS += -DMULTIPLE_SE # Application specific (not needed by PSA)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`examples/psa_crypto` uses a custom environment variable to specify the presence of a secure element. When building within Docker, this environment variable needs to be explicitly passed down.


### Testing procedure

`make -C examples/psa_crypto BOARD=nrf52840dk SECURE_ELEMENT=1 BUILD_IN_DOCKER=1` fails on `master` and compiles fine with this fix.


### Issues/PRs references

Another instance of #20618. Maybe it's worth checking all the example applications for similar issues.
