### PR TITLE
build system: rename ethernet feature into netif_ethernet

### DIFF
--- a/boards/native/common_features.inc.mk
+++ b/boards/native/common_features.inc.mk
@@ -8,6 +8,6 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_qdec
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += motor_driver
 FEATURES_PROVIDED += netif

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -14,7 +14,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -14,7 +14,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += tinyusb_device
 

--- a/boards/nucleo-f439zi/Makefile.features
+++ b/boards/nucleo-f439zi/Makefile.features
@@ -13,7 +13,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += tinyusb_device
 

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -20,7 +20,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -19,7 +19,7 @@ FEATURES_PROVIDED += periph_freqm
 FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/stm32f746g-disco/features-shared.mk
+++ b/boards/stm32f746g-disco/features-shared.mk
@@ -17,6 +17,6 @@ FEATURES_PROVIDED += periph_usbdev_hs
 FEATURES_PROVIDED += periph_usbdev_hs_ulpi
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += tinyusb_device

--- a/features.yaml
+++ b/features.yaml
@@ -877,10 +877,10 @@ groups:
 - title: Board Features
   help: These features indicate features of the board
   features:
-  - name: ethernet
-    help: The board has Ethernet connectivity
   - name: netif
     help: The board has a network interface
+  - name: netif_ethernet
+    help: The board has an Ethernet network interface
   - name: highlevel_stdio
     help: A high-level stdio method (such as CDC ACM) is used. This requires a
           running thread and set-up and will not print during a crash.

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -126,13 +126,13 @@ FEATURES_EXISTING := \
     esp_wifi \
     esp_wifi_ap \
     esp_wifi_enterprise \
-    ethernet \
     gecko_sdk_librail_fpu \
     gecko_sdk_librail_nonfpu \
     highlevel_stdio \
     libstdcpp \
     motor_driver \
     netif \
+    netif_ethernet \
     newlib \
     no_idle_thread \
     periph_adc \


### PR DESCRIPTION
### Contribution description

This renames the `ethernet` feature into `netif_ethernet`. The goal is to eventually have a number of `netif_<type>` features that would allow filtering boards by the time of connectivity the have.

### Testing procedure

The `ethernet` feature has not yet been used, so renaming it should not cause any issue. The CI will test this, though.

### Issues/PRs references

None