### PR TITLE
boards/arduino-nano-33-ble-sense: add support for arduino-nano-33-ble-sense

### DIFF
--- a/boards/arduino-nano-33-ble-sense/Kconfig
+++ b/boards/arduino-nano-33-ble-sense/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Méwen Berthelot
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-nano-33-ble-sense" if BOARD_ARDUINO_NANO_33_BLE_SENSE
+
+config BOARD_ARDUINO_NANO_33_BLE_SENSE
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/arduino-nano-33-ble-sense/Makefile
+++ b/boards/arduino-nano-33-ble-sense/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-nano-33-ble-sense/Makefile.dep
+++ b/boards/arduino-nano-33-ble-sense/Makefile.dep
@@ -1,0 +1,9 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += hts221
+  USEMODULE += lps22hb
+  USEMODULE += apds9960
+endif
+
+include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/arduino-nano-33-ble-sense/Makefile.features
+++ b/boards/arduino-nano-33-ble-sense/Makefile.features
@@ -1,0 +1,12 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/arduino-nano-33-ble-sense/Makefile.include
+++ b/boards/arduino-nano-33-ble-sense/Makefile.include
@@ -1,0 +1,21 @@
+# Bossa is the default programmer
+PROGRAMMER ?= bossa
+
+ifeq ($(PROGRAMMER),bossa)
+  # The preinstalled Arduino bootloader must also be taken into account so
+  # ROM_OFFSET skips the space taken by such bootloader.
+  ROM_OFFSET ?= 0x10000
+
+  # This board requires a BOSSA version from arduino's fork and adapted to
+  # nrf52.
+  BOSSA_VERSION = nrf52
+  BOSSA_ARDUINO_PREFLASH = yes
+  PREFLASH_DELAY = 1
+endif
+
+PROGRAMMERS_SUPPORTED += bossa
+
+TESTRUNNER_CONNECT_DELAY ?= 2
+$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/arduino-nano-33-ble-sense/board.c
+++ b/boards/arduino-nano-33-ble-sense/board.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  2024 Méwen Berthelot
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble-sense
+ * @{
+ *
+ * @file
+ * @brief       Board specific initialization for Arduino Nano 33 BLE sense
+ *
+ * @author      Méwen Berthelot <berthelotmewen@gmail.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+
+/*
+ *  VDD needs to be set in order to have the sensors powered.
+ *  It also seems that if the internal I2C pins are not set as input,
+ *  all the sensors connected will not work.
+ */
+    gpio_init(VDD, GPIO_OUT);
+    gpio_set(VDD);
+
+    gpio_init(SCL1, GPIO_IN);
+    gpio_init(SDA1, GPIO_IN);
+
+}

--- a/boards/arduino-nano-33-ble-sense/doc.txt
+++ b/boards/arduino-nano-33-ble-sense/doc.txt
@@ -1,0 +1,51 @@
+/**
+@defgroup    boards_arduino-nano-33-ble-sense Arduino Nano 33 BLE sense
+@ingroup     boards
+@brief       Support for the Arduino Nano 33 BLE Sense
+
+### General information
+
+The [Arduino Nano 33 BLE sense](https://store.arduino.cc/arduino-nano-33-ble-sense) board
+is an opensource, micro development kit using the nRF52840 SoC.
+This board provides 802.15.4 and BLE connectivity.
+
+### Pinout
+
+<img src="https://content.arduino.cc/assets/Pinout-NANOsense_latest.png"
+     alt="pinout" style="height:800px;"/>
+
+### Flash the board
+
+Use `BOARD=arduino-nano-33-ble-sense` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=arduino-nano-33-ble-sense -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=arduino-nano-33-ble-sense -C examples/hello-world term
+```
+ */
+
+### Internal devices
+
+#### Supported
+
+- hts221 (Temperature and Humidity sensor)
+- apds9960 (Proximity, ambient light and gesture sensor)
+- lps22hb (Pressure and Temperature sensor)
+
+#### Not yet supported
+
+- LSM9DS1 (9-axis inertial module - Accelerometer)
+- MP34DT06JTR (Microphone)
+
+### Hardware reference
+
+- https://docs.arduino.cc/resources/pinouts/ABX00031-full-pinout.pdf

