### PR TITLE
cpu/nrf5x_common: fix ztimer issue on warm-boot

### DIFF
--- a/cpu/nrf5x_common/clock.c
+++ b/cpu/nrf5x_common/clock.c
@@ -78,10 +78,18 @@ void clock_hfxo_release(void)
     irq_restore(state);
 }
 
+/**
+ * True if the low frequency clock (LFCLK) has been started by RIOT.
+ * We don't rely on NRF_CLOCK->LFCLKSTAT since that register appears to be latched
+ * for a short amount of time after a soft reset on at least nRF52832 and nRF52840.
+ * @see https://devzone.nordicsemi.com/f/nordic-q-a/35792/nrf_clock--lfclkstat-register-contents-are-not-properly-evaluated-after-a-system-reset-if-rtc-compare-event-1-or-2-are-used/138995
+ */
+static bool clock_lf_running = false;
+
 void clock_start_lf(void)
 {
     /* abort if LF clock is already running */
-    if (NRF_CLOCK->LFCLKSTAT & CLOCK_LFCLKSTAT_STATE_Msk) {
+    if (clock_lf_running) {
         return;
     }
 
@@ -92,6 +100,7 @@ void clock_start_lf(void)
     NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
     NRF_CLOCK->TASKS_LFCLKSTART = 1;
     while (NRF_CLOCK->EVENTS_LFCLKSTARTED == 0) {}
+    clock_lf_running = true;
 
     /* calibrate the RC LF clock if applicable */
 #if (CLOCK_HFCLK && (CLOCK_LFCLK == 0))
@@ -105,4 +114,5 @@ void clock_stop_lf(void)
 {
     NRF_CLOCK->TASKS_LFCLKSTOP = 1;
     while (NRF_CLOCK->LFCLKSTAT & CLOCK_LFCLKSTAT_STATE_Msk) {}
+    clock_lf_running = false;
 }


### PR DESCRIPTION
### Contribution description

We have been experiencing problems when using `ztimer` on the `feather-nrf52840-sense` boards under certain compiler versions (see https://github.com/inetrg/exercises/pull/5#issuecomment-2012535937 and following) after warm-boot (directly after flashing or after pressing the reset button on the board), while after a cold-boot (un- and re-plugging) the board would behave normally.

I've spent quite some time debugging this issue and finally found the culprit: the `NRF_CLOCK->LFCLKSTAT` is apparently latched for some short time after a softreset (see [this comment](https://devzone.nordicsemi.com/f/nordic-q-a/35792/nrf_clock--lfclkstat-register-contents-are-not-properly-evaluated-after-a-system-reset-if-rtc-compare-event-1-or-2-are-used/138995) by Nordic, sadly it is not reported as an erratum) and wrongly reports the low-frequency clock to be running just after a reboot. In `clock_start_lf()` of `cpu/nrf5x_common/clock.c`, starting the clock is skipped iff the register reports the clock to be running. Apparently different compiler versions (reproducibly) lead to slightly different startup timings, which would explain why the issue only happens with some toolchain versions.

The [linked discussion](https://devzone.nordicsemi.com/f/nordic-q-a/35792/nrf_clock--lfclkstat-register-contents-are-not-properly-evaluated-after-a-system-reset-if-rtc-compare-event-1-or-2-are-used/139013) suggests to add a check for the reset cause and ignoring the (wrong) state of the LFCLK after a soft reset. To avoid the interdependence with the `RESETREAS` register (which might need to be read and cleared in a future version of RIOT or be expected to be untouched by some application code), I propose a different approach with this PR: Adding a static variable that remembers whether the LFCLK has been started (by RIOT) or not. If anyone has a better suggestion for a work-around, please shout out :)

The above linked discussion is about nRF52832 (locally confirmed with an `nrf52dk`), but I can confirm this issue exists on nRF52840-based boards (I have tested `feather-nrf52840-sense`, `feather-nrf52840-express`, `nrf52840dk` and `nrf52840dongle`) as well. I have also tested `calliope-mini` (with nRF51) where I didn't see the problem, but the suggested workaround should not harm unless the user application code tinkers with LFCLK itself.

While the issue exists on all tested nRF52840-based boards, it has become especially apparent on `feather-nrf52840-sense` since the reset button triggers the bootloader, which itself [triggers a soft-reset](https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/main.c#L219) into the application. But with the following diff, it is reproducible on the other nRF52840-boards as well.

### Testing procedure

Apply the following diff to current `master`:

```diff
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9baf..f1164cd53d 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -7,6 +7,9 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index 213128ac64..5b0ca9072a 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,13 +20,31 @@
  */
 
 #include <stdio.h>
+#include "ztimer.h"
+#include "busy_wait.h"
 
 int main(void)
 {
+    /* busy wait 5s to allow for UART to connect */
+    busy_wait_us(5000000);
+
     puts("Hello World!");
 
+    /* test ztimer time difference using busy loop for 10ms */
+    ztimer_acquire(ZTIMER_MSEC);
+    ztimer_now_t start = ztimer_now(ZTIMER_MSEC);
+    busy_wait_us(10000);
+    printf("difference (exp. 10): %ld\n", ztimer_now(ZTIMER_MSEC) - start);
+    ztimer_release(ZTIMER_MSEC);
+
+    /* sleep for 1s - never returns iff time difference was 0 (ztimer not running) */
+    ztimer_sleep(ZTIMER_MSEC, 1000);
+
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s CPU.\n", RIOT_CPU);
 
+    /* trigger soft-reset */
+    NVIC_SystemReset();
+
     return 0;
 }
```

Compile with an affected compiler version (debian stable `arm-gcc-none-eabi 12.2.1` is known to have the problem) and flash to some nRF52840 or nRF52832 based board: After the first soft-reset (either triggered from the bootloader in case of the Adafruit boards or triggered by the application code), the reported ztimer difference will be zero and the application will hang during `ztimer_sleep` as time is not advancing.

With the proposed workaround added, the code should behave as expected.


### Issues/PRs references

https://github.com/inetrg/exercises/pull/5
