### PR TITLE
Makefile.include: creation of CACHEDIR.TAG as a dependency of pkg-prepare

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -688,7 +688,6 @@ BUILDDEPS += $(RIOTBUILD_CONFIG_HEADER_C)
 BUILDDEPS += pkg-prepare
 BUILDDEPS += $(APPDEPS)
 BUILDDEPS += $(MODULE_LIST_DIR)
-BUILDDEPS += $(BUILD_DIR)/CACHEDIR.TAG
 
 # Build dependencies depend on clean (if a make goal), as clean may wipe them.
 # Without them depending on clean parallel builds occasionally fail due to
@@ -754,11 +753,6 @@ $(_SUBMAKE_LIBS): $(APPLICATION_MODULE).module pkg-build $(GENSRC)
 # 'print-size' triggers a rebuild. Use 'info-buildsize' if you do not need to rebuild.
 print-size: $(ELFFILE)
 	$(Q)$(SIZE) $(SIZEFLAGS) $<
-
-$(BUILD_DIR)/CACHEDIR.TAG:
-	$(Q)mkdir -p "$(BUILD_DIR)"
-	$(Q)echo "Signature: 8a477f597d28d172789f06886806bc55" > "$@"
-	$(Q)echo "# This folder contains RIOT's build cache" >> "$@"
 
 %.hex: %.elf
 	$(Q)$(OBJCOPY) $(OFLAGS) -Oihex $< $@

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -82,8 +82,15 @@ PKG_CUSTOM_PREPARED ?=
 # Declare 'all' first to have it being the default target
 all: prepare
 
+BUILD_DIR ?= $(RIOTBASE)/build
+
+$(BUILD_DIR)/CACHEDIR.TAG:
+	$(Q)mkdir -p "$(BUILD_DIR)"
+	$(Q)echo "Signature: 8a477f597d28d172789f06886806bc55" > "$@"
+	$(Q)echo "# This folder contains RIOT's build cache" >> "$@"
+
 # Add noop builtin to avoid "Nothing to be done for prepare" message
-prepare: $(PKG_PREPARED)
+prepare: $(PKG_PREPARED) | $(BUILD_DIR)/CACHEDIR.TAG
 	@:
 
 # Allow packages to add a custom step to be `prepared`.


### PR DESCRIPTION
### Contribution description

The cached dir, only build for now, are not created by default so I added a small default target that will create the build dir and the CACHEDIR whenever a make command is called.

### Testing procedure

Both commands should have the same behavior now. Previously pkg-prepare was not creating `build/CACHEDIR.TAG` and was creating the `build/` directory through `pkg/pkg.mk`.

```bash
make pkg-prepare
```

```bash
make
```

### Issues/PRs references

N/A
