### PR TITLE
sys/net/application_layer/gcoap: fix Observe notifications correlation

### DIFF
--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -9,9 +9,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
-    chronos \
+    derfmega128 \
     i-nucleo-lrwan1 \
-    im880b \
+    microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-c031c6 \
@@ -26,6 +26,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     olimex-msp430-h1611 \
     olimex-msp430-h2618 \
     samd10-xmini \
+    saml10-xpro \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
@@ -37,4 +39,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     weact-g030f6 \
     z1 \
+    zigduino \
     #

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -54,6 +54,9 @@ USEMODULE += shell_cmds_default
 USEMODULE += uri_parser
 USEMODULE += ps
 
+# /rtc resource for regular observe notifications
+FEATURES_OPTIONAL += periph_rtc
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
@@ -80,6 +83,13 @@ DOCKER_ENV_VARS += USE_ZEP
 DOCKER_ENV_VARS += ZEP_PORT_BASE
 
 include $(RIOTBASE)/Makefile.include
+
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
+  USEMODULE += event_periodic
+  USEMODULE += event_periodic_callback
+  USEMODULE += event_thread
+  USEMODULE += ztimer_msec
+endif
 
 # For now this goes after the inclusion of Makefile.include so Kconfig symbols
 # are available. Only set configuration via CFLAGS if Kconfig is not being used

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -8,7 +8,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atmega8 \
     atxmega-a3bu-xplained \
+    blackpill-stm32f103c8 \
     bluepill-stm32f030c8 \
+    bluepill-stm32f103c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \
@@ -16,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \

--- a/examples/gcoap/client.c
+++ b/examples/gcoap/client.c
@@ -191,6 +191,8 @@ static int _print_usage(char **argv)
     printf("       %s proxy unset\n", argv[0]);
     printf("Options\n");
     printf("    -c  Send confirmably (defaults to non-confirmable)\n");
