### PR TITLE
boards/nucleo-l452re: add pinout to doc page

### DIFF
--- a/boards/nucleo-l452re/doc.txt
+++ b/boards/nucleo-l452re/doc.txt
@@ -8,6 +8,10 @@
 The Nucleo-L452RE is a board from ST's Nucleo family supporting ARM Cortex-M4
 STM32L452RE microcontroller with 160KiB of RAM and 512KiB of Flash.
 
+## Pinout
+
+@image html pinouts/nucleo-l452re.svg "Pinout for the nucleo-l452re (from STM board manual)" width=50%
+
 ### MCU
 
 | MCU        |   STM32L452RE       |

--- a/doc/doxygen/src/pinouts/nucleo-l452re.svg
+++ b/doc/doxygen/src/pinouts/nucleo-l452re.svg
@@ -1,0 +1,6859 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="561.10663"
+   height="280.03995"
+   viewBox="0 0 561.10663 280.03995"
+   sodipodi:docname="nucleo-l452re.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path4" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path6" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path8" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath10">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path11" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath12">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path12" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path13" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath14">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path14" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path16" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path17" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path18" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath19">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path19" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath20">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path20" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath21">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path21" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path22" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath23">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path23" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path24" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath25">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path25" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath26">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path26" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path27" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath28">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path28" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath29">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path29" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath30">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path30" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath31">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path31" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath32">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path32" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path33" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path34" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path35" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path36" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path37" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path38" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path39" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath40">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path40" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath41">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path41" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath42">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path42" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path43" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath44">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path44" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath45">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path45" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath46">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path46" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path47" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath48">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path48" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath49">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path49" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath50">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path50" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath51">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path51" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath52">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path52" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath53">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path53" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath54">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path54" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath55">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path55" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath56">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path56" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath57">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path57" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath58">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path58" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath59">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path59" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath60">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path60" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath61">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path61" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath62">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path62" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath63">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path63" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath64">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path64" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath65">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path65" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath66">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path66" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath67">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path67" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath68">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path68" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath69">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path69" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath70">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path70" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath71">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path71" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath72">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path72" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath73">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path73" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath74">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path74" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath75">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path75" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath76">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path76" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath77">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path77" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath78">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path78" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath79">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path79" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath80">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path80" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath81">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path81" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath82">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path82" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath83">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path83" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath84">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path84" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath85">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path85" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath86">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path86" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath87">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path87" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath88">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path88" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath89">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path89" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath90">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path90" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath91">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path91" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath92">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path92" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath93">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path93" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath94">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path94" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath95">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path95" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath96">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path96" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath97">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path97" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath98">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path98" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath99">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path99" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath100">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path100" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath101">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path101" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath102">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path102" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath103">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path103" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath104">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path104" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath105">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path105" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath106">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path106" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath107">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path107" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath108">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path108" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath109">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path109" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath110">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path110" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath111">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path111" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath112">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path112" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath113">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path113" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath114">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path114" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath115">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path115" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath116">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path116" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath117">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path117" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath118">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path118" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath119">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path119" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath120">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path120" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath121">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path121" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath122">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path122" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath123">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path123" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath124">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path124" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath125">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path125" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath126">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path126" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath127">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path127" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath128">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path128" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath129">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path129" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath130">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path130" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath131">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path131" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath132">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path132" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath133">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path133" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath134">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path134" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath135">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path135" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath136">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path136" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath137">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path137" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath138">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path138" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath139">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path139" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath140">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path140" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath141">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path141" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath142">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path142" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath143">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path143" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path144" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path145" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath146">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path146" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path147" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path148" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path149" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path150" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path151" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path152" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path153" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path154" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path155" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path156" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path157" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path158" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path159" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path160" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path161" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="matrix(0.96731702,-0.24182926,0.2352989,0.9411753,0,0)"
+         id="path162" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path163" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path164" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path165" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path166" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path167" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path168" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path169" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path170" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path171" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path172" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path173" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path174" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path175" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path176" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path177" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path178" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path179" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path180" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path181" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path182" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path183" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path184" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path185" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path186" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path187" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path188" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path189" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path190" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path191" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path192" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path193" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path194" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path195" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path196" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path197" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path198" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path199" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path200" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path201" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path202" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path203" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path204" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path205" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path206" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path207" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path208" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path209" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path210" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path211" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path212" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path213" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path214" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path215" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path216" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path217" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path218" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path219" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path220" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path221" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path222" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path223" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path224" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path225" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path226" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path227" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path228" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path229" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path230" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path231" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path232" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path233" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path234" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path235" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path236" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path237" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path238" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path239" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path240" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path241" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path242" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path243" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path244" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path245" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path246" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path247" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path248" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path249" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path250" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path251" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path252" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path253" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path254" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path255" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path256" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path257" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path258" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path259" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path260" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path261" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path262" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path263" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path264" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path265" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path266" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path267" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path268" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path269" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path270" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path271" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path272" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path274" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path275" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path276" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path278" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path279" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path280" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path281" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path282" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path283" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path284" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath286">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path286" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath287">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path287" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath288">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path288" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath289">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath290">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path290" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath291">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path291" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath292">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path292" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath293">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path293" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath294">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path294" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath295">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path295" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath296">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path296" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath297">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path297" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath298">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path298" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath299">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path299" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath300">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path300" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath301">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path301" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath302">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path302" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath303">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path303" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath304">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path304" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath305">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path305" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath306">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path306" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath307">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path307" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath308">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path308" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath309">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path309" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath310">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path310" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath311">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path311" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath312">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path312" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath313">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path313" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath314">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path314" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath315">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path315" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath316">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path316" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath317">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path317" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath318">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path318" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath319">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path319" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath320">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath321">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path321" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath322">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path322" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath323">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path323" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath324">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path324" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath325">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path325" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath326">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path326" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath327">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path327" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath328">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath329">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path329" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath330">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path330" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath331">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path331" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath332">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path332" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath333">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path333" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath334">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path334" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath335">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path335" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath336">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path336" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath337">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path337" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath338">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path338" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath339">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path339" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath340">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path340" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath341">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path341" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath342">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path342" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath343">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path343" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath344">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath345">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path345" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath346">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path346" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath347">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path347" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath348">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path348" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath349">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path349" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath350">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path350" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath351">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path351" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath352">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path352" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath353">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path353" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath354">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath355">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path355" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath356">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path356" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath357">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path357" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath358">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path358" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath359">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path359" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath360">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath361">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path361" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath362">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path362" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath363">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path363" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath364">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path364" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath365">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath366">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path366" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path367" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath368">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path368" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath369">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path369" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath370">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path370" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath371">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath372">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path372" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path373" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath374">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path374" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath375">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path375" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath376">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath377">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path377" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath378">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path378" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath379">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path379" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath380">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path380" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath381">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath382">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path382" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path383" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath384">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path384" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath385">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path385" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath386">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path386" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath387">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath388">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path388" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path389" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath390">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path390" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath391">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path391" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath392">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath393">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path393" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath394">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path394" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath395">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path395" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath396">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path396" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath397">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath398">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path398" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path399" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath400">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path400" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath401">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path401" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath402">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path402" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath403">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path403" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath404">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path404" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path405" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath406">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path406" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath407">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path407" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath408">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath409">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path409" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath410">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path410" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath411">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path411" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath412">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path412" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath413">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path413" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path414" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath415">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path415" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath416">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path416" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath417">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path417" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath418">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path418" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath419">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path419" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath420">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path420" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath421">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path421" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath422">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path422" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath423">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path423" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath424">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath425">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path425" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath426">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path426" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath427">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path427" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath428">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path428" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath429">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path429" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath430">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path430" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath431">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path431" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath432">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path432" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath433">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path433" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath434">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath435">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path435" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath436">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path436" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath437">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path437" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath438">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path438" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath439">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path439" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath440">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path440" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath441">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path441" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath442">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path442" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath443">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path443" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath444">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path444" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath445">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path445" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath446">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path446" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath447">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path447" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath448">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path448" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath449">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path449" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath450">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path450" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath451">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path451" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath452">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path452" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath453">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path453" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath454">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path454" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath455">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path455" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath456">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path456" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath457">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path457" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath458">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path458" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath459">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path459" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath460">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path460" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath461">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path461" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath462">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path462" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath463">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path463" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath464">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path464" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath465">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path465" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath466">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path466" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath467">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path467" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath468">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.0277883,1)"
+         id="path468" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath469">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path469" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath470">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path470" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath471">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path471" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath472">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path472" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath473">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path473" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath474">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path474" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath475">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path475" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath476">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path476" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath477">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path477" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath478">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path478" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath479">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path479" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath480">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path480" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath481">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path481" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath482">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path482" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath483">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path483" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath484">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path484" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath485">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path485" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath486">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path486" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath487">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path487" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath488">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path488" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath489">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path489" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath490">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path490" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath491">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path491" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath492">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path492" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath493">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path493" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath494">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path494" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath495">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path495" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath496">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path496" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath497">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path497" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath498">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path498" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath499">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path499" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath500">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path500" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath501">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path501" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath502">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path502" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath503">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path503" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath504">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path504" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath505">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path505" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath506">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path506" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath507">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path507" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath508">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path508" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath509">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path509" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath510">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         id="path510" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath511">
+      <path
+         d="M 0,0 H 421 V 211 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path511" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.8445692"
+     inkscape:cx="280.55331"
+     inkscape:cy="140.14112"
+     inkscape:window-width="1680"
+     inkscape:window-height="981"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="561.10663"
+       height="280.03995"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <g
+     id="g1"
+     inkscape:groupmode="layer"
+     inkscape:label="1">
+    <g
+       id="g2">
+      <path
+         d="m 0,46.367 h 0.238 v 0.48 H 0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath1)"
+         id="path2" />
+    </g>
+    <g
+       id="g1020">
+      <g
+         clip-path="url(#clipPath511)"
+         id="g1019">
+        <path
+           d="m 370.602,204.855 h 0.882 l 1.118,3.063 1.121,-3.063 h 0.882 v 4.497 h -0.578 v -3.946 l -1.129,3.082 h -0.593 l -1.129,-3.082 v 3.946 h -0.574 z m 7.621,0.149 v 0.594 c -0.223,-0.11 -0.438,-0.192 -0.637,-0.246 -0.199,-0.055 -0.391,-0.082 -0.574,-0.082 -0.324,0 -0.574,0.062 -0.75,0.191 -0.172,0.129 -0.258,0.312 -0.258,0.551 0,0.195 0.055,0.347 0.172,0.449 0.117,0.101 0.336,0.184 0.66,0.246 l 0.359,0.074 c 0.442,0.086 0.766,0.239 0.977,0.457 0.211,0.219 0.316,0.508 0.316,0.875 0,0.434 -0.144,0.766 -0.429,0.989 -0.282,0.226 -0.7,0.339 -1.247,0.339 -0.207,0 -0.429,-0.027 -0.664,-0.074 -0.23,-0.047 -0.472,-0.117 -0.722,-0.215 v -0.625 c 0.238,0.141 0.476,0.243 0.707,0.313 0.23,0.07 0.457,0.105 0.679,0.105 0.336,0 0.598,-0.066 0.782,-0.203 0.183,-0.137 0.273,-0.332 0.273,-0.586 0,-0.218 -0.066,-0.39 -0.199,-0.515 -0.129,-0.125 -0.344,-0.219 -0.645,-0.282 l -0.363,-0.074 c -0.441,-0.09 -0.758,-0.23 -0.957,-0.422 -0.195,-0.195 -0.297,-0.461 -0.297,-0.804 0,-0.399 0.137,-0.711 0.41,-0.942 0.274,-0.226 0.649,-0.34 1.125,-0.34 0.207,0 0.414,0.016 0.629,0.055 0.211,0.039 0.43,0.098 0.653,0.172 z m 0.968,0.976 h 0.575 l 1.023,2.832 1.027,-2.832 h 0.571 l -1.231,3.372 h -0.734 z m 5.09,-0.593 -1.492,2.398 h 1.492 z m -0.156,-0.532 h 0.746 v 2.93 h 0.625 v 0.508 h -0.625 v 1.059 h -0.59 v -1.059 h -1.972 v -0.586 z m 3.492,0.532 -1.492,2.398 h 1.492 z m -0.156,-0.532 h 0.746 v 2.93 h 0.625 v 0.508 h -0.625 v 1.059 h -0.59 v -1.059 h -1.972 v -0.586 z m 3.66,2.075 c 0.281,0.062 0.504,0.191 0.66,0.386 0.16,0.2 0.242,0.442 0.242,0.731 0,0.441 -0.148,0.785 -0.445,1.027 -0.297,0.246 -0.719,0.367 -1.266,0.367 -0.183,0 -0.374,-0.019 -0.57,-0.058 -0.191,-0.035 -0.39,-0.09 -0.597,-0.164 v -0.59 c 0.164,0.098 0.343,0.172 0.539,0.223 0.195,0.05 0.398,0.078 0.609,0.078 0.371,0 0.656,-0.078 0.848,-0.227 0.195,-0.152 0.293,-0.371 0.293,-0.656 0,-0.266 -0.09,-0.473 -0.274,-0.621 -0.18,-0.153 -0.43,-0.227 -0.75,-0.227 h -0.512 v -0.5 h 0.536 c 0.289,0 0.511,-0.058 0.668,-0.176 0.152,-0.121 0.23,-0.293 0.23,-0.519 0,-0.231 -0.082,-0.406 -0.242,-0.531 -0.156,-0.121 -0.383,-0.184 -0.68,-0.184 -0.164,0 -0.336,0.016 -0.523,0.055 -0.184,0.035 -0.391,0.09 -0.614,0.168 v -0.543 c 0.227,-0.067 0.438,-0.114 0.633,-0.145 0.196,-0.031 0.383,-0.047 0.555,-0.047 0.449,0 0.805,0.106 1.066,0.317 0.262,0.207 0.395,0.488 0.395,0.847 0,0.25 -0.07,0.461 -0.211,0.633 -0.137,0.168 -0.336,0.289 -0.59,0.356 z m 2.809,-1.672 c -0.305,0 -0.535,0.152 -0.688,0.465 -0.152,0.304 -0.23,0.769 -0.23,1.386 0,0.618 0.078,1.079 0.23,1.387 0.153,0.309 0.383,0.461 0.688,0.461 0.304,0 0.535,-0.152 0.687,-0.461 0.156,-0.308 0.231,-0.769 0.231,-1.387 0,-0.617 -0.075,-1.082 -0.231,-1.386 -0.152,-0.313 -0.383,-0.465 -0.687,-0.465 z m 0,-0.481 c 0.488,0 0.863,0.2 1.121,0.598 0.261,0.398 0.39,0.977 0.39,1.734 0,0.758 -0.129,1.336 -0.39,1.735 -0.258,0.398 -0.633,0.597 -1.121,0.597 -0.492,0 -0.868,-0.199 -1.125,-0.597 -0.258,-0.399 -0.387,-0.977 -0.387,-1.735 0,-0.757 0.129,-1.336 0.387,-1.734 0.257,-0.398 0.633,-0.598 1.125,-0.598 z m 2.578,4.063 h 2.066 v 0.512 h -2.777 v -0.512 c 0.226,-0.238 0.531,-0.559 0.918,-0.961 0.387,-0.402 0.633,-0.664 0.73,-0.777 0.192,-0.219 0.325,-0.407 0.399,-0.555 0.074,-0.152 0.113,-0.305 0.113,-0.449 0,-0.239 -0.082,-0.434 -0.246,-0.586 -0.164,-0.149 -0.375,-0.223 -0.637,-0.223 -0.183,0 -0.383,0.031 -0.59,0.098 -0.203,0.066 -0.422,0.168 -0.656,0.301 v -0.614 c 0.238,-0.097 0.461,-0.172 0.668,-0.222 0.207,-0.051 0.395,-0.075 0.566,-0.075 0.454,0 0.817,0.114 1.086,0.348 0.27,0.234 0.403,0.543 0.403,0.934 0,0.183 -0.035,0.359 -0.102,0.527 -0.066,0.164 -0.187,0.359 -0.367,0.582 -0.047,0.059 -0.203,0.227 -0.465,0.508 -0.262,0.277 -0.633,0.664 -1.109,1.164 z m 3.902,0.512 -1.668,-4.497 h 0.617 l 1.387,3.786 1.387,-3.786 h 0.617 l -1.668,4.497 z m 3.031,-0.512 h 0.965 v -3.43 l -1.051,0.219 v -0.555 l 1.047,-0.219 h 0.59 v 3.985 h 0.969 v 0.512 h -2.52 z"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath3)"
+           id="path512" />
+        <path
+           d="M 4.962,3.852 H 420.136 V 213.625 H 4.962 Z"
+           style="fill:none;stroke:#ffffff;stroke-width:0.256491;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath4)"
+           id="path513" />
+        <path
+           d="m 157.133,182.418 6.07,4.441 h 72.856 l 6.07,-4.441 h -84.996"
+           style="fill:#dedede;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath5)"
+           id="path514" />
+        <path
+           d="M 133.387,15.508 H 292.133 V 182.414 H 133.387 Z"
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath6)"
+           id="path515" />
+        <path
+           d="m 171.109,174.172 v 1.406 h 0.621 c 0.231,0 0.407,-0.062 0.532,-0.183 0.125,-0.122 0.187,-0.297 0.187,-0.52 0,-0.227 -0.062,-0.398 -0.187,-0.52 -0.125,-0.125 -0.301,-0.183 -0.532,-0.183 z m -0.492,-0.418 h 1.113 c 0.411,0 0.719,0.094 0.926,0.285 0.211,0.191 0.313,0.469 0.313,0.836 0,0.367 -0.102,0.648 -0.313,0.836 -0.207,0.187 -0.515,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 6.067,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.277 -0.536,-0.355 -0.187,-0.082 -0.386,-0.121 -0.597,-0.121 -0.418,0 -0.735,0.132 -0.957,0.394 -0.223,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.109,0.871 0.332,1.133 0.222,0.261 0.539,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.597,-0.117 0.192,-0.078 0.368,-0.199 0.536,-0.355 v 0.527 c -0.176,0.121 -0.36,0.211 -0.551,0.273 -0.192,0.059 -0.395,0.09 -0.61,0.09 -0.554,0 -0.988,-0.176 -1.304,-0.519 -0.317,-0.348 -0.477,-0.825 -0.477,-1.422 0,-0.606 0.16,-1.078 0.477,-1.426 0.316,-0.348 0.75,-0.519 1.304,-0.519 0.215,0 0.422,0.027 0.614,0.089 0.195,0.059 0.375,0.149 0.547,0.266 z m 1.976,0.047 c -0.254,0 -0.445,0.125 -0.574,0.383 -0.125,0.257 -0.188,0.644 -0.188,1.16 0,0.512 0.063,0.898 0.188,1.156 0.129,0.254 0.32,0.383 0.574,0.383 0.258,0 0.449,-0.129 0.574,-0.383 0.129,-0.258 0.192,-0.644 0.192,-1.156 0,-0.516 -0.063,-0.903 -0.192,-1.16 -0.125,-0.258 -0.316,-0.383 -0.574,-0.383 z m 0,-0.402 c 0.41,0 0.723,0.164 0.938,0.5 0.214,0.328 0.324,0.812 0.324,1.445 0,0.629 -0.11,1.109 -0.324,1.445 -0.215,0.328 -0.528,0.496 -0.938,0.496 -0.406,0 -0.719,-0.168 -0.937,-0.496 -0.215,-0.336 -0.321,-0.816 -0.321,-1.445 0,-0.633 0.106,-1.117 0.321,-1.445 0.218,-0.336 0.531,-0.5 0.937,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath7)"
+           id="path516" />
+        <path
+           d="m 171.109,168.293 v 1.406 h 0.621 c 0.231,0 0.407,-0.058 0.532,-0.183 0.125,-0.121 0.187,-0.293 0.187,-0.52 0,-0.226 -0.062,-0.398 -0.187,-0.519 -0.125,-0.122 -0.301,-0.184 -0.532,-0.184 z m -0.492,-0.418 h 1.113 c 0.411,0 0.719,0.098 0.926,0.289 0.211,0.188 0.313,0.465 0.313,0.832 0,0.367 -0.102,0.649 -0.313,0.836 -0.207,0.191 -0.515,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 6.067,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.277 -0.536,-0.355 -0.187,-0.078 -0.386,-0.117 -0.597,-0.117 -0.418,0 -0.735,0.128 -0.957,0.39 -0.223,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.109,0.871 0.332,1.133 0.222,0.261 0.539,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.597,-0.117 0.192,-0.078 0.368,-0.195 0.536,-0.355 v 0.527 c -0.176,0.121 -0.36,0.211 -0.551,0.273 -0.192,0.059 -0.395,0.09 -0.61,0.09 -0.554,0 -0.988,-0.172 -1.304,-0.519 -0.317,-0.348 -0.477,-0.821 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.422 0.316,-0.352 0.75,-0.523 1.304,-0.523 0.215,0 0.422,0.031 0.614,0.089 0.195,0.059 0.375,0.149 0.547,0.266 z m 1.007,3.031 h 0.805 v -2.859 l -0.875,0.184 v -0.461 l 0.871,-0.184 h 0.492 v 3.32 h 0.809 v 0.426 h -2.102 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath8)"
+           id="path517" />
+        <path
+           d="m 171.027,162.516 v 1.41 h 0.621 c 0.231,0 0.407,-0.063 0.532,-0.184 0.125,-0.125 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.399 -0.187,-0.52 -0.125,-0.121 -0.301,-0.183 -0.532,-0.183 z m -0.492,-0.414 h 1.113 c 0.411,0 0.719,0.093 0.926,0.285 0.211,0.187 0.317,0.465 0.317,0.832 0,0.371 -0.106,0.648 -0.317,0.84 -0.207,0.187 -0.515,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 3.828,1.957 v 1.371 h 0.789 c 0.266,0 0.465,-0.055 0.59,-0.168 0.129,-0.114 0.192,-0.285 0.192,-0.52 0,-0.234 -0.063,-0.406 -0.192,-0.515 -0.125,-0.114 -0.324,-0.168 -0.59,-0.168 z m 0,-1.543 v 1.129 h 0.731 c 0.238,0 0.418,-0.043 0.535,-0.137 0.121,-0.094 0.18,-0.235 0.18,-0.426 0,-0.191 -0.059,-0.332 -0.18,-0.426 -0.117,-0.094 -0.297,-0.14 -0.535,-0.14 z m -0.492,-0.414 h 1.258 c 0.375,0 0.668,0.078 0.871,0.238 0.203,0.16 0.305,0.39 0.305,0.687 0,0.227 -0.055,0.411 -0.157,0.547 -0.105,0.133 -0.257,0.219 -0.46,0.254 0.242,0.051 0.429,0.164 0.566,0.336 0.133,0.168 0.203,0.379 0.203,0.633 0,0.336 -0.113,0.594 -0.332,0.777 -0.223,0.18 -0.539,0.274 -0.945,0.274 h -1.309 z m 4.434,0.332 c -0.254,0 -0.446,0.128 -0.575,0.386 -0.128,0.254 -0.191,0.641 -0.191,1.157 0,0.515 0.063,0.898 0.191,1.156 0.129,0.258 0.321,0.383 0.575,0.383 0.254,0 0.445,-0.125 0.57,-0.383 0.129,-0.258 0.195,-0.641 0.195,-1.156 0,-0.516 -0.066,-0.903 -0.195,-1.157 -0.125,-0.258 -0.316,-0.386 -0.57,-0.386 z m 0,-0.403 c 0.406,0 0.718,0.168 0.933,0.5 0.215,0.332 0.324,0.813 0.324,1.446 0,0.632 -0.109,1.113 -0.324,1.445 -0.215,0.332 -0.527,0.496 -0.933,0.496 -0.41,0 -0.723,-0.164 -0.938,-0.496 -0.215,-0.332 -0.324,-0.813 -0.324,-1.445 0,-0.633 0.109,-1.114 0.324,-1.446 0.215,-0.332 0.528,-0.5 0.938,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath9)"
+           id="path518" />
+        <path
+           d="m 171.121,156.691 v 1.407 h 0.621 c 0.231,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.188,-0.297 0.188,-0.523 0,-0.223 -0.063,-0.395 -0.188,-0.52 -0.125,-0.121 -0.3,-0.18 -0.531,-0.18 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.094 0.926,0.286 0.211,0.191 0.316,0.468 0.316,0.832 0,0.371 -0.105,0.652 -0.316,0.839 -0.207,0.188 -0.516,0.286 -0.926,0.286 h -0.621 v 1.504 h -0.492 z m 4.183,0.5 -0.671,1.864 h 1.343 z m -0.281,-0.5 h 0.563 l 1.386,3.747 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.519 z m 3.797,0.442 -1.246,2 h 1.246 z m -0.129,-0.442 h 0.617 v 2.442 h 0.524 v 0.422 h -0.524 v 0.883 h -0.488 v -0.883 h -1.644 v -0.489 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath10)"
+           id="path519" />
+        <path
+           d="m 170.887,150.863 v 1.407 h 0.621 c 0.226,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.188,-0.297 0.188,-0.52 0,-0.226 -0.063,-0.398 -0.188,-0.519 -0.125,-0.125 -0.305,-0.184 -0.531,-0.184 z m -0.492,-0.418 h 1.113 c 0.406,0 0.715,0.094 0.926,0.285 0.207,0.192 0.312,0.469 0.312,0.836 0,0.368 -0.105,0.649 -0.312,0.836 -0.211,0.192 -0.52,0.286 -0.926,0.286 h -0.621 v 1.503 h -0.492 z m 4.179,0.5 -0.668,1.864 h 1.34 z m -0.277,-0.5 h 0.558 l 1.391,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.523,3.321 h 0.809 v -2.86 l -0.879,0.184 v -0.465 l 0.871,-0.18 h 0.496 v 3.321 h 0.805 v 0.425 h -2.102 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath11)"
+           id="path520" />
+        <path
+           d="m 170.887,145.035 v 1.406 h 0.621 c 0.226,0 0.406,-0.058 0.531,-0.179 0.125,-0.125 0.188,-0.297 0.188,-0.524 0,-0.222 -0.063,-0.398 -0.188,-0.519 -0.125,-0.121 -0.305,-0.184 -0.531,-0.184 z m -0.492,-0.418 h 1.113 c 0.406,0 0.715,0.098 0.926,0.289 0.207,0.188 0.312,0.465 0.312,0.832 0,0.371 -0.105,0.649 -0.312,0.84 -0.211,0.188 -0.52,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 4.179,0.5 -0.668,1.867 h 1.34 z m -0.277,-0.5 h 0.558 l 1.391,3.75 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 3.492,0.336 c -0.254,0 -0.441,0.129 -0.57,0.387 -0.129,0.254 -0.192,0.64 -0.192,1.156 0,0.512 0.063,0.899 0.192,1.156 0.129,0.258 0.316,0.383 0.57,0.383 0.258,0 0.449,-0.125 0.574,-0.383 0.129,-0.257 0.196,-0.644 0.196,-1.156 0,-0.516 -0.067,-0.902 -0.196,-1.156 -0.125,-0.258 -0.316,-0.387 -0.574,-0.387 z m 0,-0.402 c 0.41,0 0.723,0.168 0.938,0.5 0.214,0.332 0.324,0.812 0.324,1.445 0,0.629 -0.11,1.113 -0.324,1.445 -0.215,0.332 -0.528,0.497 -0.938,0.497 -0.406,0 -0.719,-0.165 -0.937,-0.497 -0.215,-0.332 -0.321,-0.816 -0.321,-1.445 0,-0.633 0.106,-1.113 0.321,-1.445 0.218,-0.332 0.531,-0.5 0.937,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath12)"
+           id="path521" />
+        <path
+           d="m 170.379,138.793 h 0.664 l 1.617,3.133 v -3.133 h 0.477 v 3.746 h -0.664 l -1.614,-3.133 v 3.133 h -0.48 z m 6.34,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.281 -0.531,-0.359 -0.188,-0.078 -0.387,-0.117 -0.598,-0.117 -0.418,0 -0.738,0.132 -0.957,0.394 -0.223,0.262 -0.332,0.641 -0.332,1.133 0,0.496 0.109,0.871 0.332,1.137 0.219,0.261 0.539,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.598,-0.117 0.187,-0.078 0.363,-0.199 0.531,-0.355 v 0.527 c -0.172,0.121 -0.356,0.211 -0.551,0.27 -0.191,0.062 -0.395,0.093 -0.609,0.093 -0.551,0 -0.985,-0.175 -1.305,-0.519 -0.316,-0.348 -0.477,-0.824 -0.477,-1.426 0,-0.602 0.161,-1.074 0.477,-1.422 0.32,-0.348 0.754,-0.519 1.305,-0.519 0.218,0 0.421,0.027 0.617,0.089 0.191,0.059 0.375,0.145 0.543,0.266 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath13)"
+           id="path522" />
+        <path
+           d="m 171.75,136.711 -1.391,-3.746 h 0.516 l 1.156,3.152 1.157,-3.152 h 0.511 l -1.39,3.746 z m 2.395,-3.746 h 0.496 v 3.746 h -0.496 z m 1.39,0 h 0.664 l 1.617,3.133 v -3.133 h 0.481 v 3.746 h -0.664 l -1.617,-3.133 v 3.133 h -0.481 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath14)"
+           id="path523" />
+        <path
+           d="m 173.039,130.352 v -1.008 h -0.805 v -0.418 h 1.293 v 1.609 c -0.187,0.141 -0.398,0.246 -0.629,0.317 -0.23,0.07 -0.472,0.105 -0.734,0.105 -0.57,0 -1.016,-0.172 -1.34,-0.512 -0.32,-0.343 -0.48,-0.82 -0.48,-1.429 0,-0.614 0.16,-1.09 0.48,-1.43 0.324,-0.344 0.77,-0.516 1.34,-0.516 0.238,0 0.465,0.032 0.676,0.09 0.215,0.063 0.414,0.149 0.594,0.266 v 0.539 c -0.184,-0.156 -0.375,-0.277 -0.582,-0.356 -0.204,-0.082 -0.418,-0.121 -0.645,-0.121 -0.449,0 -0.781,0.125 -1.008,0.383 -0.222,0.254 -0.336,0.637 -0.336,1.145 0,0.504 0.114,0.886 0.336,1.14 0.227,0.258 0.559,0.383 1.008,0.383 0.172,0 0.328,-0.012 0.465,-0.043 0.137,-0.031 0.258,-0.082 0.367,-0.144 z m 1.406,-3.215 h 0.664 l 1.618,3.136 v -3.136 h 0.476 v 3.746 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z m 4.102,0.418 v 2.914 h 0.598 c 0.503,0 0.871,-0.117 1.101,-0.352 0.234,-0.234 0.352,-0.605 0.352,-1.109 0,-0.504 -0.118,-0.871 -0.352,-1.102 -0.23,-0.234 -0.598,-0.351 -1.101,-0.351 z m -0.492,-0.418 h 1.015 c 0.703,0 1.223,0.152 1.555,0.457 0.328,0.301 0.496,0.773 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.422 -0.332,0.304 -0.848,0.453 -1.551,0.453 h -1.015 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath15)"
+           id="path524" />
+        <path
+           d="m 173.039,124.523 v -1.007 h -0.805 v -0.414 h 1.293 v 1.609 c -0.187,0.137 -0.398,0.242 -0.629,0.312 -0.23,0.071 -0.472,0.106 -0.734,0.106 -0.57,0 -1.016,-0.168 -1.34,-0.512 -0.32,-0.34 -0.48,-0.816 -0.48,-1.429 0,-0.61 0.16,-1.09 0.48,-1.43 0.324,-0.344 0.77,-0.516 1.34,-0.516 0.238,0 0.465,0.031 0.676,0.094 0.215,0.059 0.414,0.148 0.594,0.266 v 0.539 c -0.184,-0.161 -0.375,-0.282 -0.582,-0.36 -0.204,-0.082 -0.418,-0.121 -0.645,-0.121 -0.449,0 -0.781,0.129 -1.008,0.383 -0.222,0.258 -0.336,0.641 -0.336,1.145 0,0.507 0.114,0.886 0.336,1.144 0.227,0.254 0.559,0.383 1.008,0.383 0.172,0 0.328,-0.016 0.465,-0.047 0.137,-0.031 0.258,-0.078 0.367,-0.145 z m 1.406,-3.211 h 0.664 l 1.618,3.133 v -3.133 h 0.476 v 3.747 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z m 4.102,0.415 v 2.914 h 0.598 c 0.503,0 0.871,-0.118 1.101,-0.352 0.234,-0.234 0.352,-0.601 0.352,-1.109 0,-0.5 -0.118,-0.868 -0.352,-1.102 -0.23,-0.234 -0.598,-0.351 -1.101,-0.351 z m -0.492,-0.415 h 1.015 c 0.703,0 1.223,0.153 1.555,0.454 0.328,0.3 0.496,0.773 0.496,1.414 0,0.648 -0.168,1.121 -0.5,1.425 -0.332,0.301 -0.848,0.454 -1.551,0.454 h -1.015 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath16)"
+           id="path525" />
+        <path
+           d="m 172.293,116.008 v 1.398 h 1.359 v 0.426 h -1.359 v 1.398 h -0.41 v -1.398 h -1.36 v -0.426 h 1.36 v -1.398 z m 1.16,-0.524 h 1.938 v 0.426 h -1.485 v 0.918 c 0.071,-0.023 0.145,-0.043 0.215,-0.055 0.07,-0.011 0.145,-0.019 0.215,-0.019 0.406,0 0.73,0.117 0.965,0.344 0.238,0.23 0.359,0.539 0.359,0.933 0,0.403 -0.125,0.715 -0.367,0.938 -0.246,0.222 -0.59,0.336 -1.035,0.336 -0.153,0 -0.309,-0.016 -0.469,-0.039 -0.156,-0.028 -0.32,-0.071 -0.488,-0.121 v -0.512 c 0.144,0.082 0.297,0.144 0.453,0.183 0.156,0.043 0.32,0.063 0.496,0.063 0.281,0 0.504,-0.078 0.668,-0.231 0.164,-0.152 0.246,-0.359 0.246,-0.617 0,-0.261 -0.082,-0.469 -0.246,-0.621 -0.164,-0.152 -0.387,-0.23 -0.668,-0.23 -0.133,0 -0.266,0.015 -0.395,0.047 -0.132,0.031 -0.265,0.078 -0.402,0.14 z m 3.672,3.746 -1.391,-3.746 h 0.516 l 1.152,3.157 1.16,-3.157 h 0.512 l -1.39,3.746 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath17)"
+           id="path526" />
+        <path
+           d="m 172.227,110.184 v 1.394 h 1.359 v 0.43 h -1.359 v 1.394 h -0.411 v -1.394 h -1.359 v -0.43 h 1.359 v -1.394 z m 2.648,1.199 c 0.238,0.055 0.422,0.16 0.555,0.324 0.132,0.164 0.199,0.367 0.199,0.609 0,0.368 -0.125,0.653 -0.371,0.856 -0.25,0.203 -0.602,0.305 -1.055,0.305 -0.152,0 -0.312,-0.016 -0.473,-0.047 -0.164,-0.032 -0.328,-0.078 -0.503,-0.141 v -0.488 c 0.136,0.082 0.289,0.144 0.449,0.187 0.164,0.039 0.336,0.063 0.512,0.063 0.308,0 0.542,-0.063 0.707,-0.188 0.16,-0.129 0.242,-0.308 0.242,-0.547 0,-0.222 -0.075,-0.394 -0.227,-0.519 -0.148,-0.125 -0.359,-0.188 -0.629,-0.188 h -0.422 v -0.418 h 0.442 c 0.246,0 0.429,-0.046 0.558,-0.144 0.129,-0.102 0.192,-0.246 0.192,-0.434 0,-0.191 -0.067,-0.34 -0.199,-0.441 -0.133,-0.106 -0.321,-0.156 -0.571,-0.156 -0.133,0 -0.277,0.015 -0.433,0.046 -0.153,0.028 -0.325,0.075 -0.508,0.141 v -0.453 c 0.183,-0.055 0.359,-0.094 0.523,-0.121 0.164,-0.027 0.321,-0.039 0.465,-0.039 0.375,0 0.668,0.086 0.887,0.262 0.219,0.175 0.328,0.41 0.328,0.71 0,0.208 -0.059,0.383 -0.172,0.524 -0.117,0.144 -0.281,0.242 -0.496,0.297 z m 2.184,2.019 -1.391,-3.746 h 0.516 l 1.152,3.156 1.156,-3.156 h 0.516 l -1.391,3.746 z m 3.933,-2.019 c 0.235,0.055 0.418,0.16 0.551,0.324 0.133,0.164 0.199,0.367 0.199,0.609 0,0.368 -0.121,0.653 -0.371,0.856 -0.246,0.203 -0.598,0.305 -1.055,0.305 -0.152,0 -0.308,-0.016 -0.472,-0.047 -0.16,-0.032 -0.328,-0.078 -0.5,-0.141 v -0.488 c 0.136,0.082 0.285,0.144 0.449,0.187 0.164,0.039 0.332,0.063 0.512,0.063 0.308,0 0.543,-0.063 0.703,-0.188 0.164,-0.129 0.246,-0.308 0.246,-0.547 0,-0.222 -0.078,-0.394 -0.227,-0.519 -0.152,-0.125 -0.359,-0.188 -0.629,-0.188 h -0.425 v -0.418 h 0.445 c 0.242,0 0.43,-0.046 0.555,-0.144 0.129,-0.102 0.195,-0.246 0.195,-0.434 0,-0.191 -0.066,-0.34 -0.199,-0.441 -0.133,-0.106 -0.324,-0.156 -0.571,-0.156 -0.136,0 -0.281,0.015 -0.433,0.046 -0.156,0.028 -0.324,0.075 -0.512,0.141 v -0.453 c 0.188,-0.055 0.363,-0.094 0.524,-0.121 0.168,-0.027 0.32,-0.039 0.464,-0.039 0.375,0 0.672,0.086 0.891,0.262 0.219,0.175 0.324,0.41 0.324,0.71 0,0.208 -0.054,0.383 -0.172,0.524 -0.117,0.144 -0.281,0.242 -0.492,0.297 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath18)"
+           id="path527" />
+        <path
+           d="m 172.195,105.82 c 0.106,0.039 0.211,0.118 0.309,0.235 0.101,0.121 0.203,0.289 0.305,0.5 l 0.5,1.023 h -0.532 l -0.465,-0.961 c -0.121,-0.254 -0.238,-0.418 -0.351,-0.5 -0.113,-0.082 -0.266,-0.125 -0.461,-0.125 h -0.539 v 1.586 h -0.492 v -3.746 h 1.113 c 0.418,0 0.727,0.09 0.934,0.266 0.203,0.179 0.304,0.449 0.304,0.812 0,0.235 -0.05,0.43 -0.16,0.586 -0.105,0.156 -0.262,0.266 -0.465,0.324 z m -1.234,-1.574 v 1.332 h 0.621 c 0.238,0 0.418,-0.058 0.535,-0.168 0.125,-0.113 0.184,-0.281 0.184,-0.5 0,-0.219 -0.059,-0.383 -0.184,-0.496 -0.117,-0.109 -0.297,-0.168 -0.535,-0.168 z m 3.117,-0.414 h 2.305 v 0.426 h -1.813 v 1.109 h 1.739 v 0.426 h -1.739 v 1.359 h 1.856 v 0.426 h -2.348 z m 5.52,0.121 v 0.496 c -0.188,-0.094 -0.364,-0.16 -0.528,-0.207 -0.168,-0.047 -0.328,-0.066 -0.484,-0.066 -0.266,0 -0.473,0.051 -0.621,0.16 -0.145,0.105 -0.219,0.258 -0.219,0.457 0,0.164 0.051,0.289 0.145,0.375 0.097,0.082 0.281,0.152 0.554,0.203 l 0.297,0.063 c 0.367,0.074 0.637,0.199 0.813,0.382 0.175,0.18 0.261,0.422 0.261,0.727 0,0.363 -0.117,0.637 -0.355,0.824 -0.234,0.188 -0.582,0.281 -1.039,0.281 -0.172,0 -0.356,-0.019 -0.551,-0.058 -0.195,-0.039 -0.394,-0.102 -0.605,-0.18 v -0.519 c 0.203,0.113 0.398,0.203 0.589,0.261 0.192,0.059 0.379,0.086 0.567,0.086 0.281,0 0.5,-0.058 0.652,-0.172 0.153,-0.113 0.231,-0.273 0.231,-0.484 0,-0.184 -0.059,-0.328 -0.168,-0.434 -0.11,-0.101 -0.289,-0.179 -0.539,-0.23 l -0.301,-0.063 c -0.367,-0.074 -0.633,-0.191 -0.797,-0.351 -0.164,-0.164 -0.246,-0.387 -0.246,-0.672 0,-0.332 0.109,-0.594 0.336,-0.781 0.23,-0.192 0.543,-0.289 0.941,-0.289 0.172,0 0.344,0.015 0.524,0.05 0.175,0.032 0.359,0.079 0.543,0.141 z m 1.152,-0.121 h 2.305 v 0.426 h -1.813 v 1.109 h 1.735 v 0.426 h -1.735 v 1.359 h 1.856 v 0.426 h -2.348 z m 2.828,0 h 3.082 v 0.426 h -1.293 v 3.32 h -0.496 v -3.32 h -1.293 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath19)"
+           id="path528" />
+        <path
+           d="m 170.316,98.004 h 0.496 v 3.746 h -0.496 z m 2.872,0.344 c -0.36,0 -0.645,0.136 -0.856,0.41 -0.207,0.277 -0.312,0.648 -0.312,1.121 0,0.473 0.105,0.848 0.312,1.121 0.211,0.273 0.496,0.41 0.856,0.41 0.359,0 0.64,-0.137 0.851,-0.41 0.207,-0.273 0.313,-0.648 0.313,-1.121 0,-0.473 -0.106,-0.844 -0.313,-1.121 -0.211,-0.274 -0.492,-0.41 -0.851,-0.41 z m 0,-0.41 c 0.511,0 0.917,0.175 1.226,0.527 0.305,0.351 0.457,0.824 0.457,1.414 0,0.594 -0.152,1.062 -0.457,1.418 -0.309,0.351 -0.715,0.527 -1.226,0.527 -0.512,0 -0.922,-0.176 -1.231,-0.527 -0.305,-0.352 -0.457,-0.824 -0.457,-1.418 0,-0.59 0.152,-1.063 0.457,-1.414 0.309,-0.352 0.719,-0.527 1.231,-0.527 z m 4.14,2.054 c 0.106,0.039 0.207,0.117 0.305,0.238 0.101,0.122 0.203,0.286 0.305,0.497 l 0.5,1.023 h -0.532 l -0.465,-0.961 c -0.121,-0.25 -0.238,-0.418 -0.351,-0.5 -0.113,-0.082 -0.266,-0.121 -0.461,-0.121 h -0.539 v 1.582 h -0.492 v -3.746 h 1.113 c 0.418,0 0.727,0.09 0.934,0.269 0.203,0.176 0.308,0.45 0.308,0.809 0,0.238 -0.055,0.434 -0.164,0.586 -0.105,0.156 -0.258,0.266 -0.461,0.324 z m -1.238,-1.57 v 1.328 h 0.621 c 0.238,0 0.418,-0.055 0.539,-0.168 0.121,-0.113 0.184,-0.281 0.184,-0.5 0,-0.219 -0.063,-0.383 -0.184,-0.492 -0.121,-0.113 -0.301,-0.168 -0.539,-0.168 z m 3.117,-0.418 h 2.305 v 0.426 h -1.809 v 1.109 h 1.735 v 0.426 h -1.735 v 1.359 h 1.856 v 0.426 h -2.352 z m 3.336,0 h 2.094 v 0.426 h -1.602 v 1.105 h 1.445 v 0.426 h -1.445 v 1.789 h -0.492 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath20)"
+           id="path529" />
+        <path
+           d="m 170.379,92.176 h 0.664 l 1.617,3.136 v -3.136 h 0.477 v 3.746 h -0.664 l -1.614,-3.133 v 3.133 h -0.48 z m 6.34,0.289 V 93 c -0.168,-0.16 -0.344,-0.277 -0.531,-0.355 -0.188,-0.079 -0.387,-0.118 -0.598,-0.118 -0.418,0 -0.738,0.129 -0.957,0.391 -0.223,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.109,0.871 0.332,1.133 0.219,0.261 0.539,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.598,-0.117 0.187,-0.078 0.363,-0.195 0.531,-0.356 v 0.532 c -0.172,0.117 -0.356,0.207 -0.551,0.269 -0.191,0.059 -0.395,0.09 -0.609,0.09 -0.551,0 -0.985,-0.172 -1.305,-0.519 -0.316,-0.348 -0.477,-0.821 -0.477,-1.422 0,-0.602 0.161,-1.078 0.477,-1.422 0.32,-0.348 0.754,-0.524 1.305,-0.524 0.218,0 0.421,0.032 0.617,0.09 0.191,0.059 0.375,0.149 0.543,0.266 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath21)"
+           id="path530" />
+        <path
+           d="m 173.039,89.562 v -1.007 h -0.805 v -0.418 h 1.293 v 1.609 c -0.187,0.141 -0.398,0.246 -0.629,0.316 -0.23,0.071 -0.472,0.106 -0.734,0.106 -0.57,0 -1.016,-0.172 -1.34,-0.512 -0.32,-0.344 -0.48,-0.82 -0.48,-1.429 0,-0.614 0.16,-1.09 0.48,-1.43 0.324,-0.344 0.77,-0.516 1.34,-0.516 0.238,0 0.465,0.031 0.676,0.09 0.215,0.063 0.414,0.149 0.594,0.266 v 0.539 c -0.184,-0.156 -0.375,-0.278 -0.582,-0.356 -0.204,-0.082 -0.418,-0.121 -0.645,-0.121 -0.449,0 -0.781,0.129 -1.008,0.383 -0.222,0.258 -0.336,0.637 -0.336,1.145 0,0.503 0.114,0.886 0.336,1.14 0.227,0.258 0.559,0.387 1.008,0.387 0.172,0 0.328,-0.016 0.465,-0.047 0.137,-0.031 0.258,-0.082 0.367,-0.145 z m 1.406,-3.214 h 0.664 l 1.618,3.136 v -3.136 h 0.476 v 3.75 h -0.664 l -1.617,-3.137 v 3.137 h -0.477 z m 4.102,0.418 v 2.914 h 0.598 c 0.503,0 0.871,-0.118 1.101,-0.352 0.234,-0.234 0.352,-0.605 0.352,-1.109 0,-0.5 -0.118,-0.867 -0.352,-1.102 -0.23,-0.234 -0.598,-0.351 -1.101,-0.351 z m -0.492,-0.418 h 1.015 c 0.703,0 1.223,0.152 1.555,0.457 0.328,0.3 0.496,0.773 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.422 -0.332,0.304 -0.848,0.457 -1.551,0.457 h -1.015 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath22)"
+           id="path531" />
+        <path
+           d="m 170.395,80.523 h 2.304 v 0.426 h -1.812 v 1.11 h 1.734 v 0.425 h -1.734 v 1.36 h 1.855 v 0.426 h -2.347 z m 3.382,0 h 1.938 v 0.426 h -1.485 v 0.918 c 0.071,-0.023 0.141,-0.043 0.215,-0.055 0.071,-0.011 0.141,-0.019 0.215,-0.019 0.406,0 0.727,0.113 0.965,0.344 0.238,0.23 0.355,0.539 0.355,0.929 0,0.403 -0.121,0.719 -0.363,0.942 -0.246,0.222 -0.59,0.336 -1.035,0.336 -0.152,0 -0.309,-0.016 -0.469,-0.043 -0.156,-0.028 -0.32,-0.067 -0.488,-0.121 v -0.508 c 0.145,0.082 0.297,0.144 0.453,0.183 0.156,0.04 0.32,0.059 0.496,0.059 0.281,0 0.504,-0.074 0.668,-0.226 0.164,-0.153 0.246,-0.36 0.246,-0.622 0,-0.261 -0.082,-0.464 -0.246,-0.617 -0.164,-0.152 -0.387,-0.23 -0.668,-0.23 -0.133,0 -0.265,0.015 -0.398,0.047 -0.129,0.027 -0.262,0.074 -0.399,0.14 z m 3.672,3.747 -1.394,-3.747 h 0.515 l 1.157,3.153 1.156,-3.153 h 0.512 l -1.387,3.747 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath23)"
+           id="path532" />
+        <path
+           d="m 170.852,75.113 v 1.407 h 0.621 c 0.226,0 0.406,-0.059 0.531,-0.184 0.125,-0.121 0.187,-0.293 0.187,-0.52 0,-0.226 -0.062,-0.398 -0.187,-0.519 -0.125,-0.125 -0.305,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.406,0 0.715,0.098 0.925,0.285 0.207,0.192 0.313,0.469 0.313,0.836 0,0.368 -0.106,0.649 -0.313,0.836 -0.21,0.192 -0.519,0.286 -0.925,0.286 h -0.621 v 1.503 h -0.493 z m 3.829,0.418 v 2.914 h 0.593 c 0.504,0 0.871,-0.117 1.106,-0.351 0.234,-0.235 0.351,-0.606 0.351,-1.11 0,-0.504 -0.117,-0.871 -0.351,-1.101 -0.235,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.497,-0.418 h 1.016 c 0.707,0 1.223,0.153 1.555,0.457 0.332,0.301 0.496,0.77 0.496,1.414 0,0.645 -0.168,1.122 -0.5,1.422 -0.332,0.305 -0.848,0.453 -1.551,0.453 h -1.016 z m 4.082,3.321 h 1.719 v 0.425 h -2.312 v -0.425 c 0.187,-0.2 0.441,-0.465 0.761,-0.801 0.325,-0.336 0.528,-0.551 0.614,-0.649 0.156,-0.183 0.265,-0.336 0.328,-0.461 0.062,-0.128 0.094,-0.253 0.094,-0.375 0,-0.199 -0.067,-0.363 -0.204,-0.488 -0.136,-0.125 -0.312,-0.187 -0.531,-0.187 -0.152,0 -0.316,0.027 -0.488,0.082 -0.172,0.054 -0.356,0.14 -0.551,0.254 v -0.516 c 0.199,-0.078 0.383,-0.141 0.555,-0.184 0.176,-0.043 0.332,-0.062 0.476,-0.062 0.375,0 0.676,0.098 0.903,0.289 0.222,0.195 0.336,0.453 0.336,0.781 0,0.153 -0.028,0.297 -0.086,0.438 -0.055,0.136 -0.157,0.301 -0.305,0.488 -0.039,0.047 -0.168,0.187 -0.387,0.418 -0.218,0.234 -0.527,0.555 -0.922,0.973 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath24)"
+           id="path533" />
+        <path
+           d="m 170.914,69.285 v 1.41 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.183 0.125,-0.125 0.188,-0.297 0.188,-0.524 0,-0.222 -0.063,-0.398 -0.188,-0.519 -0.125,-0.121 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.414 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.188 0.316,0.465 0.316,0.832 0,0.371 -0.105,0.649 -0.316,0.84 -0.207,0.188 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 6.066,0.285 v 0.535 c -0.168,-0.156 -0.343,-0.277 -0.535,-0.355 -0.187,-0.078 -0.387,-0.117 -0.598,-0.117 -0.414,0 -0.734,0.133 -0.957,0.394 -0.218,0.262 -0.332,0.637 -0.332,1.133 0,0.492 0.114,0.871 0.332,1.133 0.223,0.262 0.543,0.394 0.957,0.394 0.211,0 0.411,-0.039 0.598,-0.121 0.192,-0.078 0.367,-0.195 0.535,-0.355 v 0.531 c -0.176,0.121 -0.355,0.211 -0.55,0.27 -0.192,0.062 -0.395,0.09 -0.61,0.09 -0.555,0 -0.988,-0.172 -1.305,-0.52 -0.316,-0.348 -0.476,-0.82 -0.476,-1.422 0,-0.601 0.16,-1.074 0.476,-1.422 0.317,-0.347 0.75,-0.523 1.305,-0.523 0.219,0 0.422,0.031 0.613,0.09 0.196,0.058 0.375,0.148 0.547,0.265 z m 1.008,3.032 h 0.805 v -2.856 l -0.875,0.18 v -0.461 l 0.871,-0.18 h 0.492 v 3.317 h 0.809 v 0.429 h -2.102 z m 2.41,0 h 0.805 v -2.856 l -0.875,0.18 v -0.461 l 0.871,-0.18 h 0.492 v 3.317 h 0.805 v 0.429 h -2.098 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath25)"
+           id="path534" />
+        <path
+           d="m 116.328,174.172 v 1.41 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.184 0.125,-0.125 0.188,-0.296 0.188,-0.523 0,-0.223 -0.063,-0.398 -0.188,-0.52 -0.125,-0.121 -0.3,-0.183 -0.531,-0.183 z m -0.492,-0.414 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.187 0.316,0.465 0.316,0.832 0,0.371 -0.105,0.648 -0.316,0.84 -0.207,0.187 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 6.066,0.285 v 0.535 c -0.168,-0.156 -0.343,-0.277 -0.535,-0.355 -0.187,-0.078 -0.387,-0.118 -0.597,-0.118 -0.415,0 -0.735,0.129 -0.958,0.395 -0.218,0.262 -0.332,0.637 -0.332,1.133 0,0.492 0.114,0.871 0.332,1.133 0.223,0.261 0.543,0.394 0.958,0.394 0.21,0 0.41,-0.039 0.597,-0.121 0.192,-0.078 0.367,-0.195 0.535,-0.355 v 0.531 c -0.175,0.121 -0.355,0.211 -0.55,0.269 -0.192,0.063 -0.395,0.09 -0.61,0.09 -0.554,0 -0.988,-0.172 -1.304,-0.519 -0.317,-0.348 -0.477,-0.821 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.422 0.316,-0.348 0.75,-0.523 1.304,-0.523 0.219,0 0.422,0.031 0.613,0.089 0.196,0.059 0.375,0.149 0.547,0.266 z m 2.418,1.441 c 0.235,0.051 0.418,0.157 0.551,0.321 0.133,0.164 0.199,0.367 0.199,0.609 0,0.367 -0.121,0.656 -0.371,0.859 -0.246,0.2 -0.597,0.301 -1.054,0.301 -0.153,0 -0.309,-0.015 -0.473,-0.047 -0.16,-0.031 -0.328,-0.074 -0.5,-0.136 v -0.493 c 0.137,0.082 0.285,0.145 0.449,0.188 0.164,0.043 0.332,0.062 0.508,0.062 0.312,0 0.547,-0.062 0.707,-0.187 0.164,-0.125 0.246,-0.309 0.246,-0.547 0,-0.223 -0.078,-0.394 -0.23,-0.516 -0.149,-0.128 -0.356,-0.191 -0.625,-0.191 h -0.426 v -0.414 h 0.445 c 0.242,0 0.426,-0.051 0.555,-0.148 0.129,-0.102 0.195,-0.247 0.195,-0.434 0,-0.191 -0.066,-0.34 -0.203,-0.441 -0.129,-0.102 -0.32,-0.157 -0.566,-0.157 -0.137,0 -0.282,0.016 -0.434,0.047 -0.156,0.031 -0.328,0.078 -0.512,0.141 v -0.453 c 0.188,-0.051 0.364,-0.094 0.524,-0.118 0.164,-0.027 0.32,-0.042 0.465,-0.042 0.375,0 0.671,0.089 0.89,0.265 0.215,0.172 0.324,0.41 0.324,0.707 0,0.207 -0.054,0.383 -0.172,0.528 -0.117,0.14 -0.281,0.238 -0.492,0.296 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath26)"
+           id="path535" />
+        <path
+           d="m 116.473,168.344 v 1.41 h 0.617 c 0.23,0 0.41,-0.063 0.535,-0.184 0.125,-0.121 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.399 -0.187,-0.52 -0.125,-0.121 -0.305,-0.183 -0.535,-0.183 z m -0.496,-0.414 h 1.113 c 0.41,0 0.719,0.093 0.926,0.285 0.211,0.187 0.316,0.465 0.316,0.832 0,0.371 -0.105,0.648 -0.316,0.84 -0.207,0.187 -0.516,0.281 -0.926,0.281 h -0.617 v 1.508 h -0.496 z m 6.066,0.289 v 0.531 c -0.168,-0.156 -0.344,-0.277 -0.531,-0.355 -0.188,-0.079 -0.387,-0.118 -0.598,-0.118 -0.418,0 -0.738,0.133 -0.957,0.395 -0.223,0.262 -0.332,0.637 -0.332,1.133 0,0.496 0.109,0.871 0.332,1.136 0.219,0.258 0.539,0.391 0.957,0.391 0.211,0 0.41,-0.039 0.598,-0.117 0.187,-0.082 0.363,-0.199 0.531,-0.36 v 0.532 c -0.172,0.121 -0.355,0.211 -0.551,0.269 -0.191,0.063 -0.394,0.09 -0.609,0.09 -0.551,0 -0.985,-0.172 -1.305,-0.519 -0.316,-0.348 -0.476,-0.821 -0.476,-1.422 0,-0.602 0.16,-1.075 0.476,-1.422 0.32,-0.348 0.754,-0.524 1.305,-0.524 0.219,0 0.422,0.032 0.617,0.09 0.191,0.059 0.375,0.149 0.543,0.27 z m 1.348,3.031 h 1.722 v 0.426 h -2.316 v -0.426 c 0.187,-0.199 0.445,-0.469 0.765,-0.801 0.325,-0.336 0.528,-0.554 0.61,-0.652 0.16,-0.18 0.269,-0.336 0.332,-0.461 0.062,-0.125 0.094,-0.25 0.094,-0.375 0,-0.199 -0.067,-0.359 -0.203,-0.484 -0.137,-0.125 -0.313,-0.188 -0.532,-0.188 -0.156,0 -0.32,0.027 -0.492,0.082 -0.168,0.055 -0.351,0.137 -0.547,0.25 v -0.512 c 0.199,-0.082 0.383,-0.144 0.555,-0.187 0.172,-0.039 0.332,-0.063 0.473,-0.063 0.378,0 0.679,0.098 0.906,0.293 0.222,0.196 0.336,0.453 0.336,0.778 0,0.152 -0.028,0.3 -0.086,0.437 -0.055,0.141 -0.156,0.301 -0.305,0.488 -0.039,0.047 -0.172,0.188 -0.387,0.422 -0.218,0.231 -0.527,0.555 -0.925,0.973 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath27)"
+           id="path536" />
+        <path
+           d="m 113.406,165.848 -1.394,-3.746 h 0.515 l 1.157,3.156 1.156,-3.156 h 0.512 l -1.387,3.746 z m 2.887,-1.789 v 1.375 h 0.789 c 0.266,0 0.465,-0.059 0.59,-0.172 0.129,-0.114 0.191,-0.285 0.191,-0.516 0,-0.234 -0.062,-0.41 -0.191,-0.519 -0.125,-0.114 -0.324,-0.168 -0.59,-0.168 z m 0,-1.539 v 1.128 h 0.73 c 0.239,0 0.418,-0.046 0.536,-0.14 0.121,-0.094 0.179,-0.235 0.179,-0.426 0,-0.187 -0.058,-0.328 -0.179,-0.422 -0.118,-0.094 -0.297,-0.14 -0.536,-0.14 z m -0.492,-0.418 h 1.258 c 0.375,0 0.668,0.082 0.871,0.242 0.203,0.16 0.304,0.386 0.304,0.683 0,0.231 -0.054,0.411 -0.156,0.547 -0.105,0.137 -0.258,0.219 -0.461,0.254 0.242,0.055 0.434,0.164 0.567,0.336 0.132,0.168 0.203,0.383 0.203,0.637 0,0.332 -0.114,0.59 -0.332,0.773 -0.223,0.184 -0.539,0.274 -0.946,0.274 h -1.308 z m 4.551,0.5 -0.668,1.863 h 1.339 z m -0.278,-0.5 h 0.559 l 1.39,3.746 h -0.515 l -0.332,-0.961 h -1.641 l -0.332,0.961 h -0.519 z m 1.52,0 h 3.082 v 0.425 h -1.293 v 3.321 h -0.496 v -3.321 h -1.293 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath28)"
+           id="path537" />
+        <path
+           d="m 116.613,156.691 v 1.407 h 0.621 c 0.227,0 0.407,-0.059 0.532,-0.18 0.125,-0.125 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.399 -0.187,-0.52 -0.125,-0.121 -0.305,-0.184 -0.532,-0.184 z m -0.492,-0.418 h 1.113 c 0.407,0 0.715,0.098 0.926,0.289 0.207,0.188 0.313,0.465 0.313,0.833 0,0.371 -0.106,0.648 -0.313,0.839 -0.211,0.188 -0.519,0.282 -0.926,0.282 h -0.621 v 1.507 h -0.492 z m 3.332,0 h 0.496 v 1.539 h 1.793 v -1.539 h 0.492 v 3.75 h -0.492 v -1.785 h -1.793 v 1.785 h -0.496 z m 3.742,3.321 H 124 v -2.856 l -0.875,0.18 v -0.461 l 0.871,-0.184 h 0.492 v 3.321 h 0.805 v 0.429 h -2.098 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath29)"
+           id="path538" />
+        <path
+           d="m 116.473,150.863 v 1.41 h 0.617 c 0.23,0 0.41,-0.062 0.535,-0.183 0.125,-0.125 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.305,-0.184 -0.535,-0.184 z m -0.496,-0.414 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.188 0.316,0.465 0.316,0.832 0,0.372 -0.105,0.649 -0.316,0.84 -0.207,0.188 -0.516,0.282 -0.926,0.282 h -0.617 v 1.507 h -0.496 z m 3.335,0 h 0.493 v 1.535 h 1.793 v -1.535 h 0.492 v 3.746 h -0.492 v -1.785 h -1.793 v 1.785 h -0.493 z m 4.711,0.332 c -0.253,0 -0.445,0.129 -0.574,0.387 -0.129,0.254 -0.191,0.641 -0.191,1.156 0,0.516 0.062,0.899 0.191,1.156 0.129,0.258 0.321,0.387 0.574,0.387 0.254,0 0.446,-0.129 0.571,-0.387 0.129,-0.257 0.195,-0.64 0.195,-1.156 0,-0.515 -0.066,-0.902 -0.195,-1.156 -0.125,-0.258 -0.317,-0.387 -0.571,-0.387 z m 0,-0.402 c 0.407,0 0.719,0.168 0.934,0.5 0.215,0.332 0.324,0.812 0.324,1.445 0,0.633 -0.109,1.114 -0.324,1.446 -0.215,0.332 -0.527,0.496 -0.934,0.496 -0.41,0 -0.722,-0.164 -0.937,-0.496 -0.215,-0.332 -0.324,-0.813 -0.324,-1.446 0,-0.633 0.109,-1.113 0.324,-1.445 0.215,-0.332 0.527,-0.5 0.937,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath30)"
+           id="path539" />
+        <path
+           d="m 113.652,145.039 v 1.406 h 0.621 c 0.231,0 0.407,-0.062 0.532,-0.183 0.125,-0.121 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.394 -0.187,-0.515 -0.125,-0.125 -0.301,-0.184 -0.532,-0.184 z m -0.492,-0.418 h 1.113 c 0.411,0 0.715,0.094 0.926,0.285 0.211,0.192 0.313,0.469 0.313,0.832 0,0.371 -0.102,0.653 -0.313,0.84 -0.211,0.188 -0.515,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 6.063,0.289 v 0.535 c -0.164,-0.16 -0.34,-0.277 -0.532,-0.359 -0.187,-0.078 -0.386,-0.117 -0.597,-0.117 -0.418,0 -0.735,0.133 -0.957,0.394 -0.223,0.262 -0.332,0.641 -0.332,1.133 0,0.496 0.109,0.875 0.332,1.137 0.222,0.262 0.539,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.597,-0.117 0.192,-0.078 0.368,-0.199 0.532,-0.355 v 0.527 c -0.172,0.121 -0.356,0.211 -0.547,0.274 -0.192,0.058 -0.395,0.089 -0.61,0.089 -0.554,0 -0.988,-0.175 -1.304,-0.519 -0.317,-0.348 -0.477,-0.824 -0.477,-1.426 0,-0.601 0.16,-1.074 0.477,-1.422 0.316,-0.347 0.75,-0.519 1.304,-0.519 0.215,0 0.422,0.027 0.614,0.09 0.195,0.058 0.375,0.144 0.543,0.265 z m 1.011,3.031 h 0.805 v -2.859 l -0.875,0.18 v -0.461 l 0.871,-0.18 h 0.492 v 3.32 h 0.809 v 0.426 h -2.102 z m 2.7,-3.32 h 1.937 v 0.426 h -1.484 v 0.918 c 0.07,-0.024 0.14,-0.043 0.215,-0.055 0.07,-0.012 0.14,-0.019 0.214,-0.019 0.407,0 0.727,0.113 0.965,0.343 0.239,0.231 0.356,0.539 0.356,0.93 0,0.406 -0.121,0.719 -0.364,0.941 -0.246,0.223 -0.589,0.336 -1.035,0.336 -0.152,0 -0.308,-0.015 -0.468,-0.043 -0.157,-0.023 -0.321,-0.066 -0.489,-0.117 v -0.511 c 0.145,0.082 0.297,0.144 0.453,0.183 0.157,0.039 0.321,0.059 0.496,0.059 0.282,0 0.504,-0.074 0.668,-0.227 0.164,-0.152 0.247,-0.359 0.247,-0.621 0,-0.258 -0.083,-0.465 -0.247,-0.617 -0.164,-0.152 -0.386,-0.231 -0.668,-0.231 -0.132,0 -0.265,0.016 -0.394,0.047 -0.133,0.032 -0.266,0.078 -0.402,0.141 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath31)"
+           id="path540" />
+        <path
+           d="m 113.652,139.211 v 1.406 h 0.621 c 0.231,0 0.407,-0.058 0.532,-0.183 0.125,-0.122 0.187,-0.293 0.187,-0.52 0,-0.226 -0.062,-0.398 -0.187,-0.519 -0.125,-0.122 -0.301,-0.184 -0.532,-0.184 z m -0.492,-0.418 h 1.113 c 0.411,0 0.715,0.098 0.926,0.289 0.211,0.188 0.313,0.465 0.313,0.832 0,0.371 -0.102,0.648 -0.313,0.836 -0.211,0.191 -0.515,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 6.063,0.289 v 0.535 c -0.164,-0.16 -0.34,-0.277 -0.532,-0.355 -0.187,-0.078 -0.386,-0.117 -0.597,-0.117 -0.418,0 -0.735,0.128 -0.957,0.394 -0.223,0.258 -0.332,0.637 -0.332,1.133 0,0.492 0.109,0.871 0.332,1.133 0.222,0.261 0.539,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.597,-0.117 0.192,-0.078 0.368,-0.195 0.532,-0.355 v 0.531 c -0.172,0.117 -0.356,0.211 -0.547,0.269 -0.192,0.059 -0.395,0.09 -0.61,0.09 -0.554,0 -0.988,-0.172 -1.304,-0.519 -0.317,-0.348 -0.477,-0.821 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.422 0.316,-0.348 0.75,-0.523 1.304,-0.523 0.215,0 0.422,0.031 0.614,0.089 0.195,0.059 0.375,0.149 0.543,0.266 z m 1.011,3.031 h 0.805 v -2.855 l -0.875,0.18 v -0.461 l 0.871,-0.184 h 0.492 v 3.32 h 0.809 v 0.426 h -2.102 z m 4.051,-2.879 -1.246,2 h 1.246 z m -0.129,-0.441 h 0.617 v 2.441 h 0.52 v 0.422 h -0.52 v 0.883 h -0.488 v -0.883 h -1.648 v -0.488 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath32)"
+           id="path541" />
+        <path
+           d="m 113.652,133.383 v 1.41 h 0.621 c 0.231,0 0.407,-0.063 0.532,-0.184 0.125,-0.125 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.398 -0.187,-0.52 -0.125,-0.121 -0.301,-0.183 -0.532,-0.183 z m -0.492,-0.414 h 1.113 c 0.411,0 0.715,0.093 0.926,0.285 0.211,0.187 0.313,0.465 0.313,0.832 0,0.371 -0.102,0.648 -0.313,0.84 -0.211,0.187 -0.515,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 6.063,0.285 v 0.535 c -0.164,-0.156 -0.34,-0.277 -0.532,-0.355 -0.187,-0.079 -0.386,-0.118 -0.597,-0.118 -0.418,0 -0.735,0.129 -0.957,0.395 -0.223,0.258 -0.332,0.637 -0.332,1.133 0,0.492 0.109,0.871 0.332,1.133 0.222,0.261 0.539,0.394 0.957,0.394 0.211,0 0.41,-0.043 0.597,-0.121 0.192,-0.078 0.368,-0.195 0.532,-0.355 v 0.531 c -0.172,0.121 -0.356,0.211 -0.547,0.269 -0.192,0.059 -0.395,0.09 -0.61,0.09 -0.554,0 -0.988,-0.172 -1.304,-0.519 -0.317,-0.348 -0.477,-0.821 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.422 0.316,-0.348 0.75,-0.524 1.304,-0.524 0.215,0 0.422,0.032 0.614,0.09 0.195,0.059 0.375,0.149 0.543,0.266 z m 1.011,3.031 h 0.805 v -2.855 l -0.875,0.179 v -0.461 l 0.871,-0.179 h 0.492 v 3.316 h 0.809 v 0.43 h -2.102 z m 4.188,-1.594 c 0.238,0.055 0.422,0.161 0.555,0.325 0.132,0.164 0.199,0.367 0.199,0.609 0,0.367 -0.125,0.656 -0.371,0.855 -0.246,0.204 -0.598,0.305 -1.055,0.305 -0.152,0 -0.312,-0.015 -0.473,-0.047 -0.164,-0.031 -0.328,-0.074 -0.504,-0.136 v -0.493 c 0.137,0.082 0.289,0.145 0.45,0.188 0.164,0.043 0.336,0.062 0.511,0.062 0.309,0 0.543,-0.062 0.707,-0.187 0.161,-0.125 0.243,-0.309 0.243,-0.547 0,-0.223 -0.075,-0.395 -0.227,-0.52 -0.148,-0.125 -0.359,-0.187 -0.629,-0.187 h -0.422 v -0.414 h 0.442 c 0.246,0 0.429,-0.051 0.558,-0.149 0.129,-0.101 0.192,-0.246 0.192,-0.433 0,-0.192 -0.067,-0.34 -0.2,-0.442 -0.132,-0.101 -0.32,-0.156 -0.57,-0.156 -0.133,0 -0.277,0.016 -0.433,0.047 -0.153,0.031 -0.325,0.078 -0.508,0.141 v -0.453 c 0.187,-0.051 0.359,-0.094 0.523,-0.121 0.164,-0.024 0.32,-0.04 0.465,-0.04 0.375,0 0.668,0.09 0.887,0.266 0.218,0.172 0.328,0.41 0.328,0.707 0,0.207 -0.059,0.383 -0.172,0.527 -0.117,0.141 -0.281,0.239 -0.496,0.293 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath33)"
+           id="path542" />
+        <path
+           d="m 116.602,127.559 v 1.406 h 0.621 c 0.226,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.395 -0.187,-0.52 -0.125,-0.121 -0.305,-0.179 -0.531,-0.179 z m -0.493,-0.418 h 1.114 c 0.406,0 0.715,0.093 0.925,0.285 0.207,0.191 0.313,0.469 0.313,0.832 0,0.371 -0.106,0.652 -0.313,0.84 -0.21,0.187 -0.519,0.285 -0.925,0.285 h -0.621 v 1.504 h -0.493 z m 3.829,1.957 v 1.371 h 0.789 c 0.265,0 0.461,-0.055 0.589,-0.168 0.129,-0.113 0.192,-0.285 0.192,-0.52 0,-0.234 -0.063,-0.406 -0.192,-0.515 -0.128,-0.114 -0.324,-0.168 -0.589,-0.168 z m 0,-1.539 v 1.129 h 0.726 c 0.242,0 0.422,-0.047 0.539,-0.141 0.117,-0.094 0.18,-0.235 0.18,-0.426 0,-0.187 -0.063,-0.332 -0.18,-0.426 -0.117,-0.09 -0.297,-0.136 -0.539,-0.136 z m -0.497,-0.418 h 1.262 c 0.375,0 0.664,0.078 0.867,0.242 0.203,0.16 0.305,0.387 0.305,0.683 0,0.231 -0.051,0.411 -0.156,0.547 -0.102,0.137 -0.254,0.219 -0.457,0.254 0.242,0.055 0.429,0.164 0.562,0.336 0.137,0.168 0.203,0.379 0.203,0.633 0,0.336 -0.109,0.594 -0.332,0.777 -0.218,0.184 -0.535,0.274 -0.945,0.274 h -1.309 z m 3.254,0 h 2.344 v 0.214 l -1.32,3.532 h -0.516 l 1.242,-3.321 h -1.75 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath34)"
+           id="path543" />
+        <path
+           d="m 117.055,124.527 v -1.007 h -0.805 v -0.418 h 1.293 v 1.609 c -0.191,0.141 -0.402,0.246 -0.629,0.316 -0.23,0.071 -0.476,0.106 -0.734,0.106 -0.571,0 -1.016,-0.172 -1.34,-0.512 -0.32,-0.344 -0.481,-0.82 -0.481,-1.43 0,-0.613 0.161,-1.089 0.481,-1.429 0.324,-0.344 0.769,-0.516 1.34,-0.516 0.234,0 0.461,0.031 0.675,0.09 0.215,0.059 0.411,0.148 0.594,0.266 v 0.539 c -0.183,-0.157 -0.379,-0.278 -0.582,-0.36 -0.207,-0.078 -0.422,-0.117 -0.648,-0.117 -0.446,0 -0.781,0.125 -1.004,0.383 -0.223,0.254 -0.336,0.637 -0.336,1.144 0,0.504 0.113,0.887 0.336,1.141 0.223,0.258 0.558,0.383 1.004,0.383 0.176,0 0.332,-0.016 0.469,-0.043 0.136,-0.031 0.257,-0.082 0.367,-0.145 z m 1.406,-3.215 h 0.664 l 1.613,3.137 v -3.137 h 0.481 v 3.747 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z m 4.101,0.418 v 2.915 h 0.594 c 0.504,0 0.871,-0.118 1.106,-0.352 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.504 -0.117,-0.872 -0.351,-1.102 -0.235,-0.234 -0.602,-0.352 -1.106,-0.352 z m -0.492,-0.418 h 1.012 c 0.707,0 1.227,0.153 1.555,0.458 0.332,0.3 0.496,0.769 0.496,1.414 0,0.644 -0.164,1.121 -0.496,1.421 -0.332,0.305 -0.852,0.454 -1.555,0.454 h -1.012 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath35)"
+           id="path544" />
+        <path
+           d="m 113.793,115.902 v 1.41 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.188,-0.297 0.188,-0.524 0,-0.222 -0.063,-0.398 -0.188,-0.519 -0.125,-0.121 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.414 h 1.113 c 0.406,0 0.715,0.094 0.926,0.285 0.207,0.188 0.312,0.465 0.312,0.832 0,0.372 -0.105,0.649 -0.312,0.84 -0.211,0.188 -0.52,0.282 -0.926,0.282 h -0.621 v 1.507 h -0.492 z m 4.179,0.5 -0.668,1.864 h 1.34 z m -0.277,-0.5 h 0.559 l 1.39,3.746 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.52 z m 2.524,3.321 h 0.808 v -2.86 l -0.879,0.18 v -0.461 l 0.871,-0.18 h 0.496 v 3.321 h 0.805 v 0.425 h -2.101 z m 2.703,-3.321 h 1.933 v 0.426 h -1.484 v 0.918 c 0.074,-0.023 0.144,-0.043 0.215,-0.055 0.074,-0.015 0.144,-0.019 0.215,-0.019 0.406,0 0.73,0.113 0.968,0.344 0.239,0.226 0.356,0.539 0.356,0.929 0,0.403 -0.121,0.719 -0.367,0.942 -0.243,0.222 -0.586,0.332 -1.032,0.332 -0.152,0 -0.308,-0.012 -0.468,-0.039 -0.161,-0.028 -0.321,-0.067 -0.493,-0.121 v -0.508 c 0.149,0.082 0.297,0.14 0.454,0.183 0.156,0.039 0.324,0.059 0.496,0.059 0.281,0 0.504,-0.074 0.672,-0.227 0.164,-0.152 0.246,-0.359 0.246,-0.621 0,-0.261 -0.082,-0.469 -0.246,-0.621 -0.168,-0.152 -0.391,-0.226 -0.672,-0.226 -0.129,0 -0.262,0.015 -0.395,0.046 -0.129,0.028 -0.262,0.075 -0.398,0.137 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath36)"
+           id="path545" />
+        <path
+           d="m 113.793,110.074 v 1.41 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.188,-0.297 0.188,-0.524 0,-0.222 -0.063,-0.394 -0.188,-0.519 -0.125,-0.121 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.414 h 1.113 c 0.406,0 0.715,0.094 0.926,0.285 0.207,0.188 0.312,0.469 0.312,0.832 0,0.371 -0.105,0.649 -0.312,0.84 -0.211,0.188 -0.52,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 4.179,0.5 -0.668,1.863 h 1.34 z m -0.277,-0.5 h 0.559 l 1.39,3.746 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.52 z m 2.524,3.32 h 0.808 v -2.859 l -0.879,0.18 v -0.461 l 0.871,-0.18 h 0.496 v 3.32 h 0.805 v 0.426 h -2.101 z m 4.05,-2.878 -1.246,2 h 1.246 z m -0.129,-0.442 h 0.622 v 2.442 h 0.519 v 0.421 h -0.519 v 0.883 h -0.493 v -0.883 h -1.644 v -0.492 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath37)"
+           id="path546" />
+        <path
+           d="m 113.934,104.25 v 1.406 h 0.621 c 0.23,0 0.406,-0.058 0.531,-0.183 0.125,-0.121 0.191,-0.293 0.191,-0.52 0,-0.226 -0.066,-0.398 -0.191,-0.519 -0.125,-0.125 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.098 0.925,0.285 0.211,0.192 0.317,0.469 0.317,0.836 0,0.367 -0.106,0.649 -0.317,0.836 -0.207,0.191 -0.515,0.285 -0.925,0.285 h -0.621 v 1.504 h -0.493 z m 4.184,0.5 -0.668,1.863 h 1.34 z m -0.277,-0.5 h 0.558 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.523,3.32 h 0.805 v -2.859 l -0.875,0.184 v -0.465 l 0.871,-0.18 h 0.492 v 3.32 h 0.805 v 0.426 h -2.098 z m 4.188,-1.593 c 0.238,0.05 0.421,0.16 0.55,0.324 0.137,0.164 0.203,0.367 0.203,0.605 0,0.371 -0.124,0.657 -0.371,0.86 -0.25,0.203 -0.601,0.304 -1.054,0.304 -0.157,0 -0.313,-0.015 -0.477,-0.047 -0.16,-0.031 -0.328,-0.078 -0.5,-0.14 v -0.488 c 0.137,0.082 0.289,0.144 0.449,0.187 0.164,0.039 0.332,0.063 0.512,0.063 0.309,0 0.543,-0.063 0.707,-0.188 0.16,-0.129 0.242,-0.309 0.242,-0.551 0,-0.218 -0.074,-0.39 -0.226,-0.515 -0.149,-0.125 -0.36,-0.188 -0.629,-0.188 h -0.422 v -0.418 h 0.441 c 0.243,0 0.43,-0.047 0.559,-0.148 0.129,-0.098 0.191,-0.242 0.191,-0.43 0,-0.191 -0.066,-0.34 -0.199,-0.441 -0.133,-0.106 -0.32,-0.157 -0.57,-0.157 -0.133,0 -0.277,0.016 -0.434,0.047 -0.156,0.028 -0.324,0.074 -0.511,0.141 v -0.453 c 0.187,-0.055 0.363,-0.094 0.527,-0.121 0.164,-0.028 0.316,-0.039 0.465,-0.039 0.371,0 0.668,0.086 0.886,0.261 0.219,0.176 0.329,0.411 0.329,0.707 0,0.211 -0.059,0.387 -0.176,0.528 -0.113,0.144 -0.278,0.242 -0.492,0.297 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath38)"
+           id="path547" />
+        <path
+           d="m 118.363,98.004 h 0.664 l 1.614,3.137 v -3.137 h 0.48 v 3.75 h -0.664 l -1.617,-3.137 v 3.137 h -0.477 z m 6.34,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.277 -0.535,-0.355 -0.188,-0.078 -0.387,-0.118 -0.598,-0.118 -0.414,0 -0.734,0.129 -0.957,0.395 -0.218,0.258 -0.332,0.637 -0.332,1.133 0,0.492 0.114,0.871 0.332,1.133 0.223,0.261 0.543,0.394 0.957,0.394 0.211,0 0.41,-0.043 0.598,-0.121 0.191,-0.078 0.367,-0.195 0.535,-0.355 v 0.531 c -0.176,0.117 -0.355,0.211 -0.551,0.269 -0.191,0.059 -0.394,0.09 -0.609,0.09 -0.555,0 -0.988,-0.172 -1.305,-0.519 -0.316,-0.348 -0.476,-0.821 -0.476,-1.422 0,-0.602 0.16,-1.078 0.476,-1.422 0.317,-0.348 0.75,-0.523 1.305,-0.523 0.219,0 0.422,0.031 0.613,0.089 0.196,0.059 0.375,0.149 0.547,0.266 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath39)"
+           id="path548" />
+        <path
+           d="m 118.363,92.18 h 0.664 l 1.614,3.132 V 92.18 h 0.48 v 3.746 h -0.664 l -1.617,-3.137 v 3.137 h -0.477 z m 6.34,0.289 V 93 c -0.168,-0.156 -0.344,-0.277 -0.535,-0.355 -0.188,-0.079 -0.387,-0.118 -0.598,-0.118 -0.414,0 -0.734,0.133 -0.957,0.395 -0.218,0.262 -0.332,0.637 -0.332,1.133 0,0.496 0.114,0.871 0.332,1.136 0.223,0.258 0.543,0.391 0.957,0.391 0.211,0 0.41,-0.039 0.598,-0.117 0.191,-0.082 0.367,-0.199 0.535,-0.36 v 0.532 c -0.176,0.121 -0.355,0.211 -0.551,0.269 -0.191,0.063 -0.394,0.09 -0.609,0.09 -0.555,0 -0.988,-0.172 -1.305,-0.519 -0.316,-0.348 -0.476,-0.821 -0.476,-1.422 0,-0.602 0.16,-1.075 0.476,-1.422 0.317,-0.348 0.75,-0.524 1.305,-0.524 0.219,0 0.422,0.032 0.613,0.09 0.196,0.059 0.375,0.149 0.547,0.27 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath40)"
+           id="path549" />
+        <path
+           d="m 109.168,88.309 v 1.371 h 0.789 c 0.266,0 0.461,-0.055 0.59,-0.168 0.129,-0.114 0.191,-0.285 0.191,-0.52 0,-0.234 -0.062,-0.406 -0.191,-0.515 -0.129,-0.114 -0.324,-0.168 -0.59,-0.168 z m 0,-1.543 v 1.132 h 0.727 c 0.242,0 0.421,-0.046 0.539,-0.14 0.117,-0.094 0.179,-0.235 0.179,-0.426 0,-0.187 -0.062,-0.332 -0.179,-0.426 -0.118,-0.094 -0.297,-0.14 -0.539,-0.14 z m -0.496,-0.414 h 1.262 c 0.375,0 0.664,0.078 0.867,0.238 0.203,0.164 0.304,0.39 0.304,0.687 0,0.231 -0.05,0.411 -0.156,0.547 -0.101,0.137 -0.254,0.219 -0.457,0.254 0.242,0.051 0.43,0.164 0.563,0.336 0.136,0.168 0.203,0.379 0.203,0.633 0,0.336 -0.11,0.594 -0.332,0.777 -0.223,0.184 -0.535,0.274 -0.946,0.274 h -1.308 z m 4.816,0.343 c -0.359,0 -0.644,0.137 -0.855,0.41 -0.211,0.274 -0.317,0.649 -0.317,1.122 0,0.472 0.106,0.847 0.317,1.121 0.211,0.273 0.496,0.41 0.855,0.41 0.356,0 0.641,-0.137 0.848,-0.41 0.211,-0.274 0.316,-0.649 0.316,-1.121 0,-0.473 -0.105,-0.848 -0.316,-1.122 -0.207,-0.273 -0.492,-0.41 -0.848,-0.41 z m 0,-0.414 c 0.512,0 0.918,0.18 1.227,0.531 0.305,0.352 0.457,0.825 0.457,1.415 0,0.593 -0.152,1.062 -0.457,1.418 -0.309,0.351 -0.715,0.527 -1.227,0.527 -0.511,0 -0.922,-0.176 -1.23,-0.527 -0.309,-0.352 -0.461,-0.825 -0.461,-1.418 0,-0.59 0.152,-1.063 0.461,-1.415 0.308,-0.351 0.719,-0.531 1.23,-0.531 z m 3.891,0.414 c -0.359,0 -0.645,0.137 -0.856,0.41 -0.211,0.274 -0.316,0.649 -0.316,1.122 0,0.472 0.105,0.847 0.316,1.121 0.211,0.273 0.497,0.41 0.856,0.41 0.355,0 0.641,-0.137 0.848,-0.41 0.211,-0.274 0.316,-0.649 0.316,-1.121 0,-0.473 -0.105,-0.848 -0.316,-1.122 -0.207,-0.273 -0.493,-0.41 -0.848,-0.41 z m 0,-0.414 c 0.508,0 0.918,0.18 1.223,0.531 0.308,0.352 0.46,0.825 0.46,1.415 0,0.593 -0.152,1.062 -0.46,1.418 -0.305,0.351 -0.715,0.527 -1.223,0.527 -0.516,0 -0.926,-0.176 -1.231,-0.527 -0.308,-0.352 -0.46,-0.825 -0.46,-1.418 0,-0.59 0.152,-1.063 0.46,-1.415 0.305,-0.351 0.715,-0.531 1.231,-0.531 z m 1.902,0.071 h 3.086 v 0.425 h -1.293 v 3.321 h -0.496 v -3.321 h -1.297 z m 4.66,0.332 c -0.253,0 -0.445,0.128 -0.574,0.386 -0.125,0.258 -0.191,0.641 -0.191,1.157 0,0.515 0.066,0.902 0.191,1.156 0.129,0.258 0.321,0.387 0.574,0.387 0.258,0 0.446,-0.129 0.575,-0.387 0.129,-0.254 0.191,-0.641 0.191,-1.156 0,-0.516 -0.062,-0.899 -0.191,-1.157 -0.129,-0.258 -0.317,-0.386 -0.575,-0.386 z m 0,-0.403 c 0.411,0 0.719,0.168 0.934,0.5 0.219,0.332 0.328,0.813 0.328,1.446 0,0.632 -0.109,1.113 -0.328,1.445 -0.215,0.332 -0.523,0.5 -0.934,0.5 -0.406,0 -0.718,-0.168 -0.937,-0.5 -0.215,-0.332 -0.32,-0.813 -0.32,-1.445 0,-0.633 0.105,-1.114 0.32,-1.446 0.219,-0.332 0.531,-0.5 0.937,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath41)"
+           id="path550" />
+        <path
+           d="m 116.074,84.27 -1.394,-3.747 h 0.515 l 1.157,3.157 1.156,-3.157 h 0.512 l -1.387,3.747 z m 2.887,-3.329 v 2.914 h 0.598 c 0.5,0 0.867,-0.117 1.101,-0.351 0.235,-0.234 0.352,-0.606 0.352,-1.109 0,-0.504 -0.117,-0.872 -0.352,-1.102 -0.234,-0.234 -0.601,-0.352 -1.101,-0.352 z m -0.492,-0.418 h 1.011 c 0.708,0 1.227,0.153 1.555,0.454 0.332,0.304 0.496,0.773 0.496,1.418 0,0.644 -0.164,1.121 -0.496,1.421 -0.332,0.305 -0.851,0.454 -1.555,0.454 h -1.011 z m 4.101,0.418 v 2.914 h 0.598 c 0.504,0 0.871,-0.117 1.102,-0.351 0.234,-0.234 0.351,-0.606 0.351,-1.109 0,-0.504 -0.117,-0.872 -0.351,-1.102 -0.231,-0.234 -0.598,-0.352 -1.102,-0.352 z m -0.492,-0.418 h 1.012 c 0.707,0 1.226,0.153 1.558,0.454 0.329,0.304 0.493,0.773 0.493,1.418 0,0.644 -0.164,1.121 -0.496,1.421 -0.333,0.305 -0.852,0.454 -1.555,0.454 h -1.012 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath42)"
+           id="path551" />
+        <path
+           d="m 113.652,75.113 v 1.41 h 0.621 c 0.231,0 0.407,-0.062 0.532,-0.183 0.125,-0.125 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.532,-0.184 z m -0.492,-0.414 h 1.113 c 0.411,0 0.715,0.094 0.926,0.285 0.211,0.188 0.313,0.465 0.313,0.832 0,0.372 -0.102,0.649 -0.313,0.84 -0.211,0.188 -0.515,0.282 -0.926,0.282 h -0.621 v 1.507 h -0.492 z m 6.063,0.285 v 0.536 c -0.164,-0.157 -0.34,-0.278 -0.532,-0.356 -0.187,-0.078 -0.386,-0.117 -0.597,-0.117 -0.418,0 -0.735,0.133 -0.957,0.394 -0.223,0.262 -0.332,0.637 -0.332,1.133 0,0.492 0.109,0.871 0.332,1.133 0.222,0.262 0.539,0.395 0.957,0.395 0.211,0 0.41,-0.04 0.597,-0.122 0.192,-0.078 0.368,-0.195 0.532,-0.355 v 0.531 c -0.172,0.121 -0.356,0.211 -0.547,0.27 -0.192,0.062 -0.395,0.09 -0.61,0.09 -0.554,0 -0.988,-0.172 -1.304,-0.52 -0.317,-0.348 -0.477,-0.82 -0.477,-1.422 0,-0.601 0.16,-1.074 0.477,-1.422 0.316,-0.347 0.75,-0.523 1.304,-0.523 0.215,0 0.422,0.031 0.614,0.09 0.195,0.058 0.375,0.148 0.543,0.265 z m 1.011,3.032 h 0.805 V 75.16 l -0.875,0.18 v -0.461 l 0.871,-0.18 h 0.492 v 3.317 h 0.809 v 0.429 h -2.102 z m 3.121,0 h 1.719 v 0.429 h -2.312 v -0.429 c 0.187,-0.196 0.441,-0.465 0.761,-0.797 0.325,-0.34 0.528,-0.555 0.614,-0.653 0.156,-0.179 0.265,-0.336 0.328,-0.461 0.062,-0.128 0.094,-0.25 0.094,-0.375 0,-0.199 -0.067,-0.359 -0.204,-0.484 -0.136,-0.125 -0.312,-0.191 -0.531,-0.191 -0.152,0 -0.316,0.031 -0.488,0.086 -0.172,0.054 -0.356,0.136 -0.551,0.25 v -0.512 c 0.199,-0.082 0.383,-0.145 0.555,-0.188 0.176,-0.039 0.332,-0.062 0.476,-0.062 0.375,0 0.676,0.098 0.903,0.293 0.222,0.191 0.336,0.453 0.336,0.777 0,0.153 -0.028,0.301 -0.086,0.438 -0.055,0.136 -0.157,0.301 -0.305,0.488 -0.039,0.047 -0.168,0.187 -0.387,0.422 -0.218,0.23 -0.527,0.555 -0.922,0.969 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath43)"
+           id="path552" />
+        <path
+           d="m 177.539,32.672 h 1.063 l 2.586,5.012 v -5.012 h 0.765 v 5.992 h -1.062 l -2.586,-5.016 v 5.016 h -0.766 z m 5.688,0 h 0.793 v 3.64 c 0,0.641 0.113,1.106 0.339,1.387 0.227,0.281 0.594,0.422 1.102,0.422 0.504,0 0.871,-0.141 1.098,-0.422 0.226,-0.281 0.339,-0.746 0.339,-1.387 v -3.64 h 0.793 v 3.738 c 0,0.785 -0.187,1.375 -0.566,1.774 -0.375,0.398 -0.93,0.597 -1.664,0.597 -0.738,0 -1.293,-0.199 -1.672,-0.597 -0.375,-0.399 -0.562,-0.989 -0.562,-1.774 z m 10.234,0.461 v 0.855 c -0.266,-0.254 -0.551,-0.445 -0.852,-0.57 -0.3,-0.125 -0.621,-0.191 -0.957,-0.191 -0.668,0 -1.179,0.211 -1.531,0.632 -0.355,0.418 -0.531,1.024 -0.531,1.813 0,0.789 0.176,1.394 0.531,1.816 0.352,0.418 0.863,0.625 1.531,0.625 0.336,0 0.657,-0.062 0.957,-0.187 0.301,-0.125 0.586,-0.317 0.852,-0.571 v 0.848 c -0.277,0.192 -0.57,0.336 -0.879,0.434 -0.309,0.097 -0.633,0.144 -0.977,0.144 -0.882,0 -1.578,-0.277 -2.085,-0.832 -0.508,-0.554 -0.762,-1.316 -0.762,-2.277 0,-0.961 0.254,-1.723 0.762,-2.274 0.507,-0.558 1.203,-0.836 2.085,-0.836 0.348,0 0.676,0.047 0.985,0.145 0.308,0.094 0.598,0.234 0.871,0.426 z m 1.406,-0.461 h 0.789 v 5.308 h 2.84 v 0.684 h -3.629 z m 4.449,0 h 3.688 v 0.68 h -2.899 v 1.777 h 2.778 v 0.68 h -2.778 v 2.171 h 2.969 v 0.684 h -3.758 z m 7.704,0.547 c -0.571,0 -1.028,0.222 -1.368,0.66 -0.336,0.437 -0.504,1.035 -0.504,1.793 0,0.758 0.168,1.351 0.504,1.793 0.34,0.437 0.797,0.656 1.368,0.656 0.574,0 1.027,-0.219 1.359,-0.656 0.336,-0.442 0.504,-1.035 0.504,-1.793 0,-0.758 -0.168,-1.356 -0.504,-1.793 -0.332,-0.438 -0.785,-0.66 -1.359,-0.66 z m 0,-0.657 c 0.82,0 1.472,0.282 1.96,0.848 0.493,0.563 0.735,1.317 0.735,2.262 0,0.945 -0.242,1.699 -0.735,2.266 -0.488,0.562 -1.14,0.843 -1.96,0.843 -0.821,0 -1.477,-0.281 -1.969,-0.843 -0.489,-0.563 -0.735,-1.317 -0.735,-2.266 0,-0.945 0.246,-1.699 0.735,-2.262 0.492,-0.566 1.148,-0.848 1.969,-0.848 z m 3.464,3.52 h 2.106 v 0.66 h -2.106 z m 3.059,-3.41 h 0.789 v 5.308 h 2.84 v 0.684 h -3.629 z m 6.684,0.703 -1.993,3.203 h 1.993 z m -0.207,-0.703 h 0.992 v 3.906 h 0.832 v 0.672 h -0.832 v 1.414 h -0.785 V 37.25 h -2.633 v -0.781 z m 2.496,0 h 3.097 v 0.68 h -2.375 v 1.468 c 0.114,-0.039 0.231,-0.066 0.344,-0.086 0.113,-0.023 0.23,-0.031 0.344,-0.031 0.652,0 1.168,0.184 1.547,0.547 0.379,0.367 0.57,0.863 0.57,1.492 0,0.645 -0.195,1.145 -0.586,1.504 -0.391,0.356 -0.941,0.535 -1.652,0.535 -0.246,0 -0.496,-0.023 -0.75,-0.066 -0.254,-0.043 -0.516,-0.106 -0.785,-0.192 v -0.816 c 0.234,0.133 0.476,0.231 0.726,0.293 0.25,0.066 0.516,0.098 0.793,0.098 0.449,0 0.809,-0.121 1.07,-0.364 0.262,-0.246 0.395,-0.574 0.395,-0.992 0,-0.418 -0.133,-0.75 -0.395,-0.992 -0.261,-0.242 -0.621,-0.367 -1.07,-0.367 -0.211,0 -0.422,0.027 -0.633,0.074 -0.207,0.047 -0.422,0.121 -0.64,0.223 z m 5.121,5.308 h 2.754 v 0.684 h -3.703 V 37.98 c 0.296,-0.316 0.707,-0.742 1.222,-1.281 0.516,-0.535 0.844,-0.883 0.977,-1.039 0.25,-0.289 0.425,-0.535 0.527,-0.738 0.102,-0.203 0.152,-0.402 0.152,-0.598 0,-0.32 -0.109,-0.578 -0.328,-0.777 -0.218,-0.203 -0.5,-0.301 -0.847,-0.301 -0.25,0 -0.512,0.043 -0.786,0.129 -0.273,0.09 -0.566,0.223 -0.878,0.402 v -0.816 c 0.316,-0.133 0.613,-0.231 0.89,-0.297 0.274,-0.07 0.528,-0.102 0.758,-0.102 0.602,0 1.086,0.157 1.445,0.465 0.36,0.313 0.539,0.727 0.539,1.246 0,0.247 -0.047,0.481 -0.136,0.704 -0.09,0.218 -0.254,0.476 -0.489,0.777 -0.066,0.078 -0.273,0.301 -0.621,0.676 -0.351,0.367 -0.843,0.886 -1.476,1.55 z m 6.465,-2.125 c 0.168,0.059 0.332,0.184 0.492,0.375 0.16,0.196 0.32,0.458 0.484,0.797 l 0.801,1.637 h -0.848 l -0.746,-1.539 c -0.195,-0.398 -0.383,-0.668 -0.562,-0.797 -0.18,-0.133 -0.426,-0.195 -0.739,-0.195 h -0.859 v 2.531 h -0.789 v -5.992 h 1.781 c 0.664,0 1.164,0.14 1.492,0.43 0.329,0.285 0.493,0.718 0.493,1.296 0,0.375 -0.086,0.688 -0.258,0.938 -0.172,0.25 -0.418,0.422 -0.742,0.519 z m -1.977,-2.519 v 2.129 h 0.992 c 0.379,0 0.664,-0.09 0.86,-0.27 0.195,-0.183 0.293,-0.449 0.293,-0.797 0,-0.351 -0.098,-0.617 -0.293,-0.793 -0.196,-0.179 -0.481,-0.269 -0.86,-0.269 z m 4.984,-0.664 h 3.688 v 0.68 h -2.899 v 1.777 h 2.778 v 0.68 h -2.778 v 2.171 h 2.969 v 0.684 h -3.758 z"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath44)"
+           id="path553" />
+        <path
+           d="m 300.922,173.754 h 0.664 l 1.613,3.133 v -3.133 h 0.481 v 3.746 h -0.664 l -1.618,-3.133 v 3.133 h -0.476 z m 6.34,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.277 -0.535,-0.355 -0.188,-0.082 -0.387,-0.121 -0.598,-0.121 -0.414,0 -0.734,0.132 -0.957,0.394 -0.219,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.113,0.871 0.332,1.133 0.223,0.261 0.543,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.598,-0.117 0.191,-0.078 0.367,-0.199 0.535,-0.355 v 0.527 c -0.176,0.121 -0.356,0.211 -0.551,0.273 -0.191,0.059 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.176 -1.305,-0.519 -0.317,-0.348 -0.477,-0.825 -0.477,-1.422 0,-0.606 0.16,-1.078 0.477,-1.426 0.316,-0.348 0.75,-0.519 1.305,-0.519 0.218,0 0.421,0.027 0.613,0.089 0.195,0.059 0.375,0.149 0.547,0.266 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath45)"
+           id="path554" />
+        <path
+           d="m 300.922,167.926 h 0.664 l 1.613,3.136 v -3.136 h 0.481 v 3.746 h -0.664 l -1.618,-3.133 v 3.133 h -0.476 z m 6.34,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.277 -0.535,-0.355 -0.188,-0.079 -0.387,-0.122 -0.598,-0.122 -0.414,0 -0.734,0.133 -0.957,0.395 -0.219,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.113,0.871 0.332,1.133 0.223,0.261 0.543,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.598,-0.117 0.191,-0.078 0.367,-0.195 0.535,-0.356 v 0.528 c -0.176,0.121 -0.356,0.211 -0.551,0.273 -0.191,0.059 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.172 -1.305,-0.519 -0.317,-0.348 -0.477,-0.825 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.426 0.316,-0.348 0.75,-0.52 1.305,-0.52 0.218,0 0.421,0.032 0.613,0.09 0.195,0.059 0.375,0.149 0.547,0.266 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath46)"
+           id="path555" />
+        <path
+           d="m 301.438,162.516 v 1.41 h 0.621 c 0.23,0 0.406,-0.063 0.531,-0.184 0.125,-0.125 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.399 -0.187,-0.52 -0.125,-0.121 -0.301,-0.183 -0.531,-0.183 z m -0.493,-0.414 h 1.114 c 0.41,0 0.718,0.093 0.925,0.285 0.211,0.187 0.317,0.465 0.317,0.832 0,0.371 -0.106,0.648 -0.317,0.84 -0.207,0.187 -0.515,0.281 -0.925,0.281 h -0.621 v 1.508 h -0.493 z m 6.067,0.285 v 0.535 c -0.168,-0.156 -0.344,-0.277 -0.535,-0.356 -0.188,-0.078 -0.387,-0.117 -0.598,-0.117 -0.414,0 -0.734,0.129 -0.957,0.395 -0.219,0.261 -0.332,0.636 -0.332,1.133 0,0.492 0.113,0.871 0.332,1.132 0.223,0.262 0.543,0.395 0.957,0.395 0.211,0 0.41,-0.039 0.598,-0.121 0.191,-0.078 0.367,-0.195 0.535,-0.356 v 0.532 c -0.176,0.121 -0.356,0.211 -0.551,0.269 -0.191,0.063 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.172 -1.305,-0.52 -0.317,-0.347 -0.477,-0.82 -0.477,-1.421 0,-0.602 0.16,-1.079 0.477,-1.422 0.316,-0.348 0.75,-0.524 1.305,-0.524 0.218,0 0.421,0.031 0.613,0.09 0.195,0.059 0.375,0.149 0.547,0.266 z m 2.277,0.156 -1.246,2 h 1.246 z m -0.129,-0.441 h 0.621 v 2.441 h 0.52 v 0.422 h -0.52 v 0.883 h -0.492 v -0.883 h -1.644 v -0.492 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath47)"
+           id="path556" />
+        <path
+           d="m 302.355,156.773 -0.667,1.864 h 1.339 z m -0.277,-0.5 h 0.559 l 1.39,3.747 h -0.515 l -0.332,-0.961 h -1.641 l -0.332,0.961 h -0.519 z m 4.879,3.211 v -1.004 h -0.805 v -0.418 h 1.293 v 1.61 c -0.191,0.137 -0.398,0.242 -0.629,0.316 -0.23,0.071 -0.472,0.106 -0.734,0.106 -0.57,0 -1.016,-0.172 -1.34,-0.512 -0.32,-0.344 -0.48,-0.82 -0.48,-1.434 0,-0.609 0.16,-1.086 0.48,-1.429 0.324,-0.34 0.77,-0.512 1.34,-0.512 0.238,0 0.461,0.027 0.676,0.09 0.215,0.058 0.414,0.148 0.594,0.265 v 0.54 c -0.184,-0.161 -0.375,-0.278 -0.582,-0.36 -0.204,-0.078 -0.422,-0.121 -0.649,-0.121 -0.445,0 -0.781,0.129 -1.004,0.387 -0.222,0.254 -0.336,0.637 -0.336,1.14 0,0.508 0.114,0.887 0.336,1.145 0.223,0.254 0.559,0.383 1.004,0.383 0.176,0 0.332,-0.016 0.469,-0.047 0.137,-0.031 0.258,-0.078 0.367,-0.145 z m 1.406,-3.211 h 0.664 l 1.618,3.133 v -3.133 h 0.476 v 3.747 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z m 4.102,0.418 v 2.911 h 0.597 c 0.504,0 0.872,-0.118 1.102,-0.352 0.234,-0.23 0.352,-0.602 0.352,-1.105 0,-0.504 -0.118,-0.872 -0.352,-1.102 -0.23,-0.234 -0.598,-0.352 -1.102,-0.352 z m -0.492,-0.418 h 1.011 c 0.707,0 1.227,0.153 1.559,0.454 0.328,0.3 0.492,0.773 0.492,1.418 0,0.644 -0.164,1.117 -0.496,1.421 -0.332,0.301 -0.851,0.454 -1.555,0.454 h -1.011 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath48)"
+           id="path557" />
+        <path
+           d="m 301.453,150.863 v 1.407 h 0.621 c 0.231,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.192,-0.297 0.192,-0.52 0,-0.226 -0.067,-0.398 -0.192,-0.519 -0.125,-0.125 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.192 0.316,0.469 0.316,0.836 0,0.368 -0.105,0.649 -0.316,0.836 -0.207,0.192 -0.516,0.286 -0.926,0.286 h -0.621 v 1.503 h -0.492 z m 3.828,1.957 v 1.375 h 0.793 c 0.266,0 0.461,-0.058 0.586,-0.172 0.129,-0.113 0.195,-0.285 0.195,-0.515 0,-0.235 -0.066,-0.41 -0.195,-0.52 -0.125,-0.113 -0.32,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.731 c 0.242,0 0.421,-0.047 0.539,-0.14 0.117,-0.094 0.175,-0.235 0.175,-0.426 0,-0.188 -0.058,-0.328 -0.175,-0.422 -0.118,-0.094 -0.297,-0.141 -0.539,-0.141 z m -0.492,-0.418 h 1.258 c 0.379,0 0.668,0.082 0.871,0.243 0.203,0.16 0.304,0.386 0.304,0.683 0,0.231 -0.05,0.41 -0.156,0.547 -0.105,0.137 -0.258,0.219 -0.457,0.254 0.242,0.055 0.43,0.164 0.563,0.336 0.136,0.168 0.203,0.383 0.203,0.637 0,0.332 -0.113,0.589 -0.332,0.773 -0.223,0.184 -0.535,0.273 -0.946,0.273 h -1.308 z m 3.465,3.321 h 0.804 v -2.86 l -0.875,0.184 v -0.465 l 0.871,-0.18 h 0.493 v 3.321 h 0.804 v 0.425 h -2.097 z m 4.187,-1.594 c 0.239,0.051 0.422,0.16 0.551,0.324 0.137,0.164 0.203,0.367 0.203,0.606 0,0.371 -0.125,0.656 -0.371,0.859 -0.25,0.203 -0.602,0.305 -1.055,0.305 -0.156,0 -0.312,-0.016 -0.476,-0.047 -0.16,-0.031 -0.328,-0.078 -0.5,-0.141 v -0.488 c 0.137,0.082 0.289,0.144 0.449,0.187 0.164,0.039 0.332,0.063 0.512,0.063 0.308,0 0.543,-0.063 0.707,-0.192 0.16,-0.125 0.242,-0.304 0.242,-0.546 0,-0.219 -0.074,-0.391 -0.227,-0.516 -0.148,-0.125 -0.359,-0.188 -0.629,-0.188 h -0.421 v -0.418 h 0.441 c 0.242,0 0.43,-0.046 0.559,-0.148 0.128,-0.098 0.191,-0.242 0.191,-0.43 0,-0.191 -0.066,-0.34 -0.199,-0.441 -0.133,-0.106 -0.321,-0.156 -0.571,-0.156 -0.132,0 -0.277,0.015 -0.433,0.047 -0.156,0.027 -0.324,0.074 -0.512,0.136 v -0.449 c 0.188,-0.055 0.363,-0.094 0.528,-0.121 0.164,-0.027 0.316,-0.039 0.464,-0.039 0.371,0 0.668,0.086 0.887,0.262 0.219,0.175 0.328,0.41 0.328,0.707 0,0.207 -0.058,0.382 -0.176,0.527 -0.113,0.145 -0.277,0.242 -0.492,0.297 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath49)"
+           id="path558" />
+        <path
+           d="m 301.453,145.035 v 1.406 h 0.621 c 0.231,0 0.406,-0.058 0.531,-0.179 0.125,-0.125 0.192,-0.297 0.192,-0.524 0,-0.222 -0.067,-0.398 -0.192,-0.519 -0.125,-0.121 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.098 0.926,0.289 0.211,0.188 0.316,0.465 0.316,0.832 0,0.371 -0.105,0.649 -0.316,0.84 -0.207,0.188 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 3.828,1.961 v 1.371 h 0.793 c 0.266,0 0.461,-0.054 0.586,-0.168 0.129,-0.113 0.195,-0.289 0.195,-0.519 0,-0.235 -0.066,-0.407 -0.195,-0.516 -0.125,-0.113 -0.32,-0.168 -0.586,-0.168 z m 0,-1.543 v 1.129 h 0.731 c 0.242,0 0.421,-0.047 0.539,-0.137 0.117,-0.093 0.175,-0.238 0.175,-0.425 0,-0.192 -0.058,-0.332 -0.175,-0.426 -0.118,-0.094 -0.297,-0.141 -0.539,-0.141 z m -0.492,-0.418 h 1.258 c 0.379,0 0.668,0.082 0.871,0.242 0.203,0.161 0.304,0.391 0.304,0.688 0,0.226 -0.05,0.41 -0.156,0.547 -0.105,0.133 -0.258,0.218 -0.457,0.25 0.242,0.054 0.43,0.168 0.563,0.34 0.136,0.168 0.203,0.378 0.203,0.632 0,0.336 -0.113,0.594 -0.332,0.778 -0.223,0.179 -0.535,0.273 -0.946,0.273 h -1.308 z m 3.465,3.321 h 0.804 v -2.856 l -0.875,0.18 v -0.461 l 0.871,-0.184 h 0.493 v 3.321 h 0.804 v 0.429 h -2.097 z m 4.05,-2.876 -1.246,2 h 1.246 z m -0.132,-0.445 h 0.621 v 2.445 h 0.519 v 0.418 h -0.519 v 0.887 h -0.489 v -0.887 h -1.648 v -0.488 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath50)"
+           id="path559" />
+        <path
+           d="m 301.453,139.211 v 1.406 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.183 0.125,-0.122 0.192,-0.297 0.192,-0.524 0,-0.222 -0.067,-0.394 -0.192,-0.519 -0.125,-0.121 -0.3,-0.18 -0.531,-0.18 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.188 0.316,0.469 0.316,0.832 0,0.371 -0.105,0.652 -0.316,0.84 -0.207,0.188 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 3.828,1.957 v 1.371 h 0.793 c 0.266,0 0.461,-0.055 0.586,-0.168 0.129,-0.113 0.195,-0.285 0.195,-0.519 0,-0.235 -0.066,-0.407 -0.195,-0.516 -0.125,-0.113 -0.32,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.731 c 0.242,0 0.421,-0.047 0.539,-0.141 0.117,-0.094 0.175,-0.234 0.175,-0.426 0,-0.187 -0.058,-0.332 -0.175,-0.425 -0.118,-0.094 -0.297,-0.137 -0.539,-0.137 z m -0.492,-0.418 h 1.258 c 0.379,0 0.668,0.078 0.871,0.242 0.203,0.16 0.304,0.387 0.304,0.684 0,0.23 -0.05,0.41 -0.156,0.547 -0.105,0.136 -0.258,0.218 -0.457,0.254 0.242,0.054 0.43,0.164 0.563,0.335 0.136,0.168 0.203,0.379 0.203,0.633 0,0.336 -0.113,0.594 -0.332,0.778 -0.223,0.183 -0.535,0.273 -0.946,0.273 h -1.308 z m 3.465,3.32 h 0.804 v -2.859 l -0.875,0.18 v -0.461 l 0.871,-0.18 h 0.493 v 3.32 h 0.804 v 0.426 h -2.097 z m 2.699,-3.32 h 1.937 v 0.426 h -1.484 v 0.918 c 0.07,-0.024 0.141,-0.043 0.215,-0.055 0.07,-0.012 0.141,-0.02 0.215,-0.02 0.406,0 0.726,0.114 0.965,0.344 0.238,0.231 0.355,0.539 0.355,0.93 0,0.402 -0.121,0.719 -0.363,0.941 -0.246,0.223 -0.59,0.336 -1.035,0.336 -0.153,0 -0.309,-0.015 -0.469,-0.043 -0.156,-0.027 -0.32,-0.066 -0.488,-0.121 v -0.508 c 0.144,0.082 0.296,0.145 0.453,0.184 0.156,0.039 0.32,0.059 0.496,0.059 0.281,0 0.504,-0.075 0.668,-0.227 0.164,-0.152 0.246,-0.359 0.246,-0.621 0,-0.262 -0.082,-0.465 -0.246,-0.617 -0.164,-0.153 -0.387,-0.231 -0.668,-0.231 -0.133,0 -0.266,0.016 -0.399,0.047 -0.129,0.027 -0.261,0.074 -0.398,0.141 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath51)"
+           id="path560" />
+        <path
+           d="m 301.426,133.383 v 1.406 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.184 0.129,-0.121 0.192,-0.296 0.192,-0.523 0,-0.223 -0.063,-0.394 -0.192,-0.516 -0.125,-0.125 -0.301,-0.183 -0.531,-0.183 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.191 0.316,0.469 0.316,0.832 0,0.371 -0.105,0.652 -0.316,0.84 -0.207,0.187 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 3.828,1.957 v 1.371 h 0.793 c 0.265,0 0.461,-0.055 0.586,-0.168 0.129,-0.113 0.195,-0.285 0.195,-0.52 0,-0.234 -0.066,-0.406 -0.195,-0.515 -0.125,-0.113 -0.321,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.73 c 0.242,0 0.422,-0.047 0.539,-0.141 0.117,-0.094 0.176,-0.234 0.176,-0.426 0,-0.187 -0.059,-0.328 -0.176,-0.422 -0.117,-0.093 -0.297,-0.14 -0.539,-0.14 z m -0.492,-0.418 h 1.257 c 0.379,0 0.668,0.082 0.871,0.242 0.204,0.16 0.305,0.387 0.305,0.684 0,0.23 -0.051,0.41 -0.156,0.547 -0.106,0.136 -0.258,0.218 -0.457,0.253 0.242,0.055 0.43,0.164 0.562,0.336 0.133,0.168 0.203,0.379 0.203,0.637 0,0.332 -0.113,0.59 -0.332,0.774 -0.222,0.183 -0.539,0.273 -0.945,0.273 h -1.308 z m 3.464,3.32 h 0.805 v -2.859 l -0.875,0.179 v -0.46 l 0.871,-0.18 h 0.492 v 3.32 h 0.805 v 0.426 h -2.098 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath52)"
+           id="path561" />
+        <path
+           d="m 301.426,127.555 v 1.406 h 0.621 c 0.23,0 0.406,-0.059 0.531,-0.184 0.129,-0.121 0.192,-0.293 0.192,-0.519 0,-0.227 -0.063,-0.399 -0.192,-0.52 -0.125,-0.121 -0.301,-0.183 -0.531,-0.183 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.097 0.926,0.289 0.211,0.187 0.316,0.465 0.316,0.832 0,0.371 -0.105,0.648 -0.316,0.836 -0.207,0.191 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 3.828,1.957 v 1.375 h 0.793 c 0.265,0 0.461,-0.059 0.586,-0.168 0.129,-0.113 0.195,-0.289 0.195,-0.52 0,-0.234 -0.066,-0.406 -0.195,-0.519 -0.125,-0.11 -0.321,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.73 c 0.242,0 0.422,-0.047 0.539,-0.137 0.117,-0.094 0.176,-0.238 0.176,-0.426 0,-0.191 -0.059,-0.332 -0.176,-0.426 -0.117,-0.093 -0.297,-0.14 -0.539,-0.14 z m -0.492,-0.418 h 1.257 c 0.379,0 0.668,0.082 0.871,0.242 0.204,0.16 0.305,0.391 0.305,0.683 0,0.231 -0.051,0.415 -0.156,0.547 -0.106,0.137 -0.258,0.223 -0.457,0.254 0.242,0.055 0.43,0.168 0.562,0.336 0.133,0.172 0.203,0.383 0.203,0.637 0,0.336 -0.113,0.594 -0.332,0.773 -0.222,0.184 -0.539,0.274 -0.945,0.274 h -1.308 z m 3.804,3.32 h 1.719 v 0.426 h -2.313 v -0.426 c 0.188,-0.199 0.442,-0.465 0.762,-0.801 0.324,-0.336 0.528,-0.551 0.613,-0.648 0.157,-0.184 0.266,-0.336 0.329,-0.461 0.062,-0.129 0.093,-0.254 0.093,-0.375 0,-0.199 -0.066,-0.36 -0.203,-0.488 -0.136,-0.125 -0.312,-0.188 -0.531,-0.188 -0.152,0 -0.316,0.027 -0.488,0.082 -0.172,0.059 -0.356,0.141 -0.551,0.254 v -0.512 c 0.199,-0.082 0.383,-0.144 0.555,-0.187 0.175,-0.043 0.332,-0.063 0.476,-0.063 0.375,0 0.676,0.098 0.903,0.293 0.222,0.192 0.335,0.453 0.335,0.778 0,0.152 -0.027,0.3 -0.085,0.437 -0.055,0.137 -0.157,0.301 -0.305,0.488 -0.039,0.047 -0.168,0.188 -0.387,0.422 -0.219,0.231 -0.527,0.555 -0.922,0.969 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath53)"
+           id="path562" />
+        <path
+           d="m 303.582,124.523 v -1.007 h -0.805 v -0.414 h 1.293 v 1.609 c -0.191,0.137 -0.402,0.242 -0.629,0.312 -0.23,0.071 -0.476,0.106 -0.734,0.106 -0.57,0 -1.016,-0.168 -1.34,-0.512 -0.32,-0.34 -0.48,-0.816 -0.48,-1.429 0,-0.61 0.16,-1.09 0.48,-1.43 0.324,-0.344 0.77,-0.516 1.34,-0.516 0.234,0 0.461,0.031 0.676,0.094 0.215,0.059 0.41,0.148 0.594,0.266 v 0.539 c -0.184,-0.161 -0.379,-0.282 -0.582,-0.36 -0.207,-0.082 -0.422,-0.121 -0.649,-0.121 -0.445,0 -0.781,0.129 -1.004,0.383 -0.222,0.258 -0.336,0.641 -0.336,1.145 0,0.507 0.114,0.886 0.336,1.144 0.223,0.254 0.559,0.383 1.004,0.383 0.176,0 0.332,-0.016 0.469,-0.047 0.137,-0.031 0.258,-0.078 0.367,-0.145 z m 1.406,-3.211 h 0.664 l 1.614,3.133 v -3.133 h 0.48 v 3.747 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z m 4.102,0.415 v 2.914 h 0.594 c 0.504,0 0.871,-0.118 1.105,-0.352 0.234,-0.234 0.352,-0.601 0.352,-1.109 0,-0.5 -0.118,-0.868 -0.352,-1.102 -0.234,-0.234 -0.601,-0.351 -1.105,-0.351 z m -0.492,-0.415 h 1.011 c 0.707,0 1.227,0.153 1.555,0.454 0.332,0.3 0.496,0.773 0.496,1.414 0,0.648 -0.164,1.121 -0.496,1.425 -0.332,0.301 -0.852,0.454 -1.555,0.454 h -1.011 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath54)"
+           id="path563" />
+        <path
+           d="m 301.453,115.902 v 1.407 h 0.621 c 0.231,0 0.406,-0.059 0.531,-0.184 0.125,-0.121 0.192,-0.297 0.192,-0.52 0,-0.226 -0.067,-0.398 -0.192,-0.519 -0.125,-0.125 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.098 0.926,0.286 0.211,0.191 0.316,0.468 0.316,0.835 0,0.368 -0.105,0.649 -0.316,0.836 -0.207,0.192 -0.516,0.286 -0.926,0.286 h -0.621 v 1.503 h -0.492 z m 3.828,1.957 v 1.375 h 0.793 c 0.262,0 0.461,-0.058 0.586,-0.168 0.129,-0.117 0.195,-0.289 0.195,-0.519 0,-0.234 -0.066,-0.406 -0.195,-0.52 -0.125,-0.109 -0.324,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.731 c 0.242,0 0.418,-0.047 0.535,-0.136 0.121,-0.094 0.179,-0.239 0.179,-0.43 0,-0.188 -0.058,-0.328 -0.179,-0.422 -0.117,-0.094 -0.293,-0.141 -0.535,-0.141 z m -0.492,-0.418 h 1.258 c 0.379,0 0.668,0.082 0.871,0.243 0.203,0.16 0.304,0.386 0.304,0.683 0,0.231 -0.05,0.414 -0.156,0.547 -0.105,0.137 -0.258,0.223 -0.461,0.254 0.242,0.055 0.434,0.168 0.567,0.336 0.132,0.168 0.203,0.383 0.203,0.637 0,0.332 -0.113,0.593 -0.332,0.773 -0.223,0.184 -0.539,0.273 -0.946,0.273 h -1.308 z m 3.465,3.321 h 0.804 v -2.86 l -0.878,0.184 v -0.465 l 0.874,-0.18 h 0.493 v 3.321 h 0.804 v 0.425 h -2.097 z m 2.406,0 h 0.809 v -2.86 l -0.879,0.184 v -0.465 l 0.871,-0.18 h 0.496 v 3.321 h 0.805 v 0.425 h -2.102 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath55)"
+           id="path564" />
+        <path
+           d="m 301.453,110.074 v 1.406 h 0.621 c 0.231,0 0.406,-0.058 0.531,-0.183 0.125,-0.121 0.192,-0.293 0.192,-0.52 0,-0.226 -0.067,-0.398 -0.192,-0.519 -0.125,-0.121 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.098 0.926,0.289 0.211,0.188 0.316,0.465 0.316,0.832 0,0.368 -0.105,0.649 -0.316,0.836 -0.207,0.192 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 3.828,1.957 v 1.375 h 0.793 c 0.266,0 0.461,-0.058 0.586,-0.168 0.129,-0.113 0.195,-0.289 0.195,-0.519 0,-0.235 -0.066,-0.406 -0.195,-0.52 -0.125,-0.109 -0.32,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.731 c 0.242,0 0.421,-0.047 0.539,-0.137 0.117,-0.093 0.175,-0.238 0.175,-0.429 0,-0.188 -0.058,-0.328 -0.175,-0.422 -0.118,-0.094 -0.297,-0.141 -0.539,-0.141 z m -0.492,-0.418 h 1.258 c 0.379,0 0.668,0.082 0.871,0.242 0.203,0.161 0.304,0.391 0.304,0.684 0,0.23 -0.05,0.414 -0.156,0.547 -0.105,0.137 -0.258,0.223 -0.457,0.254 0.242,0.055 0.43,0.168 0.563,0.336 0.136,0.172 0.203,0.383 0.203,0.636 0,0.333 -0.113,0.594 -0.332,0.774 -0.223,0.183 -0.535,0.273 -0.946,0.273 h -1.308 z m 3.465,3.321 h 0.804 v -2.86 l -0.875,0.184 v -0.461 l 0.871,-0.184 h 0.493 v 3.321 h 0.804 v 0.425 h -2.097 z m 3.117,0 h 1.723 v 0.425 h -2.313 v -0.425 c 0.184,-0.2 0.441,-0.465 0.762,-0.801 0.324,-0.336 0.527,-0.551 0.609,-0.649 0.16,-0.183 0.27,-0.336 0.332,-0.461 0.063,-0.128 0.094,-0.254 0.094,-0.375 0,-0.199 -0.066,-0.363 -0.203,-0.488 -0.137,-0.125 -0.313,-0.187 -0.531,-0.187 -0.157,0 -0.317,0.027 -0.493,0.082 -0.168,0.054 -0.351,0.14 -0.547,0.254 v -0.512 c 0.2,-0.082 0.383,-0.145 0.555,-0.188 0.172,-0.043 0.332,-0.062 0.473,-0.062 0.379,0 0.68,0.098 0.906,0.289 0.223,0.195 0.336,0.457 0.336,0.781 0,0.152 -0.027,0.297 -0.086,0.438 -0.055,0.136 -0.156,0.3 -0.305,0.488 -0.039,0.047 -0.171,0.187 -0.386,0.422 -0.219,0.23 -0.528,0.554 -0.926,0.969 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath56)"
+           id="path565" />
+        <path
+           d="m 301.453,104.246 v 1.41 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.192,-0.297 0.192,-0.524 0,-0.222 -0.067,-0.398 -0.192,-0.519 -0.125,-0.121 -0.3,-0.184 -0.531,-0.184 z m -0.492,-0.414 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.188 0.316,0.465 0.316,0.832 0,0.371 -0.105,0.649 -0.316,0.84 -0.207,0.188 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.492 z m 4.184,0.5 -0.668,1.863 h 1.339 z m -0.278,-0.5 h 0.559 l 1.386,3.746 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.519 z m 2.524,3.32 h 0.804 v -2.859 l -0.875,0.18 v -0.461 l 0.871,-0.18 h 0.493 v 3.32 h 0.804 v 0.426 h -2.097 z m 2.41,0 h 0.804 v -2.859 l -0.878,0.18 v -0.461 l 0.875,-0.18 h 0.492 v 3.32 h 0.804 v 0.426 h -2.097 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath57)"
+           id="path566" />
+        <path
+           d="m 301.453,98.422 v 1.406 h 0.621 c 0.231,0 0.406,-0.062 0.531,-0.183 0.125,-0.122 0.192,-0.297 0.192,-0.52 0,-0.227 -0.067,-0.398 -0.192,-0.52 -0.125,-0.125 -0.3,-0.183 -0.531,-0.183 z m -0.492,-0.418 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.191 0.316,0.469 0.316,0.836 0,0.367 -0.105,0.648 -0.316,0.836 -0.207,0.191 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.492 z m 4.184,0.5 -0.668,1.863 h 1.339 z m -0.278,-0.5 h 0.559 l 1.386,3.746 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.519 z m 2.524,3.32 h 0.804 v -2.859 l -0.875,0.183 v -0.464 l 0.871,-0.18 h 0.493 v 3.32 h 0.804 v 0.426 h -2.097 z m 3.117,0 h 1.722 v 0.426 h -2.312 v -0.426 c 0.184,-0.199 0.441,-0.465 0.762,-0.801 0.324,-0.335 0.527,-0.554 0.609,-0.648 0.16,-0.184 0.27,-0.336 0.332,-0.465 0.063,-0.125 0.094,-0.25 0.094,-0.371 0,-0.199 -0.067,-0.363 -0.203,-0.488 -0.137,-0.125 -0.313,-0.188 -0.532,-0.188 -0.156,0 -0.316,0.028 -0.492,0.082 -0.168,0.055 -0.351,0.141 -0.547,0.25 v -0.511 c 0.2,-0.082 0.383,-0.141 0.555,-0.184 0.172,-0.043 0.332,-0.062 0.477,-0.062 0.375,0 0.675,0.097 0.902,0.289 0.223,0.195 0.336,0.453 0.336,0.777 0,0.156 -0.027,0.301 -0.086,0.441 -0.055,0.137 -0.156,0.297 -0.305,0.485 -0.039,0.05 -0.172,0.191 -0.386,0.422 -0.219,0.23 -0.528,0.554 -0.926,0.972 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath58)"
+           id="path567" />
+        <path
+           d="m 300.922,92.176 h 0.664 l 1.613,3.136 v -3.136 h 0.481 v 3.75 h -0.664 l -1.618,-3.137 v 3.137 h -0.476 z m 6.34,0.289 V 93 c -0.168,-0.16 -0.344,-0.277 -0.535,-0.355 -0.188,-0.079 -0.387,-0.118 -0.598,-0.118 -0.414,0 -0.734,0.129 -0.957,0.395 -0.219,0.258 -0.332,0.637 -0.332,1.133 0,0.492 0.113,0.871 0.332,1.133 0.223,0.261 0.543,0.394 0.957,0.394 0.211,0 0.41,-0.043 0.598,-0.121 0.191,-0.078 0.367,-0.195 0.535,-0.356 v 0.532 c -0.176,0.117 -0.356,0.211 -0.551,0.269 -0.191,0.059 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.172 -1.305,-0.519 -0.317,-0.348 -0.477,-0.821 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.422 0.316,-0.348 0.75,-0.524 1.305,-0.524 0.218,0 0.421,0.032 0.613,0.09 0.195,0.059 0.375,0.149 0.547,0.266 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath59)"
+           id="path568" />
+        <path
+           d="m 300.891,86.352 h 0.496 v 2.273 c 0,0.402 0.07,0.691 0.211,0.867 0.14,0.176 0.371,0.266 0.687,0.266 0.317,0 0.547,-0.09 0.688,-0.266 0.14,-0.176 0.211,-0.465 0.211,-0.867 v -2.273 h 0.496 v 2.336 c 0,0.488 -0.118,0.859 -0.356,1.109 -0.234,0.246 -0.578,0.371 -1.039,0.371 -0.461,0 -0.808,-0.125 -1.043,-0.371 -0.234,-0.25 -0.351,-0.621 -0.351,-1.109 z m 3.714,0 h 1.934 v 0.425 h -1.484 v 0.918 c 0.074,-0.027 0.144,-0.043 0.215,-0.054 0.074,-0.016 0.144,-0.02 0.214,-0.02 0.411,0 0.731,0.113 0.969,0.344 0.238,0.226 0.356,0.539 0.356,0.93 0,0.402 -0.121,0.714 -0.368,0.941 -0.242,0.223 -0.586,0.332 -1.031,0.332 -0.152,0 -0.308,-0.012 -0.469,-0.039 -0.156,-0.027 -0.32,-0.067 -0.492,-0.121 V 89.5 c 0.149,0.082 0.301,0.141 0.457,0.184 0.156,0.039 0.321,0.058 0.492,0.058 0.286,0 0.508,-0.074 0.672,-0.226 0.164,-0.153 0.246,-0.36 0.246,-0.621 0,-0.262 -0.082,-0.469 -0.246,-0.622 -0.164,-0.152 -0.386,-0.226 -0.672,-0.226 -0.128,0 -0.261,0.015 -0.394,0.043 -0.129,0.031 -0.262,0.078 -0.399,0.14 z m 3.672,3.746 -1.394,-3.746 h 0.515 l 1.157,3.152 1.156,-3.152 h 0.512 l -1.387,3.746 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath60)"
+           id="path569" />
+        <path
+           d="m 301.438,80.941 v 1.407 h 0.621 c 0.23,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.395 -0.187,-0.516 -0.125,-0.125 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.094 0.925,0.286 0.211,0.191 0.317,0.468 0.317,0.832 0,0.371 -0.106,0.652 -0.317,0.839 -0.207,0.188 -0.515,0.286 -0.925,0.286 h -0.621 v 1.504 h -0.493 z m 6.067,0.289 v 0.536 c -0.168,-0.16 -0.344,-0.278 -0.535,-0.36 -0.188,-0.078 -0.387,-0.117 -0.598,-0.117 -0.414,0 -0.734,0.133 -0.957,0.395 -0.219,0.261 -0.332,0.64 -0.332,1.132 0,0.497 0.113,0.875 0.332,1.137 0.223,0.262 0.543,0.391 0.957,0.391 0.211,0 0.41,-0.039 0.598,-0.117 0.191,-0.079 0.367,-0.2 0.535,-0.356 v 0.527 c -0.176,0.122 -0.356,0.211 -0.551,0.274 -0.191,0.058 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.176 -1.305,-0.52 -0.317,-0.347 -0.477,-0.824 -0.477,-1.426 0,-0.601 0.16,-1.074 0.477,-1.421 0.316,-0.348 0.75,-0.52 1.305,-0.52 0.218,0 0.421,0.027 0.613,0.09 0.195,0.058 0.375,0.144 0.547,0.265 z m 0.926,-0.289 h 1.937 v 0.426 h -1.484 v 0.918 c 0.07,-0.023 0.144,-0.043 0.214,-0.055 0.071,-0.011 0.145,-0.019 0.215,-0.019 0.407,0 0.731,0.113 0.969,0.344 0.234,0.23 0.356,0.539 0.356,0.929 0,0.407 -0.122,0.719 -0.368,0.942 -0.242,0.222 -0.589,0.336 -1.031,0.336 -0.152,0 -0.308,-0.016 -0.469,-0.043 -0.16,-0.024 -0.324,-0.067 -0.492,-0.117 v -0.512 c 0.149,0.082 0.297,0.144 0.453,0.183 0.157,0.04 0.324,0.059 0.496,0.059 0.282,0 0.504,-0.074 0.668,-0.226 0.168,-0.153 0.25,-0.36 0.25,-0.622 0,-0.257 -0.082,-0.464 -0.25,-0.617 -0.164,-0.152 -0.386,-0.23 -0.668,-0.23 -0.132,0 -0.261,0.015 -0.394,0.047 -0.129,0.031 -0.266,0.078 -0.402,0.14 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath61)"
+           id="path570" />
+        <path
+           d="m 301.438,75.113 v 1.407 h 0.621 c 0.23,0 0.406,-0.059 0.531,-0.184 0.125,-0.121 0.187,-0.293 0.187,-0.52 0,-0.226 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.098 0.925,0.289 0.211,0.188 0.317,0.465 0.317,0.832 0,0.372 -0.106,0.649 -0.317,0.836 -0.207,0.192 -0.515,0.286 -0.925,0.286 h -0.621 v 1.503 h -0.493 z m 6.067,0.289 v 0.536 c -0.168,-0.161 -0.344,-0.278 -0.535,-0.356 -0.188,-0.078 -0.387,-0.117 -0.598,-0.117 -0.414,0 -0.734,0.129 -0.957,0.394 -0.219,0.258 -0.332,0.637 -0.332,1.133 0,0.492 0.113,0.871 0.332,1.133 0.223,0.262 0.543,0.391 0.957,0.391 0.211,0 0.41,-0.039 0.598,-0.118 0.191,-0.078 0.367,-0.195 0.535,-0.355 v 0.531 c -0.176,0.117 -0.356,0.211 -0.551,0.27 -0.191,0.058 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.172 -1.305,-0.52 -0.317,-0.348 -0.477,-0.82 -0.477,-1.422 0,-0.601 0.16,-1.078 0.477,-1.422 0.316,-0.347 0.75,-0.523 1.305,-0.523 0.218,0 0.421,0.031 0.613,0.09 0.195,0.058 0.375,0.148 0.547,0.265 z m 2.039,1.383 c -0.223,0 -0.399,0.078 -0.528,0.235 -0.128,0.156 -0.195,0.367 -0.195,0.64 0,0.27 0.067,0.481 0.195,0.641 0.129,0.152 0.305,0.23 0.528,0.23 0.222,0 0.394,-0.078 0.523,-0.23 0.133,-0.16 0.196,-0.371 0.196,-0.641 0,-0.273 -0.063,-0.484 -0.196,-0.64 -0.129,-0.157 -0.301,-0.235 -0.523,-0.235 z m 0.976,-1.586 v 0.461 c -0.121,-0.062 -0.246,-0.105 -0.375,-0.14 -0.125,-0.032 -0.25,-0.047 -0.371,-0.047 -0.328,0 -0.574,0.113 -0.75,0.34 -0.168,0.226 -0.265,0.566 -0.293,1.023 0.098,-0.145 0.219,-0.258 0.364,-0.332 0.144,-0.082 0.304,-0.121 0.476,-0.121 0.367,0 0.656,0.117 0.867,0.344 0.215,0.23 0.321,0.539 0.321,0.933 0,0.383 -0.11,0.692 -0.332,0.926 -0.223,0.23 -0.516,0.348 -0.883,0.348 -0.422,0 -0.746,-0.164 -0.969,-0.496 -0.223,-0.332 -0.332,-0.817 -0.332,-1.446 0,-0.594 0.137,-1.062 0.41,-1.414 0.274,-0.355 0.641,-0.531 1.102,-0.531 0.121,0 0.246,0.012 0.371,0.039 0.129,0.023 0.258,0.062 0.394,0.113 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath62)"
+           id="path571" />
+        <path
+           d="m 301.438,69.285 v 1.41 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.394 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.414 h 1.114 c 0.41,0 0.718,0.094 0.925,0.285 0.211,0.188 0.317,0.465 0.317,0.832 0,0.371 -0.106,0.649 -0.317,0.84 -0.207,0.188 -0.515,0.281 -0.925,0.281 h -0.621 v 1.508 h -0.493 z m 6.067,0.289 v 0.531 c -0.168,-0.156 -0.344,-0.277 -0.535,-0.355 -0.188,-0.078 -0.387,-0.117 -0.598,-0.117 -0.414,0 -0.734,0.133 -0.957,0.394 -0.219,0.262 -0.332,0.637 -0.332,1.133 0,0.496 0.113,0.871 0.332,1.137 0.223,0.258 0.543,0.39 0.957,0.39 0.211,0 0.41,-0.039 0.598,-0.117 0.191,-0.078 0.367,-0.199 0.535,-0.359 v 0.531 c -0.176,0.121 -0.356,0.211 -0.551,0.27 -0.191,0.062 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.172 -1.305,-0.52 -0.317,-0.348 -0.477,-0.82 -0.477,-1.422 0,-0.601 0.16,-1.074 0.477,-1.422 0.316,-0.347 0.75,-0.523 1.305,-0.523 0.218,0 0.421,0.031 0.613,0.094 0.195,0.058 0.375,0.144 0.547,0.265 z m 1.976,1.676 c -0.234,0 -0.418,0.066 -0.554,0.195 -0.133,0.129 -0.2,0.305 -0.2,0.531 0,0.227 0.067,0.403 0.2,0.532 0.136,0.129 0.32,0.195 0.554,0.195 0.235,0 0.422,-0.066 0.555,-0.195 0.137,-0.129 0.203,-0.309 0.203,-0.532 0,-0.226 -0.066,-0.402 -0.203,-0.531 -0.133,-0.129 -0.316,-0.195 -0.555,-0.195 z m -0.492,-0.215 c -0.211,-0.055 -0.375,-0.152 -0.496,-0.305 -0.117,-0.148 -0.176,-0.328 -0.176,-0.543 0,-0.3 0.106,-0.535 0.309,-0.711 0.211,-0.171 0.496,-0.261 0.855,-0.261 0.364,0 0.649,0.09 0.856,0.261 0.207,0.176 0.308,0.411 0.308,0.711 0,0.215 -0.058,0.395 -0.175,0.543 -0.118,0.153 -0.282,0.25 -0.493,0.305 0.239,0.059 0.422,0.168 0.555,0.336 0.133,0.164 0.199,0.367 0.199,0.605 0,0.364 -0.105,0.641 -0.324,0.836 -0.215,0.196 -0.523,0.29 -0.926,0.29 -0.402,0 -0.711,-0.094 -0.926,-0.29 -0.214,-0.195 -0.324,-0.472 -0.324,-0.836 0,-0.238 0.067,-0.441 0.2,-0.605 0.136,-0.168 0.32,-0.277 0.558,-0.336 z m -0.18,-0.801 c 0,0.196 0.059,0.348 0.176,0.453 0.117,0.11 0.285,0.165 0.496,0.165 0.211,0 0.379,-0.055 0.496,-0.165 0.121,-0.105 0.18,-0.257 0.18,-0.453 0,-0.191 -0.059,-0.343 -0.18,-0.453 -0.117,-0.109 -0.285,-0.164 -0.496,-0.164 -0.211,0 -0.379,0.055 -0.496,0.164 -0.117,0.11 -0.176,0.262 -0.176,0.453 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath63)"
+           id="path572" />
+        <path
+           d="m 247.141,124.645 v 1.406 h 0.621 c 0.23,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.187,-0.297 0.187,-0.519 0,-0.227 -0.062,-0.399 -0.187,-0.52 -0.125,-0.125 -0.301,-0.183 -0.531,-0.183 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.097 0.926,0.285 0.21,0.191 0.312,0.468 0.312,0.836 0,0.367 -0.102,0.648 -0.312,0.836 -0.208,0.191 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.493 z m 4.184,0.5 -0.672,1.863 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.457,3.668 v -0.461 c 0.121,0.058 0.246,0.105 0.375,0.136 0.125,0.035 0.25,0.051 0.371,0.051 0.328,0 0.574,-0.113 0.746,-0.336 0.172,-0.226 0.27,-0.57 0.297,-1.027 -0.094,0.144 -0.215,0.254 -0.359,0.332 -0.145,0.074 -0.305,0.113 -0.481,0.113 -0.367,0 -0.656,-0.113 -0.867,-0.34 -0.211,-0.226 -0.317,-0.535 -0.317,-0.929 0,-0.383 0.11,-0.692 0.332,-0.926 0.219,-0.231 0.516,-0.348 0.883,-0.348 0.422,0 0.742,0.164 0.965,0.5 0.223,0.328 0.332,0.813 0.332,1.445 0,0.59 -0.137,1.063 -0.41,1.415 -0.27,0.351 -0.637,0.527 -1.098,0.527 -0.125,0 -0.25,-0.012 -0.375,-0.039 -0.129,-0.024 -0.257,-0.063 -0.394,-0.113 z m 0.98,-1.586 c 0.219,0 0.395,-0.079 0.524,-0.235 0.133,-0.156 0.195,-0.371 0.195,-0.64 0,-0.27 -0.062,-0.481 -0.195,-0.637 -0.129,-0.156 -0.305,-0.235 -0.524,-0.235 -0.222,0 -0.398,0.079 -0.527,0.235 -0.129,0.156 -0.195,0.367 -0.195,0.637 0,0.269 0.066,0.484 0.195,0.64 0.129,0.156 0.305,0.235 0.527,0.235 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath64)"
+           id="path573" />
+        <path
+           d="m 246.871,118.816 v 1.407 h 0.617 c 0.231,0 0.41,-0.059 0.535,-0.184 0.125,-0.121 0.188,-0.293 0.188,-0.519 0,-0.227 -0.063,-0.399 -0.188,-0.52 -0.125,-0.125 -0.304,-0.184 -0.535,-0.184 z m -0.496,-0.418 h 1.113 c 0.41,0 0.719,0.098 0.926,0.286 0.211,0.191 0.316,0.468 0.316,0.836 0,0.367 -0.105,0.648 -0.316,0.835 -0.207,0.192 -0.516,0.286 -0.926,0.286 h -0.617 v 1.504 h -0.496 z m 6.066,0.29 v 0.535 c -0.168,-0.161 -0.343,-0.278 -0.531,-0.356 -0.187,-0.078 -0.387,-0.117 -0.598,-0.117 -0.417,0 -0.738,0.129 -0.96,0.391 -0.219,0.261 -0.332,0.64 -0.332,1.136 0,0.493 0.113,0.871 0.332,1.133 0.222,0.262 0.543,0.391 0.96,0.391 0.211,0 0.411,-0.039 0.598,-0.117 0.188,-0.079 0.363,-0.196 0.531,-0.356 v 0.527 c -0.171,0.122 -0.355,0.211 -0.55,0.274 -0.192,0.059 -0.395,0.09 -0.61,0.09 -0.551,0 -0.988,-0.172 -1.304,-0.52 -0.317,-0.347 -0.477,-0.824 -0.477,-1.422 0,-0.601 0.16,-1.078 0.477,-1.425 0.316,-0.348 0.753,-0.52 1.304,-0.52 0.219,0 0.422,0.031 0.617,0.09 0.192,0.058 0.375,0.148 0.543,0.266 z m 0.801,-0.29 h 2.344 v 0.215 l -1.324,3.532 h -0.516 l 1.246,-3.321 h -1.75 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath65)"
+           id="path574" />
+        <path
+           d="m 247.141,112.988 v 1.41 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.183 0.125,-0.125 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.414 h 1.114 c 0.41,0 0.718,0.094 0.926,0.285 0.21,0.188 0.312,0.465 0.312,0.832 0,0.371 -0.102,0.649 -0.312,0.84 -0.208,0.188 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.493 z m 3.829,1.957 v 1.371 h 0.789 c 0.265,0 0.464,-0.054 0.589,-0.168 0.129,-0.113 0.192,-0.285 0.192,-0.519 0,-0.235 -0.063,-0.406 -0.192,-0.516 -0.125,-0.113 -0.324,-0.168 -0.589,-0.168 z m 0,-1.543 v 1.129 h 0.73 c 0.238,0 0.418,-0.043 0.535,-0.137 0.121,-0.093 0.18,-0.234 0.18,-0.425 0,-0.192 -0.059,-0.332 -0.18,-0.426 -0.117,-0.094 -0.297,-0.141 -0.535,-0.141 z m -0.493,-0.414 h 1.258 c 0.375,0 0.668,0.078 0.871,0.238 0.203,0.161 0.305,0.391 0.305,0.688 0,0.227 -0.055,0.41 -0.156,0.547 -0.106,0.133 -0.258,0.219 -0.461,0.254 0.242,0.051 0.429,0.164 0.566,0.336 0.133,0.168 0.203,0.379 0.203,0.633 0,0.335 -0.113,0.593 -0.332,0.777 -0.222,0.18 -0.539,0.273 -0.945,0.273 h -1.309 z m 4.493,1.668 c -0.223,0 -0.399,0.078 -0.528,0.235 -0.129,0.156 -0.191,0.371 -0.191,0.64 0,0.27 0.062,0.485 0.191,0.641 0.129,0.156 0.305,0.234 0.528,0.234 0.222,0 0.398,-0.078 0.527,-0.234 0.129,-0.156 0.195,-0.371 0.195,-0.641 0,-0.269 -0.066,-0.484 -0.195,-0.64 -0.129,-0.157 -0.305,-0.235 -0.527,-0.235 z m 0.98,-1.586 v 0.461 c -0.125,-0.058 -0.25,-0.105 -0.375,-0.137 -0.129,-0.031 -0.25,-0.05 -0.375,-0.05 -0.324,0 -0.574,0.113 -0.746,0.34 -0.172,0.226 -0.27,0.566 -0.293,1.023 0.094,-0.145 0.215,-0.254 0.359,-0.332 0.145,-0.078 0.305,-0.117 0.481,-0.117 0.363,0 0.652,0.113 0.867,0.344 0.211,0.226 0.316,0.535 0.316,0.929 0,0.383 -0.109,0.692 -0.332,0.926 -0.218,0.234 -0.515,0.348 -0.882,0.348 -0.422,0 -0.743,-0.164 -0.965,-0.496 -0.223,-0.333 -0.336,-0.813 -0.336,-1.446 0,-0.59 0.136,-1.062 0.41,-1.414 0.273,-0.355 0.641,-0.531 1.102,-0.531 0.124,0 0.246,0.012 0.374,0.039 0.126,0.023 0.258,0.062 0.395,0.113 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath66)"
+           id="path575" />
+        <path
+           d="m 247.141,107.164 v 1.406 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.394 -0.187,-0.515 -0.125,-0.125 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.094 0.926,0.285 0.21,0.192 0.312,0.469 0.312,0.832 0,0.371 -0.102,0.653 -0.312,0.84 -0.208,0.188 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.493 z m 4.184,0.5 -0.672,1.863 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.316,0 h 2.344 v 0.215 l -1.324,3.531 h -0.516 l 1.246,-3.32 h -1.75 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath67)"
+           id="path576" />
+        <path
+           d="m 247.141,101.336 v 1.406 h 0.621 c 0.23,0 0.406,-0.058 0.531,-0.18 0.125,-0.124 0.187,-0.296 0.187,-0.523 0,-0.223 -0.062,-0.398 -0.187,-0.519 -0.125,-0.122 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.098 0.926,0.289 0.21,0.188 0.312,0.465 0.312,0.832 0,0.371 -0.102,0.649 -0.312,0.836 -0.208,0.191 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.493 z m 4.184,0.5 -0.672,1.867 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 3.554,1.672 c -0.218,0 -0.394,0.078 -0.527,0.234 -0.125,0.156 -0.191,0.367 -0.191,0.641 0,0.269 0.066,0.48 0.191,0.64 0.133,0.153 0.309,0.231 0.527,0.231 0.223,0 0.399,-0.078 0.528,-0.231 0.129,-0.16 0.195,-0.371 0.195,-0.64 0,-0.274 -0.066,-0.485 -0.195,-0.641 -0.129,-0.156 -0.305,-0.234 -0.528,-0.234 z m 0.981,-1.586 v 0.461 c -0.125,-0.063 -0.25,-0.106 -0.375,-0.141 -0.125,-0.031 -0.25,-0.047 -0.375,-0.047 -0.324,0 -0.574,0.114 -0.746,0.34 -0.172,0.227 -0.27,0.567 -0.293,1.024 0.098,-0.145 0.215,-0.258 0.359,-0.332 0.149,-0.079 0.305,-0.121 0.481,-0.121 0.367,0 0.656,0.117 0.867,0.343 0.211,0.231 0.32,0.539 0.32,0.934 0,0.383 -0.113,0.691 -0.332,0.926 -0.222,0.23 -0.515,0.347 -0.887,0.347 -0.417,0 -0.742,-0.164 -0.964,-0.496 -0.223,-0.332 -0.336,-0.816 -0.336,-1.445 0,-0.594 0.136,-1.063 0.41,-1.414 0.273,-0.356 0.64,-0.531 1.101,-0.531 0.125,0 0.25,0.011 0.375,0.039 0.125,0.023 0.258,0.062 0.395,0.113 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath68)"
+           id="path577" />
+        <path
+           d="m 247.141,95.508 v 1.41 h 0.621 c 0.23,0 0.406,-0.063 0.531,-0.184 0.125,-0.125 0.187,-0.296 0.187,-0.523 0,-0.223 -0.062,-0.399 -0.187,-0.52 -0.125,-0.121 -0.301,-0.183 -0.531,-0.183 z m -0.493,-0.414 h 1.114 c 0.41,0 0.718,0.094 0.926,0.285 0.21,0.187 0.312,0.465 0.312,0.832 0,0.371 -0.102,0.648 -0.312,0.84 -0.208,0.187 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.493 z m 4.184,0.496 -0.672,1.867 h 1.344 z m -0.281,-0.496 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.445,0 h 1.938 v 0.426 h -1.485 v 0.918 c 0.071,-0.028 0.141,-0.043 0.215,-0.055 0.07,-0.016 0.141,-0.02 0.215,-0.02 0.406,0 0.726,0.114 0.965,0.344 0.238,0.227 0.355,0.539 0.355,0.93 0,0.402 -0.121,0.715 -0.363,0.941 -0.246,0.223 -0.59,0.332 -1.035,0.332 -0.153,0 -0.309,-0.012 -0.469,-0.039 -0.156,-0.027 -0.32,-0.066 -0.488,-0.121 v -0.508 c 0.144,0.082 0.297,0.141 0.453,0.184 0.156,0.039 0.32,0.058 0.496,0.058 0.281,0 0.504,-0.074 0.668,-0.226 0.164,-0.153 0.246,-0.36 0.246,-0.621 0,-0.262 -0.082,-0.469 -0.246,-0.621 -0.164,-0.153 -0.387,-0.227 -0.668,-0.227 -0.133,0 -0.266,0.016 -0.395,0.043 -0.132,0.031 -0.265,0.078 -0.402,0.141 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath69)"
+           id="path578" />
+        <path
+           d="m 247.594,92.477 v -1.004 h -0.805 v -0.418 h 1.293 v 1.609 c -0.187,0.137 -0.398,0.242 -0.629,0.316 -0.23,0.071 -0.473,0.106 -0.734,0.106 -0.571,0 -1.016,-0.172 -1.34,-0.512 -0.32,-0.344 -0.481,-0.82 -0.481,-1.433 0,-0.61 0.161,-1.086 0.481,-1.43 0.324,-0.344 0.769,-0.512 1.34,-0.512 0.238,0 0.461,0.028 0.676,0.09 0.214,0.059 0.414,0.149 0.593,0.266 v 0.539 c -0.183,-0.16 -0.375,-0.278 -0.582,-0.36 -0.203,-0.082 -0.422,-0.121 -0.648,-0.121 -0.446,0 -0.781,0.129 -1.004,0.383 -0.223,0.258 -0.336,0.641 -0.336,1.145 0,0.507 0.113,0.886 0.336,1.144 0.223,0.254 0.558,0.383 1.004,0.383 0.176,0 0.332,-0.016 0.469,-0.047 0.136,-0.031 0.257,-0.078 0.367,-0.144 z M 249,89.266 h 0.664 l 1.617,3.132 v -3.132 h 0.477 v 3.746 h -0.664 l -1.617,-3.133 v 3.133 H 249 Z m 4.102,0.418 v 2.91 h 0.597 c 0.504,0 0.871,-0.117 1.102,-0.352 0.234,-0.234 0.351,-0.601 0.351,-1.109 0,-0.5 -0.117,-0.867 -0.351,-1.102 -0.231,-0.23 -0.598,-0.347 -1.102,-0.347 z m -0.493,-0.418 h 1.012 c 0.707,0 1.227,0.152 1.559,0.453 0.328,0.301 0.492,0.773 0.492,1.414 0,0.648 -0.164,1.121 -0.496,1.426 -0.332,0.3 -0.852,0.453 -1.555,0.453 h -1.012 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath70)"
+           id="path579" />
+        <path
+           d="m 243.52,83.938 -0.668,1.863 h 1.339 z m -0.278,-0.5 h 0.559 l 1.39,3.746 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.519 z m 2.965,3.746 -1.391,-3.746 h 0.512 l 1.156,3.156 1.157,-3.156 h 0.515 l -1.39,3.746 z m 2.887,-3.329 v 2.915 h 0.597 c 0.5,0 0.871,-0.118 1.102,-0.352 0.234,-0.234 0.352,-0.606 0.352,-1.109 0,-0.504 -0.118,-0.871 -0.352,-1.102 -0.231,-0.234 -0.602,-0.352 -1.102,-0.352 z m -0.492,-0.417 h 1.011 c 0.707,0 1.227,0.152 1.555,0.457 0.332,0.3 0.496,0.769 0.496,1.414 0,0.644 -0.164,1.121 -0.496,1.421 -0.332,0.305 -0.852,0.454 -1.555,0.454 h -1.011 z m 4.101,0.417 v 2.915 h 0.598 c 0.504,0 0.871,-0.118 1.101,-0.352 0.235,-0.234 0.352,-0.606 0.352,-1.109 0,-0.504 -0.117,-0.871 -0.352,-1.102 -0.23,-0.234 -0.597,-0.352 -1.101,-0.352 z m -0.492,-0.417 h 1.016 c 0.703,0 1.222,0.152 1.554,0.457 0.328,0.3 0.496,0.769 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.421 -0.332,0.305 -0.847,0.454 -1.55,0.454 h -1.016 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath71)"
+           id="path580" />
+        <path
+           d="m 247.141,78.027 v 1.407 h 0.621 c 0.23,0 0.406,-0.059 0.531,-0.18 0.125,-0.125 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.098 0.926,0.289 0.21,0.188 0.312,0.465 0.312,0.832 0,0.372 -0.102,0.649 -0.312,0.836 -0.208,0.192 -0.516,0.286 -0.926,0.286 h -0.621 v 1.503 h -0.493 z m 3.829,1.957 v 1.375 h 0.789 c 0.265,0 0.464,-0.054 0.589,-0.168 0.129,-0.113 0.192,-0.289 0.192,-0.519 0,-0.234 -0.063,-0.406 -0.192,-0.516 -0.125,-0.113 -0.324,-0.172 -0.589,-0.172 z m 0,-1.539 v 1.129 h 0.73 c 0.238,0 0.418,-0.047 0.535,-0.136 0.121,-0.094 0.18,-0.239 0.18,-0.426 0,-0.192 -0.059,-0.332 -0.18,-0.426 -0.117,-0.094 -0.297,-0.141 -0.535,-0.141 z m -0.493,-0.418 h 1.258 c 0.375,0 0.668,0.082 0.871,0.243 0.203,0.16 0.305,0.39 0.305,0.683 0,0.231 -0.055,0.414 -0.156,0.551 -0.106,0.133 -0.258,0.219 -0.461,0.25 0.242,0.055 0.429,0.168 0.566,0.336 0.133,0.172 0.203,0.383 0.203,0.637 0,0.336 -0.113,0.593 -0.332,0.773 -0.222,0.184 -0.539,0.273 -0.945,0.273 h -1.309 z m 3.391,3.672 v -0.465 c 0.125,0.063 0.25,0.11 0.379,0.141 0.125,0.031 0.25,0.047 0.371,0.047 0.324,0 0.574,-0.113 0.746,-0.336 0.172,-0.227 0.27,-0.57 0.293,-1.027 -0.094,0.144 -0.211,0.254 -0.355,0.332 -0.149,0.078 -0.309,0.113 -0.485,0.113 -0.363,0 -0.652,-0.109 -0.863,-0.336 -0.215,-0.23 -0.32,-0.539 -0.32,-0.934 0,-0.382 0.113,-0.691 0.332,-0.925 0.222,-0.231 0.515,-0.348 0.886,-0.348 0.418,0 0.743,0.168 0.961,0.5 0.223,0.332 0.336,0.812 0.336,1.445 0,0.59 -0.136,1.063 -0.41,1.414 -0.273,0.352 -0.637,0.528 -1.098,0.528 -0.125,0 -0.25,-0.012 -0.375,-0.039 -0.128,-0.024 -0.261,-0.063 -0.398,-0.11 z m 0.984,-1.59 c 0.219,0 0.395,-0.078 0.524,-0.234 0.129,-0.156 0.195,-0.367 0.195,-0.641 0,-0.269 -0.066,-0.48 -0.195,-0.636 -0.129,-0.157 -0.305,-0.235 -0.524,-0.235 -0.222,0 -0.398,0.078 -0.527,0.235 -0.129,0.156 -0.195,0.367 -0.195,0.636 0,0.274 0.066,0.485 0.195,0.641 0.129,0.156 0.305,0.234 0.527,0.234 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath72)"
+           id="path581" />
+        <path
+           d="m 247.141,72.199 v 1.41 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.394 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.414 h 1.114 c 0.41,0 0.718,0.094 0.926,0.285 0.21,0.188 0.312,0.469 0.312,0.832 0,0.371 -0.102,0.649 -0.312,0.84 -0.208,0.188 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.493 z m 3.829,1.957 v 1.371 h 0.789 c 0.265,0 0.464,-0.054 0.589,-0.168 0.129,-0.113 0.192,-0.285 0.192,-0.519 0,-0.235 -0.063,-0.406 -0.192,-0.516 -0.125,-0.113 -0.324,-0.168 -0.589,-0.168 z m 0,-1.543 v 1.133 h 0.73 c 0.238,0 0.418,-0.047 0.535,-0.141 0.121,-0.093 0.18,-0.234 0.18,-0.425 0,-0.188 -0.059,-0.332 -0.18,-0.426 -0.117,-0.094 -0.297,-0.141 -0.535,-0.141 z m -0.493,-0.414 h 1.258 c 0.375,0 0.668,0.078 0.871,0.238 0.203,0.165 0.305,0.391 0.305,0.688 0,0.23 -0.055,0.41 -0.156,0.547 -0.106,0.137 -0.258,0.219 -0.461,0.254 0.242,0.05 0.429,0.164 0.566,0.336 0.133,0.168 0.203,0.379 0.203,0.632 0,0.336 -0.113,0.594 -0.332,0.778 -0.222,0.183 -0.539,0.273 -0.945,0.273 h -1.309 z m 4.434,1.965 c -0.234,0 -0.422,0.066 -0.555,0.195 -0.136,0.129 -0.203,0.305 -0.203,0.532 0,0.226 0.067,0.402 0.203,0.531 0.133,0.129 0.321,0.195 0.555,0.195 0.234,0 0.418,-0.066 0.551,-0.195 0.136,-0.129 0.203,-0.309 0.203,-0.531 0,-0.227 -0.067,-0.403 -0.203,-0.532 -0.133,-0.129 -0.317,-0.195 -0.551,-0.195 z m -0.496,-0.215 c -0.211,-0.055 -0.375,-0.152 -0.496,-0.305 -0.117,-0.148 -0.176,-0.328 -0.176,-0.542 0,-0.301 0.105,-0.536 0.312,-0.711 0.208,-0.172 0.493,-0.262 0.856,-0.262 0.359,0 0.644,0.09 0.852,0.262 0.207,0.175 0.312,0.41 0.312,0.711 0,0.214 -0.062,0.394 -0.18,0.542 -0.117,0.153 -0.281,0.25 -0.492,0.305 0.238,0.059 0.426,0.168 0.555,0.336 0.133,0.164 0.203,0.367 0.203,0.606 0,0.363 -0.109,0.64 -0.328,0.835 -0.215,0.196 -0.524,0.293 -0.922,0.293 -0.402,0 -0.715,-0.097 -0.93,-0.293 -0.215,-0.195 -0.32,-0.472 -0.32,-0.835 0,-0.239 0.066,-0.442 0.199,-0.606 0.133,-0.168 0.317,-0.277 0.555,-0.336 z m -0.18,-0.801 c 0,0.196 0.059,0.348 0.176,0.457 0.117,0.106 0.285,0.161 0.5,0.161 0.211,0 0.375,-0.055 0.492,-0.161 0.121,-0.109 0.184,-0.261 0.184,-0.457 0,-0.191 -0.063,-0.343 -0.184,-0.453 -0.117,-0.109 -0.281,-0.164 -0.492,-0.164 -0.215,0 -0.383,0.055 -0.5,0.164 -0.117,0.11 -0.176,0.262 -0.176,0.453 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath73)"
+           id="path582" />
+        <path
+           d="m 246.871,66.375 v 1.406 h 0.617 c 0.231,0 0.41,-0.058 0.535,-0.183 0.125,-0.121 0.188,-0.293 0.188,-0.52 0,-0.226 -0.063,-0.398 -0.188,-0.519 -0.125,-0.125 -0.304,-0.184 -0.535,-0.184 z m -0.496,-0.418 h 1.113 c 0.41,0 0.719,0.098 0.926,0.285 0.211,0.192 0.316,0.469 0.316,0.836 0,0.367 -0.105,0.649 -0.316,0.836 -0.207,0.191 -0.516,0.285 -0.926,0.285 h -0.617 v 1.504 h -0.496 z m 6.066,0.289 v 0.535 c -0.168,-0.16 -0.343,-0.277 -0.531,-0.355 -0.187,-0.078 -0.387,-0.121 -0.598,-0.121 -0.417,0 -0.738,0.133 -0.96,0.394 -0.219,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.113,0.871 0.332,1.133 0.222,0.261 0.543,0.39 0.96,0.39 0.211,0 0.411,-0.039 0.598,-0.117 0.188,-0.078 0.363,-0.195 0.531,-0.355 v 0.527 c -0.171,0.121 -0.355,0.211 -0.55,0.274 -0.192,0.058 -0.395,0.089 -0.61,0.089 -0.551,0 -0.988,-0.172 -1.304,-0.519 -0.317,-0.348 -0.477,-0.824 -0.477,-1.422 0,-0.602 0.16,-1.078 0.477,-1.426 0.316,-0.348 0.753,-0.519 1.304,-0.519 0.219,0 0.422,0.031 0.617,0.089 0.192,0.059 0.375,0.149 0.543,0.266 z m 0.938,3.379 v -0.461 c 0.125,0.063 0.25,0.106 0.379,0.137 0.125,0.035 0.25,0.051 0.371,0.051 0.328,0 0.574,-0.114 0.746,-0.336 0.172,-0.227 0.27,-0.571 0.293,-1.028 -0.094,0.145 -0.211,0.254 -0.356,0.332 -0.148,0.075 -0.308,0.114 -0.484,0.114 -0.363,0 -0.652,-0.114 -0.863,-0.34 -0.215,-0.227 -0.32,-0.535 -0.32,-0.93 0,-0.383 0.113,-0.691 0.332,-0.926 0.222,-0.23 0.515,-0.347 0.886,-0.347 0.418,0 0.742,0.164 0.961,0.5 0.227,0.328 0.336,0.812 0.336,1.445 0,0.59 -0.137,1.062 -0.41,1.414 -0.273,0.352 -0.637,0.527 -1.098,0.527 -0.125,0 -0.25,-0.011 -0.375,-0.039 -0.129,-0.023 -0.261,-0.062 -0.398,-0.113 z m 0.984,-1.586 c 0.219,0 0.395,-0.078 0.524,-0.234 0.129,-0.157 0.195,-0.367 0.195,-0.641 0,-0.269 -0.066,-0.48 -0.195,-0.637 -0.129,-0.156 -0.305,-0.234 -0.524,-0.234 -0.222,0 -0.398,0.078 -0.527,0.234 -0.129,0.157 -0.195,0.368 -0.195,0.637 0,0.274 0.066,0.484 0.195,0.641 0.129,0.156 0.305,0.234 0.527,0.234 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath74)"
+           id="path583" />
+        <path
+           d="m 247.141,174.176 v 1.406 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.184 0.125,-0.121 0.187,-0.296 0.187,-0.519 0,-0.227 -0.062,-0.399 -0.187,-0.52 -0.125,-0.125 -0.301,-0.183 -0.531,-0.183 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.094 0.926,0.285 0.21,0.191 0.312,0.469 0.312,0.836 0,0.367 -0.102,0.648 -0.312,0.836 -0.208,0.191 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.493 z m 4.184,0.5 -0.672,1.863 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 3.933,1.726 c 0.239,0.051 0.422,0.161 0.555,0.325 0.133,0.164 0.199,0.367 0.199,0.605 0,0.371 -0.125,0.656 -0.371,0.859 -0.25,0.204 -0.601,0.305 -1.055,0.305 -0.152,0 -0.312,-0.016 -0.472,-0.047 -0.164,-0.031 -0.328,-0.078 -0.504,-0.14 v -0.489 c 0.137,0.082 0.289,0.145 0.449,0.188 0.164,0.039 0.336,0.062 0.512,0.062 0.308,0 0.543,-0.062 0.707,-0.191 0.16,-0.125 0.242,-0.305 0.242,-0.547 0,-0.219 -0.074,-0.391 -0.226,-0.516 -0.149,-0.125 -0.36,-0.187 -0.629,-0.187 h -0.422 v -0.418 h 0.441 c 0.246,0 0.43,-0.047 0.559,-0.148 0.129,-0.098 0.191,-0.243 0.191,-0.43 0,-0.192 -0.066,-0.34 -0.199,-0.442 -0.133,-0.105 -0.32,-0.156 -0.57,-0.156 -0.133,0 -0.278,0.016 -0.434,0.047 -0.152,0.027 -0.324,0.074 -0.508,0.141 v -0.453 c 0.184,-0.055 0.36,-0.094 0.524,-0.122 0.164,-0.027 0.32,-0.039 0.465,-0.039 0.374,0 0.667,0.086 0.886,0.262 0.219,0.176 0.328,0.41 0.328,0.707 0,0.207 -0.058,0.383 -0.172,0.528 -0.117,0.144 -0.281,0.242 -0.496,0.296 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath75)"
+           id="path584" />
+        <path
+           d="m 247.285,168.348 v 1.406 h 0.617 c 0.231,0 0.41,-0.059 0.536,-0.184 0.124,-0.121 0.187,-0.293 0.187,-0.519 0,-0.227 -0.063,-0.399 -0.187,-0.52 -0.126,-0.125 -0.305,-0.183 -0.536,-0.183 z m -0.496,-0.418 h 1.113 c 0.41,0 0.719,0.097 0.926,0.285 0.211,0.191 0.317,0.469 0.317,0.836 0,0.367 -0.106,0.648 -0.317,0.836 -0.207,0.191 -0.516,0.285 -0.926,0.285 h -0.617 v 1.504 h -0.496 z m 4.184,0.5 -0.668,1.863 h 1.34 z m -0.278,-0.5 h 0.559 l 1.391,3.746 h -0.516 l -0.332,-0.961 h -1.641 l -0.332,0.961 h -0.523 z m 2.864,3.32 h 1.722 v 0.426 h -2.316 v -0.426 c 0.187,-0.199 0.441,-0.465 0.765,-0.801 0.325,-0.336 0.528,-0.551 0.61,-0.648 0.156,-0.184 0.265,-0.336 0.328,-0.461 0.066,-0.129 0.098,-0.254 0.098,-0.375 0,-0.199 -0.071,-0.363 -0.207,-0.488 -0.133,-0.125 -0.313,-0.188 -0.528,-0.188 -0.156,0 -0.32,0.027 -0.492,0.082 -0.172,0.055 -0.355,0.141 -0.551,0.254 v -0.516 c 0.2,-0.082 0.387,-0.14 0.559,-0.183 0.172,-0.043 0.328,-0.063 0.473,-0.063 0.378,0 0.679,0.098 0.902,0.289 0.226,0.196 0.34,0.453 0.34,0.782 0,0.152 -0.032,0.296 -0.086,0.437 -0.059,0.137 -0.16,0.301 -0.305,0.488 -0.043,0.047 -0.172,0.188 -0.391,0.418 -0.218,0.235 -0.523,0.555 -0.921,0.973 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath76)"
+           id="path585" />
+        <path
+           d="m 244.477,162.52 v 1.41 h 0.621 c 0.226,0 0.406,-0.063 0.531,-0.184 0.125,-0.125 0.187,-0.297 0.187,-0.523 0,-0.223 -0.062,-0.399 -0.187,-0.52 -0.125,-0.121 -0.305,-0.183 -0.531,-0.183 z m -0.493,-0.415 h 1.114 c 0.406,0 0.714,0.094 0.925,0.286 0.207,0.187 0.313,0.464 0.313,0.832 0,0.371 -0.106,0.648 -0.313,0.839 -0.211,0.188 -0.519,0.282 -0.925,0.282 h -0.621 v 1.508 h -0.493 z m 4.18,0.497 -0.668,1.867 h 1.34 z m -0.277,-0.497 h 0.558 l 1.391,3.747 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.523,3.317 h 0.809 v -2.856 l -0.879,0.18 v -0.461 l 0.871,-0.18 h 0.496 v 3.317 h 0.805 v 0.43 h -2.102 z m 3.75,-2.984 c -0.254,0 -0.445,0.128 -0.574,0.386 -0.125,0.254 -0.188,0.641 -0.188,1.156 0,0.516 0.063,0.899 0.188,1.157 0.129,0.258 0.32,0.386 0.574,0.386 0.258,0 0.449,-0.128 0.574,-0.386 0.129,-0.258 0.192,-0.641 0.192,-1.157 0,-0.515 -0.063,-0.902 -0.192,-1.156 -0.125,-0.258 -0.316,-0.386 -0.574,-0.386 z m 0,-0.403 c 0.41,0 0.723,0.168 0.938,0.5 0.214,0.332 0.324,0.813 0.324,1.445 0,0.633 -0.11,1.114 -0.324,1.446 -0.215,0.332 -0.528,0.496 -0.938,0.496 -0.406,0 -0.719,-0.164 -0.937,-0.496 -0.215,-0.332 -0.321,-0.813 -0.321,-1.446 0,-0.632 0.106,-1.113 0.321,-1.445 0.218,-0.332 0.531,-0.5 0.937,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath77)"
+           id="path586" />
+        <path
+           d="m 247.285,156.695 v 1.407 h 0.617 c 0.231,0 0.41,-0.063 0.536,-0.184 0.124,-0.121 0.187,-0.297 0.187,-0.523 0,-0.223 -0.063,-0.395 -0.187,-0.516 -0.126,-0.125 -0.305,-0.184 -0.536,-0.184 z m -0.496,-0.418 h 1.113 c 0.41,0 0.719,0.094 0.926,0.285 0.211,0.192 0.317,0.469 0.317,0.833 0,0.371 -0.106,0.652 -0.317,0.839 -0.207,0.188 -0.516,0.286 -0.926,0.286 h -0.617 v 1.503 h -0.496 z m 3.828,1.957 v 1.371 h 0.793 c 0.266,0 0.461,-0.054 0.586,-0.167 0.129,-0.114 0.195,-0.286 0.195,-0.52 0,-0.234 -0.066,-0.406 -0.195,-0.516 -0.125,-0.113 -0.32,-0.168 -0.586,-0.168 z m 0,-1.539 v 1.129 h 0.731 c 0.242,0 0.422,-0.047 0.539,-0.14 0.117,-0.094 0.175,-0.235 0.175,-0.426 0,-0.188 -0.058,-0.328 -0.175,-0.422 -0.117,-0.094 -0.297,-0.141 -0.539,-0.141 z m -0.492,-0.418 h 1.258 c 0.379,0 0.668,0.082 0.871,0.243 0.203,0.16 0.305,0.386 0.305,0.683 0,0.231 -0.051,0.41 -0.157,0.547 -0.105,0.137 -0.257,0.219 -0.457,0.254 0.243,0.055 0.43,0.164 0.563,0.336 0.137,0.168 0.203,0.379 0.203,0.637 0,0.332 -0.109,0.589 -0.332,0.773 -0.223,0.184 -0.535,0.273 -0.945,0.273 h -1.309 z m 4.871,1.727 c 0.238,0.051 0.422,0.16 0.555,0.324 0.133,0.164 0.199,0.367 0.199,0.606 0,0.371 -0.125,0.656 -0.371,0.859 -0.246,0.203 -0.598,0.305 -1.055,0.305 -0.152,0 -0.312,-0.016 -0.472,-0.051 -0.164,-0.027 -0.329,-0.074 -0.504,-0.137 v -0.488 c 0.136,0.082 0.289,0.144 0.453,0.183 0.16,0.043 0.332,0.063 0.508,0.063 0.308,0 0.546,-0.063 0.707,-0.188 0.16,-0.125 0.242,-0.304 0.242,-0.546 0,-0.219 -0.074,-0.391 -0.227,-0.516 -0.148,-0.125 -0.359,-0.188 -0.625,-0.188 h -0.426 v -0.418 h 0.446 c 0.242,0 0.426,-0.05 0.554,-0.148 0.129,-0.098 0.192,-0.242 0.192,-0.43 0,-0.195 -0.067,-0.339 -0.199,-0.441 -0.133,-0.105 -0.321,-0.156 -0.567,-0.156 -0.136,0 -0.281,0.015 -0.437,0.043 -0.153,0.031 -0.324,0.078 -0.508,0.14 v -0.449 c 0.187,-0.055 0.359,-0.094 0.523,-0.121 0.164,-0.027 0.321,-0.039 0.465,-0.039 0.375,0 0.668,0.086 0.887,0.262 0.219,0.175 0.328,0.41 0.328,0.707 0,0.207 -0.059,0.382 -0.172,0.527 -0.117,0.145 -0.281,0.242 -0.496,0.297 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath78)"
+           id="path587" />
+        <path
+           d="m 247.141,150.867 v 1.406 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.183 0.125,-0.121 0.187,-0.297 0.187,-0.52 0,-0.226 -0.062,-0.398 -0.187,-0.519 -0.125,-0.125 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.098 0.926,0.285 0.21,0.192 0.312,0.469 0.312,0.836 0,0.368 -0.102,0.649 -0.312,0.836 -0.208,0.192 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.493 z m 3.829,1.957 v 1.375 h 0.789 c 0.265,0 0.464,-0.058 0.589,-0.168 0.129,-0.117 0.192,-0.289 0.192,-0.519 0,-0.235 -0.063,-0.41 -0.192,-0.52 -0.125,-0.109 -0.324,-0.168 -0.589,-0.168 z m 0,-1.539 v 1.129 h 0.73 c 0.238,0 0.418,-0.047 0.535,-0.141 0.121,-0.089 0.18,-0.234 0.18,-0.425 0,-0.188 -0.059,-0.328 -0.18,-0.422 -0.117,-0.094 -0.297,-0.141 -0.535,-0.141 z m -0.493,-0.418 h 1.258 c 0.375,0 0.668,0.082 0.871,0.242 0.203,0.161 0.305,0.387 0.305,0.684 0,0.23 -0.055,0.41 -0.156,0.547 -0.106,0.137 -0.258,0.219 -0.461,0.254 0.242,0.054 0.429,0.164 0.566,0.336 0.133,0.168 0.203,0.383 0.203,0.636 0,0.332 -0.113,0.59 -0.332,0.774 -0.222,0.183 -0.539,0.273 -0.945,0.273 h -1.309 z m 3.383,0 h 1.934 v 0.426 h -1.485 v 0.918 c 0.075,-0.023 0.145,-0.043 0.215,-0.055 0.074,-0.011 0.145,-0.019 0.215,-0.019 0.41,0 0.731,0.113 0.969,0.343 0.238,0.231 0.355,0.54 0.355,0.93 0,0.406 -0.121,0.719 -0.367,0.942 -0.242,0.222 -0.586,0.336 -1.031,0.336 -0.152,0 -0.309,-0.016 -0.469,-0.04 -0.156,-0.027 -0.32,-0.07 -0.492,-0.121 v -0.511 c 0.148,0.082 0.301,0.144 0.457,0.183 0.156,0.039 0.32,0.063 0.496,0.063 0.281,0 0.504,-0.078 0.668,-0.231 0.164,-0.152 0.246,-0.359 0.246,-0.621 0,-0.258 -0.082,-0.465 -0.246,-0.617 -0.164,-0.152 -0.387,-0.23 -0.668,-0.23 -0.133,0 -0.266,0.015 -0.398,0.046 -0.129,0.032 -0.262,0.079 -0.399,0.141 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath79)"
+           id="path588" />
+        <path
+           d="m 247.141,145.039 v 1.41 h 0.621 c 0.23,0 0.406,-0.062 0.531,-0.183 0.125,-0.125 0.187,-0.297 0.187,-0.524 0,-0.222 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.301,-0.184 -0.531,-0.184 z m -0.493,-0.414 h 1.114 c 0.41,0 0.718,0.094 0.926,0.285 0.21,0.188 0.312,0.465 0.312,0.832 0,0.371 -0.102,0.649 -0.312,0.84 -0.208,0.188 -0.516,0.281 -0.926,0.281 h -0.621 v 1.508 h -0.493 z m 3.829,1.957 v 1.371 h 0.789 c 0.265,0 0.464,-0.055 0.589,-0.168 0.129,-0.113 0.192,-0.289 0.192,-0.519 0,-0.235 -0.063,-0.407 -0.192,-0.516 -0.125,-0.113 -0.324,-0.168 -0.589,-0.168 z m 0,-1.543 v 1.129 h 0.73 c 0.238,0 0.418,-0.047 0.535,-0.137 0.121,-0.093 0.18,-0.238 0.18,-0.426 0,-0.191 -0.059,-0.332 -0.18,-0.425 -0.117,-0.094 -0.297,-0.141 -0.535,-0.141 z m -0.493,-0.414 h 1.258 c 0.375,0 0.668,0.078 0.871,0.238 0.203,0.16 0.305,0.391 0.305,0.688 0,0.226 -0.055,0.41 -0.156,0.547 -0.106,0.132 -0.258,0.218 -0.461,0.25 0.242,0.054 0.429,0.168 0.566,0.34 0.133,0.167 0.203,0.378 0.203,0.632 0,0.336 -0.113,0.594 -0.332,0.778 -0.222,0.179 -0.539,0.273 -0.945,0.273 h -1.309 z m 4.731,0.441 -1.242,2 h 1.242 z m -0.129,-0.441 h 0.621 v 2.441 h 0.52 v 0.418 h -0.52 v 0.887 h -0.492 v -0.887 h -1.645 v -0.488 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath80)"
+           id="path589" />
+        <path
+           d="m 244.477,139.215 v 1.406 h 0.621 c 0.226,0 0.406,-0.062 0.531,-0.183 0.125,-0.122 0.187,-0.297 0.187,-0.524 0,-0.223 -0.062,-0.394 -0.187,-0.519 -0.125,-0.122 -0.305,-0.18 -0.531,-0.18 z m -0.493,-0.418 h 1.114 c 0.406,0 0.714,0.094 0.925,0.285 0.207,0.191 0.313,0.469 0.313,0.832 0,0.371 -0.106,0.652 -0.313,0.84 -0.211,0.187 -0.519,0.285 -0.925,0.285 h -0.621 v 1.504 h -0.493 z m 3.828,1.957 v 1.371 h 0.79 c 0.265,0 0.46,-0.055 0.589,-0.168 0.129,-0.113 0.192,-0.285 0.192,-0.519 0,-0.235 -0.063,-0.407 -0.192,-0.516 -0.129,-0.113 -0.324,-0.168 -0.589,-0.168 z m 0,-1.539 v 1.129 h 0.731 c 0.238,0 0.418,-0.047 0.535,-0.141 0.121,-0.094 0.18,-0.234 0.18,-0.426 0,-0.187 -0.059,-0.332 -0.18,-0.422 -0.117,-0.093 -0.297,-0.14 -0.535,-0.14 z m -0.496,-0.418 h 1.262 c 0.375,0 0.664,0.078 0.871,0.242 0.203,0.16 0.305,0.387 0.305,0.684 0,0.23 -0.055,0.41 -0.156,0.547 -0.106,0.136 -0.258,0.218 -0.461,0.253 0.242,0.055 0.429,0.165 0.566,0.336 0.133,0.168 0.199,0.379 0.199,0.633 0,0.336 -0.109,0.594 -0.332,0.778 -0.218,0.183 -0.535,0.273 -0.941,0.273 h -1.313 z m 3.465,3.32 h 0.809 v -2.859 l -0.879,0.18 v -0.461 l 0.871,-0.18 h 0.496 v 3.32 h 0.805 v 0.426 h -2.102 z m 3.75,-2.988 c -0.254,0 -0.445,0.129 -0.574,0.387 -0.125,0.257 -0.187,0.64 -0.187,1.156 0,0.516 0.062,0.902 0.187,1.16 0.129,0.254 0.32,0.383 0.574,0.383 0.258,0 0.449,-0.129 0.574,-0.383 0.129,-0.258 0.192,-0.644 0.192,-1.16 0,-0.516 -0.063,-0.899 -0.192,-1.156 -0.125,-0.258 -0.316,-0.387 -0.574,-0.387 z m 0,-0.399 c 0.41,0 0.723,0.165 0.938,0.497 0.215,0.332 0.324,0.816 0.324,1.445 0,0.633 -0.109,1.113 -0.324,1.445 -0.215,0.332 -0.528,0.5 -0.938,0.5 -0.406,0 -0.719,-0.168 -0.937,-0.5 -0.215,-0.332 -0.321,-0.812 -0.321,-1.445 0,-0.629 0.106,-1.113 0.321,-1.445 0.218,-0.332 0.531,-0.497 0.937,-0.497 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath81)"
+           id="path590" />
+        <path
+           d="m 247.141,133.387 v 1.406 h 0.621 c 0.23,0 0.406,-0.063 0.531,-0.184 0.125,-0.121 0.187,-0.297 0.187,-0.519 0,-0.227 -0.062,-0.399 -0.187,-0.52 -0.125,-0.125 -0.301,-0.183 -0.531,-0.183 z m -0.493,-0.418 h 1.114 c 0.41,0 0.718,0.093 0.926,0.285 0.21,0.191 0.312,0.469 0.312,0.836 0,0.367 -0.102,0.648 -0.312,0.836 -0.208,0.187 -0.516,0.285 -0.926,0.285 h -0.621 v 1.504 h -0.493 z m 4.184,0.5 -0.672,1.863 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 3.496,1.969 c -0.235,0 -0.418,0.062 -0.555,0.191 -0.133,0.129 -0.199,0.305 -0.199,0.531 0,0.227 0.066,0.402 0.199,0.531 0.137,0.129 0.32,0.196 0.555,0.196 0.234,0 0.418,-0.067 0.555,-0.196 0.132,-0.129 0.203,-0.304 0.203,-0.531 0,-0.226 -0.071,-0.402 -0.203,-0.531 -0.133,-0.129 -0.321,-0.191 -0.555,-0.191 z m -0.492,-0.219 c -0.215,-0.051 -0.379,-0.153 -0.496,-0.301 -0.118,-0.148 -0.176,-0.332 -0.176,-0.547 0,-0.297 0.101,-0.535 0.308,-0.711 0.207,-0.172 0.493,-0.258 0.856,-0.258 0.363,0 0.648,0.086 0.855,0.258 0.203,0.176 0.309,0.414 0.309,0.711 0,0.215 -0.059,0.399 -0.18,0.547 -0.117,0.148 -0.281,0.25 -0.488,0.301 0.238,0.058 0.422,0.168 0.555,0.336 0.132,0.164 0.199,0.367 0.199,0.605 0,0.363 -0.109,0.645 -0.324,0.836 -0.215,0.195 -0.524,0.293 -0.926,0.293 -0.402,0 -0.711,-0.098 -0.93,-0.293 -0.215,-0.191 -0.32,-0.473 -0.32,-0.836 0,-0.238 0.066,-0.441 0.199,-0.605 0.133,-0.168 0.32,-0.278 0.559,-0.336 z m -0.184,-0.801 c 0,0.195 0.059,0.348 0.176,0.457 0.121,0.109 0.285,0.164 0.5,0.164 0.211,0 0.375,-0.055 0.496,-0.164 0.121,-0.109 0.18,-0.262 0.18,-0.457 0,-0.191 -0.059,-0.344 -0.18,-0.453 -0.121,-0.11 -0.285,-0.164 -0.496,-0.164 -0.215,0 -0.379,0.054 -0.5,0.164 -0.117,0.109 -0.176,0.262 -0.176,0.453 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath82)"
+           id="path591" />
+        <path
+           d="m 233.223,124.645 v 2.914 h 0.593 c 0.504,0 0.872,-0.118 1.106,-0.352 0.234,-0.234 0.351,-0.602 0.351,-1.109 0,-0.5 -0.117,-0.868 -0.351,-1.102 -0.234,-0.234 -0.602,-0.351 -1.106,-0.351 z m -0.493,-0.415 h 1.012 c 0.707,0 1.223,0.149 1.555,0.454 0.332,0.3 0.496,0.773 0.496,1.414 0,0.648 -0.168,1.121 -0.5,1.425 -0.332,0.301 -0.848,0.454 -1.551,0.454 h -1.012 z m 4.708,1.965 c -0.235,0 -0.418,0.067 -0.555,0.196 -0.133,0.129 -0.199,0.304 -0.199,0.531 0,0.226 0.066,0.402 0.199,0.531 0.137,0.129 0.32,0.195 0.555,0.195 0.234,0 0.417,-0.066 0.554,-0.195 0.133,-0.129 0.203,-0.308 0.203,-0.531 0,-0.227 -0.07,-0.402 -0.203,-0.531 -0.133,-0.129 -0.32,-0.196 -0.554,-0.196 z m -0.493,-0.215 c -0.211,-0.054 -0.379,-0.152 -0.496,-0.304 -0.117,-0.149 -0.176,-0.328 -0.176,-0.543 0,-0.301 0.102,-0.535 0.309,-0.711 0.211,-0.172 0.492,-0.262 0.856,-0.262 0.363,0 0.648,0.09 0.855,0.262 0.207,0.176 0.309,0.41 0.309,0.711 0,0.215 -0.059,0.394 -0.18,0.543 -0.117,0.152 -0.277,0.25 -0.488,0.304 0.238,0.059 0.421,0.168 0.554,0.336 0.133,0.164 0.2,0.368 0.2,0.606 0,0.363 -0.11,0.64 -0.325,0.836 -0.215,0.195 -0.523,0.289 -0.925,0.289 -0.403,0 -0.711,-0.094 -0.93,-0.289 -0.215,-0.196 -0.32,-0.473 -0.32,-0.836 0,-0.238 0.066,-0.442 0.199,-0.606 0.133,-0.168 0.32,-0.277 0.558,-0.336 z m -0.183,-0.8 c 0,0.195 0.058,0.347 0.176,0.453 0.121,0.109 0.285,0.164 0.5,0.164 0.21,0 0.374,-0.055 0.496,-0.164 0.121,-0.106 0.179,-0.258 0.179,-0.453 0,-0.192 -0.058,-0.344 -0.179,-0.453 -0.122,-0.11 -0.286,-0.165 -0.496,-0.165 -0.215,0 -0.379,0.055 -0.5,0.165 -0.118,0.109 -0.176,0.261 -0.176,0.453 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath83)"
+           id="path592" />
+        <path
+           d="m 233.223,118.816 v 2.914 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.351 0.234,-0.234 0.351,-0.602 0.351,-1.109 0,-0.5 -0.117,-0.868 -0.351,-1.102 -0.234,-0.234 -0.602,-0.352 -1.106,-0.352 z m -0.493,-0.414 h 1.012 c 0.707,0 1.223,0.153 1.555,0.453 0.332,0.301 0.496,0.774 0.496,1.415 0,0.648 -0.168,1.121 -0.5,1.425 -0.332,0.301 -0.848,0.453 -1.551,0.453 h -1.012 z m 3.668,3.668 v -0.461 c 0.122,0.059 0.247,0.106 0.375,0.137 0.125,0.031 0.25,0.047 0.375,0.047 0.325,0 0.571,-0.109 0.743,-0.336 0.171,-0.227 0.273,-0.566 0.297,-1.023 -0.094,0.14 -0.215,0.254 -0.36,0.328 -0.144,0.078 -0.305,0.117 -0.48,0.117 -0.368,0 -0.653,-0.113 -0.868,-0.34 -0.21,-0.227 -0.316,-0.539 -0.316,-0.93 0,-0.386 0.109,-0.695 0.332,-0.925 0.219,-0.235 0.516,-0.348 0.883,-0.348 0.422,0 0.742,0.164 0.965,0.496 0.222,0.332 0.332,0.813 0.332,1.445 0,0.594 -0.137,1.063 -0.41,1.418 -0.27,0.352 -0.637,0.528 -1.098,0.528 -0.121,0 -0.25,-0.016 -0.375,-0.039 -0.129,-0.024 -0.258,-0.063 -0.395,-0.114 z m 0.981,-1.59 c 0.223,0 0.394,-0.078 0.523,-0.23 0.133,-0.156 0.196,-0.371 0.196,-0.641 0,-0.269 -0.063,-0.48 -0.196,-0.636 -0.129,-0.161 -0.3,-0.239 -0.523,-0.239 -0.223,0 -0.399,0.078 -0.527,0.239 -0.129,0.156 -0.192,0.367 -0.192,0.636 0,0.27 0.063,0.485 0.192,0.641 0.128,0.152 0.304,0.23 0.527,0.23 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath84)"
+           id="path593" />
+        <path
+           d="m 230.559,112.992 v 2.914 h 0.593 c 0.504,0 0.871,-0.117 1.106,-0.351 0.234,-0.235 0.351,-0.606 0.351,-1.11 0,-0.504 -0.117,-0.871 -0.351,-1.101 -0.235,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.497,-0.418 h 1.016 c 0.703,0 1.223,0.153 1.555,0.457 0.328,0.301 0.496,0.77 0.496,1.414 0,0.645 -0.168,1.121 -0.5,1.422 -0.332,0.305 -0.848,0.453 -1.551,0.453 h -1.016 z m 3.743,3.321 h 0.804 v -2.86 l -0.879,0.184 v -0.461 l 0.875,-0.184 h 0.493 v 3.321 h 0.804 v 0.425 h -2.097 z m 3.746,-2.985 c -0.254,0 -0.446,0.129 -0.571,0.387 -0.128,0.254 -0.191,0.641 -0.191,1.156 0,0.512 0.063,0.899 0.191,1.156 0.125,0.254 0.317,0.383 0.571,0.383 0.258,0 0.449,-0.129 0.574,-0.383 0.129,-0.257 0.195,-0.644 0.195,-1.156 0,-0.515 -0.066,-0.902 -0.195,-1.156 -0.125,-0.258 -0.316,-0.387 -0.574,-0.387 z m 0,-0.402 c 0.41,0 0.722,0.168 0.937,0.5 0.215,0.332 0.324,0.812 0.324,1.445 0,0.629 -0.109,1.113 -0.324,1.445 -0.215,0.332 -0.527,0.497 -0.937,0.497 -0.406,0 -0.719,-0.165 -0.938,-0.497 -0.215,-0.332 -0.32,-0.816 -0.32,-1.445 0,-0.633 0.105,-1.113 0.32,-1.445 0.219,-0.332 0.532,-0.5 0.938,-0.5 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath85)"
+           id="path594" />
+        <path
+           d="m 230.559,107.164 v 2.914 h 0.593 c 0.504,0 0.871,-0.117 1.106,-0.351 0.234,-0.235 0.351,-0.602 0.351,-1.11 0,-0.5 -0.117,-0.867 -0.351,-1.101 -0.235,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.497,-0.414 h 1.016 c 0.703,0 1.223,0.148 1.555,0.453 0.328,0.301 0.496,0.774 0.496,1.414 0,0.649 -0.168,1.121 -0.5,1.422 -0.332,0.305 -0.848,0.457 -1.551,0.457 h -1.016 z m 3.743,3.32 h 0.804 v -2.859 l -0.879,0.18 v -0.461 l 0.875,-0.18 h 0.493 v 3.32 h 0.804 v 0.426 h -2.097 z m 2.406,0 h 0.809 v -2.859 l -0.879,0.18 v -0.461 l 0.871,-0.18 h 0.496 v 3.32 h 0.804 v 0.426 h -2.101 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath86)"
+           id="path595" />
+        <path
+           d="m 230.559,101.34 v 2.91 h 0.593 c 0.504,0 0.871,-0.117 1.106,-0.348 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.504 -0.117,-0.871 -0.351,-1.102 -0.235,-0.234 -0.602,-0.351 -1.106,-0.351 z m -0.497,-0.418 h 1.016 c 0.703,0 1.223,0.152 1.555,0.453 0.328,0.301 0.496,0.773 0.496,1.418 0,0.645 -0.168,1.117 -0.5,1.422 -0.332,0.301 -0.848,0.453 -1.551,0.453 h -1.016 z m 3.743,3.32 h 0.804 v -2.859 l -0.879,0.179 v -0.46 l 0.875,-0.18 h 0.493 v 3.32 h 0.804 v 0.426 h -2.097 z m 3.117,0 h 1.723 v 0.426 h -2.317 v -0.426 c 0.188,-0.199 0.442,-0.465 0.766,-0.801 0.324,-0.336 0.527,-0.554 0.609,-0.648 0.16,-0.184 0.27,-0.336 0.332,-0.465 0.063,-0.125 0.094,-0.25 0.094,-0.371 0,-0.199 -0.07,-0.363 -0.207,-0.488 -0.133,-0.125 -0.309,-0.188 -0.527,-0.188 -0.157,0 -0.321,0.028 -0.493,0.082 -0.172,0.055 -0.351,0.141 -0.547,0.25 v -0.511 c 0.196,-0.082 0.383,-0.145 0.555,-0.184 0.172,-0.043 0.332,-0.063 0.473,-0.063 0.379,0 0.679,0.098 0.906,0.29 0.223,0.195 0.336,0.453 0.336,0.777 0,0.156 -0.031,0.301 -0.086,0.441 -0.055,0.137 -0.156,0.297 -0.305,0.485 -0.043,0.05 -0.172,0.191 -0.39,0.422 -0.215,0.23 -0.524,0.554 -0.922,0.972 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath87)"
+           id="path596" />
+        <path
+           d="m 230.559,95.512 v 2.914 h 0.593 c 0.504,0 0.871,-0.117 1.106,-0.352 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.504 -0.117,-0.871 -0.351,-1.102 -0.235,-0.234 -0.602,-0.351 -1.106,-0.351 z m -0.497,-0.418 h 1.016 c 0.703,0 1.223,0.152 1.555,0.453 0.328,0.305 0.496,0.773 0.496,1.418 0,0.644 -0.168,1.117 -0.5,1.422 -0.332,0.301 -0.848,0.453 -1.551,0.453 h -1.016 z m 3.743,3.32 h 0.804 v -2.859 l -0.879,0.183 v -0.465 l 0.875,-0.179 h 0.493 v 3.32 h 0.804 v 0.426 h -2.097 z m 4.187,-1.594 c 0.235,0.051 0.418,0.16 0.551,0.325 0.133,0.164 0.199,0.367 0.199,0.605 0,0.371 -0.121,0.656 -0.371,0.859 -0.246,0.203 -0.598,0.305 -1.055,0.305 -0.152,0 -0.308,-0.016 -0.472,-0.047 -0.16,-0.031 -0.328,-0.078 -0.5,-0.14 v -0.489 c 0.136,0.082 0.285,0.145 0.449,0.188 0.164,0.039 0.332,0.062 0.512,0.062 0.308,0 0.543,-0.062 0.703,-0.191 0.164,-0.125 0.246,-0.305 0.246,-0.547 0,-0.219 -0.078,-0.391 -0.227,-0.516 -0.152,-0.125 -0.359,-0.187 -0.629,-0.187 h -0.425 v -0.418 h 0.445 c 0.242,0 0.43,-0.047 0.559,-0.149 0.125,-0.097 0.191,-0.242 0.191,-0.429 0,-0.192 -0.066,-0.34 -0.199,-0.442 -0.133,-0.105 -0.324,-0.156 -0.571,-0.156 -0.136,0 -0.281,0.016 -0.433,0.047 -0.156,0.027 -0.324,0.074 -0.512,0.141 v -0.453 c 0.188,-0.055 0.363,-0.094 0.527,-0.122 0.165,-0.027 0.317,-0.039 0.461,-0.039 0.375,0 0.672,0.086 0.891,0.262 0.219,0.176 0.328,0.41 0.328,0.707 0,0.211 -0.058,0.387 -0.176,0.527 -0.113,0.145 -0.281,0.243 -0.492,0.297 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath88)"
+           id="path597" />
+        <path
+           d="m 230.871,92.48 v -1.007 h -0.809 v -0.414 h 1.297 v 1.605 c -0.191,0.141 -0.402,0.246 -0.632,0.316 -0.227,0.071 -0.473,0.106 -0.735,0.106 -0.57,0 -1.015,-0.168 -1.336,-0.512 -0.32,-0.344 -0.48,-0.82 -0.48,-1.429 0,-0.614 0.16,-1.09 0.48,-1.43 0.321,-0.344 0.766,-0.516 1.336,-0.516 0.238,0 0.465,0.031 0.676,0.09 0.215,0.063 0.414,0.149 0.594,0.266 v 0.543 c -0.18,-0.16 -0.375,-0.282 -0.578,-0.36 -0.207,-0.082 -0.422,-0.121 -0.649,-0.121 -0.445,0 -0.781,0.129 -1.008,0.383 -0.222,0.258 -0.332,0.637 -0.332,1.145 0,0.503 0.11,0.886 0.332,1.14 0.227,0.258 0.563,0.387 1.008,0.387 0.176,0 0.328,-0.016 0.465,-0.047 0.137,-0.031 0.262,-0.082 0.371,-0.145 z m 1.402,-3.21 h 0.665 l 1.617,3.132 V 89.27 h 0.48 v 3.746 h -0.664 l -1.617,-3.137 v 3.137 h -0.481 z m 4.106,0.414 v 2.914 h 0.594 c 0.504,0 0.871,-0.118 1.105,-0.352 0.234,-0.234 0.352,-0.605 0.352,-1.109 0,-0.5 -0.118,-0.867 -0.352,-1.102 -0.234,-0.234 -0.601,-0.351 -1.105,-0.351 z m -0.496,-0.414 h 1.015 c 0.707,0 1.223,0.148 1.555,0.453 0.332,0.3 0.496,0.773 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.422 -0.332,0.304 -0.847,0.457 -1.551,0.457 h -1.015 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath89)"
+           id="path598" />
+        <path
+           d="m 226.797,83.941 -0.672,1.864 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.747 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.964,3.747 -1.39,-3.747 h 0.515 l 1.153,3.153 1.16,-3.153 h 0.512 l -1.391,3.747 z m 2.891,-3.329 v 2.911 h 0.594 c 0.504,0 0.871,-0.118 1.105,-0.352 0.235,-0.234 0.352,-0.602 0.352,-1.106 0,-0.503 -0.117,-0.871 -0.352,-1.101 -0.234,-0.234 -0.601,-0.352 -1.105,-0.352 z m -0.496,-0.418 h 1.016 c 0.707,0 1.222,0.153 1.554,0.454 0.328,0.3 0.496,0.773 0.496,1.417 0,0.645 -0.168,1.118 -0.5,1.422 -0.332,0.301 -0.847,0.454 -1.55,0.454 h -1.016 z m 4.105,0.418 v 2.911 h 0.594 c 0.504,0 0.871,-0.118 1.106,-0.352 0.234,-0.234 0.351,-0.602 0.351,-1.106 0,-0.503 -0.117,-0.871 -0.351,-1.101 -0.235,-0.234 -0.602,-0.352 -1.106,-0.352 z m -0.492,-0.418 h 1.012 c 0.707,0 1.223,0.153 1.555,0.454 0.332,0.3 0.496,0.773 0.496,1.417 0,0.645 -0.168,1.118 -0.5,1.422 -0.332,0.301 -0.848,0.454 -1.551,0.454 h -1.012 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath90)"
+           id="path599" />
+        <path
+           d="m 230.559,78.031 v 2.91 h 0.593 c 0.504,0 0.871,-0.113 1.106,-0.347 0.234,-0.235 0.351,-0.606 0.351,-1.11 0,-0.504 -0.117,-0.871 -0.351,-1.101 -0.235,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.497,-0.418 h 1.016 c 0.703,0 1.223,0.153 1.555,0.453 0.328,0.301 0.496,0.774 0.496,1.418 0,0.645 -0.168,1.118 -0.5,1.422 -0.332,0.301 -0.848,0.453 -1.551,0.453 h -1.016 z m 3.743,3.321 h 0.804 v -2.86 l -0.879,0.184 v -0.465 l 0.875,-0.18 h 0.493 v 3.321 h 0.804 v 0.425 h -2.097 z m 4.047,-2.879 -1.243,2 h 1.243 z m -0.129,-0.442 h 0.621 v 2.442 h 0.519 v 0.422 h -0.519 v 0.882 h -0.492 v -0.882 h -1.645 v -0.489 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath91)"
+           id="path600" />
+        <path
+           d="m 230.559,72.203 v 2.914 h 0.593 c 0.504,0 0.871,-0.117 1.106,-0.351 0.234,-0.235 0.351,-0.606 0.351,-1.11 0,-0.5 -0.117,-0.867 -0.351,-1.101 -0.235,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.497,-0.418 h 1.016 c 0.703,0 1.223,0.153 1.555,0.457 0.328,0.301 0.496,0.774 0.496,1.414 0,0.645 -0.168,1.121 -0.5,1.422 -0.332,0.305 -0.848,0.457 -1.551,0.457 h -1.016 z m 3.743,3.32 h 0.804 V 72.25 l -0.879,0.18 v -0.461 l 0.875,-0.184 h 0.493 v 3.32 h 0.804 v 0.43 h -2.097 z m 2.699,-3.32 h 1.934 v 0.43 h -1.485 v 0.918 c 0.074,-0.028 0.145,-0.043 0.215,-0.055 0.074,-0.016 0.144,-0.023 0.215,-0.023 0.406,0 0.73,0.117 0.969,0.343 0.238,0.231 0.355,0.543 0.355,0.934 0,0.402 -0.121,0.715 -0.367,0.941 -0.242,0.223 -0.586,0.332 -1.031,0.332 -0.153,0 -0.309,-0.011 -0.469,-0.039 -0.16,-0.027 -0.32,-0.066 -0.492,-0.121 v -0.507 c 0.148,0.082 0.3,0.14 0.457,0.183 0.156,0.039 0.32,0.059 0.492,0.059 0.281,0 0.508,-0.078 0.672,-0.231 0.164,-0.148 0.246,-0.355 0.246,-0.617 0,-0.262 -0.082,-0.469 -0.246,-0.621 -0.164,-0.152 -0.391,-0.227 -0.672,-0.227 -0.129,0 -0.262,0.016 -0.395,0.043 -0.129,0.032 -0.261,0.078 -0.398,0.141 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath92)"
+           id="path601" />
+        <path
+           d="m 233.223,174.176 v 2.914 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.352 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.5 -0.117,-0.867 -0.351,-1.102 -0.234,-0.234 -0.602,-0.351 -1.106,-0.351 z m -0.493,-0.414 h 1.012 c 0.707,0 1.223,0.148 1.555,0.453 0.332,0.301 0.496,0.773 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.422 -0.332,0.304 -0.848,0.457 -1.551,0.457 h -1.012 z m 4.708,0.332 c -0.254,0 -0.446,0.129 -0.575,0.386 -0.125,0.254 -0.191,0.641 -0.191,1.157 0,0.515 0.066,0.898 0.191,1.156 0.129,0.258 0.321,0.387 0.575,0.387 0.253,0 0.445,-0.129 0.574,-0.387 0.129,-0.258 0.191,-0.641 0.191,-1.156 0,-0.516 -0.062,-0.903 -0.191,-1.157 -0.129,-0.257 -0.321,-0.386 -0.574,-0.386 z m 0,-0.403 c 0.41,0 0.718,0.168 0.933,0.5 0.219,0.332 0.324,0.813 0.324,1.446 0,0.633 -0.105,1.113 -0.324,1.445 -0.215,0.332 -0.523,0.496 -0.933,0.496 -0.411,0 -0.723,-0.164 -0.938,-0.496 -0.215,-0.332 -0.324,-0.812 -0.324,-1.445 0,-0.633 0.109,-1.114 0.324,-1.446 0.215,-0.332 0.527,-0.5 0.938,-0.5 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath93)"
+           id="path602" />
+        <path
+           d="m 233.363,168.348 v 2.914 h 0.598 c 0.5,0 0.871,-0.117 1.101,-0.352 0.235,-0.234 0.352,-0.601 0.352,-1.109 0,-0.5 -0.117,-0.867 -0.352,-1.102 -0.23,-0.234 -0.601,-0.351 -1.101,-0.351 z m -0.492,-0.414 h 1.012 c 0.707,0 1.226,0.148 1.555,0.453 0.332,0.301 0.496,0.773 0.496,1.414 0,0.648 -0.164,1.121 -0.496,1.426 -0.333,0.3 -0.852,0.453 -1.555,0.453 h -1.012 z m 3.738,3.32 h 0.805 v -2.859 l -0.875,0.179 v -0.461 l 0.871,-0.179 h 0.492 v 3.32 h 0.809 v 0.426 h -2.102 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath94)"
+           id="path603" />
+        <path
+           d="m 233.223,162.523 v 2.915 h 0.593 c 0.504,0 0.872,-0.118 1.106,-0.352 0.234,-0.234 0.351,-0.606 0.351,-1.109 0,-0.504 -0.117,-0.872 -0.351,-1.102 -0.234,-0.234 -0.602,-0.352 -1.106,-0.352 z m -0.493,-0.418 h 1.012 c 0.707,0 1.223,0.153 1.555,0.454 0.332,0.3 0.496,0.773 0.496,1.418 0,0.644 -0.168,1.117 -0.5,1.421 -0.332,0.301 -0.848,0.454 -1.551,0.454 h -1.012 z m 4.079,3.321 h 1.718 v 0.426 h -2.312 v -0.426 c 0.187,-0.199 0.441,-0.465 0.762,-0.801 0.324,-0.336 0.527,-0.551 0.613,-0.648 0.156,-0.184 0.265,-0.336 0.328,-0.465 0.062,-0.125 0.094,-0.25 0.094,-0.371 0,-0.2 -0.067,-0.364 -0.203,-0.489 -0.137,-0.125 -0.313,-0.187 -0.532,-0.187 -0.152,0 -0.316,0.027 -0.488,0.082 -0.172,0.055 -0.355,0.141 -0.551,0.25 v -0.512 c 0.2,-0.082 0.383,-0.14 0.559,-0.183 0.172,-0.043 0.328,-0.063 0.473,-0.063 0.375,0 0.679,0.098 0.902,0.289 0.226,0.195 0.336,0.453 0.336,0.777 0,0.157 -0.028,0.301 -0.086,0.442 -0.055,0.137 -0.156,0.297 -0.305,0.484 -0.039,0.051 -0.168,0.192 -0.387,0.422 -0.218,0.231 -0.527,0.555 -0.921,0.973 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath95)"
+           id="path604" />
+        <path
+           d="m 233.223,156.695 v 2.914 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.351 0.234,-0.235 0.351,-0.606 0.351,-1.11 0,-0.5 -0.117,-0.867 -0.351,-1.101 -0.234,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.493,-0.418 h 1.012 c 0.707,0 1.223,0.153 1.555,0.457 0.332,0.301 0.496,0.774 0.496,1.414 0,0.645 -0.168,1.122 -0.5,1.422 -0.332,0.305 -0.848,0.457 -1.551,0.457 h -1.012 z m 5.145,1.727 c 0.238,0.055 0.422,0.16 0.555,0.324 0.132,0.164 0.199,0.367 0.199,0.61 0,0.367 -0.125,0.656 -0.371,0.855 -0.246,0.203 -0.598,0.305 -1.055,0.305 -0.152,0 -0.312,-0.016 -0.473,-0.047 -0.164,-0.031 -0.328,-0.078 -0.5,-0.137 v -0.492 c 0.137,0.082 0.286,0.144 0.45,0.187 0.16,0.043 0.332,0.063 0.508,0.063 0.308,0 0.546,-0.063 0.707,-0.188 0.16,-0.125 0.242,-0.308 0.242,-0.546 0,-0.223 -0.075,-0.395 -0.227,-0.52 -0.148,-0.125 -0.359,-0.188 -0.625,-0.188 h -0.426 v -0.414 h 0.446 c 0.242,0 0.425,-0.05 0.554,-0.148 0.129,-0.102 0.192,-0.246 0.192,-0.434 0,-0.191 -0.067,-0.339 -0.199,-0.441 -0.133,-0.102 -0.321,-0.156 -0.567,-0.156 -0.137,0 -0.281,0.015 -0.437,0.047 -0.153,0.031 -0.325,0.078 -0.508,0.14 v -0.453 c 0.187,-0.051 0.359,-0.094 0.523,-0.121 0.164,-0.023 0.321,-0.039 0.465,-0.039 0.375,0 0.668,0.09 0.887,0.266 0.219,0.171 0.328,0.41 0.328,0.707 0,0.207 -0.059,0.382 -0.172,0.527 -0.117,0.141 -0.281,0.238 -0.496,0.293 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath96)"
+           id="path605" />
+        <path
+           d="m 233.223,150.867 v 2.914 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.351 0.234,-0.235 0.351,-0.602 0.351,-1.11 0,-0.5 -0.117,-0.867 -0.351,-1.101 -0.234,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.493,-0.414 h 1.012 c 0.707,0 1.223,0.149 1.555,0.453 0.332,0.301 0.496,0.774 0.496,1.414 0,0.645 -0.168,1.121 -0.5,1.422 -0.332,0.305 -0.848,0.457 -1.551,0.457 h -1.012 z m 5.008,0.442 -1.246,2 h 1.246 z m -0.129,-0.442 h 0.618 v 2.442 h 0.523 v 0.421 h -0.523 v 0.883 h -0.489 v -0.883 h -1.644 v -0.492 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath97)"
+           id="path606" />
+        <path
+           d="m 233.223,145.043 v 2.91 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.348 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.504 -0.117,-0.871 -0.351,-1.101 -0.234,-0.235 -0.602,-0.352 -1.106,-0.352 z m -0.493,-0.418 h 1.012 c 0.707,0 1.223,0.152 1.555,0.453 0.332,0.301 0.496,0.774 0.496,1.418 0,0.645 -0.168,1.117 -0.5,1.422 -0.332,0.301 -0.848,0.453 -1.551,0.453 h -1.012 z m 3.657,0 h 1.937 v 0.426 h -1.484 v 0.918 c 0.07,-0.024 0.14,-0.043 0.215,-0.055 0.07,-0.012 0.14,-0.019 0.215,-0.019 0.406,0 0.726,0.113 0.964,0.343 0.239,0.231 0.36,0.539 0.36,0.93 0,0.406 -0.125,0.719 -0.367,0.941 -0.247,0.223 -0.59,0.336 -1.036,0.336 -0.152,0 -0.308,-0.015 -0.468,-0.043 -0.157,-0.023 -0.321,-0.066 -0.489,-0.117 v -0.512 c 0.145,0.082 0.297,0.145 0.454,0.184 0.156,0.039 0.32,0.063 0.496,0.063 0.281,0 0.504,-0.079 0.668,-0.231 0.164,-0.152 0.246,-0.359 0.246,-0.621 0,-0.258 -0.082,-0.465 -0.246,-0.617 -0.164,-0.153 -0.387,-0.231 -0.668,-0.231 -0.133,0 -0.266,0.016 -0.395,0.047 -0.133,0.031 -0.266,0.078 -0.402,0.141 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath98)"
+           id="path607" />
+        <path
+           d="m 233.223,139.215 v 2.914 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.352 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.504 -0.117,-0.871 -0.351,-1.102 -0.234,-0.234 -0.602,-0.351 -1.106,-0.351 z m -0.493,-0.418 h 1.012 c 0.707,0 1.223,0.152 1.555,0.457 0.332,0.301 0.496,0.773 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.422 -0.332,0.305 -0.848,0.453 -1.551,0.453 h -1.012 z m 4.77,1.672 c -0.223,0 -0.398,0.078 -0.527,0.234 -0.129,0.156 -0.196,0.367 -0.196,0.641 0,0.269 0.067,0.48 0.196,0.64 0.129,0.153 0.304,0.231 0.527,0.231 0.219,0 0.395,-0.078 0.523,-0.231 0.129,-0.16 0.196,-0.371 0.196,-0.64 0,-0.274 -0.067,-0.485 -0.196,-0.641 -0.128,-0.156 -0.304,-0.234 -0.523,-0.234 z m 0.977,-1.586 v 0.461 c -0.122,-0.063 -0.25,-0.106 -0.375,-0.141 -0.125,-0.031 -0.25,-0.047 -0.375,-0.047 -0.325,0 -0.575,0.114 -0.747,0.34 -0.171,0.227 -0.269,0.566 -0.292,1.024 0.097,-0.145 0.214,-0.258 0.363,-0.332 0.144,-0.079 0.301,-0.122 0.476,-0.122 0.368,0 0.657,0.118 0.868,0.344 0.214,0.231 0.32,0.539 0.32,0.934 0,0.383 -0.113,0.691 -0.332,0.926 -0.223,0.23 -0.516,0.347 -0.883,0.347 -0.422,0 -0.746,-0.164 -0.969,-0.496 -0.222,-0.332 -0.336,-0.816 -0.336,-1.445 0,-0.594 0.137,-1.063 0.41,-1.414 0.274,-0.356 0.641,-0.532 1.102,-0.532 0.125,0 0.25,0.012 0.375,0.04 0.125,0.023 0.258,0.062 0.395,0.113 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath99)"
+           id="path608" />
+        <path
+           d="m 233.223,133.387 v 2.914 h 0.593 c 0.504,0 0.872,-0.117 1.106,-0.352 0.234,-0.234 0.351,-0.605 0.351,-1.109 0,-0.5 -0.117,-0.867 -0.351,-1.102 -0.234,-0.234 -0.602,-0.351 -1.106,-0.351 z m -0.493,-0.414 h 1.012 c 0.707,0 1.223,0.148 1.555,0.453 0.332,0.301 0.496,0.773 0.496,1.414 0,0.644 -0.168,1.121 -0.5,1.422 -0.332,0.304 -0.848,0.457 -1.551,0.457 h -1.012 z m 3.528,0 h 2.344 v 0.215 l -1.325,3.531 h -0.515 l 1.246,-3.321 h -1.75 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath100)"
+           id="path609" />
+        <path
+           d="m 191.824,174.262 -0.668,1.863 h 1.34 z m -0.277,-0.5 h 0.558 l 1.391,3.746 h -0.516 l -0.332,-0.961 h -1.64 l -0.332,0.961 h -0.52 z m 2.445,0 h 1.934 v 0.426 h -1.485 v 0.917 c 0.075,-0.023 0.145,-0.043 0.215,-0.054 0.074,-0.012 0.145,-0.02 0.215,-0.02 0.406,0 0.731,0.114 0.969,0.344 0.238,0.23 0.355,0.539 0.355,0.93 0,0.402 -0.121,0.718 -0.367,0.941 -0.242,0.223 -0.586,0.336 -1.031,0.336 -0.152,0 -0.309,-0.016 -0.469,-0.043 -0.16,-0.027 -0.32,-0.066 -0.492,-0.121 v -0.508 c 0.148,0.082 0.297,0.145 0.453,0.184 0.156,0.039 0.324,0.058 0.496,0.058 0.281,0 0.508,-0.074 0.672,-0.226 0.164,-0.153 0.246,-0.36 0.246,-0.621 0,-0.262 -0.082,-0.469 -0.246,-0.617 -0.164,-0.153 -0.391,-0.231 -0.672,-0.231 -0.129,0 -0.262,0.016 -0.394,0.047 -0.129,0.027 -0.262,0.074 -0.399,0.141 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath101)"
+           id="path610" />
+        <path
+           d="m 191.824,168.434 -0.668,1.863 h 1.34 z m -0.277,-0.5 h 0.558 l 1.391,3.746 h -0.516 l -0.332,-0.961 h -1.64 l -0.332,0.961 h -0.52 z m 3.793,0.441 -1.246,2 h 1.246 z m -0.129,-0.441 h 0.621 v 2.441 h 0.52 v 0.422 h -0.52 v 0.883 h -0.492 v -0.883 h -1.645 v -0.488 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath102)"
+           id="path611" />
+        <path
+           d="m 191.895,162.605 -0.668,1.864 h 1.339 z m -0.278,-0.5 h 0.559 l 1.39,3.747 h -0.511 l -0.332,-0.961 h -1.645 l -0.332,0.961 h -0.519 z m 3.934,1.727 c 0.234,0.055 0.422,0.16 0.551,0.324 0.132,0.164 0.203,0.367 0.203,0.61 0,0.367 -0.125,0.656 -0.371,0.855 -0.25,0.203 -0.602,0.305 -1.055,0.305 -0.156,0 -0.313,-0.016 -0.477,-0.047 -0.16,-0.031 -0.328,-0.078 -0.5,-0.137 v -0.492 c 0.137,0.082 0.286,0.145 0.45,0.188 0.164,0.042 0.332,0.062 0.511,0.062 0.309,0 0.543,-0.062 0.703,-0.188 0.164,-0.124 0.246,-0.308 0.246,-0.546 0,-0.223 -0.074,-0.395 -0.226,-0.52 -0.152,-0.125 -0.359,-0.187 -0.629,-0.187 h -0.426 v -0.414 h 0.446 c 0.242,0 0.429,-0.051 0.558,-0.149 0.129,-0.101 0.192,-0.246 0.192,-0.434 0,-0.191 -0.067,-0.339 -0.2,-0.441 -0.132,-0.101 -0.324,-0.156 -0.57,-0.156 -0.133,0 -0.281,0.015 -0.434,0.047 -0.156,0.031 -0.324,0.078 -0.511,0.14 v -0.453 c 0.187,-0.054 0.363,-0.094 0.527,-0.121 0.164,-0.027 0.316,-0.039 0.461,-0.039 0.375,0 0.672,0.09 0.891,0.262 0.218,0.176 0.328,0.41 0.328,0.711 0,0.207 -0.059,0.383 -0.176,0.527 -0.113,0.141 -0.277,0.238 -0.492,0.293 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath103)"
+           id="path612" />
+        <path
+           d="m 191.992,156.781 -0.672,1.864 h 1.344 z m -0.281,-0.5 h 0.562 l 1.387,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.332,0.961 h -0.52 z m 2.867,3.321 h 1.719 v 0.425 h -2.313 v -0.425 c 0.188,-0.2 0.442,-0.469 0.762,-0.801 0.324,-0.336 0.527,-0.555 0.613,-0.653 0.157,-0.179 0.266,-0.336 0.329,-0.46 0.062,-0.126 0.093,-0.25 0.093,-0.376 0,-0.199 -0.066,-0.359 -0.203,-0.484 -0.137,-0.125 -0.312,-0.187 -0.531,-0.187 -0.152,0 -0.317,0.027 -0.488,0.082 -0.172,0.054 -0.356,0.136 -0.551,0.25 v -0.512 c 0.199,-0.082 0.383,-0.145 0.554,-0.188 0.176,-0.039 0.333,-0.062 0.477,-0.062 0.375,0 0.676,0.098 0.902,0.293 0.223,0.195 0.336,0.453 0.336,0.777 0,0.153 -0.027,0.301 -0.086,0.438 -0.054,0.14 -0.156,0.301 -0.304,0.488 -0.039,0.051 -0.168,0.188 -0.387,0.422 -0.219,0.23 -0.527,0.555 -0.922,0.973 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath104)"
+           id="path613" />
+        <path
+           d="m 191.754,150.953 -0.668,1.863 h 1.34 z m -0.277,-0.5 h 0.558 l 1.391,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.333,0.961 h -0.519 z m 2.523,3.32 h 0.809 v -2.859 l -0.879,0.18 v -0.461 l 0.871,-0.18 h 0.496 v 3.32 h 0.805 v 0.426 H 194 Z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath105)"
+           id="path614" />
+        <path
+           d="m 191.754,145.125 -0.668,1.863 h 1.34 z m -0.277,-0.5 h 0.558 l 1.391,3.746 h -0.512 l -0.332,-0.961 h -1.644 l -0.333,0.961 h -0.519 z m 3.492,0.336 c -0.254,0 -0.446,0.129 -0.571,0.387 -0.128,0.254 -0.191,0.64 -0.191,1.156 0,0.512 0.063,0.898 0.191,1.156 0.125,0.254 0.317,0.383 0.571,0.383 0.258,0 0.449,-0.129 0.574,-0.383 0.129,-0.258 0.195,-0.644 0.195,-1.156 0,-0.516 -0.066,-0.902 -0.195,-1.156 -0.125,-0.258 -0.316,-0.387 -0.574,-0.387 z m 0,-0.402 c 0.41,0 0.722,0.168 0.937,0.5 0.215,0.332 0.324,0.812 0.324,1.445 0,0.629 -0.109,1.113 -0.324,1.445 -0.215,0.332 -0.527,0.496 -0.937,0.496 -0.407,0 -0.719,-0.164 -0.938,-0.496 -0.215,-0.332 -0.32,-0.816 -0.32,-1.445 0,-0.633 0.105,-1.113 0.32,-1.445 0.219,-0.332 0.531,-0.5 0.938,-0.5 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath106)"
+           id="path615" />
+        <path
+           d="m 190.957,136.719 -1.391,-3.746 h 0.516 l 1.152,3.152 1.157,-3.152 h 0.515 l -1.39,3.746 z m 2.395,-3.746 h 0.492 v 3.746 h -0.492 z m 1.39,0 h 0.664 l 1.617,3.132 v -3.132 h 0.477 v 3.746 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath107)"
+           id="path616" />
+        <path
+           d="m 192.246,130.355 v -1.003 h -0.805 v -0.418 h 1.293 v 1.609 c -0.191,0.137 -0.402,0.242 -0.629,0.316 -0.23,0.071 -0.476,0.106 -0.734,0.106 -0.57,0 -1.016,-0.172 -1.34,-0.512 -0.32,-0.344 -0.48,-0.82 -0.48,-1.43 0,-0.613 0.16,-1.089 0.48,-1.429 0.324,-0.344 0.77,-0.516 1.34,-0.516 0.234,0 0.461,0.031 0.676,0.09 0.215,0.059 0.41,0.148 0.594,0.266 v 0.539 c -0.184,-0.161 -0.379,-0.278 -0.582,-0.36 -0.207,-0.078 -0.422,-0.121 -0.649,-0.121 -0.445,0 -0.781,0.129 -1.004,0.387 -0.222,0.254 -0.336,0.637 -0.336,1.144 0,0.504 0.114,0.883 0.336,1.141 0.223,0.254 0.559,0.383 1.004,0.383 0.176,0 0.332,-0.016 0.469,-0.043 0.137,-0.031 0.258,-0.082 0.367,-0.149 z m 1.406,-3.21 h 0.664 l 1.614,3.132 v -3.132 h 0.48 v 3.746 h -0.664 l -1.617,-3.133 v 3.133 h -0.477 z m 4.102,0.417 v 2.915 h 0.598 c 0.5,0 0.867,-0.118 1.101,-0.352 0.235,-0.234 0.352,-0.605 0.352,-1.109 0,-0.504 -0.117,-0.871 -0.352,-1.102 -0.234,-0.234 -0.601,-0.352 -1.101,-0.352 z m -0.492,-0.417 h 1.011 c 0.707,0 1.227,0.152 1.555,0.453 0.332,0.304 0.496,0.773 0.496,1.418 0,0.644 -0.164,1.117 -0.496,1.422 -0.332,0.3 -0.851,0.453 -1.555,0.453 h -1.011 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath108)"
+           id="path617" />
+        <path
+           d="m 192.246,124.531 v -1.008 h -0.805 v -0.414 h 1.293 v 1.606 c -0.191,0.14 -0.402,0.246 -0.629,0.316 -0.23,0.071 -0.476,0.106 -0.734,0.106 -0.57,0 -1.016,-0.168 -1.34,-0.512 -0.32,-0.344 -0.48,-0.82 -0.48,-1.43 0,-0.613 0.16,-1.09 0.48,-1.429 0.324,-0.344 0.77,-0.516 1.34,-0.516 0.234,0 0.461,0.031 0.676,0.09 0.215,0.062 0.41,0.148 0.594,0.265 v 0.543 c -0.184,-0.16 -0.379,-0.281 -0.582,-0.359 -0.207,-0.082 -0.422,-0.121 -0.649,-0.121 -0.445,0 -0.781,0.129 -1.004,0.383 -0.222,0.258 -0.336,0.637 -0.336,1.144 0,0.504 0.114,0.887 0.336,1.141 0.223,0.258 0.559,0.387 1.004,0.387 0.176,0 0.332,-0.016 0.469,-0.047 0.137,-0.031 0.258,-0.082 0.367,-0.145 z m 1.406,-3.211 h 0.664 l 1.614,3.133 v -3.133 h 0.48 v 3.746 h -0.664 l -1.617,-3.136 v 3.136 h -0.477 z m 4.102,0.414 v 2.914 h 0.598 c 0.5,0 0.867,-0.117 1.101,-0.351 0.235,-0.235 0.352,-0.606 0.352,-1.109 0,-0.5 -0.117,-0.868 -0.352,-1.102 -0.234,-0.234 -0.601,-0.352 -1.101,-0.352 z m -0.492,-0.414 h 1.011 c 0.707,0 1.227,0.149 1.555,0.453 0.332,0.301 0.496,0.774 0.496,1.415 0,0.644 -0.164,1.121 -0.496,1.421 -0.332,0.305 -0.851,0.457 -1.555,0.457 h -1.011 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath109)"
+           id="path618" />
+        <path
+           d="m 191.5,116.016 v 1.398 h 1.359 v 0.426 H 191.5 v 1.398 h -0.41 v -1.398 h -1.36 v -0.426 h 1.36 v -1.398 z m 1.16,-0.524 h 1.934 v 0.426 h -1.485 v 0.918 c 0.075,-0.024 0.145,-0.043 0.215,-0.055 0.074,-0.011 0.145,-0.019 0.215,-0.019 0.41,0 0.731,0.113 0.969,0.343 0.238,0.231 0.355,0.54 0.355,0.93 0,0.406 -0.121,0.719 -0.367,0.942 -0.242,0.222 -0.586,0.335 -1.031,0.335 -0.153,0 -0.309,-0.015 -0.469,-0.042 -0.156,-0.024 -0.32,-0.067 -0.492,-0.118 v -0.511 c 0.148,0.082 0.301,0.144 0.457,0.183 0.156,0.039 0.32,0.059 0.496,0.059 0.281,0 0.504,-0.074 0.668,-0.227 0.164,-0.152 0.246,-0.359 0.246,-0.621 0,-0.262 -0.082,-0.465 -0.246,-0.617 -0.164,-0.152 -0.387,-0.23 -0.668,-0.23 -0.133,0 -0.266,0.015 -0.398,0.046 -0.129,0.028 -0.262,0.075 -0.399,0.141 z m 3.672,3.746 -1.394,-3.746 h 0.515 l 1.156,3.153 1.157,-3.153 h 0.511 l -1.386,3.746 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath110)"
+           id="path619" />
+        <path
+           d="m 191.434,110.188 v 1.398 h 1.359 v 0.426 h -1.359 v 1.398 h -0.411 v -1.398 h -1.359 v -0.426 h 1.359 v -1.398 z m 2.648,1.203 c 0.234,0.05 0.418,0.16 0.551,0.324 0.133,0.164 0.199,0.367 0.199,0.605 0,0.371 -0.121,0.657 -0.371,0.86 -0.246,0.203 -0.598,0.304 -1.055,0.304 -0.152,0 -0.308,-0.015 -0.472,-0.046 -0.161,-0.032 -0.329,-0.079 -0.5,-0.141 v -0.488 c 0.136,0.082 0.285,0.144 0.449,0.187 0.164,0.039 0.332,0.063 0.512,0.063 0.308,0 0.543,-0.063 0.703,-0.192 0.164,-0.125 0.246,-0.305 0.246,-0.547 0,-0.218 -0.078,-0.39 -0.227,-0.515 -0.152,-0.125 -0.359,-0.188 -0.629,-0.188 h -0.426 v -0.418 h 0.446 c 0.242,0 0.43,-0.047 0.558,-0.148 0.125,-0.098 0.192,-0.242 0.192,-0.43 0,-0.191 -0.067,-0.34 -0.199,-0.441 -0.133,-0.106 -0.325,-0.157 -0.571,-0.157 -0.136,0 -0.281,0.016 -0.433,0.047 -0.157,0.028 -0.325,0.075 -0.512,0.137 v -0.449 c 0.187,-0.055 0.363,-0.094 0.527,-0.121 0.164,-0.028 0.317,-0.039 0.461,-0.039 0.375,0 0.672,0.086 0.891,0.261 0.219,0.176 0.328,0.411 0.328,0.707 0,0.207 -0.059,0.383 -0.176,0.528 -0.113,0.144 -0.277,0.242 -0.492,0.297 z m 2.184,2.019 -1.395,-3.746 h 0.516 l 1.156,3.156 1.156,-3.156 h 0.512 l -1.387,3.746 z m 3.929,-2.019 c 0.239,0.05 0.422,0.16 0.555,0.324 0.133,0.164 0.199,0.367 0.199,0.605 0,0.371 -0.125,0.657 -0.371,0.86 -0.246,0.203 -0.598,0.304 -1.055,0.304 -0.152,0 -0.312,-0.015 -0.472,-0.046 -0.164,-0.032 -0.328,-0.079 -0.5,-0.141 v -0.488 c 0.137,0.082 0.285,0.144 0.449,0.187 0.16,0.039 0.332,0.063 0.508,0.063 0.308,0 0.547,-0.063 0.707,-0.192 0.16,-0.125 0.242,-0.305 0.242,-0.547 0,-0.218 -0.074,-0.39 -0.227,-0.515 -0.148,-0.125 -0.359,-0.188 -0.625,-0.188 h -0.425 v -0.418 h 0.445 c 0.242,0 0.426,-0.047 0.555,-0.148 0.129,-0.098 0.191,-0.242 0.191,-0.43 0,-0.191 -0.066,-0.34 -0.199,-0.441 -0.133,-0.106 -0.32,-0.157 -0.567,-0.157 -0.136,0 -0.281,0.016 -0.437,0.047 -0.152,0.028 -0.324,0.075 -0.508,0.137 v -0.449 c 0.188,-0.055 0.36,-0.094 0.524,-0.121 0.164,-0.028 0.32,-0.039 0.464,-0.039 0.375,0 0.668,0.086 0.887,0.261 0.219,0.176 0.328,0.411 0.328,0.707 0,0.207 -0.058,0.383 -0.172,0.528 -0.117,0.144 -0.281,0.242 -0.496,0.297 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath111)"
+           id="path620" />
+        <path
+           d="m 191.402,105.828 c 0.106,0.035 0.207,0.113 0.309,0.234 0.101,0.122 0.199,0.286 0.301,0.497 l 0.5,1.027 h -0.528 l -0.468,-0.961 c -0.118,-0.254 -0.235,-0.418 -0.352,-0.5 -0.109,-0.082 -0.266,-0.125 -0.461,-0.125 h -0.535 v 1.586 h -0.496 v -3.75 h 1.113 c 0.418,0 0.731,0.09 0.934,0.269 0.207,0.18 0.308,0.45 0.308,0.813 0,0.234 -0.054,0.43 -0.16,0.586 -0.105,0.156 -0.262,0.262 -0.465,0.324 z m -1.234,-1.574 v 1.332 h 0.617 c 0.238,0 0.418,-0.059 0.539,-0.168 0.121,-0.117 0.184,-0.281 0.184,-0.5 0,-0.219 -0.063,-0.387 -0.184,-0.496 -0.121,-0.113 -0.301,-0.168 -0.539,-0.168 z m 3.117,-0.418 h 2.305 v 0.43 h -1.813 v 1.109 h 1.735 v 0.426 h -1.735 v 1.355 h 1.856 v 0.43 h -2.348 z m 5.52,0.125 v 0.492 c -0.188,-0.09 -0.364,-0.16 -0.532,-0.203 -0.164,-0.047 -0.324,-0.07 -0.48,-0.07 -0.27,0 -0.477,0.054 -0.621,0.164 -0.145,0.105 -0.219,0.258 -0.219,0.457 0,0.164 0.047,0.289 0.145,0.375 0.097,0.082 0.281,0.152 0.55,0.203 l 0.297,0.062 c 0.371,0.071 0.641,0.2 0.817,0.383 0.176,0.18 0.261,0.422 0.261,0.727 0,0.363 -0.117,0.637 -0.355,0.824 -0.238,0.187 -0.582,0.281 -1.039,0.281 -0.176,0 -0.359,-0.019 -0.555,-0.058 -0.191,-0.043 -0.394,-0.102 -0.601,-0.18 v -0.52 c 0.199,0.114 0.394,0.2 0.589,0.258 0.192,0.059 0.379,0.09 0.567,0.09 0.281,0 0.496,-0.058 0.648,-0.172 0.157,-0.113 0.231,-0.277 0.231,-0.484 0,-0.188 -0.055,-0.328 -0.164,-0.434 -0.11,-0.105 -0.289,-0.179 -0.539,-0.234 l -0.301,-0.059 c -0.371,-0.074 -0.637,-0.195 -0.801,-0.355 -0.164,-0.16 -0.246,-0.383 -0.246,-0.668 0,-0.332 0.113,-0.594 0.34,-0.785 0.226,-0.188 0.543,-0.285 0.941,-0.285 0.168,0 0.344,0.015 0.52,0.046 0.18,0.032 0.359,0.082 0.547,0.145 z m 1.148,-0.125 h 2.305 v 0.43 h -1.813 v 1.109 h 1.739 v 0.426 h -1.739 v 1.355 h 1.856 v 0.43 h -2.348 z m 2.832,0 h 3.082 v 0.43 h -1.293 v 3.32 h -0.496 v -3.32 h -1.293 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath112)"
+           id="path621" />
+        <path
+           d="m 189.523,98.012 h 0.493 v 3.746 h -0.493 z m 2.872,0.343 c -0.36,0 -0.645,0.137 -0.856,0.411 -0.211,0.273 -0.316,0.648 -0.316,1.121 0,0.472 0.105,0.843 0.316,1.121 0.211,0.273 0.496,0.41 0.856,0.41 0.355,0 0.64,-0.137 0.847,-0.41 0.211,-0.278 0.317,-0.649 0.317,-1.121 0,-0.473 -0.106,-0.848 -0.317,-1.121 -0.207,-0.274 -0.492,-0.411 -0.847,-0.411 z m 0,-0.414 c 0.507,0 0.917,0.18 1.222,0.532 0.309,0.351 0.461,0.824 0.461,1.414 0,0.59 -0.152,1.062 -0.461,1.418 -0.305,0.347 -0.715,0.523 -1.222,0.523 -0.516,0 -0.926,-0.176 -1.231,-0.523 -0.309,-0.352 -0.461,-0.825 -0.461,-1.418 0,-0.59 0.152,-1.063 0.461,-1.414 0.305,-0.352 0.715,-0.532 1.231,-0.532 z m 4.136,2.059 c 0.106,0.039 0.211,0.117 0.309,0.238 0.101,0.117 0.203,0.285 0.305,0.496 l 0.5,1.024 h -0.532 l -0.465,-0.961 c -0.121,-0.25 -0.238,-0.418 -0.351,-0.5 -0.113,-0.082 -0.266,-0.125 -0.461,-0.125 h -0.539 v 1.586 h -0.492 v -3.746 h 1.113 c 0.414,0 0.727,0.09 0.934,0.265 0.203,0.18 0.304,0.45 0.304,0.813 0,0.234 -0.051,0.43 -0.16,0.586 -0.105,0.156 -0.262,0.265 -0.465,0.324 z m -1.234,-1.574 v 1.332 h 0.621 c 0.238,0 0.414,-0.059 0.535,-0.168 0.125,-0.113 0.184,-0.281 0.184,-0.5 0,-0.219 -0.059,-0.383 -0.184,-0.496 -0.121,-0.11 -0.297,-0.168 -0.535,-0.168 z m 3.117,-0.414 h 2.305 v 0.426 h -1.813 v 1.109 h 1.739 v 0.426 h -1.739 v 1.359 h 1.856 v 0.426 h -2.348 z m 3.336,0 h 2.094 v 0.426 h -1.602 v 1.105 h 1.446 v 0.426 h -1.446 v 1.789 h -0.492 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath113)"
+           id="path622" />
+        <path
+           d="m 189.586,92.184 h 0.664 l 1.613,3.132 v -3.132 h 0.481 v 3.746 h -0.664 l -1.618,-3.133 v 3.133 h -0.476 z m 6.34,0.289 v 0.535 c -0.168,-0.16 -0.344,-0.278 -0.535,-0.356 -0.188,-0.082 -0.387,-0.121 -0.598,-0.121 -0.414,0 -0.734,0.133 -0.957,0.395 -0.219,0.262 -0.332,0.64 -0.332,1.136 0,0.493 0.113,0.872 0.332,1.133 0.223,0.262 0.543,0.391 0.957,0.391 0.211,0 0.41,-0.039 0.598,-0.117 0.191,-0.078 0.367,-0.199 0.535,-0.356 v 0.528 c -0.176,0.121 -0.356,0.211 -0.551,0.273 -0.191,0.059 -0.395,0.09 -0.609,0.09 -0.555,0 -0.989,-0.176 -1.305,-0.52 -0.316,-0.347 -0.477,-0.824 -0.477,-1.422 0,-0.605 0.161,-1.078 0.477,-1.425 0.316,-0.348 0.75,-0.52 1.305,-0.52 0.218,0 0.422,0.028 0.613,0.09 0.195,0.059 0.375,0.148 0.547,0.266 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath114)"
+           id="path623" />
+        <path
+           d="M 367.258,57.754 H 105.039"
+           style="fill:none;stroke:#ffffff;stroke-width:2.22022;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:86.5836, 19.981, 33.3013, 19.981, 33.3013, 19.981;stroke-dashoffset:0;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath115)"
+           id="path624" />
+        <path
+           d="m 179.875,195.562 h 5.668 v 5.824 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath116)"
+           id="path625" />
+        <path
+           d="m 184.873,195.559 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath117)"
+           id="path626" />
+        <path
+           d="m 193.422,197.066 -0.668,1.864 h 1.34 z m -0.277,-0.5 h 0.558 l 1.387,3.746 h -0.512 l -0.332,-0.96 h -1.644 l -0.332,0.96 h -0.52 z m 3.519,1.368 c -0.051,-0.032 -0.105,-0.051 -0.168,-0.067 -0.058,-0.012 -0.121,-0.019 -0.195,-0.019 -0.254,0 -0.449,0.086 -0.586,0.254 -0.133,0.168 -0.203,0.414 -0.203,0.73 v 1.48 h -0.45 v -2.808 h 0.45 v 0.434 c 0.097,-0.168 0.218,-0.297 0.371,-0.379 0.148,-0.082 0.336,-0.125 0.551,-0.125 0.031,0 0.066,0.004 0.101,0.007 0.039,0.004 0.078,0.012 0.125,0.02 z m 1.891,-0.004 v -1.52 h 0.449 v 3.902 h -0.449 v -0.421 c -0.098,0.168 -0.215,0.293 -0.36,0.375 -0.144,0.078 -0.316,0.121 -0.519,0.121 -0.328,0 -0.598,-0.137 -0.809,-0.407 -0.207,-0.273 -0.308,-0.628 -0.308,-1.07 0,-0.441 0.101,-0.797 0.308,-1.07 0.211,-0.27 0.481,-0.406 0.809,-0.406 0.203,0 0.375,0.043 0.519,0.125 0.145,0.078 0.262,0.203 0.36,0.371 z m -1.532,0.98 c 0,0.34 0.067,0.606 0.204,0.801 0.136,0.191 0.32,0.289 0.558,0.289 0.238,0 0.426,-0.098 0.563,-0.289 0.136,-0.195 0.207,-0.461 0.207,-0.801 0,-0.34 -0.071,-0.605 -0.207,-0.797 -0.137,-0.195 -0.325,-0.293 -0.563,-0.293 -0.238,0 -0.422,0.098 -0.558,0.293 -0.137,0.192 -0.204,0.457 -0.204,0.797 z m 2.309,0.293 v -1.699 h 0.449 v 1.684 c 0,0.265 0.051,0.464 0.153,0.597 0.101,0.133 0.25,0.199 0.453,0.199 0.242,0 0.433,-0.078 0.574,-0.238 0.141,-0.16 0.211,-0.375 0.211,-0.648 v -1.594 h 0.449 v 2.808 h -0.449 v -0.429 c -0.11,0.168 -0.234,0.297 -0.379,0.379 -0.145,0.082 -0.313,0.125 -0.5,0.125 -0.316,0 -0.555,-0.102 -0.715,-0.301 -0.164,-0.203 -0.246,-0.496 -0.246,-0.883 z m 2.672,-1.699 h 0.449 v 2.808 h -0.449 z m 0,-1.094 h 0.449 v 0.582 h -0.449 z m 3.418,2.207 v 1.695 h -0.449 v -1.679 c 0,-0.266 -0.051,-0.465 -0.153,-0.598 -0.101,-0.133 -0.25,-0.199 -0.453,-0.199 -0.242,0 -0.433,0.078 -0.574,0.238 -0.141,0.16 -0.211,0.375 -0.211,0.649 v 1.589 h -0.449 v -2.808 h 0.449 v 0.434 c 0.109,-0.168 0.234,-0.293 0.379,-0.379 0.148,-0.082 0.316,-0.125 0.508,-0.125 0.312,0 0.551,0.101 0.711,0.3 0.16,0.2 0.242,0.496 0.242,0.883 z m 1.41,-0.789 c -0.238,0 -0.43,0.094 -0.57,0.289 -0.141,0.192 -0.211,0.457 -0.211,0.793 0,0.336 0.07,0.602 0.207,0.797 0.14,0.191 0.332,0.289 0.574,0.289 0.242,0 0.43,-0.098 0.57,-0.293 0.141,-0.195 0.211,-0.457 0.211,-0.793 0,-0.332 -0.07,-0.598 -0.211,-0.789 -0.14,-0.195 -0.328,-0.293 -0.57,-0.293 z m 0,-0.394 c 0.391,0 0.699,0.132 0.922,0.394 0.223,0.258 0.336,0.621 0.336,1.082 0,0.461 -0.113,0.82 -0.336,1.086 -0.223,0.258 -0.531,0.391 -0.922,0.391 -0.391,0 -0.699,-0.133 -0.922,-0.391 -0.222,-0.266 -0.332,-0.625 -0.332,-1.086 0,-0.461 0.11,-0.824 0.332,-1.082 0.223,-0.262 0.531,-0.394 0.922,-0.394 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath118)"
+           id="path627" />
+        <path
+           d="m 228.066,196.145 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath119)"
+           id="path628" />
+        <path
+           d="m 234.404,196.141 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath120)"
+           id="path629" />
+        <path
+           d="m 240.273,196.566 h 0.735 l 0.93,2.551 0.937,-2.551 h 0.734 v 3.746 h -0.48 v -3.289 l -0.941,2.571 h -0.497 l -0.937,-2.571 v 3.289 h -0.481 z m 5.317,1.262 c -0.242,0 -0.434,0.094 -0.57,0.289 -0.141,0.192 -0.211,0.457 -0.211,0.793 0,0.336 0.07,0.602 0.207,0.797 0.14,0.191 0.332,0.289 0.574,0.289 0.238,0 0.43,-0.098 0.566,-0.293 0.141,-0.195 0.211,-0.457 0.211,-0.793 0,-0.332 -0.07,-0.598 -0.211,-0.789 -0.136,-0.195 -0.328,-0.293 -0.566,-0.293 z m 0,-0.394 c 0.39,0 0.695,0.132 0.918,0.394 0.226,0.258 0.336,0.621 0.336,1.082 0,0.461 -0.11,0.82 -0.336,1.086 -0.223,0.258 -0.528,0.391 -0.918,0.391 -0.395,0 -0.699,-0.133 -0.922,-0.391 -0.223,-0.266 -0.332,-0.625 -0.332,-1.086 0,-0.461 0.109,-0.824 0.332,-1.082 0.223,-0.262 0.527,-0.394 0.922,-0.394 z m 3.16,0.5 c -0.051,-0.032 -0.105,-0.051 -0.168,-0.067 -0.059,-0.012 -0.121,-0.019 -0.195,-0.019 -0.254,0 -0.449,0.086 -0.586,0.254 -0.133,0.168 -0.203,0.414 -0.203,0.73 v 1.48 h -0.45 v -2.808 h 0.45 v 0.434 c 0.097,-0.168 0.218,-0.297 0.371,-0.379 0.152,-0.082 0.336,-0.125 0.551,-0.125 0.031,0 0.066,0.004 0.101,0.007 0.039,0.004 0.078,0.012 0.125,0.02 z m 0.594,1.957 v 1.492 h -0.453 v -3.879 h 0.453 v 0.426 c 0.094,-0.168 0.215,-0.293 0.355,-0.371 0.145,-0.082 0.321,-0.125 0.52,-0.125 0.332,0 0.601,0.136 0.808,0.406 0.207,0.273 0.313,0.629 0.313,1.07 0,0.442 -0.106,0.797 -0.313,1.07 -0.207,0.27 -0.476,0.407 -0.808,0.407 -0.199,0 -0.375,-0.043 -0.52,-0.121 -0.14,-0.082 -0.261,-0.207 -0.355,-0.375 z m 1.527,-0.981 c 0,-0.34 -0.066,-0.605 -0.203,-0.797 -0.137,-0.195 -0.32,-0.293 -0.559,-0.293 -0.238,0 -0.425,0.098 -0.562,0.293 -0.137,0.192 -0.203,0.457 -0.203,0.797 0,0.34 0.066,0.606 0.203,0.801 0.137,0.191 0.324,0.289 0.562,0.289 0.239,0 0.422,-0.098 0.559,-0.289 0.137,-0.195 0.203,-0.461 0.203,-0.801 z m 2.938,-0.293 v 1.695 h -0.45 v -1.679 c 0,-0.266 -0.05,-0.465 -0.152,-0.598 -0.102,-0.133 -0.254,-0.199 -0.453,-0.199 -0.242,0 -0.434,0.078 -0.574,0.238 -0.141,0.16 -0.211,0.375 -0.211,0.653 v 1.585 h -0.449 v -3.902 h 0.449 v 1.528 c 0.109,-0.168 0.234,-0.293 0.379,-0.379 0.148,-0.082 0.316,-0.125 0.504,-0.125 0.316,0 0.554,0.101 0.714,0.3 0.161,0.2 0.243,0.496 0.243,0.883 z m 1.41,-0.789 c -0.242,0 -0.43,0.094 -0.571,0.289 -0.14,0.192 -0.21,0.457 -0.21,0.793 0,0.336 0.07,0.602 0.207,0.797 0.14,0.191 0.332,0.289 0.574,0.289 0.238,0 0.429,-0.098 0.57,-0.293 0.141,-0.195 0.211,-0.457 0.211,-0.793 0,-0.332 -0.07,-0.598 -0.211,-0.789 -0.141,-0.195 -0.332,-0.293 -0.57,-0.293 z m 0,-0.394 c 0.39,0 0.699,0.132 0.922,0.394 0.222,0.258 0.332,0.621 0.332,1.082 0,0.461 -0.11,0.82 -0.332,1.086 -0.223,0.258 -0.532,0.391 -0.922,0.391 -0.391,0 -0.699,-0.133 -0.922,-0.391 -0.223,-0.266 -0.332,-0.625 -0.332,-1.086 0,-0.461 0.109,-0.824 0.332,-1.082 0.223,-0.262 0.531,-0.394 0.922,-0.394 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath121)"
+           id="path630" />
+        <path
+           d="m 113.867,69.285 v 1.406 h 0.617 c 0.231,0 0.411,-0.058 0.536,-0.183 0.125,-0.121 0.187,-0.293 0.187,-0.52 0,-0.226 -0.062,-0.398 -0.187,-0.519 -0.125,-0.121 -0.305,-0.184 -0.536,-0.184 z m -0.496,-0.418 h 1.113 c 0.411,0 0.719,0.098 0.926,0.285 0.211,0.192 0.317,0.469 0.317,0.836 0,0.367 -0.106,0.649 -0.317,0.836 -0.207,0.192 -0.515,0.285 -0.926,0.285 h -0.617 v 1.504 h -0.496 z m 6.067,0.289 v 0.535 c -0.165,-0.16 -0.344,-0.277 -0.532,-0.355 -0.187,-0.078 -0.386,-0.117 -0.597,-0.117 -0.418,0 -0.739,0.129 -0.957,0.39 -0.223,0.262 -0.332,0.641 -0.332,1.137 0,0.492 0.109,0.871 0.332,1.133 0.218,0.262 0.539,0.391 0.957,0.391 0.211,0 0.41,-0.04 0.597,-0.118 0.188,-0.078 0.367,-0.195 0.532,-0.355 v 0.527 c -0.172,0.121 -0.356,0.211 -0.551,0.274 -0.192,0.058 -0.395,0.09 -0.61,0.09 -0.55,0 -0.984,-0.172 -1.304,-0.52 -0.317,-0.348 -0.473,-0.824 -0.473,-1.422 0,-0.601 0.156,-1.078 0.473,-1.422 0.32,-0.351 0.754,-0.523 1.304,-0.523 0.219,0 0.422,0.031 0.618,0.09 0.191,0.058 0.375,0.148 0.543,0.265 z m 1.011,3.032 h 0.805 v -2.86 l -0.879,0.184 v -0.465 l 0.875,-0.18 h 0.492 v 3.321 h 0.805 v 0.425 h -2.098 z m 3.746,-2.985 c -0.254,0 -0.445,0.129 -0.57,0.387 -0.129,0.254 -0.191,0.64 -0.191,1.156 0,0.512 0.062,0.899 0.191,1.156 0.125,0.254 0.316,0.383 0.57,0.383 0.258,0 0.45,-0.129 0.575,-0.383 0.128,-0.257 0.195,-0.644 0.195,-1.156 0,-0.516 -0.067,-0.902 -0.195,-1.156 -0.125,-0.258 -0.317,-0.387 -0.575,-0.387 z m 0,-0.402 c 0.41,0 0.723,0.168 0.938,0.5 0.215,0.332 0.324,0.812 0.324,1.445 0,0.629 -0.109,1.113 -0.324,1.445 -0.215,0.332 -0.528,0.497 -0.938,0.497 -0.406,0 -0.718,-0.165 -0.937,-0.497 -0.215,-0.332 -0.32,-0.816 -0.32,-1.445 0,-0.633 0.105,-1.113 0.32,-1.445 0.219,-0.332 0.531,-0.5 0.937,-0.5 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath122)"
+           id="path631" />
+        <path
+           d="M 268.345,169.918 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath123)"
+           id="path632" />
+        <path
+           d="M 268.345,175.742 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath124)"
+           id="path633" />
+        <path
+           d="M 268.345,158.262 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath125)"
+           id="path634" />
+        <path
+           d="M 268.345,164.09 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath126)"
+           id="path635" />
+        <path
+           d="M 268.345,146.609 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath127)"
+           id="path636" />
+        <path
+           d="M 268.345,152.434 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath128)"
+           id="path637" />
+        <path
+           d="M 268.345,134.953 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath129)"
+           id="path638" />
+        <path
+           d="M 268.345,140.781 H 303.31"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath130)"
+           id="path639" />
+        <path
+           d="m 288.74,88.336 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath131)"
+           id="path640" />
+        <path
+           d="m 280.883,15.205 11.659,-10e-4"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath132)"
+           id="path641" />
+        <path
+           d="m 268.345,85.426 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath133)"
+           id="path642" />
+        <path
+           d="m 288.74,82.512 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath134)"
+           id="path643" />
+        <path
+           d="M 279.512,9.72 291.171,9.719"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath135)"
+           id="path644" />
+        <path
+           d="m 268.345,79.598 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath136)"
+           id="path645" />
+        <path
+           d="m 288.74,76.684 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath137)"
+           id="path646" />
+        <path
+           d="M 278.145,4.237 H 289.8"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath138)"
+           id="path647" />
+        <path
+           d="m 268.345,73.77 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath139)"
+           id="path648" />
+        <path
+           d="m 288.74,105.816 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath140)"
+           id="path649" />
+        <path
+           d="m 284.996,31.657 h 11.659"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath141)"
+           id="path650" />
+        <path
+           d="m 268.345,102.906 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath142)"
+           id="path651" />
+        <path
+           d="m 288.74,99.992 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath143)"
+           id="path652" />
+        <path
+           d="m 283.626,26.176 11.659,-10e-4"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath144)"
+           id="path653" />
+        <path
+           d="m 268.345,97.078 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath145)"
+           id="path654" />
+        <path
+           d="m 288.74,94.164 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath146)"
+           id="path655" />
+        <path
+           d="m 282.255,20.69 h 11.658"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath147)"
+           id="path656" />
+        <path
+           d="m 268.345,91.25 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath148)"
+           id="path657" />
+        <path
+           d="m 288.74,129.125 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath149)"
+           id="path658" />
+        <path
+           d="M 290.481,53.595 302.14,53.594"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath150)"
+           id="path659" />
+        <path
+           d="m 268.345,126.215 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath151)"
+           id="path660" />
+        <path
+           d="m 288.74,123.301 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath152)"
+           id="path661" />
+        <path
+           d="m 289.11,48.109 h 11.658"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath153)"
+           id="path662" />
+        <path
+           d="m 268.345,120.387 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath154)"
+           id="path663" />
+        <path
+           d="m 288.74,117.473 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath155)"
+           id="path664" />
+        <path
+           d="m 287.739,42.628 11.659,-10e-4"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath156)"
+           id="path665" />
+        <path
+           d="m 268.345,114.559 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath157)"
+           id="path666" />
+        <path
+           d="m 288.74,111.645 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath158)"
+           id="path667" />
+        <path
+           d="m 286.368,37.142 h 11.658"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath159)"
+           id="path668" />
+        <path
+           d="m 268.345,108.73 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath160)"
+           id="path669" />
+        <path
+           d="m 288.74,70.855 h 14.562"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath161)"
+           id="path670" />
+        <path
+           d="m 276.77,-1.247 11.659,-10e-4"
+           style="fill:none;stroke:#000000;stroke-width:1.19694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="matrix(1.2973,0.33333333,-0.324332,1.3333333,0,0)"
+           clip-path="url(#clipPath162)"
+           id="path671" />
+        <path
+           d="m 268.345,67.941 h 8.736"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath163)"
+           id="path672" />
+        <path
+           d="m 266.832,123.305 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath164)"
+           id="path673" />
+        <path
+           d="m 274.243,123.305 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath165)"
+           id="path674" />
+        <path
+           d="m 266.832,117.48 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath166)"
+           id="path675" />
+        <path
+           d="m 274.243,117.477 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath167)"
+           id="path676" />
+        <path
+           d="m 266.832,111.652 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath168)"
+           id="path677" />
+        <path
+           d="m 274.243,111.648 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath169)"
+           id="path678" />
+        <path
+           d="m 266.832,105.824 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath170)"
+           id="path679" />
+        <path
+           d="m 274.243,105.824 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath171)"
+           id="path680" />
+        <path
+           d="m 266.832,100 h 5.668 v 5.824 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath172)"
+           id="path681" />
+        <path
+           d="m 274.243,99.996 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath173)"
+           id="path682" />
+        <path
+           d="M 266.832,94.172 H 272.5 V 100 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath174)"
+           id="path683" />
+        <path
+           d="m 274.243,94.168 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath175)"
+           id="path684" />
+        <path
+           d="m 266.832,88.344 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath176)"
+           id="path685" />
+        <path
+           d="m 274.243,88.344 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath177)"
+           id="path686" />
+        <path
+           d="m 266.832,82.516 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath178)"
+           id="path687" />
+        <path
+           d="m 274.243,82.516 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath179)"
+           id="path688" />
+        <path
+           d="m 266.832,76.691 h 5.668 v 5.824 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath180)"
+           id="path689" />
+        <path
+           d="m 274.243,76.688 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath181)"
+           id="path690" />
+        <path
+           d="m 266.832,70.863 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath182)"
+           id="path691" />
+        <path
+           d="m 274.243,70.859 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath183)"
+           id="path692" />
+        <path
+           d="m 267.691,75.012 v -0.418 h 0.68 v -1.93 l -0.66,0.426 v -0.445 l 0.691,-0.461 h 0.52 v 2.41 h 0.629 v 0.418 z m 4.032,-1.414 c 0,0.476 -0.078,0.84 -0.239,1.086 -0.16,0.246 -0.398,0.371 -0.718,0.371 -0.629,0 -0.946,-0.489 -0.946,-1.457 0,-0.34 0.035,-0.614 0.106,-0.828 0.066,-0.215 0.172,-0.372 0.308,-0.473 0.137,-0.102 0.321,-0.156 0.547,-0.156 0.324,0 0.563,0.121 0.715,0.367 0.152,0.242 0.227,0.605 0.227,1.09 z m -0.551,0 c 0,-0.262 -0.012,-0.465 -0.035,-0.61 -0.028,-0.144 -0.067,-0.246 -0.121,-0.308 -0.055,-0.063 -0.133,-0.094 -0.239,-0.094 -0.109,0 -0.195,0.031 -0.25,0.094 -0.058,0.062 -0.097,0.168 -0.121,0.312 -0.023,0.145 -0.035,0.344 -0.035,0.606 0,0.257 0.012,0.461 0.035,0.605 0.028,0.145 0.067,0.25 0.121,0.313 0.055,0.062 0.137,0.093 0.243,0.093 0.105,0 0.183,-0.031 0.242,-0.097 0.054,-0.067 0.097,-0.172 0.121,-0.321 0.027,-0.144 0.039,-0.343 0.039,-0.593 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath184)"
+           id="path693" />
+        <path
+           d="m 270.637,79.383 c 0,0.5 -0.09,0.875 -0.27,1.125 -0.179,0.25 -0.433,0.371 -0.762,0.371 -0.242,0 -0.429,-0.051 -0.57,-0.156 -0.137,-0.11 -0.23,-0.278 -0.289,-0.508 l 0.516,-0.074 c 0.05,0.199 0.168,0.297 0.351,0.297 0.153,0 0.27,-0.079 0.352,-0.227 0.086,-0.152 0.129,-0.375 0.129,-0.672 -0.047,0.098 -0.129,0.176 -0.242,0.234 -0.114,0.059 -0.235,0.086 -0.364,0.086 -0.242,0 -0.433,-0.086 -0.578,-0.254 -0.14,-0.167 -0.215,-0.398 -0.215,-0.687 0,-0.297 0.086,-0.531 0.25,-0.699 0.168,-0.164 0.407,-0.25 0.711,-0.25 0.332,0 0.578,0.117 0.739,0.355 0.16,0.235 0.242,0.586 0.242,1.059 z m -0.582,-0.399 c 0,-0.175 -0.039,-0.312 -0.114,-0.418 -0.074,-0.101 -0.171,-0.156 -0.296,-0.156 -0.122,0 -0.219,0.047 -0.29,0.137 -0.066,0.09 -0.101,0.215 -0.101,0.375 0,0.156 0.035,0.281 0.101,0.375 0.071,0.094 0.168,0.141 0.29,0.141 0.117,0 0.214,-0.04 0.293,-0.122 0.078,-0.082 0.117,-0.191 0.117,-0.332 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath185)"
+           id="path694" />
+        <path
+           d="m 270.66,85.871 c 0,0.266 -0.086,0.469 -0.254,0.617 -0.172,0.145 -0.418,0.219 -0.734,0.219 -0.313,0 -0.555,-0.074 -0.731,-0.219 -0.171,-0.144 -0.257,-0.351 -0.257,-0.613 0,-0.18 0.05,-0.332 0.152,-0.457 0.102,-0.125 0.238,-0.199 0.41,-0.23 V 85.18 c -0.148,-0.035 -0.269,-0.11 -0.359,-0.227 -0.09,-0.117 -0.137,-0.254 -0.137,-0.406 0,-0.235 0.078,-0.414 0.238,-0.551 0.16,-0.133 0.387,-0.199 0.676,-0.199 0.301,0 0.527,0.066 0.688,0.195 0.16,0.133 0.242,0.317 0.242,0.559 0,0.152 -0.047,0.289 -0.137,0.402 -0.09,0.117 -0.211,0.192 -0.367,0.223 v 0.008 c 0.18,0.031 0.316,0.105 0.418,0.226 0.101,0.117 0.152,0.274 0.152,0.461 z m -0.633,-1.293 c 0,-0.133 -0.031,-0.23 -0.089,-0.293 -0.059,-0.062 -0.153,-0.094 -0.274,-0.094 -0.234,0 -0.355,0.129 -0.355,0.387 0,0.274 0.121,0.406 0.359,0.406 0.121,0 0.211,-0.031 0.27,-0.093 0.058,-0.063 0.089,-0.168 0.089,-0.313 z m 0.063,1.246 c 0,-0.297 -0.141,-0.445 -0.43,-0.445 -0.133,0 -0.234,0.039 -0.305,0.117 -0.07,0.078 -0.105,0.192 -0.105,0.336 0,0.168 0.035,0.289 0.105,0.363 0.071,0.078 0.176,0.114 0.321,0.114 0.144,0 0.246,-0.036 0.312,-0.114 0.071,-0.074 0.102,-0.199 0.102,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath186)"
+           id="path695" />
+        <path
+           d="m 270.609,90.113 c -0.125,0.199 -0.242,0.395 -0.351,0.586 -0.113,0.188 -0.207,0.379 -0.289,0.571 -0.082,0.187 -0.149,0.382 -0.196,0.585 -0.046,0.204 -0.07,0.415 -0.07,0.641 h -0.574 c 0,-0.238 0.031,-0.465 0.09,-0.684 0.062,-0.222 0.148,-0.445 0.261,-0.671 0.114,-0.231 0.321,-0.567 0.618,-1.012 h -1.368 v -0.465 h 1.879 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath187)"
+           id="path696" />
+        <path
+           d="m 270.641,97.395 c 0,0.304 -0.082,0.539 -0.246,0.71 -0.165,0.172 -0.395,0.258 -0.684,0.258 -0.324,0 -0.57,-0.117 -0.746,-0.351 -0.172,-0.235 -0.262,-0.578 -0.262,-1.039 0,-0.504 0.09,-0.883 0.266,-1.137 0.176,-0.258 0.429,-0.387 0.758,-0.387 0.234,0 0.418,0.055 0.55,0.16 0.137,0.106 0.231,0.27 0.289,0.493 l -0.519,0.074 c -0.051,-0.188 -0.16,-0.278 -0.332,-0.278 -0.149,0 -0.262,0.075 -0.348,0.227 -0.082,0.148 -0.125,0.379 -0.125,0.687 0.059,-0.101 0.141,-0.179 0.242,-0.23 0.106,-0.055 0.223,-0.082 0.356,-0.082 0.246,0 0.441,0.082 0.586,0.242 0.14,0.16 0.215,0.379 0.215,0.653 z m -0.555,0.019 c 0,-0.164 -0.035,-0.285 -0.109,-0.371 -0.071,-0.082 -0.168,-0.125 -0.297,-0.125 -0.121,0 -0.215,0.039 -0.289,0.117 -0.075,0.082 -0.11,0.188 -0.11,0.317 0,0.164 0.039,0.3 0.114,0.41 0.078,0.105 0.175,0.16 0.3,0.16 0.125,0 0.219,-0.043 0.289,-0.133 0.071,-0.094 0.102,-0.219 0.102,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath188)"
+           id="path697" />
+        <path
+           d="m 270.672,103.207 c 0,0.301 -0.09,0.539 -0.274,0.719 -0.179,0.176 -0.429,0.262 -0.746,0.262 -0.277,0 -0.496,-0.063 -0.664,-0.188 -0.164,-0.129 -0.269,-0.316 -0.308,-0.559 l 0.55,-0.046 c 0.028,0.121 0.079,0.21 0.153,0.265 0.074,0.055 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.047 0.328,-0.137 0.082,-0.089 0.125,-0.218 0.125,-0.386 0,-0.149 -0.039,-0.266 -0.117,-0.356 -0.078,-0.09 -0.183,-0.133 -0.324,-0.133 -0.152,0 -0.273,0.059 -0.371,0.184 h -0.535 l 0.093,-1.594 h 1.657 v 0.418 h -1.157 l -0.046,0.715 c 0.132,-0.121 0.3,-0.18 0.5,-0.18 0.261,0 0.472,0.082 0.629,0.25 0.156,0.168 0.234,0.395 0.234,0.684 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath189)"
+           id="path698" />
+        <path
+           d="m 270.395,109.398 v 0.579 h -0.524 v -0.579 h -1.254 v -0.421 l 1.164,-1.829 h 0.614 v 1.832 h 0.367 v 0.418 z m -0.524,-1.343 c 0,-0.075 0.004,-0.153 0.008,-0.235 0.004,-0.086 0.008,-0.14 0.012,-0.164 -0.036,0.074 -0.098,0.184 -0.184,0.324 l -0.641,1 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath190)"
+           id="path699" />
+        <path
+           d="m 270.641,115.02 c 0,0.265 -0.086,0.468 -0.254,0.613 -0.172,0.144 -0.414,0.219 -0.727,0.219 -0.293,0 -0.527,-0.071 -0.703,-0.211 -0.176,-0.141 -0.277,-0.344 -0.309,-0.606 l 0.559,-0.051 c 0.035,0.274 0.188,0.407 0.453,0.407 0.133,0 0.235,-0.032 0.305,-0.098 0.074,-0.066 0.109,-0.172 0.109,-0.309 0,-0.125 -0.043,-0.222 -0.133,-0.289 -0.086,-0.066 -0.218,-0.101 -0.394,-0.101 h -0.192 v -0.453 h 0.18 c 0.16,0 0.277,-0.036 0.356,-0.098 0.082,-0.07 0.121,-0.164 0.121,-0.285 0,-0.117 -0.032,-0.211 -0.094,-0.274 -0.066,-0.066 -0.156,-0.101 -0.277,-0.101 -0.114,0 -0.207,0.031 -0.278,0.097 -0.066,0.063 -0.105,0.153 -0.117,0.274 l -0.551,-0.043 c 0.032,-0.242 0.129,-0.434 0.297,-0.57 0.168,-0.137 0.387,-0.207 0.656,-0.207 0.29,0 0.516,0.066 0.676,0.199 0.164,0.133 0.246,0.316 0.246,0.555 0,0.175 -0.05,0.32 -0.152,0.433 -0.102,0.113 -0.246,0.191 -0.438,0.227 v 0.007 c 0.211,0.028 0.375,0.098 0.489,0.215 0.113,0.118 0.172,0.266 0.172,0.45 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath191)"
+           id="path700" />
+        <path
+           d="m 268.695,121.629 v -0.391 c 0.075,-0.16 0.176,-0.32 0.305,-0.472 0.133,-0.157 0.301,-0.317 0.5,-0.481 0.195,-0.164 0.328,-0.293 0.406,-0.398 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.367 -0.363,-0.367 -0.117,0 -0.207,0.031 -0.269,0.098 -0.059,0.062 -0.098,0.16 -0.118,0.289 l -0.554,-0.032 c 0.031,-0.261 0.129,-0.461 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.528,0.07 0.688,0.211 0.156,0.14 0.238,0.336 0.238,0.586 0,0.133 -0.027,0.254 -0.078,0.359 -0.051,0.106 -0.117,0.207 -0.195,0.297 -0.079,0.09 -0.168,0.176 -0.266,0.254 -0.098,0.078 -0.191,0.156 -0.281,0.23 -0.09,0.075 -0.176,0.149 -0.25,0.227 -0.074,0.074 -0.129,0.156 -0.168,0.246 h 1.281 v 0.461 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath192)"
+           id="path701" />
+        <path
+           d="m 268.809,127.457 v -0.418 h 0.683 v -1.93 l -0.66,0.422 v -0.441 l 0.688,-0.461 h 0.519 v 2.41 h 0.633 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath193)"
+           id="path702" />
+        <path
+           d="m 266.832,172.836 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath194)"
+           id="path703" />
+        <path
+           d="m 274.243,172.832 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath195)"
+           id="path704" />
+        <path
+           d="m 266.832,167.008 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath196)"
+           id="path705" />
+        <path
+           d="m 274.243,167.008 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath197)"
+           id="path706" />
+        <path
+           d="m 266.832,161.18 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath198)"
+           id="path707" />
+        <path
+           d="m 274.243,161.18 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath199)"
+           id="path708" />
+        <path
+           d="m 266.832,155.355 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath200)"
+           id="path709" />
+        <path
+           d="m 274.243,155.352 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath201)"
+           id="path710" />
+        <path
+           d="m 266.832,149.527 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath202)"
+           id="path711" />
+        <path
+           d="m 274.243,149.527 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath203)"
+           id="path712" />
+        <path
+           d="m 266.832,143.699 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath204)"
+           id="path713" />
+        <path
+           d="m 274.243,143.699 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath205)"
+           id="path714" />
+        <path
+           d="m 266.832,137.875 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath206)"
+           id="path715" />
+        <path
+           d="m 274.243,137.871 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath207)"
+           id="path716" />
+        <path
+           d="m 266.832,132.047 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath208)"
+           id="path717" />
+        <path
+           d="m 274.243,132.043 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath209)"
+           id="path718" />
+        <path
+           d="m 270.66,135.398 c 0,0.266 -0.086,0.473 -0.258,0.622 -0.168,0.144 -0.414,0.218 -0.73,0.218 -0.313,0 -0.555,-0.074 -0.731,-0.218 -0.171,-0.149 -0.257,-0.352 -0.257,-0.618 0,-0.179 0.05,-0.332 0.152,-0.453 0.102,-0.125 0.238,-0.203 0.41,-0.23 v -0.012 c -0.148,-0.031 -0.269,-0.105 -0.359,-0.227 -0.09,-0.117 -0.137,-0.253 -0.137,-0.406 0,-0.23 0.078,-0.414 0.238,-0.547 0.16,-0.132 0.387,-0.203 0.676,-0.203 0.301,0 0.527,0.067 0.688,0.199 0.16,0.129 0.238,0.313 0.238,0.555 0,0.156 -0.043,0.289 -0.137,0.406 -0.09,0.118 -0.211,0.192 -0.363,0.219 v 0.012 c 0.18,0.027 0.316,0.101 0.418,0.223 0.101,0.121 0.152,0.273 0.152,0.46 z m -0.633,-1.289 c 0,-0.132 -0.031,-0.23 -0.089,-0.293 -0.059,-0.062 -0.153,-0.093 -0.274,-0.093 -0.234,0 -0.355,0.129 -0.355,0.386 0,0.27 0.121,0.407 0.359,0.407 0.121,0 0.211,-0.032 0.27,-0.098 0.058,-0.063 0.089,-0.164 0.089,-0.309 z m 0.063,1.243 c 0,-0.293 -0.141,-0.442 -0.43,-0.442 -0.133,0 -0.234,0.039 -0.305,0.117 -0.07,0.078 -0.105,0.188 -0.105,0.336 0,0.164 0.035,0.285 0.105,0.364 0.071,0.074 0.176,0.113 0.321,0.113 0.144,0 0.246,-0.039 0.312,-0.113 0.071,-0.079 0.102,-0.204 0.102,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath210)"
+           id="path719" />
+        <path
+           d="m 270.605,139.645 c -0.121,0.199 -0.238,0.394 -0.351,0.582 -0.109,0.191 -0.203,0.378 -0.285,0.57 -0.082,0.191 -0.149,0.387 -0.196,0.59 -0.046,0.199 -0.07,0.414 -0.07,0.636 h -0.574 c 0,-0.234 0.031,-0.461 0.09,-0.679 0.062,-0.223 0.148,-0.446 0.261,-0.676 0.114,-0.227 0.321,-0.563 0.618,-1.008 h -1.368 v -0.465 h 1.875 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath211)"
+           id="path720" />
+        <path
+           d="m 270.637,146.926 c 0,0.301 -0.082,0.539 -0.246,0.707 -0.164,0.172 -0.391,0.258 -0.68,0.258 -0.324,0 -0.57,-0.118 -0.746,-0.348 -0.172,-0.234 -0.262,-0.582 -0.262,-1.039 0,-0.508 0.09,-0.887 0.266,-1.141 0.176,-0.254 0.429,-0.383 0.758,-0.383 0.234,0 0.418,0.055 0.55,0.161 0.137,0.105 0.231,0.269 0.285,0.492 l -0.515,0.074 c -0.051,-0.187 -0.16,-0.281 -0.332,-0.281 -0.149,0 -0.262,0.074 -0.348,0.226 -0.082,0.153 -0.125,0.383 -0.125,0.688 0.059,-0.098 0.141,-0.176 0.242,-0.231 0.106,-0.05 0.223,-0.078 0.356,-0.078 0.246,0 0.441,0.078 0.582,0.239 0.144,0.164 0.215,0.378 0.215,0.656 z m -0.551,0.015 c 0,-0.16 -0.035,-0.281 -0.109,-0.367 -0.071,-0.086 -0.168,-0.129 -0.297,-0.129 -0.121,0 -0.215,0.039 -0.289,0.121 -0.075,0.079 -0.11,0.184 -0.11,0.317 0,0.164 0.039,0.301 0.114,0.41 0.078,0.105 0.175,0.16 0.3,0.16 0.125,0 0.219,-0.047 0.289,-0.137 0.071,-0.089 0.102,-0.214 0.102,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath212)"
+           id="path721" />
+        <path
+           d="m 270.672,152.738 c 0,0.297 -0.09,0.535 -0.274,0.715 -0.179,0.176 -0.429,0.266 -0.746,0.266 -0.277,0 -0.496,-0.063 -0.664,-0.192 -0.164,-0.129 -0.269,-0.312 -0.308,-0.554 l 0.55,-0.047 c 0.028,0.121 0.079,0.207 0.153,0.262 0.074,0.054 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.043 0.328,-0.133 0.082,-0.09 0.121,-0.219 0.121,-0.387 0,-0.148 -0.035,-0.27 -0.113,-0.355 -0.078,-0.09 -0.183,-0.137 -0.324,-0.137 -0.152,0 -0.273,0.062 -0.371,0.183 h -0.535 l 0.093,-1.593 h 1.657 v 0.422 h -1.157 l -0.046,0.714 c 0.132,-0.121 0.3,-0.179 0.5,-0.179 0.261,0 0.468,0.082 0.625,0.25 0.16,0.168 0.238,0.394 0.238,0.683 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath213)"
+           id="path722" />
+        <path
+           d="m 270.395,158.93 v 0.574 h -0.524 v -0.574 h -1.254 v -0.426 l 1.164,-1.828 h 0.614 v 1.832 h 0.367 v 0.422 z m -0.524,-1.348 c 0,-0.07 0,-0.148 0.004,-0.234 0.008,-0.082 0.012,-0.137 0.012,-0.16 -0.032,0.074 -0.094,0.183 -0.184,0.324 l -0.637,0.996 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath214)"
+           id="path723" />
+        <path
+           d="m 270.637,164.547 c 0,0.265 -0.082,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.293,0 -0.527,-0.07 -0.703,-0.211 -0.176,-0.137 -0.277,-0.34 -0.309,-0.606 l 0.559,-0.05 c 0.035,0.273 0.188,0.41 0.453,0.41 0.133,0 0.235,-0.035 0.305,-0.102 0.074,-0.066 0.109,-0.168 0.109,-0.308 0,-0.125 -0.043,-0.219 -0.133,-0.289 -0.086,-0.067 -0.218,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.16,0 0.277,-0.031 0.356,-0.098 0.082,-0.066 0.121,-0.164 0.121,-0.285 0,-0.117 -0.032,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.102 -0.273,-0.102 -0.114,0 -0.207,0.035 -0.278,0.098 -0.066,0.062 -0.105,0.156 -0.117,0.273 l -0.551,-0.039 c 0.032,-0.246 0.129,-0.437 0.297,-0.574 0.168,-0.137 0.387,-0.207 0.656,-0.207 0.29,0 0.516,0.066 0.676,0.203 0.164,0.133 0.242,0.316 0.242,0.551 0,0.176 -0.05,0.32 -0.152,0.433 -0.098,0.118 -0.242,0.192 -0.434,0.231 v 0.008 c 0.211,0.023 0.372,0.093 0.485,0.215 0.117,0.113 0.172,0.265 0.172,0.445 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath215)"
+           id="path724" />
+        <path
+           d="m 268.695,171.16 v -0.39 c 0.075,-0.165 0.176,-0.321 0.305,-0.477 0.133,-0.152 0.301,-0.313 0.5,-0.481 0.195,-0.16 0.328,-0.292 0.406,-0.398 0.078,-0.105 0.117,-0.207 0.117,-0.305 0,-0.25 -0.121,-0.371 -0.363,-0.371 -0.117,0 -0.207,0.032 -0.269,0.098 -0.059,0.066 -0.098,0.16 -0.118,0.293 l -0.554,-0.035 c 0.031,-0.262 0.129,-0.461 0.285,-0.598 0.16,-0.141 0.379,-0.207 0.652,-0.207 0.297,0 0.528,0.07 0.684,0.207 0.16,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.359 -0.051,0.11 -0.117,0.207 -0.195,0.297 -0.079,0.09 -0.168,0.176 -0.266,0.254 -0.098,0.078 -0.191,0.156 -0.281,0.231 -0.09,0.074 -0.176,0.152 -0.25,0.226 -0.074,0.078 -0.129,0.16 -0.168,0.246 h 1.277 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath216)"
+           id="path725" />
+        <path
+           d="m 268.809,176.984 v -0.418 h 0.683 v -1.929 l -0.66,0.425 v -0.445 l 0.688,-0.461 h 0.519 v 2.41 h 0.633 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath217)"
+           id="path726" />
+        <path
+           d="m 278.102,172.836 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath218)"
+           id="path727" />
+        <path
+           d="m 285.825,172.832 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath219)"
+           id="path728" />
+        <path
+           d="m 278.102,167.008 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath220)"
+           id="path729" />
+        <path
+           d="m 285.825,167.008 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath221)"
+           id="path730" />
+        <path
+           d="m 278.102,161.18 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath222)"
+           id="path731" />
+        <path
+           d="m 285.825,161.18 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath223)"
+           id="path732" />
+        <path
+           d="m 278.102,155.355 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath224)"
+           id="path733" />
+        <path
+           d="m 285.825,155.352 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath225)"
+           id="path734" />
+        <path
+           d="m 278.102,149.527 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath226)"
+           id="path735" />
+        <path
+           d="m 285.825,149.527 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath227)"
+           id="path736" />
+        <path
+           d="m 278.102,143.699 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath228)"
+           id="path737" />
+        <path
+           d="m 285.825,143.699 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath229)"
+           id="path738" />
+        <path
+           d="m 278.102,137.875 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath230)"
+           id="path739" />
+        <path
+           d="m 285.825,137.871 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath231)"
+           id="path740" />
+        <path
+           d="m 278.102,132.047 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath232)"
+           id="path741" />
+        <path
+           d="m 285.825,132.043 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath233)"
+           id="path742" />
+        <path
+           d="m 278.102,126.219 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath234)"
+           id="path743" />
+        <path
+           d="m 285.825,126.219 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath235)"
+           id="path744" />
+        <path
+           d="m 278.102,120.391 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath236)"
+           id="path745" />
+        <path
+           d="m 285.825,120.391 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath237)"
+           id="path746" />
+        <path
+           d="m 278.102,114.566 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath238)"
+           id="path747" />
+        <path
+           d="m 285.825,114.562 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath239)"
+           id="path748" />
+        <path
+           d="m 278.102,108.738 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath240)"
+           id="path749" />
+        <path
+           d="m 285.825,108.738 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath241)"
+           id="path750" />
+        <path
+           d="m 278.102,102.91 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath242)"
+           id="path751" />
+        <path
+           d="m 285.825,102.91 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath243)"
+           id="path752" />
+        <path
+           d="m 278.102,97.086 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath244)"
+           id="path753" />
+        <path
+           d="m 285.825,97.082 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath245)"
+           id="path754" />
+        <path
+           d="m 278.102,91.258 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath246)"
+           id="path755" />
+        <path
+           d="m 285.825,91.254 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath247)"
+           id="path756" />
+        <path
+           d="m 278.102,85.43 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath248)"
+           id="path757" />
+        <path
+           d="m 285.825,85.43 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath249)"
+           id="path758" />
+        <path
+           d="m 278.102,79.605 h 5.668 v 5.824 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath250)"
+           id="path759" />
+        <path
+           d="m 285.825,79.602 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath251)"
+           id="path760" />
+        <path
+           d="m 278.102,73.777 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath252)"
+           id="path761" />
+        <path
+           d="m 285.825,73.773 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath253)"
+           id="path762" />
+        <path
+           d="m 278.102,67.949 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath254)"
+           id="path763" />
+        <path
+           d="m 285.825,67.945 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath255)"
+           id="path764" />
+        <path
+           d="m 283.77,172.836 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath256)"
+           id="path765" />
+        <path
+           d="m 291.651,172.832 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath257)"
+           id="path766" />
+        <path
+           d="m 283.77,167.008 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath258)"
+           id="path767" />
+        <path
+           d="m 291.651,167.008 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath259)"
+           id="path768" />
+        <path
+           d="m 283.77,161.18 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath260)"
+           id="path769" />
+        <path
+           d="m 291.651,161.18 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath261)"
+           id="path770" />
+        <path
+           d="m 283.77,155.355 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath262)"
+           id="path771" />
+        <path
+           d="m 291.651,155.352 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath263)"
+           id="path772" />
+        <path
+           d="m 283.77,149.527 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath264)"
+           id="path773" />
+        <path
+           d="m 291.651,149.527 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath265)"
+           id="path774" />
+        <path
+           d="m 283.77,143.699 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath266)"
+           id="path775" />
+        <path
+           d="m 291.651,143.699 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath267)"
+           id="path776" />
+        <path
+           d="m 283.77,137.875 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath268)"
+           id="path777" />
+        <path
+           d="m 291.651,137.871 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath269)"
+           id="path778" />
+        <path
+           d="m 283.77,132.047 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath270)"
+           id="path779" />
+        <path
+           d="m 291.651,132.043 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath271)"
+           id="path780" />
+        <path
+           d="m 283.77,126.219 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath272)"
+           id="path781" />
+        <path
+           d="m 291.651,126.219 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath273)"
+           id="path782" />
+        <path
+           d="m 283.77,120.391 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath274)"
+           id="path783" />
+        <path
+           d="m 291.651,120.391 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath275)"
+           id="path784" />
+        <path
+           d="m 283.77,114.566 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath276)"
+           id="path785" />
+        <path
+           d="m 291.651,114.562 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath277)"
+           id="path786" />
+        <path
+           d="m 283.77,108.738 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath278)"
+           id="path787" />
+        <path
+           d="m 291.651,108.738 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath279)"
+           id="path788" />
+        <path
+           d="m 283.77,102.91 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath280)"
+           id="path789" />
+        <path
+           d="m 291.651,102.91 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath281)"
+           id="path790" />
+        <path
+           d="m 283.77,97.086 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath282)"
+           id="path791" />
+        <path
+           d="m 291.651,97.082 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath283)"
+           id="path792" />
+        <path
+           d="m 283.77,91.258 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath284)"
+           id="path793" />
+        <path
+           d="m 291.651,91.254 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath285)"
+           id="path794" />
+        <path
+           d="m 283.77,85.43 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath286)"
+           id="path795" />
+        <path
+           d="m 291.651,85.43 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath287)"
+           id="path796" />
+        <path
+           d="m 283.77,79.605 h 5.668 v 5.824 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath288)"
+           id="path797" />
+        <path
+           d="m 291.651,79.602 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath289)"
+           id="path798" />
+        <path
+           d="m 283.77,73.777 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath290)"
+           id="path799" />
+        <path
+           d="m 291.651,73.773 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath291)"
+           id="path800" />
+        <path
+           d="m 283.77,67.949 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath292)"
+           id="path801" />
+        <path
+           d="m 291.651,67.945 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath293)"
+           id="path802" />
+        <path
+           d="m 280.078,72.391 v -0.418 h 0.684 v -1.93 l -0.66,0.422 v -0.442 l 0.687,-0.461 h 0.52 v 2.411 h 0.632 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath294)"
+           id="path803" />
+        <path
+           d="m 281.906,77.434 c 0,0.265 -0.082,0.468 -0.254,0.613 -0.168,0.144 -0.41,0.219 -0.722,0.219 -0.293,0 -0.532,-0.071 -0.703,-0.211 -0.176,-0.141 -0.278,-0.344 -0.309,-0.606 l 0.559,-0.051 c 0.035,0.274 0.187,0.407 0.453,0.407 0.129,0 0.234,-0.032 0.304,-0.098 0.075,-0.066 0.11,-0.172 0.11,-0.309 0,-0.125 -0.043,-0.222 -0.133,-0.289 -0.086,-0.066 -0.219,-0.101 -0.395,-0.101 h -0.191 v -0.453 h 0.18 c 0.16,0 0.277,-0.035 0.355,-0.098 0.082,-0.07 0.121,-0.164 0.121,-0.285 0,-0.117 -0.031,-0.207 -0.097,-0.274 -0.063,-0.066 -0.153,-0.101 -0.274,-0.101 -0.113,0 -0.207,0.031 -0.277,0.098 -0.067,0.062 -0.11,0.152 -0.117,0.273 l -0.551,-0.043 c 0.031,-0.242 0.129,-0.434 0.297,-0.57 0.168,-0.137 0.386,-0.207 0.656,-0.207 0.289,0 0.512,0.066 0.676,0.199 0.16,0.133 0.242,0.316 0.242,0.555 0,0.175 -0.051,0.32 -0.152,0.433 -0.098,0.113 -0.246,0.192 -0.434,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.484,0.214 0.118,0.118 0.172,0.266 0.172,0.45 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath295)"
+           id="path804" />
+        <path
+           d="m 281.941,83.102 c 0,0.3 -0.093,0.539 -0.273,0.718 -0.184,0.176 -0.43,0.266 -0.746,0.266 -0.277,0 -0.5,-0.066 -0.664,-0.191 -0.168,-0.129 -0.27,-0.313 -0.309,-0.555 l 0.551,-0.047 c 0.027,0.121 0.078,0.207 0.152,0.262 0.071,0.054 0.164,0.082 0.274,0.082 0.136,0 0.246,-0.043 0.328,-0.133 0.082,-0.09 0.121,-0.219 0.121,-0.387 0,-0.152 -0.039,-0.269 -0.113,-0.355 -0.078,-0.09 -0.184,-0.137 -0.324,-0.137 -0.153,0 -0.278,0.063 -0.372,0.184 h -0.535 l 0.094,-1.594 h 1.656 v 0.422 h -1.156 l -0.047,0.715 c 0.133,-0.122 0.301,-0.184 0.5,-0.184 0.262,0 0.469,0.086 0.625,0.254 0.16,0.168 0.238,0.394 0.238,0.68 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath296)"
+           id="path805" />
+        <path
+           d="m 281.875,87.492 c -0.121,0.199 -0.238,0.395 -0.352,0.582 -0.109,0.188 -0.203,0.379 -0.285,0.571 -0.082,0.191 -0.148,0.386 -0.195,0.589 -0.047,0.2 -0.07,0.414 -0.07,0.637 h -0.575 c 0,-0.234 0.032,-0.461 0.09,-0.683 0.063,-0.219 0.149,-0.446 0.262,-0.672 0.113,-0.227 0.316,-0.567 0.617,-1.008 H 280 v -0.465 h 1.875 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath297)"
+           id="path806" />
+        <path
+           d="m 281.902,94.238 c 0,0.504 -0.09,0.879 -0.265,1.125 -0.18,0.25 -0.434,0.375 -0.762,0.375 -0.242,0 -0.43,-0.054 -0.57,-0.16 -0.137,-0.105 -0.235,-0.273 -0.289,-0.504 L 280.531,95 c 0.051,0.195 0.168,0.293 0.352,0.293 0.152,0 0.269,-0.074 0.351,-0.227 0.086,-0.148 0.129,-0.375 0.129,-0.671 -0.047,0.101 -0.129,0.179 -0.242,0.238 -0.113,0.055 -0.234,0.082 -0.363,0.082 -0.242,0 -0.438,-0.082 -0.578,-0.25 -0.145,-0.172 -0.215,-0.403 -0.215,-0.692 0,-0.296 0.086,-0.527 0.25,-0.695 0.168,-0.168 0.406,-0.25 0.711,-0.25 0.332,0 0.574,0.117 0.734,0.352 0.164,0.234 0.242,0.586 0.242,1.058 z m -0.578,-0.394 c 0,-0.176 -0.039,-0.317 -0.113,-0.418 -0.074,-0.106 -0.176,-0.156 -0.297,-0.156 -0.121,0 -0.219,0.046 -0.289,0.136 -0.066,0.09 -0.102,0.215 -0.102,0.371 0,0.161 0.036,0.285 0.102,0.379 0.07,0.094 0.168,0.141 0.289,0.141 0.117,0 0.215,-0.039 0.293,-0.121 0.078,-0.086 0.117,-0.196 0.117,-0.332 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath298)"
+           id="path807" />
+        <path
+           d="m 278.957,101.523 v -0.418 h 0.684 v -1.929 l -0.661,0.426 v -0.446 l 0.688,-0.461 h 0.52 v 2.41 h 0.632 v 0.418 z m 2.008,0 v -0.418 h 0.68 v -1.929 l -0.661,0.426 v -0.446 l 0.692,-0.461 h 0.519 v 2.41 h 0.629 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath299)"
+           id="path808" />
+        <path
+           d="m 278.957,107.352 v -0.418 h 0.684 v -1.93 l -0.661,0.422 v -0.442 l 0.688,-0.461 h 0.52 v 2.411 h 0.632 v 0.418 z m 4.055,-0.786 c 0,0.266 -0.086,0.473 -0.254,0.618 -0.168,0.144 -0.41,0.214 -0.723,0.214 -0.297,0 -0.531,-0.07 -0.707,-0.207 -0.172,-0.14 -0.277,-0.343 -0.305,-0.609 l 0.559,-0.047 c 0.035,0.27 0.184,0.406 0.449,0.406 0.133,0 0.235,-0.035 0.309,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.043,-0.223 -0.133,-0.289 -0.089,-0.07 -0.218,-0.101 -0.394,-0.101 h -0.192 v -0.457 h 0.18 c 0.156,0 0.278,-0.032 0.356,-0.098 0.078,-0.067 0.117,-0.16 0.117,-0.285 0,-0.117 -0.031,-0.207 -0.094,-0.274 -0.062,-0.066 -0.156,-0.101 -0.277,-0.101 -0.114,0 -0.203,0.035 -0.274,0.097 -0.07,0.067 -0.109,0.157 -0.121,0.274 l -0.547,-0.039 c 0.028,-0.246 0.125,-0.434 0.293,-0.574 0.168,-0.137 0.391,-0.208 0.66,-0.208 0.289,0 0.512,0.067 0.672,0.204 0.164,0.132 0.246,0.316 0.246,0.55 0,0.176 -0.05,0.321 -0.152,0.438 -0.101,0.113 -0.246,0.187 -0.437,0.226 v 0.008 c 0.21,0.024 0.375,0.098 0.488,0.215 0.113,0.117 0.172,0.266 0.172,0.445 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath300)"
+           id="path809" />
+        <path
+           d="m 278.957,113.18 v -0.418 h 0.684 v -1.93 l -0.661,0.422 v -0.445 l 0.688,-0.457 h 0.52 v 2.41 h 0.632 v 0.418 z m 4.086,-0.942 c 0,0.301 -0.09,0.539 -0.273,0.715 -0.18,0.18 -0.43,0.266 -0.747,0.266 -0.273,0 -0.496,-0.063 -0.664,-0.192 -0.164,-0.129 -0.265,-0.312 -0.304,-0.554 l 0.547,-0.047 c 0.031,0.121 0.082,0.207 0.152,0.265 0.074,0.055 0.168,0.082 0.277,0.082 0.137,0 0.246,-0.046 0.324,-0.136 0.083,-0.09 0.125,-0.219 0.125,-0.387 0,-0.148 -0.039,-0.266 -0.117,-0.355 -0.074,-0.09 -0.183,-0.133 -0.32,-0.133 -0.152,0 -0.277,0.058 -0.375,0.179 h -0.535 l 0.097,-1.589 h 1.653 v 0.418 h -1.156 l -0.043,0.714 c 0.132,-0.121 0.296,-0.179 0.496,-0.179 0.261,0 0.472,0.082 0.629,0.25 0.156,0.168 0.234,0.394 0.234,0.683 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath301)"
+           id="path810" />
+        <path
+           d="m 278.957,119.008 v -0.422 h 0.684 v -1.926 l -0.661,0.422 v -0.445 l 0.688,-0.457 h 0.52 v 2.406 h 0.632 v 0.422 z m 4.023,-2.383 c -0.125,0.203 -0.242,0.398 -0.351,0.586 -0.109,0.187 -0.207,0.379 -0.289,0.57 -0.082,0.192 -0.145,0.387 -0.195,0.586 -0.047,0.203 -0.071,0.414 -0.071,0.641 h -0.57 c 0,-0.235 0.031,-0.465 0.09,-0.684 0.058,-0.219 0.144,-0.445 0.258,-0.672 0.113,-0.23 0.32,-0.566 0.617,-1.011 h -1.367 v -0.461 h 1.878 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath302)"
+           id="path811" />
+        <path
+           d="m 278.957,124.836 v -0.422 h 0.684 v -1.93 l -0.661,0.426 v -0.445 l 0.688,-0.461 h 0.52 v 2.41 h 0.632 v 0.422 z m 4.051,-1.461 c 0,0.5 -0.09,0.875 -0.27,1.125 -0.176,0.25 -0.429,0.375 -0.758,0.375 -0.242,0 -0.433,-0.055 -0.57,-0.16 -0.137,-0.106 -0.234,-0.274 -0.293,-0.504 l 0.516,-0.074 c 0.051,0.195 0.168,0.293 0.351,0.293 0.157,0 0.274,-0.075 0.356,-0.227 0.082,-0.152 0.125,-0.375 0.129,-0.672 -0.051,0.102 -0.133,0.18 -0.246,0.239 -0.11,0.054 -0.231,0.082 -0.364,0.082 -0.242,0 -0.433,-0.082 -0.578,-0.254 -0.14,-0.168 -0.211,-0.399 -0.211,-0.688 0,-0.297 0.082,-0.527 0.25,-0.695 0.168,-0.168 0.407,-0.25 0.711,-0.25 0.328,0 0.574,0.117 0.735,0.351 0.16,0.235 0.242,0.586 0.242,1.059 z m -0.582,-0.395 c 0,-0.175 -0.035,-0.316 -0.114,-0.418 -0.074,-0.105 -0.171,-0.156 -0.296,-0.156 -0.121,0 -0.215,0.043 -0.286,0.137 -0.07,0.09 -0.105,0.211 -0.105,0.371 0,0.156 0.035,0.281 0.105,0.379 0.071,0.094 0.165,0.141 0.29,0.141 0.117,0 0.214,-0.043 0.289,-0.125 0.078,-0.082 0.117,-0.192 0.117,-0.329 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath303)"
+           id="path812" />
+        <path
+           d="m 278.844,130.66 v -0.39 c 0.074,-0.165 0.176,-0.321 0.304,-0.473 0.133,-0.156 0.301,-0.317 0.5,-0.485 0.196,-0.16 0.329,-0.292 0.407,-0.394 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.371 -0.363,-0.371 -0.118,0 -0.207,0.035 -0.27,0.102 -0.059,0.062 -0.098,0.16 -0.117,0.289 l -0.555,-0.031 c 0.031,-0.262 0.129,-0.465 0.285,-0.602 0.16,-0.137 0.379,-0.207 0.653,-0.207 0.297,0 0.527,0.07 0.683,0.211 0.16,0.137 0.239,0.332 0.239,0.586 0,0.133 -0.024,0.25 -0.075,0.359 -0.05,0.106 -0.117,0.203 -0.195,0.297 -0.078,0.09 -0.168,0.172 -0.266,0.254 -0.097,0.078 -0.191,0.152 -0.281,0.231 -0.09,0.074 -0.176,0.148 -0.25,0.226 -0.074,0.074 -0.129,0.156 -0.168,0.242 h 1.278 v 0.465 z m 2.34,0 v -0.418 h 0.679 v -1.93 l -0.66,0.422 v -0.441 l 0.692,-0.461 h 0.519 v 2.41 h 0.629 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath304)"
+           id="path813" />
+        <path
+           d="m 278.844,136.488 v -0.39 c 0.074,-0.164 0.176,-0.321 0.304,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.484 0.196,-0.161 0.329,-0.293 0.407,-0.399 0.078,-0.101 0.117,-0.203 0.117,-0.304 0,-0.247 -0.121,-0.372 -0.363,-0.372 -0.118,0 -0.207,0.036 -0.27,0.098 -0.059,0.066 -0.098,0.164 -0.117,0.293 l -0.555,-0.031 c 0.031,-0.262 0.129,-0.465 0.285,-0.602 0.16,-0.136 0.379,-0.207 0.653,-0.207 0.297,0 0.527,0.071 0.683,0.211 0.16,0.137 0.239,0.332 0.239,0.586 0,0.133 -0.024,0.25 -0.075,0.359 -0.05,0.106 -0.117,0.204 -0.195,0.297 -0.078,0.09 -0.168,0.172 -0.266,0.25 -0.097,0.082 -0.191,0.157 -0.281,0.235 -0.09,0.074 -0.176,0.148 -0.25,0.226 -0.074,0.074 -0.129,0.157 -0.168,0.242 h 1.278 v 0.465 z m 4.168,-0.785 c 0,0.266 -0.086,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.297,0 -0.531,-0.07 -0.707,-0.211 -0.172,-0.14 -0.277,-0.34 -0.305,-0.605 l 0.559,-0.051 c 0.035,0.273 0.184,0.41 0.449,0.41 0.133,0 0.235,-0.035 0.309,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.309 0,-0.125 -0.043,-0.219 -0.133,-0.289 -0.089,-0.067 -0.218,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.156,0 0.278,-0.031 0.356,-0.097 0.078,-0.067 0.117,-0.165 0.117,-0.286 0,-0.117 -0.031,-0.207 -0.094,-0.273 -0.062,-0.066 -0.156,-0.102 -0.277,-0.102 -0.114,0 -0.203,0.036 -0.274,0.098 -0.07,0.063 -0.109,0.156 -0.121,0.274 l -0.547,-0.04 c 0.028,-0.246 0.125,-0.437 0.293,-0.574 0.168,-0.136 0.391,-0.207 0.66,-0.207 0.289,0 0.512,0.067 0.672,0.203 0.164,0.129 0.246,0.317 0.246,0.551 0,0.176 -0.05,0.32 -0.152,0.434 -0.101,0.117 -0.246,0.191 -0.437,0.226 v 0.012 c 0.21,0.023 0.375,0.094 0.488,0.215 0.113,0.113 0.172,0.265 0.172,0.445 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath305)"
+           id="path814" />
+        <path
+           d="m 278.844,142.316 v -0.39 c 0.074,-0.164 0.176,-0.321 0.304,-0.477 0.133,-0.152 0.301,-0.312 0.5,-0.48 0.196,-0.16 0.329,-0.293 0.407,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.367 -0.363,-0.367 -0.118,0 -0.207,0.031 -0.27,0.097 -0.059,0.067 -0.098,0.16 -0.117,0.293 l -0.555,-0.035 c 0.031,-0.262 0.129,-0.461 0.285,-0.598 0.16,-0.14 0.379,-0.207 0.653,-0.207 0.297,0 0.527,0.071 0.683,0.207 0.16,0.141 0.239,0.336 0.239,0.586 0,0.133 -0.024,0.254 -0.075,0.36 -0.05,0.109 -0.117,0.207 -0.195,0.297 -0.078,0.089 -0.168,0.175 -0.266,0.253 -0.097,0.079 -0.191,0.157 -0.281,0.231 -0.09,0.074 -0.176,0.152 -0.25,0.226 -0.074,0.079 -0.129,0.161 -0.168,0.247 h 1.278 v 0.464 z m 4.199,-0.941 c 0,0.297 -0.09,0.539 -0.273,0.715 -0.18,0.176 -0.43,0.265 -0.747,0.265 -0.273,0 -0.496,-0.062 -0.664,-0.191 -0.164,-0.129 -0.265,-0.312 -0.304,-0.555 l 0.547,-0.047 c 0.031,0.122 0.082,0.208 0.152,0.262 0.074,0.055 0.168,0.082 0.277,0.082 0.137,0 0.246,-0.043 0.324,-0.133 0.083,-0.089 0.125,-0.218 0.125,-0.386 0,-0.149 -0.039,-0.27 -0.117,-0.356 -0.074,-0.09 -0.183,-0.136 -0.32,-0.136 -0.152,0 -0.277,0.062 -0.375,0.183 h -0.535 l 0.097,-1.59 h 1.653 v 0.418 h -1.156 l -0.043,0.715 c 0.132,-0.121 0.296,-0.18 0.496,-0.18 0.261,0 0.472,0.082 0.629,0.25 0.156,0.168 0.234,0.395 0.234,0.684 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath306)"
+           id="path815" />
+        <path
+           d="m 278.844,148.141 v -0.391 c 0.074,-0.16 0.176,-0.32 0.304,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.48 0.196,-0.164 0.329,-0.297 0.407,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.367 -0.363,-0.367 -0.118,0 -0.207,0.031 -0.27,0.097 -0.059,0.063 -0.098,0.16 -0.117,0.289 l -0.555,-0.031 c 0.031,-0.262 0.129,-0.461 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.653,-0.207 0.297,0 0.527,0.07 0.683,0.21 0.16,0.141 0.239,0.336 0.239,0.586 0,0.133 -0.024,0.254 -0.075,0.36 -0.05,0.105 -0.117,0.207 -0.195,0.297 -0.078,0.089 -0.168,0.175 -0.266,0.254 -0.097,0.078 -0.191,0.156 -0.281,0.23 -0.09,0.074 -0.176,0.148 -0.25,0.227 -0.074,0.074 -0.129,0.156 -0.168,0.246 h 1.278 v 0.461 z m 4.136,-2.379 c -0.125,0.199 -0.242,0.394 -0.351,0.582 -0.109,0.191 -0.207,0.379 -0.289,0.57 -0.082,0.191 -0.145,0.387 -0.195,0.59 -0.047,0.199 -0.071,0.414 -0.071,0.637 h -0.57 c 0,-0.235 0.031,-0.461 0.09,-0.68 0.058,-0.223 0.144,-0.445 0.258,-0.676 0.113,-0.226 0.32,-0.562 0.617,-1.008 h -1.367 v -0.465 h 1.878 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath307)"
+           id="path816" />
+        <path
+           d="m 278.844,153.969 v -0.391 c 0.074,-0.164 0.176,-0.32 0.304,-0.476 0.133,-0.153 0.301,-0.313 0.5,-0.481 0.196,-0.16 0.329,-0.293 0.407,-0.398 0.078,-0.102 0.117,-0.207 0.117,-0.305 0,-0.246 -0.121,-0.371 -0.363,-0.371 -0.118,0 -0.207,0.035 -0.27,0.098 -0.059,0.066 -0.098,0.164 -0.117,0.293 l -0.555,-0.032 c 0.031,-0.261 0.129,-0.465 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.653,-0.207 0.297,0 0.527,0.07 0.683,0.211 0.16,0.136 0.239,0.332 0.239,0.586 0,0.128 -0.024,0.25 -0.075,0.359 -0.05,0.105 -0.117,0.203 -0.195,0.297 -0.078,0.09 -0.168,0.172 -0.266,0.25 -0.097,0.082 -0.191,0.156 -0.281,0.23 -0.09,0.078 -0.176,0.153 -0.25,0.231 -0.074,0.074 -0.129,0.156 -0.168,0.242 h 1.278 v 0.465 z m 4.164,-1.461 c 0,0.504 -0.09,0.879 -0.27,1.129 -0.176,0.246 -0.429,0.371 -0.758,0.371 -0.242,0 -0.433,-0.051 -0.57,-0.156 -0.137,-0.11 -0.234,-0.278 -0.293,-0.508 l 0.516,-0.074 c 0.051,0.195 0.168,0.296 0.351,0.296 0.157,0 0.274,-0.078 0.356,-0.226 0.082,-0.152 0.125,-0.375 0.129,-0.676 -0.051,0.102 -0.133,0.18 -0.246,0.238 -0.11,0.055 -0.231,0.086 -0.364,0.086 -0.242,0 -0.433,-0.086 -0.578,-0.254 -0.14,-0.172 -0.211,-0.398 -0.211,-0.687 0,-0.297 0.082,-0.531 0.25,-0.699 0.168,-0.168 0.407,-0.25 0.711,-0.25 0.328,0 0.574,0.117 0.735,0.355 0.16,0.231 0.242,0.586 0.242,1.055 z m -0.582,-0.395 c 0,-0.175 -0.035,-0.312 -0.114,-0.418 -0.074,-0.105 -0.171,-0.156 -0.296,-0.156 -0.121,0 -0.215,0.047 -0.286,0.137 -0.07,0.09 -0.105,0.215 -0.105,0.375 0,0.156 0.035,0.281 0.105,0.375 0.071,0.094 0.165,0.14 0.29,0.14 0.117,0 0.214,-0.039 0.289,-0.121 0.078,-0.082 0.117,-0.195 0.117,-0.332 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath308)"
+           id="path817" />
+        <path
+           d="m 280.785,159.012 c 0,0.265 -0.082,0.468 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.722,0.219 -0.293,0 -0.528,-0.071 -0.704,-0.211 -0.175,-0.141 -0.277,-0.34 -0.308,-0.606 l 0.558,-0.05 c 0.036,0.273 0.188,0.41 0.454,0.41 0.132,0 0.234,-0.035 0.304,-0.102 0.075,-0.066 0.11,-0.168 0.11,-0.308 0,-0.125 -0.043,-0.223 -0.133,-0.289 -0.086,-0.067 -0.219,-0.098 -0.395,-0.098 h -0.191 v -0.457 h 0.18 c 0.16,0 0.277,-0.031 0.355,-0.098 0.082,-0.066 0.121,-0.164 0.121,-0.285 0,-0.117 -0.031,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.102 -0.273,-0.102 -0.113,0 -0.207,0.031 -0.277,0.098 -0.067,0.062 -0.106,0.156 -0.117,0.273 l -0.551,-0.043 c 0.031,-0.242 0.129,-0.433 0.297,-0.57 0.168,-0.137 0.386,-0.207 0.656,-0.207 0.289,0 0.515,0.066 0.676,0.199 0.164,0.133 0.242,0.316 0.242,0.555 0,0.175 -0.051,0.32 -0.153,0.433 -0.097,0.114 -0.242,0.192 -0.433,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.484,0.214 0.117,0.118 0.172,0.266 0.172,0.45 z m 0.399,0.785 v -0.418 h 0.679 v -1.93 l -0.66,0.422 v -0.441 l 0.692,-0.461 h 0.519 v 2.41 h 0.629 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath309)"
+           id="path818" />
+        <path
+           d="m 280.785,164.84 c 0,0.262 -0.082,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.215 -0.722,0.215 -0.293,0 -0.528,-0.066 -0.704,-0.207 -0.175,-0.141 -0.277,-0.344 -0.308,-0.606 l 0.558,-0.05 c 0.036,0.269 0.188,0.406 0.454,0.406 0.132,0 0.234,-0.031 0.304,-0.098 0.075,-0.07 0.11,-0.172 0.11,-0.308 0,-0.125 -0.043,-0.223 -0.133,-0.289 -0.086,-0.067 -0.219,-0.102 -0.395,-0.102 h -0.191 v -0.453 h 0.18 c 0.16,0 0.277,-0.035 0.355,-0.102 0.082,-0.066 0.121,-0.16 0.121,-0.285 0,-0.113 -0.031,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.098 -0.273,-0.098 -0.113,0 -0.207,0.031 -0.277,0.094 -0.067,0.066 -0.106,0.156 -0.117,0.273 l -0.551,-0.039 c 0.031,-0.242 0.129,-0.433 0.297,-0.57 0.168,-0.141 0.386,-0.207 0.656,-0.207 0.289,0 0.515,0.066 0.676,0.199 0.164,0.133 0.242,0.317 0.242,0.551 0,0.18 -0.051,0.324 -0.153,0.437 -0.097,0.114 -0.242,0.188 -0.433,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.484,0.215 0.117,0.117 0.172,0.265 0.172,0.449 z m 2.227,0 c 0,0.262 -0.086,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.215 -0.723,0.215 -0.297,0 -0.531,-0.066 -0.707,-0.207 -0.172,-0.141 -0.277,-0.344 -0.305,-0.606 l 0.559,-0.05 c 0.035,0.269 0.184,0.406 0.449,0.406 0.133,0 0.235,-0.031 0.309,-0.098 0.074,-0.07 0.109,-0.172 0.109,-0.308 0,-0.125 -0.043,-0.223 -0.133,-0.289 -0.089,-0.067 -0.218,-0.102 -0.394,-0.102 h -0.192 v -0.453 h 0.18 c 0.156,0 0.278,-0.035 0.356,-0.102 0.078,-0.066 0.117,-0.16 0.117,-0.285 0,-0.113 -0.031,-0.207 -0.094,-0.273 -0.062,-0.067 -0.156,-0.098 -0.277,-0.098 -0.114,0 -0.203,0.031 -0.274,0.094 -0.07,0.066 -0.109,0.156 -0.121,0.273 l -0.547,-0.039 c 0.028,-0.242 0.125,-0.433 0.293,-0.57 0.168,-0.141 0.391,-0.207 0.66,-0.207 0.289,0 0.512,0.066 0.672,0.199 0.164,0.133 0.246,0.317 0.246,0.551 0,0.18 -0.05,0.324 -0.152,0.437 -0.101,0.114 -0.246,0.188 -0.437,0.227 v 0.008 c 0.21,0.027 0.375,0.097 0.488,0.215 0.113,0.117 0.172,0.265 0.172,0.449 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath310)"
+           id="path819" />
+        <path
+           d="m 280.785,170.664 c 0,0.266 -0.082,0.473 -0.254,0.617 -0.168,0.145 -0.41,0.215 -0.722,0.215 -0.293,0 -0.528,-0.07 -0.704,-0.207 -0.175,-0.141 -0.277,-0.344 -0.308,-0.609 l 0.558,-0.047 c 0.036,0.269 0.188,0.406 0.454,0.406 0.132,0 0.234,-0.035 0.304,-0.101 0.075,-0.067 0.11,-0.168 0.11,-0.305 0,-0.129 -0.043,-0.223 -0.133,-0.289 -0.086,-0.071 -0.219,-0.102 -0.395,-0.102 h -0.191 v -0.457 h 0.18 c 0.16,0 0.277,-0.031 0.355,-0.097 0.082,-0.067 0.121,-0.161 0.121,-0.286 0,-0.117 -0.031,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.102 -0.273,-0.102 -0.113,0 -0.207,0.035 -0.277,0.098 -0.067,0.066 -0.106,0.156 -0.117,0.273 l -0.551,-0.039 c 0.031,-0.246 0.129,-0.433 0.297,-0.574 0.168,-0.137 0.386,-0.207 0.656,-0.207 0.289,0 0.515,0.067 0.676,0.203 0.164,0.133 0.242,0.317 0.242,0.551 0,0.176 -0.051,0.32 -0.153,0.438 -0.097,0.113 -0.242,0.187 -0.433,0.226 v 0.008 c 0.211,0.023 0.371,0.098 0.484,0.215 0.117,0.117 0.172,0.265 0.172,0.445 z m 2.258,-0.156 c 0,0.301 -0.09,0.539 -0.273,0.719 -0.18,0.175 -0.43,0.261 -0.747,0.261 -0.273,0 -0.496,-0.062 -0.664,-0.187 -0.164,-0.129 -0.265,-0.317 -0.304,-0.559 l 0.547,-0.047 c 0.031,0.121 0.082,0.211 0.152,0.266 0.074,0.055 0.168,0.082 0.277,0.082 0.137,0 0.246,-0.047 0.324,-0.137 0.083,-0.09 0.125,-0.218 0.125,-0.386 0,-0.149 -0.039,-0.266 -0.117,-0.356 -0.074,-0.09 -0.183,-0.133 -0.32,-0.133 -0.152,0 -0.277,0.059 -0.375,0.184 h -0.535 l 0.097,-1.594 h 1.653 v 0.422 h -1.156 l -0.043,0.711 c 0.132,-0.117 0.296,-0.18 0.496,-0.18 0.261,0 0.472,0.086 0.629,0.25 0.156,0.168 0.234,0.399 0.234,0.684 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath311)"
+           id="path820" />
+        <path
+           d="m 280.785,176.492 c 0,0.266 -0.082,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.722,0.219 -0.293,0 -0.528,-0.07 -0.704,-0.207 -0.175,-0.14 -0.277,-0.344 -0.308,-0.609 l 0.558,-0.051 c 0.036,0.273 0.188,0.41 0.454,0.41 0.132,0 0.234,-0.035 0.304,-0.101 0.075,-0.067 0.11,-0.168 0.11,-0.309 0,-0.125 -0.043,-0.219 -0.133,-0.289 -0.086,-0.066 -0.219,-0.098 -0.395,-0.098 h -0.191 v -0.457 h 0.18 c 0.16,0 0.277,-0.031 0.355,-0.097 0.082,-0.067 0.121,-0.164 0.121,-0.286 0,-0.117 -0.031,-0.207 -0.098,-0.273 -0.062,-0.066 -0.152,-0.102 -0.273,-0.102 -0.113,0 -0.207,0.036 -0.277,0.098 -0.067,0.063 -0.106,0.156 -0.117,0.274 l -0.551,-0.039 c 0.031,-0.247 0.129,-0.438 0.297,-0.575 0.168,-0.136 0.386,-0.207 0.656,-0.207 0.289,0 0.515,0.067 0.676,0.203 0.164,0.133 0.242,0.317 0.242,0.551 0,0.176 -0.051,0.32 -0.153,0.438 -0.097,0.113 -0.242,0.187 -0.433,0.226 v 0.008 c 0.211,0.023 0.371,0.094 0.484,0.215 0.117,0.113 0.172,0.265 0.172,0.445 z m 2.195,-1.594 c -0.125,0.2 -0.242,0.395 -0.351,0.582 -0.109,0.188 -0.207,0.379 -0.289,0.571 -0.082,0.191 -0.145,0.387 -0.195,0.59 -0.047,0.199 -0.071,0.414 -0.071,0.636 h -0.57 c 0,-0.234 0.031,-0.461 0.09,-0.683 0.058,-0.219 0.144,-0.446 0.258,-0.672 0.113,-0.227 0.32,-0.567 0.617,-1.008 h -1.367 v -0.465 h 1.878 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath312)"
+           id="path821" />
+        <path
+           d="M 285.777,72.391 V 72 c 0.071,-0.164 0.172,-0.32 0.305,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.484 0.191,-0.16 0.328,-0.293 0.402,-0.395 0.078,-0.105 0.118,-0.207 0.118,-0.308 0,-0.246 -0.118,-0.371 -0.36,-0.371 -0.117,0 -0.207,0.035 -0.269,0.101 -0.063,0.063 -0.102,0.16 -0.121,0.289 l -0.551,-0.031 c 0.031,-0.262 0.125,-0.465 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.07 0.684,0.21 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.027,0.25 -0.078,0.36 -0.051,0.105 -0.113,0.203 -0.195,0.297 -0.078,0.089 -0.168,0.172 -0.266,0.254 -0.094,0.078 -0.187,0.152 -0.281,0.23 -0.09,0.074 -0.172,0.148 -0.25,0.227 -0.074,0.074 -0.129,0.156 -0.164,0.242 h 1.277 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath313)"
+           id="path822" />
+        <path
+           d="m 287.473,77.641 v 0.578 h -0.524 v -0.578 h -1.25 v -0.422 l 1.16,-1.828 h 0.614 v 1.832 h 0.367 v 0.418 z m -0.524,-1.344 c 0,-0.074 0.004,-0.152 0.008,-0.235 0.004,-0.085 0.008,-0.14 0.012,-0.164 -0.035,0.075 -0.094,0.184 -0.184,0.325 l -0.64,1 h 0.804 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath314)"
+           id="path823" />
+        <path
+           d="m 287.719,83.117 c 0,0.305 -0.082,0.539 -0.246,0.711 -0.164,0.172 -0.391,0.258 -0.68,0.258 -0.324,0 -0.574,-0.117 -0.75,-0.352 -0.172,-0.234 -0.258,-0.578 -0.258,-1.039 0,-0.504 0.086,-0.883 0.262,-1.136 0.18,-0.258 0.43,-0.387 0.758,-0.387 0.234,0 0.418,0.055 0.55,0.16 0.137,0.106 0.235,0.27 0.29,0.492 l -0.52,0.074 c -0.047,-0.187 -0.16,-0.277 -0.332,-0.277 -0.145,0 -0.262,0.074 -0.348,0.227 -0.082,0.148 -0.125,0.379 -0.125,0.687 0.059,-0.101 0.141,-0.176 0.246,-0.23 0.106,-0.055 0.223,-0.082 0.352,-0.082 0.246,0 0.441,0.082 0.586,0.242 0.144,0.16 0.215,0.379 0.215,0.652 z m -0.551,0.02 c 0,-0.164 -0.035,-0.285 -0.109,-0.367 -0.071,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.039 -0.293,0.121 -0.071,0.078 -0.11,0.183 -0.11,0.312 0,0.164 0.039,0.301 0.114,0.41 0.078,0.106 0.179,0.161 0.3,0.161 0.125,0 0.223,-0.043 0.289,-0.133 0.071,-0.094 0.106,-0.219 0.106,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath315)"
+           id="path824" />
+        <path
+           d="m 287.738,89.074 c 0,0.266 -0.082,0.473 -0.254,0.617 -0.172,0.149 -0.414,0.219 -0.73,0.219 -0.313,0 -0.559,-0.07 -0.731,-0.219 -0.171,-0.144 -0.257,-0.347 -0.257,-0.613 0,-0.18 0.05,-0.332 0.152,-0.457 0.102,-0.121 0.238,-0.199 0.406,-0.23 v -0.008 c -0.148,-0.031 -0.265,-0.11 -0.359,-0.227 -0.09,-0.117 -0.137,-0.254 -0.137,-0.406 0,-0.23 0.082,-0.414 0.238,-0.551 0.161,-0.133 0.387,-0.199 0.68,-0.199 0.297,0 0.527,0.066 0.684,0.195 0.16,0.133 0.242,0.317 0.242,0.559 0,0.152 -0.047,0.289 -0.137,0.406 -0.09,0.113 -0.211,0.188 -0.363,0.219 v 0.008 c 0.176,0.031 0.316,0.105 0.414,0.226 0.102,0.117 0.152,0.274 0.152,0.461 z m -0.633,-1.289 c 0,-0.137 -0.027,-0.234 -0.089,-0.293 -0.059,-0.066 -0.149,-0.097 -0.27,-0.097 -0.238,0 -0.355,0.128 -0.355,0.39 0,0.27 0.121,0.403 0.359,0.403 0.121,0 0.207,-0.032 0.266,-0.094 0.062,-0.063 0.089,-0.164 0.089,-0.309 z m 0.067,1.242 c 0,-0.297 -0.145,-0.441 -0.43,-0.441 -0.133,0 -0.234,0.039 -0.308,0.113 -0.071,0.078 -0.106,0.192 -0.106,0.336 0,0.168 0.035,0.289 0.106,0.363 0.07,0.079 0.179,0.118 0.324,0.118 0.14,0 0.246,-0.039 0.312,-0.118 0.067,-0.074 0.102,-0.199 0.102,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath316)"
+           id="path825" />
+        <path
+           d="m 284.77,95.699 v -0.422 h 0.683 v -1.929 l -0.66,0.425 v -0.445 l 0.687,-0.457 H 286 v 2.406 h 0.633 v 0.422 z m 4.035,-1.418 c 0,0.481 -0.082,0.84 -0.243,1.086 -0.16,0.25 -0.398,0.371 -0.714,0.371 -0.633,0 -0.946,-0.484 -0.946,-1.457 0,-0.336 0.032,-0.613 0.102,-0.828 0.07,-0.215 0.172,-0.371 0.312,-0.473 0.137,-0.101 0.321,-0.152 0.547,-0.152 0.325,0 0.563,0.121 0.715,0.363 0.149,0.243 0.227,0.606 0.227,1.09 z m -0.551,0 c 0,-0.258 -0.016,-0.461 -0.039,-0.605 -0.024,-0.145 -0.063,-0.25 -0.117,-0.313 -0.055,-0.062 -0.137,-0.093 -0.239,-0.093 -0.113,0 -0.195,0.031 -0.254,0.097 -0.054,0.063 -0.097,0.164 -0.121,0.309 -0.023,0.144 -0.035,0.347 -0.035,0.605 0,0.262 0.012,0.461 0.039,0.61 0.024,0.144 0.067,0.246 0.121,0.308 0.055,0.063 0.137,0.094 0.243,0.094 0.101,0 0.183,-0.031 0.238,-0.098 0.058,-0.066 0.098,-0.172 0.125,-0.316 0.023,-0.149 0.039,-0.344 0.039,-0.598 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath317)"
+           id="path826" />
+        <path
+           d="m 284.77,101.527 v -0.422 h 0.683 v -1.929 l -0.66,0.426 v -0.446 l 0.687,-0.461 H 286 v 2.41 h 0.633 v 0.422 z m 2.113,0 v -0.394 c 0.07,-0.16 0.172,-0.321 0.305,-0.473 0.132,-0.152 0.296,-0.316 0.5,-0.48 0.191,-0.16 0.324,-0.293 0.402,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.368 -0.359,-0.368 -0.118,0 -0.207,0.032 -0.27,0.098 -0.062,0.063 -0.101,0.16 -0.121,0.289 l -0.551,-0.031 c 0.032,-0.262 0.125,-0.461 0.285,-0.598 0.161,-0.14 0.375,-0.207 0.653,-0.207 0.297,0 0.523,0.067 0.683,0.207 0.157,0.141 0.239,0.336 0.239,0.586 0,0.133 -0.028,0.254 -0.078,0.36 -0.051,0.105 -0.118,0.207 -0.196,0.296 -0.078,0.09 -0.168,0.176 -0.265,0.254 -0.098,0.079 -0.192,0.157 -0.282,0.231 -0.09,0.074 -0.175,0.152 -0.25,0.226 -0.074,0.079 -0.129,0.161 -0.164,0.246 h 1.278 v 0.461 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath318)"
+           id="path827" />
+        <path
+           d="m 284.77,107.352 v -0.418 h 0.683 v -1.93 l -0.66,0.422 v -0.442 l 0.687,-0.461 H 286 v 2.411 h 0.633 v 0.418 z m 3.808,-0.575 v 0.575 h -0.523 v -0.575 h -1.25 v -0.425 l 1.16,-1.829 h 0.613 v 1.832 h 0.367 v 0.422 z m -0.523,-1.347 c 0,-0.071 0.004,-0.149 0.007,-0.235 0.004,-0.082 0.008,-0.136 0.012,-0.16 -0.035,0.074 -0.097,0.184 -0.183,0.324 l -0.641,0.996 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath319)"
+           id="path828" />
+        <path
+           d="m 284.77,113.18 v -0.418 h 0.683 v -1.93 l -0.66,0.422 v -0.442 l 0.687,-0.46 H 286 v 2.41 h 0.633 v 0.418 z m 4.054,-0.926 c 0,0.301 -0.082,0.539 -0.246,0.707 -0.164,0.172 -0.39,0.258 -0.68,0.258 -0.324,0 -0.574,-0.117 -0.75,-0.348 -0.171,-0.234 -0.257,-0.582 -0.257,-1.039 0,-0.508 0.086,-0.887 0.261,-1.141 0.176,-0.253 0.43,-0.382 0.758,-0.382 0.235,0 0.418,0.054 0.551,0.16 0.137,0.105 0.23,0.269 0.289,0.492 l -0.52,0.074 c -0.05,-0.187 -0.16,-0.281 -0.332,-0.281 -0.148,0 -0.261,0.078 -0.347,0.226 -0.082,0.153 -0.125,0.383 -0.125,0.692 0.058,-0.102 0.14,-0.18 0.246,-0.234 0.101,-0.051 0.219,-0.079 0.351,-0.079 0.247,0 0.442,0.079 0.586,0.243 0.141,0.16 0.215,0.375 0.215,0.652 z m -0.551,0.016 c 0,-0.161 -0.039,-0.282 -0.109,-0.368 -0.074,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.039 -0.293,0.122 -0.074,0.078 -0.109,0.183 -0.109,0.316 0,0.164 0.039,0.301 0.113,0.41 0.078,0.106 0.176,0.16 0.301,0.16 0.125,0 0.219,-0.047 0.289,-0.136 0.07,-0.09 0.105,-0.215 0.105,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath320)"
+           id="path829" />
+        <path
+           d="m 284.77,119.008 v -0.418 h 0.683 v -1.93 l -0.66,0.422 v -0.445 l 0.687,-0.457 H 286 v 2.41 h 0.633 v 0.418 z m 4.074,-0.797 c 0,0.266 -0.086,0.469 -0.254,0.617 -0.172,0.149 -0.414,0.219 -0.731,0.219 -0.316,0 -0.558,-0.07 -0.73,-0.219 -0.172,-0.144 -0.258,-0.351 -0.258,-0.613 0,-0.18 0.051,-0.332 0.152,-0.457 0.102,-0.125 0.235,-0.199 0.407,-0.231 v -0.007 c -0.149,-0.032 -0.27,-0.11 -0.36,-0.227 -0.09,-0.117 -0.136,-0.254 -0.136,-0.406 0,-0.235 0.078,-0.414 0.238,-0.551 0.16,-0.133 0.387,-0.199 0.68,-0.199 0.296,0 0.523,0.066 0.683,0.195 0.16,0.133 0.242,0.316 0.242,0.559 0,0.152 -0.047,0.289 -0.136,0.406 -0.09,0.113 -0.211,0.187 -0.364,0.219 v 0.007 c 0.176,0.032 0.313,0.106 0.414,0.227 0.102,0.117 0.153,0.273 0.153,0.461 z m -0.633,-1.293 c 0,-0.133 -0.031,-0.23 -0.09,-0.293 -0.059,-0.063 -0.148,-0.094 -0.269,-0.094 -0.239,0 -0.356,0.129 -0.356,0.387 0,0.273 0.117,0.406 0.359,0.406 0.118,0 0.207,-0.031 0.266,-0.094 0.059,-0.062 0.09,-0.168 0.09,-0.312 z m 0.066,1.246 c 0,-0.297 -0.144,-0.445 -0.429,-0.445 -0.133,0 -0.239,0.039 -0.309,0.117 -0.07,0.078 -0.105,0.191 -0.105,0.336 0,0.168 0.035,0.289 0.105,0.363 0.07,0.078 0.18,0.113 0.324,0.113 0.141,0 0.246,-0.035 0.313,-0.113 0.066,-0.074 0.101,-0.199 0.101,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath321)"
+           id="path830" />
+        <path
+           d="m 284.656,124.836 v -0.395 c 0.071,-0.16 0.172,-0.32 0.305,-0.472 0.133,-0.153 0.301,-0.313 0.5,-0.481 0.191,-0.16 0.328,-0.293 0.406,-0.398 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.367 -0.363,-0.367 -0.117,0 -0.207,0.031 -0.269,0.098 -0.063,0.062 -0.102,0.16 -0.118,0.289 l -0.554,-0.031 c 0.031,-0.262 0.125,-0.461 0.285,-0.598 0.16,-0.141 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.066 0.684,0.207 0.16,0.14 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.359 -0.051,0.11 -0.117,0.207 -0.195,0.297 -0.082,0.09 -0.168,0.176 -0.266,0.254 -0.098,0.078 -0.192,0.156 -0.281,0.23 -0.094,0.075 -0.176,0.153 -0.25,0.227 -0.075,0.078 -0.133,0.16 -0.168,0.246 h 1.277 v 0.465 z m 4.149,-1.418 c 0,0.48 -0.082,0.84 -0.243,1.086 -0.16,0.246 -0.398,0.371 -0.714,0.371 -0.633,0 -0.946,-0.484 -0.946,-1.457 0,-0.336 0.032,-0.613 0.102,-0.828 0.07,-0.215 0.172,-0.371 0.312,-0.473 0.137,-0.101 0.321,-0.152 0.547,-0.152 0.325,0 0.563,0.121 0.715,0.363 0.149,0.242 0.227,0.606 0.227,1.09 z m -0.551,0 c 0,-0.262 -0.016,-0.461 -0.039,-0.606 -0.024,-0.144 -0.063,-0.25 -0.117,-0.312 -0.055,-0.062 -0.137,-0.094 -0.239,-0.094 -0.113,0 -0.195,0.032 -0.254,0.094 -0.054,0.062 -0.097,0.168 -0.121,0.312 -0.023,0.145 -0.035,0.344 -0.035,0.606 0,0.258 0.012,0.461 0.039,0.605 0.024,0.145 0.067,0.25 0.121,0.313 0.055,0.062 0.137,0.094 0.243,0.094 0.101,0 0.183,-0.032 0.238,-0.098 0.058,-0.066 0.098,-0.172 0.125,-0.32 0.023,-0.145 0.039,-0.344 0.039,-0.594 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath322)"
+           id="path831" />
+        <path
+           d="m 284.656,130.66 v -0.39 c 0.071,-0.161 0.172,-0.321 0.305,-0.473 0.133,-0.156 0.301,-0.317 0.5,-0.485 0.191,-0.16 0.328,-0.292 0.406,-0.394 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.371 -0.363,-0.371 -0.117,0 -0.207,0.035 -0.269,0.102 -0.063,0.062 -0.102,0.16 -0.118,0.289 l -0.554,-0.031 c 0.031,-0.262 0.125,-0.465 0.285,-0.602 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.07 0.684,0.211 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.023,0.25 -0.074,0.359 -0.051,0.106 -0.117,0.207 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.254 -0.098,0.078 -0.192,0.152 -0.281,0.231 -0.094,0.074 -0.176,0.148 -0.25,0.226 -0.075,0.074 -0.133,0.156 -0.168,0.242 h 1.277 v 0.465 z m 2.227,0 v -0.39 c 0.07,-0.161 0.172,-0.321 0.305,-0.473 0.132,-0.156 0.296,-0.317 0.5,-0.485 0.191,-0.16 0.324,-0.292 0.402,-0.394 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.371 -0.359,-0.371 -0.118,0 -0.207,0.035 -0.27,0.102 -0.062,0.062 -0.101,0.16 -0.121,0.289 l -0.551,-0.031 c 0.032,-0.262 0.125,-0.465 0.285,-0.602 0.161,-0.137 0.375,-0.207 0.653,-0.207 0.297,0 0.523,0.07 0.683,0.211 0.157,0.137 0.239,0.332 0.239,0.586 0,0.133 -0.028,0.25 -0.078,0.359 -0.051,0.106 -0.118,0.207 -0.196,0.297 -0.078,0.09 -0.168,0.172 -0.265,0.254 -0.098,0.078 -0.192,0.152 -0.282,0.231 -0.09,0.074 -0.175,0.148 -0.25,0.226 -0.074,0.074 -0.129,0.156 -0.164,0.242 h 1.278 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath323)"
+           id="path832" />
+        <path
+           d="m 284.656,136.488 v -0.39 c 0.071,-0.164 0.172,-0.321 0.305,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.484 0.191,-0.161 0.328,-0.293 0.406,-0.395 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.247 -0.121,-0.372 -0.363,-0.372 -0.117,0 -0.207,0.036 -0.269,0.102 -0.063,0.062 -0.102,0.16 -0.118,0.289 l -0.554,-0.031 c 0.031,-0.262 0.125,-0.465 0.285,-0.602 0.16,-0.136 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.071 0.684,0.211 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.023,0.25 -0.074,0.359 -0.051,0.106 -0.117,0.204 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.254 -0.098,0.078 -0.192,0.153 -0.281,0.231 -0.094,0.074 -0.176,0.148 -0.25,0.226 -0.075,0.074 -0.133,0.157 -0.168,0.242 h 1.277 v 0.465 z m 3.922,-0.574 v 0.574 h -0.523 v -0.574 h -1.25 v -0.426 l 1.16,-1.828 h 0.613 v 1.832 h 0.367 v 0.422 z m -0.523,-1.348 c 0,-0.07 0.004,-0.148 0.007,-0.234 0.004,-0.082 0.008,-0.137 0.012,-0.16 -0.035,0.074 -0.097,0.18 -0.183,0.324 l -0.641,0.996 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath324)"
+           id="path833" />
+        <path
+           d="m 284.656,142.316 v -0.39 c 0.071,-0.164 0.172,-0.321 0.305,-0.477 0.133,-0.152 0.301,-0.312 0.5,-0.48 0.191,-0.16 0.328,-0.293 0.406,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.304 0,-0.25 -0.121,-0.371 -0.363,-0.371 -0.117,0 -0.207,0.031 -0.269,0.097 -0.063,0.067 -0.102,0.16 -0.118,0.293 l -0.554,-0.035 c 0.031,-0.262 0.125,-0.461 0.285,-0.598 0.16,-0.14 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.071 0.684,0.207 0.16,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.36 -0.051,0.109 -0.117,0.207 -0.195,0.297 -0.082,0.089 -0.168,0.175 -0.266,0.253 -0.098,0.079 -0.192,0.157 -0.281,0.231 -0.094,0.074 -0.176,0.152 -0.25,0.226 -0.075,0.079 -0.133,0.161 -0.168,0.247 h 1.277 v 0.464 z m 4.168,-0.925 c 0,0.3 -0.082,0.535 -0.246,0.707 -0.164,0.172 -0.39,0.257 -0.68,0.257 -0.324,0 -0.574,-0.117 -0.75,-0.347 -0.171,-0.235 -0.257,-0.582 -0.257,-1.043 0,-0.504 0.086,-0.883 0.261,-1.137 0.176,-0.254 0.43,-0.383 0.758,-0.383 0.235,0 0.418,0.051 0.551,0.157 0.137,0.109 0.23,0.269 0.289,0.492 l -0.52,0.074 c -0.05,-0.184 -0.16,-0.277 -0.332,-0.277 -0.148,0 -0.261,0.074 -0.347,0.226 -0.082,0.153 -0.125,0.379 -0.125,0.688 0.058,-0.098 0.14,-0.176 0.246,-0.231 0.101,-0.054 0.219,-0.078 0.351,-0.078 0.247,0 0.442,0.078 0.586,0.238 0.141,0.161 0.215,0.379 0.215,0.657 z m -0.551,0.015 c 0,-0.16 -0.039,-0.285 -0.109,-0.367 -0.074,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.039 -0.293,0.121 -0.074,0.078 -0.109,0.184 -0.109,0.317 0,0.164 0.039,0.3 0.113,0.406 0.078,0.109 0.176,0.16 0.301,0.16 0.125,0 0.219,-0.043 0.289,-0.133 0.07,-0.09 0.105,-0.215 0.105,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath325)"
+           id="path834" />
+        <path
+           d="m 284.656,148.141 v -0.391 c 0.071,-0.16 0.172,-0.32 0.305,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.48 0.191,-0.164 0.328,-0.293 0.406,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.367 -0.363,-0.367 -0.117,0 -0.207,0.031 -0.269,0.097 -0.063,0.063 -0.102,0.16 -0.118,0.289 l -0.554,-0.031 c 0.031,-0.262 0.125,-0.461 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.07 0.684,0.21 0.16,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.36 -0.051,0.105 -0.117,0.207 -0.195,0.297 -0.082,0.089 -0.168,0.175 -0.266,0.254 -0.098,0.078 -0.192,0.156 -0.281,0.23 -0.094,0.074 -0.176,0.148 -0.25,0.227 -0.075,0.074 -0.133,0.156 -0.168,0.246 h 1.277 v 0.461 z m 4.188,-0.797 c 0,0.265 -0.086,0.472 -0.254,0.621 -0.172,0.144 -0.414,0.219 -0.731,0.219 -0.316,0 -0.558,-0.075 -0.73,-0.219 -0.172,-0.149 -0.258,-0.352 -0.258,-0.617 0,-0.18 0.051,-0.332 0.152,-0.453 0.102,-0.125 0.235,-0.204 0.407,-0.231 v -0.008 c -0.149,-0.035 -0.27,-0.109 -0.36,-0.23 -0.09,-0.117 -0.136,-0.25 -0.136,-0.406 0,-0.231 0.078,-0.415 0.238,-0.547 0.16,-0.133 0.387,-0.203 0.68,-0.203 0.296,0 0.523,0.066 0.683,0.199 0.16,0.129 0.242,0.316 0.242,0.554 0,0.157 -0.047,0.289 -0.136,0.407 -0.09,0.117 -0.211,0.191 -0.364,0.222 v 0.008 c 0.176,0.028 0.313,0.102 0.414,0.223 0.102,0.121 0.153,0.273 0.153,0.461 z m -0.633,-1.289 c 0,-0.133 -0.031,-0.231 -0.09,-0.293 -0.059,-0.063 -0.148,-0.094 -0.269,-0.094 -0.239,0 -0.356,0.129 -0.356,0.387 0,0.269 0.117,0.406 0.359,0.406 0.118,0 0.207,-0.031 0.266,-0.094 0.059,-0.066 0.09,-0.168 0.09,-0.312 z m 0.066,1.246 c 0,-0.297 -0.144,-0.446 -0.429,-0.446 -0.133,0 -0.239,0.04 -0.309,0.118 -0.07,0.078 -0.105,0.187 -0.105,0.336 0,0.164 0.035,0.285 0.105,0.363 0.07,0.074 0.18,0.113 0.324,0.113 0.141,0 0.246,-0.039 0.313,-0.113 0.066,-0.078 0.101,-0.203 0.101,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath326)"
+           id="path835" />
+        <path
+           d="m 286.598,153.184 c 0,0.265 -0.086,0.468 -0.254,0.613 -0.168,0.144 -0.41,0.219 -0.723,0.219 -0.297,0 -0.531,-0.071 -0.703,-0.211 -0.176,-0.141 -0.277,-0.34 -0.309,-0.606 l 0.559,-0.051 c 0.035,0.274 0.187,0.411 0.453,0.411 0.129,0 0.231,-0.036 0.305,-0.102 0.074,-0.066 0.109,-0.168 0.109,-0.309 0,-0.125 -0.043,-0.222 -0.133,-0.289 -0.09,-0.066 -0.218,-0.097 -0.394,-0.097 h -0.192 v -0.457 h 0.18 c 0.156,0 0.277,-0.032 0.356,-0.098 0.078,-0.066 0.121,-0.164 0.121,-0.285 0,-0.117 -0.035,-0.207 -0.098,-0.274 -0.063,-0.066 -0.152,-0.101 -0.273,-0.101 -0.114,0 -0.207,0.031 -0.278,0.098 -0.07,0.062 -0.109,0.156 -0.117,0.273 l -0.551,-0.039 c 0.028,-0.246 0.129,-0.438 0.297,-0.574 0.168,-0.137 0.387,-0.207 0.656,-0.207 0.289,0 0.512,0.066 0.676,0.203 0.16,0.129 0.242,0.316 0.242,0.551 0,0.175 -0.05,0.32 -0.152,0.433 -0.102,0.113 -0.246,0.192 -0.434,0.227 v 0.011 c 0.211,0.024 0.371,0.094 0.485,0.215 0.113,0.114 0.172,0.266 0.172,0.446 z m 2.207,-0.629 c 0,0.476 -0.082,0.84 -0.243,1.086 -0.16,0.246 -0.398,0.367 -0.714,0.367 -0.633,0 -0.946,-0.485 -0.946,-1.453 0,-0.34 0.032,-0.617 0.102,-0.832 0.07,-0.211 0.172,-0.371 0.312,-0.473 0.137,-0.102 0.321,-0.152 0.547,-0.152 0.325,0 0.563,0.121 0.715,0.363 0.149,0.242 0.227,0.605 0.227,1.094 z m -0.551,0 c 0,-0.262 -0.016,-0.465 -0.039,-0.61 -0.024,-0.144 -0.063,-0.25 -0.117,-0.312 -0.055,-0.063 -0.137,-0.094 -0.239,-0.094 -0.113,0 -0.195,0.031 -0.254,0.098 -0.054,0.062 -0.097,0.164 -0.121,0.308 -0.023,0.145 -0.035,0.348 -0.035,0.61 0,0.257 0.012,0.461 0.039,0.605 0.024,0.145 0.067,0.246 0.121,0.313 0.055,0.062 0.137,0.093 0.243,0.093 0.101,0 0.183,-0.035 0.238,-0.097 0.058,-0.071 0.098,-0.176 0.125,-0.321 0.023,-0.148 0.039,-0.343 0.039,-0.593 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath327)"
+           id="path836" />
+        <path
+           d="m 286.598,159.012 c 0,0.265 -0.086,0.468 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.297,0 -0.531,-0.071 -0.703,-0.211 -0.176,-0.141 -0.277,-0.34 -0.309,-0.606 l 0.559,-0.05 c 0.035,0.273 0.187,0.41 0.453,0.41 0.129,0 0.231,-0.035 0.305,-0.102 0.074,-0.066 0.109,-0.168 0.109,-0.308 0,-0.125 -0.043,-0.223 -0.133,-0.289 -0.09,-0.067 -0.218,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.156,0 0.277,-0.031 0.356,-0.098 0.078,-0.066 0.121,-0.164 0.121,-0.285 0,-0.117 -0.035,-0.207 -0.098,-0.273 -0.063,-0.067 -0.152,-0.102 -0.273,-0.102 -0.114,0 -0.207,0.031 -0.278,0.098 -0.07,0.062 -0.109,0.156 -0.117,0.273 l -0.551,-0.043 c 0.028,-0.242 0.129,-0.433 0.297,-0.57 0.168,-0.137 0.387,-0.207 0.656,-0.207 0.289,0 0.512,0.066 0.676,0.199 0.16,0.133 0.242,0.316 0.242,0.555 0,0.175 -0.05,0.32 -0.152,0.433 -0.102,0.114 -0.246,0.192 -0.434,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.485,0.214 0.113,0.118 0.172,0.266 0.172,0.45 z m 0.285,0.785 v -0.391 c 0.07,-0.164 0.172,-0.32 0.305,-0.476 0.132,-0.153 0.296,-0.313 0.5,-0.481 0.191,-0.16 0.324,-0.293 0.402,-0.398 0.078,-0.102 0.117,-0.207 0.117,-0.305 0,-0.246 -0.121,-0.371 -0.359,-0.371 -0.118,0 -0.207,0.035 -0.27,0.098 -0.062,0.066 -0.101,0.164 -0.121,0.293 l -0.551,-0.032 c 0.032,-0.265 0.125,-0.464 0.285,-0.601 0.161,-0.137 0.375,-0.207 0.653,-0.207 0.297,0 0.523,0.07 0.683,0.207 0.157,0.14 0.239,0.336 0.239,0.59 0,0.129 -0.028,0.25 -0.078,0.359 -0.051,0.106 -0.118,0.203 -0.196,0.297 -0.078,0.09 -0.168,0.172 -0.265,0.25 -0.098,0.082 -0.192,0.156 -0.282,0.23 -0.09,0.079 -0.175,0.153 -0.25,0.231 -0.074,0.074 -0.129,0.156 -0.164,0.242 h 1.278 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath328)"
+           id="path837" />
+        <path
+           d="m 286.598,164.84 c 0,0.262 -0.086,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.215 -0.723,0.215 -0.297,0 -0.531,-0.066 -0.703,-0.207 -0.176,-0.141 -0.277,-0.344 -0.309,-0.606 l 0.559,-0.05 c 0.035,0.269 0.187,0.406 0.453,0.406 0.129,0 0.231,-0.031 0.305,-0.098 0.074,-0.07 0.109,-0.172 0.109,-0.308 0,-0.125 -0.043,-0.223 -0.133,-0.289 -0.09,-0.067 -0.218,-0.102 -0.394,-0.102 h -0.192 v -0.453 h 0.18 c 0.156,0 0.277,-0.035 0.356,-0.102 0.078,-0.066 0.121,-0.16 0.121,-0.285 0,-0.113 -0.035,-0.207 -0.098,-0.269 -0.063,-0.071 -0.152,-0.102 -0.273,-0.102 -0.114,0 -0.207,0.031 -0.278,0.098 -0.07,0.062 -0.109,0.152 -0.117,0.269 l -0.551,-0.039 c 0.028,-0.242 0.129,-0.433 0.297,-0.57 0.168,-0.141 0.387,-0.207 0.656,-0.207 0.289,0 0.512,0.066 0.676,0.199 0.16,0.133 0.242,0.317 0.242,0.551 0,0.18 -0.05,0.324 -0.152,0.437 -0.102,0.114 -0.246,0.188 -0.434,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.485,0.215 0.113,0.117 0.172,0.265 0.172,0.449 z m 1.98,0.207 v 0.578 h -0.523 v -0.578 h -1.25 v -0.422 l 1.16,-1.832 h 0.613 v 1.836 h 0.367 v 0.418 z m -0.523,-1.344 c 0,-0.074 0.004,-0.152 0.007,-0.234 0.004,-0.086 0.008,-0.141 0.012,-0.164 -0.035,0.074 -0.097,0.183 -0.183,0.324 l -0.641,1 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath329)"
+           id="path838" />
+        <path
+           d="m 286.598,170.664 c 0,0.266 -0.086,0.473 -0.254,0.617 -0.168,0.145 -0.41,0.215 -0.723,0.215 -0.297,0 -0.531,-0.07 -0.703,-0.207 -0.176,-0.141 -0.277,-0.344 -0.309,-0.609 l 0.559,-0.047 c 0.035,0.269 0.187,0.406 0.453,0.406 0.129,0 0.231,-0.035 0.305,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.043,-0.223 -0.133,-0.289 -0.09,-0.071 -0.218,-0.102 -0.394,-0.102 h -0.192 v -0.457 h 0.18 c 0.156,0 0.277,-0.031 0.356,-0.097 0.078,-0.067 0.121,-0.161 0.121,-0.286 0,-0.117 -0.035,-0.207 -0.098,-0.273 -0.063,-0.067 -0.152,-0.102 -0.273,-0.102 -0.114,0 -0.207,0.035 -0.278,0.098 -0.07,0.066 -0.109,0.156 -0.117,0.273 l -0.551,-0.039 c 0.028,-0.246 0.129,-0.433 0.297,-0.574 0.168,-0.137 0.387,-0.207 0.656,-0.207 0.289,0 0.512,0.067 0.676,0.203 0.16,0.133 0.242,0.317 0.242,0.551 0,0.176 -0.05,0.32 -0.152,0.438 -0.102,0.113 -0.246,0.187 -0.434,0.226 v 0.008 c 0.211,0.023 0.371,0.098 0.485,0.215 0.113,0.117 0.172,0.265 0.172,0.445 z m 2.226,-0.141 c 0,0.301 -0.082,0.539 -0.246,0.711 -0.164,0.172 -0.39,0.258 -0.68,0.258 -0.324,0 -0.574,-0.117 -0.75,-0.351 -0.171,-0.235 -0.257,-0.582 -0.257,-1.039 0,-0.504 0.086,-0.883 0.261,-1.141 0.176,-0.254 0.43,-0.383 0.758,-0.383 0.235,0 0.418,0.055 0.551,0.16 0.137,0.106 0.23,0.27 0.289,0.492 l -0.52,0.075 c -0.05,-0.188 -0.16,-0.282 -0.332,-0.282 -0.148,0 -0.261,0.079 -0.347,0.227 -0.082,0.152 -0.125,0.383 -0.125,0.691 0.058,-0.101 0.14,-0.179 0.246,-0.23 0.101,-0.055 0.219,-0.082 0.351,-0.082 0.247,0 0.442,0.082 0.586,0.242 0.141,0.16 0.215,0.379 0.215,0.652 z m -0.551,0.016 c 0,-0.16 -0.039,-0.281 -0.109,-0.367 -0.074,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.043 -0.293,0.121 -0.074,0.082 -0.109,0.184 -0.109,0.316 0,0.165 0.039,0.301 0.113,0.411 0.078,0.105 0.176,0.16 0.301,0.16 0.125,0 0.219,-0.047 0.289,-0.133 0.07,-0.094 0.105,-0.219 0.105,-0.379 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath330)"
+           id="path839" />
+        <path
+           d="m 286.598,176.492 c 0,0.266 -0.086,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.297,0 -0.531,-0.07 -0.703,-0.207 -0.176,-0.14 -0.277,-0.344 -0.309,-0.609 l 0.559,-0.051 c 0.035,0.273 0.187,0.41 0.453,0.41 0.129,0 0.231,-0.035 0.305,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.043,-0.223 -0.133,-0.293 -0.09,-0.066 -0.218,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.156,0 0.277,-0.031 0.356,-0.097 0.078,-0.067 0.121,-0.161 0.121,-0.286 0,-0.117 -0.035,-0.207 -0.098,-0.273 -0.063,-0.066 -0.152,-0.102 -0.273,-0.102 -0.114,0 -0.207,0.036 -0.278,0.098 -0.07,0.067 -0.109,0.156 -0.117,0.274 l -0.551,-0.039 c 0.028,-0.247 0.129,-0.438 0.297,-0.575 0.168,-0.136 0.387,-0.207 0.656,-0.207 0.289,0 0.512,0.067 0.676,0.203 0.16,0.133 0.242,0.317 0.242,0.551 0,0.176 -0.05,0.32 -0.152,0.438 -0.102,0.113 -0.246,0.187 -0.434,0.226 v 0.008 c 0.211,0.023 0.371,0.098 0.485,0.215 0.113,0.113 0.172,0.265 0.172,0.445 z m 2.246,-0.012 c 0,0.266 -0.086,0.473 -0.254,0.618 -0.172,0.148 -0.414,0.218 -0.731,0.218 -0.316,0 -0.558,-0.07 -0.73,-0.218 -0.172,-0.145 -0.258,-0.348 -0.258,-0.614 0,-0.179 0.051,-0.332 0.152,-0.453 0.102,-0.125 0.235,-0.203 0.407,-0.234 v -0.008 c -0.149,-0.031 -0.27,-0.109 -0.36,-0.227 -0.09,-0.117 -0.136,-0.253 -0.136,-0.406 0,-0.23 0.078,-0.414 0.238,-0.547 0.16,-0.136 0.387,-0.203 0.68,-0.203 0.296,0 0.523,0.067 0.683,0.199 0.16,0.129 0.242,0.313 0.242,0.555 0,0.152 -0.047,0.289 -0.136,0.406 -0.09,0.118 -0.211,0.188 -0.364,0.219 v 0.008 c 0.176,0.031 0.313,0.105 0.414,0.227 0.102,0.117 0.153,0.273 0.153,0.46 z m -0.633,-1.289 c 0,-0.136 -0.031,-0.234 -0.09,-0.293 -0.059,-0.062 -0.148,-0.097 -0.269,-0.097 -0.239,0 -0.356,0.133 -0.356,0.39 0,0.27 0.117,0.403 0.359,0.403 0.118,0 0.207,-0.032 0.266,-0.094 0.059,-0.062 0.09,-0.164 0.09,-0.309 z m 0.066,1.243 c 0,-0.293 -0.144,-0.442 -0.429,-0.442 -0.133,0 -0.239,0.039 -0.309,0.117 -0.07,0.075 -0.105,0.188 -0.105,0.332 0,0.168 0.035,0.289 0.105,0.364 0.07,0.078 0.18,0.117 0.324,0.117 0.141,0 0.246,-0.039 0.313,-0.117 0.066,-0.075 0.101,-0.2 0.101,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath331)"
+           id="path840" />
+        <path
+           d="m 134.179,82.512 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath332)"
+           id="path841" />
+        <path
+           d="m 134.179,70.855 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath333)"
+           id="path842" />
+        <path
+           d="m 134.179,76.684 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath334)"
+           id="path843" />
+        <path
+           d="m 134.179,169.918 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath335)"
+           id="path844" />
+        <path
+           d="m 134.179,175.742 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath336)"
+           id="path845" />
+        <path
+           d="m 134.179,158.262 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath337)"
+           id="path846" />
+        <path
+           d="m 134.179,164.09 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath338)"
+           id="path847" />
+        <path
+           d="m 134.179,146.609 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath339)"
+           id="path848" />
+        <path
+           d="m 134.179,152.434 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath340)"
+           id="path849" />
+        <path
+           d="m 134.179,134.953 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath341)"
+           id="path850" />
+        <path
+           d="m 134.179,140.781 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath342)"
+           id="path851" />
+        <path
+           d="m 134.179,123.301 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath343)"
+           id="path852" />
+        <path
+           d="m 134.179,129.125 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath344)"
+           id="path853" />
+        <path
+           d="m 134.179,111.645 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath345)"
+           id="path854" />
+        <path
+           d="m 134.179,117.473 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath346)"
+           id="path855" />
+        <path
+           d="m 134.179,99.992 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath347)"
+           id="path856" />
+        <path
+           d="m 134.179,105.82 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath348)"
+           id="path857" />
+        <path
+           d="m 134.179,88.336 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath349)"
+           id="path858" />
+        <path
+           d="m 134.179,94.164 h 34.964"
+           style="fill:none;stroke:#000000;stroke-width:1.2338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath350)"
+           id="path859" />
+        <path
+           d="m 153.301,172.836 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath351)"
+           id="path860" />
+        <path
+           d="m 157.557,172.832 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath352)"
+           id="path861" />
+        <path
+           d="m 153.301,167.008 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath353)"
+           id="path862" />
+        <path
+           d="m 157.557,167.008 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath354)"
+           id="path863" />
+        <path
+           d="m 153.301,161.18 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath355)"
+           id="path864" />
+        <path
+           d="m 157.557,161.18 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath356)"
+           id="path865" />
+        <path
+           d="m 153.301,155.355 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath357)"
+           id="path866" />
+        <path
+           d="m 157.557,155.352 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath358)"
+           id="path867" />
+        <path
+           d="m 153.301,149.527 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath359)"
+           id="path868" />
+        <path
+           d="m 157.557,149.527 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath360)"
+           id="path869" />
+        <path
+           d="m 153.301,143.699 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath361)"
+           id="path870" />
+        <path
+           d="m 157.557,143.699 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath362)"
+           id="path871" />
+        <path
+           d="m 155.277,147.852 v -0.422 h 0.684 v -1.926 l -0.66,0.422 v -0.446 l 0.687,-0.457 h 0.52 v 2.407 h 0.633 v 0.422 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath363)"
+           id="path872" />
+        <path
+           d="m 155.164,153.68 v -0.395 c 0.074,-0.16 0.176,-0.32 0.305,-0.473 0.133,-0.152 0.301,-0.316 0.5,-0.48 0.195,-0.16 0.328,-0.293 0.406,-0.398 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.367 -0.363,-0.367 -0.117,0 -0.207,0.031 -0.27,0.097 -0.058,0.063 -0.097,0.161 -0.117,0.29 l -0.554,-0.032 c 0.031,-0.261 0.128,-0.461 0.285,-0.597 0.16,-0.141 0.379,-0.207 0.652,-0.207 0.297,0 0.527,0.066 0.684,0.207 0.16,0.14 0.238,0.336 0.238,0.586 0,0.132 -0.024,0.253 -0.074,0.359 -0.051,0.105 -0.118,0.207 -0.196,0.297 -0.078,0.09 -0.168,0.176 -0.265,0.254 -0.098,0.078 -0.192,0.156 -0.282,0.23 -0.089,0.074 -0.175,0.153 -0.25,0.227 -0.074,0.078 -0.128,0.16 -0.168,0.246 h 1.278 v 0.461 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath364)"
+           id="path873" />
+        <path
+           d="m 157.105,158.719 c 0,0.265 -0.082,0.469 -0.253,0.613 -0.168,0.145 -0.411,0.219 -0.723,0.219 -0.293,0 -0.527,-0.071 -0.703,-0.207 -0.176,-0.141 -0.278,-0.344 -0.309,-0.61 l 0.559,-0.05 c 0.035,0.273 0.187,0.41 0.453,0.41 0.133,0 0.234,-0.035 0.305,-0.102 0.074,-0.066 0.109,-0.168 0.109,-0.308 0,-0.125 -0.043,-0.219 -0.133,-0.289 -0.086,-0.067 -0.219,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.16,0 0.277,-0.031 0.355,-0.098 0.082,-0.066 0.121,-0.164 0.121,-0.285 0,-0.117 -0.031,-0.207 -0.097,-0.273 -0.063,-0.067 -0.153,-0.102 -0.274,-0.102 -0.113,0 -0.207,0.035 -0.277,0.098 -0.066,0.062 -0.105,0.156 -0.117,0.273 l -0.551,-0.039 c 0.031,-0.246 0.129,-0.437 0.297,-0.574 0.168,-0.137 0.387,-0.207 0.656,-0.207 0.289,0 0.516,0.066 0.676,0.203 0.164,0.133 0.242,0.316 0.242,0.551 0,0.175 -0.051,0.32 -0.152,0.437 -0.098,0.114 -0.242,0.188 -0.434,0.227 v 0.008 c 0.211,0.023 0.371,0.093 0.485,0.214 0.117,0.114 0.171,0.266 0.171,0.446 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath365)"
+           id="path874" />
+        <path
+           d="m 156.863,164.758 v 0.574 h -0.523 v -0.574 h -1.254 v -0.426 l 1.164,-1.828 h 0.613 v 1.832 h 0.367 v 0.422 z m -0.523,-1.348 c 0,-0.07 0,-0.148 0.004,-0.234 0.008,-0.082 0.011,-0.137 0.011,-0.16 -0.031,0.074 -0.093,0.179 -0.183,0.324 l -0.637,0.996 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath366)"
+           id="path875" />
+        <path
+           d="m 157.141,170.219 c 0,0.297 -0.09,0.539 -0.274,0.715 -0.179,0.175 -0.429,0.265 -0.746,0.265 -0.277,0 -0.496,-0.062 -0.664,-0.191 -0.164,-0.129 -0.269,-0.313 -0.309,-0.555 l 0.551,-0.047 c 0.028,0.121 0.078,0.207 0.153,0.262 0.074,0.055 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.043 0.328,-0.133 0.082,-0.09 0.121,-0.219 0.121,-0.387 0,-0.148 -0.035,-0.269 -0.113,-0.355 -0.078,-0.09 -0.184,-0.137 -0.324,-0.137 -0.153,0 -0.274,0.063 -0.371,0.184 h -0.536 l 0.094,-1.59 h 1.656 v 0.418 h -1.156 l -0.047,0.715 c 0.133,-0.121 0.301,-0.18 0.5,-0.18 0.262,0 0.469,0.082 0.625,0.25 0.16,0.168 0.239,0.395 0.239,0.684 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath367)"
+           id="path876" />
+        <path
+           d="m 157.105,176.059 c 0,0.304 -0.082,0.539 -0.246,0.711 -0.164,0.171 -0.39,0.257 -0.679,0.257 -0.325,0 -0.571,-0.117 -0.746,-0.351 -0.172,-0.235 -0.262,-0.578 -0.262,-1.039 0,-0.504 0.09,-0.883 0.266,-1.137 0.175,-0.258 0.429,-0.387 0.757,-0.387 0.235,0 0.418,0.055 0.551,0.16 0.137,0.106 0.231,0.27 0.285,0.493 l -0.515,0.074 c -0.051,-0.188 -0.161,-0.278 -0.332,-0.278 -0.149,0 -0.262,0.075 -0.348,0.227 -0.082,0.149 -0.125,0.379 -0.125,0.688 0.059,-0.102 0.141,-0.18 0.242,-0.231 0.106,-0.055 0.223,-0.082 0.356,-0.082 0.246,0 0.441,0.082 0.582,0.242 0.144,0.16 0.214,0.379 0.214,0.653 z m -0.55,0.019 c 0,-0.164 -0.035,-0.285 -0.11,-0.367 -0.07,-0.086 -0.168,-0.129 -0.297,-0.129 -0.121,0 -0.214,0.039 -0.289,0.117 -0.074,0.082 -0.109,0.188 -0.109,0.317 0,0.164 0.039,0.3 0.113,0.41 0.078,0.105 0.176,0.16 0.301,0.16 0.125,0 0.219,-0.043 0.289,-0.133 0.07,-0.094 0.102,-0.219 0.102,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath368)"
+           id="path877" />
+        <path
+           d="m 153.301,132.047 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath369)"
+           id="path878" />
+        <path
+           d="m 157.557,132.043 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath370)"
+           id="path879" />
+        <path
+           d="m 153.301,126.219 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath371)"
+           id="path880" />
+        <path
+           d="m 157.557,126.219 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath372)"
+           id="path881" />
+        <path
+           d="m 153.301,120.391 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath373)"
+           id="path882" />
+        <path
+           d="m 157.557,120.391 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath374)"
+           id="path883" />
+        <path
+           d="m 153.301,114.566 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath375)"
+           id="path884" />
+        <path
+           d="m 157.557,114.562 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath376)"
+           id="path885" />
+        <path
+           d="m 153.301,108.738 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath377)"
+           id="path886" />
+        <path
+           d="m 157.557,108.738 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath378)"
+           id="path887" />
+        <path
+           d="m 153.301,102.91 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath379)"
+           id="path888" />
+        <path
+           d="m 157.557,102.91 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath380)"
+           id="path889" />
+        <path
+           d="m 153.301,97.086 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath381)"
+           id="path890" />
+        <path
+           d="m 157.557,97.082 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath382)"
+           id="path891" />
+        <path
+           d="m 153.301,91.258 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath383)"
+           id="path892" />
+        <path
+           d="m 157.557,91.254 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath384)"
+           id="path893" />
+        <path
+           d="m 155.277,95.406 v -0.418 h 0.684 v -1.929 l -0.66,0.425 v -0.445 l 0.687,-0.461 h 0.52 v 2.41 h 0.633 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath385)"
+           id="path894" />
+        <path
+           d="m 155.164,101.234 v -0.39 c 0.074,-0.164 0.176,-0.321 0.305,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.484 0.195,-0.16 0.328,-0.293 0.406,-0.399 0.078,-0.101 0.117,-0.207 0.117,-0.304 0,-0.246 -0.121,-0.372 -0.363,-0.372 -0.117,0 -0.207,0.036 -0.27,0.098 -0.058,0.067 -0.097,0.164 -0.117,0.293 l -0.554,-0.031 c 0.031,-0.262 0.128,-0.465 0.285,-0.602 0.16,-0.136 0.379,-0.207 0.652,-0.207 0.297,0 0.527,0.071 0.684,0.211 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.024,0.25 -0.074,0.36 -0.051,0.105 -0.118,0.203 -0.196,0.296 -0.078,0.09 -0.168,0.172 -0.265,0.25 -0.098,0.082 -0.192,0.157 -0.282,0.235 -0.089,0.074 -0.175,0.148 -0.25,0.226 -0.074,0.075 -0.128,0.157 -0.168,0.243 h 1.278 v 0.464 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath386)"
+           id="path895" />
+        <path
+           d="m 157.105,106.277 c 0,0.266 -0.082,0.469 -0.253,0.614 -0.168,0.144 -0.411,0.218 -0.723,0.218 -0.293,0 -0.527,-0.07 -0.703,-0.211 -0.176,-0.14 -0.278,-0.343 -0.309,-0.605 l 0.559,-0.051 c 0.035,0.274 0.187,0.406 0.453,0.406 0.133,0 0.234,-0.031 0.305,-0.097 0.074,-0.067 0.109,-0.172 0.109,-0.309 0,-0.125 -0.043,-0.222 -0.133,-0.289 -0.086,-0.066 -0.219,-0.101 -0.394,-0.101 h -0.192 v -0.454 h 0.18 c 0.16,0 0.277,-0.035 0.355,-0.097 0.082,-0.071 0.121,-0.164 0.121,-0.285 0,-0.118 -0.031,-0.211 -0.097,-0.274 -0.063,-0.066 -0.153,-0.101 -0.274,-0.101 -0.113,0 -0.207,0.031 -0.277,0.097 -0.066,0.063 -0.105,0.153 -0.117,0.274 l -0.551,-0.043 c 0.031,-0.242 0.129,-0.434 0.297,-0.571 0.168,-0.136 0.387,-0.207 0.656,-0.207 0.289,0 0.516,0.067 0.676,0.2 0.164,0.132 0.242,0.316 0.242,0.554 0,0.176 -0.051,0.321 -0.152,0.434 -0.098,0.113 -0.242,0.191 -0.434,0.226 v 0.008 c 0.211,0.028 0.371,0.098 0.485,0.215 0.117,0.117 0.171,0.266 0.171,0.449 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath387)"
+           id="path896" />
+        <path
+           d="m 156.863,112.312 v 0.575 h -0.523 v -0.575 h -1.254 v -0.425 l 1.164,-1.828 h 0.613 v 1.832 h 0.367 v 0.421 z m -0.523,-1.343 c 0,-0.074 0,-0.153 0.004,-0.239 0.008,-0.082 0.011,-0.136 0.011,-0.16 -0.031,0.075 -0.093,0.184 -0.183,0.325 l -0.637,0.996 h 0.805 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath388)"
+           id="path897" />
+        <path
+           d="m 157.141,117.773 c 0,0.301 -0.09,0.539 -0.274,0.715 -0.179,0.18 -0.429,0.266 -0.746,0.266 -0.277,0 -0.496,-0.063 -0.664,-0.192 -0.164,-0.124 -0.269,-0.312 -0.309,-0.554 l 0.551,-0.047 c 0.028,0.121 0.078,0.211 0.153,0.266 0.074,0.054 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.047 0.328,-0.137 0.082,-0.09 0.121,-0.219 0.121,-0.387 0,-0.148 -0.035,-0.265 -0.113,-0.355 -0.078,-0.09 -0.184,-0.133 -0.324,-0.133 -0.153,0 -0.274,0.058 -0.371,0.18 h -0.536 l 0.094,-1.59 h 1.656 v 0.418 h -1.156 l -0.047,0.715 c 0.133,-0.122 0.301,-0.18 0.5,-0.18 0.262,0 0.469,0.082 0.625,0.25 0.16,0.168 0.239,0.394 0.239,0.683 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath389)"
+           id="path898" />
+        <path
+           d="m 157.105,123.617 c 0,0.301 -0.082,0.539 -0.246,0.707 -0.164,0.172 -0.39,0.258 -0.679,0.258 -0.325,0 -0.571,-0.117 -0.746,-0.348 -0.172,-0.234 -0.262,-0.582 -0.262,-1.039 0,-0.507 0.09,-0.886 0.266,-1.14 0.175,-0.254 0.429,-0.383 0.757,-0.383 0.235,0 0.418,0.055 0.551,0.16 0.137,0.106 0.231,0.27 0.285,0.492 l -0.515,0.074 c -0.051,-0.187 -0.161,-0.281 -0.332,-0.281 -0.149,0 -0.262,0.078 -0.348,0.227 -0.082,0.152 -0.125,0.383 -0.125,0.691 0.059,-0.101 0.141,-0.18 0.242,-0.234 0.106,-0.051 0.223,-0.078 0.356,-0.078 0.246,0 0.441,0.078 0.582,0.242 0.144,0.16 0.214,0.375 0.214,0.652 z m -0.55,0.016 c 0,-0.16 -0.035,-0.281 -0.11,-0.367 -0.07,-0.086 -0.168,-0.129 -0.297,-0.129 -0.121,0 -0.214,0.039 -0.289,0.121 -0.074,0.078 -0.109,0.183 -0.109,0.316 0,0.164 0.039,0.301 0.113,0.41 0.078,0.106 0.176,0.161 0.301,0.161 0.125,0 0.219,-0.047 0.289,-0.137 0.07,-0.09 0.102,-0.215 0.102,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath390)"
+           id="path899" />
+        <path
+           d="m 157.074,127.988 c -0.121,0.2 -0.238,0.395 -0.351,0.586 -0.11,0.188 -0.203,0.379 -0.285,0.571 -0.083,0.187 -0.149,0.382 -0.196,0.585 -0.047,0.204 -0.07,0.415 -0.07,0.641 h -0.574 c 0,-0.238 0.031,-0.465 0.09,-0.683 0.062,-0.223 0.148,-0.446 0.261,-0.672 0.113,-0.231 0.321,-0.567 0.617,-1.012 h -1.367 v -0.465 h 1.875 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath391)"
+           id="path900" />
+        <path
+           d="m 157.129,135.398 c 0,0.266 -0.086,0.473 -0.258,0.618 -0.168,0.148 -0.414,0.222 -0.73,0.222 -0.313,0 -0.555,-0.074 -0.731,-0.222 -0.172,-0.145 -0.258,-0.348 -0.258,-0.614 0,-0.179 0.051,-0.332 0.153,-0.453 0.101,-0.125 0.238,-0.203 0.41,-0.234 v -0.008 c -0.149,-0.031 -0.27,-0.109 -0.36,-0.227 -0.089,-0.117 -0.136,-0.253 -0.136,-0.406 0,-0.23 0.078,-0.414 0.238,-0.547 0.16,-0.136 0.387,-0.203 0.676,-0.203 0.301,0 0.527,0.067 0.687,0.199 0.16,0.129 0.239,0.313 0.239,0.555 0,0.152 -0.043,0.289 -0.137,0.406 -0.09,0.118 -0.211,0.188 -0.363,0.219 v 0.008 c 0.179,0.031 0.316,0.105 0.418,0.227 0.101,0.117 0.152,0.273 0.152,0.46 z m -0.633,-1.289 c 0,-0.136 -0.031,-0.234 -0.09,-0.293 -0.058,-0.062 -0.152,-0.093 -0.273,-0.093 -0.235,0 -0.356,0.129 -0.356,0.386 0,0.27 0.121,0.407 0.36,0.407 0.121,0 0.211,-0.032 0.269,-0.098 0.059,-0.063 0.09,-0.164 0.09,-0.309 z m 0.063,1.243 c 0,-0.293 -0.141,-0.442 -0.43,-0.442 -0.133,0 -0.234,0.039 -0.305,0.117 -0.07,0.075 -0.105,0.188 -0.105,0.332 0,0.168 0.035,0.289 0.105,0.364 0.071,0.078 0.176,0.117 0.321,0.117 0.144,0 0.246,-0.039 0.312,-0.117 0.07,-0.075 0.102,-0.2 0.102,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath392)"
+           id="path901" />
+        <path
+           d="m 136.148,172.836 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath393)"
+           id="path902" />
+        <path
+           d="m 139.932,172.832 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath394)"
+           id="path903" />
+        <path
+           d="m 136.148,167.008 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath395)"
+           id="path904" />
+        <path
+           d="m 139.932,167.008 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath396)"
+           id="path905" />
+        <path
+           d="m 136.148,161.18 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath397)"
+           id="path906" />
+        <path
+           d="m 139.932,161.18 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath398)"
+           id="path907" />
+        <path
+           d="m 136.148,155.355 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath399)"
+           id="path908" />
+        <path
+           d="m 139.932,155.352 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath400)"
+           id="path909" />
+        <path
+           d="m 136.148,149.527 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath401)"
+           id="path910" />
+        <path
+           d="m 139.932,149.527 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath402)"
+           id="path911" />
+        <path
+           d="m 136.148,143.699 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath403)"
+           id="path912" />
+        <path
+           d="m 139.932,143.699 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath404)"
+           id="path913" />
+        <path
+           d="m 136.148,137.875 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath405)"
+           id="path914" />
+        <path
+           d="m 139.932,137.871 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath406)"
+           id="path915" />
+        <path
+           d="m 136.148,132.047 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath407)"
+           id="path916" />
+        <path
+           d="m 139.932,132.043 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath408)"
+           id="path917" />
+        <path
+           d="m 136.148,126.219 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath409)"
+           id="path918" />
+        <path
+           d="m 139.932,126.219 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath410)"
+           id="path919" />
+        <path
+           d="m 136.148,120.391 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath411)"
+           id="path920" />
+        <path
+           d="m 139.932,120.391 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath412)"
+           id="path921" />
+        <path
+           d="m 136.148,114.566 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath413)"
+           id="path922" />
+        <path
+           d="m 139.932,114.562 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath414)"
+           id="path923" />
+        <path
+           d="m 136.148,108.738 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath415)"
+           id="path924" />
+        <path
+           d="m 139.932,108.738 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath416)"
+           id="path925" />
+        <path
+           d="m 136.148,102.91 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath417)"
+           id="path926" />
+        <path
+           d="m 139.932,102.91 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath418)"
+           id="path927" />
+        <path
+           d="m 136.148,97.086 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath419)"
+           id="path928" />
+        <path
+           d="m 139.932,97.082 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath420)"
+           id="path929" />
+        <path
+           d="m 136.148,91.258 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath421)"
+           id="path930" />
+        <path
+           d="m 139.932,91.254 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath422)"
+           id="path931" />
+        <path
+           d="m 136.148,85.43 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath423)"
+           id="path932" />
+        <path
+           d="m 139.932,85.43 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath424)"
+           id="path933" />
+        <path
+           d="m 136.148,79.605 h 5.672 v 5.824 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath425)"
+           id="path934" />
+        <path
+           d="m 139.932,79.602 h 5.825 v 5.824 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath426)"
+           id="path935" />
+        <path
+           d="m 136.148,73.777 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath427)"
+           id="path936" />
+        <path
+           d="m 139.932,73.773 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath428)"
+           id="path937" />
+        <path
+           d="m 136.148,67.949 h 5.672 v 5.828 h -5.672 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath429)"
+           id="path938" />
+        <path
+           d="m 139.932,67.945 h 5.825 v 5.828 h -5.825 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath430)"
+           id="path939" />
+        <path
+           d="m 141.82,172.836 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath431)"
+           id="path940" />
+        <path
+           d="m 145.757,172.832 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath432)"
+           id="path941" />
+        <path
+           d="m 141.82,167.008 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath433)"
+           id="path942" />
+        <path
+           d="m 145.757,167.008 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath434)"
+           id="path943" />
+        <path
+           d="m 141.82,161.18 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath435)"
+           id="path944" />
+        <path
+           d="m 145.757,161.18 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath436)"
+           id="path945" />
+        <path
+           d="m 141.82,155.355 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath437)"
+           id="path946" />
+        <path
+           d="m 145.757,155.352 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath438)"
+           id="path947" />
+        <path
+           d="m 141.82,149.527 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath439)"
+           id="path948" />
+        <path
+           d="m 145.757,149.527 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath440)"
+           id="path949" />
+        <path
+           d="m 141.82,143.699 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath441)"
+           id="path950" />
+        <path
+           d="m 145.757,143.699 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath442)"
+           id="path951" />
+        <path
+           d="m 141.82,137.875 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath443)"
+           id="path952" />
+        <path
+           d="m 145.757,137.871 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath444)"
+           id="path953" />
+        <path
+           d="m 141.82,132.047 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath445)"
+           id="path954" />
+        <path
+           d="m 145.757,132.043 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath446)"
+           id="path955" />
+        <path
+           d="m 141.82,126.219 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath447)"
+           id="path956" />
+        <path
+           d="m 145.757,126.219 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath448)"
+           id="path957" />
+        <path
+           d="m 141.82,120.391 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath449)"
+           id="path958" />
+        <path
+           d="m 145.757,120.391 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath450)"
+           id="path959" />
+        <path
+           d="m 141.82,114.566 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath451)"
+           id="path960" />
+        <path
+           d="m 145.757,114.562 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath452)"
+           id="path961" />
+        <path
+           d="m 141.82,108.738 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath453)"
+           id="path962" />
+        <path
+           d="m 145.757,108.738 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath454)"
+           id="path963" />
+        <path
+           d="m 141.82,102.91 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath455)"
+           id="path964" />
+        <path
+           d="m 145.757,102.91 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath456)"
+           id="path965" />
+        <path
+           d="m 141.82,97.086 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath457)"
+           id="path966" />
+        <path
+           d="m 145.757,97.082 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath458)"
+           id="path967" />
+        <path
+           d="m 141.82,91.258 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath459)"
+           id="path968" />
+        <path
+           d="m 145.757,91.254 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath460)"
+           id="path969" />
+        <path
+           d="m 141.82,85.43 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath461)"
+           id="path970" />
+        <path
+           d="m 145.757,85.43 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath462)"
+           id="path971" />
+        <path
+           d="m 141.82,79.605 h 5.668 v 5.824 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath463)"
+           id="path972" />
+        <path
+           d="m 145.757,79.602 h 5.829 v 5.824 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath464)"
+           id="path973" />
+        <path
+           d="m 141.82,73.777 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath465)"
+           id="path974" />
+        <path
+           d="m 145.757,73.773 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath466)"
+           id="path975" />
+        <path
+           d="m 141.82,67.949 h 5.668 v 5.828 h -5.668 z"
+           style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath467)"
+           id="path976" />
+        <path
+           d="m 145.757,67.945 h 5.829 v 5.828 h -5.829 z"
+           style="fill:none;stroke:#000000;stroke-width:0.740074;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           transform="scale(1.297284,1.3333333)"
+           clip-path="url(#clipPath468)"
+           id="path977" />
+        <path
+           d="m 138.129,72.391 v -0.418 h 0.68 v -1.93 l -0.661,0.422 v -0.442 l 0.692,-0.461 h 0.519 v 2.411 h 0.629 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath469)"
+           id="path978" />
+        <path
+           d="m 139.957,77.434 c 0,0.265 -0.086,0.468 -0.254,0.613 -0.172,0.144 -0.41,0.219 -0.723,0.219 -0.296,0 -0.531,-0.071 -0.707,-0.211 -0.171,-0.141 -0.277,-0.344 -0.304,-0.606 l 0.558,-0.051 c 0.035,0.274 0.184,0.407 0.45,0.407 0.132,0 0.234,-0.032 0.308,-0.098 0.07,-0.066 0.11,-0.172 0.11,-0.309 0,-0.125 -0.047,-0.222 -0.133,-0.289 -0.09,-0.066 -0.223,-0.101 -0.395,-0.101 h -0.191 v -0.453 h 0.179 c 0.157,0 0.274,-0.035 0.356,-0.098 0.078,-0.07 0.117,-0.164 0.117,-0.285 0,-0.117 -0.031,-0.207 -0.094,-0.274 -0.062,-0.066 -0.156,-0.101 -0.277,-0.101 -0.113,0 -0.203,0.031 -0.273,0.098 -0.071,0.062 -0.11,0.152 -0.122,0.273 l -0.546,-0.043 c 0.027,-0.242 0.125,-0.434 0.293,-0.57 0.168,-0.137 0.386,-0.207 0.66,-0.207 0.285,0 0.511,0.066 0.672,0.199 0.164,0.133 0.246,0.316 0.246,0.555 0,0.175 -0.051,0.32 -0.153,0.433 -0.101,0.113 -0.246,0.192 -0.437,0.227 v 0.008 c 0.211,0.027 0.375,0.097 0.488,0.214 0.113,0.118 0.172,0.266 0.172,0.45 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath470)"
+           id="path979" />
+        <path
+           d="m 139.988,83.102 c 0,0.3 -0.09,0.539 -0.273,0.718 -0.18,0.176 -0.43,0.266 -0.746,0.266 -0.274,0 -0.496,-0.066 -0.664,-0.191 -0.164,-0.129 -0.266,-0.313 -0.305,-0.555 l 0.547,-0.047 c 0.031,0.121 0.082,0.207 0.152,0.262 0.074,0.054 0.164,0.082 0.278,0.082 0.136,0 0.246,-0.043 0.324,-0.133 0.082,-0.09 0.125,-0.219 0.125,-0.387 0,-0.152 -0.039,-0.269 -0.117,-0.355 -0.075,-0.09 -0.184,-0.137 -0.321,-0.137 -0.152,0 -0.277,0.063 -0.375,0.184 h -0.535 l 0.098,-1.594 h 1.652 v 0.422 h -1.156 l -0.043,0.715 c 0.133,-0.122 0.297,-0.184 0.496,-0.184 0.262,0 0.473,0.086 0.629,0.254 0.156,0.168 0.234,0.394 0.234,0.68 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath471)"
+           id="path980" />
+        <path
+           d="m 139.926,87.492 c -0.125,0.199 -0.242,0.395 -0.352,0.582 -0.109,0.188 -0.207,0.379 -0.289,0.571 -0.082,0.191 -0.144,0.386 -0.195,0.589 -0.047,0.2 -0.07,0.414 -0.07,0.637 h -0.571 c 0,-0.234 0.028,-0.461 0.09,-0.683 0.059,-0.219 0.145,-0.446 0.258,-0.672 0.113,-0.227 0.32,-0.567 0.617,-1.008 h -1.367 v -0.465 h 1.879 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath472)"
+           id="path981" />
+        <path
+           d="m 139.953,94.238 c 0,0.504 -0.09,0.879 -0.269,1.125 -0.176,0.25 -0.43,0.375 -0.758,0.375 -0.242,0 -0.434,-0.054 -0.571,-0.16 -0.136,-0.105 -0.234,-0.273 -0.293,-0.504 L 138.578,95 c 0.051,0.195 0.168,0.293 0.352,0.293 0.156,0 0.273,-0.074 0.355,-0.227 0.082,-0.148 0.125,-0.375 0.129,-0.671 -0.051,0.101 -0.133,0.179 -0.246,0.238 -0.109,0.055 -0.23,0.082 -0.363,0.082 -0.243,0 -0.434,-0.082 -0.578,-0.25 -0.141,-0.172 -0.211,-0.403 -0.211,-0.692 0,-0.296 0.082,-0.527 0.25,-0.695 0.168,-0.168 0.402,-0.25 0.711,-0.25 0.328,0 0.574,0.117 0.734,0.352 0.16,0.234 0.242,0.586 0.242,1.058 z m -0.582,-0.394 c 0,-0.176 -0.035,-0.317 -0.113,-0.418 -0.074,-0.106 -0.172,-0.156 -0.297,-0.156 -0.121,0 -0.215,0.046 -0.285,0.136 -0.071,0.09 -0.106,0.215 -0.106,0.371 0,0.161 0.035,0.285 0.106,0.379 0.066,0.094 0.164,0.141 0.289,0.141 0.117,0 0.215,-0.039 0.289,-0.121 0.078,-0.086 0.117,-0.196 0.117,-0.332 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath473)"
+           id="path982" />
+        <path
+           d="m 137.008,101.523 v -0.418 h 0.683 v -1.929 l -0.66,0.426 v -0.446 l 0.688,-0.461 h 0.519 v 2.41 h 0.633 v 0.418 z m 2.004,0 v -0.418 h 0.683 v -1.929 l -0.66,0.426 v -0.446 l 0.688,-0.461 h 0.519 v 2.41 h 0.633 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath474)"
+           id="path983" />
+        <path
+           d="m 137.008,107.352 v -0.418 h 0.683 v -1.93 l -0.66,0.422 v -0.442 l 0.688,-0.461 h 0.519 v 2.411 h 0.633 v 0.418 z m 4.051,-0.786 c 0,0.266 -0.082,0.473 -0.254,0.618 -0.168,0.144 -0.41,0.214 -0.723,0.214 -0.293,0 -0.527,-0.07 -0.703,-0.207 -0.176,-0.14 -0.277,-0.343 -0.309,-0.609 l 0.559,-0.047 c 0.035,0.27 0.187,0.406 0.453,0.406 0.133,0 0.234,-0.035 0.305,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.043,-0.223 -0.133,-0.289 -0.086,-0.07 -0.218,-0.101 -0.394,-0.101 h -0.192 v -0.457 h 0.18 c 0.16,0 0.277,-0.032 0.355,-0.098 0.083,-0.067 0.122,-0.16 0.122,-0.285 0,-0.117 -0.032,-0.207 -0.098,-0.274 -0.063,-0.066 -0.152,-0.101 -0.274,-0.101 -0.113,0 -0.207,0.035 -0.277,0.097 -0.066,0.067 -0.105,0.157 -0.117,0.274 l -0.551,-0.039 c 0.031,-0.246 0.129,-0.434 0.297,-0.574 0.168,-0.137 0.387,-0.208 0.656,-0.208 0.289,0 0.516,0.067 0.676,0.204 0.164,0.132 0.242,0.316 0.242,0.55 0,0.176 -0.05,0.321 -0.152,0.438 -0.098,0.113 -0.242,0.187 -0.434,0.226 v 0.008 c 0.211,0.024 0.371,0.098 0.485,0.215 0.117,0.117 0.172,0.266 0.172,0.445 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath475)"
+           id="path984" />
+        <path
+           d="m 137.008,113.18 v -0.418 h 0.683 v -1.93 l -0.66,0.422 v -0.445 l 0.688,-0.457 h 0.519 v 2.41 h 0.633 v 0.418 z m 4.086,-0.942 c 0,0.301 -0.09,0.539 -0.274,0.715 -0.179,0.18 -0.429,0.266 -0.746,0.266 -0.277,0 -0.496,-0.063 -0.664,-0.192 -0.164,-0.129 -0.269,-0.312 -0.308,-0.554 l 0.55,-0.047 c 0.028,0.121 0.078,0.207 0.153,0.265 0.074,0.055 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.046 0.328,-0.136 0.082,-0.09 0.121,-0.219 0.121,-0.387 0,-0.148 -0.035,-0.266 -0.113,-0.355 -0.078,-0.09 -0.184,-0.133 -0.324,-0.133 -0.152,0 -0.274,0.058 -0.371,0.179 h -0.535 l 0.093,-1.589 h 1.657 v 0.418 h -1.157 l -0.047,0.714 c 0.133,-0.121 0.301,-0.179 0.5,-0.179 0.262,0 0.469,0.082 0.625,0.25 0.161,0.168 0.239,0.394 0.239,0.683 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath476)"
+           id="path985" />
+        <path
+           d="m 137.008,119.008 v -0.422 h 0.683 v -1.926 l -0.66,0.422 v -0.445 l 0.688,-0.457 h 0.519 v 2.406 h 0.633 v 0.422 z m 4.019,-2.383 c -0.121,0.203 -0.238,0.398 -0.351,0.586 -0.11,0.187 -0.203,0.379 -0.285,0.57 -0.082,0.192 -0.149,0.387 -0.196,0.586 -0.047,0.203 -0.07,0.414 -0.07,0.641 h -0.574 c 0,-0.235 0.031,-0.465 0.09,-0.684 0.062,-0.219 0.148,-0.445 0.261,-0.672 0.114,-0.23 0.321,-0.566 0.618,-1.011 h -1.368 v -0.461 h 1.875 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath477)"
+           id="path986" />
+        <path
+           d="m 137.008,124.836 v -0.422 h 0.683 v -1.93 l -0.66,0.426 v -0.445 l 0.688,-0.461 h 0.519 v 2.41 h 0.633 v 0.422 z m 4.047,-1.461 c 0,0.5 -0.086,0.875 -0.266,1.125 -0.18,0.25 -0.434,0.375 -0.762,0.375 -0.242,0 -0.429,-0.055 -0.57,-0.16 -0.137,-0.106 -0.23,-0.274 -0.289,-0.504 l 0.516,-0.074 c 0.05,0.195 0.168,0.293 0.351,0.293 0.153,0 0.27,-0.075 0.352,-0.227 0.086,-0.152 0.129,-0.375 0.129,-0.672 -0.047,0.102 -0.129,0.18 -0.243,0.239 -0.113,0.054 -0.234,0.082 -0.363,0.082 -0.242,0 -0.433,-0.082 -0.578,-0.254 -0.141,-0.168 -0.215,-0.399 -0.215,-0.688 0,-0.297 0.086,-0.527 0.25,-0.695 0.168,-0.168 0.406,-0.25 0.711,-0.25 0.332,0 0.574,0.117 0.734,0.351 0.165,0.235 0.243,0.586 0.243,1.059 z m -0.578,-0.395 c 0,-0.175 -0.039,-0.316 -0.114,-0.418 -0.074,-0.105 -0.172,-0.156 -0.297,-0.156 -0.121,0 -0.218,0.043 -0.289,0.137 -0.066,0.09 -0.101,0.211 -0.101,0.371 0,0.156 0.035,0.281 0.101,0.379 0.071,0.094 0.168,0.141 0.289,0.141 0.118,0 0.215,-0.043 0.293,-0.125 0.079,-0.082 0.118,-0.192 0.118,-0.329 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath478)"
+           id="path987" />
+        <path
+           d="m 136.895,130.66 v -0.39 c 0.07,-0.165 0.171,-0.321 0.304,-0.473 0.133,-0.156 0.301,-0.317 0.5,-0.485 0.192,-0.16 0.328,-0.292 0.406,-0.394 0.079,-0.106 0.118,-0.207 0.118,-0.309 0,-0.246 -0.121,-0.371 -0.364,-0.371 -0.117,0 -0.207,0.035 -0.269,0.102 -0.063,0.062 -0.102,0.16 -0.117,0.289 l -0.555,-0.031 c 0.031,-0.262 0.125,-0.465 0.285,-0.602 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.07 0.684,0.211 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.023,0.25 -0.074,0.359 -0.051,0.106 -0.117,0.203 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.254 -0.097,0.078 -0.191,0.152 -0.281,0.231 -0.094,0.074 -0.176,0.148 -0.25,0.226 -0.074,0.074 -0.133,0.156 -0.168,0.242 h 1.277 v 0.465 z m 2.335,0 v -0.418 h 0.684 v -1.93 l -0.66,0.422 v -0.441 l 0.687,-0.461 h 0.52 v 2.41 h 0.633 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath479)"
+           id="path988" />
+        <path
+           d="m 136.895,136.488 v -0.39 c 0.07,-0.164 0.171,-0.321 0.304,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.484 0.192,-0.161 0.328,-0.293 0.406,-0.399 0.079,-0.101 0.118,-0.203 0.118,-0.304 0,-0.247 -0.121,-0.372 -0.364,-0.372 -0.117,0 -0.207,0.036 -0.269,0.098 -0.063,0.066 -0.102,0.164 -0.117,0.293 l -0.555,-0.031 c 0.031,-0.262 0.125,-0.465 0.285,-0.602 0.16,-0.136 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.071 0.684,0.211 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.023,0.25 -0.074,0.359 -0.051,0.106 -0.117,0.204 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.25 -0.097,0.082 -0.191,0.157 -0.281,0.235 -0.094,0.074 -0.176,0.148 -0.25,0.226 -0.074,0.074 -0.133,0.157 -0.168,0.242 h 1.277 v 0.465 z m 4.164,-0.785 c 0,0.266 -0.082,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.293,0 -0.527,-0.07 -0.703,-0.211 -0.176,-0.14 -0.277,-0.34 -0.309,-0.605 l 0.559,-0.051 c 0.035,0.273 0.187,0.41 0.453,0.41 0.133,0 0.234,-0.035 0.305,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.309 0,-0.125 -0.043,-0.219 -0.133,-0.289 -0.086,-0.067 -0.218,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.16,0 0.277,-0.031 0.355,-0.097 0.083,-0.067 0.122,-0.165 0.122,-0.286 0,-0.117 -0.032,-0.207 -0.098,-0.273 -0.063,-0.066 -0.152,-0.102 -0.274,-0.102 -0.113,0 -0.207,0.036 -0.277,0.098 -0.066,0.063 -0.105,0.156 -0.117,0.274 l -0.551,-0.04 c 0.031,-0.246 0.129,-0.437 0.297,-0.574 0.168,-0.136 0.387,-0.207 0.656,-0.207 0.289,0 0.516,0.067 0.676,0.203 0.164,0.129 0.242,0.317 0.242,0.551 0,0.176 -0.05,0.32 -0.152,0.434 -0.098,0.117 -0.242,0.191 -0.434,0.226 v 0.012 c 0.211,0.023 0.371,0.094 0.485,0.215 0.117,0.113 0.172,0.265 0.172,0.445 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath480)"
+           id="path989" />
+        <path
+           d="m 136.895,142.316 v -0.39 c 0.07,-0.164 0.171,-0.321 0.304,-0.477 0.133,-0.152 0.301,-0.312 0.5,-0.48 0.192,-0.16 0.328,-0.293 0.406,-0.399 0.079,-0.105 0.118,-0.207 0.118,-0.308 0,-0.246 -0.121,-0.367 -0.364,-0.367 -0.117,0 -0.207,0.031 -0.269,0.097 -0.063,0.067 -0.102,0.16 -0.117,0.293 l -0.555,-0.035 c 0.031,-0.262 0.125,-0.461 0.285,-0.598 0.16,-0.14 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.071 0.684,0.207 0.16,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.36 -0.051,0.109 -0.117,0.207 -0.195,0.297 -0.082,0.089 -0.168,0.175 -0.266,0.253 -0.097,0.079 -0.191,0.157 -0.281,0.231 -0.094,0.074 -0.176,0.152 -0.25,0.226 -0.074,0.079 -0.133,0.161 -0.168,0.247 h 1.277 v 0.464 z m 4.199,-0.941 c 0,0.297 -0.09,0.539 -0.274,0.715 -0.179,0.176 -0.429,0.265 -0.746,0.265 -0.277,0 -0.496,-0.062 -0.664,-0.191 -0.164,-0.129 -0.269,-0.312 -0.308,-0.555 l 0.55,-0.047 c 0.028,0.122 0.078,0.208 0.153,0.262 0.074,0.055 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.043 0.328,-0.133 0.082,-0.089 0.121,-0.218 0.121,-0.386 0,-0.149 -0.035,-0.27 -0.113,-0.356 -0.078,-0.09 -0.184,-0.136 -0.324,-0.136 -0.152,0 -0.274,0.062 -0.371,0.183 h -0.535 l 0.093,-1.59 h 1.657 v 0.418 h -1.157 l -0.047,0.715 c 0.133,-0.121 0.301,-0.18 0.5,-0.18 0.262,0 0.469,0.082 0.625,0.25 0.161,0.168 0.239,0.395 0.239,0.684 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath481)"
+           id="path990" />
+        <path
+           d="m 136.895,148.141 v -0.391 c 0.07,-0.16 0.171,-0.32 0.304,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.48 0.192,-0.164 0.328,-0.297 0.406,-0.399 0.079,-0.105 0.118,-0.207 0.118,-0.308 0,-0.246 -0.121,-0.367 -0.364,-0.367 -0.117,0 -0.207,0.031 -0.269,0.097 -0.063,0.063 -0.102,0.16 -0.117,0.289 l -0.555,-0.031 c 0.031,-0.262 0.125,-0.461 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.07 0.684,0.21 0.16,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.36 -0.051,0.105 -0.117,0.207 -0.195,0.297 -0.082,0.089 -0.168,0.175 -0.266,0.254 -0.097,0.078 -0.191,0.156 -0.281,0.23 -0.094,0.074 -0.176,0.148 -0.25,0.227 -0.074,0.074 -0.133,0.156 -0.168,0.246 h 1.277 v 0.461 z m 4.132,-2.379 c -0.121,0.199 -0.238,0.394 -0.351,0.582 -0.11,0.191 -0.203,0.379 -0.285,0.57 -0.082,0.191 -0.149,0.387 -0.196,0.59 -0.047,0.199 -0.07,0.414 -0.07,0.637 h -0.574 c 0,-0.235 0.031,-0.461 0.09,-0.68 0.062,-0.223 0.148,-0.445 0.261,-0.676 0.114,-0.226 0.321,-0.562 0.618,-1.008 h -1.368 v -0.465 h 1.875 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath482)"
+           id="path991" />
+        <path
+           d="m 136.895,153.969 v -0.391 c 0.07,-0.164 0.171,-0.32 0.304,-0.476 0.133,-0.153 0.301,-0.313 0.5,-0.481 0.192,-0.16 0.328,-0.293 0.406,-0.398 0.079,-0.102 0.118,-0.207 0.118,-0.305 0,-0.246 -0.121,-0.371 -0.364,-0.371 -0.117,0 -0.207,0.035 -0.269,0.098 -0.063,0.066 -0.102,0.164 -0.117,0.293 l -0.555,-0.032 c 0.031,-0.261 0.125,-0.465 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.524,0.07 0.684,0.211 0.16,0.136 0.238,0.332 0.238,0.586 0,0.128 -0.023,0.25 -0.074,0.359 -0.051,0.105 -0.117,0.203 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.25 -0.097,0.082 -0.191,0.156 -0.281,0.23 -0.094,0.078 -0.176,0.153 -0.25,0.231 -0.074,0.074 -0.133,0.156 -0.168,0.242 h 1.277 v 0.465 z m 4.16,-1.461 c 0,0.504 -0.086,0.879 -0.266,1.129 -0.18,0.246 -0.434,0.371 -0.762,0.371 -0.242,0 -0.429,-0.051 -0.57,-0.156 -0.137,-0.11 -0.23,-0.278 -0.289,-0.508 l 0.516,-0.074 c 0.05,0.195 0.168,0.296 0.351,0.296 0.153,0 0.27,-0.078 0.352,-0.226 0.086,-0.152 0.129,-0.375 0.129,-0.676 -0.047,0.102 -0.129,0.18 -0.243,0.238 -0.113,0.055 -0.234,0.086 -0.363,0.086 -0.242,0 -0.433,-0.086 -0.578,-0.254 -0.141,-0.172 -0.215,-0.398 -0.215,-0.687 0,-0.297 0.086,-0.531 0.25,-0.699 0.168,-0.168 0.406,-0.25 0.711,-0.25 0.332,0 0.574,0.117 0.734,0.355 0.165,0.231 0.243,0.586 0.243,1.055 z m -0.578,-0.395 c 0,-0.175 -0.039,-0.312 -0.114,-0.418 -0.074,-0.105 -0.172,-0.156 -0.297,-0.156 -0.121,0 -0.218,0.047 -0.289,0.137 -0.066,0.09 -0.101,0.215 -0.101,0.375 0,0.156 0.035,0.281 0.101,0.375 0.071,0.094 0.168,0.14 0.289,0.14 0.118,0 0.215,-0.039 0.293,-0.121 0.079,-0.082 0.118,-0.195 0.118,-0.332 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath483)"
+           id="path992" />
+        <path
+           d="m 138.836,159.012 c 0,0.265 -0.086,0.468 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.297,0 -0.531,-0.071 -0.703,-0.211 -0.176,-0.141 -0.277,-0.34 -0.308,-0.606 l 0.558,-0.05 c 0.035,0.273 0.188,0.41 0.453,0.41 0.129,0 0.231,-0.035 0.305,-0.102 0.074,-0.066 0.109,-0.168 0.109,-0.308 0,-0.125 -0.043,-0.223 -0.132,-0.289 -0.09,-0.067 -0.219,-0.098 -0.395,-0.098 h -0.191 v -0.457 h 0.179 c 0.157,0 0.278,-0.031 0.356,-0.098 0.078,-0.066 0.121,-0.164 0.121,-0.285 0,-0.117 -0.035,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.102 -0.273,-0.102 -0.113,0 -0.207,0.031 -0.278,0.098 -0.07,0.062 -0.109,0.156 -0.117,0.273 l -0.55,-0.043 c 0.027,-0.242 0.128,-0.433 0.296,-0.57 0.168,-0.137 0.387,-0.207 0.657,-0.207 0.289,0 0.511,0.066 0.675,0.199 0.161,0.133 0.243,0.316 0.243,0.555 0,0.175 -0.051,0.32 -0.153,0.433 -0.101,0.114 -0.246,0.192 -0.433,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.484,0.214 0.113,0.118 0.172,0.266 0.172,0.45 z m 0.394,0.785 v -0.418 h 0.684 v -1.93 l -0.66,0.422 v -0.441 l 0.687,-0.461 h 0.52 v 2.41 h 0.633 v 0.418 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath484)"
+           id="path993" />
+        <path
+           d="m 138.836,164.84 c 0,0.262 -0.086,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.215 -0.723,0.215 -0.297,0 -0.531,-0.066 -0.703,-0.207 -0.176,-0.141 -0.277,-0.344 -0.308,-0.606 l 0.558,-0.05 c 0.035,0.269 0.188,0.406 0.453,0.406 0.129,0 0.231,-0.031 0.305,-0.098 0.074,-0.07 0.109,-0.172 0.109,-0.308 0,-0.125 -0.043,-0.223 -0.132,-0.289 -0.09,-0.067 -0.219,-0.102 -0.395,-0.102 h -0.191 v -0.453 h 0.179 c 0.157,0 0.278,-0.035 0.356,-0.102 0.078,-0.066 0.121,-0.16 0.121,-0.285 0,-0.113 -0.035,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.098 -0.273,-0.098 -0.113,0 -0.207,0.031 -0.278,0.094 -0.07,0.066 -0.109,0.156 -0.117,0.273 l -0.55,-0.039 c 0.027,-0.242 0.128,-0.433 0.296,-0.57 0.168,-0.141 0.387,-0.207 0.657,-0.207 0.289,0 0.511,0.066 0.675,0.199 0.161,0.133 0.243,0.317 0.243,0.551 0,0.18 -0.051,0.324 -0.153,0.437 -0.101,0.114 -0.246,0.188 -0.433,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.484,0.215 0.113,0.117 0.172,0.265 0.172,0.449 z m 2.223,0 c 0,0.262 -0.082,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.215 -0.723,0.215 -0.293,0 -0.527,-0.066 -0.703,-0.207 -0.176,-0.141 -0.277,-0.344 -0.309,-0.606 l 0.559,-0.05 c 0.035,0.269 0.187,0.406 0.453,0.406 0.133,0 0.234,-0.031 0.305,-0.098 0.074,-0.07 0.109,-0.172 0.109,-0.308 0,-0.125 -0.043,-0.223 -0.133,-0.289 -0.086,-0.067 -0.218,-0.102 -0.394,-0.102 h -0.192 v -0.453 h 0.18 c 0.16,0 0.277,-0.035 0.355,-0.102 0.083,-0.066 0.122,-0.16 0.122,-0.285 0,-0.113 -0.032,-0.207 -0.098,-0.273 -0.063,-0.067 -0.152,-0.098 -0.274,-0.098 -0.113,0 -0.207,0.031 -0.277,0.094 -0.066,0.066 -0.105,0.156 -0.117,0.273 l -0.551,-0.039 c 0.031,-0.242 0.129,-0.433 0.297,-0.57 0.168,-0.141 0.387,-0.207 0.656,-0.207 0.289,0 0.516,0.066 0.676,0.199 0.164,0.133 0.242,0.317 0.242,0.551 0,0.18 -0.05,0.324 -0.152,0.437 -0.098,0.114 -0.242,0.188 -0.434,0.227 v 0.008 c 0.211,0.027 0.371,0.097 0.485,0.215 0.117,0.117 0.172,0.265 0.172,0.449 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath485)"
+           id="path994" />
+        <path
+           d="m 138.836,170.664 c 0,0.266 -0.086,0.473 -0.254,0.617 -0.168,0.145 -0.41,0.215 -0.723,0.215 -0.297,0 -0.531,-0.07 -0.703,-0.207 -0.176,-0.141 -0.277,-0.344 -0.308,-0.609 l 0.558,-0.047 c 0.035,0.269 0.188,0.406 0.453,0.406 0.129,0 0.231,-0.035 0.305,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.043,-0.223 -0.132,-0.289 -0.09,-0.071 -0.219,-0.102 -0.395,-0.102 h -0.191 v -0.457 h 0.179 c 0.157,0 0.278,-0.031 0.356,-0.097 0.078,-0.067 0.121,-0.161 0.121,-0.286 0,-0.117 -0.035,-0.207 -0.098,-0.273 -0.062,-0.067 -0.152,-0.102 -0.273,-0.102 -0.113,0 -0.207,0.035 -0.278,0.098 -0.07,0.066 -0.109,0.156 -0.117,0.273 l -0.55,-0.039 c 0.027,-0.246 0.128,-0.433 0.296,-0.574 0.168,-0.137 0.387,-0.207 0.657,-0.207 0.289,0 0.511,0.067 0.675,0.203 0.161,0.133 0.243,0.317 0.243,0.551 0,0.176 -0.051,0.32 -0.153,0.438 -0.101,0.113 -0.246,0.187 -0.433,0.226 v 0.008 c 0.211,0.023 0.371,0.098 0.484,0.215 0.113,0.117 0.172,0.265 0.172,0.445 z m 2.258,-0.156 c 0,0.301 -0.09,0.539 -0.274,0.719 -0.179,0.175 -0.429,0.261 -0.746,0.261 -0.277,0 -0.496,-0.062 -0.664,-0.187 -0.164,-0.129 -0.269,-0.317 -0.308,-0.559 l 0.55,-0.047 c 0.028,0.121 0.078,0.211 0.153,0.266 0.074,0.055 0.164,0.082 0.273,0.082 0.137,0 0.246,-0.047 0.328,-0.137 0.082,-0.09 0.121,-0.218 0.121,-0.386 0,-0.149 -0.035,-0.266 -0.113,-0.356 -0.078,-0.09 -0.184,-0.133 -0.324,-0.133 -0.152,0 -0.274,0.059 -0.371,0.184 h -0.535 l 0.093,-1.594 h 1.657 v 0.422 h -1.157 l -0.047,0.711 c 0.133,-0.117 0.301,-0.18 0.5,-0.18 0.262,0 0.469,0.086 0.625,0.25 0.161,0.168 0.239,0.399 0.239,0.684 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath486)"
+           id="path995" />
+        <path
+           d="m 138.836,176.492 c 0,0.266 -0.086,0.469 -0.254,0.613 -0.168,0.145 -0.41,0.219 -0.723,0.219 -0.297,0 -0.531,-0.07 -0.703,-0.207 -0.176,-0.14 -0.277,-0.344 -0.308,-0.609 l 0.558,-0.051 c 0.035,0.273 0.188,0.41 0.453,0.41 0.129,0 0.231,-0.035 0.305,-0.101 0.074,-0.067 0.109,-0.168 0.109,-0.309 0,-0.125 -0.043,-0.219 -0.132,-0.289 -0.09,-0.066 -0.219,-0.098 -0.395,-0.098 h -0.191 v -0.457 h 0.179 c 0.157,0 0.278,-0.031 0.356,-0.097 0.078,-0.067 0.121,-0.164 0.121,-0.286 0,-0.117 -0.035,-0.207 -0.098,-0.273 -0.062,-0.066 -0.152,-0.102 -0.273,-0.102 -0.113,0 -0.207,0.036 -0.278,0.098 -0.07,0.063 -0.109,0.156 -0.117,0.274 l -0.55,-0.039 c 0.027,-0.247 0.128,-0.438 0.296,-0.575 0.168,-0.136 0.387,-0.207 0.657,-0.207 0.289,0 0.511,0.067 0.675,0.203 0.161,0.133 0.243,0.317 0.243,0.551 0,0.176 -0.051,0.32 -0.153,0.438 -0.101,0.113 -0.246,0.187 -0.433,0.226 v 0.008 c 0.211,0.023 0.371,0.094 0.484,0.215 0.113,0.113 0.172,0.265 0.172,0.445 z m 2.191,-1.594 c -0.121,0.2 -0.238,0.395 -0.351,0.582 -0.11,0.188 -0.203,0.379 -0.285,0.571 -0.082,0.191 -0.149,0.387 -0.196,0.59 -0.047,0.199 -0.07,0.414 -0.07,0.636 h -0.574 c 0,-0.234 0.031,-0.461 0.09,-0.683 0.062,-0.219 0.148,-0.446 0.261,-0.672 0.114,-0.227 0.321,-0.567 0.618,-1.008 h -1.368 v -0.465 h 1.875 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath487)"
+           id="path996" />
+        <path
+           d="M 143.824,72.391 V 72 c 0.074,-0.164 0.176,-0.32 0.305,-0.473 0.133,-0.156 0.301,-0.316 0.5,-0.484 0.195,-0.16 0.328,-0.293 0.406,-0.395 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.371 -0.363,-0.371 -0.117,0 -0.207,0.035 -0.269,0.101 -0.059,0.063 -0.098,0.16 -0.118,0.289 l -0.554,-0.031 c 0.031,-0.262 0.129,-0.465 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.652,-0.207 0.297,0 0.527,0.07 0.684,0.21 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.023,0.25 -0.074,0.36 -0.051,0.105 -0.117,0.203 -0.195,0.297 -0.079,0.089 -0.168,0.172 -0.266,0.254 -0.098,0.078 -0.192,0.152 -0.281,0.23 -0.09,0.074 -0.176,0.148 -0.25,0.227 -0.075,0.074 -0.129,0.156 -0.168,0.242 h 1.277 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath488)"
+           id="path997" />
+        <path
+           d="m 145.523,77.641 v 0.578 H 145 v -0.578 h -1.254 v -0.422 l 1.164,-1.828 h 0.613 v 1.832 h 0.368 v 0.418 z M 145,76.297 c 0,-0.074 0,-0.152 0.004,-0.235 0.008,-0.085 0.012,-0.14 0.012,-0.164 -0.032,0.075 -0.094,0.184 -0.184,0.325 l -0.637,1 H 145 Z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath489)"
+           id="path998" />
+        <path
+           d="m 145.766,83.117 c 0,0.305 -0.082,0.539 -0.246,0.711 -0.165,0.172 -0.391,0.258 -0.68,0.258 -0.324,0 -0.57,-0.117 -0.746,-0.352 -0.172,-0.234 -0.262,-0.578 -0.262,-1.039 0,-0.504 0.09,-0.883 0.266,-1.136 0.175,-0.258 0.429,-0.387 0.757,-0.387 0.235,0 0.418,0.055 0.551,0.16 0.137,0.106 0.231,0.27 0.285,0.492 l -0.515,0.074 c -0.051,-0.187 -0.16,-0.277 -0.332,-0.277 -0.149,0 -0.262,0.074 -0.348,0.227 -0.082,0.148 -0.125,0.379 -0.125,0.687 0.059,-0.101 0.141,-0.176 0.242,-0.23 0.106,-0.055 0.223,-0.082 0.356,-0.082 0.246,0 0.441,0.082 0.582,0.242 0.144,0.16 0.215,0.379 0.215,0.652 z m -0.551,0.02 c 0,-0.164 -0.035,-0.285 -0.11,-0.367 -0.07,-0.086 -0.167,-0.129 -0.296,-0.129 -0.121,0 -0.215,0.039 -0.289,0.121 -0.075,0.078 -0.11,0.183 -0.11,0.312 0,0.164 0.039,0.301 0.113,0.41 0.079,0.106 0.176,0.161 0.301,0.161 0.125,0 0.219,-0.043 0.289,-0.133 0.071,-0.094 0.102,-0.219 0.102,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath490)"
+           id="path999" />
+        <path
+           d="m 145.789,89.074 c 0,0.266 -0.086,0.473 -0.258,0.617 -0.168,0.149 -0.414,0.219 -0.73,0.219 -0.313,0 -0.555,-0.07 -0.731,-0.219 -0.172,-0.144 -0.258,-0.347 -0.258,-0.613 0,-0.18 0.051,-0.332 0.153,-0.457 0.101,-0.121 0.238,-0.199 0.41,-0.23 v -0.008 c -0.148,-0.031 -0.27,-0.11 -0.359,-0.227 -0.09,-0.117 -0.137,-0.254 -0.137,-0.406 0,-0.23 0.078,-0.414 0.238,-0.551 0.16,-0.133 0.387,-0.199 0.676,-0.199 0.301,0 0.527,0.066 0.687,0.195 0.161,0.133 0.239,0.317 0.239,0.559 0,0.152 -0.043,0.289 -0.137,0.406 -0.09,0.113 -0.211,0.188 -0.363,0.219 v 0.008 c 0.179,0.031 0.316,0.105 0.418,0.226 0.101,0.117 0.152,0.274 0.152,0.461 z m -0.633,-1.289 c 0,-0.137 -0.031,-0.234 -0.09,-0.293 -0.058,-0.066 -0.152,-0.097 -0.273,-0.097 -0.234,0 -0.355,0.128 -0.355,0.39 0,0.27 0.121,0.403 0.359,0.403 0.121,0 0.211,-0.032 0.269,-0.094 0.059,-0.063 0.09,-0.164 0.09,-0.309 z m 0.063,1.242 c 0,-0.297 -0.141,-0.441 -0.43,-0.441 -0.133,0 -0.234,0.039 -0.305,0.113 -0.07,0.078 -0.105,0.192 -0.105,0.336 0,0.168 0.035,0.289 0.105,0.363 0.071,0.079 0.176,0.118 0.321,0.118 0.144,0 0.246,-0.039 0.312,-0.118 0.071,-0.074 0.102,-0.199 0.102,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath491)"
+           id="path1000" />
+        <path
+           d="m 142.82,95.699 v -0.422 h 0.68 v -1.929 l -0.66,0.425 v -0.445 l 0.691,-0.457 h 0.52 v 2.406 h 0.629 v 0.422 z m 4.032,-1.418 c 0,0.481 -0.079,0.84 -0.239,1.086 -0.16,0.25 -0.398,0.371 -0.718,0.371 -0.629,0 -0.946,-0.484 -0.946,-1.457 0,-0.336 0.035,-0.613 0.106,-0.828 0.066,-0.215 0.172,-0.371 0.308,-0.473 0.137,-0.101 0.321,-0.152 0.547,-0.152 0.324,0 0.563,0.121 0.715,0.363 0.152,0.243 0.227,0.606 0.227,1.09 z m -0.551,0 c 0,-0.258 -0.012,-0.461 -0.035,-0.605 -0.028,-0.145 -0.067,-0.25 -0.121,-0.313 -0.055,-0.062 -0.133,-0.093 -0.239,-0.093 -0.109,0 -0.195,0.031 -0.25,0.097 -0.058,0.063 -0.097,0.164 -0.121,0.309 -0.023,0.144 -0.035,0.347 -0.035,0.605 0,0.262 0.012,0.461 0.035,0.61 0.027,0.144 0.067,0.246 0.121,0.308 0.055,0.063 0.137,0.094 0.242,0.094 0.106,0 0.184,-0.031 0.243,-0.098 0.054,-0.066 0.097,-0.172 0.121,-0.316 0.027,-0.149 0.039,-0.344 0.039,-0.598 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath492)"
+           id="path1001" />
+        <path
+           d="m 142.82,101.527 v -0.422 h 0.68 v -1.929 l -0.66,0.426 v -0.446 l 0.691,-0.461 h 0.52 v 2.41 h 0.629 v 0.422 z m 2.11,0 v -0.394 c 0.07,-0.16 0.172,-0.321 0.304,-0.473 0.133,-0.152 0.301,-0.316 0.5,-0.48 0.192,-0.16 0.328,-0.293 0.407,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.368 -0.363,-0.368 -0.118,0 -0.207,0.032 -0.27,0.098 -0.063,0.063 -0.102,0.16 -0.117,0.289 l -0.555,-0.031 c 0.031,-0.262 0.125,-0.461 0.285,-0.598 0.16,-0.14 0.379,-0.207 0.653,-0.207 0.297,0 0.523,0.067 0.683,0.207 0.16,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.023,0.254 -0.074,0.36 -0.05,0.105 -0.117,0.207 -0.195,0.296 -0.082,0.09 -0.168,0.176 -0.266,0.254 -0.097,0.079 -0.191,0.157 -0.281,0.231 -0.094,0.074 -0.176,0.152 -0.25,0.226 -0.074,0.079 -0.133,0.161 -0.168,0.246 h 1.277 v 0.461 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath493)"
+           id="path1002" />
+        <path
+           d="m 142.82,107.352 v -0.418 h 0.68 v -1.93 l -0.66,0.422 v -0.442 l 0.691,-0.461 h 0.52 v 2.411 h 0.629 v 0.418 z m 3.809,-0.575 v 0.575 h -0.524 v -0.575 h -1.253 v -0.425 l 1.164,-1.829 h 0.613 v 1.832 h 0.367 v 0.422 z m -0.524,-1.347 c 0,-0.071 0,-0.149 0.004,-0.235 0.004,-0.082 0.008,-0.136 0.012,-0.16 -0.035,0.074 -0.094,0.184 -0.183,0.324 l -0.637,0.996 h 0.804 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath494)"
+           id="path1003" />
+        <path
+           d="m 142.82,113.18 v -0.418 h 0.68 v -1.93 l -0.66,0.422 v -0.442 l 0.691,-0.46 h 0.52 v 2.41 h 0.629 v 0.418 z m 4.051,-0.926 c 0,0.301 -0.082,0.539 -0.246,0.707 -0.164,0.172 -0.391,0.258 -0.68,0.258 -0.324,0 -0.574,-0.117 -0.746,-0.348 -0.176,-0.234 -0.261,-0.582 -0.261,-1.039 0,-0.508 0.089,-0.887 0.265,-1.141 0.176,-0.253 0.43,-0.382 0.758,-0.382 0.23,0 0.414,0.054 0.551,0.16 0.133,0.105 0.23,0.269 0.285,0.492 l -0.516,0.074 c -0.051,-0.187 -0.16,-0.281 -0.332,-0.281 -0.148,0 -0.265,0.078 -0.347,0.226 -0.086,0.153 -0.125,0.383 -0.125,0.692 0.058,-0.102 0.136,-0.18 0.242,-0.234 0.105,-0.051 0.222,-0.079 0.355,-0.079 0.246,0 0.438,0.079 0.582,0.243 0.145,0.16 0.215,0.375 0.215,0.652 z m -0.551,0.016 c 0,-0.161 -0.035,-0.282 -0.109,-0.368 -0.07,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.039 -0.289,0.122 -0.074,0.078 -0.109,0.183 -0.109,0.316 0,0.164 0.035,0.301 0.113,0.41 0.074,0.106 0.176,0.16 0.301,0.16 0.121,0 0.218,-0.047 0.289,-0.136 0.066,-0.09 0.101,-0.215 0.101,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath495)"
+           id="path1004" />
+        <path
+           d="m 142.82,119.008 v -0.418 h 0.68 v -1.93 l -0.66,0.422 v -0.445 l 0.691,-0.457 h 0.52 v 2.41 h 0.629 v 0.418 z m 4.075,-0.797 c 0,0.266 -0.086,0.469 -0.258,0.617 -0.172,0.149 -0.414,0.219 -0.731,0.219 -0.312,0 -0.558,-0.07 -0.73,-0.219 -0.172,-0.144 -0.258,-0.351 -0.258,-0.613 0,-0.18 0.051,-0.332 0.152,-0.457 0.102,-0.125 0.239,-0.199 0.41,-0.231 v -0.007 c -0.148,-0.032 -0.269,-0.11 -0.359,-0.227 -0.094,-0.117 -0.137,-0.254 -0.137,-0.406 0,-0.235 0.078,-0.414 0.239,-0.551 0.16,-0.133 0.382,-0.199 0.675,-0.199 0.297,0 0.528,0.066 0.688,0.195 0.16,0.133 0.238,0.316 0.238,0.559 0,0.152 -0.047,0.289 -0.136,0.406 -0.09,0.113 -0.211,0.187 -0.364,0.219 v 0.007 c 0.176,0.032 0.317,0.106 0.418,0.227 0.102,0.117 0.153,0.273 0.153,0.461 z m -0.633,-1.293 c 0,-0.133 -0.032,-0.23 -0.09,-0.293 -0.063,-0.063 -0.152,-0.094 -0.274,-0.094 -0.238,0 -0.355,0.129 -0.355,0.387 0,0.273 0.121,0.406 0.359,0.406 0.121,0 0.211,-0.031 0.27,-0.094 0.058,-0.062 0.09,-0.168 0.09,-0.312 z m 0.062,1.246 c 0,-0.297 -0.144,-0.445 -0.429,-0.445 -0.133,0 -0.235,0.039 -0.305,0.117 -0.07,0.078 -0.106,0.191 -0.106,0.336 0,0.168 0.036,0.289 0.106,0.363 0.07,0.078 0.176,0.113 0.32,0.113 0.141,0 0.246,-0.035 0.313,-0.113 0.066,-0.074 0.101,-0.199 0.101,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath496)"
+           id="path1005" />
+        <path
+           d="m 142.707,124.836 v -0.395 c 0.07,-0.16 0.172,-0.32 0.305,-0.472 0.133,-0.153 0.297,-0.313 0.5,-0.481 0.191,-0.16 0.328,-0.293 0.402,-0.398 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.367 -0.359,-0.367 -0.117,0 -0.207,0.031 -0.27,0.098 -0.062,0.062 -0.101,0.16 -0.121,0.289 l -0.551,-0.031 c 0.032,-0.262 0.125,-0.461 0.286,-0.598 0.16,-0.141 0.375,-0.207 0.652,-0.207 0.297,0 0.523,0.066 0.684,0.207 0.156,0.14 0.238,0.336 0.238,0.586 0,0.133 -0.028,0.254 -0.078,0.359 -0.051,0.11 -0.114,0.207 -0.196,0.297 -0.078,0.09 -0.168,0.176 -0.265,0.254 -0.094,0.078 -0.188,0.156 -0.281,0.23 -0.09,0.075 -0.172,0.153 -0.25,0.227 -0.075,0.078 -0.129,0.16 -0.165,0.246 h 1.278 v 0.465 z m 4.145,-1.418 c 0,0.48 -0.079,0.84 -0.239,1.086 -0.16,0.246 -0.398,0.371 -0.718,0.371 -0.629,0 -0.946,-0.484 -0.946,-1.457 0,-0.336 0.035,-0.613 0.106,-0.828 0.066,-0.215 0.172,-0.371 0.308,-0.473 0.137,-0.101 0.321,-0.152 0.547,-0.152 0.324,0 0.563,0.121 0.715,0.363 0.152,0.242 0.227,0.606 0.227,1.09 z m -0.551,0 c 0,-0.262 -0.012,-0.461 -0.035,-0.606 -0.028,-0.144 -0.067,-0.25 -0.121,-0.312 -0.055,-0.062 -0.133,-0.094 -0.239,-0.094 -0.109,0 -0.195,0.032 -0.25,0.094 -0.058,0.062 -0.097,0.168 -0.121,0.312 -0.023,0.145 -0.035,0.344 -0.035,0.606 0,0.258 0.012,0.461 0.035,0.605 0.027,0.145 0.067,0.25 0.121,0.313 0.055,0.062 0.137,0.094 0.242,0.094 0.106,0 0.184,-0.032 0.243,-0.098 0.054,-0.066 0.097,-0.172 0.121,-0.32 0.027,-0.145 0.039,-0.344 0.039,-0.594 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath497)"
+           id="path1006" />
+        <path
+           d="m 142.707,130.66 v -0.39 c 0.07,-0.161 0.172,-0.321 0.305,-0.473 0.133,-0.156 0.297,-0.317 0.5,-0.485 0.191,-0.16 0.328,-0.292 0.402,-0.394 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.371 -0.359,-0.371 -0.117,0 -0.207,0.035 -0.27,0.102 -0.062,0.062 -0.101,0.16 -0.121,0.289 l -0.551,-0.031 c 0.032,-0.262 0.125,-0.465 0.286,-0.602 0.16,-0.137 0.375,-0.207 0.652,-0.207 0.297,0 0.523,0.07 0.684,0.211 0.156,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.028,0.25 -0.078,0.359 -0.051,0.106 -0.114,0.207 -0.196,0.297 -0.078,0.09 -0.168,0.172 -0.265,0.254 -0.094,0.078 -0.188,0.152 -0.281,0.231 -0.09,0.074 -0.172,0.148 -0.25,0.226 -0.075,0.074 -0.129,0.156 -0.165,0.242 h 1.278 v 0.465 z m 2.223,0 v -0.39 c 0.07,-0.161 0.172,-0.321 0.304,-0.473 0.133,-0.156 0.301,-0.317 0.5,-0.485 0.192,-0.16 0.328,-0.292 0.407,-0.394 0.078,-0.106 0.117,-0.207 0.117,-0.309 0,-0.246 -0.121,-0.371 -0.363,-0.371 -0.118,0 -0.207,0.035 -0.27,0.102 -0.063,0.062 -0.102,0.16 -0.117,0.289 l -0.555,-0.031 c 0.031,-0.262 0.125,-0.465 0.285,-0.602 0.16,-0.137 0.379,-0.207 0.653,-0.207 0.297,0 0.523,0.07 0.683,0.211 0.16,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.023,0.25 -0.074,0.359 -0.05,0.106 -0.117,0.207 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.254 -0.097,0.078 -0.191,0.152 -0.281,0.231 -0.094,0.074 -0.176,0.148 -0.25,0.226 -0.074,0.074 -0.133,0.156 -0.168,0.242 h 1.277 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath498)"
+           id="path1007" />
+        <path
+           d="m 142.707,136.488 v -0.39 c 0.07,-0.164 0.172,-0.321 0.305,-0.473 0.133,-0.156 0.297,-0.316 0.5,-0.484 0.191,-0.161 0.328,-0.293 0.402,-0.395 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.247 -0.121,-0.372 -0.359,-0.372 -0.117,0 -0.207,0.036 -0.27,0.102 -0.062,0.062 -0.101,0.16 -0.121,0.289 l -0.551,-0.031 c 0.032,-0.262 0.125,-0.465 0.286,-0.602 0.16,-0.136 0.375,-0.207 0.652,-0.207 0.297,0 0.523,0.071 0.684,0.211 0.156,0.137 0.238,0.332 0.238,0.586 0,0.133 -0.028,0.25 -0.078,0.359 -0.051,0.106 -0.114,0.204 -0.196,0.297 -0.078,0.09 -0.168,0.172 -0.265,0.254 -0.094,0.078 -0.188,0.153 -0.281,0.231 -0.09,0.074 -0.172,0.148 -0.25,0.226 -0.075,0.074 -0.129,0.157 -0.165,0.242 h 1.278 v 0.465 z m 3.922,-0.574 v 0.574 h -0.524 v -0.574 h -1.253 v -0.426 l 1.164,-1.828 h 0.613 v 1.832 h 0.367 v 0.422 z m -0.524,-1.348 c 0,-0.07 0,-0.148 0.004,-0.234 0.004,-0.082 0.008,-0.137 0.012,-0.16 -0.035,0.074 -0.094,0.18 -0.183,0.324 l -0.637,0.996 h 0.804 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath499)"
+           id="path1008" />
+        <path
+           d="m 142.707,142.316 v -0.39 c 0.07,-0.164 0.172,-0.321 0.305,-0.477 0.133,-0.152 0.297,-0.312 0.5,-0.48 0.191,-0.16 0.328,-0.293 0.402,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.304 0,-0.25 -0.121,-0.371 -0.359,-0.371 -0.117,0 -0.207,0.031 -0.27,0.097 -0.062,0.067 -0.101,0.16 -0.121,0.293 l -0.551,-0.035 c 0.032,-0.262 0.125,-0.461 0.286,-0.598 0.16,-0.14 0.375,-0.207 0.652,-0.207 0.297,0 0.523,0.071 0.684,0.207 0.156,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.028,0.254 -0.078,0.36 -0.051,0.109 -0.114,0.207 -0.196,0.297 -0.078,0.089 -0.168,0.175 -0.265,0.253 -0.094,0.079 -0.188,0.157 -0.281,0.231 -0.09,0.074 -0.172,0.152 -0.25,0.226 -0.075,0.079 -0.129,0.161 -0.165,0.247 h 1.278 v 0.464 z m 4.164,-0.925 c 0,0.3 -0.082,0.535 -0.246,0.707 -0.164,0.172 -0.391,0.257 -0.68,0.257 -0.324,0 -0.574,-0.117 -0.746,-0.347 -0.176,-0.235 -0.261,-0.582 -0.261,-1.043 0,-0.504 0.089,-0.883 0.265,-1.137 0.176,-0.254 0.43,-0.383 0.758,-0.383 0.23,0 0.414,0.051 0.551,0.157 0.133,0.109 0.23,0.269 0.285,0.492 l -0.516,0.074 c -0.051,-0.184 -0.16,-0.277 -0.332,-0.277 -0.148,0 -0.265,0.074 -0.347,0.226 -0.086,0.153 -0.125,0.379 -0.125,0.688 0.058,-0.098 0.136,-0.176 0.242,-0.231 0.105,-0.054 0.222,-0.078 0.355,-0.078 0.246,0 0.438,0.078 0.582,0.238 0.145,0.161 0.215,0.379 0.215,0.657 z m -0.551,0.015 c 0,-0.16 -0.035,-0.285 -0.109,-0.367 -0.07,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.039 -0.289,0.121 -0.074,0.078 -0.109,0.184 -0.109,0.317 0,0.164 0.035,0.3 0.113,0.406 0.074,0.109 0.176,0.16 0.301,0.16 0.121,0 0.218,-0.043 0.289,-0.133 0.066,-0.09 0.101,-0.215 0.101,-0.375 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath500)"
+           id="path1009" />
+        <path
+           d="m 142.707,148.141 v -0.391 c 0.07,-0.16 0.172,-0.32 0.305,-0.473 0.133,-0.156 0.297,-0.316 0.5,-0.48 0.191,-0.164 0.328,-0.293 0.402,-0.399 0.078,-0.105 0.117,-0.207 0.117,-0.308 0,-0.246 -0.121,-0.367 -0.359,-0.367 -0.117,0 -0.207,0.031 -0.27,0.097 -0.062,0.063 -0.101,0.16 -0.121,0.289 l -0.551,-0.031 c 0.032,-0.262 0.125,-0.461 0.286,-0.601 0.16,-0.137 0.375,-0.207 0.652,-0.207 0.297,0 0.523,0.07 0.684,0.21 0.156,0.141 0.238,0.336 0.238,0.586 0,0.133 -0.028,0.254 -0.078,0.36 -0.051,0.105 -0.114,0.207 -0.196,0.297 -0.078,0.089 -0.168,0.175 -0.265,0.254 -0.094,0.078 -0.188,0.156 -0.281,0.23 -0.09,0.074 -0.172,0.148 -0.25,0.227 -0.075,0.074 -0.129,0.156 -0.165,0.246 h 1.278 v 0.461 z m 4.188,-0.797 c 0,0.265 -0.086,0.472 -0.258,0.621 -0.172,0.144 -0.414,0.219 -0.731,0.219 -0.312,0 -0.558,-0.075 -0.73,-0.219 -0.172,-0.149 -0.258,-0.352 -0.258,-0.617 0,-0.18 0.051,-0.332 0.152,-0.453 0.102,-0.125 0.239,-0.204 0.41,-0.231 v -0.008 c -0.148,-0.035 -0.269,-0.109 -0.359,-0.23 -0.094,-0.117 -0.137,-0.25 -0.137,-0.406 0,-0.231 0.078,-0.415 0.239,-0.547 0.16,-0.133 0.382,-0.203 0.675,-0.203 0.297,0 0.528,0.066 0.688,0.199 0.16,0.129 0.238,0.316 0.238,0.554 0,0.157 -0.047,0.289 -0.136,0.407 -0.09,0.117 -0.211,0.191 -0.364,0.222 v 0.008 c 0.176,0.028 0.317,0.102 0.418,0.223 0.102,0.121 0.153,0.273 0.153,0.461 z m -0.633,-1.289 c 0,-0.133 -0.032,-0.231 -0.09,-0.293 -0.063,-0.063 -0.152,-0.094 -0.274,-0.094 -0.238,0 -0.355,0.129 -0.355,0.387 0,0.269 0.121,0.406 0.359,0.406 0.121,0 0.211,-0.031 0.27,-0.094 0.058,-0.066 0.09,-0.168 0.09,-0.312 z m 0.062,1.246 c 0,-0.297 -0.144,-0.446 -0.429,-0.446 -0.133,0 -0.235,0.04 -0.305,0.118 -0.07,0.078 -0.106,0.187 -0.106,0.336 0,0.164 0.036,0.285 0.106,0.363 0.07,0.074 0.176,0.113 0.32,0.113 0.141,0 0.246,-0.039 0.313,-0.113 0.066,-0.078 0.101,-0.203 0.101,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath501)"
+           id="path1010" />
+        <path
+           d="m 144.648,153.184 c 0,0.265 -0.086,0.468 -0.253,0.613 -0.172,0.144 -0.411,0.219 -0.723,0.219 -0.297,0 -0.531,-0.071 -0.707,-0.211 -0.172,-0.141 -0.277,-0.34 -0.305,-0.606 l 0.559,-0.051 c 0.035,0.274 0.183,0.411 0.449,0.411 0.133,0 0.234,-0.036 0.309,-0.102 0.07,-0.066 0.109,-0.168 0.109,-0.309 0,-0.125 -0.047,-0.222 -0.133,-0.289 -0.09,-0.066 -0.223,-0.097 -0.394,-0.097 h -0.192 v -0.457 h 0.18 c 0.156,0 0.273,-0.032 0.355,-0.098 0.078,-0.066 0.118,-0.164 0.118,-0.285 0,-0.117 -0.032,-0.207 -0.094,-0.274 -0.063,-0.066 -0.156,-0.101 -0.278,-0.101 -0.113,0 -0.203,0.031 -0.273,0.098 -0.07,0.062 -0.109,0.156 -0.121,0.273 l -0.547,-0.039 c 0.027,-0.246 0.125,-0.438 0.293,-0.574 0.168,-0.137 0.387,-0.207 0.66,-0.207 0.285,0 0.512,0.066 0.672,0.203 0.164,0.129 0.246,0.316 0.246,0.551 0,0.175 -0.051,0.32 -0.152,0.433 -0.102,0.113 -0.246,0.192 -0.438,0.227 v 0.011 c 0.211,0.024 0.375,0.094 0.489,0.215 0.113,0.114 0.171,0.266 0.171,0.446 z m 2.204,-0.629 c 0,0.476 -0.079,0.84 -0.239,1.086 -0.16,0.246 -0.398,0.367 -0.718,0.367 -0.629,0 -0.946,-0.485 -0.946,-1.453 0,-0.34 0.035,-0.617 0.106,-0.832 0.066,-0.211 0.172,-0.371 0.308,-0.473 0.137,-0.102 0.321,-0.152 0.547,-0.152 0.324,0 0.563,0.121 0.715,0.363 0.152,0.242 0.227,0.605 0.227,1.094 z m -0.551,0 c 0,-0.262 -0.012,-0.465 -0.035,-0.61 -0.028,-0.144 -0.067,-0.25 -0.121,-0.312 -0.055,-0.063 -0.133,-0.094 -0.239,-0.094 -0.109,0 -0.195,0.031 -0.25,0.098 -0.058,0.062 -0.097,0.164 -0.121,0.308 -0.023,0.145 -0.035,0.348 -0.035,0.61 0,0.257 0.012,0.461 0.035,0.605 0.027,0.145 0.067,0.246 0.121,0.313 0.055,0.062 0.137,0.093 0.242,0.093 0.106,0 0.184,-0.035 0.243,-0.097 0.054,-0.071 0.097,-0.176 0.121,-0.321 0.027,-0.148 0.039,-0.343 0.039,-0.593 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath502)"
+           id="path1011" />
+        <path
+           d="m 144.648,159.012 c 0,0.265 -0.086,0.468 -0.253,0.613 -0.172,0.145 -0.411,0.219 -0.723,0.219 -0.297,0 -0.531,-0.071 -0.707,-0.211 -0.172,-0.141 -0.277,-0.34 -0.305,-0.606 l 0.559,-0.05 c 0.035,0.273 0.183,0.41 0.449,0.41 0.133,0 0.234,-0.035 0.309,-0.102 0.07,-0.066 0.109,-0.168 0.109,-0.308 0,-0.125 -0.047,-0.223 -0.133,-0.289 -0.09,-0.067 -0.223,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.156,0 0.273,-0.031 0.355,-0.098 0.078,-0.066 0.118,-0.164 0.118,-0.285 0,-0.117 -0.032,-0.207 -0.094,-0.273 -0.063,-0.067 -0.156,-0.102 -0.278,-0.102 -0.113,0 -0.203,0.031 -0.273,0.098 -0.07,0.062 -0.109,0.156 -0.121,0.273 l -0.547,-0.043 c 0.027,-0.242 0.125,-0.433 0.293,-0.57 0.168,-0.137 0.387,-0.207 0.66,-0.207 0.285,0 0.512,0.066 0.672,0.199 0.164,0.133 0.246,0.316 0.246,0.555 0,0.175 -0.051,0.32 -0.152,0.433 -0.102,0.114 -0.246,0.192 -0.438,0.227 v 0.008 c 0.211,0.027 0.375,0.097 0.489,0.214 0.113,0.118 0.171,0.266 0.171,0.45 z m 0.282,0.785 v -0.391 c 0.07,-0.164 0.172,-0.32 0.304,-0.476 0.133,-0.153 0.301,-0.313 0.5,-0.481 0.192,-0.16 0.328,-0.293 0.407,-0.398 0.078,-0.102 0.117,-0.207 0.117,-0.305 0,-0.246 -0.121,-0.371 -0.363,-0.371 -0.118,0 -0.207,0.035 -0.27,0.098 -0.063,0.066 -0.102,0.164 -0.117,0.293 l -0.555,-0.032 c 0.031,-0.265 0.125,-0.464 0.285,-0.601 0.16,-0.137 0.379,-0.207 0.653,-0.207 0.297,0 0.523,0.07 0.683,0.207 0.16,0.14 0.238,0.336 0.238,0.59 0,0.129 -0.023,0.25 -0.074,0.359 -0.05,0.106 -0.117,0.203 -0.195,0.297 -0.082,0.09 -0.168,0.172 -0.266,0.25 -0.097,0.082 -0.191,0.156 -0.281,0.23 -0.094,0.079 -0.176,0.153 -0.25,0.231 -0.074,0.074 -0.133,0.156 -0.168,0.242 h 1.277 v 0.465 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath503)"
+           id="path1012" />
+        <path
+           d="m 144.648,164.84 c 0,0.262 -0.086,0.469 -0.253,0.613 -0.172,0.145 -0.411,0.215 -0.723,0.215 -0.297,0 -0.531,-0.066 -0.707,-0.207 -0.172,-0.141 -0.277,-0.344 -0.305,-0.606 l 0.559,-0.05 c 0.035,0.269 0.183,0.406 0.449,0.406 0.133,0 0.234,-0.031 0.309,-0.098 0.07,-0.07 0.109,-0.172 0.109,-0.308 0,-0.125 -0.047,-0.223 -0.133,-0.289 -0.09,-0.067 -0.223,-0.102 -0.394,-0.102 h -0.192 v -0.453 h 0.18 c 0.156,0 0.273,-0.035 0.355,-0.102 0.078,-0.066 0.118,-0.16 0.118,-0.285 0,-0.113 -0.032,-0.207 -0.094,-0.269 -0.063,-0.071 -0.156,-0.102 -0.278,-0.102 -0.113,0 -0.203,0.031 -0.273,0.098 -0.07,0.062 -0.109,0.152 -0.121,0.269 l -0.547,-0.039 c 0.027,-0.242 0.125,-0.433 0.293,-0.57 0.168,-0.141 0.387,-0.207 0.66,-0.207 0.285,0 0.512,0.066 0.672,0.199 0.164,0.133 0.246,0.317 0.246,0.551 0,0.18 -0.051,0.324 -0.152,0.437 -0.102,0.114 -0.246,0.188 -0.438,0.227 v 0.008 c 0.211,0.027 0.375,0.097 0.489,0.215 0.113,0.117 0.171,0.265 0.171,0.449 z m 1.981,0.207 v 0.578 h -0.524 v -0.578 h -1.253 v -0.422 l 1.164,-1.832 h 0.613 v 1.836 h 0.367 v 0.418 z m -0.524,-1.344 c 0,-0.074 0,-0.152 0.004,-0.234 0.004,-0.086 0.008,-0.141 0.012,-0.164 -0.035,0.074 -0.094,0.183 -0.183,0.324 l -0.637,1 h 0.804 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath504)"
+           id="path1013" />
+        <path
+           d="m 144.648,170.664 c 0,0.266 -0.086,0.473 -0.253,0.617 -0.172,0.145 -0.411,0.215 -0.723,0.215 -0.297,0 -0.531,-0.07 -0.707,-0.207 -0.172,-0.141 -0.277,-0.344 -0.305,-0.609 l 0.559,-0.047 c 0.035,0.269 0.183,0.406 0.449,0.406 0.133,0 0.234,-0.035 0.309,-0.101 0.07,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.047,-0.223 -0.133,-0.289 -0.09,-0.071 -0.223,-0.102 -0.394,-0.102 h -0.192 v -0.457 h 0.18 c 0.156,0 0.273,-0.031 0.355,-0.097 0.078,-0.067 0.118,-0.161 0.118,-0.286 0,-0.117 -0.032,-0.207 -0.094,-0.273 -0.063,-0.067 -0.156,-0.102 -0.278,-0.102 -0.113,0 -0.203,0.035 -0.273,0.098 -0.07,0.066 -0.109,0.156 -0.121,0.273 l -0.547,-0.039 c 0.027,-0.246 0.125,-0.433 0.293,-0.574 0.168,-0.137 0.387,-0.207 0.66,-0.207 0.285,0 0.512,0.067 0.672,0.203 0.164,0.133 0.246,0.317 0.246,0.551 0,0.176 -0.051,0.32 -0.152,0.438 -0.102,0.113 -0.246,0.187 -0.438,0.226 v 0.008 c 0.211,0.023 0.375,0.098 0.489,0.215 0.113,0.117 0.171,0.265 0.171,0.445 z m 2.223,-0.141 c 0,0.301 -0.082,0.539 -0.246,0.711 -0.164,0.172 -0.391,0.258 -0.68,0.258 -0.324,0 -0.574,-0.117 -0.746,-0.351 -0.176,-0.235 -0.261,-0.582 -0.261,-1.039 0,-0.504 0.089,-0.883 0.265,-1.141 0.176,-0.254 0.43,-0.383 0.758,-0.383 0.23,0 0.414,0.055 0.551,0.16 0.133,0.106 0.23,0.27 0.285,0.492 l -0.516,0.075 c -0.051,-0.188 -0.16,-0.282 -0.332,-0.282 -0.148,0 -0.265,0.079 -0.347,0.227 -0.086,0.152 -0.125,0.383 -0.125,0.691 0.058,-0.101 0.136,-0.179 0.242,-0.23 0.105,-0.055 0.222,-0.082 0.355,-0.082 0.246,0 0.438,0.082 0.582,0.242 0.145,0.16 0.215,0.379 0.215,0.652 z m -0.551,0.016 c 0,-0.16 -0.035,-0.281 -0.109,-0.367 -0.07,-0.086 -0.172,-0.129 -0.297,-0.129 -0.121,0 -0.219,0.043 -0.289,0.121 -0.074,0.082 -0.109,0.184 -0.109,0.316 0,0.165 0.035,0.301 0.113,0.411 0.074,0.105 0.176,0.16 0.301,0.16 0.121,0 0.218,-0.047 0.289,-0.133 0.066,-0.094 0.101,-0.219 0.101,-0.379 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath505)"
+           id="path1014" />
+        <path
+           d="m 144.648,176.492 c 0,0.266 -0.086,0.469 -0.253,0.613 -0.172,0.145 -0.411,0.219 -0.723,0.219 -0.297,0 -0.531,-0.07 -0.707,-0.207 -0.172,-0.14 -0.277,-0.344 -0.305,-0.609 l 0.559,-0.051 c 0.035,0.273 0.183,0.41 0.449,0.41 0.133,0 0.234,-0.035 0.309,-0.101 0.07,-0.067 0.109,-0.168 0.109,-0.305 0,-0.129 -0.047,-0.223 -0.133,-0.293 -0.09,-0.066 -0.223,-0.098 -0.394,-0.098 h -0.192 v -0.457 h 0.18 c 0.156,0 0.273,-0.031 0.355,-0.097 0.078,-0.067 0.118,-0.161 0.118,-0.286 0,-0.117 -0.032,-0.207 -0.094,-0.273 -0.063,-0.066 -0.156,-0.102 -0.278,-0.102 -0.113,0 -0.203,0.036 -0.273,0.098 -0.07,0.067 -0.109,0.156 -0.121,0.274 l -0.547,-0.039 c 0.027,-0.247 0.125,-0.438 0.293,-0.575 0.168,-0.136 0.387,-0.207 0.66,-0.207 0.285,0 0.512,0.067 0.672,0.203 0.164,0.133 0.246,0.317 0.246,0.551 0,0.176 -0.051,0.32 -0.152,0.438 -0.102,0.113 -0.246,0.187 -0.438,0.226 v 0.008 c 0.211,0.023 0.375,0.098 0.489,0.215 0.113,0.113 0.171,0.265 0.171,0.445 z m 2.247,-0.012 c 0,0.266 -0.086,0.473 -0.258,0.618 -0.172,0.148 -0.414,0.218 -0.731,0.218 -0.312,0 -0.558,-0.07 -0.73,-0.218 -0.172,-0.145 -0.258,-0.348 -0.258,-0.614 0,-0.179 0.051,-0.332 0.152,-0.453 0.102,-0.125 0.239,-0.203 0.41,-0.234 v -0.008 c -0.148,-0.031 -0.269,-0.109 -0.359,-0.227 -0.094,-0.117 -0.137,-0.253 -0.137,-0.406 0,-0.23 0.078,-0.414 0.239,-0.547 0.16,-0.136 0.382,-0.203 0.675,-0.203 0.297,0 0.528,0.067 0.688,0.199 0.16,0.129 0.238,0.313 0.238,0.555 0,0.152 -0.047,0.289 -0.136,0.406 -0.09,0.118 -0.211,0.188 -0.364,0.219 v 0.008 c 0.176,0.031 0.317,0.105 0.418,0.227 0.102,0.117 0.153,0.273 0.153,0.46 z m -0.633,-1.289 c 0,-0.136 -0.032,-0.234 -0.09,-0.293 -0.063,-0.062 -0.152,-0.097 -0.274,-0.097 -0.238,0 -0.355,0.133 -0.355,0.39 0,0.27 0.121,0.403 0.359,0.403 0.121,0 0.211,-0.032 0.27,-0.094 0.058,-0.062 0.09,-0.164 0.09,-0.309 z m 0.062,1.243 c 0,-0.293 -0.144,-0.442 -0.429,-0.442 -0.133,0 -0.235,0.039 -0.305,0.117 -0.07,0.075 -0.106,0.188 -0.106,0.332 0,0.168 0.036,0.289 0.106,0.364 0.07,0.078 0.176,0.117 0.32,0.117 0.141,0 0.246,-0.039 0.313,-0.117 0.066,-0.075 0.101,-0.2 0.101,-0.371 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath506)"
+           id="path1015" />
+        <path
+           d="m 139.188,65.469 c 0.433,0 0.734,-0.227 0.902,-0.672 l 0.629,0.242 c -0.133,0.34 -0.332,0.594 -0.594,0.762 -0.262,0.168 -0.574,0.25 -0.937,0.25 -0.555,0 -0.985,-0.16 -1.286,-0.485 -0.3,-0.32 -0.453,-0.773 -0.453,-1.351 0,-0.578 0.149,-1.027 0.438,-1.336 0.293,-0.313 0.715,-0.469 1.265,-0.469 0.407,0 0.735,0.086 0.989,0.254 0.254,0.164 0.433,0.406 0.535,0.731 l -0.637,0.179 c -0.051,-0.179 -0.156,-0.32 -0.316,-0.422 -0.157,-0.105 -0.34,-0.16 -0.555,-0.16 -0.324,0 -0.57,0.106 -0.742,0.313 -0.168,0.207 -0.25,0.511 -0.25,0.91 0,0.406 0.086,0.719 0.258,0.933 0.175,0.211 0.425,0.321 0.754,0.321 z m 4.097,0.531 -1.5,-2.723 c 0.031,0.266 0.043,0.477 0.043,0.637 V 66 h -0.637 v -3.535 h 0.821 l 1.523,2.746 c -0.031,-0.254 -0.047,-0.484 -0.047,-0.691 v -2.055 h 0.641 V 66 Z m 3.742,-2.977 c -0.156,0.25 -0.3,0.497 -0.441,0.731 -0.137,0.234 -0.254,0.473 -0.359,0.711 -0.102,0.238 -0.184,0.484 -0.243,0.738 -0.058,0.25 -0.089,0.516 -0.089,0.797 h -0.715 c 0,-0.293 0.039,-0.578 0.113,-0.852 0.074,-0.277 0.184,-0.558 0.324,-0.843 0.141,-0.285 0.399,-0.707 0.774,-1.262 h -1.711 v -0.578 h 2.347 z m 132.93,2.446 c 0.438,0 0.738,-0.227 0.906,-0.672 l 0.629,0.242 c -0.137,0.34 -0.332,0.594 -0.597,0.762 -0.258,0.168 -0.571,0.25 -0.938,0.25 -0.551,0 -0.98,-0.16 -1.281,-0.485 -0.301,-0.32 -0.453,-0.773 -0.453,-1.351 0,-0.578 0.144,-1.027 0.437,-1.336 0.293,-0.313 0.715,-0.469 1.266,-0.469 0.406,0 0.734,0.086 0.988,0.254 0.254,0.164 0.43,0.406 0.535,0.731 l -0.637,0.179 c -0.054,-0.179 -0.16,-0.32 -0.316,-0.422 -0.156,-0.105 -0.34,-0.16 -0.555,-0.16 -0.324,0 -0.574,0.106 -0.742,0.313 -0.168,0.207 -0.25,0.511 -0.25,0.91 0,0.406 0.086,0.719 0.258,0.933 0.176,0.211 0.426,0.321 0.75,0.321 z m 4.102,0.531 -1.5,-2.723 c 0.027,0.266 0.043,0.477 0.043,0.637 V 66 h -0.641 v -3.535 h 0.824 l 1.52,2.746 c -0.028,-0.254 -0.043,-0.484 -0.043,-0.691 v -2.055 h 0.64 V 66 Z m 1.496,0 v -0.523 h 0.851 v -2.415 l -0.828,0.532 v -0.555 l 0.863,-0.574 h 0.649 v 3.012 h 0.789 V 66 Z m 5.039,-1.77 c 0,0.598 -0.102,1.051 -0.301,1.36 -0.199,0.305 -0.496,0.461 -0.895,0.461 -0.789,0 -1.183,-0.606 -1.183,-1.821 0,-0.421 0.043,-0.769 0.129,-1.035 0.086,-0.269 0.218,-0.465 0.39,-0.593 0.172,-0.125 0.399,-0.192 0.684,-0.192 0.406,0 0.703,0.152 0.894,0.457 0.188,0.301 0.282,0.758 0.282,1.363 z m -0.688,0 c 0,-0.324 -0.015,-0.578 -0.047,-0.761 -0.031,-0.18 -0.082,-0.309 -0.148,-0.387 -0.07,-0.078 -0.168,-0.117 -0.297,-0.117 -0.141,0 -0.246,0.039 -0.316,0.117 -0.071,0.082 -0.121,0.211 -0.153,0.391 -0.027,0.179 -0.043,0.433 -0.043,0.757 0,0.325 0.016,0.575 0.047,0.758 0.031,0.18 0.082,0.309 0.149,0.391 0.07,0.078 0.172,0.117 0.304,0.117 0.129,0 0.231,-0.043 0.301,-0.125 0.07,-0.082 0.121,-0.215 0.152,-0.398 0.036,-0.18 0.051,-0.43 0.051,-0.743 z m -22.445,1.239 c 0.434,0 0.734,-0.227 0.902,-0.672 l 0.629,0.242 c -0.137,0.34 -0.332,0.594 -0.594,0.762 -0.261,0.168 -0.574,0.25 -0.937,0.25 -0.555,0 -0.984,-0.16 -1.285,-0.485 -0.301,-0.32 -0.453,-0.773 -0.453,-1.351 0,-0.578 0.144,-1.027 0.437,-1.336 0.293,-0.313 0.715,-0.469 1.266,-0.469 0.406,0 0.734,0.086 0.988,0.254 0.254,0.164 0.434,0.406 0.535,0.731 l -0.637,0.179 c -0.05,-0.179 -0.16,-0.32 -0.316,-0.422 -0.156,-0.105 -0.34,-0.16 -0.555,-0.16 -0.324,0 -0.574,0.106 -0.742,0.313 -0.168,0.207 -0.25,0.511 -0.25,0.91 0,0.406 0.086,0.719 0.258,0.933 0.176,0.211 0.426,0.321 0.754,0.321 z m 4.098,0.531 -1.5,-2.723 c 0.027,0.266 0.043,0.477 0.043,0.637 V 66 h -0.641 v -3.535 h 0.824 l 1.52,2.746 c -0.028,-0.254 -0.043,-0.484 -0.043,-0.691 v -2.055 h 0.64 V 66 Z m 3.82,-1.176 c 0,0.375 -0.113,0.672 -0.34,0.895 -0.227,0.219 -0.539,0.332 -0.934,0.332 -0.343,0 -0.621,-0.082 -0.832,-0.239 -0.203,-0.16 -0.332,-0.394 -0.382,-0.695 l 0.687,-0.058 c 0.035,0.152 0.098,0.261 0.192,0.328 0.089,0.07 0.203,0.105 0.343,0.105 0.172,0 0.305,-0.058 0.407,-0.172 0.101,-0.109 0.156,-0.273 0.156,-0.48 0,-0.188 -0.051,-0.336 -0.145,-0.445 -0.097,-0.114 -0.23,-0.168 -0.402,-0.168 -0.191,0 -0.348,0.074 -0.469,0.226 h -0.668 l 0.121,-1.988 h 2.067 v 0.523 h -1.446 l -0.054,0.895 c 0.164,-0.153 0.371,-0.227 0.621,-0.227 0.328,0 0.59,0.106 0.785,0.313 0.195,0.211 0.293,0.496 0.293,0.855 z"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath507)"
+           id="path1016" />
+        <path
+           d="m 267.461,184.34 c 0.434,0 0.734,-0.223 0.902,-0.672 l 0.629,0.242 c -0.137,0.34 -0.332,0.598 -0.594,0.762 -0.261,0.168 -0.574,0.25 -0.937,0.25 -0.555,0 -0.984,-0.16 -1.285,-0.481 -0.301,-0.324 -0.453,-0.773 -0.453,-1.355 0,-0.578 0.144,-1.024 0.437,-1.336 0.293,-0.312 0.715,-0.469 1.266,-0.469 0.406,0 0.734,0.086 0.988,0.254 0.254,0.164 0.434,0.41 0.535,0.731 l -0.637,0.179 c -0.05,-0.175 -0.16,-0.316 -0.316,-0.422 -0.156,-0.105 -0.34,-0.156 -0.555,-0.156 -0.324,0 -0.574,0.102 -0.742,0.309 -0.168,0.207 -0.25,0.512 -0.25,0.91 0,0.406 0.086,0.719 0.258,0.934 0.176,0.214 0.426,0.32 0.754,0.32 z m 4.098,0.531 -1.5,-2.723 c 0.027,0.266 0.043,0.477 0.043,0.637 v 2.086 h -0.641 v -3.535 h 0.824 l 1.52,2.746 c -0.028,-0.254 -0.043,-0.484 -0.043,-0.691 v -2.055 h 0.64 v 3.535 z m 3.773,-1.824 c 0,0.629 -0.109,1.098 -0.332,1.406 -0.223,0.313 -0.539,0.469 -0.949,0.469 -0.305,0 -0.543,-0.067 -0.715,-0.199 -0.172,-0.133 -0.293,-0.344 -0.363,-0.633 l 0.644,-0.09 c 0.063,0.242 0.211,0.367 0.438,0.367 0.195,0 0.34,-0.094 0.445,-0.285 0.102,-0.187 0.156,-0.469 0.16,-0.84 -0.062,0.125 -0.164,0.227 -0.305,0.297 -0.14,0.07 -0.293,0.106 -0.457,0.106 -0.3,0 -0.543,-0.106 -0.722,-0.317 -0.176,-0.211 -0.266,-0.5 -0.266,-0.859 0,-0.371 0.106,-0.664 0.313,-0.871 0.211,-0.211 0.507,-0.317 0.89,-0.317 0.41,0 0.719,0.149 0.918,0.446 0.203,0.289 0.301,0.73 0.301,1.32 z m -0.723,-0.492 c 0,-0.223 -0.047,-0.395 -0.144,-0.524 -0.09,-0.129 -0.215,-0.195 -0.371,-0.195 -0.149,0 -0.27,0.055 -0.356,0.172 -0.086,0.109 -0.133,0.265 -0.133,0.465 0,0.195 0.047,0.351 0.133,0.472 0.086,0.117 0.207,0.176 0.36,0.176 0.148,0 0.269,-0.051 0.363,-0.152 0.098,-0.106 0.148,-0.242 0.148,-0.414 z"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath508)"
+           id="path1017" />
+        <path
+           d="m 153.785,65.469 c 0.434,0 0.738,-0.227 0.906,-0.672 l 0.629,0.242 c -0.136,0.34 -0.336,0.594 -0.597,0.762 -0.262,0.168 -0.575,0.25 -0.938,0.25 -0.555,0 -0.98,-0.16 -1.285,-0.485 -0.301,-0.32 -0.449,-0.773 -0.449,-1.351 0,-0.578 0.144,-1.027 0.437,-1.336 0.289,-0.313 0.711,-0.469 1.266,-0.469 0.402,0 0.734,0.086 0.988,0.254 0.254,0.164 0.43,0.406 0.531,0.731 l -0.632,0.179 c -0.055,-0.179 -0.161,-0.32 -0.317,-0.422 -0.156,-0.105 -0.344,-0.16 -0.554,-0.16 -0.329,0 -0.575,0.106 -0.743,0.313 -0.168,0.207 -0.254,0.511 -0.254,0.91 0,0.406 0.086,0.719 0.262,0.933 0.172,0.211 0.422,0.321 0.75,0.321 z m 4.098,0.531 -1.496,-2.723 c 0.027,0.266 0.043,0.477 0.043,0.637 V 66 h -0.641 v -3.535 h 0.824 l 1.52,2.746 c -0.028,-0.254 -0.043,-0.484 -0.043,-0.691 v -2.055 h 0.64 V 66 Z m 3.781,-1.156 c 0,0.375 -0.102,0.672 -0.305,0.886 -0.207,0.211 -0.488,0.321 -0.851,0.321 -0.406,0 -0.719,-0.145 -0.934,-0.438 -0.219,-0.293 -0.324,-0.726 -0.324,-1.301 0,-0.628 0.109,-1.105 0.328,-1.421 0.223,-0.321 0.535,-0.481 0.945,-0.481 0.293,0 0.524,0.067 0.692,0.199 0.168,0.133 0.289,0.336 0.359,0.614 l -0.648,0.093 c -0.063,-0.23 -0.199,-0.347 -0.414,-0.347 -0.184,0 -0.332,0.093 -0.438,0.285 -0.101,0.187 -0.156,0.473 -0.156,0.859 0.074,-0.125 0.176,-0.222 0.309,-0.289 0.128,-0.066 0.277,-0.101 0.441,-0.101 0.305,0 0.551,0.101 0.73,0.3 0.176,0.204 0.266,0.477 0.266,0.821 z m -0.687,0.019 c 0,-0.199 -0.047,-0.355 -0.137,-0.461 -0.09,-0.105 -0.215,-0.16 -0.371,-0.16 -0.153,0 -0.274,0.051 -0.364,0.153 -0.089,0.097 -0.136,0.23 -0.136,0.394 0,0.203 0.047,0.375 0.14,0.512 0.098,0.133 0.223,0.199 0.375,0.199 0.157,0 0.278,-0.055 0.364,-0.168 0.086,-0.113 0.129,-0.27 0.129,-0.469 z"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath509)"
+           id="path1018" />
+        <path
+           d="m 154.07,184.34 c 0.434,0 0.735,-0.223 0.903,-0.672 l 0.629,0.242 c -0.133,0.34 -0.332,0.598 -0.594,0.762 -0.262,0.168 -0.574,0.25 -0.938,0.25 -0.554,0 -0.984,-0.16 -1.285,-0.481 -0.301,-0.324 -0.453,-0.773 -0.453,-1.355 0,-0.578 0.148,-1.024 0.438,-1.336 0.292,-0.312 0.714,-0.469 1.265,-0.469 0.406,0 0.735,0.086 0.988,0.254 0.254,0.164 0.434,0.41 0.536,0.731 l -0.637,0.179 c -0.051,-0.175 -0.156,-0.316 -0.317,-0.422 -0.156,-0.105 -0.339,-0.156 -0.554,-0.156 -0.324,0 -0.571,0.102 -0.742,0.309 -0.168,0.207 -0.25,0.512 -0.25,0.91 0,0.406 0.086,0.719 0.257,0.934 0.176,0.214 0.426,0.32 0.754,0.32 z m 4.098,0.531 -1.5,-2.723 c 0.031,0.266 0.043,0.477 0.043,0.637 v 2.086 h -0.637 v -3.535 h 0.821 l 1.523,2.746 c -0.031,-0.254 -0.047,-0.484 -0.047,-0.691 v -2.055 h 0.641 v 3.535 z m 3.809,-0.996 c 0,0.332 -0.11,0.59 -0.321,0.773 -0.215,0.184 -0.519,0.274 -0.914,0.274 -0.39,0 -0.695,-0.09 -0.914,-0.274 -0.215,-0.183 -0.32,-0.437 -0.32,-0.769 0,-0.223 0.062,-0.414 0.187,-0.567 0.129,-0.156 0.297,-0.253 0.512,-0.289 v -0.011 c -0.184,-0.043 -0.336,-0.137 -0.449,-0.285 -0.113,-0.145 -0.172,-0.317 -0.172,-0.508 0,-0.289 0.102,-0.516 0.301,-0.684 0.199,-0.168 0.48,-0.254 0.843,-0.254 0.375,0 0.661,0.082 0.86,0.246 0.199,0.164 0.301,0.395 0.301,0.696 0,0.195 -0.059,0.363 -0.172,0.507 -0.114,0.145 -0.266,0.239 -0.453,0.278 v 0.008 c 0.218,0.039 0.394,0.132 0.519,0.281 0.125,0.148 0.192,0.344 0.192,0.578 z m -0.793,-1.613 c 0,-0.168 -0.036,-0.289 -0.114,-0.367 -0.074,-0.079 -0.187,-0.118 -0.34,-0.118 -0.292,0 -0.441,0.161 -0.441,0.485 0,0.34 0.149,0.508 0.449,0.508 0.149,0 0.262,-0.04 0.332,-0.118 0.078,-0.082 0.114,-0.211 0.114,-0.39 z m 0.082,1.554 c 0,-0.367 -0.18,-0.554 -0.539,-0.554 -0.165,0 -0.293,0.05 -0.383,0.148 -0.086,0.094 -0.133,0.235 -0.133,0.418 0,0.207 0.047,0.36 0.133,0.453 0.09,0.098 0.222,0.145 0.402,0.145 0.18,0 0.309,-0.047 0.391,-0.145 0.086,-0.093 0.129,-0.25 0.129,-0.465 z"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath510)"
+           id="path1019" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
#### Contribution description

This PR adds missing pinout diagram from board manual mb1136 for nucleo-l452re board.

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l452re.html
```

### Issues/PRs references

None