### PR TITLE
cpu/samd5x: handle CAN errors

### DIFF
--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -75,6 +75,16 @@ extern "C" {
 #define CANDEV_SAMD5X_MAX_TX_BUFFER 32
 #define CANDEV_SAMD5X_MSG_RAM_MAX_SIZE 448
 
+/* SAMD5x CAN controller error codes (values from datasheet section 39.8.14) */
+#define CANDEV_SAMD5X_NO_ERROR 0
+#define CANDEV_SAMD5X_STUFF_ERROR 1
+#define CANDEV_SAMD5X_FORM_ERROR 2
+#define CANDEV_SAMD5X_ACK_ERROR 3
+#define CANDEV_SAMD5X_BIT1_ERROR 4
+#define CANDEV_SAMD5X_BIT0_ERROR 5
+#define CANDEV_SAMD5X_CRC_ERROR 6
+#define CANDEV_SAMD5X_NO_CHANGE_ERROR 7
+
 /**
  * @brief CAN device configuration descriptor
  */

--- a/tests/drivers/candev/main.c
+++ b/tests/drivers/candev/main.c
@@ -256,12 +256,15 @@ static void _can_event_callback(candev_t *dev, candev_event_t event, void *arg)
         DEBUG("_can_event: CANDEV_EVENT_RX_ERROR\n");
         break;
     case CANDEV_EVENT_BUS_OFF:
+        DEBUG("_can_event: CANDEV_EVENT_BUS_OFF\n");
         dev->state = CAN_STATE_BUS_OFF;
         break;
     case CANDEV_EVENT_ERROR_PASSIVE:
+        DEBUG("_can_event: CANDEV_EVENT_ERROR_PASSIVE\n");
         dev->state = CAN_STATE_ERROR_PASSIVE;
         break;
     case CANDEV_EVENT_ERROR_WARNING:
+        DEBUG("_can_event: CANDEV_EVENT_ERROR_WARNING\n");
         dev->state = CAN_STATE_ERROR_WARNING;
         break;
     default:


### PR DESCRIPTION
### Contribution description

This PR adds the handling of the CAN errors related interrupts.
The CAN errors are coded in this way:
![image](https://github.com/RIOT-OS/RIOT/assets/53952217/566c7247-7d85-4ec5-8445-af2493f7c5e7)


### Testing procedure

You can generate a CAN error by trying to send a CAN frame from the CAN controller (Board used is same54-xpro) without terminating the bus (i.e not connecting the CANH and CANL pins of the same54-xpro). An ACK error will be generated then and handled.