+    printf("    -o  include Observe registration option\n");
+    printf("    -d  include Observe deregistration option\n");
     return 1;
 }
 

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -1077,6 +1077,9 @@ static inline ssize_t gcoap_response(coap_pkt_t *pdu, uint8_t *buf,
  *
  * First verifies that an observer has been registered for the resource.
  *
+ * @post    If this function returns @see GCOAP_OBS_INIT_OK you have to call
+ *          @ref gcoap_obs_send() afterwards to release a mutex.
+ *
  * @param[out] pdu      Notification metadata
  * @param[out] buf      Buffer containing the PDU
  * @param[in] len       Length of the buffer

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -552,6 +552,10 @@ extern "C" {
 /**
  * @ingroup net_gcoap_conf
  * @brief   Maximum number of Observe clients
+ *
+ * @note As documented in this file, the implementation is limited to one observer per resource.
+ *       Therefore, every stored observer is associated with a different resource.
+ *       If you have only one observable resource, you could set this value to 1.
  */
 #ifndef CONFIG_GCOAP_OBS_CLIENTS_MAX
 #define CONFIG_GCOAP_OBS_CLIENTS_MAX   (2)
@@ -559,7 +563,24 @@ extern "C" {
 
 /**
  * @ingroup net_gcoap_conf
+ * @brief   Maximum number of local notifying endpoint addresses
+ *
+ * @note As documented in this file, the implementation is limited to one observer per resource.
+ *       Therefore, every stored local endpoint alias is associated with an observation context
+ *       of a different resource.
+ *       If you have only one observable resource, you could set this value to 1.
+ */
+#ifndef CONFIG_GCOAP_OBS_NOTIFIERS_MAX
+#define CONFIG_GCOAP_OBS_NOTIFIERS_MAX  (2)
+#endif
+
+/**
+ * @ingroup net_gcoap_conf
  * @brief   Maximum number of registrations for Observable resources
+ *
+ * @note As documented in this file, the implementation is limited to one observer per resource.
+ *       Therefore, every stored observation context is associated with a different resource.
+ *       If you have only one observable resource, you could set this value to 1.
  */
 #ifndef CONFIG_GCOAP_OBS_REGISTRATIONS_MAX
 #define CONFIG_GCOAP_OBS_REGISTRATIONS_MAX     (2)
@@ -839,6 +860,7 @@ struct gcoap_request_memo {
  */
 typedef struct {
     sock_udp_ep_t *observer;            /**< Client endpoint; unused if null */
+    sock_udp_ep_t *notifier;            /**< Local endpoint to send notifications */
     const coap_resource_t *resource;    /**< Entity being observed */
     uint8_t token[GCOAP_TOKENLEN_MAX];  /**< Client token for notifications */
     uint16_t last_msgid;                /**< Message ID of last notification */

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -897,6 +897,22 @@ kernel_pid_t gcoap_init(void);
 void gcoap_register_listener(gcoap_listener_t *listener);
 
 /**
+ * @brief   Iterate through all registered listeners and check for a resource, matching by @p uri_path
+ *
+ *  This functions returns resources matching a subpath @see COAP_MATCH_SUBTREE.
+ *  If an exact match is required, check with `strncmp()`.
+ *
+ * @param[in, out]  last_listener       A pointer to NULL for the first call, otherwise the last returned listener
+ * @param[in]       last_resource       NULL for the first call, otherwise the last returned resource
+ * @param[in]       uri_path            The URI path to search for
+ *
+ * @return  The resource that matches the URI path
+ */
+const coap_resource_t *gcoap_get_resource_by_path_iterator(const gcoap_listener_t **last_listener,
+                                                           const coap_resource_t *last_resource,
+                                                           const char *uri_path);
+
+/**
  * @brief   Initializes a CoAP request PDU on a buffer.
  *
  * If @p code is COAP_CODE_EMPTY, prepares a complete "CoAP ping" 4 byte empty

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -2245,7 +2245,7 @@ extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
  * @return <0 if the resource path sorts before the URI
  * @return >0 if the resource path sorts after the URI
  */
-int coap_match_path(const coap_resource_t *resource, uint8_t *uri);
+int coap_match_path(const coap_resource_t *resource, const uint8_t *uri);
 
 #if defined(MODULE_GCOAP) || defined(DOXYGEN)
 /**

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -184,7 +184,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     return 0;
 }
 
-int coap_match_path(const coap_resource_t *resource, uint8_t *uri)
+int coap_match_path(const coap_resource_t *resource, const uint8_t *uri)
 {
     assert(resource && uri);
     int res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When a CONfirmable CoAP request with an Observe option is sent, the sending client has to store the CoAP token to match multiple responses from the server sending Observe notifications.
The `gcoap` memo is not cleared when the 2.xx response for the client registration contains an Observe option.

https://github.com/RIOT-OS/RIOT/blob/3f41494e59dc915fe17f67ba3b40d0827b9b3a36/sys/net/application_layer/gcoap/gcoap.c#L521-L531

For a confirmable request with a token length >0, the problem happens right before, where the resend buffer is released by actually overwriting the first byte of the request header in `pdu_buf` with 0. The first byte contains the token length which is required to match in:

https://github.com/RIOT-OS/RIOT/blob/3f41494e59dc915fe17f67ba3b40d0827b9b3a36/sys/net/application_layer/gcoap/gcoap.c#L888-L914

There, the overwritten request header is accessed in `gcoap_request_memo_get_hdr()`.

https://github.com/RIOT-OS/RIOT/blob/3f41494e59dc915fe17f67ba3b40d0827b9b3a36/sys/include/net/gcoap.h#L1182-L1190


 Solution:

When a response is received, the retransmission buffer is released, but before the header is copied to `hdr_buf` in: 

https://github.com/RIOT-OS/RIOT/blob/3f41494e59dc915fe17f67ba3b40d0827b9b3a36/sys/include/net/gcoap.h#L809-L833

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Internal project. CoAP Observe is not so well tested. I hope the explanation makes sense.
In `examples/gcoap/client.c`:

https://github.com/RIOT-OS/RIOT/blob/3f41494e59dc915fe17f67ba3b40d0827b9b3a36/examples/gcoap/client.c#L397-L408

the notification is sent right after the registration was sent.  I have not tried that.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Depends on and includes #20711