--- a/boards/arduino-nano-33-ble-sense/include/board.h
+++ b/boards/arduino-nano-33-ble-sense/include/board.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2024 Méwen Berthelot
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble-sense
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino Nano 33 BLE sense
+ *
+ * @author      Méwen Berthelot <berthelotmewen@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LEDs pin configuration
+ * @{
+ */
+#define LED0_PIN                GPIO_PIN(0, 13)
+#define LED0_MASK               (1 << 13)
+#define LED0_ON                 (NRF_P0->OUTCLR = LED0_MASK)
+#define LED0_OFF                (NRF_P0->OUTSET = LED0_MASK)
+#define LED0_TOGGLE             (NRF_P0->OUT   ^= LED0_MASK)
+
+#define LED1_PIN                GPIO_PIN(0, 24)
+#define LED1_MASK               (1 << 24)
+#define LED1_ON                 (NRF_P0->OUTCLR = LED1_MASK)
+#define LED1_OFF                (NRF_P0->OUTSET = LED1_MASK)
+#define LED1_TOGGLE             (NRF_P0->OUT   ^= LED1_MASK)
+
+#define LED2_PIN                GPIO_PIN(0, 16)
+#define LED2_MASK               (1 << 16)
+#define LED2_ON                 (NRF_P0->OUTCLR = LED2_MASK)
+#define LED2_OFF                (NRF_P0->OUTSET = LED2_MASK)
+#define LED2_TOGGLE             (NRF_P0->OUT   ^= LED2_MASK)
+
+#define LED3_PIN                GPIO_PIN(0, 6)
+#define LED3_MASK               (1 << 6)
+#define LED3_ON                 (NRF_P0->OUTCLR = LED3_MASK)
+#define LED3_OFF                (NRF_P0->OUTSET = LED3_MASK)
+#define LED3_TOGGLE             (NRF_P0->OUT   ^= LED3_MASK)
+
+#define LED4_PIN                GPIO_PIN(1, 9)
+#define LED4_MASK               (1 << 9)
+#define LED4_ON                 (NRF_P1->OUTCLR = LED4_MASK)
+#define LED4_OFF                (NRF_P1->OUTSET = LED4_MASK)
+#define LED4_TOGGLE             (NRF_P1->OUT   ^= LED4_MASK)
+/** @} */
+
+/**
+ * @name    Internal powering pin definition
+ * @{
+ */
+#define VDD                     GPIO_PIN(0, 22) /**< Internal VDD pin */
+/** @} */
+
+/**
+ * @name    Internal I2C pins definition
+ * @{
+ */
+#define SCL1                     GPIO_PIN(0, 15) /**< Internal SCL I2C pin */
+#define SDA1                     GPIO_PIN(0, 14) /**< Internal SDA I2C pin */
+/** @} */
+
+/**
+ * @name    HTS221 sensor configuration
+ * @{
+ */
+#define HTS221_PARAM_I2C        I2C_DEV(1) /**< I2C device */
+/** @} */
+
+/**
+ * @name    LPS22HB sensor configuration
+ * @{
+ */
+#define LPSXXX_PARAM_ADDR       (0x5c) /**< I2C address */
+#define LPSXXX_PARAM_I2C        I2C_DEV(1) /**< I2C device */
+/** @} */
+
+/**
+ * @name    APDS9960 sensor configuration
+ * @{
+ */
+#define APDS99XX_PARAM_DEV      I2C_DEV(1) /**< I2C device */
+#define APDS99XX_PARAM_INT_PIN  GPIO_PIN(0, 19) /**< Interrupt pin */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/arduino-nano-33-ble-sense/include/gpio_params.h
+++ b/boards/arduino-nano-33-ble-sense/include/gpio_params.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble-sense
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Méwen Berthelot <berthelotmewen@gmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED0 (Orange)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+    },
+    {
+        .name  = "LED1 (RED)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED2 (GREEN)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED3 (BLUE)",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED4 (PWR)",
+        .pin   = LED4_PIN,
+        .mode  = GPIO_OUT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/arduino-nano-33-ble-sense/include/periph_conf.h
+++ b/boards/arduino-nano-33-ble-sense/include/periph_conf.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Méwen Berthelot
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble-sense
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Arduino Nano 33 BLE Sense
+ *
+ * @author      Méwen Berthelot <berthelotmewen@gmail.com>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @name    UART configuration
+     * @{
+     */
+    static const uart_conf_t uart_config[] = {
+        {
+            .dev = NRF_UARTE0,
+            .rx_pin = GPIO_PIN(1, 10),
+            .tx_pin = GPIO_PIN(1, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+            .rts_pin = GPIO_UNDEF,
+            .cts_pin = GPIO_UNDEF,
+#endif
+            .irqn = UARTE0_UART0_IRQn,
+        },
+    };
+
+#define UART_0_ISR (isr_uart0)
+
+#define UART_NUMOF ARRAY_SIZE(uart_config)
+    /** @} */
+
+    /**
+     * @name    I2C configuration
+     * @{
+     */
+    static const i2c_conf_t i2c_config[] = {
+        {
+         .dev = NRF_TWIM0,
+         .scl = GPIO_PIN(0, 2),
+         .sda = GPIO_PIN(0, 31),
+         .speed = I2C_SPEED_NORMAL
+        },
+        {
+         .dev = NRF_TWIM1,
+         .scl = GPIO_PIN(0, 15),
+         .sda = GPIO_PIN(0, 14),
+         .speed = I2C_SPEED_NORMAL
+        },
+    };
+
+#define I2C_NUMOF (sizeof(i2c_config) / sizeof(i2c_config[0]))
+    /** @} */
+
+    /**
+     * @name    SPI configuration
+     * @{
+     */
+    static const spi_conf_t spi_config[] = {
+        {
+            .dev = NRF_SPIM0,
+            .sclk = GPIO_PIN(0, 13),
+            .mosi = GPIO_PIN(1, 1),
+            .miso = GPIO_PIN(1, 8),
+        }};
+
+#define SPI_NUMOF ARRAY_SIZE(spi_config)
+    /** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/arduino-nano-33-ble-sense/reset.c
+++ b/boards/arduino-nano-33-ble-sense/reset.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano-33-ble-sense
+ * @{
+ * @file
+ * @brief       Implementation for managing the Arduino bootloader
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "cpu.h"
+#include "usb_board_reset.h"
+
+/* Set the value used by the bootloader to select between boot in
+   application and boot in bootloader mode. */
+#define NRF52_DOUBLE_TAP_MAGIC_NUMBER (0xb0)
+
+void usb_board_reset_in_bootloader(void)
+{
+    NRF_POWER->GPREGRET = NRF52_DOUBLE_TAP_MAGIC_NUMBER;
+
+    usb_board_reset_in_application();
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_USB_BOARD_RESET */


### PR DESCRIPTION

### Contribution description

This PR adds support for arduino-nano-33-ble-sense. Please note that it provides all the configuration to use the internal sensors and actuators but not all of them since they are not currently supported by RIOT (or only the older versions are supported such as LSM6DSXX).

This code is based on the code of the arduino-nano-33-ble as they share the same base (the sense version mostly provides sensors and actuators in addition).

### Testing procedure

1.  Check the generated doc
2.  Run a few test examples



