### PR TITLE
drivers: don't call i2c_init()

### DIFF
--- a/drivers/aip31068/aip31068.c
+++ b/drivers/aip31068/aip31068.c
@@ -109,8 +109,6 @@ int aip31068_init(aip31068_t *dev, const aip31068_params_t *params)
     dev->_curr_display_control = 0;
     dev->_curr_entry_mode_set = 0;
 
-    i2c_init(dev->params.i2c_dev);
-
     uint8_t _function_set = 0;
 
     /* configure bit mode */

--- a/drivers/pca9633/pca9633.c
+++ b/drivers/pca9633/pca9633.c
@@ -66,8 +66,6 @@ int pca9633_init(pca9633_t *dev, const pca9633_params_t *params)
 
     dev->params = *params;
 
-    i2c_init(dev->params.i2c_dev);
-
     int rc = _write_reg(dev, PCA9633_REG_MODE1, 0x0);
     _write_reg(dev, PCA9633_REG_MODE2, 0x0);
 

--- a/drivers/sdp3x/sdp3x.c
+++ b/drivers/sdp3x/sdp3x.c
@@ -55,7 +55,6 @@ int sdp3x_init(sdp3x_t *dev, const sdp3x_params_t *params)
     dev->params = *params;
     dev->continuous_measurement = false;
 
-    i2c_init(DEV_I2C);
     sdp3x_soft_reset(dev);
 
     /* try to read product number to check if sensor is connected and working */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is already called by `periph_init()`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

found in https://github.com/RIOT-OS/RIOT/pull/20668#discussion_r1603247384
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
