### PR TITLE
nanocoap: fix coap_block2_finish() when option size is shrinking

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -409,6 +409,7 @@ typedef struct {
     size_t end;                     /**< End offset of the current block    */
     size_t cur;                     /**< Offset of the generated content    */
     uint8_t *opt;                   /**< Pointer to the placed option       */
+    uint8_t obytes;                 /**< size of the placed option          */
 } coap_block_slicer_t;
 
 #if defined(MODULE_NANOCOAP_RESOURCES) || DOXYGEN

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -994,10 +994,9 @@ void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
  * @param[in]     slicer      Preallocated slicer struct to use
  * @param[in]     option      option number (block1 or block2)
  *
- * @return      true if the `more` bit is set in the block option
- * @return      false if the `more` bit is not set the block option
+ * @return      number of bytes by which the CoAP header shrunk
  */
-bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
+int coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
 
 /**
  * @brief Finish a block1 request
@@ -1010,10 +1009,9 @@ bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
  *
  * @param[in]     slicer      Preallocated slicer struct to use
  *
- * @return      true if the `more` bit is set in the block option
- * @return      false if the `more` bit is not set the block option
+ * @return      number of bytes by which the CoAP header shrunk
  */
-static inline bool coap_block1_finish(coap_block_slicer_t *slicer)
+static inline int coap_block1_finish(coap_block_slicer_t *slicer)
 {
     return coap_block_finish(slicer, COAP_OPT_BLOCK1);
 }
@@ -1029,10 +1027,9 @@ static inline bool coap_block1_finish(coap_block_slicer_t *slicer)
  *
  * @param[in]     slicer      Preallocated slicer struct to use
  *
- * @return      true if the `more` bit is set in the block option
- * @return      false if the `more` bit is not set the block option
+ * @return      number of bytes by which the CoAP header shrunk
  */
-static inline bool coap_block2_finish(coap_block_slicer_t *slicer)
+static inline int coap_block2_finish(coap_block_slicer_t *slicer)
 {
     return coap_block_finish(slicer, COAP_OPT_BLOCK2);
 }

--- a/sys/net/application_layer/nanocoap/fileserver.c
+++ b/sys/net/application_layer/nanocoap/fileserver.c
@@ -269,7 +269,7 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     vfs_close(fd);
 
     slicer.cur = slicer.end + more;
-    coap_block2_finish(&slicer);
+    resp_len -= coap_block2_finish(&slicer);
 
     if (read == 0) {
         /* Rewind to clear payload marker */

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1326,7 +1326,7 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
     coap_block_slicer_init(slicer, blknum, coap_szx2size(szx));
 }
 
-bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
+int coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
 {
     assert(slicer->opt);
 
@@ -1346,9 +1346,9 @@ bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
         /* if the option grew larger, we already corrupted content */
         assert(obytes < slicer->obytes);
         memmove(slicer->opt + obytes, slicer->opt + slicer->obytes,
-                slicer->cur - slicer->obytes);
+                1 + slicer->cur - slicer->obytes);
     }
-    return more;
+    return slicer->obytes - obytes;
 }
 
 ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The CoAP block option gets written twice: First a 'dummy' value is written by `coap_opt_add_block2()`, later this gets overwritten by the real option value by `coap_block2_finish()`.

The problem arises when the size of the option changes.
If the option ends up smaller than the dummy, we have garbage bytes after the real option value, corrupting the packet.

To fix this, move the packet contents in case the option size shrank. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #20686

