### PR TITLE
build system: clean up netif features

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -33,6 +33,10 @@ FEATURES_CONFLICT += periph_usbdev:tinyusb_host
 FEATURES_CONFLICT_MSG += "Package tinyUSB is not yet compatible with periph_usbdev."
 
 # Features provided implicitly
+ifneq (,$(filter periph_eth,$(FEATURES_PROVIDED)))
+  FEATURES_PROVIDED += netif_ethernet
+endif
+
 ifneq (,$(filter netif_%,$(FEATURES_PROVIDED)))
   FEATURES_PROVIDED += netif
 endif

--- a/Makefile.features
+++ b/Makefile.features
@@ -31,3 +31,8 @@ FEATURES_CONFLICT_MSG += "Only one GPIO IRQ implementation can be used."
 FEATURES_CONFLICT += periph_usbdev:tinyusb_device
 FEATURES_CONFLICT += periph_usbdev:tinyusb_host
 FEATURES_CONFLICT_MSG += "Package tinyUSB is not yet compatible with periph_usbdev."
+
+# Features provided implicitly
+ifneq (,$(filter netif_%,$(FEATURES_PROVIDED)))
+  FEATURES_PROVIDED += netif
+endif

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.features
@@ -4,8 +4,8 @@ CPU_MODEL = esp32-wrover
 include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board
-FEATURES_PROVIDED += esp_eth
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -19,7 +19,7 @@ FEATURES_CONFLICT += periph_sdmmc:periph_spi
 FEATURES_CONFLICT_MSG += "SD/MMC and SPI cannot be used at the same time on this board."
 
 # unique features of the board
-FEATURES_PROVIDED += esp_eth        # Ethernet MAC (EMAC)
 FEATURES_PROVIDED += periph_can     # CAN peripheral interface
+FEATURES_PROVIDED += periph_eth     # Ethernet MAC (EMAC)
 
 FEATURES_PROVIDED += arduino_pins

--- a/boards/native/common_features.inc.mk
+++ b/boards/native/common_features.inc.mk
@@ -8,6 +8,5 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_qdec
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += motor_driver
-FEATURES_PROVIDED += netif
+FEATURES_PROVIDED += netif_ethernet

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -15,7 +15,6 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += netif_ethernet
-FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device
 

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -14,7 +14,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device
 

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -14,7 +14,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += tinyusb_device
 
 # load the common Makefile.features for Nucleo boards

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -15,7 +15,6 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += netif_ethernet
-FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += tinyusb_device
 
 # load the common Makefile.features for Nucleo boards

--- a/boards/nucleo-f439zi/Makefile.features
+++ b/boards/nucleo-f439zi/Makefile.features
@@ -13,7 +13,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += tinyusb_device
 
 # load the common Makefile.features for Nucleo boards

--- a/boards/nucleo-f439zi/Makefile.features
+++ b/boards/nucleo-f439zi/Makefile.features
@@ -14,7 +14,6 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += netif_ethernet
-FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += tinyusb_device
 
 # load the common Makefile.features for Nucleo boards

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -20,7 +20,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device
 

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -21,7 +21,6 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += netif_ethernet
-FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device
 

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -19,6 +19,5 @@ FEATURES_PROVIDED += periph_freqm
 FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -20,6 +20,5 @@ FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += netif_ethernet
-FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/stm32f746g-disco/features-shared.mk
+++ b/boards/stm32f746g-disco/features-shared.mk
@@ -17,5 +17,4 @@ FEATURES_PROVIDED += periph_usbdev_hs
 FEATURES_PROVIDED += periph_usbdev_hs_ulpi
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += netif_ethernet
 FEATURES_PROVIDED += tinyusb_device

--- a/boards/stm32f746g-disco/features-shared.mk
+++ b/boards/stm32f746g-disco/features-shared.mk
@@ -18,5 +18,4 @@ FEATURES_PROVIDED += periph_usbdev_hs_ulpi
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += netif_ethernet
-FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += tinyusb_device

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -32,7 +32,7 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
 endif
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))
-  FEATURES_REQUIRED += esp_eth
+  FEATURES_REQUIRED += periph_eth
   USEMODULE += esp_idf_eth
   USEMODULE += esp_idf_event
   USEMODULE += esp_idf_gpio

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -74,7 +74,7 @@ check_not_parsing_features() {
     # These two files contain sanity checks using FEATURES_ so are allowed
     pathspec+=(':!Makefile.include' ':!makefiles/info-global.inc.mk')
 
-    # We extend features provided in Makefile.features based on what is
+    # We extend FEATURES_PROVIDED in Makefile.features based on what is
     # already provided to avoid clutter in each boards Makefile.features.
     # E.g. `periph_eth` will pull in `netif_ethernet`, which
     # will pull in `netif`.

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -74,6 +74,12 @@ check_not_parsing_features() {
     # These two files contain sanity checks using FEATURES_ so are allowed
     pathspec+=(':!Makefile.include' ':!makefiles/info-global.inc.mk')
 
+    # We extend features provided in Makefile.features based on what is
+    # already provided to avoid clutter in each boards Makefile.features.
+    # E.g. `periph_eth` will pull in `netif_ethernet`, which
+    # will pull in `netif`.
+    pathspec+=(':!Makefile.features')
+
     git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
         | error_with_message 'Modules should not check the content of FEATURES_PROVIDED/REQUIRED/OPTIONAL'
 }

--- a/features.yaml
+++ b/features.yaml
@@ -138,10 +138,6 @@ groups:
     - title: ESP Specific Features
       help: These features are only available on (some) ESP MCUs.
       features:
-      - name: esp_eth
-        help: >
-              An ESP Ethernet peripherals is available.
-              (FIXME: `periph_eth` instead.)
       - name: esp_jtag
         help: The MCU supports JTAG for programming and debugging. Enable this
               feature to expose the interface at the cost of having fewer pins as

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -114,7 +114,6 @@ FEATURES_EXISTING := \
     esp_ble \
     esp_ble_esp32 \
     esp_ble_esp32c3 \
-    esp_eth \
     esp_hw_counter \
     esp_jtag \
     esp_now \


### PR DESCRIPTION
### Contribution description

- If any `netif_%` (currently only `netif_ethernet`, but more are to come) is provided, the `netif` feature is implicitly provided
    - The explicit addition of the `netif` feature from boards that already provide `netif_ethernet` is dropped, consequently
- Boards that previously provided `esp_eth` now instead provide `periph_eth` for consistancy
- Boards that provided `periph_eth` no longer need to provide `netif_ethernet`
    - boards that have an external Ethernet MAC (such es `w5100`, `w5500`, `enc28j60`, `encx24j600`, etc.) would still need to provide `netif_ethernet` by hand
    - from all other boards, `FEATURES_PROVIDED += netif_ethernet` is dropped, relying on it being added implicitly

### Testing procedure

This should not change any generated binaries.

### Issues/PRs references

Follow up to https://github.com/RIOT-OS/RIOT/issues/20694