### PR TITLE
sys/ztimer64: fix build when PRIu64 is not defined

### DIFF
--- a/sys/ztimer64/ztimer64.c
+++ b/sys/ztimer64/ztimer64.c
@@ -302,7 +302,13 @@ void ztimer64_clock_print(const ztimer64_clock_t *clock)
     const ztimer64_base_t *entry = clock->first;
 
     while (entry) {
+#ifdef PRIu64
         printf("0x%08" PRIxPTR ":%" PRIu64 "\n", (uintptr_t)entry, entry->target);
+#else
+        printf("0x%08" PRIxPTR ":%" PRIu32 "%s\n",
+               (uintptr_t)entry, (uint32_t)entry->target,
+               entry->target > UINT32_MAX ? " !TRUNC!" : "");
+#endif
         entry = entry->next;
     }
     puts("");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

After upgrading to Ubuntu 24.04, ztimer64 would fail to build:

```
/home/benpicco/dev/RIOT/sys/ztimer64/ztimer64.c: In function 'ztimer64_clock_print':
/home/benpicco/dev/RIOT/sys/ztimer64/ztimer64.c:306:36: error: expected ')' before 'PRIu64'
  306 |         printf("0x%08" PRIxPTR ":%" PRIu64 "\n", (uintptr_t)entry, entry->target);
      |               ~                    ^~~~~~~
      |                                    )
/home/benpicco/dev/RIOT/sys/ztimer64/ztimer64.c:35:1: note: 'PRIu64' is defined in header '<inttypes.h>'; did you forget to '#include <inttypes.h>'?
   34 | #include "debug.h"
  +++ |+#include <inttypes.h>
   35 | 
/home/benpicco/dev/RIOT/sys/ztimer64/ztimer64.c:306:16: error: format '%x' expects a matching 'unsigned int' argument [-Werror=format=]
  306 |         printf("0x%08" PRIxPTR ":%" PRIu64 "\n", (uintptr_t)entry, entry->target);
      |                ^~~~~~~
/home/benpicco/dev/RIOT/sys/ztimer64/ztimer64.c:306:16: error: spurious trailing '%' in format [-Werror=format=]
cc1: all warnings being treated as errors
```


### Testing procedure

`tests/sys/ztimer64_msg` can be built again.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
