### PR TITLE
nanocoap_sock: add nanocoap_get_blockwise_to_buf()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -585,6 +585,29 @@ ssize_t nanocoap_get_blockwise_url_to_buf(const char *url,
                                           void *buf, size_t len);
 
 /**
+ * @brief    Performs a blockwise CoAP GET request, store the response
+ *           in a buffer.
+ *
+ * This function will fetch the content of the specified resource path via
+ * block-wise-transfer.
+ * The blocks will be re-assembled into @p buf
+ *
+ * @param[in]   sock       socket to use for the request
+ * @param[in]   path       pointer to source path
+ * @param[in]   blksize    sender suggested SZX for the COAP block request
+ * @param[in]   buf        Target buffer
+ * @param[in]   len        Target buffer length
+ *
+ * @returns     <0 on error
+ * @returns     -EINVAL    if an invalid url is provided
+ * @returns     -ENOBUFS   if the provided buffer was too small
+ * @returns     size of the response payload on success
+ */
+ssize_t nanocoap_get_blockwise_to_buf(nanocoap_sock_t *sock, const char *path,
+                                      coap_blksize_t blksize,
+                                      void *buf, size_t len);
+
+/**
  * @brief   Simple synchronous CoAP request
  *
  * @param[in]       sock    socket to use for the request

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -811,6 +811,17 @@ ssize_t nanocoap_get_blockwise_url_to_buf(const char *url,
     return (res < 0) ? (ssize_t)res : (ssize_t)_buf.len;
 }
 
+ssize_t nanocoap_get_blockwise_to_buf(nanocoap_sock_t *sock, const char *path,
+                                      coap_blksize_t blksize,
+                                      void *buf, size_t len)
+{
+    _buf_t _buf = { .ptr = buf, .len = len };
+
+    int res = nanocoap_sock_get_blockwise(sock, path, blksize, _2buf, &_buf);
+
+    return (res < 0) ? (ssize_t)res : (ssize_t)_buf.len;
+}
+
 int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
 {
     nanocoap_sock_t sock;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Just like `nanocoap_get_blockwise_url_to_buf()`, but with a socket instead of a URL.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
