### PR TITLE
drivers/at: expose some internal API

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -325,7 +325,7 @@ ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command,
     return at_readline_skip_empty(dev, resp_buf, len, false, timeout);
 }
 
-static ssize_t get_resp_with_prefix(at_dev_t *dev, const char *resp_prefix,
+ssize_t at_get_resp_with_prefix(at_dev_t *dev, const char *resp_prefix,
                                     char *resp_buf, size_t len, uint32_t timeout)
 {
     ssize_t res;
@@ -368,7 +368,7 @@ ssize_t at_send_cmd_get_resp_wait_ok(at_dev_t *dev, const char *command, const c
     if (res) {
         return res;
     }
-    res = get_resp_with_prefix(dev, resp_prefix, resp_buf, len, timeout);
+    res = at_get_resp_with_prefix(dev, resp_prefix, resp_buf, len, timeout);
     if (res < 1) {
         /* error or OK (empty response) */
         return res;
@@ -438,7 +438,7 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command, char *resp_buf
     return get_lines(dev, resp_buf, len, timeout);
 }
 
-static int wait_prompt(at_dev_t *dev, uint32_t timeout)
+int at_wait_prompt(at_dev_t *dev, uint32_t timeout)
 {
     ssize_t res;
     do {
@@ -467,7 +467,7 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout
     if (res) {
         return (int)res;
     }
-    return wait_prompt(dev, timeout);
+    return at_wait_prompt(dev, timeout);
 }
 
 int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
@@ -665,11 +665,6 @@ ssize_t _emb_read_line_or_echo(at_dev_t *dev, char const *cmd, char *resp_buf,
                         size_t len, uint32_t timeout);
 __attribute__((alias("get_lines")))
 ssize_t _emb_get_lines(at_dev_t *dev, char *resp_buf, size_t len, uint32_t timeout);
-__attribute__((alias("get_resp_with_prefix")))
-ssize_t _emb_get_resp_with_prefix(at_dev_t *dev, const char *resp_prefix,
-                                    char *resp_buf, size_t len, uint32_t timeout);
 __attribute__((alias("wait_echo")))
 int _emb_wait_echo(at_dev_t *dev, char const *command, uint32_t timeout);
-__attribute__((alias("wait_prompt")))
-int _emb_wait_prompt(at_dev_t *dev, uint32_t timeout);
 #endif

--- a/tests/drivers/at_unit/tests-at.c
+++ b/tests/drivers/at_unit/tests-at.c
@@ -106,10 +106,7 @@ static void assert_urc_count(unsigned expected)
 int _emb_read_line_or_echo(at_dev_t *dev, char const *cmd, char *resp_buf,
                         size_t len, uint32_t timeout);
 ssize_t _emb_get_lines(at_dev_t *dev, char *resp_buf, size_t len, uint32_t timeout);
-ssize_t _emb_get_resp_with_prefix(at_dev_t *dev, const char *resp_prefix,
-                                    char *resp_buf, size_t len, uint32_t timeout);
 int _emb_wait_echo(at_dev_t *dev, char const *command, uint32_t timeout);
-int _emb_wait_prompt(at_dev_t *dev, uint32_t timeout);
 
 static void inject_resp_str(at_dev_t *dev, char const *str)
 {
@@ -344,7 +341,7 @@ void test_get_resp_with_prefix(void)
                     AT_RECV_EOL
                     "+RESPONSE: 123"
                     AT_RECV_EOL);
-    res = _emb_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
+    res = at_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
     TEST_ASSERT(res > 0);
     res = strcmp("123", resp_buf);
     TEST_ASSERT(res == 0);
@@ -356,7 +353,7 @@ void test_get_resp_with_prefix(void)
                     AT_RECV_EOL
                     "OK"
                     AT_RECV_EOL);
-    res = _emb_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
+    res = at_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
     TEST_ASSERT(res == 0);
 
     inject_resp_str(dev,
@@ -365,7 +362,7 @@ void test_get_resp_with_prefix(void)
                     AT_RECV_EOL
                     AT_RECV_EOL "+CME ERROR: 1"
                     AT_RECV_EOL);
-    res = _emb_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
+    res = at_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
     TEST_ASSERT(res == -AT_ERR_EXTENDED);
     res = strncmp("1", dev->rp_buf, 1);
     TEST_ASSERT(res == 0);
@@ -377,14 +374,14 @@ void test_get_resp_with_prefix(void)
                     AT_RECV_EOL
                     "ERROR"
                     AT_RECV_EOL);
-    res = _emb_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
+    res = at_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
     TEST_ASSERT(res == -1);
 
     inject_resp_str(dev,
                     AT_RECV_EOL
                     UNIT_TEST_SHORT_URC
                     AT_RECV_EOL);
-    res = _emb_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
+    res = at_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
     TEST_ASSERT(res == -ETIMEDOUT);
 
     inject_resp_str(dev,
@@ -392,7 +389,7 @@ void test_get_resp_with_prefix(void)
                     AT_RECV_EOL
                     "+RESPONSE: 123"
                     AT_RECV_EOL);
-    res = _emb_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
+    res = at_get_resp_with_prefix(dev, "+RESPONSE: ", resp_buf, sizeof(resp_buf), 10000);
     TEST_ASSERT(res > 0);
     res = strcmp("123", resp_buf);
     TEST_ASSERT(res == 0);
@@ -500,7 +497,7 @@ void test_wait_prompt(void)
                     AT_RECV_EOL
                     ">"
                     "123");
-    res = _emb_wait_prompt(dev, 1000);
+    res = at_wait_prompt(dev, 1000);
     TEST_ASSERT(res == 0);
     res = isrpipe_read_timeout(&dev->isrpipe, (unsigned char *)resp_buf, sizeof(resp_buf), 1000);
     TEST_ASSERT(res == 3);
@@ -512,7 +509,7 @@ void test_wait_prompt(void)
                     AT_RECV_EOL
                     ">"
                     "456");
-    res = _emb_wait_prompt(dev, 1000);
+    res = at_wait_prompt(dev, 1000);
     TEST_ASSERT(res == 0);
     res = isrpipe_read_timeout(&dev->isrpipe, (unsigned char *)resp_buf, sizeof(resp_buf), 1000);
     TEST_ASSERT(res == 3);
@@ -525,13 +522,13 @@ void test_wait_prompt(void)
                     AT_RECV_EOL
                     "ERROR"
                     AT_RECV_EOL);
-    res = _emb_wait_prompt(dev, 1000);
+    res = at_wait_prompt(dev, 1000);
     TEST_ASSERT(res == -1);
 
     inject_resp_str(dev,
                     ">"
                     "123");
-    res = _emb_wait_prompt(dev, 1000);
+    res = at_wait_prompt(dev, 1000);
     TEST_ASSERT(res == 0);
     res = isrpipe_read_timeout(&dev->isrpipe, (unsigned char *)resp_buf, sizeof(resp_buf), 1000);
     TEST_ASSERT(res == 3);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Some static functions in the AT driver are meanwhile enough logically self-contained that they make sense to be exposed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
No logic was touched. Nevertheless, tested with `./tests/drivers/at_unit/test_all_configs.sh`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->




<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
