### PR TITLE
boards/nucleo144: fix I2Cs row name in MCU tables

### DIFF
--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -26,7 +26,7 @@ STM32F767ZI microcontroller with 512KiB of RAM and 2 MiB of Flash.
 | Timers       | 18 (2x watchdog, 1 SysTick, 2x 32-bit, 13x 16-bit) |
 | ADCs         | 3x 12 bit (up to 24 channels) |
 | UARTs        | 4                   |
-| I2cs         | 4                   |
+| I2Cs         | 4                   |
 | SPIs         | 6                   |
 | CAN          | 3                   |
 | RTC          | 1                   |

--- a/boards/nucleo-l552ze-q/doc.txt
+++ b/boards/nucleo-l552ze-q/doc.txt
@@ -26,7 +26,7 @@ of Flash.
 | TrustZone    | yes                          |
 | Timers       | 16                           |
 | UARTs        | 6 (3xUSART, 2xUART, 1xLPUART)|
-| I2cs         | 4                            |
+| I2Cs         | 4                            |
 | SPIs         | 3                            |
 | CAN          | 1                            |
 | Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l552ze.pdf)|

--- a/boards/nucleo-u575zi-q/doc.txt
+++ b/boards/nucleo-u575zi-q/doc.txt
@@ -27,7 +27,7 @@ ture-description-include-personalized-no-cpn-medium.jpg)
 | TrustZone    | yes                          |
 | Timers       | 17                           |
 | UARTs        | 6 (3xUSART, 2xUART, 1xLPUART)|
-| I2cs         | 4                            |
+| I2Cs         | 4                            |
 | SPIs         | 3                            |
 | CAN          | 1                            |
 | Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32u575zi.pdf)|


### PR DESCRIPTION
### Contribution description

During review of PR #20671 @dylad spot in document page issue with row name in MCU table - was `I2cs` -> should be `I2Cs` [review](https://github.com/RIOT-OS/RIOT/pull/20671#pullrequestreview-2057095940). 

This PR fix this issue in other nucleo boards - f767, l552 and u575.

### Testing procedure

Generate doc and read the page.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f767zi.html
xdg-open doc/doxygen/html/group__boards__nucleo-l552ze-q.html
xdg-open doc/doxygen/html/group__boards__nucleo-u575zi-q.html
```

### Issues/PRs references

See also #20671
