### PR TITLE
pkg/mpaland-printf: Add alternative stdio as package

### DIFF
--- a/pkg/mpaland-printf/Makefile
+++ b/pkg/mpaland-printf/Makefile
@@ -1,0 +1,10 @@
+PKG_NAME=mpaland-printf
+PKG_URL=https://github.com/mpaland/printf
+# 4.0.0
+PKG_VERSION=0dd4b64bc778bf55229428cefccba4c0a81f384b
+PKG_LICENSE=MIT
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTPKG)/$(PKG_NAME)/$(PKG_NAME).mk

--- a/pkg/mpaland-printf/Makefile.dep
+++ b/pkg/mpaland-printf/Makefile.dep
@@ -1,0 +1,4 @@
+# mpaland's printf does not implement non-standard format specifiers. For
+# AVR MCUs we do need the ability to print from PROGMEM, though. Hence, this
+# is not compatible with AVR MCUs.
+FEATURES_BLACKLIST += arch_avr8

--- a/pkg/mpaland-printf/Makefile.include
+++ b/pkg/mpaland-printf/Makefile.include
@@ -1,0 +1,17 @@
+# wrap stdio functions to use mpaland's printf instead of the one from the
+# standard C lib
+LINKFLAGS += -Wl,-wrap=printf
+LINKFLAGS += -Wl,-wrap=sprintf
+LINKFLAGS += -Wl,-wrap=snprintf
+LINKFLAGS += -Wl,-wrap=vprintf
+LINKFLAGS += -Wl,-wrap=vsnprintf
+LINKFLAGS += -Wl,-wrap=putchar
+LINKFLAGS += -Wl,-wrap=puts
+
+# Workaround for bug in the newlib headers shipped with e.g. Ubuntu 24.04 LTS
+# not defining PRId64 / PRIu64 / PRIx64 / PRIo64 in <inttypes.h> due to an issue
+# in <machine/_default_types.h>. Tested to cause no regression on fixed newlib
+# headers.
+ifneq (,$(filter newlib,$(FEATURES_USED)))
+  CFLAGS += -D__int64_t_defined=1
+endif

--- a/pkg/mpaland-printf/doc.md
+++ b/pkg/mpaland-printf/doc.md
@@ -1,0 +1,27 @@
+@defgroup   pkg_mpaland-printf   mpaland's printf
+@ingroup    pkg
+@brief      mpaland's printf implementation is a lean, thread-safe and
+            feature-complete printf implementation
+
+# License
+
+Licensed under the MIT license.
+
+# Usage
+
+Add `USEPKG += mpaland-printf` to the application's `Makefile` or compile
+using `USEPKG=mpaland-printf make BOARD=<BOARD> -C <APP_DIR>`.
+
+# Features
+
+The package implements all standard format specifiers. However, support
+for floating point is disabled by default due to the immense ROM overhead
+on MCUs without FPU.
+
+@note   Support for floating point formatting can be enabled
+        via the `printf_float` module, i.e., by adding
+        `USEMODULE += printf_float` to the application's `Makefile`.
+@note   Support for non-standard format specifiers such as needed for
+        printing from flash on AVR MCUs are not implemented.
+
+@see    https://github.com/mpaland/printf

