### PR TITLE
cpu/nrf5x_common: properly calibrate RC-based low-frequency clock

### DIFF
--- a/cpu/nrf5x_common/clock.c
+++ b/cpu/nrf5x_common/clock.c
@@ -103,10 +103,12 @@ void clock_start_lf(void)
     clock_lf_running = true;
 
     /* calibrate the RC LF clock if applicable */
-#if (CLOCK_HFCLK && (CLOCK_LFCLK == 0))
+#if (CLOCK_LFCLK == CLOCK_LFCLKSRC_SRC_RC)
+    clock_hfxo_request();
     NRF_CLOCK->EVENTS_DONE = 0;
     NRF_CLOCK->TASKS_CAL = 1;
     while (NRF_CLOCK->EVENTS_DONE == 0) {}
+    clock_hfxo_release();
 #endif
 }
 


### PR DESCRIPTION
### Contribution description

@BOZHENG001 encountered the issue where all NimBLE-based examples would fail to establish connection while advertising works normally on `feather-nrf52840-sense`, while they work properly on `nrf52840dk`. As suggested by @andrzej-kaczmarek in https://github.com/apache/mynewt-nimble/issues/1777#issuecomment-2109931363, this is an issue with the internal RC low-frequency clock which needs to be calibrated.

While RIOT already tries to do so, it currently ignores the fact that the high-frequency clock needs to be manually started for the calibration to succeed. This is documented for nRF51 [here on page 53](https://docs.nordicsemi.com/bundle/nRF51-Series/resource/nRF51_RM_v3.0.1.pdf) and for nRF52-series for example [here for nRF52832](https://docs.nordicsemi.com/bundle/ps_nrf52832/page/clock.html#d910e282) and [here for nRF52840](https://docs.nordicsemi.com/bundle/ps_nrf52840/page/clock.html#ariaid-title6). The documentation of nRF5240 [does not explicitly mention](https://docs.nordicsemi.com/bundle/ps_nrf5340/page/chapters/clock/doc/clock.html#ariaid-title9) the necessity to manually start the HFCLK, but it shouldn't harm there either.

### Testing procedure

`make -C examples/nimble_heart_rate_sensor BOARD=feather-nrf52840-sense flash term` fails to establish a connection (e.g. to the Android app "nRF Connect"). This is also possible to reproduce with `BOARD=nrf52840dk` after switching to the internal RC oscillator:
```diff
diff --git a/boards/common/nrf52xxxdk/include/periph_conf_common.h b/boards/common/nrf52xxxdk/include/periph_conf_common.h
index 0b7bbdd019..af35d672ff 100644
--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -22,7 +22,7 @@
 #define PERIPH_CONF_COMMON_H
 
 #include "periph_cpu.h"
-#include "cfg_clock_32_1.h"
+#include "cfg_clock_32_0.h"
 #include "cfg_i2c_default.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
```

With this PR, connection can be reliably established.

### Issues/PRs references

The issue has also been discussed on Matrix with @maribu, thanks for your input!
