### PR TITLE
sys/event.h: Fixed documentation error by adding a type cast.

### DIFF
--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -81,7 +81,7 @@
  *
  * static custom_event_t custom_event = { .super.handler = custom_handler, .text = "CUSTOM EVENT" };
  *
- * [...] event_post(&queue, &custom_event)
+ * [...] event_post(&queue, (event_t *)&custom_event)
  * ~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * @{


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I added a type cast to the custom_event pointer because event_post only accepts a pointer to the built-in event_t. 

### Testing procedure

Look at the generated documentation of sys/event.h.