### PR TITLE
sys/psa_crypto: remove keysize determination from Kconfig files

### DIFF
--- a/sys/include/psa_crypto/psa/crypto_sizes.h
+++ b/sys/include/psa_crypto/psa/crypto_sizes.h
@@ -51,13 +51,12 @@ extern "C" {
 #define PSA_BYTES_TO_BITS(bytes) ((bytes) * 8)
 
 /**
- * @brief   Maximum key size determined by the build system.
+ * @brief   Maximum key size in bytes, determined by the build system.
  *
  * @details The maximum key size is set automatically, depending on
  *          the features chosen at compile-time. They should not be
  *          changed manually.
  */
-#ifndef CONFIG_PSA_MAX_KEY_SIZE
 #if (IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1) || \
      IS_USED(MODULE_PSA_ASYMMETRIC_ECC_ED25519) || \
      IS_USED(MODULE_PSA_CIPHER_AES_256_CBC) || \
@@ -72,7 +71,6 @@ extern "C" {
 #define CONFIG_PSA_MAX_KEY_SIZE 16
 #else
 #define CONFIG_PSA_MAX_KEY_SIZE 0
-#endif
 #endif
 
 /**

--- a/sys/psa_crypto/Kconfig.keys
+++ b/sys/psa_crypto/Kconfig.keys
@@ -7,46 +7,6 @@
 
 menu "PSA Key Management Configuration"
 
-config PSA_KEY_SIZE_128
-    bool "Application uses key of size 128 Bits"
-    default USEMODULE_PSA_CIPHER_AES_128_CBC
-    default USEMODULE_PSA_CIPHER_AES_128_ECB
-    help
-      Indicates that the maximum PSA key size should be at least 128 bits.
-
-config PSA_KEY_SIZE_192
-    bool "Application uses key of size 192 Bits"
-    default USEMODULE_PSA_CIPHER_AES_192_CBC
-    default USEMODULE_PSA_ASYMMETRIC_ECC_P192R1
-    help
-      Indicates that the maximum PSA key size should be at least 192 bits.
-
-config PSA_KEY_SIZE_256
-    bool "Application uses key of size 256 Bits"
-    default USEMODULE_PSA_ASYMMETRIC_ECC_P256R1
-    default USEMODULE_PSA_ASYMMETRIC_ECC_ED25519
-    default USEMODULE_PSA_CIPHER_AES_256_CBC
-    default USEMODULE_PSA_MAC_HMAC_SHA_256
-    default USEMODULE_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256
-    help
-      Indicates that the maximum PSA key size should be at least 256 bits.
-
-config PSA_KEY_SIZE_512
-    bool "Application uses key of size 512 Bits"
-    default USEMODULE_PSA_CIPHER_AES_128_CBC
-    help
-      Indicates that the maximum PSA key size should be at least 512 bits.
-
-config PSA_MAX_KEY_SIZE
-    int
-    default 64 if PSA_KEY_SIZE_512
-    default 32 if PSA_KEY_SIZE_256
-    default 24 if PSA_KEY_SIZE_192
-    default 16 if PSA_KEY_SIZE_128
-    default 0
-    help
-      Indicates the maximum PSA key size in bytes.
-
 config PSA_PROTECTED_KEY_COUNT
     int "Specifies number of allocated protected key slots"
     default 5 if USEMODULE_PSA_SECURE_ELEMENT


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There were some left-overs from Kconfig dependency modeling (#20438) in the PSA crypto implementation, namely the determination of the maximum key size. This PR removes that and now also unconditionally sets the maximum key size in the C header file.


### Testing procedure

Look at the changes, CI should do.


### Issues/PRs references

Noted thanks to a discussion with @darthdrannel
