### PR TITLE
sys/event: change example in doc to be type safe

### DIFF
--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -75,13 +75,13 @@
  *
  * static void custom_handler(event_t *event)
  * {
- *     custom_event_t *custom_event = (custom_event_t *)event;
+ *     custom_event_t *custom_event = container_of(event, custom_event_t, super);
  *     printf("triggered custom event with text: \"%s\"\n", custom_event->text);
  * }
  *
  * static custom_event_t custom_event = { .super.handler = custom_handler, .text = "CUSTOM EVENT" };
  *
- * [...] event_post(&queue, (event_t *)&custom_event)
+ * [...] event_post(&queue, &custom_event.super)
  * ~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * @{


### PR DESCRIPTION
### Contribution description

C is not a particularly safe language, but let's at least encourage best practices so that the few safety features C have are effectively used.

### Testing procedure

The example code should compile and not contain casts where not needed.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/20704