--- a/pkg/mpaland-printf/mpaland-printf.mk
+++ b/pkg/mpaland-printf/mpaland-printf.mk
@@ -1,0 +1,7 @@
+MODULE := mpaland-printf
+
+SRC := \
+  printf.c \
+  #
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/mpaland-printf/patches/0001-RIOT-integration.patch
+++ b/pkg/mpaland-printf/patches/0001-RIOT-integration.patch
@@ -1,0 +1,50 @@
+From 04f0f9616f74bbb93a2994d627d4ab476bd81d31 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 11 May 2024 17:51:01 +0200
+Subject: [PATCH 1/4] RIOT integration
+
+Use stdio_write() from stdio_base.h for output
+---
+ printf.c | 8 ++++++++
+ printf.h | 2 +-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/printf.c b/printf.c
+index 8a700ad..4a17672 100644
+--- a/printf.c
++++ b/printf.c
+@@ -34,6 +34,7 @@
+ #include <stdint.h>
+ 
+ #include "printf.h"
++#include "stdio_base.h"
+ 
+ 
+ // define this globally (e.g. gcc -DPRINTF_INCLUDE_CONFIG_H ...) to include the
+@@ -912,3 +913,10 @@ int fctprintf(void (*out)(char character, void* arg), void* arg, const char* for
+   va_end(va);
+   return ret;
+ }
++
++
++/* RIOT integration: Use stdio_write for output */
++static void _putchar(char character)
++{
++    stdio_write(&character, sizeof(character));
++}
+diff --git a/printf.h b/printf.h
+index 6075bc2..154930a 100644
+--- a/printf.h
++++ b/printf.h
+@@ -46,7 +46,7 @@ extern "C" {
+  * This function is declared here only. You have to write your custom implementation somewhere
+  * \param character Character to output
+  */
+-void _putchar(char character);
++static void _putchar(char character);
+ 
+ 
+ /**
+-- 
+2.43.0
+

--- a/pkg/mpaland-printf/patches/0002-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
+++ b/pkg/mpaland-printf/patches/0002-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
@@ -1,0 +1,66 @@
+From 2070026e3325ad7640c5cddc9cb1254aa63d61bb Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 11 May 2024 17:51:38 +0200
+Subject: [PATCH 2/4] Wrapper targets: Add endpoints for -Wl,wrap=...
+
+This adds aliases needed to wrap printf() and friends.
+---
+ printf.c | 38 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/printf.c b/printf.c
+index 4a17672..e06c9aa 100644
+--- a/printf.c
++++ b/printf.c
+@@ -32,6 +32,7 @@
+ 
+ #include <stdbool.h>
+ #include <stdint.h>
++#include <string.h>
+ 
+ #include "printf.h"
+ #include "stdio_base.h"
+@@ -920,3 +921,40 @@ static void _putchar(char character)
+ {
+     stdio_write(&character, sizeof(character));
+ }
++
++
++/* provide entry points for linker to redirect stdio */
++__attribute__((alias("printf_")))
++int __wrap_printf(const char* format, ...);
++
++
++__attribute__((alias("sprintf_")))
++int __wrap_sprintf(char* buffer, const char* format, ...);
++
++
++__attribute__((alias("snprintf_")))
++int __wrap_snprintf(char* buffer, size_t count, const char* format, ...);
++
++
++__attribute__((alias("vprintf_")))
++int __wrap_vprintf(const char* format, va_list va);
++
++
++__attribute__((alias("vsnprintf_")))
++int __wrap_vsnprintf(char* buffer, size_t count, const char* format, va_list va);
++
++
++int __wrap_putchar(int c)
++{
++    _putchar((char)c);
++    return 1;
++}
++
++
++int __wrap_puts(const char *s)
++{
++    size_t len = strlen(s);
++    stdio_write(s, len);
++    stdio_write("\n", 1);
++    return len + 1;
++}
+-- 
+2.43.0
+

--- a/pkg/mpaland-printf/patches/0003-RIOT-integration-Enable-floating-support-based-on-mo.patch
+++ b/pkg/mpaland-printf/patches/0003-RIOT-integration-Enable-floating-support-based-on-mo.patch
@@ -1,0 +1,26 @@
+From 33f690a4882dc567df328a900c5d12e113feb15c Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 11 May 2024 18:38:51 +0200
+Subject: [PATCH 3/4] RIOT integration: Enable floating support based on module
+ selection
+
+---
+ printf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/printf.c b/printf.c
+index e06c9aa..5266cf7 100644
+--- a/printf.c
++++ b/printf.c
+@@ -62,7 +62,7 @@
+ 
+ // support for the floating point type (%f)
+ // default: activated
+-#ifndef PRINTF_DISABLE_SUPPORT_FLOAT
++#ifdef MODULE_PRINTF_FLOAT
+ #define PRINTF_SUPPORT_FLOAT
+ #endif
+ 
+-- 
+2.43.0
+

--- a/pkg/mpaland-printf/patches/0004-Fix-parsing-of-int8_t.patch
+++ b/pkg/mpaland-printf/patches/0004-Fix-parsing-of-int8_t.patch
@@ -1,0 +1,28 @@
+From 81ef21a29faafbdb95800ce40b2e20b533b88ebd Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 11 May 2024 22:42:21 +0200
+Subject: [PATCH 4/4] Fix parsing of `int8_t`
+
+The code assumes that `char` is signed, but the C standard allows
+`char` to be either signed or unsigned. Instead, `singed char` and
+`unsigned char` need to be used for portable code.
+---
+ printf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/printf.c b/printf.c
+index 5266cf7..3f5f66a 100644
+--- a/printf.c
++++ b/printf.c
+@@ -734,7 +734,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
+             idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long)(value > 0 ? value : 0 - value), value < 0, base, precision, width, flags);
+           }
+           else {
+-            const int value = (flags & FLAGS_CHAR) ? (char)va_arg(va, int) : (flags & FLAGS_SHORT) ? (short int)va_arg(va, int) : va_arg(va, int);
++            const int value = (flags & FLAGS_CHAR) ? (signed char)va_arg(va, int) : (flags & FLAGS_SHORT) ? (short int)va_arg(va, int) : va_arg(va, int);
+             idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int)(value > 0 ? value : 0 - value), value < 0, base, precision, width, flags);
+           }
+         }
+-- 
+2.43.0
+

