### PR TITLE
pkg/wamr: updated package to WAMR 1.3.3

### DIFF
--- a/pkg/wamr/Makefile
+++ b/pkg/wamr/Makefile
@@ -1,10 +1,10 @@
 PKG_NAME=wamr
 PKG_URL=https://github.com/bytecodealliance/wasm-micro-runtime.git
-ifeq ($(PKG_BLEADING),1)
+ifeq ($(PKG_BLEEDING),1)
   PKG_VERSION=main
 else
-  PKG_VERSION=dc4dcc3d6fba42dbe93cf9050fad8e0cfa4b88d0
-  #release tag: WAMR-1.1.1
+  PKG_VERSION=3f5e2bd23bcb8eb3767c8e17789c6a2e3e912a08
+  #release tag: WAMR-1.3.3
 endif
 PKG_LICENSE=Apache-2.0
 


### PR DESCRIPTION
### Contribution description

This PR updates WAMR to its 1.3.3 version referenced by this commit hash : 3f5e2bd23bcb8eb3767c8e17789c6a2e3e912a08.

I'd like some opinions about whether the `PKG_BLEEDING` condition (and variable) should be kept because this variable is not used somewhere else. Also the `main` tag does not exist and anyway tag names are not supported there, only commits hashes are.

### Testing procedure

Use various boards to see if the example/wamr still work.

I tested it with this example and another homemade one and the behavior was the same as the old version. The tests were made using an arduino nano 33 ble (and sense) and a dwm1001. 

Please note that the text+data values are slightly larger but the bss (ram) new use is not significant from what I saw.

### Issues/PRs references

N/A