### PR TITLE
nanocoap sock: stop retransmissions after empty ACK

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -204,7 +204,7 @@ static ssize_t _separate_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap
     static event_timeout_t event_timeout;
     static event_callback_t event_timed = EVENT_CALLBACK_INIT(_send_response, &_separate_ctx);
 
-    if (event_timeout_is_pending(&event_timeout)) {
+    if (event_timeout_is_pending(&event_timeout) && !sock_udp_ep_equal(context->remote, &_separate_ctx.remote)) {
         puts("_separate_handler(): response already scheduled");
         return coap_build_reply(pkt, COAP_CODE_SERVICE_UNAVAILABLE, buf, len, 0);
     }

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -296,7 +296,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 _send_ack(sock, pkt);
                 /* fall-through */
             case COAP_TYPE_ACK:
-                if (cb && coap_get_code_raw(pkt) == COAP_CODE_EMPTY) {
+                if (coap_get_code_raw(pkt) == COAP_CODE_EMPTY) {
                     /* empty ACK, wait for separate response */
                     state = STATE_RESPONSE_RCVD;
                     deadline = _deadline_from_interval(CONFIG_COAP_SEPARATE_RESPONSE_TIMEOUT_MS

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -267,7 +267,6 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 DEBUG("nanocoap: timeout waiting for response\n");
                 timeout *= 2;
                 deadline = _deadline_from_interval(timeout);
-                state = STATE_REQUEST_SEND;
                 continue;
             }
             if (res < 0) {
@@ -302,6 +301,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                     state = STATE_RESPONSE_RCVD;
                     deadline = _deadline_from_interval(CONFIG_COAP_SEPARATE_RESPONSE_TIMEOUT_MS
                                                      * US_PER_MS);
+                    tries_left = 0; /* stop retransmissions */
                     DEBUG("nanocoap: wait for separate response\n");
                     continue;
                 }

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -52,7 +52,7 @@
 
 enum {
     STATE_REQUEST_SEND,     /**< request was just sent or will be sent again */
-    STATE_RESPONSE_RCVD,    /**< response received but might be invalid      */
+    STATE_STOP_RETRANSMIT,  /**< stop retransmissions due to a matching empty ACK */
     STATE_RESPONSE_OK,      /**< valid response was received                 */
 };
 
@@ -212,10 +212,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
     while (1) {
         switch (state) {
         case STATE_REQUEST_SEND:
-            if (tries_left == 0) {
-                DEBUG("nanocoap: maximum retries reached\n");
-                return -ETIMEDOUT;
-            }
+            assert(tries_left > 0);
             --tries_left;
 
             DEBUG("nanocoap: send %u bytes (%u tries left)\n",
@@ -235,7 +232,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
             /* ctx must have been released at this point */
             assert(ctx == NULL);
             /* fall-through */
-        case STATE_RESPONSE_RCVD:
+        case STATE_STOP_RETRANSMIT:
         case STATE_RESPONSE_OK:
             if (ctx == NULL) {
                 DEBUG("nanocoap: waiting for response (timeout: %"PRIu32" µs)\n",
@@ -257,13 +254,17 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 /* no more data */
                 /* sock_udp_recv_buf() needs to be called in a loop until ctx is NULL again
                  * to release the buffer */
-                if (state == STATE_RESPONSE_RCVD) {
+                if (state == STATE_STOP_RETRANSMIT) {
                     continue;
                 }
                 return res;
             }
             res = tmp;
             if (res == -ETIMEDOUT) {
+                if (tries_left == 0) {
+                    DEBUG("nanocoap: maximum retries reached\n");
+                    return -ETIMEDOUT;
+                }
                 DEBUG("nanocoap: timeout waiting for response\n");
                 timeout *= 2;
                 deadline = _deadline_from_interval(timeout);
@@ -275,7 +276,6 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
             }
 
             /* parse response */
-            state = STATE_RESPONSE_RCVD;
             if (coap_parse(pkt, payload, res) < 0) {
                 DEBUG("nanocoap: error parsing packet\n");
                 continue;
@@ -285,20 +285,16 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 continue;
             }
 
-            state = STATE_RESPONSE_OK;
             DEBUG("nanocoap: response code=%i\n", coap_get_code_decimal(pkt));
             switch (coap_get_type(pkt)) {
             case COAP_TYPE_RST:
                 /* TODO: handle different? */
                 res = -EBADMSG;
                 break;
-            case COAP_TYPE_CON:
-                _send_ack(sock, pkt);
-                /* fall-through */
             case COAP_TYPE_ACK:
                 if (coap_get_code_raw(pkt) == COAP_CODE_EMPTY) {
                     /* empty ACK, wait for separate response */
-                    state = STATE_RESPONSE_RCVD;
+                    state = STATE_STOP_RETRANSMIT;
                     deadline = _deadline_from_interval(CONFIG_COAP_SEPARATE_RESPONSE_TIMEOUT_MS
                                                      * US_PER_MS);
                     tries_left = 0; /* stop retransmissions */
@@ -306,7 +302,13 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                     continue;
                 }
                 /* fall-through */
+            case COAP_TYPE_CON:
             case COAP_TYPE_NON:
+                state = STATE_RESPONSE_OK;
+                if (coap_get_type(pkt) == COAP_TYPE_CON) {
+                    /* send ACK */
+                    _send_ack(sock, pkt);
+                }
                 /* call user callback */
                 if (cb) {
                     res = cb(arg, pkt);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `nanocoap_sock_request_cb()` function does a synchronous CoAP request.
This PR fixes that further retransmissions are done, even though a matching empty ACK was received.
The behavior is mandatory for CoAP and should also be done when no response callback is set, because the ACK is not the actual response.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `examples/nanocoap_server` and `tests/net/nanocoap_cli` and increase the timeout for the `/separate` resource.
Without this fix, the client keeps retransmitting even after the empty ACK.

 Test when I set the server separate response delay to 10 seconds.

```
client get fe80::4d3:11ff:fe35:6a43 5683 /well-known/core
client get fe80::4d3:11ff:fe35:6a43 5683 /well-known/core
nanocli: sending msg ID 1, 22 bytes
nanocli: msg send failed: -6
> client get fe80::4d3:11ff:fe35:6a43 5683 /.well-known/core
client get fe80::4d3:11ff:fe35:6a43 5683 /.well-known/core
nanocli: sending msg ID 1, 23 bytes
nanocli: response Success, code 2.05, 16 bytes
</vfs>,</separat
> client get fe80::4d3:11ff:fe35:6a43 5683 /separate
client get fe80::4d3:11ff:fe35:6a43 5683 /separate
nanocli: sending msg ID 1, 15 bytes
nanocli: response Success, code 2.05, 28 bytes
00000000  54  68  69  73  20  69  73  20  61  20  64  65  6C  61  79  65
00000010  64  20  72  65  73  70  6F  6E  73  65  2E  00
```
~~bug: Look at `</vfs>,</separat`~~ no bug just blockwise transfer


When I disable the ACK on the server side I can see retransmissions in wireshark:

![Screenshot from 2024-05-27 11-46-07](https://github.com/RIOT-OS/RIOT/assets/15147337/922f6d72-dc94-4473-99e0-9f944cb60246)


But another bug: The serveice unavailable ACK is treated as the response. :( 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

first split out of #20696 