--- a/tests/sys/snprintf/Makefile
+++ b/tests/sys/snprintf/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.sys_common
+
+# avrlibc's snprintf doesn't support uint64_t / int64_t and even fails
+# to compile due to PRI*64 macros not being defined
+FEATURES_BLACKLIST := arch_avr8
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/snprintf/Makefile.board.dep
+++ b/tests/sys/snprintf/Makefile.board.dep
@@ -1,0 +1,4 @@
+# newlib's printf is known to be incomplete, despite being bloated
+ifneq (,$(filter newlib,$(USEMODULE)))
+  USEPKG += mpaland-printf
+endif

--- a/tests/sys/snprintf/README.md
+++ b/tests/sys/snprintf/README.md
@@ -1,0 +1,6 @@
+# snprintf
+
+This test aims to test if the stdio implementations correctly implements
+standard format specifiers. Instead of relying on the transport of stdout to
+be fast and reliable, it will use snprintf to format in-memory and compare
+in the app with correctness.

--- a/tests/sys/snprintf/main.c
+++ b/tests/sys/snprintf/main.c
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2024 Marian Buschsieweke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       snprintf test (correctness of standard format specifier
+ *              implementation)
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ *
+ * @}
+ */
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static bool failed = false;
+
+static void check(const char *expected, const char *got, int retval)
+{
+    if (retval != (int)strlen(expected)) {
+        failed = true;
+        printf("snprintf() returned %d, but expected %u\n",
+               retval, (unsigned)strlen(expected));
+    }
+
+    if (strcmp(expected, got) != 0) {
+        printf("Expected: \"%s\"\n"
+               "Got:      \"%s\"\n",
+               expected, got);
+        failed = true;
+    }
+}
+
+static void test_int8(void)
+{
+    static uint8_t u8 = 10;
+    static int8_t s8 = -3;
+
+    /* memory barrier to prevent the compiler from constant folding on the
+     * snprintf calls */
+    __asm__ volatile ("" ::: "memory");
+
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf), "%" PRIu8, u8);
+    check("10", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIx8, u8);
+    check("a", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIx8, u8);
+    check("0xa", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIX8, u8);
+    check("A", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIX8, u8);
+    check("0XA", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIo8, u8);
+    check("12", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIo8, u8);
+    check("012", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRId8, s8);
+    check("-3", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIi8, s8);
+    check("-3", buf, len);
+}
+
+static void test_int16(void)
+{
+    static uint16_t u16 = 45054;
+    static int16_t s16 = -1337;
+
+    /* memory barrier to prevent the compiler from constant folding on the
+     * snprintf calls */
+    __asm__ volatile ("" ::: "memory");
+
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf), "%" PRIu16, u16);
+    check("45054", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIx16, u16);
+    check("affe", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIx16, u16);
+    check("0xaffe", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIX16, u16);
+    check("AFFE", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIX16, u16);
+    check("0XAFFE", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIo16, u16);
+    check("127776", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIo16, u16);
+    check("0127776", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRId16, s16);
+    check("-1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIi16, s16);
+    check("-1337", buf, len);
+}
+
+static void test_int32(void)
+{
+    static uint32_t u32 = 2952663863;
+    static int32_t s32 = -2147483648;
+
+    /* memory barrier to prevent the compiler from constant folding on the
+     * snprintf calls */
+    __asm__ volatile ("" ::: "memory");
+
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf), "%" PRIu32, u32);
+    check("2952663863", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIx32, u32);
+    check("affe1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIx32, u32);
+    check("0xaffe1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIX32, u32);
+    check("AFFE1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIX32, u32);
+    check("0XAFFE1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIo32, u32);
+    check("25777411467", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIo32, u32);
+    check("025777411467", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRId32, s32);
+    check("-2147483648", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIi32, s32);
+    check("-2147483648", buf, len);
+}
+
+static void test_int64(void)
+{
+    static uint64_t u64 = 16045690984050070327ULL;
+    static int64_t s64 = -9223372036854775807LL;
+
+    /* memory barrier to prevent the compiler from constant folding on the
+     * snprintf calls */
+    __asm__ volatile ("" ::: "memory");
+
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf), "%" PRIu64, u64);
+    check("16045690984050070327", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIx64, u64);
+    check("deadbeefaffe1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIx64, u64);
+    check("0xdeadbeefaffe1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIX64, u64);
+    check("DEADBEEFAFFE1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIX64, u64);
+    check("0XDEADBEEFAFFE1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIo64, u64);
+    check("1572555756765777411467", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%#" PRIo64, u64);
+    check("01572555756765777411467", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRId64, s64);
+    check("-9223372036854775807", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%" PRIi64, s64);
+    check("-9223372036854775807", buf, len);
+}
+
+static void test_size(void)
+{
+    static size_t s = 42;
+    static ssize_t ss = -1;
+    static ptrdiff_t p = 1337;
+
+    /* memory barrier to prevent the compiler from constant folding on the
+     * snprintf calls */
+    __asm__ volatile ("" ::: "memory");
+
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf), "%zu", s);
+    check("42", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%zd", ss);
+    check("-1", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%td", p);
+    check("1337", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%tu", p);
+    check("1337", buf, len);
+}
+
+static void test_flags_widths(void)
+{
+    static uint16_t u16 = 42;
+    static int16_t s16 = -42;
+
+    /* memory barrier to prevent the compiler from constant folding on the
+     * snprintf calls */
+    __asm__ volatile ("" ::: "memory");
+
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf), "%03" PRIu16, u16);
+    check("042", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%3" PRIu16, u16);
+    check(" 42", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%-3" PRIu16, u16);
+    check("42 ", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%*" PRIu16, 8, u16);
+    check("      42", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%-*" PRIu16, 8, u16);
+    check("42      ", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%+" PRId16, (int16_t)u16);
+    check("+42", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%04" PRId16, s16);
+    check("-042", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%4" PRId16, s16);
+    check(" -42", buf, len);
+
+    len = snprintf(buf, sizeof(buf), "%-4" PRId16, s16);
+    check("-42 ", buf, len);
+}
+
+int main(void)
+{
+    puts("Testing snprintf() implementation...");
+    test_int8();
+    test_int16();
+    test_int32();
+    test_int64();
+    test_size();
+    test_flags_widths();
+
+    if (failed) {
+        puts("TEST FAILED!");
+    }
+    else {
+        puts("Test succeeded");
+    }
+
+    return 0;
+}

--- a/tests/sys/snprintf/tests/01-run.py
+++ b/tests/sys/snprintf/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2024 Marian Buschsieweke
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("Testing snprintf() implementation...")
+    child.expect_exact("Test succeeded")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This packs the stdio implementation from https://github.com/mpaland/printf as alternative to what the used standard C lib provides with the intent to provide a thread-safe, smaller, and more feature-complete alternative on newlib targets.

Compared to `newlib_nano` this reduces `.text` by a bit more than 200 B while adding support for standard format specifiers such as `RPIu8`, `PRIu16`, `PRIu64`, `%z`, and `%t`.

Note that `newlib_nano`'s stdio can be thread-safe in reentrant mode at the cost of RAM (per thread) and latency. Especially the increase in latency can be prohibitive when real time requirements need to be met.

[1]: https://github.com/mpaland/printf

### Testing procedure

A test application has been added in `tests/sys/snprintf`. This will use the package if `newlib` is used. It should pass, but removing `Makefile.board.dep` (which pulls in the `mpaland-printf` package) should a failing test.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/20361