### PR TITLE
boards/nucleo-l4r5zi and l496zg: add pinout to documentation page

### DIFF
--- a/boards/nucleo-l496zg/doc.txt
+++ b/boards/nucleo-l496zg/doc.txt
@@ -8,6 +8,10 @@
 The Nucleo-L496ZG is a board from ST's Nucleo family supporting ARM Cortex-M4
 STM32L496ZG ultra-low-pawer microcontroller with 320KiB of RAM and 1 MiB of Flash.
 
+## Pinout
+
+@image html pinouts/nucleo-l496zg.svg "Pinout for the nucleo-l496zg (from STM board manual)" width=55%
+
 ### MCU
 
 | MCU        |   STM32L496ZG      |

--- a/boards/nucleo-l4r5zi/doc.txt
+++ b/boards/nucleo-l4r5zi/doc.txt
@@ -12,6 +12,10 @@ STM32L4R5ZI microcontroller with 640KiB of RAM and 2MiB of ROM Flash.
 
 ![Nucleo144 L4R5ZI](https://www.st.com/bin/ecommerce/api/image.PF264781.en.feature-description-include-personalized-no-cpn-large.jpg)
 
+## Pinout
+
+@image html pinouts/nucleo-l4r5zi.svg "Pinout for the nucleo-l4r5zi (from STM board manual)" width=55%
+
 ### MCU
 
 | MCU          | STM32L4R5ZI                                        |

--- a/doc/doxygen/src/pinouts/nucleo-l496zg.svg
+++ b/doc/doxygen/src/pinouts/nucleo-l496zg.svg
@@ -1,0 +1,5847 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="614.23865"
+   height="676.71863"
+   viewBox="0 0 614.23865 676.7186"
+   sodipodi:docname="nucleo-l496zg.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath2">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path4" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path6" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path8" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath10">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path11" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath12">
+      <path
+         d="M 0,0.02 H 595 V 842 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path12" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13">
+      <path
+         d="M 71.52,737.039 H 99.899 V 752.16 H 71.52 Z"
+         transform="scale(1.3333333)"
+         id="path13" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath14">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path14" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path16" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path17" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path18" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath19">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path19" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath20">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path20" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath21">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path21" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path22" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath23">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path23" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path24" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath25">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path25" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath26">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path26" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path27" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath28">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path28" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath29">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path29" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath30">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path30" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath31">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path31" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath32">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path32" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path33" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path34" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path35" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path36" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path37" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path38" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <path
+         d="M 0,0.02 H 595 V 842 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path39" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath40">
+      <path
+         d="m 67.262,173.461 h 460.68 V 681 H 67.262 Z"
+         transform="scale(1.3333333)"
+         id="path40" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath41">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path41" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath42">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path42" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path43" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath44">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path44" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath45">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path45" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath46">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path46" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path47" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath48">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path48" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath49">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path49" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath50">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path50" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath51">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path51" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath52">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path52" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath53">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path53" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath54">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path54" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath55">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path55" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath56">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path56" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath57">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path57" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath58">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path58" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath59">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path59" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath60">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path60" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath61">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path61" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath62">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path62" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath63">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path63" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath64">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path64" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath65">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path65" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath66">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path66" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath67">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path67" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath68">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path68" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath69">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path69" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath70">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path70" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath71">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path71" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath72">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path72" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath73">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path73" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath74">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path74" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath75">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path75" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath76">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path76" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath77">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path77" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath78">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path78" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath79">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path79" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath80">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path80" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath81">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path81" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath82">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path82" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath83">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path83" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath84">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path84" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath85">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path85" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath86">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path86" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath87">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path87" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath88">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path88" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath89">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path89" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath90">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path90" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath91">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path91" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath92">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path92" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath93">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path93" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath94">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path94" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath95">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path95" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath96">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path96" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath97">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path97" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath98">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path98" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath99">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path99" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath100">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path100" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath101">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path101" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath102">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path102" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath103">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path103" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath104">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path104" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath105">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path105" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath106">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path106" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath107">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path107" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath108">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path108" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath109">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path109" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath110">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path110" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath111">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path111" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath112">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path112" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath113">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path113" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath114">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path114" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath115">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path115" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath116">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path116" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath117">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path117" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath118">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path118" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath119">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path119" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath120">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path120" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath121">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path121" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath122">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path122" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath123">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path123" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath124">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path124" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath125">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path125" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath126">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path126" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath127">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path127" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath128">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path128" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath129">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path129" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath130">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path130" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath131">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path131" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath132">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path132" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath133">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path133" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath134">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path134" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath135">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path135" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath136">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path136" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath137">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path137" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath138">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path138" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath139">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path139" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath140">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path140" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath141">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path141" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath142">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path142" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath143">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path143" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path144" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path145" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath146">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path146" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path147" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path148" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path149" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path150" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path151" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path152" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path153" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path154" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path155" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path156" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path157" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path158" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path159" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path160" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path161" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path162" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path163" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path164" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path165" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path166" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path167" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path168" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path169" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path170" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path171" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path172" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path173" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path174" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path175" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path176" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path177" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path178" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path179" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path180" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path181" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path182" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path183" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path184" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path185" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path186" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path187" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path188" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path189" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path190" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path191" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path192" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path193" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path194" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path195" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path196" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path197" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path198" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path199" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path200" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path201" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path202" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path203" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path204" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path205" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path206" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path207" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path208" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path209" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path210" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path211" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path212" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path213" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path214" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path215" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path216" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path217" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path218" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path219" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path220" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path221" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path222" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path223" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path224" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path225" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path226" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path227" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path228" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path229" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path230" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path231" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path232" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path233" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path234" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path235" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path236" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path237" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path238" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path239" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path240" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path241" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path242" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path243" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path244" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path245" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path246" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path247" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path248" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path249" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path250" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path251" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path252" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path253" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path254" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path255" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path256" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path257" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path258" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path259" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path260" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path261" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path262" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path263" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path264" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path265" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path266" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path267" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path268" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path269" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path270" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path271" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path272" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path274" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path275" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path276" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path278" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path279" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path280" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path281" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path282" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path283" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path284" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath286">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path286" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath287">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path287" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath288">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path288" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath289">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath290">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path290" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath291">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path291" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath292">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path292" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath293">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path293" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath294">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path294" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath295">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path295" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath296">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path296" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath297">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path297" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath298">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path298" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath299">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path299" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath300">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path300" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath301">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path301" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath302">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path302" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath303">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path303" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath304">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path304" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath305">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path305" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath306">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path306" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath307">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path307" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath308">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path308" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath309">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path309" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath310">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path310" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath311">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path311" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath312">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path312" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath313">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path313" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath314">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path314" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath315">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path315" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath316">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path316" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath317">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path317" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath318">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path318" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath319">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path319" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath320">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath321">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path321" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath322">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path322" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath323">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path323" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath324">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path324" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath325">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path325" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath326">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path326" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath327">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path327" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath328">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath329">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path329" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath330">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path330" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath331">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path331" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath332">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path332" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath333">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path333" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath334">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path334" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath335">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path335" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath336">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path336" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath337">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path337" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath338">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path338" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath339">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path339" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath340">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path340" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath341">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path341" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath342">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path342" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath343">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path343" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath344">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath345">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path345" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath346">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path346" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath347">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path347" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath348">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path348" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath349">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path349" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath350">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path350" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath351">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path351" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath352">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path352" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath353">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path353" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath354">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath355">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path355" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath356">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path356" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath357">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path357" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath358">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path358" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath359">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path359" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath360">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath361">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path361" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath362">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path362" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath363">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path363" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath364">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path364" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath365">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath366">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path366" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path367" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath368">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path368" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath369">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path369" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath370">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path370" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath371">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath372">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path372" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path373" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath374">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path374" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath375">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path375" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath376">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath377">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path377" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath378">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path378" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath379">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path379" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath380">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path380" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath381">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath382">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path382" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path383" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath384">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path384" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath385">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path385" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath386">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path386" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath387">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath388">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path388" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path389" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath390">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path390" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath391">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path391" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath392">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath393">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path393" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath394">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path394" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath395">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path395" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath396">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path396" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath397">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath398">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path398" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path399" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath400">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path400" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath401">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path401" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath402">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path402" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath403">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path403" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath404">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path404" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path405" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath406">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path406" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath407">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path407" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath408">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath409">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path409" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath410">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path410" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath411">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path411" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath412">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path412" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath413">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path413" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path414" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath415">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path415" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath416">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path416" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath417">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path417" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath418">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path418" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath419">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path419" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath420">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path420" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath421">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path421" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath422">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path422" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath423">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path423" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath424">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath425">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path425" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath426">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path426" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath427">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path427" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath428">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path428" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath429">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path429" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath430">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path430" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath431">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path431" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath432">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path432" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath433">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path433" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath434">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath435">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path435" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath436">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path436" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath437">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path437" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath438">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path438" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath439">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path439" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath440">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path440" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath441">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path441" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath442">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path442" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath443">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path443" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath444">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path444" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath445">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path445" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath446">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path446" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath447">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path447" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath448">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path448" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath449">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path449" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath450">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path450" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath451">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path451" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath452">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path452" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath453">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path453" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath454">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path454" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath455">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path455" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath456">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path456" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath457">
+      <path
+         d="M 0,0.02 H 595 V 842 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path457" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath458">
+      <path
+         d="m 67.262,173.461 h 460.68 V 681 H 67.262 Z"
+         transform="scale(1.3333333)"
+         id="path458" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath459">
+      <path
+         d="M 120.539,173.461 H 474.66 V 681 H 120.539 Z"
+         transform="scale(1.3333333)"
+         id="path459" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath460">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path460" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath461">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path461" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath462">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path462" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath463">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path463" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.85741877"
+     inkscape:cx="306.15145"
+     inkscape:cy="285.15821"
+     inkscape:window-width="1680"
+     inkscape:window-height="981"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="614.23865"
+       height="676.71863"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <g
+     id="g1"
+     inkscape:groupmode="layer"
+     inkscape:label="1"
+     transform="translate(-89.682663,-231.28132)">
+    <g
+       clip-path="url(#clipPath40)"
+       id="g500">
+      <g
+         clip-path="url(#clipPath39)"
+         id="g499">
+        <path
+           d="M 120.539,173.461 H 474.66 V 681 H 120.539 Z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           transform="scale(1.3333333)"
+           clip-path="url(#clipPath38)"
+           id="path499" />
+      </g>
+    </g>
+    <g
+       clip-path="url(#clipPath459)"
+       id="g917">
+      <g
+         clip-path="url(#clipPath458)"
+         id="g916">
+        <g
+           clip-path="url(#clipPath457)"
+           id="g915">
+          <path
+             d="m 141.477,640.039 h 312.851 c 6.242,0 11.16,-5.043 11.16,-11.281 V 195.301 c 0,-6.242 -4.918,-11.281 -11.16,-11.281 H 141.477 c -6.122,0 -11.161,5.039 -11.161,11.281 v 433.457 c 0,6.238 5.039,11.281 11.161,11.281"
+             style="fill:#dddddd;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath41)"
+             id="path500" />
+          <path
+             d="m 243.926,238.023 h 1.961 v -9.535 h -1.961 v 6.485 l -3.781,-6.485 h -2.016 v 9.535 h 1.965 v -6.593 z m 9.39,-9.535 v 6.461 c 0,1.149 -0.586,1.699 -1.816,1.699 -1.23,0 -1.82,-0.55 -1.82,-1.699 v -6.461 h -1.961 v 6.461 c 0,1.071 0.289,1.832 0.929,2.406 0.692,0.629 1.7,0.969 2.852,0.969 1.152,0 2.156,-0.34 2.852,-0.969 0.64,-0.574 0.929,-1.335 0.929,-2.406 v -6.461 z m 11.813,3.231 c -0.063,-0.824 -0.234,-1.348 -0.641,-1.887 -0.73,-0.965 -1.91,-1.504 -3.336,-1.504 -2.691,0 -4.367,1.926 -4.367,5.012 0,3.074 1.66,4.984 4.317,4.984 2.382,0 3.949,-1.375 4.07,-3.558 h -1.91 c -0.133,1.214 -0.891,1.91 -2.11,1.91 -1.515,0 -2.406,-1.231 -2.406,-3.309 0,-2.109 0.93,-3.363 2.473,-3.363 1.14,0 1.781,0.551 2.043,1.715 z m 3.574,-3.231 h -1.961 v 9.535 h 6.528 v -1.636 h -4.567 z m 8.02,5.426 h 4.566 v -1.633 h -4.566 v -2.16 h 4.929 v -1.633 h -6.89 v 9.535 h 7.129 v -1.636 h -5.168 z m 10.871,-5.586 c -1.336,0 -2.434,0.445 -3.242,1.324 -0.852,0.914 -1.336,2.25 -1.336,3.676 0,1.426 0.484,2.77 1.336,3.672 0.824,0.891 1.894,1.324 3.253,1.324 1.364,0 2.434,-0.433 3.258,-1.324 0.825,-0.875 1.336,-2.262 1.336,-3.609 0,-1.489 -0.484,-2.836 -1.336,-3.739 -0.836,-0.902 -1.883,-1.324 -3.269,-1.324 z m 0.011,1.676 c 1.61,0 2.629,1.308 2.629,3.375 0,1.961 -1.058,3.269 -2.629,3.269 -1.593,0 -2.628,-1.308 -2.628,-3.32 0,-2.016 1.035,-3.324 2.628,-3.324 z m 9.004,3.543 h -3.558 v 1.769 h 3.558 z m 3.43,-5.059 h -1.961 v 9.535 h 6.527 v -1.636 h -4.566 z m 11.859,5.965 h -0.968 v -5.703 h -2.157 l -3.39,5.676 v 1.543 h 3.715 v 2.054 h 1.832 v -2.054 h 0.968 z m -2.8,0 h -2.418 l 2.418,-3.965 z m 3.785,1.41 c 0.039,1.426 1.242,2.473 2.836,2.473 1.191,0 2.093,-0.496 2.644,-1.438 0.485,-0.824 0.77,-2.226 0.77,-3.714 0,-1.364 -0.207,-2.407 -0.641,-3.114 -0.59,-0.996 -1.504,-1.519 -2.617,-1.519 -1.855,0 -3.125,1.336 -3.125,3.269 0,1.91 1.125,3.219 2.773,3.219 0.473,0 0.915,-0.129 1.204,-0.34 0.171,-0.117 0.273,-0.234 0.574,-0.574 0,1.793 -0.496,2.641 -1.528,2.641 -0.656,0 -1.085,-0.352 -1.125,-0.903 z m 2.941,-5.82 c 0.891,0 1.438,0.68 1.438,1.777 0,1.024 -0.563,1.703 -1.41,1.703 -0.84,0 -1.364,-0.656 -1.364,-1.726 0,-1.074 0.512,-1.754 1.336,-1.754 z m 10.504,0.812 c -0.09,-0.601 -0.207,-0.902 -0.445,-1.242 -0.481,-0.668 -1.332,-1.062 -2.34,-1.062 -1.152,0 -2.094,0.511 -2.656,1.441 -0.547,0.903 -0.77,1.934 -0.77,3.621 0,1.598 0.195,2.59 0.664,3.336 0.539,0.863 1.508,1.375 2.606,1.375 1.843,0 3.097,-1.375 3.097,-3.402 0,-1.777 -1.097,-3.008 -2.691,-3.008 -0.762,0 -1.27,0.223 -1.848,0.824 l 0.016,-0.195 c 0.027,-0.863 0.066,-1.141 0.195,-1.492 0.25,-0.68 0.696,-1.02 1.336,-1.02 0.586,0 0.903,0.235 1.137,0.824 z m -2.996,2.512 c 0.863,0 1.414,0.653 1.414,1.688 0,0.98 -0.601,1.699 -1.414,1.699 -0.836,0 -1.41,-0.68 -1.41,-1.676 0,-1.008 0.574,-1.711 1.41,-1.711 z m 11.238,-4.879 h -7.168 v 1.633 h 4.879 l -4.879,6.266 v 1.636 h 7.168 v -1.636 h -4.863 l 4.863,-6.266 z m 9.774,4.407 h -3.821 v 1.636 h 2.172 c -0.05,0.535 -0.183,0.864 -0.472,1.203 -0.469,0.575 -1.203,0.914 -1.946,0.914 -1.597,0 -2.722,-1.386 -2.722,-3.347 0,-2.055 0.996,-3.297 2.668,-3.297 0.679,0 1.257,0.195 1.687,0.574 0.274,0.238 0.418,0.461 0.59,0.957 h 1.844 c -0.235,-1.976 -1.832,-3.207 -4.133,-3.207 -2.746,0 -4.617,2.027 -4.617,5 0,2.891 1.883,4.996 4.461,4.996 1.281,0 2.144,-0.457 2.875,-1.531 l 0.238,1.254 h 1.176 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath42)"
+             id="path501" />
+          <path
+             d="M 466.211,274.984 H 131.035"
+             style="fill:none;stroke:#ffffff;stroke-width:2.838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:110.684, 25.542, 42.571, 25.542, 42.571, 25.542;stroke-dashoffset:0;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath43)"
+             id="path502" />
+          <path
+             d="m 385.148,308.883 c -0.035,-0.414 -0.121,-0.68 -0.324,-0.949 -0.371,-0.489 -0.965,-0.758 -1.683,-0.758 -1.36,0 -2.203,0.969 -2.203,2.527 0,1.551 0.835,2.512 2.175,2.512 1.203,0 1.996,-0.692 2.055,-1.793 h -0.965 c -0.066,0.613 -0.449,0.965 -1.062,0.965 -0.766,0 -1.215,-0.621 -1.215,-1.672 0,-1.063 0.469,-1.695 1.25,-1.695 0.574,0 0.894,0.277 1.027,0.863 z m 3.672,3.183 h 0.989 v -4.812 h -0.989 v 3.273 l -1.91,-3.273 h -1.015 v 4.812 h 0.992 v -3.328 z m 4.793,-4.679 h -3.293 v 0.824 h 2.328 c -0.285,0.305 -0.843,1.156 -1.031,1.562 -0.32,0.68 -0.488,1.293 -0.613,2.293 h 0.93 c 0.086,-1.48 0.57,-2.617 1.679,-3.957 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath44)"
+             id="path503" />
+          <path
+             d="m 383.348,527.055 c -0.032,-0.418 -0.118,-0.68 -0.325,-0.953 -0.367,-0.489 -0.961,-0.758 -1.683,-0.758 -1.36,0 -2.203,0.968 -2.203,2.527 0,1.551 0.84,2.516 2.179,2.516 1.2,0 1.993,-0.696 2.051,-1.797 h -0.965 c -0.062,0.613 -0.445,0.965 -1.062,0.965 -0.766,0 -1.215,-0.621 -1.215,-1.668 0,-1.067 0.469,-1.699 1.25,-1.699 0.574,0 0.898,0.277 1.027,0.867 z m 3.672,3.179 h 0.988 v -4.812 h -0.988 v 3.273 l -1.907,-3.273 h -1.019 v 4.812 h 0.992 v -3.328 z m 2.878,-3.226 v 3.226 h 0.922 v -4.679 h -0.613 c -0.145,0.554 -0.625,0.84 -1.43,0.84 v 0.613 z m 3.832,-1.551 c -0.503,0 -0.929,0.211 -1.214,0.598 -0.27,0.363 -0.399,0.957 -0.399,1.871 0,0.832 0.11,1.41 0.332,1.765 0.278,0.45 0.735,0.696 1.281,0.696 0.508,0 0.922,-0.203 1.215,-0.594 0.262,-0.363 0.395,-0.965 0.395,-1.844 0,-0.855 -0.106,-1.437 -0.328,-1.801 -0.278,-0.449 -0.735,-0.691 -1.282,-0.691 z m 0,0.746 c 0.239,0 0.43,0.129 0.54,0.375 0.093,0.199 0.144,0.707 0.144,1.352 0,0.531 -0.043,1.043 -0.117,1.234 -0.106,0.277 -0.305,0.43 -0.567,0.43 -0.246,0 -0.429,-0.125 -0.542,-0.364 -0.09,-0.195 -0.145,-0.687 -0.145,-1.312 0,-0.555 0.047,-1.082 0.117,-1.273 0.102,-0.286 0.305,-0.442 0.57,-0.442 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath45)"
+             id="path504" />
+          <path
+             d="m 208.262,333.844 c -0.035,-0.414 -0.121,-0.68 -0.324,-0.949 -0.372,-0.489 -0.965,-0.758 -1.684,-0.758 -1.359,0 -2.207,0.968 -2.207,2.527 0,1.551 0.84,2.512 2.18,2.512 1.203,0 1.992,-0.692 2.054,-1.793 h -0.965 c -0.066,0.613 -0.449,0.965 -1.062,0.965 -0.766,0 -1.215,-0.621 -1.215,-1.672 0,-1.063 0.469,-1.696 1.246,-1.696 0.574,0 0.899,0.278 1.031,0.864 z m 3.668,3.183 h 0.992 v -4.812 h -0.992 v 3.273 l -1.907,-3.273 h -1.015 v 4.812 h 0.988 v -3.328 z m 4.008,-2.55 c 0.16,-0.086 0.23,-0.129 0.304,-0.196 0.192,-0.179 0.305,-0.465 0.305,-0.765 0,-0.735 -0.633,-1.27 -1.5,-1.27 -0.871,0 -1.504,0.535 -1.504,1.274 0,0.449 0.184,0.734 0.605,0.957 -0.539,0.296 -0.765,0.648 -0.765,1.203 0,0.882 0.679,1.496 1.664,1.496 0.976,0 1.656,-0.614 1.656,-1.496 0,-0.555 -0.223,-0.907 -0.765,-1.203 z m -0.883,-1.485 c 0.41,0 0.691,0.25 0.691,0.613 0,0.36 -0.289,0.618 -0.691,0.618 -0.418,0 -0.7,-0.254 -0.7,-0.621 0,-0.36 0.282,-0.61 0.7,-0.61 z m -0.016,1.856 c 0.457,0 0.742,0.304 0.742,0.793 0,0.449 -0.293,0.746 -0.742,0.746 -0.445,0 -0.73,-0.297 -0.73,-0.762 0,-0.473 0.285,-0.777 0.73,-0.777 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath46)"
+             id="path505" />
+          <path
+             d="m 208.262,527.055 c -0.035,-0.418 -0.121,-0.68 -0.324,-0.953 -0.372,-0.489 -0.965,-0.758 -1.684,-0.758 -1.359,0 -2.207,0.968 -2.207,2.527 0,1.551 0.84,2.516 2.18,2.516 1.203,0 1.992,-0.696 2.054,-1.797 h -0.965 c -0.066,0.613 -0.449,0.965 -1.062,0.965 -0.766,0 -1.215,-0.621 -1.215,-1.668 0,-1.067 0.469,-1.699 1.246,-1.699 0.574,0 0.899,0.277 1.031,0.867 z m 3.668,3.179 h 0.992 v -4.812 h -0.992 v 3.273 l -1.907,-3.273 h -1.015 v 4.812 h 0.988 v -3.328 z m 1.558,-1.089 c 0.02,0.718 0.629,1.25 1.434,1.25 0.601,0 1.055,-0.254 1.332,-0.727 0.246,-0.418 0.391,-1.125 0.391,-1.875 0,-0.688 -0.106,-1.215 -0.325,-1.57 -0.297,-0.504 -0.758,-0.766 -1.32,-0.766 -0.938,0 -1.574,0.672 -1.574,1.648 0,0.965 0.566,1.625 1.398,1.625 0.238,0 0.461,-0.066 0.606,-0.171 0.086,-0.059 0.14,-0.121 0.293,-0.289 0,0.902 -0.254,1.332 -0.774,1.332 -0.332,0 -0.547,-0.18 -0.566,-0.457 z m 1.489,-2.938 c 0.445,0 0.722,0.344 0.722,0.898 0,0.516 -0.281,0.86 -0.711,0.86 -0.422,0 -0.687,-0.332 -0.687,-0.871 0,-0.543 0.258,-0.887 0.676,-0.887 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath47)"
+             id="path506" />
+          <path
+             d="m 379.688,382.988 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath48)"
+             id="path507" />
+          <path
+             d="m 379.688,375.547 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath49)"
+             id="path508" />
+          <path
+             d="m 379.688,368.109 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath50)"
+             id="path509" />
+          <path
+             d="m 379.688,360.668 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath51)"
+             id="path510" />
+          <path
+             d="m 379.688,353.227 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath52)"
+             id="path511" />
+          <path
+             d="m 379.688,345.785 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath53)"
+             id="path512" />
+          <path
+             d="m 379.688,338.344 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath54)"
+             id="path513" />
+          <path
+             d="m 379.688,330.906 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath55)"
+             id="path514" />
+          <path
+             d="m 379.688,323.344 h 7.438 v 7.562 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath56)"
+             id="path515" />
+          <path
+             d="m 379.688,315.906 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath57)"
+             id="path516" />
+          <path
+             d="m 387.129,382.988 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath58)"
+             id="path517" />
+          <path
+             d="m 387.129,375.547 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath59)"
+             id="path518" />
+          <path
+             d="m 387.129,368.109 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath60)"
+             id="path519" />
+          <path
+             d="m 387.129,360.668 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath61)"
+             id="path520" />
+          <path
+             d="m 387.129,353.227 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath62)"
+             id="path521" />
+          <path
+             d="m 387.129,345.785 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath63)"
+             id="path522" />
+          <path
+             d="m 387.129,338.344 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath64)"
+             id="path523" />
+          <path
+             d="m 387.129,330.906 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath65)"
+             id="path524" />
+          <path
+             d="m 387.129,323.344 h 7.438 v 7.562 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath66)"
+             id="path525" />
+          <path
+             d="m 387.129,315.906 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath67)"
+             id="path526" />
+          <path
+             d="m 383.223,319.082 v 2.582 h 0.738 v -3.742 h -0.488 c -0.118,0.441 -0.504,0.672 -1.149,0.672 v 0.488 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath68)"
+             id="path527" />
+          <path
+             d="m 383.113,327.434 c 0.285,0 0.301,0 0.434,0.035 0.246,0.07 0.406,0.285 0.406,0.558 0,0.332 -0.234,0.567 -0.555,0.567 -0.347,0 -0.539,-0.199 -0.562,-0.586 h -0.715 c 0.004,0.75 0.488,1.219 1.262,1.219 0.797,0 1.308,-0.469 1.308,-1.2 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.215 0.492,-0.453 0.492,-0.797 0,-0.621 -0.465,-1.02 -1.187,-1.02 -0.547,0 -0.961,0.239 -1.125,0.645 -0.07,0.179 -0.09,0.301 -0.09,0.613 h 0.687 c 0.004,-0.199 0.02,-0.301 0.055,-0.394 0.07,-0.165 0.238,-0.266 0.457,-0.266 0.293,0 0.465,0.18 0.465,0.492 0,0.379 -0.219,0.563 -0.656,0.563 h -0.063 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath69)"
+             id="path528" />
+          <path
+             d="m 384.547,332.801 h -2 l -0.332,2.086 h 0.664 c 0.082,-0.184 0.25,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.726 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.5,-0.164 -0.519,-0.465 h -0.727 c 0.012,0.653 0.508,1.098 1.235,1.098 0.804,0 1.351,-0.551 1.351,-1.359 0,-0.77 -0.472,-1.293 -1.164,-1.293 -0.25,0 -0.433,0.066 -0.652,0.226 L 383,333.461 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath70)"
+             id="path529" />
+          <path
+             d="m 384.754,340.242 h -2.633 v 0.66 h 1.863 c -0.226,0.243 -0.675,0.926 -0.824,1.25 -0.258,0.547 -0.39,1.036 -0.492,1.832 h 0.746 c 0.066,-1.179 0.453,-2.089 1.34,-3.16 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath71)"
+             id="path530" />
+          <path
+             d="m 382.168,350.555 c 0.016,0.578 0.5,1 1.144,1 0.481,0 0.844,-0.203 1.067,-0.582 0.195,-0.332 0.312,-0.899 0.312,-1.5 0,-0.551 -0.086,-0.973 -0.257,-1.258 -0.239,-0.399 -0.61,-0.61 -1.059,-0.61 -0.75,0 -1.262,0.536 -1.262,1.317 0,0.773 0.457,1.301 1.121,1.301 0.192,0 0.368,-0.055 0.485,-0.137 0.07,-0.047 0.113,-0.094 0.234,-0.234 0,0.726 -0.203,1.066 -0.617,1.066 -0.266,0 -0.441,-0.141 -0.457,-0.363 z m 1.187,-2.348 c 0.36,0 0.583,0.273 0.583,0.715 0,0.414 -0.231,0.687 -0.571,0.687 -0.34,0 -0.551,-0.261 -0.551,-0.695 0,-0.434 0.207,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath72)"
+             id="path531" />
+          <path
+             d="m 381.785,356.406 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.446 -0.5,0.672 -1.144,0.672 v 0.492 z m 2.879,0 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.446 -0.5,0.672 -1.144,0.672 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath73)"
+             id="path532" />
+          <path
+             d="m 381.785,363.844 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.445 -0.5,0.671 -1.144,0.671 v 0.489 z m 2.766,0.91 c 0.285,0 0.301,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.563 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.718 c 0.007,0.75 0.492,1.219 1.261,1.219 0.797,0 1.313,-0.469 1.313,-1.195 0,-0.442 -0.192,-0.727 -0.613,-0.93 0.343,-0.219 0.488,-0.457 0.488,-0.797 0,-0.625 -0.465,-1.02 -1.188,-1.02 -0.543,0 -0.961,0.239 -1.125,0.645 -0.066,0.18 -0.09,0.301 -0.09,0.609 h 0.688 c 0.004,-0.199 0.023,-0.3 0.059,-0.394 0.07,-0.164 0.238,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.567 -0.653,0.567 h -0.066 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath74)"
+             id="path533" />
+          <path
+             d="m 381.785,371.285 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.441 -0.5,0.668 -1.144,0.668 v 0.492 z m 4.203,-1.16 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.188 0.246,-0.285 0.477,-0.285 0.375,0 0.601,0.269 0.601,0.722 0,0.438 -0.226,0.707 -0.601,0.707 -0.324,0 -0.504,-0.164 -0.52,-0.464 h -0.726 c 0.008,0.656 0.504,1.097 1.234,1.097 0.801,0 1.352,-0.547 1.352,-1.355 0,-0.774 -0.477,-1.293 -1.168,-1.293 -0.246,0 -0.434,0.062 -0.649,0.226 l 0.121,-0.781 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath75)"
+             id="path534" />
+          <path
+             d="m 381.785,378.727 v 2.582 h 0.738 v -3.747 h -0.492 c -0.117,0.446 -0.5,0.672 -1.144,0.672 v 0.493 z m 4.41,-1.165 h -2.636 v 0.661 h 1.863 c -0.227,0.246 -0.676,0.925 -0.82,1.254 -0.262,0.543 -0.391,1.035 -0.493,1.832 h 0.743 c 0.07,-1.184 0.457,-2.09 1.343,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath76)"
+             id="path535" />
+          <path
+             d="m 381.785,386.168 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.492 z m 1.82,1.707 c 0.016,0.578 0.504,1 1.149,1 0.48,0 0.844,-0.199 1.066,-0.582 0.196,-0.332 0.313,-0.898 0.313,-1.5 0,-0.547 -0.086,-0.969 -0.262,-1.254 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.77 0.453,1.297 1.117,1.297 0.191,0 0.371,-0.051 0.488,-0.137 0.067,-0.047 0.11,-0.094 0.231,-0.23 0,0.722 -0.2,1.066 -0.618,1.066 -0.261,0 -0.437,-0.144 -0.453,-0.367 z m 1.192,-2.348 c 0.355,0 0.578,0.274 0.578,0.719 0,0.41 -0.227,0.688 -0.57,0.688 -0.336,0 -0.547,-0.266 -0.547,-0.7 0,-0.433 0.203,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath77)"
+             id="path536" />
+          <path
+             d="m 392.23,321.004 h -1.589 c 0.101,-0.199 0.214,-0.309 0.765,-0.707 0.649,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.5,-1.187 -1.285,-1.187 -0.773,0 -1.227,0.457 -1.227,1.25 v 0.133 h 0.711 v -0.122 c 0,-0.417 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.227 0.528,0.602 0,0.418 -0.129,0.57 -0.961,1.16 -0.633,0.434 -0.832,0.762 -0.863,1.457 h 2.546 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath78)"
+             id="path537" />
+          <path
+             d="m 392.281,327.664 h -0.39 v -2.301 h -0.871 l -1.368,2.289 v 0.625 h 1.5 v 0.828 h 0.739 v -0.828 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.598 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath79)"
+             id="path538" />
+          <path
+             d="m 392.203,333.652 c -0.035,-0.242 -0.082,-0.363 -0.18,-0.5 -0.195,-0.269 -0.539,-0.429 -0.945,-0.429 -0.465,0 -0.844,0.207 -1.07,0.582 -0.223,0.363 -0.313,0.781 -0.313,1.461 0,0.644 0.078,1.046 0.27,1.347 0.215,0.348 0.605,0.555 1.051,0.555 0.746,0 1.25,-0.555 1.25,-1.371 0,-0.719 -0.442,-1.215 -1.086,-1.215 -0.305,0 -0.512,0.09 -0.746,0.332 l 0.007,-0.078 c 0.008,-0.352 0.024,-0.461 0.079,-0.606 0.101,-0.273 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.094 0.457,0.332 z m -1.207,1.016 c 0.348,0 0.57,0.262 0.57,0.68 0,0.394 -0.246,0.687 -0.57,0.687 -0.34,0 -0.57,-0.277 -0.57,-0.676 0,-0.406 0.23,-0.691 0.57,-0.691 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath80)"
+             id="path539" />
+          <path
+             d="m 391.688,341.949 c 0.124,-0.07 0.183,-0.105 0.242,-0.16 0.152,-0.141 0.242,-0.367 0.242,-0.609 0,-0.59 -0.508,-1.016 -1.199,-1.016 -0.696,0 -1.203,0.426 -1.203,1.02 0,0.359 0.148,0.586 0.484,0.765 -0.43,0.239 -0.609,0.516 -0.609,0.961 0,0.707 0.543,1.199 1.328,1.199 0.781,0 1.324,-0.492 1.324,-1.199 0,-0.445 -0.176,-0.722 -0.609,-0.961 z m -0.708,-1.187 c 0.325,0 0.551,0.199 0.551,0.488 0,0.285 -0.23,0.492 -0.551,0.492 -0.335,0 -0.562,-0.199 -0.562,-0.496 0,-0.285 0.227,-0.484 0.562,-0.484 z m -0.011,1.484 c 0.363,0 0.59,0.242 0.59,0.633 0,0.359 -0.231,0.598 -0.59,0.598 -0.36,0 -0.586,-0.239 -0.586,-0.61 0,-0.379 0.226,-0.621 0.586,-0.621 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath81)"
+             id="path540" />
+          <path
+             d="m 389.344,348.844 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.445 -0.5,0.671 -1.145,0.671 v 0.489 z m 3.062,-1.239 c -0.398,0 -0.742,0.168 -0.968,0.481 -0.219,0.289 -0.317,0.766 -0.317,1.492 0,0.668 0.082,1.133 0.262,1.418 0.222,0.356 0.586,0.551 1.023,0.551 0.41,0 0.742,-0.16 0.973,-0.473 0.211,-0.293 0.316,-0.773 0.316,-1.472 0,-0.688 -0.082,-1.153 -0.261,-1.442 -0.223,-0.359 -0.586,-0.555 -1.028,-0.555 z m 0,0.594 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.16 0.117,0.566 0.117,1.086 0,0.422 -0.035,0.832 -0.094,0.984 -0.086,0.223 -0.242,0.344 -0.457,0.344 -0.195,0 -0.34,-0.098 -0.429,-0.289 -0.075,-0.16 -0.118,-0.551 -0.118,-1.051 0,-0.445 0.036,-0.867 0.094,-1.019 0.078,-0.227 0.242,-0.356 0.453,-0.356 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath82)"
+             id="path541" />
+          <path
+             d="m 389.344,356.406 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.446 -0.5,0.672 -1.145,0.672 v 0.492 z m 4.328,1.922 h -1.59 c 0.098,-0.203 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.164 -0.632,0.434 -0.828,0.758 -0.859,1.457 h 2.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath83)"
+             id="path542" />
+          <path
+             d="m 389.344,363.844 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.445 -0.5,0.671 -1.145,0.671 v 0.489 z m 4.379,1.14 h -0.391 v -2.3 h -0.871 l -1.367,2.293 v 0.621 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.597 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath84)"
+             id="path543" />
+          <path
+             d="m 389.344,371.285 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.441 -0.5,0.672 -1.145,0.672 v 0.488 z m 4.301,-0.312 c -0.04,-0.243 -0.086,-0.364 -0.18,-0.5 -0.195,-0.27 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.203 -1.075,0.578 -0.218,0.367 -0.308,0.781 -0.308,1.465 0,0.644 0.078,1.043 0.269,1.344 0.215,0.351 0.606,0.554 1.051,0.554 0.742,0 1.25,-0.554 1.25,-1.371 0,-0.719 -0.445,-1.215 -1.086,-1.215 -0.309,0 -0.516,0.09 -0.746,0.332 l 0.004,-0.078 c 0.012,-0.347 0.027,-0.461 0.078,-0.601 0.102,-0.278 0.281,-0.414 0.539,-0.414 0.238,0 0.367,0.097 0.461,0.332 z m -1.211,1.015 c 0.347,0 0.57,0.266 0.57,0.68 0,0.398 -0.242,0.687 -0.57,0.687 -0.336,0 -0.571,-0.273 -0.571,-0.675 0,-0.407 0.235,-0.692 0.571,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath85)"
+             id="path544" />
+          <path
+             d="m 389.344,378.727 v 2.582 h 0.738 v -3.743 h -0.492 c -0.113,0.442 -0.5,0.668 -1.145,0.668 v 0.493 z m 3.781,0.543 c 0.129,-0.067 0.187,-0.106 0.242,-0.157 0.156,-0.144 0.246,-0.371 0.246,-0.613 0,-0.586 -0.508,-1.016 -1.199,-1.016 -0.699,0 -1.203,0.43 -1.203,1.02 0,0.359 0.144,0.586 0.484,0.766 -0.433,0.238 -0.613,0.519 -0.613,0.96 0,0.708 0.543,1.2 1.332,1.2 0.781,0 1.324,-0.492 1.324,-1.2 0,-0.441 -0.179,-0.722 -0.613,-0.96 z m -0.707,-1.188 c 0.328,0 0.555,0.199 0.555,0.492 0,0.285 -0.231,0.488 -0.555,0.488 -0.332,0 -0.559,-0.199 -0.559,-0.496 0,-0.285 0.227,-0.484 0.559,-0.484 z m -0.012,1.484 c 0.367,0 0.594,0.243 0.594,0.633 0,0.36 -0.234,0.598 -0.594,0.598 -0.355,0 -0.586,-0.238 -0.586,-0.609 0,-0.379 0.231,-0.622 0.586,-0.622 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath86)"
+             id="path545" />
+          <path
+             d="m 390.789,388.09 h -1.59 c 0.102,-0.203 0.219,-0.313 0.766,-0.707 0.652,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.661 0.535,-0.661 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.632,0.43 -0.828,0.758 -0.859,1.457 h 2.543 z m 1.617,-3.164 c -0.398,0 -0.742,0.168 -0.968,0.48 -0.219,0.289 -0.317,0.766 -0.317,1.496 0,0.664 0.082,1.129 0.262,1.414 0.222,0.36 0.586,0.555 1.023,0.555 0.41,0 0.742,-0.164 0.973,-0.476 0.211,-0.29 0.316,-0.77 0.316,-1.473 0,-0.688 -0.082,-1.152 -0.261,-1.442 -0.223,-0.359 -0.586,-0.554 -1.028,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.156 0.117,0.563 0.117,1.082 0,0.422 -0.035,0.832 -0.094,0.989 -0.086,0.218 -0.242,0.343 -0.457,0.343 -0.195,0 -0.34,-0.101 -0.429,-0.293 -0.075,-0.156 -0.118,-0.547 -0.118,-1.05 0,-0.442 0.036,-0.864 0.094,-1.02 0.078,-0.227 0.242,-0.352 0.453,-0.352 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath87)"
+             id="path546" />
+          <path
+             d="m 202.438,394.148 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath88)"
+             id="path547" />
+          <path
+             d="m 202.438,386.707 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath89)"
+             id="path548" />
+          <path
+             d="m 202.438,379.27 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath90)"
+             id="path549" />
+          <path
+             d="m 202.438,371.828 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath91)"
+             id="path550" />
+          <path
+             d="m 202.438,364.387 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath92)"
+             id="path551" />
+          <path
+             d="m 202.438,356.945 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath93)"
+             id="path552" />
+          <path
+             d="m 202.438,349.508 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath94)"
+             id="path553" />
+          <path
+             d="m 202.438,342.066 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath95)"
+             id="path554" />
+          <path
+             d="m 209.879,394.148 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath96)"
+             id="path555" />
+          <path
+             d="m 209.879,386.707 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath97)"
+             id="path556" />
+          <path
+             d="m 209.879,379.27 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath98)"
+             id="path557" />
+          <path
+             d="m 209.879,371.828 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath99)"
+             id="path558" />
+          <path
+             d="m 209.879,364.387 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath100)"
+             id="path559" />
+          <path
+             d="m 209.879,356.945 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath101)"
+             id="path560" />
+          <path
+             d="m 209.879,349.508 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath102)"
+             id="path561" />
+          <path
+             d="m 209.879,342.066 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath103)"
+             id="path562" />
+          <path
+             d="m 205.977,345.125 v 2.582 h 0.738 v -3.746 h -0.492 c -0.114,0.445 -0.5,0.672 -1.145,0.672 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath104)"
+             id="path563" />
+          <path
+             d="m 205.863,353.473 c 0.285,0 0.301,0 0.434,0.039 0.25,0.066 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.563 -0.555,0.563 -0.347,0 -0.535,-0.199 -0.558,-0.586 h -0.719 c 0.008,0.75 0.492,1.223 1.262,1.223 0.797,0 1.312,-0.473 1.312,-1.2 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.219 0.488,-0.453 0.488,-0.797 0,-0.625 -0.461,-1.02 -1.187,-1.02 -0.543,0 -0.961,0.238 -1.125,0.645 -0.067,0.179 -0.09,0.301 -0.09,0.613 h 0.687 c 0.004,-0.203 0.024,-0.301 0.059,-0.398 0.07,-0.164 0.238,-0.262 0.453,-0.262 0.297,0 0.465,0.18 0.465,0.488 0,0.383 -0.215,0.567 -0.652,0.567 h -0.067 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath105)"
+             id="path564" />
+          <path
+             d="m 207.301,358.965 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.188 0.246,-0.285 0.476,-0.285 0.375,0 0.602,0.265 0.602,0.722 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.504,-0.164 -0.519,-0.465 h -0.727 c 0.008,0.657 0.504,1.098 1.235,1.098 0.8,0 1.351,-0.551 1.351,-1.355 0,-0.774 -0.476,-1.297 -1.168,-1.297 -0.246,0 -0.433,0.066 -0.648,0.23 l 0.121,-0.781 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath106)"
+             id="path565" />
+          <path
+             d="m 207.508,366.402 h -2.637 v 0.66 h 1.863 c -0.226,0.243 -0.675,0.926 -0.82,1.254 -0.262,0.543 -0.391,1.036 -0.492,1.832 h 0.742 c 0.07,-1.183 0.457,-2.093 1.344,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath107)"
+             id="path566" />
+          <path
+             d="m 204.918,376.715 c 0.016,0.578 0.504,1 1.148,1 0.481,0 0.844,-0.203 1.067,-0.582 0.195,-0.332 0.312,-0.899 0.312,-1.5 0,-0.547 -0.086,-0.969 -0.261,-1.254 -0.239,-0.402 -0.606,-0.613 -1.055,-0.613 -0.75,0 -1.262,0.539 -1.262,1.32 0,0.769 0.453,1.297 1.117,1.297 0.192,0 0.371,-0.051 0.489,-0.137 0.066,-0.047 0.109,-0.094 0.23,-0.23 0,0.722 -0.199,1.066 -0.617,1.066 -0.262,0 -0.438,-0.144 -0.453,-0.367 z m 1.191,-2.348 c 0.356,0 0.579,0.274 0.579,0.719 0,0.41 -0.227,0.684 -0.571,0.684 -0.336,0 -0.547,-0.262 -0.547,-0.696 0,-0.433 0.203,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath108)"
+             id="path567" />
+          <path
+             d="m 204.535,382.445 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.442 -0.504,0.668 -1.148,0.668 v 0.492 z m 2.883,0 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.442 -0.5,0.668 -1.144,0.668 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath109)"
+             id="path568" />
+          <path
+             d="m 204.535,389.887 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.672 -1.148,0.672 v 0.492 z m 2.77,0.906 c 0.285,0 0.3,0 0.433,0.039 0.25,0.066 0.407,0.285 0.407,0.559 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.203 -0.559,-0.586 h -0.719 c 0.004,0.75 0.493,1.219 1.262,1.219 0.797,0 1.309,-0.469 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.61,-0.93 0.34,-0.215 0.489,-0.453 0.489,-0.797 0,-0.621 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.613 h 0.688 c 0.004,-0.199 0.019,-0.3 0.058,-0.394 0.067,-0.164 0.239,-0.266 0.454,-0.266 0.296,0 0.464,0.18 0.464,0.492 0,0.379 -0.214,0.563 -0.656,0.563 h -0.062 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath110)"
+             id="path569" />
+          <path
+             d="m 204.535,397.328 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.672 -1.148,0.672 v 0.492 z m 4.207,-1.164 h -2 l -0.336,2.086 h 0.668 c 0.078,-0.184 0.246,-0.285 0.473,-0.285 0.375,0 0.601,0.269 0.601,0.723 0,0.441 -0.226,0.707 -0.601,0.707 -0.32,0 -0.5,-0.161 -0.516,-0.461 h -0.73 c 0.011,0.652 0.508,1.097 1.238,1.097 0.801,0 1.352,-0.551 1.352,-1.359 0,-0.77 -0.477,-1.293 -1.168,-1.293 -0.25,0 -0.434,0.062 -0.649,0.226 l 0.121,-0.781 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath111)"
+             id="path570" />
+          <path
+             d="m 215.102,347.047 h -1.586 c 0.097,-0.199 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.836,-0.758 0.836,-1.27 0,-0.722 -0.5,-1.187 -1.281,-1.187 -0.777,0 -1.231,0.461 -1.231,1.254 v 0.129 h 0.711 v -0.121 c 0,-0.418 0.2,-0.661 0.536,-0.661 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.633,0.434 -0.828,0.758 -0.859,1.457 h 2.543 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath112)"
+             id="path571" />
+          <path
+             d="m 215.156,353.707 h -0.39 v -2.305 h -0.871 l -1.368,2.293 v 0.621 h 1.5 v 0.832 h 0.739 v -0.832 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.602 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath113)"
+             id="path572" />
+          <path
+             d="m 215.078,359.812 c -0.039,-0.242 -0.086,-0.363 -0.18,-0.5 -0.195,-0.269 -0.539,-0.429 -0.945,-0.429 -0.465,0 -0.848,0.207 -1.074,0.582 -0.219,0.363 -0.309,0.781 -0.309,1.461 0,0.644 0.078,1.047 0.266,1.347 0.219,0.348 0.609,0.555 1.051,0.555 0.746,0 1.254,-0.555 1.254,-1.371 0,-0.719 -0.446,-1.215 -1.09,-1.215 -0.305,0 -0.512,0.09 -0.742,0.332 l 0.003,-0.078 c 0.012,-0.351 0.028,-0.461 0.079,-0.601 0.101,-0.278 0.281,-0.415 0.539,-0.415 0.238,0 0.363,0.094 0.461,0.332 z m -1.211,1.016 c 0.348,0 0.571,0.262 0.571,0.68 0,0.398 -0.243,0.687 -0.571,0.687 -0.336,0 -0.57,-0.273 -0.57,-0.675 0,-0.407 0.234,-0.692 0.57,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath114)"
+             id="path573" />
+          <path
+             d="m 214.559,368.109 c 0.129,-0.07 0.183,-0.105 0.242,-0.16 0.156,-0.14 0.246,-0.367 0.246,-0.609 0,-0.586 -0.508,-1.016 -1.199,-1.016 -0.7,0 -1.207,0.43 -1.207,1.02 0,0.359 0.148,0.586 0.488,0.765 -0.434,0.239 -0.613,0.516 -0.613,0.961 0,0.707 0.543,1.2 1.332,1.2 0.781,0 1.324,-0.493 1.324,-1.2 0,-0.445 -0.18,-0.722 -0.613,-0.961 z m -0.707,-1.187 c 0.328,0 0.554,0.199 0.554,0.492 0,0.285 -0.234,0.488 -0.554,0.488 -0.332,0 -0.559,-0.199 -0.559,-0.496 0,-0.285 0.227,-0.484 0.559,-0.484 z m -0.012,1.484 c 0.367,0 0.594,0.242 0.594,0.633 0,0.359 -0.235,0.598 -0.594,0.598 -0.36,0 -0.586,-0.239 -0.586,-0.61 0,-0.379 0.226,-0.621 0.586,-0.621 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath115)"
+             id="path574" />
+          <path
+             d="m 212.215,375.004 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.488 z m 3.066,-1.238 c -0.402,0 -0.746,0.168 -0.972,0.48 -0.215,0.289 -0.317,0.766 -0.317,1.492 0,0.668 0.086,1.133 0.266,1.418 0.222,0.36 0.586,0.555 1.023,0.555 0.407,0 0.739,-0.164 0.973,-0.477 0.211,-0.289 0.316,-0.769 0.316,-1.472 0,-0.688 -0.086,-1.153 -0.265,-1.442 -0.219,-0.359 -0.586,-0.554 -1.024,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.156 0.117,0.563 0.117,1.082 0,0.422 -0.039,0.832 -0.098,0.984 -0.082,0.223 -0.242,0.344 -0.453,0.344 -0.195,0 -0.343,-0.097 -0.433,-0.289 -0.075,-0.16 -0.118,-0.551 -0.118,-1.051 0,-0.445 0.04,-0.867 0.098,-1.019 0.078,-0.227 0.242,-0.352 0.453,-0.352 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath116)"
+             id="path575" />
+          <path
+             d="m 212.215,382.445 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.442 -0.504,0.668 -1.145,0.668 v 0.492 z m 4.328,1.922 h -1.59 c 0.102,-0.199 0.219,-0.312 0.766,-0.707 0.652,-0.476 0.84,-0.754 0.84,-1.265 0,-0.727 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.414 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath117)"
+             id="path576" />
+          <path
+             d="m 212.215,389.887 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.441 -0.504,0.668 -1.145,0.668 v 0.492 z m 4.383,1.14 h -0.391 v -2.3 h -0.871 l -1.371,2.289 v 0.625 h 1.5 v 0.828 h 0.742 v -0.828 h 0.391 z m -1.133,0 h -0.977 l 0.977,-1.601 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath118)"
+             id="path577" />
+          <path
+             d="m 212.215,397.328 v 2.582 h 0.742 v -3.746 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.492 z m 4.301,-0.312 c -0.036,-0.243 -0.082,-0.364 -0.18,-0.504 -0.195,-0.266 -0.535,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.207 -1.071,0.582 -0.222,0.363 -0.312,0.781 -0.312,1.461 0,0.644 0.082,1.047 0.269,1.348 0.219,0.347 0.61,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.375 0,-0.718 -0.445,-1.215 -1.09,-1.215 -0.304,0 -0.512,0.09 -0.742,0.336 l 0.004,-0.082 c 0.012,-0.347 0.027,-0.457 0.078,-0.601 0.102,-0.274 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.093 0.461,0.332 z m -1.207,1.011 c 0.347,0 0.57,0.266 0.57,0.684 0,0.394 -0.242,0.684 -0.57,0.684 -0.34,0 -0.571,-0.274 -0.571,-0.676 0,-0.407 0.231,-0.692 0.571,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath119)"
+             id="path578" />
+          <path
+             d="m 202.438,513.312 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath120)"
+             id="path579" />
+          <path
+             d="m 202.438,505.871 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath121)"
+             id="path580" />
+          <path
+             d="m 202.438,498.434 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath122)"
+             id="path581" />
+          <path
+             d="m 202.438,490.992 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath123)"
+             id="path582" />
+          <path
+             d="m 202.438,483.551 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath124)"
+             id="path583" />
+          <path
+             d="m 202.438,476.113 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath125)"
+             id="path584" />
+          <path
+             d="m 202.438,468.672 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath126)"
+             id="path585" />
+          <path
+             d="m 202.438,461.23 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath127)"
+             id="path586" />
+          <path
+             d="m 202.438,453.789 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath128)"
+             id="path587" />
+          <path
+             d="m 202.438,446.352 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath129)"
+             id="path588" />
+          <path
+             d="m 202.438,438.91 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath130)"
+             id="path589" />
+          <path
+             d="m 202.438,431.469 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath131)"
+             id="path590" />
+          <path
+             d="m 202.438,423.91 h 7.441 v 7.559 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath132)"
+             id="path591" />
+          <path
+             d="m 202.438,416.469 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath133)"
+             id="path592" />
+          <path
+             d="m 202.438,409.027 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath134)"
+             id="path593" />
+          <path
+             d="m 209.879,513.312 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath135)"
+             id="path594" />
+          <path
+             d="m 209.879,505.871 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath136)"
+             id="path595" />
+          <path
+             d="m 209.879,498.434 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath137)"
+             id="path596" />
+          <path
+             d="m 209.879,490.992 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath138)"
+             id="path597" />
+          <path
+             d="m 209.879,483.551 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath139)"
+             id="path598" />
+          <path
+             d="m 209.879,476.113 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath140)"
+             id="path599" />
+          <path
+             d="m 209.879,468.672 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath141)"
+             id="path600" />
+          <path
+             d="m 209.879,461.23 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath142)"
+             id="path601" />
+          <path
+             d="m 209.879,453.789 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath143)"
+             id="path602" />
+          <path
+             d="m 209.879,446.352 h 7.441 v 7.438 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath144)"
+             id="path603" />
+          <path
+             d="m 209.879,438.91 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath145)"
+             id="path604" />
+          <path
+             d="m 209.879,431.469 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath146)"
+             id="path605" />
+          <path
+             d="m 209.879,423.91 h 7.441 v 7.559 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath147)"
+             id="path606" />
+          <path
+             d="m 209.879,416.469 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath148)"
+             id="path607" />
+          <path
+             d="m 209.879,409.027 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath149)"
+             id="path608" />
+          <path
+             d="m 205.977,412.207 v 2.582 h 0.738 v -3.742 h -0.492 c -0.114,0.441 -0.5,0.668 -1.145,0.668 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath150)"
+             id="path609" />
+          <path
+             d="m 205.863,420.555 c 0.285,0 0.301,0 0.434,0.039 0.25,0.066 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.567 -0.555,0.567 -0.347,0 -0.535,-0.203 -0.558,-0.586 h -0.719 c 0.008,0.75 0.492,1.219 1.262,1.219 0.797,0 1.312,-0.469 1.312,-1.2 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.215 0.488,-0.453 0.488,-0.797 0,-0.621 -0.461,-1.02 -1.187,-1.02 -0.543,0 -0.961,0.239 -1.125,0.645 -0.067,0.179 -0.09,0.301 -0.09,0.613 h 0.687 c 0.004,-0.203 0.024,-0.301 0.059,-0.398 0.07,-0.161 0.238,-0.262 0.453,-0.262 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.563 -0.652,0.563 h -0.067 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath151)"
+             id="path610" />
+          <path
+             d="m 207.301,425.926 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.184 0.246,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.722 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.504,-0.164 -0.519,-0.465 h -0.727 c 0.008,0.657 0.504,1.102 1.235,1.102 0.8,0 1.351,-0.551 1.351,-1.359 0,-0.77 -0.476,-1.293 -1.168,-1.293 -0.246,0 -0.433,0.062 -0.648,0.226 l 0.121,-0.781 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath152)"
+             id="path611" />
+          <path
+             d="m 207.508,433.367 h -2.637 v 0.66 h 1.863 c -0.226,0.243 -0.675,0.922 -0.82,1.25 -0.262,0.543 -0.391,1.035 -0.492,1.832 h 0.742 c 0.07,-1.183 0.457,-2.089 1.344,-3.16 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath153)"
+             id="path612" />
+          <path
+             d="m 204.918,443.68 c 0.016,0.574 0.504,0.996 1.148,0.996 0.481,0 0.844,-0.199 1.067,-0.578 0.195,-0.332 0.312,-0.899 0.312,-1.5 0,-0.551 -0.086,-0.973 -0.261,-1.258 -0.239,-0.402 -0.606,-0.613 -1.055,-0.613 -0.75,0 -1.262,0.539 -1.262,1.32 0,0.773 0.453,1.301 1.117,1.301 0.192,0 0.371,-0.055 0.489,-0.137 0.066,-0.051 0.109,-0.098 0.23,-0.234 0,0.722 -0.199,1.066 -0.617,1.066 -0.262,0 -0.438,-0.141 -0.453,-0.363 z m 1.191,-2.352 c 0.356,0 0.579,0.277 0.579,0.719 0,0.414 -0.227,0.687 -0.571,0.687 -0.336,0 -0.547,-0.265 -0.547,-0.695 0,-0.434 0.203,-0.711 0.539,-0.711 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath154)"
+             id="path613" />
+          <path
+             d="m 204.535,449.41 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.672 -1.148,0.672 v 0.492 z m 2.883,0 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath155)"
+             id="path614" />
+          <path
+             d="m 204.535,456.969 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.441 -0.504,0.668 -1.148,0.668 v 0.492 z m 2.77,0.91 c 0.285,0 0.3,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.559 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.719 c 0.004,0.75 0.493,1.219 1.262,1.219 0.797,0 1.309,-0.469 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.61,-0.93 0.34,-0.215 0.489,-0.453 0.489,-0.797 0,-0.621 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.613 h 0.688 c 0.004,-0.199 0.019,-0.3 0.058,-0.394 0.067,-0.164 0.239,-0.266 0.454,-0.266 0.296,0 0.464,0.18 0.464,0.492 0,0.379 -0.214,0.567 -0.656,0.567 h -0.062 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath156)"
+             id="path615" />
+          <path
+             d="m 204.535,464.41 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.672 -1.148,0.672 v 0.492 z m 4.207,-1.164 h -2 l -0.336,2.086 h 0.668 c 0.078,-0.184 0.246,-0.285 0.473,-0.285 0.375,0 0.601,0.269 0.601,0.726 0,0.438 -0.226,0.707 -0.601,0.707 -0.32,0 -0.5,-0.164 -0.516,-0.464 h -0.73 c 0.011,0.652 0.508,1.097 1.238,1.097 0.801,0 1.352,-0.551 1.352,-1.355 0,-0.774 -0.477,-1.297 -1.168,-1.297 -0.25,0 -0.434,0.066 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath157)"
+             id="path616" />
+          <path
+             d="m 204.535,471.852 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.671 -1.148,0.671 v 0.493 z m 4.414,-1.164 h -2.637 v 0.66 h 1.864 c -0.227,0.242 -0.676,0.925 -0.824,1.25 -0.258,0.547 -0.391,1.035 -0.489,1.836 h 0.742 c 0.071,-1.184 0.454,-2.094 1.344,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath158)"
+             id="path617" />
+          <path
+             d="m 204.535,479.289 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.441 -0.504,0.672 -1.148,0.672 v 0.488 z m 1.824,1.711 c 0.016,0.578 0.504,1 1.149,1 0.48,0 0.844,-0.203 1.066,-0.582 0.196,-0.332 0.309,-0.898 0.309,-1.5 0,-0.547 -0.082,-0.973 -0.258,-1.258 -0.238,-0.398 -0.605,-0.609 -1.055,-0.609 -0.75,0 -1.261,0.535 -1.261,1.32 0,0.77 0.453,1.297 1.117,1.297 0.191,0 0.371,-0.051 0.488,-0.137 0.066,-0.047 0.109,-0.093 0.231,-0.234 0,0.726 -0.2,1.066 -0.618,1.066 -0.265,0 -0.437,-0.14 -0.453,-0.363 z m 1.188,-2.348 c 0.359,0 0.582,0.274 0.582,0.719 0,0.41 -0.227,0.684 -0.57,0.684 -0.336,0 -0.551,-0.262 -0.551,-0.696 0,-0.433 0.207,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath159)"
+             id="path618" />
+          <path
+             d="m 205.984,488.652 h -1.589 c 0.097,-0.199 0.214,-0.312 0.765,-0.707 0.649,-0.476 0.84,-0.754 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.777,0 -1.231,0.461 -1.231,1.254 v 0.129 h 0.715 v -0.121 c 0,-0.414 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.23 0.528,0.605 0,0.414 -0.125,0.571 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.546 z m 1.434,-1.922 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.442 -0.5,0.668 -1.144,0.668 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath160)"
+             id="path619" />
+          <path
+             d="m 205.984,496.094 h -1.589 c 0.097,-0.203 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.504,-1.187 -1.285,-1.187 -0.777,0 -1.231,0.461 -1.231,1.25 v 0.132 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.227 0.528,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.633,0.43 -0.828,0.758 -0.859,1.457 h 2.546 z m 1.321,-1.016 c 0.285,0 0.3,0 0.433,0.039 0.25,0.067 0.407,0.285 0.407,0.559 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.203 -0.559,-0.586 h -0.719 c 0.004,0.75 0.493,1.219 1.262,1.219 0.797,0 1.309,-0.469 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.61,-0.93 0.34,-0.215 0.489,-0.453 0.489,-0.797 0,-0.625 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.614 h 0.688 c 0.004,-0.204 0.019,-0.301 0.058,-0.399 0.067,-0.164 0.239,-0.262 0.454,-0.262 0.296,0 0.464,0.18 0.464,0.493 0,0.378 -0.214,0.562 -0.656,0.562 h -0.062 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath161)"
+             id="path620" />
+          <path
+             d="m 205.984,503.531 h -1.589 c 0.097,-0.199 0.214,-0.308 0.765,-0.707 0.649,-0.472 0.84,-0.754 0.84,-1.265 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.777,0 -1.231,0.457 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.226 0.528,0.601 0,0.418 -0.125,0.571 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.546 z m 2.758,-3.082 h -2 l -0.336,2.086 h 0.668 c 0.078,-0.183 0.246,-0.285 0.473,-0.285 0.375,0 0.601,0.27 0.601,0.723 0,0.437 -0.226,0.707 -0.601,0.707 -0.32,0 -0.5,-0.164 -0.516,-0.465 h -0.73 c 0.011,0.656 0.508,1.101 1.238,1.101 0.801,0 1.352,-0.55 1.352,-1.359 0,-0.769 -0.477,-1.293 -1.168,-1.293 -0.25,0 -0.434,0.063 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath162)"
+             id="path621" />
+          <path
+             d="m 205.984,510.973 h -1.589 c 0.097,-0.2 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.84,-0.754 0.84,-1.266 0,-0.727 -0.504,-1.188 -1.285,-1.188 -0.777,0 -1.231,0.458 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.227 0.528,0.602 0,0.414 -0.125,0.57 -0.961,1.16 -0.633,0.433 -0.828,0.762 -0.859,1.457 h 2.546 z m 2.965,-3.082 h -2.637 v 0.66 h 1.864 c -0.227,0.242 -0.676,0.922 -0.824,1.25 -0.258,0.543 -0.391,1.035 -0.489,1.832 h 0.742 c 0.071,-1.184 0.454,-2.09 1.344,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath163)"
+             id="path622" />
+          <path
+             d="m 205.984,518.414 h -1.589 c 0.097,-0.199 0.214,-0.312 0.765,-0.707 0.649,-0.477 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.777,0 -1.231,0.461 -1.231,1.254 v 0.129 h 0.715 v -0.121 c 0,-0.414 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.226 0.528,0.601 0,0.418 -0.125,0.57 -0.961,1.164 -0.633,0.434 -0.828,0.758 -0.859,1.457 h 2.546 z m 0.375,-0.211 c 0.016,0.574 0.504,0.996 1.149,0.996 0.48,0 0.844,-0.199 1.066,-0.578 0.196,-0.336 0.309,-0.898 0.309,-1.5 0,-0.551 -0.082,-0.973 -0.258,-1.258 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.774 0.453,1.301 1.117,1.301 0.191,0 0.371,-0.055 0.488,-0.137 0.066,-0.05 0.109,-0.097 0.231,-0.234 0,0.723 -0.2,1.066 -0.618,1.066 -0.265,0 -0.437,-0.14 -0.453,-0.363 z m 1.188,-2.351 c 0.359,0 0.582,0.277 0.582,0.718 0,0.414 -0.227,0.688 -0.57,0.688 -0.336,0 -0.551,-0.266 -0.551,-0.699 0,-0.43 0.207,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath164)"
+             id="path623" />
+          <path
+             d="m 215.102,414.129 h -1.586 c 0.097,-0.199 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.836,-0.754 0.836,-1.266 0,-0.722 -0.5,-1.187 -1.281,-1.187 -0.777,0 -1.231,0.457 -1.231,1.25 v 0.133 h 0.711 v -0.122 c 0,-0.418 0.2,-0.66 0.536,-0.66 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath165)"
+             id="path624" />
+          <path
+             d="m 215.156,420.789 h -0.39 v -2.301 h -0.871 l -1.368,2.289 v 0.625 h 1.5 v 0.828 h 0.739 v -0.828 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.601 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath166)"
+             id="path625" />
+          <path
+             d="m 215.078,426.777 c -0.039,-0.242 -0.086,-0.363 -0.18,-0.504 -0.195,-0.265 -0.539,-0.425 -0.945,-0.425 -0.465,0 -0.848,0.207 -1.074,0.582 -0.219,0.363 -0.309,0.781 -0.309,1.461 0,0.644 0.078,1.047 0.266,1.347 0.219,0.348 0.609,0.555 1.051,0.555 0.746,0 1.254,-0.555 1.254,-1.375 0,-0.719 -0.446,-1.215 -1.09,-1.215 -0.305,0 -0.512,0.09 -0.742,0.336 l 0.003,-0.082 c 0.012,-0.348 0.028,-0.457 0.079,-0.602 0.101,-0.273 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.094 0.461,0.332 z m -1.211,1.012 c 0.348,0 0.571,0.266 0.571,0.684 0,0.394 -0.243,0.687 -0.571,0.687 -0.336,0 -0.57,-0.277 -0.57,-0.676 0,-0.41 0.234,-0.695 0.57,-0.695 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath167)"
+             id="path626" />
+          <path
+             d="m 214.559,435.074 c 0.129,-0.07 0.183,-0.105 0.242,-0.16 0.156,-0.141 0.246,-0.371 0.246,-0.613 0,-0.586 -0.508,-1.012 -1.199,-1.012 -0.7,0 -1.207,0.426 -1.207,1.02 0,0.359 0.148,0.586 0.488,0.765 -0.434,0.235 -0.613,0.516 -0.613,0.961 0,0.707 0.543,1.195 1.332,1.195 0.781,0 1.324,-0.488 1.324,-1.195 0,-0.445 -0.18,-0.726 -0.613,-0.961 z m -0.707,-1.191 c 0.328,0 0.554,0.203 0.554,0.492 0,0.285 -0.234,0.492 -0.554,0.492 -0.332,0 -0.559,-0.199 -0.559,-0.496 0,-0.285 0.227,-0.488 0.559,-0.488 z m -0.012,1.484 c 0.367,0 0.594,0.242 0.594,0.637 0,0.355 -0.235,0.594 -0.594,0.594 -0.36,0 -0.586,-0.239 -0.586,-0.606 0,-0.383 0.226,-0.625 0.586,-0.625 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath168)"
+             id="path627" />
+          <path
+             d="m 212.215,441.969 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.441 -0.504,0.668 -1.145,0.668 v 0.492 z m 3.066,-1.242 c -0.402,0 -0.746,0.171 -0.972,0.48 -0.215,0.293 -0.317,0.766 -0.317,1.496 0,0.664 0.086,1.129 0.266,1.414 0.222,0.36 0.586,0.555 1.023,0.555 0.407,0 0.739,-0.164 0.973,-0.473 0.211,-0.293 0.316,-0.773 0.316,-1.476 0,-0.684 -0.086,-1.149 -0.265,-1.442 -0.219,-0.359 -0.586,-0.554 -1.024,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.16 0.117,0.566 0.117,1.082 0,0.422 -0.039,0.836 -0.098,0.988 -0.082,0.223 -0.242,0.344 -0.453,0.344 -0.195,0 -0.343,-0.101 -0.433,-0.289 -0.075,-0.16 -0.118,-0.551 -0.118,-1.051 0,-0.445 0.04,-0.867 0.098,-1.019 0.078,-0.227 0.242,-0.356 0.453,-0.356 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath169)"
+             id="path628" />
+          <path
+             d="m 212.215,449.41 v 2.582 h 0.742 v -3.746 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.492 z m 4.328,1.922 h -1.59 c 0.102,-0.199 0.219,-0.312 0.766,-0.707 0.652,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.129 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.57 -0.961,1.164 -0.632,0.434 -0.828,0.758 -0.859,1.457 h 2.543 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath170)"
+             id="path629" />
+          <path
+             d="m 212.215,456.969 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.441 -0.504,0.671 -1.145,0.671 v 0.489 z m 4.383,1.14 h -0.391 v -2.3 h -0.871 l -1.371,2.293 v 0.621 h 1.5 v 0.828 h 0.742 v -0.828 h 0.391 z m -1.133,0 h -0.977 l 0.977,-1.597 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath171)"
+             id="path630" />
+          <path
+             d="m 212.215,464.41 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.441 -0.504,0.668 -1.145,0.668 v 0.492 z m 4.301,-0.312 c -0.036,-0.243 -0.082,-0.364 -0.18,-0.5 -0.195,-0.27 -0.535,-0.43 -0.945,-0.43 -0.465,0 -0.844,0.207 -1.071,0.582 -0.222,0.363 -0.312,0.781 -0.312,1.461 0,0.644 0.082,1.047 0.269,1.348 0.219,0.347 0.61,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.371 0,-0.719 -0.445,-1.215 -1.09,-1.215 -0.304,0 -0.512,0.09 -0.742,0.332 l 0.004,-0.078 c 0.012,-0.351 0.027,-0.461 0.078,-0.605 0.102,-0.274 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.093 0.461,0.332 z m -1.207,1.015 c 0.347,0 0.57,0.262 0.57,0.68 0,0.398 -0.242,0.687 -0.57,0.687 -0.34,0 -0.571,-0.273 -0.571,-0.675 0,-0.407 0.231,-0.692 0.571,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath172)"
+             id="path631" />
+          <path
+             d="m 212.215,471.852 v 2.582 h 0.742 v -3.746 h -0.492 c -0.117,0.445 -0.504,0.671 -1.145,0.671 v 0.493 z m 3.785,0.543 c 0.125,-0.071 0.184,-0.106 0.242,-0.161 0.153,-0.14 0.242,-0.367 0.242,-0.609 0,-0.586 -0.507,-1.016 -1.199,-1.016 -0.695,0 -1.203,0.43 -1.203,1.02 0,0.359 0.148,0.586 0.488,0.766 -0.433,0.238 -0.613,0.515 -0.613,0.96 0,0.707 0.543,1.2 1.328,1.2 0.781,0 1.328,-0.493 1.328,-1.2 0,-0.445 -0.179,-0.722 -0.613,-0.96 z m -0.707,-1.188 c 0.328,0 0.555,0.199 0.555,0.488 0,0.285 -0.235,0.493 -0.555,0.493 -0.332,0 -0.563,-0.2 -0.563,-0.497 0,-0.285 0.231,-0.484 0.563,-0.484 z m -0.012,1.484 c 0.364,0 0.59,0.243 0.59,0.633 0,0.36 -0.23,0.598 -0.59,0.598 -0.359,0 -0.586,-0.238 -0.586,-0.61 0,-0.378 0.227,-0.621 0.586,-0.621 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath173)"
+             id="path632" />
+          <path
+             d="m 213.664,481.211 h -1.59 c 0.102,-0.199 0.215,-0.309 0.766,-0.707 0.648,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.504,-1.187 -1.285,-1.187 -0.774,0 -1.231,0.457 -1.231,1.25 v 0.133 h 0.715 v -0.122 c 0,-0.417 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.227 0.531,0.602 0,0.418 -0.129,0.57 -0.961,1.16 -0.636,0.434 -0.832,0.762 -0.863,1.457 h 2.547 z m 1.617,-3.16 c -0.402,0 -0.746,0.168 -0.972,0.48 -0.215,0.289 -0.317,0.766 -0.317,1.492 0,0.668 0.086,1.133 0.266,1.418 0.222,0.356 0.586,0.555 1.023,0.555 0.407,0 0.739,-0.164 0.973,-0.476 0.211,-0.29 0.316,-0.77 0.316,-1.473 0,-0.688 -0.086,-1.152 -0.265,-1.442 -0.219,-0.359 -0.586,-0.554 -1.024,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.156 0.117,0.563 0.117,1.082 0,0.422 -0.039,0.832 -0.098,0.985 -0.082,0.222 -0.242,0.343 -0.453,0.343 -0.195,0 -0.343,-0.097 -0.433,-0.289 -0.075,-0.16 -0.118,-0.55 -0.118,-1.05 0,-0.446 0.04,-0.868 0.098,-1.02 0.078,-0.227 0.242,-0.352 0.453,-0.352 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath174)"
+             id="path633" />
+          <path
+             d="m 213.664,488.652 h -1.59 c 0.102,-0.199 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.754 0.84,-1.265 0,-0.727 -0.504,-1.192 -1.285,-1.192 -0.774,0 -1.231,0.461 -1.231,1.254 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.226 0.531,0.601 0,0.414 -0.129,0.571 -0.961,1.16 -0.636,0.434 -0.832,0.762 -0.863,1.457 h 2.547 z m 2.879,0 h -1.59 c 0.102,-0.199 0.219,-0.312 0.766,-0.707 0.652,-0.476 0.84,-0.754 0.84,-1.265 0,-0.727 -0.5,-1.192 -1.282,-1.192 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.414 -0.125,0.571 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath175)"
+             id="path634" />
+          <path
+             d="m 213.664,496.094 h -1.59 c 0.102,-0.199 0.215,-0.313 0.766,-0.707 0.648,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.504,-1.187 -1.285,-1.187 -0.774,0 -1.231,0.461 -1.231,1.254 v 0.128 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.227 0.531,0.602 0,0.418 -0.129,0.57 -0.961,1.164 -0.636,0.433 -0.832,0.758 -0.863,1.457 h 2.547 z m 2.934,-0.782 h -0.391 v -2.304 h -0.871 l -1.371,2.293 v 0.625 h 1.5 v 0.828 h 0.742 v -0.828 h 0.391 z m -1.133,0 h -0.977 l 0.977,-1.601 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath176)"
+             id="path635" />
+          <path
+             d="m 213.664,503.535 h -1.59 c 0.102,-0.203 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.774,0 -1.231,0.461 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.226 0.531,0.601 0,0.418 -0.129,0.571 -0.961,1.164 -0.636,0.43 -0.832,0.758 -0.863,1.457 h 2.547 z m 2.852,-2.234 c -0.036,-0.242 -0.082,-0.363 -0.18,-0.504 -0.195,-0.266 -0.535,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.207 -1.071,0.582 -0.222,0.363 -0.312,0.781 -0.312,1.461 0,0.645 0.082,1.047 0.269,1.348 0.219,0.347 0.61,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.375 0,-0.718 -0.445,-1.214 -1.09,-1.214 -0.304,0 -0.512,0.089 -0.742,0.335 l 0.004,-0.082 c 0.012,-0.347 0.027,-0.457 0.078,-0.601 0.102,-0.274 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.093 0.461,0.332 z m -1.207,1.011 c 0.347,0 0.57,0.266 0.57,0.684 0,0.395 -0.242,0.684 -0.57,0.684 -0.34,0 -0.571,-0.274 -0.571,-0.676 0,-0.406 0.231,-0.692 0.571,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath177)"
+             id="path636" />
+          <path
+             d="m 213.664,510.973 h -1.59 c 0.102,-0.2 0.215,-0.309 0.766,-0.707 0.648,-0.473 0.84,-0.754 0.84,-1.266 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.774,0 -1.231,0.458 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.227 0.531,0.602 0,0.418 -0.129,0.57 -0.961,1.16 -0.636,0.433 -0.832,0.762 -0.863,1.457 h 2.547 z M 216,509.598 c 0.125,-0.071 0.184,-0.106 0.242,-0.16 0.153,-0.141 0.242,-0.372 0.242,-0.614 0,-0.586 -0.507,-1.012 -1.199,-1.012 -0.695,0 -1.203,0.426 -1.203,1.02 0,0.356 0.148,0.586 0.488,0.766 -0.433,0.234 -0.613,0.515 -0.613,0.961 0,0.707 0.543,1.195 1.328,1.195 0.781,0 1.328,-0.488 1.328,-1.195 0,-0.446 -0.179,-0.727 -0.613,-0.961 z m -0.707,-1.192 c 0.328,0 0.555,0.203 0.555,0.492 0,0.286 -0.235,0.493 -0.555,0.493 -0.332,0 -0.563,-0.203 -0.563,-0.496 0,-0.286 0.231,-0.489 0.563,-0.489 z m -0.012,1.485 c 0.364,0 0.59,0.242 0.59,0.632 0,0.36 -0.23,0.598 -0.59,0.598 -0.359,0 -0.586,-0.238 -0.586,-0.605 0,-0.383 0.227,-0.625 0.586,-0.625 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath178)"
+             id="path637" />
+          <path
+             d="m 212.105,517.402 c 0.286,0 0.301,0 0.434,0.036 0.246,0.07 0.406,0.285 0.406,0.558 0,0.332 -0.234,0.566 -0.554,0.566 -0.348,0 -0.539,-0.199 -0.559,-0.585 h -0.719 c 0.004,0.75 0.492,1.218 1.262,1.218 0.797,0 1.309,-0.468 1.309,-1.199 0,-0.437 -0.188,-0.723 -0.614,-0.93 0.344,-0.214 0.492,-0.453 0.492,-0.796 0,-0.622 -0.464,-1.02 -1.187,-1.02 -0.543,0 -0.961,0.238 -1.125,0.645 -0.07,0.179 -0.09,0.3 -0.09,0.613 h 0.688 c 0.004,-0.199 0.019,-0.301 0.058,-0.395 0.067,-0.164 0.235,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.219,0.566 -0.656,0.566 h -0.063 z m 3.176,-2.152 c -0.402,0 -0.746,0.172 -0.972,0.48 -0.215,0.293 -0.317,0.766 -0.317,1.497 0,0.664 0.086,1.128 0.266,1.414 0.222,0.359 0.586,0.554 1.023,0.554 0.407,0 0.739,-0.164 0.973,-0.476 0.211,-0.289 0.316,-0.77 0.316,-1.473 0,-0.684 -0.086,-1.148 -0.265,-1.441 -0.219,-0.36 -0.586,-0.555 -1.024,-0.555 z m 0,0.598 c 0.192,0 0.344,0.105 0.434,0.3 0.074,0.161 0.117,0.567 0.117,1.082 0,0.422 -0.039,0.836 -0.098,0.989 -0.082,0.222 -0.242,0.343 -0.453,0.343 -0.195,0 -0.343,-0.101 -0.433,-0.289 -0.075,-0.16 -0.118,-0.55 -0.118,-1.05 0,-0.446 0.04,-0.868 0.098,-1.02 0.078,-0.226 0.242,-0.355 0.453,-0.355 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath179)"
+             id="path638" />
+          <path
+             d="m 379.688,513.312 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath180)"
+             id="path639" />
+          <path
+             d="m 379.688,505.871 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath181)"
+             id="path640" />
+          <path
+             d="m 379.688,498.434 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath182)"
+             id="path641" />
+          <path
+             d="m 379.688,490.992 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath183)"
+             id="path642" />
+          <path
+             d="m 379.688,483.551 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath184)"
+             id="path643" />
+          <path
+             d="m 379.688,476.113 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath185)"
+             id="path644" />
+          <path
+             d="m 379.688,468.672 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath186)"
+             id="path645" />
+          <path
+             d="m 379.688,461.23 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath187)"
+             id="path646" />
+          <path
+             d="m 379.688,453.789 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath188)"
+             id="path647" />
+          <path
+             d="m 379.688,446.352 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath189)"
+             id="path648" />
+          <path
+             d="m 379.688,438.91 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath190)"
+             id="path649" />
+          <path
+             d="m 379.688,431.469 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath191)"
+             id="path650" />
+          <path
+             d="m 379.688,423.91 h 7.438 v 7.559 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath192)"
+             id="path651" />
+          <path
+             d="m 379.688,416.469 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath193)"
+             id="path652" />
+          <path
+             d="m 379.688,409.027 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath194)"
+             id="path653" />
+          <path
+             d="m 379.688,401.59 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath195)"
+             id="path654" />
+          <path
+             d="m 379.688,394.148 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath196)"
+             id="path655" />
+          <path
+             d="m 387.129,513.312 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath197)"
+             id="path656" />
+          <path
+             d="m 387.129,505.871 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath198)"
+             id="path657" />
+          <path
+             d="m 387.129,498.434 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath199)"
+             id="path658" />
+          <path
+             d="m 387.129,490.992 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath200)"
+             id="path659" />
+          <path
+             d="m 387.129,483.551 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath201)"
+             id="path660" />
+          <path
+             d="m 387.129,476.113 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath202)"
+             id="path661" />
+          <path
+             d="m 387.129,468.672 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath203)"
+             id="path662" />
+          <path
+             d="m 387.129,461.23 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath204)"
+             id="path663" />
+          <path
+             d="m 387.129,453.789 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath205)"
+             id="path664" />
+          <path
+             d="m 387.129,446.352 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath206)"
+             id="path665" />
+          <path
+             d="m 387.129,438.91 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath207)"
+             id="path666" />
+          <path
+             d="m 387.129,431.469 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath208)"
+             id="path667" />
+          <path
+             d="m 387.129,423.91 h 7.438 v 7.559 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath209)"
+             id="path668" />
+          <path
+             d="m 387.129,416.469 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath210)"
+             id="path669" />
+          <path
+             d="m 387.129,409.027 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath211)"
+             id="path670" />
+          <path
+             d="m 387.129,401.59 h 7.438 v 7.438 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath212)"
+             id="path671" />
+          <path
+             d="m 387.129,394.148 h 7.438 v 7.441 h -7.438 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath213)"
+             id="path672" />
+          <path
+             d="m 383.223,397.328 v 2.582 h 0.738 v -3.746 h -0.488 c -0.118,0.445 -0.504,0.672 -1.149,0.672 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath214)"
+             id="path673" />
+          <path
+             d="m 383.113,405.676 c 0.285,0 0.301,0 0.434,0.035 0.246,0.07 0.406,0.285 0.406,0.562 0,0.332 -0.234,0.563 -0.555,0.563 -0.347,0 -0.539,-0.199 -0.562,-0.586 h -0.715 c 0.004,0.75 0.488,1.219 1.262,1.219 0.797,0 1.308,-0.469 1.308,-1.196 0,-0.441 -0.191,-0.726 -0.613,-0.929 0.344,-0.219 0.492,-0.457 0.492,-0.797 0,-0.625 -0.465,-1.02 -1.187,-1.02 -0.547,0 -0.961,0.239 -1.125,0.645 -0.07,0.18 -0.09,0.301 -0.09,0.609 h 0.687 c 0.004,-0.199 0.02,-0.301 0.055,-0.394 0.07,-0.164 0.238,-0.266 0.457,-0.266 0.293,0 0.465,0.18 0.465,0.492 0,0.379 -0.219,0.567 -0.656,0.567 h -0.063 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath215)"
+             id="path674" />
+          <path
+             d="m 384.547,411.047 h -2 l -0.332,2.086 h 0.664 c 0.082,-0.188 0.25,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.722 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.5,-0.164 -0.519,-0.465 h -0.727 c 0.012,0.657 0.508,1.098 1.235,1.098 0.804,0 1.351,-0.547 1.351,-1.355 0,-0.774 -0.472,-1.293 -1.164,-1.293 -0.25,0 -0.433,0.062 -0.652,0.226 L 383,411.707 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath216)"
+             id="path675" />
+          <path
+             d="m 384.754,418.484 h -2.633 v 0.661 h 1.863 c -0.226,0.246 -0.675,0.925 -0.824,1.253 -0.258,0.543 -0.39,1.036 -0.492,1.832 h 0.746 c 0.066,-1.183 0.453,-2.093 1.34,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath217)"
+             id="path676" />
+          <path
+             d="m 382.168,428.797 c 0.016,0.578 0.5,1 1.144,1 0.481,0 0.844,-0.199 1.067,-0.582 0.195,-0.332 0.312,-0.899 0.312,-1.5 0,-0.547 -0.086,-0.969 -0.257,-1.254 -0.239,-0.402 -0.61,-0.613 -1.059,-0.613 -0.75,0 -1.262,0.539 -1.262,1.32 0,0.77 0.457,1.297 1.121,1.297 0.192,0 0.368,-0.051 0.485,-0.137 0.07,-0.047 0.113,-0.094 0.234,-0.23 0,0.722 -0.203,1.066 -0.617,1.066 -0.266,0 -0.441,-0.144 -0.457,-0.367 z m 1.187,-2.348 c 0.36,0 0.583,0.274 0.583,0.719 0,0.41 -0.231,0.687 -0.571,0.687 -0.34,0 -0.551,-0.265 -0.551,-0.699 0,-0.433 0.207,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath218)"
+             id="path677" />
+          <path
+             d="m 381.785,434.527 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.442 -0.5,0.672 -1.144,0.672 v 0.488 z m 2.879,0 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.442 -0.5,0.672 -1.144,0.672 v 0.488 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath219)"
+             id="path678" />
+          <path
+             d="m 381.785,441.969 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.441 -0.5,0.668 -1.144,0.668 v 0.492 z m 2.766,0.906 c 0.285,0 0.301,0 0.433,0.039 0.25,0.066 0.407,0.285 0.407,0.559 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.203 -0.559,-0.586 h -0.718 c 0.007,0.75 0.492,1.219 1.261,1.219 0.797,0 1.313,-0.469 1.313,-1.199 0,-0.438 -0.192,-0.723 -0.613,-0.93 0.343,-0.215 0.488,-0.453 0.488,-0.797 0,-0.621 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.613 h 0.688 c 0.004,-0.199 0.023,-0.3 0.059,-0.394 0.07,-0.164 0.238,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.563 -0.653,0.563 h -0.066 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath220)"
+             id="path679" />
+          <path
+             d="m 381.785,449.41 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.492 z m 4.203,-1.164 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.184 0.246,-0.285 0.477,-0.285 0.375,0 0.601,0.269 0.601,0.723 0,0.441 -0.226,0.71 -0.601,0.71 -0.324,0 -0.504,-0.164 -0.52,-0.464 h -0.726 c 0.008,0.652 0.504,1.097 1.234,1.097 0.801,0 1.352,-0.551 1.352,-1.359 0,-0.77 -0.477,-1.293 -1.168,-1.293 -0.246,0 -0.434,0.062 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath221)"
+             id="path680" />
+          <path
+             d="m 381.785,456.969 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.441 -0.5,0.668 -1.144,0.668 v 0.492 z m 4.41,-1.16 h -2.636 v 0.66 h 1.863 c -0.227,0.242 -0.676,0.922 -0.82,1.25 -0.262,0.543 -0.391,1.035 -0.493,1.832 h 0.743 c 0.07,-1.184 0.457,-2.09 1.343,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath222)"
+             id="path681" />
+          <path
+             d="m 381.785,464.41 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.492 z m 1.82,1.711 c 0.016,0.574 0.504,0.996 1.149,0.996 0.48,0 0.844,-0.199 1.066,-0.578 0.196,-0.336 0.313,-0.898 0.313,-1.5 0,-0.551 -0.086,-0.973 -0.262,-1.258 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.77 0.453,1.301 1.117,1.301 0.191,0 0.371,-0.055 0.488,-0.141 0.067,-0.046 0.11,-0.093 0.231,-0.23 0,0.723 -0.2,1.066 -0.618,1.066 -0.261,0 -0.437,-0.14 -0.453,-0.363 z m 1.192,-2.351 c 0.355,0 0.578,0.277 0.578,0.718 0,0.414 -0.227,0.688 -0.57,0.688 -0.336,0 -0.547,-0.266 -0.547,-0.699 0,-0.43 0.203,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath223)"
+             id="path682" />
+          <path
+             d="m 383.23,473.773 h -1.589 c 0.101,-0.203 0.214,-0.312 0.765,-0.711 0.649,-0.472 0.84,-0.753 0.84,-1.265 0,-0.723 -0.5,-1.188 -1.285,-1.188 -0.773,0 -1.227,0.457 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.227 0.528,0.601 0,0.418 -0.129,0.571 -0.961,1.161 -0.637,0.433 -0.832,0.761 -0.863,1.461 h 2.546 z m 1.434,-1.921 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.445 -0.5,0.671 -1.144,0.671 v 0.493 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath224)"
+             id="path683" />
+          <path
+             d="m 383.23,481.211 h -1.589 c 0.101,-0.199 0.214,-0.309 0.765,-0.707 0.649,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.5,-1.187 -1.285,-1.187 -0.773,0 -1.227,0.457 -1.227,1.25 v 0.133 h 0.711 v -0.122 c 0,-0.417 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.227 0.528,0.602 0,0.418 -0.129,0.57 -0.961,1.16 -0.637,0.434 -0.832,0.762 -0.863,1.457 h 2.546 z m 1.321,-1.012 c 0.285,0 0.301,0 0.433,0.035 0.25,0.071 0.407,0.286 0.407,0.563 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.718 c 0.007,0.75 0.492,1.219 1.261,1.219 0.797,0 1.313,-0.469 1.313,-1.195 0,-0.442 -0.192,-0.727 -0.613,-0.93 0.343,-0.219 0.488,-0.457 0.488,-0.797 0,-0.625 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.234 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.61 h 0.688 c 0.004,-0.2 0.023,-0.301 0.059,-0.395 0.07,-0.164 0.238,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.215,0.566 -0.653,0.566 h -0.066 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath225)"
+             id="path684" />
+          <path
+             d="m 383.23,488.652 h -1.589 c 0.101,-0.199 0.214,-0.312 0.765,-0.707 0.649,-0.476 0.84,-0.754 0.84,-1.269 0,-0.723 -0.5,-1.188 -1.285,-1.188 -0.773,0 -1.227,0.461 -1.227,1.254 v 0.133 h 0.711 v -0.125 c 0,-0.414 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.23 0.528,0.605 0,0.414 -0.129,0.571 -0.961,1.16 -0.637,0.434 -0.832,0.762 -0.863,1.457 h 2.546 z m 2.758,-3.082 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.187 0.246,-0.285 0.477,-0.285 0.375,0 0.601,0.27 0.601,0.723 0,0.437 -0.226,0.707 -0.601,0.707 -0.324,0 -0.504,-0.164 -0.52,-0.465 h -0.726 c 0.008,0.656 0.504,1.098 1.234,1.098 0.801,0 1.352,-0.547 1.352,-1.356 0,-0.773 -0.477,-1.293 -1.168,-1.293 -0.246,0 -0.434,0.063 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath226)"
+             id="path685" />
+          <path
+             d="m 383.23,496.094 h -1.589 c 0.101,-0.203 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.285,-1.187 -0.773,0 -1.227,0.461 -1.227,1.25 v 0.132 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.227 0.528,0.602 0,0.418 -0.129,0.57 -0.961,1.164 -0.637,0.43 -0.832,0.758 -0.863,1.457 h 2.546 z m 2.965,-3.086 h -2.636 v 0.66 h 1.863 c -0.227,0.242 -0.676,0.926 -0.82,1.254 -0.262,0.543 -0.391,1.035 -0.493,1.832 h 0.743 c 0.07,-1.184 0.457,-2.094 1.343,-3.164 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath227)"
+             id="path686" />
+          <path
+             d="m 383.23,503.531 h -1.589 c 0.101,-0.199 0.214,-0.308 0.765,-0.707 0.649,-0.472 0.84,-0.754 0.84,-1.265 0,-0.723 -0.5,-1.188 -1.285,-1.188 -0.773,0 -1.227,0.457 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.226 0.528,0.601 0,0.418 -0.129,0.571 -0.961,1.16 -0.637,0.434 -0.832,0.762 -0.863,1.457 h 2.546 z m 0.375,-0.211 c 0.016,0.578 0.504,1 1.149,1 0.48,0 0.844,-0.199 1.066,-0.582 0.196,-0.332 0.313,-0.898 0.313,-1.5 0,-0.547 -0.086,-0.968 -0.262,-1.254 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.77 0.453,1.297 1.117,1.297 0.191,0 0.371,-0.05 0.488,-0.136 0.067,-0.047 0.11,-0.094 0.231,-0.231 0,0.723 -0.2,1.067 -0.618,1.067 -0.261,0 -0.437,-0.145 -0.453,-0.368 z m 1.192,-2.347 c 0.355,0 0.578,0.273 0.578,0.718 0,0.411 -0.227,0.684 -0.57,0.684 -0.336,0 -0.547,-0.262 -0.547,-0.695 0,-0.434 0.203,-0.707 0.539,-0.707 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath228)"
+             id="path687" />
+          <path
+             d="m 381.672,509.961 c 0.285,0 0.301,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.559 0,0.336 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.718 c 0.004,0.75 0.492,1.219 1.261,1.219 0.797,0 1.309,-0.469 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.613,-0.926 0.343,-0.219 0.492,-0.457 0.492,-0.801 0,-0.621 -0.465,-1.016 -1.188,-1.016 -0.543,0 -0.961,0.235 -1.125,0.641 -0.066,0.18 -0.089,0.301 -0.089,0.613 h 0.687 c 0.004,-0.199 0.02,-0.3 0.059,-0.394 0.066,-0.164 0.238,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.567 -0.657,0.567 h -0.062 z m 2.992,-0.91 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.441 -0.5,0.668 -1.144,0.668 v 0.492 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath229)"
+             id="path688" />
+          <path
+             d="m 381.672,517.398 c 0.285,0 0.301,0 0.433,0.04 0.25,0.066 0.407,0.285 0.407,0.558 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.203 -0.559,-0.585 h -0.718 c 0.004,0.75 0.492,1.218 1.261,1.218 0.797,0 1.309,-0.468 1.309,-1.199 0,-0.437 -0.188,-0.723 -0.613,-0.93 0.343,-0.214 0.492,-0.453 0.492,-0.796 0,-0.622 -0.465,-1.02 -1.188,-1.02 -0.543,0 -0.961,0.238 -1.125,0.645 -0.066,0.179 -0.089,0.3 -0.089,0.613 h 0.687 c 0.004,-0.199 0.02,-0.301 0.059,-0.395 0.066,-0.164 0.238,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.215,0.562 -0.657,0.562 h -0.062 z m 2.879,0 c 0.285,0 0.301,0 0.433,0.04 0.25,0.066 0.407,0.285 0.407,0.558 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.203 -0.559,-0.585 h -0.718 c 0.007,0.75 0.492,1.218 1.261,1.218 0.797,0 1.313,-0.468 1.313,-1.199 0,-0.437 -0.192,-0.723 -0.613,-0.93 0.343,-0.214 0.488,-0.453 0.488,-0.796 0,-0.622 -0.465,-1.02 -1.188,-1.02 -0.543,0 -0.961,0.238 -1.125,0.645 -0.066,0.179 -0.09,0.3 -0.09,0.613 h 0.688 c 0.004,-0.199 0.023,-0.301 0.059,-0.395 0.07,-0.164 0.238,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.215,0.562 -0.653,0.562 h -0.066 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath230)"
+             id="path689" />
+          <path
+             d="m 392.23,399.25 h -1.589 c 0.101,-0.203 0.214,-0.312 0.765,-0.707 0.649,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.285,-1.187 -0.773,0 -1.227,0.461 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.226 0.528,0.601 0,0.418 -0.129,0.57 -0.961,1.164 -0.633,0.434 -0.832,0.758 -0.863,1.457 h 2.546 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath231)"
+             id="path690" />
+          <path
+             d="m 392.281,405.906 h -0.39 v -2.301 h -0.871 l -1.368,2.293 v 0.622 h 1.5 v 0.828 h 0.739 v -0.828 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.597 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath232)"
+             id="path691" />
+          <path
+             d="m 392.203,411.895 c -0.035,-0.243 -0.082,-0.364 -0.18,-0.5 -0.195,-0.27 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.203 -1.07,0.578 -0.223,0.367 -0.313,0.781 -0.313,1.465 0,0.644 0.078,1.043 0.27,1.343 0.215,0.352 0.605,0.555 1.051,0.555 0.746,0 1.25,-0.555 1.25,-1.371 0,-0.719 -0.442,-1.215 -1.086,-1.215 -0.305,0 -0.512,0.09 -0.746,0.332 l 0.007,-0.078 c 0.008,-0.348 0.024,-0.461 0.079,-0.601 0.101,-0.278 0.281,-0.415 0.539,-0.415 0.238,0 0.363,0.098 0.457,0.333 z m -1.207,1.015 c 0.348,0 0.57,0.266 0.57,0.68 0,0.398 -0.246,0.687 -0.57,0.687 -0.34,0 -0.57,-0.273 -0.57,-0.675 0,-0.407 0.23,-0.692 0.57,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath233)"
+             id="path692" />
+          <path
+             d="m 391.688,420.191 c 0.124,-0.066 0.183,-0.105 0.242,-0.156 0.152,-0.144 0.242,-0.371 0.242,-0.613 0,-0.586 -0.508,-1.016 -1.199,-1.016 -0.696,0 -1.203,0.43 -1.203,1.02 0,0.359 0.148,0.586 0.484,0.765 -0.43,0.239 -0.609,0.52 -0.609,0.961 0,0.707 0.543,1.2 1.328,1.2 0.781,0 1.324,-0.493 1.324,-1.2 0,-0.441 -0.176,-0.722 -0.609,-0.961 z m -0.708,-1.187 c 0.325,0 0.551,0.199 0.551,0.492 0,0.285 -0.23,0.488 -0.551,0.488 -0.335,0 -0.562,-0.199 -0.562,-0.496 0,-0.285 0.227,-0.484 0.562,-0.484 z m -0.011,1.484 c 0.363,0 0.59,0.242 0.59,0.633 0,0.359 -0.231,0.598 -0.59,0.598 -0.36,0 -0.586,-0.239 -0.586,-0.61 0,-0.379 0.226,-0.621 0.586,-0.621 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath234)"
+             id="path693" />
+          <path
+             d="m 389.344,427.09 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.492 z m 3.062,-1.242 c -0.398,0 -0.742,0.168 -0.968,0.48 -0.219,0.289 -0.317,0.766 -0.317,1.496 0,0.664 0.082,1.129 0.262,1.414 0.222,0.36 0.586,0.555 1.023,0.555 0.41,0 0.742,-0.164 0.973,-0.477 0.211,-0.289 0.316,-0.769 0.316,-1.472 0,-0.688 -0.082,-1.153 -0.261,-1.442 -0.223,-0.359 -0.586,-0.554 -1.028,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.156 0.117,0.563 0.117,1.082 0,0.422 -0.035,0.832 -0.094,0.988 -0.086,0.219 -0.242,0.344 -0.457,0.344 -0.195,0 -0.34,-0.101 -0.429,-0.293 -0.075,-0.156 -0.118,-0.547 -0.118,-1.051 0,-0.441 0.036,-0.863 0.094,-1.019 0.078,-0.227 0.242,-0.352 0.453,-0.352 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath235)"
+             id="path694" />
+          <path
+             d="m 389.344,434.527 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.488 z m 4.328,1.922 h -1.59 c 0.098,-0.199 0.215,-0.308 0.766,-0.707 0.648,-0.472 0.84,-0.754 0.84,-1.265 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath236)"
+             id="path695" />
+          <path
+             d="m 389.344,441.969 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.441 -0.5,0.668 -1.145,0.668 v 0.492 z m 4.379,1.14 h -0.391 v -2.3 h -0.871 l -1.367,2.289 v 0.625 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.597 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath237)"
+             id="path696" />
+          <path
+             d="m 389.344,449.41 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.492 z m 4.301,-0.312 c -0.04,-0.243 -0.086,-0.364 -0.18,-0.5 -0.195,-0.27 -0.539,-0.43 -0.945,-0.43 -0.465,0 -0.844,0.207 -1.075,0.582 -0.218,0.363 -0.308,0.781 -0.308,1.461 0,0.644 0.078,1.047 0.269,1.348 0.215,0.347 0.606,0.554 1.051,0.554 0.742,0 1.25,-0.554 1.25,-1.375 0,-0.715 -0.445,-1.211 -1.086,-1.211 -0.309,0 -0.516,0.09 -0.746,0.332 l 0.004,-0.082 c 0.012,-0.347 0.027,-0.457 0.078,-0.601 0.102,-0.274 0.281,-0.41 0.539,-0.41 0.238,0 0.367,0.093 0.461,0.332 z m -1.211,1.015 c 0.347,0 0.57,0.262 0.57,0.68 0,0.395 -0.242,0.687 -0.57,0.687 -0.336,0 -0.571,-0.277 -0.571,-0.675 0,-0.407 0.235,-0.692 0.571,-0.692 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath238)"
+             id="path697" />
+          <path
+             d="m 389.344,456.969 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.441 -0.5,0.671 -1.145,0.671 v 0.489 z m 3.781,0.543 c 0.129,-0.067 0.187,-0.106 0.242,-0.157 0.156,-0.144 0.246,-0.371 0.246,-0.613 0,-0.586 -0.508,-1.012 -1.199,-1.012 -0.699,0 -1.203,0.426 -1.203,1.016 0,0.359 0.144,0.59 0.484,0.766 -0.433,0.238 -0.613,0.519 -0.613,0.965 0,0.707 0.543,1.195 1.332,1.195 0.781,0 1.324,-0.488 1.324,-1.195 0,-0.446 -0.179,-0.727 -0.613,-0.965 z m -0.707,-1.188 c 0.328,0 0.555,0.203 0.555,0.492 0,0.286 -0.231,0.493 -0.555,0.493 -0.332,0 -0.559,-0.204 -0.559,-0.497 0,-0.285 0.227,-0.488 0.559,-0.488 z m -0.012,1.485 c 0.367,0 0.594,0.242 0.594,0.632 0,0.36 -0.234,0.598 -0.594,0.598 -0.355,0 -0.586,-0.238 -0.586,-0.605 0,-0.383 0.231,-0.625 0.586,-0.625 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath239)"
+             id="path698" />
+          <path
+             d="m 390.789,466.332 h -1.59 c 0.102,-0.199 0.219,-0.312 0.766,-0.707 0.652,-0.477 0.84,-0.754 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.129 h 0.711 v -0.121 c 0,-0.414 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.23 0.527,0.605 0,0.414 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z m 1.617,-3.164 c -0.398,0 -0.742,0.172 -0.968,0.48 -0.219,0.293 -0.317,0.766 -0.317,1.497 0,0.664 0.082,1.128 0.262,1.414 0.222,0.359 0.586,0.554 1.023,0.554 0.41,0 0.742,-0.164 0.973,-0.476 0.211,-0.289 0.316,-0.77 0.316,-1.473 0,-0.684 -0.082,-1.148 -0.261,-1.441 -0.223,-0.36 -0.586,-0.555 -1.028,-0.555 z m 0,0.598 c 0.192,0 0.344,0.105 0.434,0.3 0.074,0.161 0.117,0.567 0.117,1.082 0,0.422 -0.035,0.836 -0.094,0.989 -0.086,0.222 -0.242,0.343 -0.457,0.343 -0.195,0 -0.34,-0.101 -0.429,-0.289 -0.075,-0.16 -0.118,-0.55 -0.118,-1.05 0,-0.446 0.036,-0.868 0.094,-1.02 0.078,-0.226 0.242,-0.355 0.453,-0.355 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath240)"
+             id="path699" />
+          <path
+             d="m 390.789,473.773 h -1.59 c 0.102,-0.203 0.219,-0.312 0.766,-0.707 0.652,-0.476 0.84,-0.757 0.84,-1.269 0,-0.723 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.227 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.165 -0.632,0.429 -0.828,0.757 -0.859,1.457 h 2.543 z m 2.883,0 h -1.59 c 0.098,-0.203 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.757 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.227 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.165 -0.632,0.429 -0.828,0.757 -0.859,1.457 h 2.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath241)"
+             id="path700" />
+          <path
+             d="m 390.789,481.211 h -1.59 c 0.102,-0.199 0.219,-0.309 0.766,-0.707 0.652,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.122 c 0,-0.417 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z m 2.934,-0.781 h -0.391 v -2.301 h -0.871 l -1.367,2.293 v 0.621 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.598 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath242)"
+             id="path701" />
+          <path
+             d="m 390.789,488.652 h -1.59 c 0.102,-0.199 0.219,-0.312 0.766,-0.707 0.652,-0.476 0.84,-0.754 0.84,-1.265 0,-0.727 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.414 -0.125,0.571 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z m 2.856,-2.234 c -0.04,-0.242 -0.086,-0.363 -0.18,-0.5 -0.195,-0.27 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.203 -1.075,0.578 -0.218,0.364 -0.308,0.782 -0.308,1.465 0,0.645 0.078,1.043 0.269,1.344 0.215,0.351 0.606,0.555 1.051,0.555 0.742,0 1.25,-0.555 1.25,-1.372 0,-0.718 -0.445,-1.214 -1.086,-1.214 -0.309,0 -0.516,0.09 -0.746,0.332 l 0.004,-0.078 c 0.012,-0.348 0.027,-0.461 0.078,-0.602 0.102,-0.277 0.281,-0.414 0.539,-0.414 0.238,0 0.367,0.098 0.461,0.332 z m -1.211,1.016 c 0.347,0 0.57,0.265 0.57,0.679 0,0.399 -0.242,0.688 -0.57,0.688 -0.336,0 -0.571,-0.274 -0.571,-0.676 0,-0.406 0.235,-0.691 0.571,-0.691 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath243)"
+             id="path702" />
+          <path
+             d="m 390.789,496.094 h -1.59 c 0.102,-0.199 0.219,-0.313 0.766,-0.707 0.652,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.128 h 0.711 v -0.121 c 0,-0.414 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.632,0.433 -0.828,0.758 -0.859,1.457 h 2.543 z m 2.336,-1.379 c 0.129,-0.067 0.187,-0.106 0.242,-0.156 0.156,-0.145 0.246,-0.371 0.246,-0.614 0,-0.586 -0.508,-1.015 -1.199,-1.015 -0.699,0 -1.203,0.429 -1.203,1.019 0,0.36 0.144,0.586 0.484,0.766 -0.433,0.238 -0.613,0.519 -0.613,0.961 0,0.707 0.543,1.199 1.332,1.199 0.781,0 1.324,-0.492 1.324,-1.199 0,-0.442 -0.179,-0.723 -0.613,-0.961 z m -0.707,-1.188 c 0.328,0 0.555,0.2 0.555,0.493 0,0.285 -0.231,0.488 -0.555,0.488 -0.332,0 -0.559,-0.199 -0.559,-0.496 0,-0.285 0.227,-0.485 0.559,-0.485 z m -0.012,1.485 c 0.367,0 0.594,0.242 0.594,0.633 0,0.359 -0.234,0.597 -0.594,0.597 -0.355,0 -0.586,-0.238 -0.586,-0.609 0,-0.379 0.231,-0.621 0.586,-0.621 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath244)"
+             id="path703" />
+          <path
+             d="m 389.234,502.52 c 0.286,0 0.301,0 0.43,0.039 0.25,0.066 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.567 -0.55,0.567 -0.352,0 -0.54,-0.204 -0.563,-0.59 h -0.719 c 0.008,0.75 0.492,1.222 1.262,1.222 0.801,0 1.312,-0.472 1.312,-1.199 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.215 0.492,-0.454 0.492,-0.797 0,-0.625 -0.464,-1.02 -1.191,-1.02 -0.543,0 -0.961,0.238 -1.121,0.645 -0.07,0.179 -0.09,0.3 -0.09,0.613 h 0.684 c 0.007,-0.203 0.023,-0.301 0.058,-0.399 0.071,-0.164 0.239,-0.261 0.453,-0.261 0.297,0 0.465,0.179 0.465,0.488 0,0.383 -0.215,0.566 -0.652,0.566 h -0.063 z m 3.172,-2.149 c -0.398,0 -0.742,0.168 -0.968,0.481 -0.219,0.289 -0.317,0.765 -0.317,1.496 0,0.664 0.082,1.129 0.262,1.414 0.222,0.359 0.586,0.554 1.023,0.554 0.41,0 0.742,-0.164 0.973,-0.476 0.211,-0.289 0.316,-0.77 0.316,-1.473 0,-0.687 -0.082,-1.152 -0.261,-1.441 -0.223,-0.36 -0.586,-0.555 -1.028,-0.555 z m 0,0.598 c 0.192,0 0.344,0.105 0.434,0.301 0.074,0.156 0.117,0.562 0.117,1.082 0,0.421 -0.035,0.832 -0.094,0.988 -0.086,0.219 -0.242,0.34 -0.457,0.34 -0.195,0 -0.34,-0.098 -0.429,-0.289 -0.075,-0.157 -0.118,-0.547 -0.118,-1.051 0,-0.442 0.036,-0.867 0.094,-1.02 0.078,-0.226 0.242,-0.351 0.453,-0.351 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath245)"
+             id="path704" />
+          <path
+             d="m 389.234,509.961 c 0.286,0 0.301,0 0.43,0.035 0.25,0.07 0.406,0.285 0.406,0.563 0,0.332 -0.23,0.562 -0.55,0.562 -0.352,0 -0.54,-0.199 -0.563,-0.586 h -0.719 c 0.008,0.75 0.492,1.219 1.262,1.219 0.801,0 1.312,-0.469 1.312,-1.195 0,-0.442 -0.191,-0.727 -0.613,-0.93 0.344,-0.219 0.492,-0.457 0.492,-0.797 0,-0.625 -0.464,-1.02 -1.191,-1.02 -0.543,0 -0.961,0.239 -1.121,0.645 -0.07,0.18 -0.09,0.301 -0.09,0.609 h 0.684 c 0.007,-0.199 0.023,-0.3 0.058,-0.394 0.071,-0.164 0.239,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.567 -0.652,0.567 h -0.063 z m 4.438,1.012 h -1.59 c 0.098,-0.2 0.215,-0.309 0.766,-0.707 0.648,-0.473 0.84,-0.754 0.84,-1.266 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.458 -1.23,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.16 -0.632,0.433 -0.828,0.762 -0.859,1.457 h 2.547 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath246)"
+             id="path705" />
+          <path
+             d="m 389.234,517.402 c 0.286,0 0.301,0 0.43,0.036 0.25,0.07 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.566 -0.55,0.566 -0.352,0 -0.54,-0.199 -0.563,-0.585 h -0.719 c 0.008,0.75 0.492,1.218 1.262,1.218 0.801,0 1.312,-0.468 1.312,-1.199 0,-0.437 -0.191,-0.723 -0.613,-0.93 0.344,-0.214 0.492,-0.453 0.492,-0.796 0,-0.622 -0.464,-1.02 -1.191,-1.02 -0.543,0 -0.961,0.238 -1.121,0.645 -0.07,0.179 -0.09,0.3 -0.09,0.613 h 0.684 c 0.007,-0.199 0.023,-0.301 0.058,-0.395 0.071,-0.164 0.239,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.215,0.566 -0.652,0.566 h -0.063 z m 4.489,0.231 h -0.391 v -2.301 h -0.871 l -1.367,2.289 v 0.625 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.602 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath247)"
+             id="path706" />
+          <path
+             d="m 257.777,345.785 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.903 -0.535,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.617 z m 0,-0.539 v -1.691 h 1.278 c 0.59,0 0.937,0.316 0.937,0.847 0,0.528 -0.347,0.844 -0.937,0.844 z m 7.594,-0.738 c -0.191,-1.059 -0.801,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.203 -1.524,0.597 -0.437,0.477 -0.676,1.164 -0.676,1.942 0,0.793 0.246,1.472 0.696,1.941 0.375,0.383 0.851,0.559 1.476,0.559 1.176,0 1.836,-0.633 1.981,-1.907 h -0.633 c -0.051,0.332 -0.117,0.555 -0.219,0.746 -0.195,0.395 -0.605,0.622 -1.121,0.622 -0.957,0 -1.562,-0.766 -1.562,-1.969 0,-1.235 0.574,-1.992 1.511,-1.992 0.387,0 0.75,0.113 0.95,0.304 0.175,0.164 0.277,0.364 0.347,0.727 z m 2.891,0.804 c 0.488,-0.296 0.64,-0.535 0.64,-0.984 0,-0.754 -0.574,-1.273 -1.406,-1.273 -0.824,0 -1.406,0.519 -1.406,1.265 0,0.457 0.152,0.688 0.633,0.992 -0.532,0.27 -0.797,0.661 -0.797,1.188 0,0.871 0.64,1.477 1.57,1.477 0.926,0 1.57,-0.606 1.57,-1.477 0,-0.527 -0.261,-0.918 -0.804,-1.188 z m -0.766,-1.742 c 0.496,0 0.813,0.297 0.813,0.77 0,0.449 -0.325,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.004 c 0.582,0 0.977,0.383 0.977,0.938 0,0.574 -0.387,0.953 -0.989,0.953 -0.57,0 -0.964,-0.391 -0.964,-0.945 0,-0.567 0.39,-0.946 0.976,-0.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath248)"
+             id="path707" />
+          <path
+             d="m 257.777,397.871 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.903 -0.535,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.617 z m 0,-0.543 v -1.691 h 1.278 c 0.59,0 0.937,0.32 0.937,0.847 0,0.528 -0.347,0.844 -0.937,0.844 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.539 h 2.613 v -0.539 h -3.23 v 4.812 h 0.617 z m 5.891,-2.489 h -2.414 l -0.352,2.547 h 0.535 c 0.274,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.016,0.43 1.016,1.125 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.145,0.566 0.286,0.738 0.265,0.355 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.614,-1.555 -1.512,-1.555 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.304 h 1.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath249)"
+             id="path708" />
+          <path
+             d="m 257.777,390.43 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.617 z m 0,-0.543 v -1.688 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.527 -0.347,0.844 -0.937,0.844 z m 4.434,0.39 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.23 v 4.813 h 0.617 z m 4.211,-0.007 h 0.316 c 0.633,0 0.969,0.296 0.969,0.871 0,0.601 -0.363,0.964 -0.965,0.964 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.633 0.207,0.844 0.242,0.461 0.699,0.695 1.34,0.695 0.961,0 1.582,-0.582 1.582,-1.488 0,-0.606 -0.231,-0.934 -0.793,-1.133 0.437,-0.18 0.656,-0.508 0.656,-0.992 0,-0.817 -0.535,-1.313 -1.426,-1.313 -0.945,0 -1.445,0.528 -1.465,1.539 h 0.579 c 0.007,-0.293 0.035,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.828,0.313 0.828,0.824 0,0.34 -0.121,0.543 -0.379,0.657 -0.156,0.066 -0.367,0.089 -0.769,0.097 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath250)"
+             id="path709" />
+          <path
+             d="m 257.777,382.988 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.262 0.414,-0.575 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.617 z m 0,-0.543 v -1.687 h 1.278 c 0.59,0 0.937,0.316 0.937,0.844 0,0.527 -0.347,0.843 -0.937,0.843 z m 3.813,2.582 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.817,-0.035 h -2.461 c 0.058,-0.394 0.269,-0.648 0.843,-0.996 l 0.66,-0.371 c 0.657,-0.363 0.993,-0.852 0.993,-1.438 0,-0.394 -0.16,-0.765 -0.438,-1.023 -0.277,-0.25 -0.617,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.215 -1.293,0.621 -0.164,0.25 -0.239,0.551 -0.25,1.031 h 0.582 c 0.019,-0.324 0.058,-0.515 0.136,-0.672 0.153,-0.293 0.458,-0.468 0.805,-0.468 0.527,0 0.926,0.382 0.926,0.894 0,0.383 -0.219,0.715 -0.633,0.953 l -0.609,0.356 c -0.977,0.562 -1.262,1.008 -1.313,2.051 h 3.114 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath251)"
+             id="path710" />
+          <path
+             d="m 257.777,375.547 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.015 0,-0.903 -0.535,-1.411 -1.485,-1.411 h -1.988 v 4.809 h 0.617 z m 0,-0.539 v -1.692 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.531 -0.347,0.848 -0.937,0.848 z m 7.594,-0.742 c -0.191,-1.055 -0.801,-1.571 -1.855,-1.571 -0.645,0 -1.168,0.207 -1.524,0.602 -0.437,0.476 -0.676,1.16 -0.676,1.941 0,0.793 0.246,1.473 0.696,1.942 0.375,0.382 0.851,0.558 1.476,0.558 1.176,0 1.836,-0.633 1.981,-1.906 h -0.633 c -0.051,0.328 -0.117,0.555 -0.219,0.746 -0.195,0.395 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.765 -1.562,-1.969 0,-1.234 0.574,-1.992 1.511,-1.992 0.387,0 0.75,0.114 0.95,0.305 0.175,0.164 0.277,0.359 0.347,0.723 z m 2.02,-0.078 v 3.398 h 0.582 v -4.77 h -0.383 c -0.207,0.731 -0.336,0.832 -1.235,0.95 v 0.422 z m 5.23,2.824 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.368 c 0.652,-0.363 0.992,-0.851 0.992,-1.441 0,-0.395 -0.16,-0.766 -0.437,-1.023 -0.278,-0.25 -0.621,-0.368 -1.063,-0.368 -0.594,0 -1.035,0.211 -1.293,0.622 -0.164,0.25 -0.238,0.546 -0.25,1.027 h 0.578 c 0.02,-0.324 0.063,-0.516 0.141,-0.672 0.152,-0.293 0.453,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.382 -0.218,0.711 -0.636,0.949 l -0.606,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.055 h 3.113 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath252)"
+             id="path711" />
+          <path
+             d="m 257.777,368.105 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.339 0.289,-0.266 0.414,-0.575 0.414,-1.02 0,-0.902 -0.535,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.617 z m 0,-0.539 v -1.691 h 1.278 c 0.59,0 0.937,0.316 0.937,0.848 0,0.527 -0.347,0.843 -0.937,0.843 z m 7.594,-0.738 c -0.191,-1.058 -0.801,-1.574 -1.855,-1.574 -0.645,0 -1.168,0.207 -1.524,0.601 -0.437,0.477 -0.676,1.165 -0.676,1.942 0,0.793 0.246,1.473 0.696,1.941 0.375,0.383 0.851,0.559 1.476,0.559 1.176,0 1.836,-0.633 1.981,-1.906 h -0.633 c -0.051,0.332 -0.117,0.554 -0.219,0.746 -0.195,0.394 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.766 -1.562,-1.969 0,-1.234 0.574,-1.992 1.511,-1.992 0.387,0 0.75,0.113 0.95,0.305 0.175,0.164 0.277,0.363 0.347,0.726 z m 2.02,-0.082 v 3.402 h 0.582 v -4.773 h -0.383 c -0.207,0.73 -0.336,0.832 -1.235,0.949 v 0.422 z m 3.601,0 v 3.402 h 0.582 v -4.773 h -0.383 c -0.207,0.73 -0.339,0.832 -1.234,0.949 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath253)"
+             id="path712" />
+          <path
+             d="m 257.777,360.668 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.617 z m 0,-0.543 v -1.687 h 1.278 c 0.59,0 0.937,0.316 0.937,0.843 0,0.528 -0.347,0.844 -0.937,0.844 z m 7.594,-0.738 c -0.191,-1.055 -0.801,-1.571 -1.855,-1.571 -0.645,0 -1.168,0.204 -1.524,0.598 -0.437,0.477 -0.676,1.164 -0.676,1.941 0,0.793 0.246,1.473 0.696,1.942 0.375,0.383 0.851,0.562 1.476,0.562 1.176,0 1.836,-0.636 1.981,-1.91 h -0.633 c -0.051,0.332 -0.117,0.555 -0.219,0.746 -0.195,0.399 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.765 -1.562,-1.964 0,-1.235 0.574,-1.997 1.511,-1.997 0.387,0 0.75,0.114 0.95,0.305 0.175,0.164 0.277,0.363 0.347,0.727 z m 2.02,-0.078 v 3.398 h 0.582 v -4.773 h -0.383 c -0.207,0.734 -0.336,0.832 -1.235,0.949 v 0.426 z m 3.707,-1.375 c -0.438,0 -0.832,0.199 -1.078,0.523 -0.301,0.422 -0.454,1.055 -0.454,1.938 0,1.613 0.528,2.464 1.532,2.464 0.988,0 1.531,-0.851 1.531,-2.421 0,-0.926 -0.145,-1.547 -0.457,-1.981 -0.242,-0.332 -0.633,-0.523 -1.074,-0.523 z m 0,0.515 c 0.625,0 0.937,0.641 0.937,1.934 0,1.359 -0.305,1.992 -0.953,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.309,-1.953 0.938,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath254)"
+             id="path713" />
+          <path
+             d="m 257.777,353.227 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.617 z m 0,-0.543 v -1.688 h 1.278 c 0.59,0 0.937,0.316 0.937,0.844 0,0.527 -0.347,0.844 -0.937,0.844 z m 7.594,-0.739 c -0.191,-1.054 -0.801,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.203 -1.524,0.602 -0.437,0.472 -0.676,1.16 -0.676,1.937 0,0.793 0.246,1.473 0.696,1.941 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.633 1.981,-1.906 h -0.633 c -0.051,0.328 -0.117,0.55 -0.219,0.742 -0.195,0.398 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.766 -1.562,-1.965 0,-1.234 0.574,-1.996 1.511,-1.996 0.387,0 0.75,0.113 0.95,0.305 0.175,0.164 0.277,0.363 0.347,0.726 z m 0.66,2.231 c 0.114,0.781 0.614,1.242 1.328,1.242 0.52,0 0.981,-0.25 1.258,-0.68 0.293,-0.468 0.426,-1.05 0.426,-1.914 0,-0.804 -0.121,-1.312 -0.398,-1.738 -0.258,-0.387 -0.668,-0.594 -1.18,-0.594 -0.891,0 -1.531,0.668 -1.531,1.594 0,0.875 0.593,1.496 1.437,1.496 0.441,0 0.774,-0.156 1.07,-0.52 -0.007,1.188 -0.379,1.84 -1.043,1.84 -0.41,0 -0.695,-0.265 -0.785,-0.726 z M 267.457,351 c 0.543,0 0.949,0.457 0.949,1.07 0,0.59 -0.394,0.996 -0.968,0.996 -0.563,0 -0.911,-0.394 -0.911,-1.027 0,-0.601 0.387,-1.039 0.93,-1.039 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath255)"
+             id="path714" />
+          <path
+             d="m 261.121,449.57 h -2.008 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.477 -1.512,1.477 -0.488,0 -0.929,-0.176 -1.211,-0.489 -0.32,-0.339 -0.511,-0.914 -0.511,-1.511 0,-1.18 0.676,-1.957 1.691,-1.957 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.91,-1.539 -2.012,-1.539 -0.59,0 -1.063,0.152 -1.441,0.461 -0.559,0.465 -0.872,1.211 -0.872,2.074 0,1.476 0.907,2.508 2.208,2.508 0.652,0 1.167,-0.246 1.64,-0.766 l 0.152,0.641 h 0.391 z m 4.742,-2.273 h -0.578 v 3.933 l -2.515,-3.933 h -0.668 v 4.812 h 0.582 v -3.898 l 2.488,3.898 h 0.691 z m 1.004,4.812 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath256)"
+             id="path715" />
+          <path
+             d="m 257.656,442.629 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.015 0,-0.903 -0.532,-1.411 -1.485,-1.411 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.531 -0.352,0.848 -0.937,0.848 z m 3.813,2.578 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.868 0,1.222 -0.5,1.863 -1.449,1.863 z m 4.938,-1.656 h 0.316 c 0.633,0 0.973,0.297 0.973,0.871 0,0.597 -0.364,0.961 -0.965,0.961 -0.641,0 -0.949,-0.321 -0.989,-1.024 h -0.582 c 0.028,0.383 0.09,0.637 0.204,0.848 0.246,0.461 0.699,0.691 1.339,0.691 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.137 0.434,-0.176 0.653,-0.508 0.653,-0.988 0,-0.82 -0.535,-1.313 -1.426,-1.313 -0.941,0 -1.445,0.528 -1.465,1.536 h 0.582 c 0.008,-0.289 0.031,-0.454 0.106,-0.598 0.132,-0.274 0.421,-0.43 0.785,-0.43 0.515,0 0.824,0.309 0.824,0.824 0,0.336 -0.117,0.543 -0.375,0.653 -0.16,0.066 -0.371,0.094 -0.773,0.101 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath257)"
+             id="path716" />
+          <path
+             d="m 257.656,435.07 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.266 0.414,-0.575 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.844 0,0.527 -0.352,0.843 -0.937,0.843 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.637 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 5.637,-0.613 v 1.156 h 0.582 v -1.156 h 0.691 v -0.519 h -0.691 v -3.098 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath258)"
+             id="path717" />
+          <path
+             d="m 257.656,427.629 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.415 -1.485,-1.415 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.528 -0.352,0.844 -0.937,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.727 h 1.137 c 0.949,0 1.449,0.641 1.449,1.868 0,1.222 -0.5,1.859 -1.449,1.859 z m 6.621,-4.137 h -2.414 l -0.351,2.547 h 0.535 c 0.269,-0.324 0.496,-0.433 0.863,-0.433 0.629,0 1.016,0.429 1.016,1.121 0,0.672 -0.387,1.082 -1.02,1.082 -0.512,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.382 0.145,0.566 0.285,0.738 0.262,0.359 0.738,0.562 1.266,0.562 0.945,0 1.605,-0.687 1.605,-1.675 0,-0.926 -0.617,-1.559 -1.511,-1.559 -0.333,0 -0.594,0.086 -0.868,0.285 l 0.188,-1.309 h 1.945 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath259)"
+             id="path718" />
+          <path
+             d="m 257.656,420.188 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.54 v -1.691 h 1.282 c 0.585,0 0.937,0.316 0.937,0.844 0,0.527 -0.352,0.847 -0.937,0.847 z m 3.813,2.579 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.407 0,-1.492 -0.742,-2.406 -1.961,-2.406 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z m 6.766,-2.993 c -0.114,-0.777 -0.614,-1.238 -1.325,-1.238 -0.515,0 -0.976,0.25 -1.253,0.68 -0.297,0.468 -0.426,1.047 -0.426,1.914 0,0.804 0.113,1.312 0.398,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.891,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.597,-1.496 -1.433,-1.496 -0.461,0 -0.825,0.172 -1.078,0.52 0.007,-1.18 0.378,-1.836 1.042,-1.836 0.411,0 0.696,0.265 0.79,0.726 z m -1.407,1.102 c 0.563,0 0.911,0.398 0.911,1.031 0,0.602 -0.395,1.035 -0.93,1.035 -0.539,0 -0.949,-0.453 -0.949,-1.062 0,-0.594 0.394,-1.004 0.968,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath260)"
+             id="path719" />
+          <path
+             d="m 257.656,412.746 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.903 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.282 c 0.585,0 0.937,0.316 0.937,0.847 0,0.528 -0.352,0.844 -0.937,0.844 z m 3.813,2.578 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.222 -0.5,1.863 -1.449,1.863 z m 6.91,-4.137 h -3.129 v 0.575 h 2.532 c -1.118,1.589 -1.575,2.566 -1.922,4.101 h 0.621 c 0.258,-1.496 0.844,-2.785 1.898,-4.187 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath261)"
+             id="path720" />
+          <path
+             d="m 257.656,517.391 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.848 0,0.527 -0.352,0.844 -0.937,0.844 z m 7.906,0.039 h -2.007 v 0.539 h 1.465 v 0.132 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.93,-0.18 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.184 0.672,-1.961 1.692,-1.961 0.73,0 1.257,0.375 1.39,0.996 h 0.629 c -0.172,-0.976 -0.91,-1.539 -2.016,-1.539 -0.585,0 -1.062,0.152 -1.437,0.465 -0.563,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.902,2.508 2.203,2.508 0.656,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.39 z m 2.067,-0.86 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath262)"
+             id="path721" />
+          <path
+             d="m 257.656,509.953 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.691 h 1.282 c 0.585,0 0.937,0.32 0.937,0.847 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.539 h 2.613 v -0.539 h -3.226 v 4.812 h 0.613 z m 3.101,1.101 c 0.114,0.778 0.614,1.243 1.329,1.243 0.519,0 0.98,-0.254 1.257,-0.68 0.293,-0.469 0.422,-1.051 0.422,-1.914 0,-0.809 -0.117,-1.317 -0.394,-1.739 -0.258,-0.39 -0.668,-0.593 -1.18,-0.593 -0.891,0 -1.531,0.668 -1.531,1.59 0,0.879 0.594,1.5 1.437,1.5 0.442,0 0.774,-0.161 1.071,-0.524 -0.008,1.188 -0.379,1.844 -1.043,1.844 -0.411,0 -0.696,-0.266 -0.786,-0.727 z m 1.426,-3.175 c 0.539,0 0.949,0.457 0.949,1.07 0,0.586 -0.394,0.996 -0.968,0.996 -0.563,0 -0.91,-0.395 -0.91,-1.031 0,-0.598 0.386,-1.035 0.929,-1.035 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath263)"
+             id="path722" />
+          <path
+             d="m 257.656,502.512 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.527 -0.352,0.844 -0.937,0.844 z m 4.434,0.39 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.226 v 4.813 h 0.613 z m 6.183,-2.488 h -3.128 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.567 -1.918,4.106 h 0.617 c 0.258,-1.5 0.848,-2.785 1.902,-4.192 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath264)"
+             id="path723" />
+          <path
+             d="m 257.656,495.07 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.262 0.414,-0.575 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.844 0,0.527 -0.352,0.843 -0.937,0.843 z m 4.434,0.391 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.543 h -3.226 v 4.812 h 0.613 z m 5.332,-0.324 c 0.488,-0.297 0.64,-0.532 0.64,-0.981 0,-0.754 -0.574,-1.273 -1.406,-1.273 -0.824,0 -1.406,0.519 -1.406,1.265 0,0.457 0.152,0.688 0.633,0.989 -0.531,0.273 -0.797,0.66 -0.797,1.191 0,0.871 0.641,1.477 1.57,1.477 0.926,0 1.571,-0.606 1.571,-1.477 0,-0.531 -0.262,-0.918 -0.805,-1.191 z m -0.766,-1.742 c 0.496,0 0.813,0.296 0.813,0.773 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.465 0.316,-0.761 0.812,-0.761 z m 0,2.007 c 0.582,0 0.977,0.383 0.977,0.938 0,0.574 -0.391,0.949 -0.988,0.949 -0.571,0 -0.965,-0.387 -0.965,-0.941 0,-0.571 0.39,-0.946 0.976,-0.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath265)"
+             id="path724" />
+          <path
+             d="m 257.656,487.629 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.015 0,-0.903 -0.532,-1.411 -1.485,-1.411 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.531 -0.352,0.848 -0.937,0.848 z m 4.434,0.387 h 2.621 v -0.539 h -2.621 v -1.54 h 2.719 v -0.539 h -3.332 v 4.809 h 3.449 v -0.539 h -2.836 z m 4.57,-0.004 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.597 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.321 -0.992,-1.024 h -0.578 c 0.024,0.383 0.09,0.637 0.203,0.848 0.246,0.461 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.606 -0.234,-0.938 -0.793,-1.137 0.434,-0.176 0.652,-0.508 0.652,-0.988 0,-0.82 -0.535,-1.313 -1.425,-1.313 -0.942,0 -1.446,0.528 -1.465,1.536 h 0.582 c 0.008,-0.289 0.031,-0.454 0.105,-0.598 0.133,-0.274 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.309 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.653 -0.161,0.066 -0.372,0.094 -0.774,0.101 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath266)"
+             id="path725" />
+          <path
+             d="m 257.656,480.188 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.289,-0.266 0.414,-0.575 0.414,-1.02 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.812 h 0.613 z m 0,-0.54 v -1.691 h 1.282 c 0.585,0 0.937,0.316 0.937,0.848 0,0.527 -0.352,0.843 -0.937,0.843 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.812 h 3.449 v -0.542 h -2.836 z m 6.398,-1.34 c -0.113,-0.781 -0.613,-1.242 -1.328,-1.242 -0.512,0 -0.976,0.25 -1.254,0.68 -0.297,0.468 -0.422,1.051 -0.422,1.914 0,0.804 0.114,1.312 0.399,1.734 0.25,0.391 0.66,0.594 1.172,0.594 0.894,0 1.531,-0.664 1.531,-1.594 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.461,0 -0.824,0.172 -1.078,0.52 0.008,-1.18 0.379,-1.832 1.043,-1.832 0.41,0 0.695,0.261 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.394 0.91,1.027 0,0.602 -0.394,1.039 -0.93,1.039 -0.539,0 -0.949,-0.457 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath267)"
+             id="path726" />
+          <path
+             d="m 257.656,465.309 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.527 -0.352,0.848 -0.937,0.848 z m 4.434,0.386 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.332 v 4.813 h 3.449 v -0.539 h -2.836 z m 5.269,1.039 v 1.153 h 0.582 v -1.153 h 0.692 v -0.523 h -0.692 v -3.094 h -0.429 l -2.125,3 v 0.617 z m 0,-0.523 h -1.464 l 1.464,-2.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath268)"
+             id="path727" />
+          <path
+             d="m 257.656,457.867 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.903 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.282 c 0.585,0 0.937,0.316 0.937,0.847 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.387 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.808 h 3.449 v -0.539 h -2.836 z m 6.453,1.617 h -2.465 c 0.063,-0.394 0.274,-0.644 0.848,-0.996 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.367 -1.063,-0.367 -0.598,0 -1.039,0.211 -1.297,0.621 -0.164,0.25 -0.234,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.672 0.152,-0.289 0.457,-0.468 0.805,-0.468 0.531,0 0.925,0.382 0.925,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.258,1.011 -1.312,2.054 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath269)"
+             id="path728" />
+          <path
+             d="m 257.656,472.75 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.843 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.332 v 4.812 h 3.449 v -0.543 h -2.836 z m 6.254,-2.489 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.324 0.496,-0.433 0.864,-0.433 0.628,0 1.015,0.425 1.015,1.121 0,0.672 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.578 c 0.078,0.382 0.144,0.566 0.281,0.738 0.265,0.355 0.742,0.562 1.269,0.562 0.942,0 1.602,-0.687 1.602,-1.675 0,-0.926 -0.613,-1.559 -1.508,-1.559 -0.332,0 -0.598,0.086 -0.867,0.281 l 0.184,-1.304 h 1.949 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath270)"
+             id="path729" />
+          <path
+             d="m 359.395,519.43 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.489 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 4.945,-1.661 h 0.317 c 0.632,0 0.968,0.297 0.968,0.875 0,0.598 -0.363,0.961 -0.961,0.961 -0.64,0 -0.953,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.637 0.203,0.848 0.242,0.461 0.699,0.691 1.34,0.691 0.965,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.23,-0.938 -0.789,-1.137 0.434,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.317 -1.425,-1.317 -0.946,0 -1.446,0.532 -1.465,1.539 h 0.582 c 0.004,-0.289 0.031,-0.453 0.105,-0.601 0.129,-0.27 0.422,-0.426 0.785,-0.426 0.512,0 0.825,0.309 0.825,0.824 0,0.336 -0.122,0.539 -0.375,0.653 -0.161,0.066 -0.372,0.093 -0.774,0.097 z m 4.293,1.043 v 1.157 h 0.578 v -1.157 h 0.696 v -0.519 h -0.696 v -3.098 h -0.426 l -2.128,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath271)"
+             id="path730" />
+          <path
+             d="m 359.395,511.988 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 5.058,-1.656 h 0.317 c 0.633,0 0.969,0.297 0.969,0.871 0,0.598 -0.364,0.961 -0.965,0.961 -0.637,0 -0.949,-0.32 -0.989,-1.02 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.844 0.243,0.461 0.7,0.692 1.34,0.692 0.961,0 1.582,-0.579 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.793,-1.136 0.438,-0.176 0.657,-0.508 0.657,-0.989 0,-0.82 -0.536,-1.312 -1.426,-1.312 -0.945,0 -1.445,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.106,-0.598 0.132,-0.273 0.421,-0.429 0.785,-0.429 0.515,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.77,0.102 z m 3.598,0 h 0.316 c 0.633,0 0.973,0.297 0.973,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.988,-1.02 h -0.582 c 0.027,0.383 0.09,0.633 0.203,0.844 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.579 1.586,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.136 0.434,-0.176 0.652,-0.508 0.652,-0.989 0,-0.82 -0.535,-1.312 -1.426,-1.312 -0.941,0 -1.445,0.527 -1.464,1.535 h 0.582 c 0.007,-0.289 0.031,-0.453 0.105,-0.598 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.824,0.308 0.824,0.824 0,0.336 -0.117,0.543 -0.374,0.652 -0.161,0.067 -0.372,0.094 -0.774,0.102 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath272)"
+             id="path731" />
+          <path
+             d="m 359.395,504.551 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.86 -1.453,1.86 z m 4.945,-1.656 h 0.317 c 0.632,0 0.968,0.296 0.968,0.871 0,0.601 -0.363,0.965 -0.961,0.965 -0.64,0 -0.953,-0.325 -0.992,-1.024 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.242,0.461 0.699,0.691 1.34,0.691 0.965,0 1.582,-0.578 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.789,-1.133 0.434,-0.18 0.652,-0.508 0.652,-0.992 0,-0.817 -0.535,-1.313 -1.425,-1.313 -0.946,0 -1.446,0.528 -1.465,1.539 h 0.582 c 0.004,-0.293 0.031,-0.457 0.105,-0.601 0.129,-0.27 0.422,-0.43 0.785,-0.43 0.512,0 0.825,0.309 0.825,0.824 0,0.336 -0.122,0.543 -0.375,0.657 -0.161,0.062 -0.372,0.089 -0.774,0.097 z m 5.473,1.625 h -2.461 c 0.058,-0.399 0.269,-0.649 0.844,-1 l 0.66,-0.368 c 0.652,-0.363 0.992,-0.851 0.992,-1.441 0,-0.395 -0.16,-0.766 -0.438,-1.02 -0.277,-0.253 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.028 h 0.578 c 0.02,-0.321 0.063,-0.512 0.141,-0.672 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.926,0.383 0.926,0.899 0,0.382 -0.219,0.711 -0.637,0.949 l -0.605,0.355 c -0.977,0.563 -1.262,1.012 -1.313,2.055 h 3.114 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath273)"
+             id="path732" />
+          <path
+             d="m 360.844,494.566 h -2.004 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.18 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.379 1.394,0.996 h 0.629 c -0.172,-0.977 -0.914,-1.535 -2.015,-1.535 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.476 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 h -0.582 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.488,3.902 h 0.692 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.637 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath274)"
+             id="path733" />
+          <path
+             d="m 359.395,489.668 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.859 -1.453,1.859 z m 4.945,-1.656 h 0.317 c 0.632,0 0.968,0.297 0.968,0.871 0,0.601 -0.363,0.965 -0.961,0.965 -0.64,0 -0.953,-0.325 -0.992,-1.024 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.242,0.465 0.699,0.695 1.34,0.695 0.965,0 1.582,-0.582 1.582,-1.484 0,-0.609 -0.23,-0.938 -0.789,-1.137 0.434,-0.179 0.652,-0.508 0.652,-0.988 0,-0.82 -0.535,-1.316 -1.425,-1.316 -0.946,0 -1.446,0.531 -1.465,1.539 h 0.582 c 0.004,-0.289 0.031,-0.454 0.105,-0.602 0.129,-0.27 0.422,-0.426 0.785,-0.426 0.512,0 0.825,0.309 0.825,0.824 0,0.336 -0.122,0.54 -0.375,0.653 -0.161,0.066 -0.372,0.094 -0.774,0.097 z m 3.844,-1.199 v 3.398 h 0.578 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.23,0.953 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath275)"
+             id="path734" />
+          <path
+             d="m 359.395,482.227 h 1.851 c 1.215,0 1.961,-0.911 1.961,-2.407 0,-1.492 -0.738,-2.406 -1.961,-2.406 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 5.058,-1.657 h 0.317 c 0.633,0 0.969,0.297 0.969,0.871 0,0.598 -0.364,0.961 -0.965,0.961 -0.637,0 -0.949,-0.32 -0.989,-1.023 h -0.582 c 0.028,0.383 0.094,0.637 0.207,0.848 0.243,0.46 0.7,0.691 1.34,0.691 0.961,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.23,-0.938 -0.793,-1.137 0.438,-0.176 0.657,-0.508 0.657,-0.988 0,-0.821 -0.536,-1.313 -1.426,-1.313 -0.945,0 -1.445,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.106,-0.597 0.132,-0.274 0.421,-0.43 0.785,-0.43 0.515,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.539 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.77,0.102 z m 3.954,-2.574 c -0.434,0 -0.829,0.195 -1.075,0.52 -0.304,0.421 -0.457,1.054 -0.457,1.941 0,1.609 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.543 -0.453,-1.98 -0.246,-0.329 -0.633,-0.52 -1.078,-0.52 z m 0,0.512 c 0.628,0 0.937,0.64 0.937,1.933 0,1.364 -0.301,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.972 0,-1.317 0.313,-1.957 0.938,-1.957 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath276)"
+             id="path735" />
+          <path
+             d="m 359.395,474.785 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.937,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.367 c 0.653,-0.364 0.992,-0.852 0.992,-1.442 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.277,-0.25 -0.621,-0.367 -1.063,-0.367 -0.593,0 -1.035,0.211 -1.292,0.621 -0.165,0.25 -0.239,0.547 -0.25,1.027 h 0.578 c 0.019,-0.324 0.062,-0.516 0.14,-0.672 0.153,-0.289 0.453,-0.469 0.805,-0.469 0.527,0 0.926,0.383 0.926,0.899 0,0.383 -0.219,0.711 -0.637,0.949 l -0.605,0.356 c -0.977,0.562 -1.262,1.011 -1.313,2.054 h 3.113 z m 0.61,-0.512 c 0.113,0.778 0.613,1.239 1.328,1.239 0.519,0 0.984,-0.25 1.262,-0.68 0.289,-0.469 0.421,-1.047 0.421,-1.914 0,-0.805 -0.121,-1.313 -0.398,-1.735 -0.254,-0.39 -0.664,-0.593 -1.18,-0.593 -0.89,0 -1.531,0.668 -1.531,1.589 0,0.879 0.594,1.5 1.438,1.5 0.445,0 0.773,-0.16 1.07,-0.523 -0.008,1.188 -0.375,1.844 -1.043,1.844 -0.41,0 -0.692,-0.266 -0.785,-0.727 z m 1.425,-3.176 c 0.543,0 0.954,0.457 0.954,1.071 0,0.586 -0.399,0.996 -0.973,0.996 -0.559,0 -0.91,-0.399 -0.91,-1.031 0,-0.602 0.39,-1.036 0.929,-1.036 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath277)"
+             id="path736" />
+          <path
+             d="m 359.395,467.348 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.86 -1.453,1.86 z m 6.824,-0.032 h -2.461 c 0.059,-0.398 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.399 -0.16,-0.766 -0.437,-1.024 -0.278,-0.254 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.028 h 0.582 c 0.02,-0.321 0.059,-0.512 0.137,-0.672 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.898 0,0.383 -0.218,0.711 -0.632,0.95 l -0.61,0.359 c -0.976,0.559 -1.261,1.008 -1.312,2.051 h 3.113 z m 2.836,-1.941 c 0.488,-0.297 0.641,-0.535 0.641,-0.984 0,-0.75 -0.575,-1.274 -1.407,-1.274 -0.824,0 -1.406,0.524 -1.406,1.266 0,0.457 0.152,0.687 0.633,0.992 -0.535,0.27 -0.797,0.66 -0.797,1.188 0,0.871 0.641,1.48 1.57,1.48 0.922,0 1.571,-0.609 1.571,-1.48 0,-0.528 -0.266,-0.918 -0.805,-1.188 z m -0.766,-1.742 c 0.496,0 0.813,0.297 0.813,0.773 0,0.446 -0.324,0.742 -0.813,0.742 -0.496,0 -0.812,-0.296 -0.812,-0.757 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.008 c 0.582,0 0.977,0.382 0.977,0.933 0,0.574 -0.391,0.953 -0.992,0.953 -0.567,0 -0.961,-0.39 -0.961,-0.945 0,-0.566 0.386,-0.941 0.976,-0.941 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath278)"
+             id="path737" />
+          <path
+             d="m 360.844,457.363 h -2.004 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.176 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.18 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.379 1.394,1 h 0.629 c -0.172,-0.977 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.476 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.247 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 h -0.582 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.488,3.902 h 0.692 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath279)"
+             id="path738" />
+          <path
+             d="m 359.395,388.742 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.852 0.992,-1.438 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.367 -1.063,-0.367 -0.594,0 -1.035,0.211 -1.293,0.617 -0.164,0.254 -0.238,0.551 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.672 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.895 0,0.383 -0.218,0.715 -0.632,0.953 l -0.61,0.356 c -0.976,0.562 -1.261,1.011 -1.312,2.05 h 3.113 z m 3.395,-4.106 h -2.415 l -0.351,2.547 h 0.535 c 0.274,-0.32 0.496,-0.433 0.867,-0.433 0.625,0 1.016,0.429 1.016,1.121 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.145,0.566 0.286,0.738 0.265,0.359 0.738,0.563 1.265,0.563 0.945,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.614,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.308 h 1.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath280)"
+             id="path739" />
+          <path
+             d="m 359.395,381.301 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 6.824,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.997 l 0.66,-0.367 c 0.656,-0.363 0.992,-0.851 0.992,-1.441 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.278,-0.25 -0.618,-0.367 -1.063,-0.367 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.028 h 0.582 c 0.02,-0.325 0.059,-0.516 0.137,-0.672 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.382 -0.218,0.71 -0.632,0.949 l -0.61,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.055 h 3.113 z m 2.414,-0.579 v 1.153 h 0.578 v -1.153 h 0.696 v -0.523 h -0.696 v -3.094 h -0.426 l -2.128,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath281)"
+             id="path740" />
+          <path
+             d="m 359.395,373.863 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.871 0,1.219 -0.5,1.859 -1.453,1.859 z m 6.824,-0.031 h -2.461 c 0.059,-0.398 0.27,-0.648 0.844,-1 l 0.66,-0.367 c 0.656,-0.363 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.278,-0.254 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.32 0.059,-0.511 0.137,-0.672 0.152,-0.289 0.457,-0.468 0.805,-0.468 0.527,0 0.925,0.382 0.925,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.261,1.011 -1.312,2.054 h 3.113 z m 1.715,-1.625 h 0.316 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.382 0.094,0.632 0.207,0.843 0.242,0.461 0.699,0.692 1.34,0.692 0.961,0 1.582,-0.578 1.582,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.132 0.437,-0.18 0.656,-0.508 0.656,-0.993 0,-0.816 -0.535,-1.312 -1.426,-1.312 -0.945,0 -1.445,0.527 -1.465,1.539 h 0.579 c 0.007,-0.293 0.035,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.828,0.312 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.656 -0.156,0.063 -0.367,0.09 -0.769,0.098 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath282)"
+             id="path741" />
+          <path
+             d="m 359.395,366.422 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.218 -0.5,1.859 -1.453,1.859 z m 6.824,-0.031 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-0.996 l 0.66,-0.372 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.398 -0.16,-0.766 -0.437,-1.023 -0.278,-0.25 -0.618,-0.372 -1.063,-0.372 -0.594,0 -1.035,0.211 -1.293,0.622 -0.164,0.25 -0.238,0.546 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.383 -0.218,0.715 -0.632,0.949 l -0.61,0.359 c -0.976,0.559 -1.261,1.008 -1.312,2.051 h 3.113 z m 3.594,0 h -2.461 c 0.058,-0.399 0.269,-0.649 0.844,-0.996 l 0.66,-0.372 c 0.652,-0.363 0.992,-0.851 0.992,-1.437 0,-0.398 -0.16,-0.766 -0.438,-1.023 -0.277,-0.25 -0.621,-0.372 -1.062,-0.372 -0.594,0 -1.035,0.211 -1.293,0.622 -0.164,0.25 -0.238,0.546 -0.25,1.031 h 0.578 c 0.02,-0.324 0.063,-0.516 0.141,-0.676 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.926,0.383 0.926,0.899 0,0.383 -0.219,0.715 -0.637,0.949 l -0.605,0.359 c -0.977,0.559 -1.262,1.008 -1.313,2.051 h 3.114 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath283)"
+             id="path742" />
+          <path
+             d="m 359.395,358.98 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.394 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.215 -1.293,0.621 -0.164,0.25 -0.238,0.551 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.671 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.894 0,0.383 -0.218,0.715 -0.632,0.953 l -0.61,0.356 c -0.976,0.562 -1.261,1.008 -1.312,2.051 h 3.113 z m 1.965,-2.824 v 3.398 h 0.578 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.23,0.953 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath284)"
+             id="path743" />
+          <path
+             d="m 359.395,351.539 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z M 360.008,351 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.367 c 0.656,-0.364 0.992,-0.852 0.992,-1.442 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.367 -1.063,-0.367 -0.594,0 -1.035,0.21 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.672 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.055 h 3.113 z m 2.07,-4.195 c -0.437,0 -0.832,0.195 -1.078,0.519 -0.301,0.422 -0.453,1.059 -0.453,1.941 0,1.61 0.527,2.461 1.531,2.461 0.989,0 1.532,-0.851 1.532,-2.421 0,-0.922 -0.145,-1.543 -0.457,-1.981 -0.243,-0.328 -0.633,-0.519 -1.075,-0.519 z m 0,0.511 c 0.625,0 0.938,0.641 0.938,1.938 0,1.359 -0.305,1.992 -0.953,1.992 -0.614,0 -0.922,-0.66 -0.922,-1.973 0,-1.316 0.308,-1.957 0.937,-1.957 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath285)"
+             id="path744" />
+          <path
+             d="m 359.395,344.102 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.411 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 5.195,-2.86 v 3.403 h 0.582 v -4.774 h -0.383 c -0.207,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z m 2.235,2.313 c 0.109,0.777 0.613,1.238 1.324,1.238 0.523,0 0.984,-0.25 1.261,-0.68 0.289,-0.468 0.422,-1.047 0.422,-1.914 0,-0.804 -0.117,-1.312 -0.394,-1.734 -0.258,-0.391 -0.668,-0.594 -1.184,-0.594 -0.89,0 -1.531,0.668 -1.531,1.59 0,0.879 0.594,1.5 1.441,1.5 0.442,0 0.77,-0.16 1.067,-0.523 -0.004,1.187 -0.375,1.843 -1.043,1.843 -0.406,0 -0.692,-0.265 -0.785,-0.726 z m 1.425,-3.176 c 0.539,0 0.949,0.457 0.949,1.07 0,0.586 -0.394,0.996 -0.968,0.996 -0.563,0 -0.914,-0.398 -0.914,-1.031 0,-0.598 0.39,-1.035 0.933,-1.035 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath286)"
+             id="path745" />
+          <path
+             d="m 359.395,336.539 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.859 -1.453,1.859 z m 5.195,-2.855 v 3.398 h 0.582 v -4.773 h -0.383 c -0.207,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 4.465,0.882 c 0.488,-0.296 0.641,-0.535 0.641,-0.984 0,-0.75 -0.575,-1.273 -1.407,-1.273 -0.824,0 -1.406,0.523 -1.406,1.269 0,0.453 0.152,0.688 0.633,0.988 -0.535,0.274 -0.797,0.661 -0.797,1.188 0,0.871 0.641,1.48 1.57,1.48 0.922,0 1.571,-0.609 1.571,-1.48 0,-0.527 -0.266,-0.914 -0.805,-1.188 z m -0.766,-1.742 c 0.496,0 0.813,0.297 0.813,0.774 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.762 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.008 c 0.582,0 0.977,0.383 0.977,0.938 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.961,-0.391 -0.961,-0.946 0,-0.566 0.386,-0.941 0.976,-0.941 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath287)"
+             id="path746" />
+          <path
+             d="m 359.395,329.098 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.407 0,-1.492 -0.738,-2.406 -1.961,-2.406 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 5.195,-2.86 v 3.399 h 0.582 v -4.77 h -0.383 c -0.207,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z m 5.317,-1.281 h -3.129 v 0.574 h 2.527 c -1.117,1.59 -1.57,2.57 -1.922,4.106 h 0.621 c 0.258,-1.496 0.844,-2.786 1.903,-4.192 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath288)"
+             id="path747" />
+          <path
+             d="m 359.395,321.656 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 5.195,-2.859 v 3.398 h 0.582 v -4.769 h -0.383 c -0.207,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 5.172,-0.129 c -0.113,-0.781 -0.617,-1.242 -1.328,-1.242 -0.516,0 -0.977,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.113,1.313 0.395,1.735 0.25,0.39 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.664 1.532,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.519 0.008,-1.179 0.375,-1.832 1.043,-1.832 0.41,0 0.691,0.262 0.785,0.727 z m -1.406,1.101 c 0.558,0 0.91,0.395 0.91,1.028 0,0.601 -0.395,1.039 -0.93,1.039 -0.543,0 -0.953,-0.457 -0.953,-1.063 0,-0.597 0.399,-1.004 0.973,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath289)"
+             id="path748" />
+          <path
+             d="m 359.395,452.105 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.859 -1.453,1.859 z m 6.824,-0.031 h -2.461 c 0.059,-0.398 0.27,-0.648 0.844,-1 l 0.66,-0.367 c 0.656,-0.363 0.992,-0.852 0.992,-1.441 0,-0.395 -0.16,-0.766 -0.437,-1.02 -0.278,-0.254 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.32 0.059,-0.511 0.137,-0.671 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.898 0,0.383 -0.218,0.711 -0.632,0.95 l -0.61,0.355 c -0.976,0.562 -1.261,1.012 -1.312,2.055 h 3.113 z m 3.688,-4.105 h -3.129 V 448 h 2.527 c -1.117,1.59 -1.57,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.903,-4.191 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath290)"
+             id="path749" />
+          <path
+             d="m 359.395,444.664 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.636 1.453,1.867 0,1.218 -0.5,1.859 -1.453,1.859 z m 6.824,-0.031 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.364 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.383 -0.218,0.715 -0.632,0.949 l -0.61,0.359 c -0.976,0.559 -1.261,1.008 -1.312,2.051 h 3.113 z m 3.543,-2.957 c -0.113,-0.781 -0.617,-1.242 -1.328,-1.242 -0.516,0 -0.977,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.113,1.313 0.395,1.739 0.25,0.386 0.66,0.593 1.175,0.593 0.891,0 1.532,-0.668 1.532,-1.597 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.523 0.008,-1.183 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.101 c 0.558,0 0.91,0.395 0.91,1.032 0,0.597 -0.395,1.035 -0.93,1.035 -0.543,0 -0.953,-0.457 -0.953,-1.063 0,-0.593 0.399,-1.004 0.973,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath291)"
+             id="path750" />
+          <path
+             d="m 365.895,435.656 0.496,1.446 h 0.683 l -1.687,-4.809 h -0.793 l -1.715,4.809 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 3.945,-0.551 c 0.488,-0.301 0.641,-0.535 0.641,-0.985 0,-0.753 -0.575,-1.273 -1.407,-1.273 -0.824,0 -1.406,0.52 -1.406,1.266 0,0.457 0.152,0.687 0.633,0.992 -0.535,0.269 -0.797,0.656 -0.797,1.187 0,0.871 0.641,1.477 1.57,1.477 0.922,0 1.571,-0.606 1.571,-1.477 0,-0.531 -0.266,-0.918 -0.805,-1.187 z m -0.766,-1.746 c 0.496,0 0.813,0.297 0.813,0.773 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.464 0.316,-0.761 0.812,-0.761 z m 0,2.008 c 0.582,0 0.977,0.382 0.977,0.937 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.961,-0.386 -0.961,-0.941 0,-0.57 0.386,-0.945 0.976,-0.945 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath292)"
+             id="path751" />
+          <path
+             d="m 365.895,428.215 0.496,1.449 h 0.683 l -1.687,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.449 z m -0.172,-0.512 h -1.532 l 0.793,-2.191 z m 4.797,-2.719 h -3.129 v 0.575 h 2.527 c -1.117,1.589 -1.57,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.789 1.903,-4.191 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath293)"
+             id="path752" />
+          <path
+             d="m 365.895,420.777 0.496,1.446 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 4.652,-1.571 c -0.113,-0.781 -0.617,-1.242 -1.328,-1.242 -0.516,0 -0.977,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.113,1.312 0.395,1.738 0.25,0.387 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.262 0.785,0.726 z m -1.406,1.102 c 0.558,0 0.91,0.395 0.91,1.031 0,0.598 -0.395,1.035 -0.93,1.035 -0.543,0 -0.953,-0.457 -0.953,-1.062 0,-0.594 0.399,-1.004 0.973,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath294)"
+             id="path753" />
+          <path
+             d="m 360.844,412.238 h -2.004 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.176 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.18 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.379 1.394,1 h 0.629 c -0.172,-0.977 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.46 -0.871,1.207 -0.871,2.074 0,1.476 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 h -0.582 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.488,3.902 h 0.692 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.223 -0.5,1.859 -1.449,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath295)"
+             id="path754" />
+          <path
+             d="m 354.973,405.895 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.789 l -1.719,4.813 h 0.656 l 0.508,-1.445 z m -0.168,-0.516 h -1.532 l 0.789,-2.191 z m 6.16,-0.578 h -2.008 v 0.539 h 1.465 v 0.133 c 0,0.859 -0.633,1.476 -1.512,1.476 -0.488,0 -0.93,-0.176 -1.215,-0.488 -0.316,-0.34 -0.507,-0.914 -0.507,-1.508 0,-1.183 0.675,-1.961 1.691,-1.961 0.73,0 1.262,0.375 1.391,0.996 h 0.628 c -0.171,-0.976 -0.91,-1.539 -2.011,-1.539 -0.59,0 -1.063,0.153 -1.442,0.461 -0.558,0.465 -0.871,1.211 -0.871,2.074 0,1.477 0.906,2.508 2.207,2.508 0.653,0 1.168,-0.242 1.641,-0.765 l 0.152,0.64 h 0.391 z m 4.625,-2.274 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.813 h 0.578 v -3.899 l 2.489,3.899 h 0.695 z m 1.125,4.813 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.489 -0.738,-2.403 -1.957,-2.403 h -1.855 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.863 -1.453,1.863 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath296)"
+             id="path755" />
+          <path
+             d="m 355.695,398.453 0.496,1.445 h 0.684 l -1.687,-4.808 h -0.793 l -1.715,4.808 h 0.652 l 0.508,-1.445 z m -0.172,-0.512 h -1.531 l 0.793,-2.191 z m 4.071,1.957 1.668,-4.808 h -0.653 l -1.336,4.07 -1.41,-4.07 h -0.66 l 1.731,4.808 z m 2.316,0 h 1.856 c 1.214,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 4.188,0.539 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath297)"
+             id="path756" />
+          <path
+             d="m 331.699,517.387 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.489,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.332 v 4.813 h 3.449 v -0.543 h -2.836 z m 4.926,-2.582 c -0.434,0 -0.829,0.2 -1.075,0.524 -0.304,0.422 -0.457,1.054 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.926 -0.145,-1.547 -0.453,-1.98 -0.246,-0.332 -0.633,-0.524 -1.078,-0.524 z m 0,0.516 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.309,-1.953 0.934,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath298)"
+             id="path757" />
+          <path
+             d="m 331.699,509.945 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.262 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.489,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.847 -0.938,0.847 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.933 -0.875,-1.168 0.442,-0.207 0.664,-0.554 0.664,-1.05 0,-0.356 -0.129,-0.661 -0.383,-0.883 -0.257,-0.235 -0.578,-0.34 -1.043,-0.34 h -1.953 z m 0.614,-2.738 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.703,0.172 0.172,0.133 0.262,0.328 0.262,0.593 0,0.266 -0.09,0.461 -0.262,0.594 -0.168,0.125 -0.359,0.172 -0.703,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.309 0.863,0.828 0,0.516 -0.324,0.828 -0.863,0.828 z m 5,-4.23 c -0.434,0 -0.829,0.195 -1.075,0.519 -0.304,0.422 -0.457,1.055 -0.457,1.942 0,1.609 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.543 -0.453,-1.981 -0.246,-0.328 -0.633,-0.519 -1.078,-0.519 z m 0,0.512 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.996 -0.949,1.996 -0.613,0 -0.922,-0.66 -0.922,-1.976 0,-1.313 0.309,-1.953 0.934,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath299)"
+             id="path758" />
+          <path
+             d="m 331.699,502.504 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.015 0,-0.903 -0.536,-1.411 -1.489,-1.411 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.531 -0.352,0.848 -0.938,0.848 z m 6.356,1.133 0.492,1.445 h 0.687 l -1.687,-4.809 h -0.793 l -1.719,4.809 h 0.656 l 0.508,-1.445 z m -0.172,-0.512 h -1.531 l 0.789,-2.191 z m 3.176,-2.813 c -0.434,0 -0.829,0.196 -1.075,0.52 -0.304,0.422 -0.457,1.059 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.921 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.516 c 0.629,0 0.937,0.637 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.316 0.309,-1.953 0.934,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath300)"
+             id="path759" />
+          <path
+             d="m 333.004,494.562 h -2.008 v 0.543 h 1.465 v 0.129 c 0,0.86 -0.633,1.481 -1.508,1.481 -0.488,0 -0.933,-0.18 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.18 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.394,0.996 h 0.626 c -0.172,-0.977 -0.911,-1.535 -2.012,-1.535 -0.59,0 -1.063,0.148 -1.442,0.461 -0.558,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.907,2.508 2.207,2.508 0.653,0 1.168,-0.242 1.641,-0.766 l 0.152,0.641 h 0.391 z m 4.746,-2.269 h -0.582 v 3.934 l -2.516,-3.934 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.695 z m 1.004,4.812 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.859 -1.453,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath301)"
+             id="path760" />
+          <path
+             d="m 328.098,487.625 h 1.511 c 0.379,0 0.676,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.812 h 0.614 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.937,0.316 0.937,0.843 0,0.528 -0.351,0.844 -0.937,0.844 z m 4.433,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.332 v 4.812 h 3.453 v -0.543 h -2.84 z m 4.824,-1.207 v 3.398 h 0.579 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.235,0.953 v 0.422 z m 4.047,2.242 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath302)"
+             id="path761" />
+          <path
+             d="m 327.98,480.184 h 1.508 c 0.379,0 0.676,-0.114 0.934,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.617 z m 0,-0.543 v -1.688 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.527 -0.347,0.844 -0.937,0.844 z m 4.43,0.39 h 2.621 v -0.539 h -2.621 v -1.539 h 2.723 v -0.543 h -3.336 v 4.813 h 3.453 v -0.539 h -2.84 z m 4.824,-1.207 v 3.399 h 0.582 v -4.774 h -0.382 c -0.207,0.735 -0.34,0.832 -1.235,0.953 v 0.422 z m 5.231,2.824 h -2.461 c 0.058,-0.394 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.395 -0.156,-0.766 -0.434,-1.024 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.215 -1.293,0.621 -0.168,0.25 -0.238,0.551 -0.25,1.032 h 0.578 c 0.02,-0.325 0.059,-0.516 0.141,-0.672 0.152,-0.293 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.894 0,0.383 -0.214,0.715 -0.632,0.954 l -0.606,0.355 c -0.976,0.563 -1.262,1.008 -1.316,2.051 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath303)"
+             id="path762" />
+          <path
+             d="m 331.699,472.742 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.903 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.93 -0.875,-1.168 0.442,-0.207 0.664,-0.554 0.664,-1.051 0,-0.355 -0.133,-0.66 -0.383,-0.882 -0.257,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.738 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.132 0.266,0.328 0.266,0.593 0,0.266 -0.094,0.461 -0.266,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.309 0.863,0.832 0,0.512 -0.324,0.824 -0.863,0.824 z m 5,-4.23 c -0.434,0 -0.832,0.195 -1.075,0.519 -0.304,0.422 -0.457,1.055 -0.457,1.942 0,1.609 0.528,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.543 -0.453,-1.981 -0.246,-0.328 -0.637,-0.519 -1.078,-0.519 z m 0,0.511 c 0.629,0 0.937,0.641 0.937,1.938 0,1.359 -0.305,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.973 0,-1.316 0.313,-1.957 0.938,-1.957 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath304)"
+             id="path763" />
+          <path
+             d="m 328.098,465.301 h 1.511 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.813 h 0.614 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.937,0.317 0.937,0.848 0,0.527 -0.351,0.844 -0.937,0.844 z m 4.433,0.39 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.813 h 3.453 v -0.543 h -2.84 z m 4.824,-1.211 v 3.403 h 0.579 v -4.774 h -0.383 c -0.203,0.731 -0.336,0.832 -1.235,0.95 v 0.421 z m 5.032,-1.277 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.324 0.496,-0.438 0.864,-0.438 0.628,0 1.015,0.43 1.015,1.122 0,0.675 -0.387,1.085 -1.023,1.085 -0.508,0 -0.817,-0.257 -0.957,-0.785 h -0.578 c 0.078,0.383 0.144,0.567 0.281,0.739 0.265,0.355 0.742,0.558 1.269,0.558 0.942,0 1.602,-0.683 1.602,-1.676 0,-0.921 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.184,-1.305 h 1.949 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath305)"
+             id="path764" />
+          <path
+             d="m 333.004,457.359 h -2.008 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.929,-0.18 -1.215,-0.489 -0.316,-0.343 -0.507,-0.918 -0.507,-1.511 0,-1.18 0.675,-1.961 1.691,-1.961 0.73,0 1.262,0.379 1.391,0.996 h 0.629 c -0.172,-0.977 -0.911,-1.535 -2.012,-1.535 -0.59,0 -1.063,0.152 -1.442,0.461 -0.558,0.461 -0.871,1.207 -0.871,2.074 0,1.476 0.907,2.508 2.207,2.508 0.653,0 1.168,-0.246 1.641,-0.766 l 0.152,0.641 h 0.391 z m 4.742,-2.269 h -0.578 v 3.933 l -2.516,-3.933 h -0.668 v 4.812 h 0.582 V 456 l 2.489,3.902 h 0.691 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.726 h 1.133 c 0.949,0 1.453,0.637 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath306)"
+             id="path765" />
+          <path
+             d="m 331.699,386.699 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.933 -0.875,-1.172 0.442,-0.203 0.664,-0.55 0.664,-1.047 0,-0.355 -0.133,-0.66 -0.383,-0.886 -0.257,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.953 z M 336.059,386 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.129 0.266,0.328 0.266,0.593 0,0.262 -0.094,0.461 -0.266,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.195 v -1.656 h 1.5 c 0.539,0 0.863,0.313 0.863,0.832 0,0.516 -0.324,0.824 -0.863,0.824 z m 5.343,-0.613 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath307)"
+             id="path766" />
+          <path
+             d="m 331.699,379.258 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.848 -0.938,0.848 z m 6.352,1.133 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.789 l -1.719,4.813 h 0.656 l 0.508,-1.445 z m -0.168,-0.516 h -1.531 l 0.789,-2.191 z m 3.519,0.809 v 1.152 h 0.582 v -1.152 h 0.692 v -0.524 h -0.692 v -3.094 h -0.429 l -2.125,3 v 0.618 z m 0,-0.524 h -1.464 l 1.464,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath308)"
+             id="path767" />
+          <path
+             d="m 331.699,371.816 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.343 0.289,-0.262 0.414,-0.575 0.414,-1.016 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.848 0,0.527 -0.352,0.843 -0.938,0.843 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.929 -0.875,-1.168 0.442,-0.203 0.664,-0.554 0.664,-1.05 0,-0.356 -0.133,-0.661 -0.383,-0.883 -0.257,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.738 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.266,0.332 0.266,0.594 0,0.265 -0.094,0.464 -0.266,0.593 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.309 0.863,0.832 0,0.512 -0.324,0.824 -0.863,0.824 z m 4.644,-1.656 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.382 0.09,0.632 0.203,0.843 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.578 1.586,-1.485 0,-0.605 -0.234,-0.937 -0.793,-1.132 0.434,-0.18 0.652,-0.512 0.652,-0.993 0,-0.816 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.308 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.652 -0.161,0.067 -0.372,0.094 -0.774,0.102 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath309)"
+             id="path768" />
+          <path
+             d="m 331.699,364.379 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.903 -0.532,-1.411 -1.485,-1.411 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.691 h 1.281 c 0.586,0 0.938,0.32 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.254 0.367,-0.594 0.367,-0.973 0,-0.578 -0.262,-0.93 -0.875,-1.168 0.442,-0.203 0.664,-0.555 0.664,-1.051 0,-0.355 -0.133,-0.656 -0.383,-0.883 -0.257,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.742 v -1.531 h 1.187 c 0.344,0 0.535,0.046 0.699,0.171 0.172,0.133 0.266,0.332 0.266,0.594 0,0.266 -0.094,0.465 -0.266,0.598 -0.164,0.125 -0.355,0.168 -0.699,0.168 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.308 0.863,0.832 0,0.515 -0.324,0.824 -0.863,0.824 z m 6.328,-4.137 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.324 0.496,-0.437 0.864,-0.437 0.628,0 1.015,0.429 1.015,1.125 0,0.672 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.578 c 0.078,0.382 0.144,0.566 0.281,0.738 0.265,0.355 0.742,0.562 1.269,0.562 0.942,0 1.602,-0.687 1.602,-1.679 0,-0.922 -0.613,-1.555 -1.512,-1.555 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.184,-1.305 h 1.949 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath310)"
+             id="path769" />
+          <path
+             d="m 331.699,356.938 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.403 0.234,-0.25 0.367,-0.594 0.367,-0.972 0,-0.579 -0.262,-0.93 -0.875,-1.168 0.442,-0.204 0.664,-0.555 0.664,-1.047 0,-0.36 -0.133,-0.66 -0.383,-0.887 -0.257,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.739 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.129 0.266,0.328 0.266,0.594 0,0.261 -0.094,0.461 -0.266,0.593 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.196 v -1.657 h 1.5 c 0.539,0 0.863,0.313 0.863,0.832 0,0.516 -0.324,0.825 -0.863,0.825 z m 5.343,-0.614 v 1.157 h 0.582 v -1.157 h 0.692 v -0.519 h -0.692 v -3.098 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.464 l 1.464,-2.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath311)"
+             id="path770" />
+          <path
+             d="m 331.699,349.496 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.352,1.137 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.789 l -1.719,4.812 h 0.656 l 0.508,-1.445 z m -0.168,-0.516 h -1.531 l 0.789,-2.191 z m 3.519,0.805 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath312)"
+             id="path771" />
+          <path
+             d="m 327.98,342.055 h 1.508 c 0.379,0 0.676,-0.11 0.934,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.809 h 0.617 z m 0,-0.539 v -1.692 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.531 -0.347,0.848 -0.937,0.848 z m 3.747,2.578 h 2.171 c 0.454,0 0.79,-0.125 1.047,-0.403 0.239,-0.25 0.371,-0.593 0.371,-0.968 0,-0.582 -0.265,-0.93 -0.878,-1.168 0.441,-0.207 0.667,-0.555 0.667,-1.051 0,-0.356 -0.132,-0.66 -0.382,-0.883 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.613,-2.739 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.7,0.172 0.171,0.133 0.265,0.332 0.265,0.594 0,0.265 -0.094,0.461 -0.265,0.594 -0.165,0.125 -0.356,0.171 -0.7,0.171 z m 0,2.2 v -1.657 h 1.496 c 0.543,0 0.867,0.309 0.867,0.832 0,0.512 -0.324,0.825 -0.867,0.825 z m 4.894,-2.86 v 3.399 h 0.582 v -4.77 h -0.382 c -0.207,0.731 -0.34,0.832 -1.235,0.949 v 0.422 z m 5.231,2.825 h -2.461 c 0.058,-0.395 0.269,-0.645 0.844,-0.997 l 0.66,-0.367 c 0.652,-0.363 0.988,-0.851 0.988,-1.441 0,-0.395 -0.156,-0.766 -0.434,-1.024 -0.277,-0.25 -0.621,-0.367 -1.062,-0.367 -0.594,0 -1.035,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.25,1.028 h 0.578 c 0.02,-0.325 0.059,-0.516 0.141,-0.672 0.152,-0.293 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.898 0,0.383 -0.214,0.711 -0.632,0.95 l -0.606,0.355 c -0.976,0.563 -1.262,1.012 -1.316,2.055 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath313)"
+             id="path772" />
+          <path
+             d="m 328.098,334.496 h 1.511 c 0.379,0 0.676,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.812 h 0.614 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.937,0.316 0.937,0.843 0,0.528 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.05,-0.402 0.239,-0.25 0.372,-0.594 0.372,-0.973 0,-0.578 -0.266,-0.93 -0.879,-1.168 0.441,-0.203 0.668,-0.554 0.668,-1.047 0,-0.359 -0.133,-0.66 -0.383,-0.886 -0.258,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.738 v -1.531 h 1.187 c 0.344,0 0.536,0.043 0.7,0.172 0.172,0.128 0.261,0.328 0.261,0.593 0,0.262 -0.089,0.461 -0.261,0.594 -0.164,0.125 -0.356,0.172 -0.7,0.172 z m 0,2.195 v -1.656 h 1.496 c 0.543,0 0.867,0.312 0.867,0.832 0,0.516 -0.324,0.824 -0.867,0.824 z m 4.894,-2.855 v 3.398 h 0.579 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.235,0.953 v 0.422 z m 3.348,1.199 h 0.317 c 0.636,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.024 h -0.582 c 0.027,0.383 0.094,0.633 0.203,0.844 0.246,0.465 0.699,0.696 1.34,0.696 0.965,0 1.586,-0.583 1.586,-1.485 0,-0.609 -0.231,-0.937 -0.793,-1.137 0.437,-0.179 0.652,-0.507 0.652,-0.992 0,-0.816 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.289 0.031,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.312 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.161,0.066 -0.372,0.09 -0.774,0.098 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath314)"
+             id="path773" />
+          <path
+             d="m 328.098,327.055 h 1.511 c 0.379,0 0.676,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.527 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.05,-0.403 0.239,-0.25 0.372,-0.593 0.372,-0.968 0,-0.582 -0.266,-0.934 -0.879,-1.168 0.441,-0.207 0.668,-0.555 0.668,-1.051 0,-0.356 -0.133,-0.66 -0.383,-0.887 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.739 v -1.531 h 1.187 c 0.344,0 0.536,0.047 0.7,0.172 0.172,0.133 0.261,0.328 0.261,0.594 0,0.262 -0.089,0.461 -0.261,0.594 -0.164,0.125 -0.356,0.171 -0.7,0.171 z m 0,2.2 v -1.66 h 1.496 c 0.543,0 0.867,0.312 0.867,0.832 0,0.515 -0.324,0.828 -0.867,0.828 z m 4.894,-2.86 v 3.399 h 0.579 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.235,0.953 v 0.422 z m 5.032,-1.281 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.32 0.496,-0.434 0.864,-0.434 0.628,0 1.019,0.43 1.019,1.121 0,0.672 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.257 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.567 0.285,0.739 0.261,0.359 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.676 0,-0.925 -0.617,-1.558 -1.512,-1.558 -0.332,0 -0.594,0.086 -0.867,0.285 l 0.187,-1.309 h 1.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath315)"
+             id="path774" />
+          <path
+             d="m 331.34,319.613 h 1.512 c 0.375,0 0.671,-0.113 0.929,-0.343 0.289,-0.262 0.414,-0.575 0.414,-1.016 0,-0.902 -0.535,-1.41 -1.484,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.934,0.316 0.934,0.844 0,0.531 -0.348,0.847 -0.934,0.847 z m 7.594,-0.742 c -0.192,-1.055 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.207 -1.523,0.601 -0.438,0.477 -0.672,1.16 -0.672,1.942 0,0.793 0.242,1.472 0.691,1.941 0.375,0.383 0.852,0.559 1.477,0.559 1.176,0 1.836,-0.633 1.98,-1.907 h -0.633 c -0.05,0.329 -0.117,0.555 -0.218,0.747 -0.196,0.394 -0.606,0.621 -1.121,0.621 -0.957,0 -1.563,-0.766 -1.563,-1.969 0,-1.235 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.113 0.949,0.304 0.18,0.164 0.277,0.36 0.352,0.723 z m 3.597,-0.211 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.512,0 -0.976,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.047 -0.422,1.915 0,0.804 0.114,1.312 0.399,1.734 0.25,0.391 0.66,0.594 1.172,0.594 0.894,0 1.531,-0.664 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.43,-1.496 -0.465,0 -0.824,0.172 -1.078,0.519 0.008,-1.179 0.379,-1.835 1.043,-1.835 0.41,0 0.695,0.265 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.398 0.91,1.031 0,0.601 -0.394,1.035 -0.93,1.035 -0.539,0 -0.949,-0.453 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath316)"
+             id="path775" />
+          <path
+             d="m 328.098,450.059 h 1.511 c 0.379,0 0.676,-0.11 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.809 h 0.614 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.531 -0.351,0.848 -0.937,0.848 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.05,-0.403 0.239,-0.25 0.372,-0.593 0.372,-0.968 0,-0.582 -0.266,-0.93 -0.879,-1.168 0.441,-0.207 0.668,-0.555 0.668,-1.051 0,-0.356 -0.133,-0.66 -0.383,-0.883 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.739 v -1.531 h 1.187 c 0.344,0 0.536,0.047 0.7,0.172 0.172,0.133 0.261,0.332 0.261,0.594 0,0.265 -0.089,0.461 -0.261,0.594 -0.164,0.124 -0.356,0.171 -0.7,0.171 z m 0,2.2 v -1.657 h 1.496 c 0.543,0 0.867,0.309 0.867,0.832 0,0.512 -0.324,0.825 -0.867,0.825 z m 4.894,-2.86 v 3.399 h 0.579 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.832 -1.235,0.949 v 0.422 z m 3.704,-1.371 c -0.434,0 -0.829,0.195 -1.075,0.52 -0.304,0.422 -0.457,1.058 -0.457,1.941 0,1.609 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.922 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.516 c 0.629,0 0.937,0.636 0.937,1.933 0,1.36 -0.301,1.993 -0.949,1.993 -0.613,0 -0.922,-0.661 -0.922,-1.973 0,-1.317 0.309,-1.953 0.934,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath317)"
+             id="path776" />
+          <path
+             d="m 331.699,442.621 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.536,-1.41 -1.489,-1.41 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.691 h 1.281 c 0.586,0 0.938,0.32 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.356,1.137 0.492,1.445 h 0.687 l -1.687,-4.812 h -0.793 l -1.719,4.812 h 0.656 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.789,-2.191 z m 4.703,1.387 h -2.461 c 0.059,-0.398 0.27,-0.648 0.844,-1 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.438 0,-0.398 -0.156,-0.769 -0.433,-1.023 -0.278,-0.254 -0.622,-0.371 -1.063,-0.371 -0.594,0 -1.039,0.211 -1.297,0.621 -0.164,0.25 -0.234,0.547 -0.25,1.027 h 0.582 c 0.02,-0.32 0.059,-0.512 0.137,-0.672 0.152,-0.289 0.457,-0.468 0.809,-0.468 0.527,0 0.921,0.382 0.921,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.258,1.011 -1.312,2.054 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath318)"
+             id="path777" />
+          <path
+             d="m 331.699,435.059 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.489,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 6.356,1.136 0.492,1.446 h 0.687 l -1.687,-4.813 h -0.793 l -1.719,4.813 h 0.656 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 3.07,-1.438 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.953 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath319)"
+             id="path778" />
+          <path
+             d="m 331.34,427.617 h 1.512 c 0.375,0 0.671,-0.113 0.929,-0.344 0.289,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.535,-1.41 -1.488,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 7.594,-0.742 c -0.192,-1.055 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.207 -1.523,0.601 -0.434,0.477 -0.672,1.16 -0.672,1.942 0,0.793 0.242,1.472 0.691,1.941 0.375,0.383 0.852,0.559 1.481,0.559 1.172,0 1.832,-0.633 1.98,-1.907 h -0.637 c -0.05,0.328 -0.117,0.555 -0.214,0.746 -0.2,0.395 -0.61,0.622 -1.125,0.622 -0.957,0 -1.563,-0.766 -1.563,-1.969 0,-1.235 0.574,-1.992 1.512,-1.992 0.39,0 0.75,0.113 0.949,0.304 0.18,0.164 0.277,0.36 0.352,0.723 z m 3.652,2.746 h -2.461 c 0.059,-0.394 0.27,-0.644 0.844,-0.996 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.622,-0.367 -1.063,-0.367 -0.594,0 -1.039,0.211 -1.297,0.621 -0.164,0.25 -0.234,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.672 0.152,-0.293 0.457,-0.468 0.809,-0.468 0.527,0 0.921,0.382 0.921,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.258,1.011 -1.312,2.054 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath320)"
+             id="path779" />
+          <path
+             d="m 331.699,420.176 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.536,-1.41 -1.489,-1.41 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.129 1.051,-0.407 0.238,-0.25 0.367,-0.593 0.367,-0.968 0,-0.582 -0.262,-0.93 -0.875,-1.168 0.442,-0.203 0.664,-0.555 0.664,-1.051 0,-0.355 -0.129,-0.66 -0.383,-0.883 -0.257,-0.23 -0.578,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.742 v -1.532 h 1.187 c 0.344,0 0.535,0.047 0.703,0.172 0.172,0.133 0.262,0.332 0.262,0.594 0,0.266 -0.09,0.465 -0.262,0.594 -0.168,0.129 -0.359,0.172 -0.703,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.308 0.863,0.832 0,0.515 -0.324,0.824 -0.863,0.824 z m 4.894,-2.86 v 3.403 h 0.582 v -4.774 h -0.383 c -0.203,0.731 -0.336,0.832 -1.234,0.95 v 0.421 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath321)"
+             id="path780" />
+          <path
+             d="m 333.004,412.234 h -2.008 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.508,1.477 -0.488,0 -0.933,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.18 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.379 1.394,0.996 h 0.626 c -0.172,-0.977 -0.911,-1.535 -2.012,-1.535 -0.59,0 -1.063,0.152 -1.442,0.461 -0.558,0.461 -0.871,1.207 -0.871,2.074 0,1.476 0.907,2.508 2.207,2.508 0.653,0 1.168,-0.246 1.641,-0.766 l 0.152,0.641 h 0.391 z m 4.746,-2.269 h -0.582 v 3.933 l -2.516,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.695 z m 1.004,4.812 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.637 1.453,1.867 0,1.219 -0.5,1.859 -1.453,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath322)"
+             id="path781" />
+          <path
+             d="m 327.012,405.891 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.512,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 6.164,-0.582 h -2.008 v 0.543 h 1.465 v 0.133 c 0,0.855 -0.633,1.476 -1.512,1.476 -0.488,0 -0.929,-0.175 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.179 0.675,-1.957 1.691,-1.957 0.73,0 1.258,0.375 1.391,0.996 h 0.629 c -0.172,-0.976 -0.911,-1.539 -2.016,-1.539 -0.586,0 -1.063,0.153 -1.438,0.461 -0.562,0.465 -0.871,1.207 -0.871,2.074 0,1.477 0.907,2.508 2.203,2.508 0.657,0 1.168,-0.246 1.645,-0.765 l 0.152,0.64 h 0.391 z m 4.621,-2.27 h -0.578 v 3.934 l -2.516,-3.934 h -0.668 v 4.813 h 0.582 v -3.902 l 2.489,3.902 h 0.691 z m 1.129,4.813 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.859 -1.453,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath323)"
+             id="path782" />
+          <path
+             d="m 327.734,398.449 0.493,1.446 h 0.687 l -1.687,-4.813 h -0.793 l -1.719,4.813 h 0.656 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 4.067,1.961 1.672,-4.813 h -0.653 l -1.336,4.074 -1.41,-4.074 h -0.66 l 1.727,4.813 z m 2.32,0 h 1.856 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.488 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.54 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 4.188,0.54 h 1.855 c 1.211,0 1.957,-0.911 1.957,-2.411 0,-1.488 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.54 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m -111.98,0.54 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.54 v -3.73 h 1.137 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 6.629,-4.14 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.321 0.497,-0.434 0.864,-0.434 0.629,0 1.019,0.43 1.019,1.121 0,0.676 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.57 0.285,0.738 0.262,0.36 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.332,0 -0.593,0.086 -0.867,0.286 l 0.188,-1.309 h 1.945 z m 2.266,-0.09 c -0.434,0 -0.833,0.195 -1.075,0.52 -0.304,0.421 -0.457,1.054 -0.457,1.941 0,1.609 0.528,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.543 -0.453,-1.98 -0.246,-0.329 -0.633,-0.52 -1.078,-0.52 z m 0,0.512 c 0.628,0 0.937,0.64 0.937,1.933 0,1.364 -0.301,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.972 0,-1.317 0.313,-1.957 0.938,-1.957 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath324)"
+             id="path783" />
+          <path
+             d="m 227.387,392.453 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,391.914 v -3.73 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.222 -0.504,1.863 -1.453,1.863 z m 5.645,-0.613 v 1.152 h 0.582 v -1.152 h 0.695 v -0.524 h -0.695 v -3.093 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.524 h -1.465 l 1.465,-2.105 z m 1.785,0.59 c 0.113,0.778 0.613,1.238 1.328,1.238 0.519,0 0.984,-0.25 1.262,-0.679 0.289,-0.469 0.421,-1.047 0.421,-1.914 0,-0.805 -0.121,-1.313 -0.398,-1.735 -0.258,-0.39 -0.664,-0.593 -1.18,-0.593 -0.89,0 -1.531,0.664 -1.531,1.589 0,0.879 0.594,1.5 1.438,1.5 0.441,0 0.773,-0.16 1.07,-0.523 -0.008,1.188 -0.375,1.844 -1.043,1.844 -0.41,0 -0.692,-0.266 -0.785,-0.727 z m 1.425,-3.176 c 0.543,0 0.95,0.457 0.95,1.071 0,0.586 -0.395,0.996 -0.969,0.996 -0.563,0 -0.91,-0.399 -0.91,-1.031 0,-0.602 0.39,-1.036 0.929,-1.036 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath325)"
+             id="path784" />
+          <path
+             d="m 227.387,385.016 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,384.473 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.871 0,1.219 -0.504,1.86 -1.453,1.86 z m 5.645,-0.614 v 1.157 h 0.582 v -1.157 h 0.695 v -0.519 h -0.695 v -3.098 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.11 z m 4.015,-0.84 c 0.488,-0.297 0.641,-0.535 0.641,-0.984 0,-0.75 -0.574,-1.274 -1.406,-1.274 -0.825,0 -1.407,0.524 -1.407,1.266 0,0.457 0.153,0.687 0.637,0.992 -0.535,0.27 -0.801,0.66 -0.801,1.188 0,0.871 0.641,1.48 1.571,1.48 0.925,0 1.57,-0.609 1.57,-1.48 0,-0.528 -0.262,-0.918 -0.805,-1.188 z m -0.765,-1.742 c 0.496,0 0.812,0.297 0.812,0.773 0,0.446 -0.324,0.742 -0.812,0.742 -0.493,0 -0.813,-0.296 -0.813,-0.757 0,-0.461 0.32,-0.758 0.813,-0.758 z m 0,2.004 c 0.582,0 0.976,0.386 0.976,0.937 0,0.574 -0.387,0.953 -0.988,0.953 -0.567,0 -0.965,-0.39 -0.965,-0.945 0,-0.566 0.391,-0.945 0.977,-0.945 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath326)"
+             id="path785" />
+          <path
+             d="m 227.387,377.574 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,377.031 v -3.726 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z m 5.645,-0.613 v 1.156 h 0.582 v -1.156 h 0.695 v -0.52 h -0.695 v -3.097 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.465 l 1.465,-2.105 z m 4.867,-3.003 h -3.129 v 0.574 h 2.531 c -1.117,1.59 -1.574,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.899,-4.191 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath327)"
+             id="path786" />
+          <path
+             d="m 227.387,370.133 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.489 -0.738,-2.403 -1.961,-2.403 h -1.855 z M 228,369.594 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 5.645,-0.617 v 1.156 h 0.582 v -1.156 h 0.695 v -0.52 h -0.695 v -3.098 h -0.43 l -2.125,3.004 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z m 4.722,-1.855 c -0.113,-0.778 -0.613,-1.243 -1.328,-1.243 -0.512,0 -0.977,0.254 -1.254,0.684 -0.297,0.469 -0.422,1.047 -0.422,1.914 0,0.805 0.114,1.313 0.399,1.734 0.25,0.391 0.66,0.594 1.172,0.594 0.894,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.497 -1.43,-1.497 -0.461,0 -0.824,0.168 -1.078,0.52 0.008,-1.18 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.266 0.785,0.727 z m -1.406,1.101 c 0.562,0 0.91,0.399 0.91,1.031 0,0.602 -0.394,1.036 -0.93,1.036 -0.539,0 -0.949,-0.454 -0.949,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath328)"
+             id="path787" />
+          <path
+             d="m 227.387,362.691 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,362.152 v -3.73 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 5.645,-0.613 v 1.152 h 0.582 v -1.152 h 0.695 v -0.523 h -0.695 v -3.094 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.106 z m 4.578,-3.004 h -2.414 l -0.352,2.55 h 0.535 c 0.27,-0.324 0.496,-0.437 0.863,-0.437 0.629,0 1.016,0.43 1.016,1.121 0,0.676 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.254 -0.957,-0.785 h -0.579 c 0.079,0.383 0.145,0.57 0.282,0.742 0.265,0.356 0.742,0.559 1.269,0.559 0.942,0 1.602,-0.688 1.602,-1.676 0,-0.926 -0.613,-1.559 -1.508,-1.559 -0.332,0 -0.598,0.086 -0.867,0.286 l 0.183,-1.309 h 1.95 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath329)"
+             id="path788" />
+          <path
+             d="m 227.387,355.254 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.855 z M 228,354.711 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.872 0,1.218 -0.504,1.859 -1.453,1.859 z m 5.645,-0.613 v 1.156 h 0.582 v -1.156 h 0.695 v -0.524 h -0.695 v -3.094 h -0.43 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.465 l 1.465,-2.105 z m 3.593,0.524 v 1.156 h 0.582 v -1.156 h 0.692 v -0.524 h -0.692 v -3.094 h -0.429 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.465 l 1.465,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath330)"
+             id="path789" />
+          <path
+             d="m 227.387,347.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,347.27 v -3.727 h 1.137 c 0.949,0 1.453,0.637 1.453,1.867 0,1.219 -0.504,1.86 -1.453,1.86 z m 5.645,-0.614 v 1.156 h 0.582 v -1.156 h 0.695 v -0.519 h -0.695 v -3.098 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z m 2.894,-0.524 h 0.316 c 0.633,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.246,0.464 0.699,0.695 1.34,0.695 0.965,0 1.586,-0.582 1.586,-1.488 0,-0.606 -0.234,-0.934 -0.793,-1.133 0.433,-0.18 0.652,-0.508 0.652,-0.992 0,-0.817 -0.535,-1.313 -1.426,-1.313 -0.941,0 -1.445,0.527 -1.464,1.539 h 0.582 c 0.007,-0.289 0.031,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.312 0.825,0.824 0,0.34 -0.118,0.543 -0.376,0.656 -0.16,0.067 -0.371,0.09 -0.773,0.098 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath331)"
+             id="path790" />
+          <path
+             d="m 231.359,449.555 h -2.007 v 0.543 h 1.464 v 0.132 c 0,0.856 -0.632,1.477 -1.507,1.477 -0.493,0 -0.934,-0.18 -1.215,-0.488 -0.317,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.18 0.672,-1.961 1.687,-1.961 0.735,0 1.262,0.379 1.395,0.996 h 0.625 c -0.172,-0.976 -0.91,-1.535 -2.012,-1.535 -0.59,0 -1.062,0.152 -1.441,0.461 -0.559,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.906,2.512 2.207,2.512 0.652,0 1.168,-0.246 1.64,-0.766 l 0.153,0.637 h 0.39 z m 4.746,-2.27 h -0.582 v 3.934 l -2.515,-3.934 h -0.668 v 4.813 h 0.582 v -3.903 l 2.488,3.903 h 0.695 z m 1.004,4.813 h 1.852 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.852 z m 0.614,-0.543 v -3.731 h 1.132 c 0.954,0 1.454,0.641 1.454,1.871 0,1.219 -0.5,1.86 -1.454,1.86 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath332)"
+             id="path791" />
+          <path
+             d="m 227.266,444.656 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.726 h 1.133 c 0.949,0 1.453,0.64 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z m 6.625,-4.136 h -2.414 l -0.348,2.546 h 0.531 c 0.274,-0.324 0.496,-0.433 0.868,-0.433 0.625,0 1.015,0.426 1.015,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.265,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.308 h 1.946 z m 3.594,0 h -2.414 l -0.352,2.546 h 0.535 c 0.27,-0.324 0.496,-0.433 0.863,-0.433 0.629,0 1.02,0.426 1.02,1.121 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.079,0.383 0.145,0.566 0.286,0.738 0.261,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.614,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.285 l 0.187,-1.308 h 1.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath333)"
+             id="path792" />
+          <path
+             d="m 227.266,437.094 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.539 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 6.625,-4.141 h -2.414 l -0.348,2.551 h 0.531 c 0.274,-0.324 0.496,-0.438 0.868,-0.438 0.625,0 1.015,0.43 1.015,1.121 0,0.676 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.253 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.571 0.285,0.743 0.265,0.355 0.738,0.558 1.265,0.558 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.946 z m 2.609,3.527 v 1.153 h 0.582 v -1.153 h 0.696 v -0.523 h -0.696 v -3.094 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath334)"
+             id="path793" />
+          <path
+             d="m 227.266,429.656 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.73 h 1.133 c 0.949,0 1.453,0.64 1.453,1.871 0,1.219 -0.504,1.859 -1.453,1.859 z m 6.625,-4.136 h -2.414 l -0.348,2.546 h 0.531 c 0.274,-0.324 0.496,-0.437 0.868,-0.437 0.625,0 1.015,0.43 1.015,1.125 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.265,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.613,-1.555 -1.512,-1.555 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.304 h 1.946 z m 1.91,2.48 h 0.316 c 0.637,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.382 0.094,0.632 0.203,0.843 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.578 1.586,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.132 0.437,-0.18 0.652,-0.508 0.652,-0.993 0,-0.816 -0.531,-1.312 -1.426,-1.312 -0.941,0 -1.445,0.527 -1.464,1.539 h 0.582 c 0.007,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.824,0.312 0.824,0.824 0,0.336 -0.117,0.543 -0.375,0.656 -0.16,0.063 -0.371,0.09 -0.773,0.098 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath335)"
+             id="path794" />
+          <path
+             d="m 227.266,422.215 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.727 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.219 -0.504,1.86 -1.453,1.86 z m 6.625,-4.137 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.324 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.426 1.015,1.122 0,0.671 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.582 c 0.082,0.383 0.148,0.567 0.285,0.739 0.265,0.355 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.676 0,-0.925 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.305 h 1.946 z m 3.793,4.106 h -2.461 c 0.058,-0.399 0.269,-0.649 0.844,-0.996 l 0.66,-0.372 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.398 -0.156,-0.766 -0.434,-1.024 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.032 h 0.582 c 0.02,-0.324 0.059,-0.516 0.141,-0.676 0.148,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.382 -0.218,0.714 -0.633,0.949 l -0.605,0.359 c -0.977,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath336)"
+             id="path795" />
+          <path
+             d="m 227.266,414.773 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.73 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 6.625,-4.14 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.321 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.43 1.015,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.265,0.36 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.286 l 0.183,-1.309 h 1.946 z m 2.164,1.281 v 3.398 h 0.578 V 410 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath337)"
+             id="path796" />
+          <path
+             d="m 227.266,519.418 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.539 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.868 0,1.222 -0.504,1.863 -1.453,1.863 z m 6.773,-2.992 c -0.113,-0.778 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.253 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.809 0.114,1.317 0.395,1.739 0.25,0.39 0.66,0.593 1.176,0.593 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.523 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.101 c 0.559,0 0.91,0.399 0.91,1.032 0,0.601 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.453 -0.953,-1.063 0,-0.594 0.399,-1.004 0.973,-1.004 z m 3.867,1.274 v 1.156 h 0.582 v -1.156 h 0.696 v -0.52 h -0.696 v -3.097 h -0.429 l -2.125,3.003 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath338)"
+             id="path797" />
+          <path
+             d="m 227.266,511.977 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.407 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 6.773,-2.993 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.468 -0.422,1.047 -0.422,1.914 0,0.804 0.114,1.312 0.395,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.52 0.008,-1.18 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.265 0.785,0.726 z m -1.406,1.102 c 0.559,0 0.91,0.398 0.91,1.031 0,0.602 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.453 -0.953,-1.062 0,-0.594 0.399,-1.004 0.973,-1.004 z m 3.168,0.234 h 0.316 c 0.637,0 0.973,0.297 0.973,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.637 0.203,0.848 0.246,0.46 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.606 -0.231,-0.938 -0.793,-1.137 0.437,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.531,-1.313 -1.426,-1.313 -0.941,0 -1.445,0.527 -1.464,1.535 h 0.582 c 0.007,-0.289 0.031,-0.453 0.105,-0.597 0.133,-0.274 0.422,-0.43 0.785,-0.43 0.516,0 0.824,0.308 0.824,0.824 0,0.336 -0.117,0.543 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.773,0.102 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath339)"
+             id="path798" />
+          <path
+             d="m 227.266,504.539 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.73 h 1.133 c 0.949,0 1.453,0.64 1.453,1.867 0,1.222 -0.504,1.863 -1.453,1.863 z m 6.773,-2.988 c -0.113,-0.781 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.313 0.395,1.735 0.25,0.39 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.665 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.519 0.008,-1.179 0.375,-1.832 1.043,-1.832 0.41,0 0.691,0.262 0.785,0.727 z m -1.406,1.101 c 0.559,0 0.91,0.395 0.91,1.028 0,0.601 -0.394,1.039 -0.93,1.039 -0.542,0 -0.953,-0.457 -0.953,-1.063 0,-0.597 0.399,-1.004 0.973,-1.004 z m 5.051,1.856 h -2.461 c 0.058,-0.399 0.269,-0.649 0.844,-1 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.434,-1.019 -0.277,-0.254 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.027 h 0.582 c 0.02,-0.32 0.059,-0.512 0.141,-0.672 0.148,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.383 -0.218,0.711 -0.633,0.949 l -0.605,0.356 c -0.977,0.562 -1.262,1.011 -1.316,2.054 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath340)"
+             id="path799" />
+          <path
+             d="m 227.266,497.098 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.727 h 1.133 c 0.949,0 1.453,0.637 1.453,1.867 0,1.219 -0.504,1.86 -1.453,1.86 z m 6.773,-2.989 c -0.113,-0.781 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.312 0.395,1.738 0.25,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.262 0.785,0.726 z m -1.406,1.102 c 0.559,0 0.91,0.394 0.91,1.031 0,0.598 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.457 -0.953,-1.062 0,-0.594 0.399,-1.004 0.973,-1.004 z m 3.422,-0.969 v 3.399 h 0.578 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.949 v 0.426 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath341)"
+             id="path800" />
+          <path
+             d="m 227.266,489.656 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.726 h 1.133 c 0.949,0 1.453,0.64 1.453,1.867 0,1.223 -0.504,1.859 -1.453,1.859 z m 6.773,-2.988 c -0.113,-0.777 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.254 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.915 0,0.808 0.114,1.316 0.395,1.738 0.25,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.523 0.008,-1.183 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.102 c 0.559,0 0.91,0.398 0.91,1.031 0,0.601 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.457 -0.953,-1.063 0,-0.593 0.399,-1.003 0.973,-1.003 z m 3.527,-2.344 c -0.437,0 -0.832,0.199 -1.078,0.523 -0.304,0.422 -0.453,1.055 -0.453,1.942 0,1.609 0.527,2.461 1.531,2.461 0.989,0 1.532,-0.852 1.532,-2.422 0,-0.926 -0.149,-1.547 -0.457,-1.981 -0.247,-0.332 -0.633,-0.523 -1.075,-0.523 z m 0,0.515 c 0.625,0 0.934,0.641 0.934,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.614,0 -0.922,-0.656 -0.922,-1.972 0,-1.313 0.308,-1.954 0.937,-1.954 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath342)"
+             id="path801" />
+          <path
+             d="m 227.266,482.215 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.489 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.539 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 6.625,-4.141 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.32 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.43 1.015,1.122 0,0.675 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.582 c 0.082,0.383 0.148,0.571 0.285,0.739 0.265,0.359 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.676 0,-0.925 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.946 z m 0.801,3.59 c 0.113,0.781 0.617,1.242 1.328,1.242 0.523,0 0.984,-0.25 1.261,-0.679 0.29,-0.469 0.422,-1.051 0.422,-1.915 0,-0.804 -0.117,-1.312 -0.394,-1.734 -0.258,-0.391 -0.668,-0.594 -1.184,-0.594 -0.89,0 -1.531,0.664 -1.531,1.59 0,0.875 0.594,1.496 1.437,1.496 0.446,0 0.774,-0.156 1.071,-0.519 -0.008,1.187 -0.375,1.84 -1.043,1.84 -0.41,0 -0.692,-0.262 -0.785,-0.727 z m 1.425,-3.172 c 0.543,0 0.954,0.453 0.954,1.067 0,0.589 -0.399,1 -0.973,1 -0.559,0 -0.91,-0.399 -0.91,-1.032 0,-0.601 0.39,-1.035 0.929,-1.035 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath343)"
+             id="path802" />
+          <path
+             d="m 227.266,474.773 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.73 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 6.625,-4.14 h -2.414 l -0.348,2.551 h 0.531 c 0.274,-0.325 0.496,-0.438 0.868,-0.438 0.625,0 1.015,0.43 1.015,1.121 0,0.676 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.254 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.57 0.285,0.742 0.265,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.286 l 0.183,-1.309 h 1.946 z m 3.035,2.168 c 0.488,-0.297 0.637,-0.535 0.637,-0.985 0,-0.754 -0.575,-1.273 -1.403,-1.273 -0.828,0 -1.406,0.519 -1.406,1.266 0,0.457 0.152,0.687 0.633,0.992 -0.535,0.269 -0.801,0.66 -0.801,1.187 0,0.871 0.641,1.477 1.574,1.477 0.922,0 1.571,-0.606 1.571,-1.477 0,-0.527 -0.266,-0.918 -0.805,-1.187 z m -0.766,-1.742 c 0.493,0 0.809,0.296 0.809,0.769 0,0.449 -0.32,0.746 -0.809,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.461 0.316,-0.757 0.812,-0.757 z m 0,2.003 c 0.578,0 0.977,0.383 0.977,0.938 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.965,-0.387 -0.965,-0.941 0,-0.567 0.391,-0.946 0.98,-0.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath344)"
+             id="path803" />
+          <path
+             d="M 227.148,467.336 H 229 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.852 z m 0.614,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.872 0,1.218 -0.5,1.859 -1.453,1.859 z m 6.738,-4.137 h -2.414 l -0.352,2.547 h 0.536 c 0.273,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.015,0.429 1.015,1.125 0,0.671 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.382 0.144,0.566 0.285,0.738 0.266,0.355 0.738,0.562 1.266,0.562 0.945,0 1.605,-0.687 1.605,-1.679 0,-0.922 -0.613,-1.555 -1.512,-1.555 -0.328,0 -0.593,0.086 -0.863,0.281 l 0.184,-1.305 h 1.945 z m 3.895,0 h -3.129 v 0.574 h 2.527 c -1.117,1.59 -1.57,2.567 -1.922,4.106 h 0.621 c 0.258,-1.5 0.844,-2.785 1.903,-4.191 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath345)"
+             id="path804" />
+          <path
+             d="M 227.148,459.895 H 229 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.852 z m 0.614,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z m 6.738,-4.137 h -2.414 l -0.352,2.547 h 0.536 c 0.273,-0.324 0.496,-0.434 0.867,-0.434 0.625,0 1.015,0.426 1.015,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.144,0.566 0.285,0.738 0.266,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.593,0.086 -0.863,0.282 l 0.184,-1.305 h 1.945 z m 3.746,1.148 c -0.109,-0.777 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.977,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.109,1.316 0.395,1.738 0.25,0.387 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.004,-1.184 0.375,-1.836 1.043,-1.836 0.406,0 0.691,0.265 0.785,0.726 z m -1.406,1.102 c 0.562,0 0.914,0.394 0.914,1.031 0,0.598 -0.399,1.035 -0.934,1.035 -0.539,0 -0.949,-0.457 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath346)"
+             id="path805" />
+          <path
+             d="m 237.488,655.617 0.496,1.445 h 0.684 l -1.688,-4.812 h -0.792 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 1.938,-1.497 v 3.457 h 0.555 v -1.796 c 0.007,-0.828 0.351,-1.2 1.109,-1.18 v -0.563 c -0.09,-0.011 -0.145,-0.019 -0.211,-0.019 -0.355,0 -0.625,0.211 -0.945,0.726 v -0.625 z m 4.973,-1.355 h -0.547 v 1.789 c -0.231,-0.348 -0.602,-0.535 -1.063,-0.535 -0.898,0 -1.484,0.723 -1.484,1.824 0,1.168 0.566,1.887 1.504,1.887 0.476,0 0.804,-0.18 1.101,-0.61 v 0.457 h 0.489 z m -1.516,1.77 c 0.594,0 0.969,0.523 0.969,1.355 0,0.797 -0.383,1.324 -0.965,1.324 -0.606,0 -1.008,-0.535 -1.008,-1.34 0,-0.804 0.402,-1.339 1.004,-1.339 z m 5.031,3.042 v -3.457 h -0.547 v 1.961 c 0,0.704 -0.371,1.168 -0.945,1.168 -0.434,0 -0.711,-0.265 -0.711,-0.679 v -2.45 h -0.551 v 2.665 c 0,0.574 0.43,0.945 1.106,0.945 0.508,0 0.828,-0.18 1.152,-0.633 v 0.48 z m 1.528,-3.457 h -0.547 v 3.457 h 0.547 z m 0,-1.355 h -0.555 v 0.695 h 0.555 z m 0.902,1.355 v 3.457 h 0.555 v -1.906 c 0,-0.707 0.371,-1.168 0.937,-1.168 0.438,0 0.715,0.262 0.715,0.68 v 2.394 h 0.547 v -2.613 c 0,-0.574 -0.43,-0.945 -1.094,-0.945 -0.516,0 -0.848,0.199 -1.148,0.68 v -0.579 z m 4.933,-0.101 c -0.976,0 -1.554,0.695 -1.554,1.855 0,1.168 0.578,1.856 1.562,1.856 0.977,0 1.567,-0.692 1.567,-1.828 0,-1.203 -0.571,-1.883 -1.575,-1.883 z m 0.008,0.508 c 0.621,0 0.992,0.511 0.992,1.367 0,0.82 -0.382,1.328 -0.992,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.836 0.375,-1.347 0.988,-1.347 z m 6.61,0.554 c -0.008,-0.679 -0.453,-1.062 -1.254,-1.062 -0.805,0 -1.328,0.418 -1.328,1.058 0,0.54 0.277,0.797 1.097,0.997 l 0.516,0.125 c 0.383,0.093 0.535,0.23 0.535,0.476 0,0.328 -0.324,0.547 -0.809,0.547 -0.296,0 -0.546,-0.086 -0.683,-0.23 -0.086,-0.102 -0.125,-0.2 -0.16,-0.446 h -0.582 c 0.027,0.801 0.476,1.184 1.383,1.184 0.871,0 1.425,-0.43 1.425,-1.098 0,-0.512 -0.293,-0.797 -0.976,-0.961 l -0.532,-0.125 c -0.449,-0.105 -0.64,-0.254 -0.64,-0.496 0,-0.324 0.285,-0.523 0.734,-0.523 0.442,0 0.68,0.191 0.692,0.554 z m 3.558,2.496 v -3.457 h -0.551 v 1.961 c 0,0.704 -0.367,1.168 -0.941,1.168 -0.437,0 -0.715,-0.265 -0.715,-0.679 v -2.45 h -0.547 v 2.665 c 0,0.574 0.43,0.945 1.102,0.945 0.508,0 0.832,-0.18 1.156,-0.633 v 0.48 z m 0.895,-4.812 v 4.812 h 0.492 v -0.441 c 0.266,0.402 0.613,0.594 1.098,0.594 0.91,0 1.504,-0.746 1.504,-1.895 0,-1.121 -0.563,-1.816 -1.477,-1.816 -0.477,0 -0.813,0.18 -1.07,0.57 v -1.824 z m 1.512,1.77 c 0.613,0 1.007,0.535 1.007,1.359 0,0.785 -0.41,1.32 -1.007,1.32 -0.59,0 -0.965,-0.527 -0.965,-1.34 0,-0.812 0.375,-1.339 0.965,-1.339 z m 4.621,0.546 c -0.008,-0.679 -0.454,-1.062 -1.254,-1.062 -0.805,0 -1.325,0.418 -1.325,1.058 0,0.54 0.274,0.797 1.094,0.997 l 0.516,0.125 c 0.383,0.093 0.535,0.23 0.535,0.476 0,0.328 -0.324,0.547 -0.805,0.547 -0.3,0 -0.55,-0.086 -0.687,-0.23 -0.086,-0.102 -0.125,-0.2 -0.16,-0.446 h -0.578 c 0.023,0.801 0.472,1.184 1.378,1.184 0.872,0 1.426,-0.43 1.426,-1.098 0,-0.512 -0.293,-0.797 -0.976,-0.961 l -0.532,-0.125 c -0.445,-0.105 -0.636,-0.254 -0.636,-0.496 0,-0.324 0.281,-0.523 0.73,-0.523 0.442,0 0.68,0.191 0.692,0.554 z m 3.855,0.954 c 0,-0.528 -0.039,-0.848 -0.137,-1.102 -0.226,-0.57 -0.754,-0.914 -1.402,-0.914 -0.961,0 -1.582,0.734 -1.582,1.875 0,1.144 0.594,1.836 1.57,1.836 0.793,0 1.34,-0.449 1.481,-1.203 h -0.555 c -0.152,0.457 -0.465,0.695 -0.906,0.695 -0.348,0 -0.645,-0.16 -0.832,-0.449 -0.133,-0.199 -0.176,-0.395 -0.184,-0.738 z m -2.535,-0.45 c 0.047,-0.64 0.437,-1.058 0.992,-1.058 0.559,0 0.949,0.437 0.949,1.058 z m 4.426,-1.465 h -0.567 v -0.953 h -0.547 v 0.953 h -0.468 v 0.45 h 0.468 v 2.613 c 0,0.355 0.235,0.547 0.664,0.547 0.145,0 0.266,-0.012 0.45,-0.047 v -0.461 c -0.078,0.02 -0.153,0.027 -0.262,0.027 -0.238,0 -0.305,-0.066 -0.305,-0.312 v -2.367 h 0.567 z m 3.718,-0.101 c -0.976,0 -1.558,0.695 -1.558,1.855 0,1.168 0.582,1.856 1.566,1.856 0.977,0 1.563,-0.692 1.563,-1.828 0,-1.203 -0.567,-1.883 -1.571,-1.883 z m 0.008,0.508 c 0.621,0 0.989,0.511 0.989,1.367 0,0.82 -0.383,1.328 -0.989,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.836 0.375,-1.347 0.988,-1.347 z m 3.621,-0.407 h -0.574 v -0.543 c 0,-0.23 0.125,-0.347 0.383,-0.347 0.047,0 0.066,0 0.191,0.004 v -0.453 c -0.125,-0.028 -0.199,-0.036 -0.308,-0.036 -0.512,0 -0.813,0.293 -0.813,0.786 v 0.589 h -0.465 v 0.45 h 0.465 v 3.007 h 0.547 v -3.007 h 0.574 z m 5.731,-1.355 h -3.465 v 0.543 h 2.707 l -2.891,3.73 v 0.539 h 3.664 v -0.539 h -2.89 l 2.875,-3.718 z m 1.238,1.355 h -0.551 v 3.457 h 0.551 z m 0,-1.355 h -0.555 v 0.695 h 0.555 z m 2.242,1.254 c -0.976,0 -1.554,0.695 -1.554,1.855 0,1.168 0.578,1.856 1.562,1.856 0.977,0 1.567,-0.692 1.567,-1.828 0,-1.203 -0.571,-1.883 -1.575,-1.883 z m 0.008,0.508 c 0.621,0 0.992,0.511 0.992,1.367 0,0.82 -0.383,1.328 -0.992,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.836 0.375,-1.347 0.988,-1.347 z m 7.125,0.722 h -3.195 v 0.461 h 3.195 z m 0,1.133 h -3.195 v 0.465 h 3.195 z m 14.344,-0.25 0.492,1.445 h 0.688 l -1.688,-4.812 h -0.793 l -1.719,4.812 h 0.657 l 0.507,-1.445 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 3.297,-2.813 c -0.434,0 -0.832,0.199 -1.074,0.523 -0.305,0.422 -0.457,1.055 -0.457,1.942 0,1.609 0.527,2.461 1.531,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.144,-1.547 -0.457,-1.981 -0.242,-0.332 -0.633,-0.523 -1.074,-0.523 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.304,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.976 0,-1.313 0.313,-1.953 0.938,-1.953 z m 5.383,0.8 h -0.567 v -0.953 h -0.551 v 0.953 h -0.468 v 0.45 h 0.468 v 2.613 c 0,0.355 0.239,0.547 0.668,0.547 0.145,0 0.266,-0.012 0.45,-0.047 v -0.461 c -0.078,0.02 -0.153,0.027 -0.266,0.027 -0.238,0 -0.301,-0.066 -0.301,-0.312 v -2.367 h 0.567 z m 1.918,-0.101 c -0.977,0 -1.559,0.695 -1.559,1.855 0,1.168 0.582,1.856 1.566,1.856 0.977,0 1.563,-0.692 1.563,-1.828 0,-1.203 -0.566,-1.883 -1.57,-1.883 z m 0.007,0.508 c 0.622,0 0.989,0.511 0.989,1.367 0,0.82 -0.383,1.328 -0.989,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.836 0.375,-1.347 0.988,-1.347 z m 6.848,1.605 0.492,1.445 h 0.688 l -1.688,-4.812 h -0.793 l -1.718,4.812 h 0.656 l 0.508,-1.445 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 4.504,-2.719 h -2.414 l -0.351,2.547 h 0.535 c 0.269,-0.321 0.496,-0.434 0.863,-0.434 0.629,0 1.019,0.43 1.019,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.145,0.566 0.285,0.738 0.262,0.36 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.617,-1.559 -1.511,-1.559 -0.333,0 -0.594,0.086 -0.868,0.286 l 0.188,-1.309 h 1.945 z m 5.91,4.355 c -0.058,0.016 -0.086,0.016 -0.117,0.016 -0.191,0 -0.297,-0.102 -0.297,-0.274 v -2.031 c 0,-0.613 -0.449,-0.945 -1.301,-0.945 -0.507,0 -0.91,0.148 -1.148,0.402 -0.16,0.18 -0.227,0.379 -0.238,0.723 h 0.554 c 0.047,-0.426 0.297,-0.617 0.813,-0.617 0.5,0 0.769,0.187 0.769,0.515 v 0.145 c -0.003,0.238 -0.125,0.324 -0.574,0.383 -0.777,0.101 -0.894,0.129 -1.109,0.211 -0.403,0.172 -0.606,0.476 -0.606,0.925 0,0.629 0.438,1.024 1.137,1.024 0.434,0 0.785,-0.153 1.172,-0.508 0.043,0.355 0.211,0.508 0.57,0.508 0.117,0 0.192,-0.012 0.375,-0.059 z m -0.965,-0.765 c 0,0.187 -0.05,0.297 -0.214,0.449 -0.227,0.207 -0.496,0.312 -0.821,0.312 -0.429,0 -0.679,-0.207 -0.679,-0.554 0,-0.364 0.238,-0.551 0.832,-0.637 0.586,-0.078 0.699,-0.105 0.882,-0.191 z m 1.497,-2.368 v 3.457 h 0.554 v -1.906 c 0,-0.707 0.371,-1.168 0.938,-1.168 0.433,0 0.711,0.262 0.711,0.68 v 2.394 h 0.55 v -2.613 c 0,-0.574 -0.429,-0.945 -1.097,-0.945 -0.516,0 -0.844,0.199 -1.149,0.68 v -0.579 z m 6.523,-1.355 h -0.547 v 1.789 c -0.23,-0.348 -0.601,-0.535 -1.062,-0.535 -0.899,0 -1.485,0.723 -1.485,1.824 0,1.168 0.567,1.887 1.504,1.887 0.477,0 0.805,-0.18 1.102,-0.61 v 0.457 h 0.488 z m -1.516,1.77 c 0.594,0 0.969,0.523 0.969,1.355 0,0.797 -0.383,1.324 -0.961,1.324 -0.609,0 -1.012,-0.535 -1.012,-1.34 0,-0.804 0.403,-1.339 1.004,-1.339 z m 4.36,3.042 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 5.293,-4.234 c -0.434,0 -0.832,0.199 -1.074,0.523 -0.305,0.422 -0.457,1.055 -0.457,1.942 0,1.609 0.527,2.461 1.531,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.144,-1.547 -0.453,-1.981 -0.246,-0.332 -0.637,-0.523 -1.078,-0.523 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.304,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.976 0,-1.313 0.313,-1.953 0.938,-1.953 z m 5.262,0.8 h -0.567 v -0.953 h -0.547 v 0.953 h -0.468 v 0.45 h 0.468 v 2.613 c 0,0.355 0.235,0.547 0.664,0.547 0.145,0 0.266,-0.012 0.45,-0.047 v -0.461 c -0.078,0.02 -0.153,0.027 -0.262,0.027 -0.238,0 -0.305,-0.066 -0.305,-0.312 v -2.367 h 0.567 z m 1.922,-0.101 c -0.981,0 -1.559,0.695 -1.559,1.855 0,1.168 0.578,1.856 1.562,1.856 0.977,0 1.567,-0.692 1.567,-1.828 0,-1.203 -0.57,-1.883 -1.57,-1.883 z m 0.003,0.508 c 0.622,0 0.993,0.511 0.993,1.367 0,0.82 -0.383,1.328 -0.993,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.836 0.375,-1.347 0.988,-1.347 z m 4.305,3.05 h 1.856 c 1.214,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 5.309,-2.859 v 3.398 h 0.578 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 5.031,-1.281 h -2.414 l -0.351,2.547 h 0.535 c 0.269,-0.321 0.496,-0.434 0.863,-0.434 0.629,0 1.016,0.43 1.016,1.121 0,0.672 -0.387,1.082 -1.02,1.082 -0.512,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.145,0.566 0.285,0.738 0.262,0.36 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.617,-1.559 -1.511,-1.559 -0.332,0 -0.594,0.086 -0.868,0.286 l 0.188,-1.309 h 1.945 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath347)"
+             id="path806" />
+          <path
+             d="m 219.719,650.957 h 7.441 v 7.562 h -7.441 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath348)"
+             id="path807" />
+          <path
+             d="m 219.719,664.039 h 7.441 v 7.441 h -7.441 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath349)"
+             id="path808" />
+          <path
+             d="m 238.676,664.988 h -3.465 v 0.539 h 2.707 l -2.895,3.731 v 0.543 h 3.665 v -0.543 h -2.891 l 2.879,-3.715 z m 1.113,1.352 h -0.547 v 3.461 h 0.547 z m 0,-1.352 h -0.555 v 0.692 h 0.555 z m 2.367,1.254 c -0.976,0 -1.558,0.692 -1.558,1.856 0,1.168 0.582,1.855 1.566,1.855 0.977,0 1.563,-0.695 1.563,-1.828 0,-1.203 -0.567,-1.883 -1.571,-1.883 z m 0.008,0.508 c 0.621,0 0.988,0.508 0.988,1.367 0,0.817 -0.382,1.324 -0.988,1.324 -0.613,0 -0.992,-0.507 -0.992,-1.343 0,-0.84 0.379,-1.348 0.992,-1.348 z m 6.984,1.504 c 0,-0.527 -0.039,-0.844 -0.14,-1.102 -0.223,-0.566 -0.75,-0.91 -1.399,-0.91 -0.964,0 -1.582,0.735 -1.582,1.875 0,1.141 0.594,1.836 1.571,1.836 0.789,0 1.34,-0.449 1.476,-1.203 h -0.554 c -0.153,0.457 -0.461,0.691 -0.903,0.691 -0.351,0 -0.648,-0.156 -0.832,-0.445 -0.133,-0.199 -0.18,-0.398 -0.183,-0.742 z m -2.535,-0.449 c 0.047,-0.637 0.434,-1.055 0.989,-1.055 0.562,0 0.953,0.438 0.953,1.055 z m 4.797,0.207 1.16,-1.672 h -0.621 l -0.832,1.254 -0.832,-1.254 h -0.625 l 1.156,1.699 -1.222,1.762 h 0.629 l 0.875,-1.328 0.867,1.328 h 0.637 z m 2.988,-1.672 h -0.566 v -0.949 h -0.551 v 0.949 h -0.469 v 0.449 h 0.469 v 2.613 c 0,0.36 0.239,0.551 0.668,0.551 0.145,0 0.266,-0.015 0.449,-0.047 v -0.465 c -0.078,0.024 -0.152,0.028 -0.265,0.028 -0.235,0 -0.301,-0.067 -0.301,-0.309 v -2.371 h 0.566 z m 3.512,1.914 c 0,-0.527 -0.039,-0.844 -0.137,-1.102 -0.226,-0.566 -0.753,-0.91 -1.402,-0.91 -0.961,0 -1.582,0.735 -1.582,1.875 0,1.141 0.594,1.836 1.57,1.836 0.793,0 1.34,-0.449 1.477,-1.203 h -0.555 c -0.148,0.457 -0.461,0.691 -0.902,0.691 -0.352,0 -0.649,-0.156 -0.832,-0.445 -0.133,-0.199 -0.18,-0.398 -0.184,-0.742 z m -2.535,-0.449 c 0.047,-0.637 0.437,-1.055 0.992,-1.055 0.559,0 0.949,0.438 0.949,1.055 z m 3.332,-1.465 v 3.461 h 0.555 v -1.91 c 0,-0.703 0.367,-1.168 0.937,-1.168 0.434,0 0.711,0.265 0.711,0.679 v 2.399 h 0.547 v -2.613 c 0,-0.575 -0.426,-0.946 -1.094,-0.946 -0.515,0 -0.843,0.199 -1.148,0.68 v -0.582 z m 6.027,0.965 c -0.007,-0.68 -0.453,-1.063 -1.254,-1.063 -0.804,0 -1.324,0.414 -1.324,1.055 0,0.543 0.278,0.801 1.094,0.996 l 0.516,0.129 c 0.382,0.09 0.535,0.23 0.535,0.473 0,0.332 -0.324,0.546 -0.805,0.546 -0.297,0 -0.551,-0.086 -0.687,-0.23 -0.086,-0.098 -0.125,-0.195 -0.161,-0.441 h -0.578 c 0.024,0.8 0.473,1.183 1.379,1.183 0.871,0 1.426,-0.43 1.426,-1.098 0,-0.515 -0.293,-0.796 -0.977,-0.964 l -0.527,-0.125 c -0.449,-0.106 -0.641,-0.25 -0.641,-0.493 0,-0.324 0.282,-0.523 0.731,-0.523 0.441,0 0.68,0.191 0.695,0.555 z m 1.461,-0.965 h -0.547 v 3.461 h 0.547 z m 0,-1.352 h -0.554 v 0.692 h 0.554 z m 2.239,1.254 c -0.977,0 -1.559,0.692 -1.559,1.856 0,1.168 0.582,1.855 1.566,1.855 0.977,0 1.563,-0.695 1.563,-1.828 0,-1.203 -0.566,-1.883 -1.57,-1.883 z m 0.007,0.508 c 0.618,0 0.989,0.508 0.989,1.367 0,0.817 -0.383,1.324 -0.989,1.324 -0.617,0 -0.992,-0.507 -0.992,-1.343 0,-0.84 0.375,-1.348 0.992,-1.348 z m 2.258,-0.41 v 3.461 h 0.555 v -1.91 c 0,-0.703 0.371,-1.168 0.937,-1.168 0.438,0 0.715,0.265 0.715,0.679 v 2.399 h 0.547 v -2.613 c 0,-0.575 -0.43,-0.946 -1.098,-0.946 -0.511,0 -0.843,0.199 -1.148,0.68 v -0.582 z m 8.582,1.129 h -3.191 v 0.465 h 3.191 z m 0,1.136 h -3.191 v 0.461 h 3.191 z m 36.188,-0.25 0.492,1.446 h 0.687 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 4.769,-1.57 c -0.113,-0.782 -0.613,-1.243 -1.328,-1.243 -0.515,0 -0.976,0.25 -1.254,0.68 -0.296,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.313 0.395,1.734 0.254,0.391 0.66,0.598 1.176,0.598 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.878 -0.594,-1.5 -1.43,-1.5 -0.464,0 -0.828,0.172 -1.078,0.524 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.696,0.262 0.785,0.727 z m -1.406,1.101 c 0.563,0 0.91,0.395 0.91,1.027 0,0.602 -0.394,1.04 -0.929,1.04 -0.543,0 -0.95,-0.458 -0.95,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 5.317,-1.031 h -0.567 v -0.949 h -0.551 v 0.949 h -0.468 v 0.449 h 0.468 v 2.613 c 0,0.36 0.239,0.551 0.668,0.551 0.145,0 0.266,-0.015 0.45,-0.047 v -0.465 c -0.079,0.024 -0.153,0.028 -0.266,0.028 -0.238,0 -0.301,-0.067 -0.301,-0.309 v -2.371 h 0.567 z m 1.921,-0.098 c -0.976,0 -1.558,0.692 -1.558,1.856 0,1.168 0.582,1.855 1.562,1.855 0.981,0 1.567,-0.695 1.567,-1.828 0,-1.203 -0.567,-1.883 -1.571,-1.883 z m 0.008,0.508 c 0.617,0 0.989,0.508 0.989,1.367 0,0.817 -0.383,1.324 -0.989,1.324 -0.617,0 -0.992,-0.507 -0.992,-1.343 0,-0.84 0.375,-1.348 0.992,-1.348 z m 6.844,1.605 0.496,1.446 h 0.688 l -1.692,-4.813 h -0.793 l -1.715,4.813 h 0.653 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 3.945,-0.555 c 0.489,-0.297 0.641,-0.535 0.641,-0.984 0,-0.75 -0.574,-1.274 -1.406,-1.274 -0.824,0 -1.406,0.524 -1.406,1.266 0,0.457 0.152,0.687 0.632,0.992 -0.535,0.27 -0.796,0.66 -0.796,1.188 0,0.871 0.64,1.48 1.57,1.48 0.922,0 1.57,-0.609 1.57,-1.48 0,-0.528 -0.266,-0.918 -0.805,-1.188 z m -0.765,-1.742 c 0.496,0 0.812,0.297 0.812,0.773 0,0.446 -0.324,0.743 -0.812,0.743 -0.496,0 -0.813,-0.297 -0.813,-0.758 0,-0.461 0.317,-0.758 0.813,-0.758 z m 0,2.008 c 0.582,0 0.976,0.383 0.976,0.933 0,0.575 -0.39,0.954 -0.992,0.954 -0.566,0 -0.961,-0.391 -0.961,-0.946 0,-0.566 0.387,-0.941 0.977,-0.941 z m 7.234,1.926 c -0.058,0.011 -0.086,0.011 -0.117,0.011 -0.191,0 -0.297,-0.097 -0.297,-0.269 v -2.031 c 0,-0.618 -0.449,-0.946 -1.301,-0.946 -0.507,0 -0.91,0.145 -1.148,0.403 -0.156,0.179 -0.223,0.375 -0.238,0.718 h 0.554 c 0.047,-0.422 0.297,-0.613 0.813,-0.613 0.5,0 0.773,0.184 0.773,0.516 v 0.144 c -0.008,0.238 -0.125,0.324 -0.574,0.383 -0.781,0.098 -0.898,0.125 -1.109,0.211 -0.403,0.172 -0.61,0.476 -0.61,0.926 0,0.625 0.438,1.023 1.137,1.023 0.437,0 0.785,-0.152 1.176,-0.512 0.039,0.36 0.211,0.512 0.566,0.512 0.121,0 0.192,-0.015 0.375,-0.062 z m -0.961,-0.766 c 0,0.184 -0.054,0.297 -0.219,0.449 -0.222,0.203 -0.496,0.309 -0.82,0.309 -0.426,0 -0.68,-0.203 -0.68,-0.555 0,-0.363 0.239,-0.547 0.833,-0.633 0.589,-0.078 0.699,-0.105 0.886,-0.191 z m 1.492,-2.371 v 3.461 h 0.555 v -1.91 c 0,-0.703 0.371,-1.168 0.938,-1.168 0.437,0 0.714,0.265 0.714,0.679 v 2.399 h 0.547 v -2.613 c 0,-0.575 -0.429,-0.946 -1.093,-0.946 -0.516,0 -0.848,0.199 -1.149,0.68 v -0.582 z m 6.528,-1.352 h -0.547 v 1.789 c -0.234,-0.351 -0.602,-0.535 -1.063,-0.535 -0.898,0 -1.488,0.719 -1.488,1.82 0,1.168 0.57,1.891 1.508,1.891 0.473,0 0.805,-0.18 1.101,-0.609 v 0.457 h 0.489 z m -1.52,1.77 c 0.594,0 0.973,0.519 0.973,1.351 0,0.801 -0.383,1.329 -0.965,1.329 -0.609,0 -1.012,-0.536 -1.012,-1.34 0,-0.805 0.403,-1.34 1.004,-1.34 z m 4.36,3.043 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.871 0,1.219 -0.504,1.86 -1.453,1.86 z m 5.187,-2.856 v 3.399 h 0.582 v -4.774 h -0.382 c -0.203,0.735 -0.336,0.832 -1.235,0.95 v 0.425 z m 5.18,-0.132 c -0.113,-0.782 -0.613,-1.243 -1.328,-1.243 -0.516,0 -0.977,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.113,1.313 0.395,1.734 0.254,0.391 0.66,0.598 1.176,0.598 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.878 -0.594,-1.5 -1.43,-1.5 -0.465,0 -0.828,0.172 -1.078,0.524 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.695,0.262 0.785,0.727 z m -1.406,1.101 c 0.562,0 0.91,0.395 0.91,1.027 0,0.602 -0.395,1.04 -0.93,1.04 -0.543,0 -0.949,-0.458 -0.949,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 5.316,-1.031 h -0.57 v -0.949 h -0.547 v 0.949 h -0.469 v 0.449 h 0.469 v 2.613 c 0,0.36 0.238,0.551 0.668,0.551 0.145,0 0.262,-0.015 0.449,-0.047 v -0.465 c -0.082,0.024 -0.152,0.028 -0.265,0.028 -0.239,0 -0.305,-0.067 -0.305,-0.309 v -2.371 h 0.57 z m 1.922,-0.098 c -0.98,0 -1.558,0.692 -1.558,1.856 0,1.168 0.578,1.855 1.562,1.855 0.977,0 1.566,-0.695 1.566,-1.828 0,-1.203 -0.57,-1.883 -1.57,-1.883 z m 0.004,0.508 c 0.621,0 0.992,0.508 0.992,1.367 0,0.817 -0.383,1.324 -0.992,1.324 -0.613,0 -0.988,-0.507 -0.988,-1.343 0,-0.84 0.375,-1.348 0.988,-1.348 z m 4.305,3.051 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.86 -1.453,1.86 z m 6.91,-4.137 h -3.129 v 0.574 h 2.528 c -1.114,1.59 -1.571,2.567 -1.922,4.106 h 0.621 c 0.258,-1.5 0.847,-2.785 1.902,-4.192 z m 3.508,4.106 h -2.461 c 0.059,-0.399 0.269,-0.649 0.844,-0.997 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.399 -0.156,-0.766 -0.433,-1.024 -0.278,-0.253 -0.622,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.028 h 0.582 c 0.02,-0.321 0.059,-0.512 0.141,-0.672 0.148,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.382 -0.214,0.711 -0.632,0.949 l -0.606,0.359 c -0.976,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath350)"
+             id="path809" />
+          <path
+             d="m 205.559,614.117 h 40.922 v 26.281 h -40.922 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.577;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath351)"
+             id="path810" />
+          <path
+             d="m 222.41,619.145 v 4.054 c 0,0.778 -0.562,1.25 -1.488,1.25 -0.426,0 -0.777,-0.101 -1.051,-0.301 -0.285,-0.218 -0.422,-0.515 -0.422,-0.949 v -4.054 h -0.738 v 4.054 c 0,1.172 0.84,1.903 2.211,1.903 1.355,0 2.226,-0.747 2.226,-1.903 v -4.054 z m 5.988,1.695 c 0,-0.399 -0.023,-0.508 -0.148,-0.778 -0.316,-0.664 -0.992,-1.011 -1.965,-1.011 -1.265,0 -2.051,0.648 -2.051,1.691 0,0.707 0.371,1.149 1.133,1.348 l 1.434,0.379 c 0.734,0.191 1.062,0.484 1.062,0.937 0,0.309 -0.168,0.625 -0.414,0.797 -0.23,0.168 -0.594,0.246 -1.062,0.246 -0.633,0 -1.051,-0.148 -1.328,-0.48 -0.215,-0.254 -0.309,-0.531 -0.301,-0.887 h -0.699 c 0.007,0.527 0.113,0.879 0.339,1.195 0.399,0.547 1.063,0.825 1.942,0.825 0.691,0 1.254,-0.161 1.625,-0.446 0.387,-0.308 0.633,-0.824 0.633,-1.324 0,-0.711 -0.442,-1.234 -1.227,-1.449 l -1.449,-0.387 c -0.699,-0.191 -0.953,-0.41 -0.953,-0.855 0,-0.586 0.515,-0.973 1.293,-0.973 0.918,0 1.433,0.41 1.441,1.172 z m 1.188,4.078 h 2.605 c 0.547,0 0.95,-0.152 1.258,-0.484 0.285,-0.301 0.446,-0.711 0.446,-1.164 0,-0.696 -0.317,-1.118 -1.055,-1.403 0.531,-0.246 0.801,-0.664 0.801,-1.258 0,-0.429 -0.157,-0.793 -0.461,-1.062 -0.309,-0.277 -0.696,-0.402 -1.25,-0.402 h -2.344 z m 0.738,-3.285 v -1.84 h 1.426 c 0.41,0 0.641,0.055 0.836,0.207 0.207,0.156 0.32,0.395 0.32,0.711 0,0.316 -0.113,0.555 -0.32,0.715 -0.195,0.148 -0.426,0.207 -0.836,0.207 z m 0,2.637 v -1.989 h 1.797 c 0.649,0 1.035,0.371 1.035,0.996 0,0.618 -0.386,0.993 -1.035,0.993 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath352)"
+             id="path811" />
+          <path
+             d="m 220.641,628.531 c -1.657,0 -2.782,1.219 -2.782,3.024 0,1.812 1.118,3.027 2.789,3.027 0.704,0 1.325,-0.215 1.79,-0.609 0.624,-0.532 1,-1.426 1,-2.371 0,-1.86 -1.102,-3.071 -2.797,-3.071 z m 0,0.649 c 1.25,0 2.058,0.941 2.058,2.406 0,1.394 -0.832,2.344 -2.051,2.344 -1.234,0 -2.05,-0.95 -2.05,-2.375 0,-1.426 0.816,-2.375 2.043,-2.375 z m 5.843,0.093 h 1.895 v -0.648 h -4.531 v 0.648 h 1.902 v 5.125 h 0.734 z m 7.61,2.075 h -2.406 V 632 h 1.757 v 0.156 c 0,1.032 -0.757,1.774 -1.812,1.774 -0.586,0 -1.117,-0.211 -1.457,-0.586 -0.383,-0.41 -0.61,-1.102 -0.61,-1.813 0,-1.418 0.809,-2.351 2.028,-2.351 0.879,0 1.511,0.449 1.672,1.195 h 0.75 c -0.207,-1.172 -1.094,-1.844 -2.414,-1.844 -0.707,0 -1.278,0.18 -1.727,0.551 -0.676,0.555 -1.047,1.453 -1.047,2.488 0,1.774 1.086,3.012 2.645,3.012 0.785,0 1.402,-0.293 1.972,-0.922 l 0.184,0.77 h 0.465 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath353)"
+             id="path812" />
+          <path
+             d="m 350.766,183.777 h 41.043 v 26.164 h -41.043 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.577;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath354)"
+             id="path813" />
+          <path
+             d="m 367.617,188.805 v 4.058 c 0,0.774 -0.562,1.25 -1.488,1.25 -0.43,0 -0.777,-0.101 -1.055,-0.301 -0.285,-0.222 -0.418,-0.515 -0.418,-0.949 v -4.058 h -0.738 v 4.058 c 0,1.172 0.84,1.899 2.211,1.899 1.355,0 2.226,-0.742 2.226,-1.899 v -4.058 z m 5.988,1.695 c 0,-0.395 -0.023,-0.504 -0.148,-0.773 -0.316,-0.668 -0.992,-1.016 -1.965,-1.016 -1.269,0 -2.051,0.648 -2.051,1.695 0,0.703 0.371,1.149 1.133,1.348 l 1.434,0.379 c 0.734,0.191 1.058,0.484 1.058,0.933 0,0.309 -0.164,0.625 -0.41,0.801 -0.23,0.168 -0.594,0.246 -1.062,0.246 -0.633,0 -1.051,-0.152 -1.328,-0.484 -0.215,-0.254 -0.313,-0.531 -0.301,-0.887 h -0.699 c 0.007,0.531 0.109,0.879 0.339,1.196 0.399,0.546 1.063,0.824 1.942,0.824 0.687,0 1.25,-0.157 1.625,-0.442 0.387,-0.308 0.633,-0.824 0.633,-1.324 0,-0.711 -0.446,-1.234 -1.227,-1.449 l -1.449,-0.387 c -0.699,-0.191 -0.953,-0.414 -0.953,-0.855 0,-0.586 0.515,-0.977 1.293,-0.977 0.918,0 1.433,0.414 1.441,1.172 z m 1.188,4.082 h 2.605 c 0.547,0 0.95,-0.152 1.258,-0.484 0.285,-0.301 0.446,-0.715 0.446,-1.164 0,-0.7 -0.317,-1.118 -1.055,-1.403 0.531,-0.246 0.801,-0.664 0.801,-1.258 0,-0.429 -0.16,-0.793 -0.461,-1.062 -0.309,-0.277 -0.696,-0.406 -1.25,-0.406 h -2.344 z m 0.734,-3.289 v -1.836 h 1.426 c 0.414,0 0.645,0.055 0.84,0.203 0.207,0.16 0.316,0.399 0.316,0.715 0,0.316 -0.109,0.555 -0.316,0.711 -0.195,0.152 -0.426,0.207 -0.84,0.207 z m 0,2.637 v -1.989 h 1.801 c 0.649,0 1.035,0.375 1.035,1 0,0.618 -0.386,0.989 -1.035,0.989 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath355)"
+             id="path814" />
+          <path
+             d="m 361.004,199.863 c 0,-0.398 -0.024,-0.508 -0.149,-0.777 -0.316,-0.664 -0.988,-1.016 -1.964,-1.016 -1.266,0 -2.051,0.653 -2.051,1.696 0,0.707 0.371,1.148 1.133,1.347 l 1.433,0.379 c 0.735,0.192 1.063,0.485 1.063,0.938 0,0.308 -0.168,0.625 -0.414,0.797 -0.231,0.168 -0.594,0.246 -1.063,0.246 -0.633,0 -1.051,-0.149 -1.328,-0.485 -0.215,-0.25 -0.309,-0.527 -0.301,-0.886 h -0.699 c 0.008,0.531 0.113,0.878 0.344,1.199 0.394,0.543 1.058,0.82 1.937,0.82 0.692,0 1.254,-0.156 1.625,-0.441 0.387,-0.309 0.633,-0.825 0.633,-1.325 0,-0.71 -0.441,-1.234 -1.226,-1.449 l -1.45,-0.386 c -0.699,-0.192 -0.949,-0.415 -0.949,-0.856 0,-0.586 0.512,-0.976 1.289,-0.976 0.918,0 1.434,0.414 1.442,1.175 z m 3.336,-1.047 h 1.894 v -0.648 h -4.531 v 0.648 h 1.902 v 5.125 h 0.735 z m 4.254,2.653 h -1.887 v 0.57 h 1.887 z m 1.64,-3.301 h -0.738 v 5.773 h 3.59 v -0.648 h -2.852 z m 4.606,0 h -0.742 v 5.773 h 0.742 z m 5.75,0 h -0.695 v 4.719 l -3.02,-4.719 h -0.797 v 5.773 h 0.695 v -4.683 l 2.985,4.683 h 0.832 z m 1.887,3.754 0.941,-0.945 2.035,2.964 h 0.875 l -2.379,-3.421 2.352,-2.352 h -0.949 l -2.875,2.922 v -2.922 h -0.735 v 5.773 h 0.735 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath356)"
+             id="path815" />
+          <path
+             d="m 182.266,519.434 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.727 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.86 -1.449,1.86 z m 6.773,-2.989 c -0.109,-0.777 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.976,0.254 -1.254,0.68 -0.297,0.469 -0.426,1.051 -0.426,1.914 0,0.808 0.114,1.316 0.399,1.738 0.25,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.078,0.524 0.008,-1.184 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.265 0.789,0.726 z m -1.406,1.102 c 0.563,0 0.914,0.398 0.914,1.031 0,0.602 -0.398,1.035 -0.933,1.035 -0.539,0 -0.95,-0.457 -0.95,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z m 4.856,-2.25 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.324 0.492,-0.434 0.863,-0.434 0.629,0 1.016,0.426 1.016,1.121 0,0.672 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.579 c 0.079,0.383 0.145,0.567 0.282,0.738 0.265,0.356 0.738,0.563 1.269,0.563 0.942,0 1.602,-0.688 1.602,-1.676 0,-0.926 -0.614,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.95 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath357)"
+             id="path816" />
+          <path
+             d="m 182.387,511.992 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.488 -0.738,-2.402 -1.957,-2.402 h -1.855 z M 183,511.453 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.773,-2.992 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.511,0 -0.976,0.25 -1.254,0.679 -0.296,0.469 -0.421,1.047 -0.421,1.914 0,0.805 0.113,1.313 0.398,1.735 0.25,0.39 0.66,0.594 1.172,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.496 -1.43,-1.496 -0.464,0 -0.828,0.172 -1.078,0.519 0.008,-1.179 0.379,-1.836 1.043,-1.836 0.41,0 0.696,0.266 0.785,0.727 z m -1.406,1.101 c 0.563,0 0.91,0.399 0.91,1.032 0,0.601 -0.394,1.035 -0.929,1.035 -0.543,0 -0.95,-0.453 -0.95,-1.063 0,-0.593 0.395,-1.004 0.969,-1.004 z m 5,-1.101 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.516,0 -0.977,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.047 -0.422,1.914 0,0.805 0.114,1.313 0.395,1.735 0.25,0.39 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.519 0.008,-1.179 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.101 c 0.559,0 0.91,0.399 0.91,1.032 0,0.601 -0.394,1.035 -0.93,1.035 -0.543,0 -0.953,-0.453 -0.953,-1.063 0,-0.593 0.399,-1.004 0.973,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath358)"
+             id="path817" />
+          <path
+             d="m 182.266,504.551 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z m 6.773,-2.992 c -0.109,-0.778 -0.613,-1.239 -1.324,-1.239 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.426,1.047 -0.426,1.914 0,0.805 0.114,1.313 0.399,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.664 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.078,0.52 0.008,-1.18 0.379,-1.832 1.043,-1.832 0.41,0 0.695,0.262 0.789,0.723 z m -1.406,1.105 c 0.563,0 0.914,0.395 0.914,1.027 0,0.602 -0.398,1.036 -0.933,1.036 -0.539,0 -0.95,-0.454 -0.95,-1.063 0,-0.594 0.395,-1 0.969,-1 z m 5.145,-2.254 h -3.129 v 0.574 h 2.527 c -1.113,1.594 -1.57,2.571 -1.918,4.106 h 0.617 c 0.258,-1.496 0.848,-2.785 1.903,-4.192 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath359)"
+             id="path818" />
+          <path
+             d="m 183.836,494.57 h -2.004 v 0.543 h 1.465 v 0.129 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.93,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.18 0.672,-1.961 1.692,-1.961 0.73,0 1.258,0.375 1.391,0.996 h 0.628 c -0.171,-0.977 -0.914,-1.535 -2.015,-1.535 -0.586,0 -1.063,0.148 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.48 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 H 188 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.691 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.871 0,1.219 -0.5,1.859 -1.449,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath360)"
+             id="path819" />
+          <path
+             d="m 182.266,489.672 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.727 h 1.137 c 0.949,0 1.449,0.641 1.449,1.868 0,1.218 -0.5,1.859 -1.449,1.859 z m 6.773,-2.988 c -0.109,-0.778 -0.613,-1.243 -1.324,-1.243 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.426,1.051 -0.426,1.914 0,0.805 0.114,1.317 0.399,1.738 0.25,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.171 -1.078,0.523 0.008,-1.184 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.266 0.789,0.727 z m -1.406,1.101 c 0.563,0 0.914,0.395 0.914,1.031 0,0.598 -0.398,1.036 -0.933,1.036 -0.539,0 -0.95,-0.457 -0.95,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 4.293,-0.086 c 0.488,-0.297 0.641,-0.535 0.641,-0.984 0,-0.75 -0.575,-1.274 -1.407,-1.274 -0.824,0 -1.406,0.524 -1.406,1.27 0,0.453 0.153,0.684 0.633,0.988 -0.531,0.27 -0.797,0.66 -0.797,1.188 0,0.871 0.641,1.48 1.57,1.48 0.926,0 1.571,-0.609 1.571,-1.48 0,-0.528 -0.262,-0.918 -0.805,-1.188 z m -0.766,-1.742 c 0.497,0 0.813,0.297 0.813,0.774 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.762 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.008 c 0.582,0 0.977,0.383 0.977,0.937 0,0.575 -0.387,0.95 -0.988,0.95 -0.571,0 -0.965,-0.391 -0.965,-0.946 0,-0.566 0.391,-0.941 0.976,-0.941 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath361)"
+             id="path820" />
+          <path
+             d="m 182.387,482.23 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z M 183,481.691 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.773,-2.992 c -0.113,-0.777 -0.613,-1.242 -1.328,-1.242 -0.511,0 -0.976,0.254 -1.254,0.68 -0.296,0.468 -0.421,1.051 -0.421,1.914 0,0.808 0.113,1.316 0.398,1.738 0.25,0.391 0.66,0.594 1.172,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.464,0 -0.828,0.172 -1.078,0.524 0.008,-1.18 0.379,-1.836 1.043,-1.836 0.41,0 0.696,0.265 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.398 0.91,1.031 0,0.602 -0.394,1.035 -0.929,1.035 -0.543,0 -0.95,-0.453 -0.95,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z m 2.063,1.34 c 0.109,0.781 0.613,1.242 1.324,1.242 0.523,0 0.984,-0.25 1.262,-0.68 0.289,-0.469 0.422,-1.051 0.422,-1.914 0,-0.805 -0.118,-1.312 -0.395,-1.734 -0.258,-0.391 -0.668,-0.598 -1.184,-0.598 -0.89,0 -1.531,0.668 -1.531,1.594 0,0.875 0.594,1.496 1.442,1.496 0.441,0 0.769,-0.156 1.066,-0.52 -0.004,1.188 -0.375,1.84 -1.039,1.84 -0.41,0 -0.695,-0.262 -0.789,-0.726 z m 1.425,-3.172 c 0.54,0 0.95,0.453 0.95,1.066 0,0.59 -0.395,0.996 -0.969,0.996 -0.563,0 -0.914,-0.394 -0.914,-1.027 0,-0.602 0.39,-1.035 0.933,-1.035 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath362)"
+             id="path821" />
+          <path
+             d="m 182.387,474.789 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.403 -1.957,-2.403 h -1.855 z M 183,474.25 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.918,-4.141 h -3.129 v 0.575 h 2.527 c -1.113,1.593 -1.57,2.57 -1.918,4.105 h 0.622 c 0.253,-1.496 0.843,-2.785 1.898,-4.191 z m 1.977,-0.089 c -0.438,0 -0.833,0.195 -1.079,0.519 -0.3,0.422 -0.453,1.059 -0.453,1.941 0,1.61 0.528,2.461 1.532,2.461 0.988,0 1.531,-0.851 1.531,-2.421 0,-0.922 -0.145,-1.543 -0.457,-1.981 -0.242,-0.328 -0.633,-0.519 -1.074,-0.519 z m 0,0.511 c 0.625,0 0.937,0.641 0.937,1.938 0,1.359 -0.305,1.992 -0.953,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.316 0.309,-1.957 0.938,-1.957 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath363)"
+             id="path822" />
+          <path
+             d="m 182.266,467.352 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.411 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z m 6.918,-4.137 h -3.129 v 0.574 h 2.531 c -1.117,1.59 -1.574,2.566 -1.922,4.106 h 0.621 c 0.258,-1.5 0.844,-2.79 1.899,-4.192 z m 1.871,1.277 v 3.403 h 0.582 v -4.774 h -0.383 c -0.207,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath364)"
+             id="path823" />
+          <path
+             d="m 182.266,459.91 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.636 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 6.918,-4.137 h -3.129 v 0.575 h 2.531 c -1.117,1.59 -1.574,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.899,-4.191 z m 3.5,4.106 h -2.461 c 0.059,-0.398 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.364 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.468 0.804,-0.468 0.528,0 0.926,0.382 0.926,0.898 0,0.383 -0.218,0.715 -0.633,0.949 l -0.609,0.36 c -0.976,0.558 -1.262,1.007 -1.312,2.05 h 3.113 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath365)"
+             id="path824" />
+          <path
+             d="m 185.344,399.906 1.672,-4.812 h -0.653 l -1.336,4.074 -1.41,-4.074 h -0.66 l 1.727,4.812 z m 3.133,-4.812 h -0.618 v 4.812 h 0.618 z m 4.785,0 h -0.582 v 3.933 l -2.512,-3.933 H 189.5 v 4.812 h 0.582 v -3.902 l 2.488,3.902 h 0.692 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath366)"
+             id="path825" />
+          <path
+             d="m 183.836,389.926 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.859 -0.633,1.48 -1.512,1.48 -0.488,0 -0.93,-0.18 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.183 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.153 -1.438,0.465 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.765 l 0.152,0.64 h 0.387 z m 4.746,-2.27 H 188 v 3.934 l -2.516,-3.934 h -0.664 v 4.809 h 0.578 v -3.899 l 2.489,3.899 h 0.695 z m 1.004,4.809 h 1.855 c 1.215,0 1.957,-0.91 1.957,-2.406 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath367)"
+             id="path826" />
+          <path
+             d="m 183.836,382.484 h -2.004 v 0.543 h 1.465 v 0.129 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.93,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.184 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.152 -1.438,0.465 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.48 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 H 188 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.578 v -3.902 l 2.489,3.902 h 0.695 z m 1.004,4.812 h 1.855 c 1.215,0 1.957,-0.914 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.543 v -3.73 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath368)"
+             id="path827" />
+          <path
+             d="m 185.32,375.824 h -1.363 v -1.367 h -0.465 v 1.367 h -1.363 v 0.461 h 1.363 v 1.367 h 0.465 v -1.367 h 1.363 z m 3.461,-2.918 h -2.418 l -0.347,2.547 h 0.531 c 0.273,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.016,0.429 1.016,1.125 0,0.671 -0.391,1.082 -1.024,1.082 -0.508,0 -0.816,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.382 0.149,0.566 0.285,0.738 0.266,0.355 0.739,0.562 1.266,0.562 0.945,0 1.605,-0.687 1.605,-1.679 0,-0.922 -0.613,-1.555 -1.511,-1.555 -0.328,0 -0.594,0.086 -0.864,0.281 l 0.184,-1.305 h 1.949 z m 3.164,4.68 1.668,-4.813 h -0.652 l -1.332,4.075 -1.414,-4.075 h -0.66 l 1.73,4.813 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath369)"
+             id="path828" />
+          <path
+             d="m 181.723,368.383 h -1.368 v -1.367 h -0.46 v 1.367 h -1.368 v 0.461 h 1.368 v 1.367 h 0.46 v -1.367 h 1.368 z m 1.773,-0.438 h 0.316 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.363,0.965 -0.961,0.965 -0.64,0 -0.953,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.242,0.464 0.699,0.695 1.34,0.695 0.965,0 1.582,-0.582 1.582,-1.485 0,-0.609 -0.23,-0.937 -0.789,-1.136 0.434,-0.18 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.317 -1.426,-1.317 -0.945,0 -1.445,0.531 -1.464,1.539 h 0.582 c 0.004,-0.289 0.031,-0.457 0.105,-0.601 0.129,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.312 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.161,0.067 -0.372,0.094 -0.774,0.098 z m 4.731,2.2 1.668,-4.813 h -0.653 l -1.336,4.074 -1.41,-4.074 h -0.66 l 1.73,4.813 z m 3.308,-2.2 h 0.317 c 0.636,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.633 0.203,0.844 0.246,0.464 0.699,0.695 1.34,0.695 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.609 -0.23,-0.937 -0.793,-1.136 0.437,-0.18 0.652,-0.508 0.652,-0.988 0,-0.821 -0.531,-1.317 -1.425,-1.317 -0.942,0 -1.446,0.531 -1.465,1.539 h 0.582 c 0.008,-0.289 0.031,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.312 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.161,0.067 -0.371,0.094 -0.774,0.098 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath370)"
+             id="path829" />
+          <path
+             d="m 173.066,360.633 h 1.582 c 0.547,0 0.793,0.262 0.793,0.855 l -0.007,0.43 c 0,0.297 0.054,0.59 0.14,0.785 h 0.742 v -0.152 c -0.23,-0.156 -0.273,-0.328 -0.289,-0.969 -0.007,-0.793 -0.132,-1.031 -0.652,-1.254 0.539,-0.269 0.758,-0.594 0.758,-1.148 0,-0.832 -0.516,-1.289 -1.465,-1.289 h -2.219 v 4.812 h 0.613 z m 0,-0.543 v -1.656 h 1.485 c 0.344,0 0.539,0.054 0.691,0.183 0.164,0.141 0.25,0.36 0.25,0.641 0,0.574 -0.289,0.832 -0.941,0.832 z m 4.782,0.422 h 2.621 v -0.539 h -2.621 v -1.539 h 2.718 v -0.543 h -3.332 v 4.812 h 3.45 v -0.539 h -2.836 z m 7.047,-1.207 c 0,-0.328 -0.02,-0.422 -0.125,-0.649 -0.266,-0.551 -0.829,-0.844 -1.641,-0.844 -1.055,0 -1.707,0.543 -1.707,1.415 0,0.585 0.308,0.957 0.941,1.121 l 1.196,0.316 c 0.613,0.16 0.886,0.402 0.886,0.777 0,0.258 -0.14,0.524 -0.343,0.668 -0.192,0.141 -0.497,0.207 -0.887,0.207 -0.527,0 -0.875,-0.128 -1.106,-0.406 -0.179,-0.211 -0.257,-0.441 -0.254,-0.738 h -0.578 c 0.004,0.441 0.09,0.734 0.282,0.996 0.332,0.457 0.886,0.687 1.617,0.687 0.574,0 1.043,-0.132 1.355,-0.371 0.321,-0.254 0.528,-0.683 0.528,-1.101 0,-0.594 -0.371,-1.028 -1.024,-1.207 l -1.207,-0.324 c -0.582,-0.157 -0.793,-0.344 -0.793,-0.711 0,-0.489 0.43,-0.813 1.074,-0.813 0.766,0 1.196,0.344 1.203,0.977 z m 1.71,1.207 h 2.622 v -0.539 h -2.622 v -1.539 h 2.719 v -0.543 h -3.332 v 4.812 h 3.453 v -0.539 h -2.84 z m 5.45,-2.078 h 1.578 v -0.543 h -3.778 v 0.543 h 1.586 v 4.269 h 0.614 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath371)"
+             id="path830" />
+          <path
+             d="m 174.918,350.453 h -0.621 v 4.809 h 0.621 z m 3.086,-0.082 c -1.379,0 -2.316,1.02 -2.316,2.524 0,1.511 0.929,2.519 2.324,2.519 0.586,0 1.101,-0.176 1.492,-0.508 0.519,-0.441 0.832,-1.187 0.832,-1.972 0,-1.551 -0.918,-2.563 -2.332,-2.563 z m 0,0.543 c 1.043,0 1.715,0.785 1.715,2.008 0,1.16 -0.692,1.953 -1.707,1.953 -1.032,0 -1.711,-0.793 -1.711,-1.98 0,-1.188 0.679,-1.981 1.703,-1.981 z m 3.82,2.277 h 1.586 c 0.547,0 0.789,0.262 0.789,0.86 l -0.004,0.426 c 0,0.296 0.051,0.589 0.137,0.785 h 0.746 v -0.149 c -0.23,-0.16 -0.277,-0.332 -0.289,-0.972 -0.008,-0.793 -0.133,-1.028 -0.656,-1.254 0.543,-0.27 0.762,-0.594 0.762,-1.149 0,-0.832 -0.516,-1.285 -1.465,-1.285 h -2.219 v 4.809 h 0.613 z m 0,-0.543 v -1.656 h 1.485 c 0.343,0 0.543,0.055 0.695,0.188 0.164,0.136 0.25,0.355 0.25,0.636 0,0.575 -0.289,0.832 -0.945,0.832 z m 4.66,0.422 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.809 h 3.453 v -0.539 h -2.84 z m 4.442,0 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.539 h -3.227 v 4.809 h 0.614 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath372)"
+             id="path831" />
+          <path
+             d="m 188.461,343.012 h -0.582 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.691 z m 4.906,1.492 c -0.191,-1.059 -0.797,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.203 -1.524,0.597 -0.437,0.477 -0.672,1.164 -0.672,1.942 0,0.793 0.243,1.472 0.692,1.941 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.637 1.981,-1.911 h -0.633 c -0.051,0.332 -0.117,0.555 -0.219,0.746 -0.195,0.399 -0.605,0.622 -1.121,0.622 -0.957,0 -1.562,-0.766 -1.562,-1.969 0,-1.235 0.574,-1.992 1.511,-1.992 0.387,0 0.75,0.113 0.95,0.304 0.179,0.164 0.277,0.364 0.347,0.727 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath373)"
+             id="path832" />
+          <path
+             d="m 188.766,450.664 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 4.625,-2.718 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.325 0.496,-0.438 0.864,-0.438 0.628,0 1.019,0.43 1.019,1.125 0,0.672 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.566 0.285,0.738 0.261,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.613,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.286 l 0.187,-1.305 h 1.946 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath374)"
+             id="path833" />
+          <path
+             d="m 188.766,443.223 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 3.64,0.805 v 1.156 h 0.582 v -1.156 h 0.696 v -0.52 h -0.696 v -3.097 h -0.429 l -2.125,3.003 v 0.614 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath375)"
+             id="path834" />
+          <path
+             d="m 188.766,435.66 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 2.941,-0.235 h 0.317 c 0.636,0 0.972,0.297 0.972,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.636 0.203,0.847 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.609 -0.23,-0.937 -0.793,-1.136 0.437,-0.176 0.652,-0.508 0.652,-0.989 0,-0.82 -0.531,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.535 h 0.582 c 0.008,-0.289 0.031,-0.453 0.105,-0.598 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.308 0.825,0.824 0,0.336 -0.118,0.539 -0.375,0.652 -0.161,0.067 -0.371,0.094 -0.774,0.102 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath376)"
+             id="path835" />
+          <path
+             d="m 188.766,428.219 0.496,1.445 h 0.687 l -1.691,-4.809 h -0.793 l -1.715,4.809 h 0.652 l 0.508,-1.445 z m -0.172,-0.512 h -1.532 l 0.793,-2.191 z m 4.824,1.383 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.367 -1.063,-0.367 -0.594,0 -1.039,0.21 -1.293,0.621 -0.168,0.25 -0.238,0.546 -0.254,1.027 h 0.582 c 0.02,-0.324 0.059,-0.516 0.141,-0.672 0.148,-0.289 0.453,-0.469 0.805,-0.469 0.527,0 0.921,0.383 0.921,0.899 0,0.383 -0.218,0.711 -0.632,0.949 l -0.606,0.355 c -0.98,0.563 -1.262,1.012 -1.316,2.055 h 3.117 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath377)"
+             id="path836" />
+          <path
+             d="m 188.766,420.781 0.496,1.446 h 0.687 l -1.691,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 3.195,-1.438 v 3.399 h 0.578 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.949 v 0.426 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath378)"
+             id="path837" />
+          <path
+             d="m 188.766,413.34 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 3.301,-2.812 c -0.438,0 -0.833,0.199 -1.079,0.523 -0.304,0.422 -0.453,1.055 -0.453,1.942 0,1.609 0.528,2.461 1.532,2.461 0.988,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.149,-1.547 -0.457,-1.981 -0.246,-0.332 -0.633,-0.523 -1.074,-0.523 z m 0,0.515 c 0.625,0 0.933,0.641 0.933,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.309,-1.953 0.938,-1.953 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath379)"
+             id="path838" />
+          <path
+             d="m 153.852,517.391 h 1.511 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.531,-1.414 -1.484,-1.414 h -1.985 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.933,0.317 0.933,0.844 0,0.527 -0.347,0.844 -0.933,0.844 z m 7.902,0.039 h -2.004 v 0.543 h 1.465 v 0.132 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.176 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.18 0.672,-1.961 1.692,-1.961 0.73,0 1.258,0.379 1.39,1 h 0.629 c -0.171,-0.98 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.387 z m 2.176,-2.231 c -0.434,0 -0.832,0.199 -1.075,0.524 -0.304,0.422 -0.457,1.054 -0.457,1.941 0,1.609 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.547 -0.453,-1.98 -0.246,-0.332 -0.633,-0.524 -1.078,-0.524 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.993 -0.949,1.993 -0.613,0 -0.926,-0.66 -0.926,-1.973 0,-1.313 0.313,-1.953 0.938,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath380)"
+             id="path839" />
+          <path
+             d="m 154.211,509.949 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.906 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.812,2.582 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.187,-2.859 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.335,0.828 -1.234,0.949 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath381)"
+             id="path840" />
+          <path
+             d="m 154.211,502.508 h 1.512 c 0.375,0 0.672,-0.11 0.929,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.531,-1.41 -1.484,-1.41 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.531 -0.352,0.848 -0.938,0.848 z m 3.812,2.578 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.293,-4.231 c -0.434,0 -0.832,0.196 -1.075,0.52 -0.304,0.422 -0.457,1.058 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.922 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.516 c 0.629,0 0.937,0.637 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.973 0,-1.316 0.313,-1.953 0.938,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath382)"
+             id="path841" />
+          <path
+             d="m 155.875,494.566 h -2.008 v 0.543 h 1.469 v 0.129 c 0,0.86 -0.637,1.481 -1.512,1.481 -0.488,0 -0.933,-0.18 -1.215,-0.489 -0.316,-0.343 -0.507,-0.918 -0.507,-1.511 0,-1.184 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.911,-1.535 -2.012,-1.535 -0.586,0 -1.063,0.148 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.48 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.148,0.641 h 0.391 z m 4.746,-2.269 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.579 v -3.902 l 2.488,3.902 h 0.695 z m 1.004,4.812 h 1.852 c 1.214,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.852 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.859 -1.453,1.859 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath383)"
+             id="path842" />
+          <path
+             d="m 154.93,487.629 h 1.511 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.535,-1.415 -1.484,-1.415 h -1.989 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.528 -0.351,0.844 -0.937,0.844 z m 4.433,0.391 h 2.297 v -0.543 h -2.297 v -1.536 h 2.614 v -0.543 h -3.227 v 4.813 h 0.613 z m 4.567,-2.582 c -0.434,0 -0.832,0.199 -1.075,0.523 -0.304,0.422 -0.457,1.055 -0.457,1.937 0,1.614 0.532,2.465 1.532,2.465 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.925 -0.145,-1.546 -0.453,-1.98 -0.246,-0.332 -0.633,-0.523 -1.078,-0.523 z m 0,0.515 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.973 0,-1.312 0.313,-1.953 0.938,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath384)"
+             id="path843" />
+          <path
+             d="m 154.93,480.188 h 1.511 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.937,0.316 0.937,0.844 0,0.527 -0.351,0.844 -0.937,0.844 z m 4.433,0.39 h 2.297 v -0.539 h -2.297 v -1.539 h 2.614 v -0.543 h -3.227 v 4.813 h 0.613 z m 4.461,-1.207 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.335,0.832 -1.234,0.953 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath385)"
+             id="path844" />
+          <path
+             d="m 154.93,472.746 h 1.511 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.808 h 0.614 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.937,0.316 0.937,0.843 0,0.532 -0.351,0.848 -0.937,0.848 z m 4.433,0.387 h 2.297 v -0.539 h -2.297 v -1.539 h 2.614 v -0.539 h -3.227 v 4.808 h 0.613 z m 6.094,1.617 h -2.465 c 0.063,-0.395 0.274,-0.645 0.848,-0.996 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.367 -1.063,-0.367 -0.594,0 -1.039,0.211 -1.297,0.617 -0.164,0.254 -0.234,0.551 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.672 0.152,-0.293 0.457,-0.469 0.809,-0.469 0.527,0 0.922,0.383 0.922,0.899 0,0.383 -0.219,0.711 -0.633,0.949 l -0.61,0.356 c -0.976,0.562 -1.257,1.011 -1.312,2.054 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath386)"
+             id="path845" />
+          <path
+             d="m 154.57,465.305 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.535,-1.41 -1.485,-1.41 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.586,0 0.937,0.317 0.937,0.848 0,0.527 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.129 1.051,-0.407 0.238,-0.25 0.371,-0.593 0.371,-0.968 0,-0.582 -0.265,-0.93 -0.879,-1.168 0.442,-0.203 0.664,-0.555 0.664,-1.051 0,-0.356 -0.129,-0.66 -0.383,-0.883 -0.253,-0.23 -0.578,-0.336 -1.042,-0.336 h -1.954 z m 0.614,-2.743 v -1.531 h 1.191 c 0.34,0 0.531,0.047 0.699,0.172 0.172,0.133 0.262,0.332 0.262,0.594 0,0.265 -0.09,0.465 -0.262,0.594 -0.168,0.125 -0.359,0.171 -0.699,0.171 z m 0,2.2 v -1.657 h 1.5 c 0.543,0 0.863,0.309 0.863,0.832 0,0.516 -0.32,0.825 -0.863,0.825 z m 6.472,-2.989 c -0.109,-0.781 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.11,1.312 0.395,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.664 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.52 0.004,-1.18 0.375,-1.832 1.043,-1.832 0.406,0 0.691,0.262 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.914,0.394 0.914,1.027 0,0.602 -0.398,1.039 -0.933,1.039 -0.539,0 -0.95,-0.457 -0.95,-1.062 0,-0.598 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath387)"
+             id="path846" />
+          <path
+             d="m 154.57,457.867 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.586,0 0.937,0.316 0.937,0.843 0,0.528 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.254 0.371,-0.594 0.371,-0.973 0,-0.578 -0.265,-0.929 -0.879,-1.168 0.442,-0.203 0.664,-0.554 0.664,-1.047 0,-0.359 -0.129,-0.66 -0.383,-0.886 -0.253,-0.231 -0.578,-0.336 -1.042,-0.336 h -1.954 z m 0.614,-2.738 v -1.531 h 1.191 c 0.34,0 0.531,0.043 0.699,0.168 0.172,0.133 0.262,0.332 0.262,0.597 0,0.262 -0.09,0.461 -0.262,0.594 -0.168,0.125 -0.359,0.172 -0.699,0.172 z m 0,2.195 v -1.656 h 1.5 c 0.543,0 0.863,0.309 0.863,0.832 0,0.516 -0.32,0.824 -0.863,0.824 z m 6.527,-0.031 h -2.461 c 0.059,-0.398 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.852 0.988,-1.438 0,-0.398 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.371 -1.063,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.141,-0.676 0.148,-0.289 0.453,-0.468 0.805,-0.468 0.527,0 0.922,0.382 0.922,0.898 0,0.383 -0.219,0.711 -0.633,0.949 l -0.606,0.36 c -0.976,0.558 -1.261,1.007 -1.316,2.05 h 3.117 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath388)"
+             id="path847" />
+          <path
+             d="m 157.383,399.902 1.672,-4.812 h -0.657 l -1.332,4.074 -1.41,-4.074 h -0.66 l 1.727,4.812 z m 3.133,-4.812 h -0.621 v 4.812 h 0.621 z m 4.785,0 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.578 V 396 l 2.488,3.902 h 0.696 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath389)"
+             id="path848" />
+          <path
+             d="m 155.875,389.922 h -2.008 v 0.539 h 1.469 v 0.133 c 0,0.859 -0.637,1.48 -1.512,1.48 -0.488,0 -0.933,-0.179 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.183 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.153 -1.438,0.461 -0.562,0.465 -0.871,1.211 -0.871,2.074 0,1.481 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.765 l 0.148,0.64 h 0.391 z m 4.746,-2.274 h -0.582 v 3.938 l -2.516,-3.938 h -0.664 v 4.813 h 0.579 v -3.899 l 2.488,3.899 h 0.695 z m 1.004,4.813 h 1.852 c 1.214,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.739,-2.407 -1.961,-2.407 h -1.852 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.863 -1.453,1.863 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath390)"
+             id="path849" />
+          <path
+             d="m 155.875,382.48 h -2.008 v 0.543 h 1.469 v 0.129 c 0,0.86 -0.637,1.481 -1.512,1.481 -0.488,0 -0.933,-0.18 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.184 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.152 -1.438,0.465 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.148,0.641 h 0.391 z m 4.746,-2.269 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.809 h 0.579 v -3.899 l 2.488,3.899 h 0.695 z m 1.004,4.809 h 1.852 c 1.214,0 1.961,-0.911 1.961,-2.407 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.852 z m 0.613,-0.54 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath391)"
+             id="path850" />
+          <path
+             d="m 157.359,375.82 h -1.363 v -1.367 h -0.465 v 1.367 h -1.363 v 0.461 h 1.363 v 1.367 h 0.465 v -1.367 h 1.363 z m 3.457,-2.918 h -2.414 l -0.351,2.547 h 0.535 c 0.273,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.016,0.429 1.016,1.125 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.382 0.145,0.566 0.285,0.738 0.262,0.355 0.739,0.562 1.266,0.562 0.945,0 1.605,-0.687 1.605,-1.679 0,-0.922 -0.613,-1.555 -1.511,-1.555 -0.332,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.304 h 1.945 z m 3.168,4.68 1.668,-4.812 H 165 l -1.332,4.07 -1.414,-4.07 h -0.66 l 1.73,4.812 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath392)"
+             id="path851" />
+          <path
+             d="m 153.762,368.379 h -1.367 v -1.367 h -0.461 v 1.367 h -1.368 v 0.461 h 1.368 v 1.367 h 0.461 v -1.367 h 1.367 z m 1.773,-0.438 h 0.317 c 0.632,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.965 -0.961,0.965 -0.64,0 -0.953,-0.324 -0.992,-1.023 h -0.582 c 0.027,0.383 0.094,0.633 0.207,0.844 0.242,0.464 0.699,0.695 1.34,0.695 0.965,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.23,-0.938 -0.789,-1.137 0.434,-0.18 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.317 -1.425,-1.317 -0.946,0 -1.446,0.528 -1.465,1.539 h 0.578 c 0.008,-0.289 0.035,-0.457 0.109,-0.601 0.129,-0.27 0.422,-0.43 0.785,-0.43 0.512,0 0.825,0.313 0.825,0.828 0,0.336 -0.122,0.539 -0.379,0.652 -0.157,0.067 -0.367,0.094 -0.77,0.098 z m 4.727,2.2 1.672,-4.813 h -0.653 l -1.336,4.074 -1.41,-4.074 h -0.66 l 1.727,4.813 z m 3.312,-2.2 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.023 h -0.578 c 0.027,0.383 0.09,0.633 0.203,0.844 0.246,0.464 0.699,0.695 1.34,0.695 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.61 -0.23,-0.938 -0.793,-1.137 0.434,-0.18 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.317 -1.425,-1.317 -0.942,0 -1.446,0.528 -1.465,1.539 h 0.582 c 0.008,-0.289 0.031,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.313 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.774,0.098 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath393)"
+             id="path852" />
+          <path
+             d="m 145.102,360.629 h 1.586 c 0.546,0 0.792,0.262 0.792,0.855 l -0.007,0.43 c 0,0.297 0.05,0.586 0.136,0.785 h 0.746 v -0.152 c -0.23,-0.156 -0.277,-0.328 -0.289,-0.969 -0.007,-0.793 -0.132,-1.031 -0.652,-1.254 0.539,-0.269 0.758,-0.594 0.758,-1.148 0,-0.832 -0.516,-1.289 -1.465,-1.289 h -2.219 v 4.812 h 0.614 z m 0,-0.543 v -1.656 h 1.488 c 0.34,0 0.539,0.05 0.691,0.183 0.164,0.141 0.25,0.36 0.25,0.641 0,0.574 -0.289,0.832 -0.941,0.832 z m 4.785,0.422 h 2.617 v -0.539 h -2.617 v -1.539 h 2.718 v -0.543 h -3.335 v 4.812 h 3.453 v -0.539 h -2.836 z m 7.043,-1.207 c 0,-0.328 -0.02,-0.422 -0.125,-0.649 -0.262,-0.554 -0.825,-0.843 -1.637,-0.843 -1.055,0 -1.707,0.543 -1.707,1.414 0,0.586 0.309,0.957 0.941,1.121 l 1.196,0.316 c 0.613,0.16 0.886,0.402 0.886,0.778 0,0.257 -0.14,0.523 -0.343,0.667 -0.192,0.141 -0.496,0.204 -0.887,0.204 -0.527,0 -0.875,-0.125 -1.109,-0.403 -0.176,-0.211 -0.254,-0.441 -0.25,-0.738 h -0.579 c 0.004,0.441 0.09,0.734 0.282,0.996 0.332,0.457 0.886,0.688 1.617,0.688 0.574,0 1.043,-0.133 1.355,-0.372 0.321,-0.253 0.528,-0.683 0.528,-1.101 0,-0.594 -0.371,-1.027 -1.024,-1.207 l -1.207,-0.324 c -0.582,-0.157 -0.793,-0.344 -0.793,-0.711 0,-0.489 0.43,-0.813 1.074,-0.813 0.766,0 1.196,0.344 1.204,0.977 z m 1.715,1.207 h 2.621 v -0.539 h -2.621 v -1.539 h 2.718 v -0.543 h -3.332 v 4.812 h 3.453 v -0.539 h -2.839 z m 5.449,-2.078 h 1.578 v -0.543 h -3.777 v 0.543 h 1.585 v 4.269 h 0.614 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath394)"
+             id="path853" />
+          <path
+             d="m 146.957,350.449 h -0.621 v 4.809 h 0.621 z m 3.086,-0.082 c -1.379,0 -2.316,1.02 -2.316,2.524 0,1.511 0.929,2.519 2.324,2.519 0.586,0 1.101,-0.176 1.492,-0.508 0.519,-0.441 0.828,-1.187 0.828,-1.972 0,-1.551 -0.914,-2.563 -2.328,-2.563 z m 0,0.543 c 1.043,0 1.715,0.785 1.715,2.008 0,1.16 -0.692,1.953 -1.707,1.953 -1.031,0 -1.711,-0.793 -1.711,-1.98 0,-1.188 0.68,-1.981 1.703,-1.981 z m 3.82,2.278 h 1.582 c 0.551,0 0.793,0.261 0.793,0.859 l -0.008,0.426 c 0,0.297 0.055,0.589 0.141,0.785 h 0.746 v -0.149 c -0.23,-0.16 -0.277,-0.332 -0.289,-0.972 -0.008,-0.793 -0.133,-1.028 -0.656,-1.254 0.543,-0.27 0.762,-0.594 0.762,-1.149 0,-0.832 -0.516,-1.285 -1.469,-1.285 h -2.215 v 4.809 h 0.613 z m 0,-0.543 v -1.657 h 1.485 c 0.343,0 0.543,0.055 0.695,0.184 0.164,0.14 0.25,0.359 0.25,0.64 0,0.575 -0.293,0.833 -0.945,0.833 z m 4.66,0.421 h 2.622 v -0.539 h -2.622 v -1.539 h 2.719 v -0.539 h -3.332 v 4.809 h 3.453 v -0.539 h -2.84 z m 4.442,0 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.539 h -3.226 v 4.809 h 0.613 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath395)"
+             id="path854" />
+          <path
+             d="m 160.621,343.008 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.579 v -3.902 l 2.488,3.902 h 0.695 z m 4.906,1.492 c -0.191,-1.059 -0.8,-1.57 -1.855,-1.57 -0.649,0 -1.168,0.203 -1.524,0.597 -0.437,0.477 -0.675,1.164 -0.675,1.942 0,0.793 0.246,1.472 0.695,1.941 0.375,0.383 0.852,0.559 1.477,0.559 1.175,0 1.835,-0.633 1.98,-1.907 h -0.633 c -0.054,0.333 -0.121,0.555 -0.219,0.747 -0.199,0.394 -0.605,0.621 -1.121,0.621 -0.957,0 -1.566,-0.766 -1.566,-1.969 0,-1.234 0.574,-1.992 1.512,-1.992 0.39,0 0.754,0.113 0.953,0.304 0.176,0.165 0.277,0.364 0.347,0.727 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath396)"
+             id="path855" />
+          <path
+             d="m 154.211,450.062 h 1.512 c 0.375,0 0.672,-0.109 0.929,-0.339 0.289,-0.266 0.414,-0.575 0.414,-1.02 0,-0.902 -0.531,-1.41 -1.484,-1.41 h -1.984 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.848 0,0.527 -0.352,0.843 -0.938,0.843 z m 7.594,-0.738 c -0.192,-1.058 -0.797,-1.574 -1.856,-1.574 -0.644,0 -1.168,0.207 -1.523,0.601 -0.434,0.477 -0.672,1.165 -0.672,1.942 0,0.793 0.242,1.473 0.691,1.941 0.375,0.383 0.852,0.559 1.481,0.559 1.172,0 1.832,-0.633 1.976,-1.906 h -0.632 c -0.051,0.332 -0.118,0.554 -0.215,0.746 -0.2,0.394 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.766 -1.563,-1.969 0,-1.234 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.113 0.949,0.305 0.18,0.164 0.277,0.363 0.352,0.726 z m 3.453,-1.359 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.325 0.496,-0.438 0.864,-0.438 0.629,0 1.015,0.43 1.015,1.121 0,0.676 -0.386,1.086 -1.019,1.086 -0.512,0 -0.821,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.566 0.285,0.738 0.262,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.617,-1.558 -1.512,-1.558 -0.332,0 -0.594,0.085 -0.867,0.285 L 163.312,448 h 1.946 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath397)"
+             id="path856" />
+          <path
+             d="m 154.211,442.625 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 7.594,-0.738 c -0.192,-1.059 -0.797,-1.571 -1.856,-1.571 -0.644,0 -1.168,0.204 -1.523,0.598 -0.434,0.477 -0.672,1.164 -0.672,1.941 0,0.793 0.242,1.473 0.691,1.942 0.375,0.383 0.852,0.562 1.481,0.562 1.172,0 1.832,-0.636 1.976,-1.91 h -0.632 c -0.051,0.332 -0.118,0.555 -0.215,0.746 -0.2,0.399 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.765 -1.563,-1.964 0,-1.235 0.574,-1.997 1.512,-1.997 0.387,0 0.75,0.114 0.949,0.305 0.18,0.164 0.277,0.363 0.352,0.727 z m 2.468,2.164 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath398)"
+             id="path857" />
+          <path
+             d="m 154.211,435.062 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.343 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.847 -0.938,0.847 z m 7.594,-0.742 c -0.192,-1.054 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.207 -1.523,0.601 -0.434,0.477 -0.672,1.161 -0.672,1.942 0,0.789 0.242,1.473 0.691,1.937 0.375,0.383 0.852,0.563 1.481,0.563 1.172,0 1.832,-0.633 1.976,-1.906 h -0.632 c -0.051,0.328 -0.118,0.554 -0.215,0.746 -0.2,0.394 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.766 -1.563,-1.969 0,-1.234 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.109 0.949,0.301 0.18,0.168 0.277,0.363 0.352,0.726 z m 2.019,-0.078 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.73 -0.335,0.828 -1.234,0.949 v 0.422 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath399)"
+             id="path858" />
+          <path
+             d="m 154.211,427.621 h 1.512 c 0.375,0 0.672,-0.109 0.929,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.903 -0.531,-1.41 -1.484,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 7.594,-0.738 c -0.192,-1.059 -0.797,-1.574 -1.856,-1.574 -0.644,0 -1.168,0.207 -1.523,0.601 -0.434,0.477 -0.672,1.164 -0.672,1.941 0,0.793 0.242,1.473 0.691,1.942 0.375,0.383 0.852,0.558 1.481,0.558 1.172,0 1.832,-0.632 1.976,-1.906 h -0.632 c -0.051,0.328 -0.118,0.555 -0.215,0.746 -0.2,0.395 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.765 -1.563,-1.968 0,-1.235 0.574,-1.993 1.512,-1.993 0.387,0 0.75,0.114 0.949,0.305 0.18,0.164 0.277,0.363 0.352,0.727 z m 1.769,1.121 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.024 h -0.578 c 0.027,0.383 0.09,0.633 0.203,0.844 0.246,0.461 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.578 1.586,-1.484 0,-0.605 -0.23,-0.937 -0.793,-1.133 0.434,-0.179 0.652,-0.511 0.652,-0.992 0,-0.816 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.273 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.309 0.825,0.825 0,0.336 -0.118,0.543 -0.375,0.652 -0.16,0.066 -0.371,0.094 -0.774,0.102 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath400)"
+             id="path859" />
+          <path
+             d="m 154.211,420.184 h 1.512 c 0.375,0 0.672,-0.114 0.929,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.02 0,-0.902 -0.531,-1.41 -1.484,-1.41 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.692 h 1.281 c 0.586,0 0.938,0.321 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 7.594,-0.739 c -0.192,-1.058 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.598 -0.434,0.476 -0.672,1.164 -0.672,1.941 0,0.793 0.242,1.473 0.691,1.941 0.375,0.383 0.852,0.563 1.481,0.563 1.172,0 1.832,-0.637 1.976,-1.91 h -0.632 c -0.051,0.332 -0.118,0.555 -0.215,0.746 -0.2,0.398 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.766 -1.563,-1.969 0,-1.234 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.113 0.949,0.305 0.18,0.164 0.277,0.363 0.352,0.726 z m 2.125,-1.453 c -0.434,0 -0.832,0.199 -1.075,0.524 -0.304,0.422 -0.457,1.054 -0.457,1.937 0,1.613 0.532,2.465 1.532,2.465 0.992,0 1.531,-0.852 1.531,-2.426 0,-0.922 -0.145,-1.543 -0.453,-1.976 -0.246,-0.332 -0.633,-0.524 -1.078,-0.524 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.993 -0.949,1.993 -0.613,0 -0.926,-0.661 -0.926,-1.973 0,-1.313 0.313,-1.953 0.938,-1.953 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath401)"
+             id="path860" />
+          <path
+             d="m 154.57,412.742 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.418,-0.574 0.418,-1.015 0,-0.906 -0.535,-1.414 -1.489,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.586,0 0.937,0.316 0.937,0.843 0,0.528 -0.351,0.844 -0.937,0.844 z m 6.356,1.137 0.492,1.445 h 0.687 l -1.691,-4.812 h -0.789 l -1.719,4.812 h 0.656 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.789,-2.191 z m 2.82,-0.238 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.023 h -0.578 c 0.027,0.382 0.09,0.632 0.203,0.843 0.246,0.465 0.699,0.696 1.34,0.696 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.609 -0.23,-0.937 -0.793,-1.137 0.434,-0.179 0.652,-0.507 0.652,-0.988 0,-0.82 -0.535,-1.316 -1.425,-1.316 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.289 0.031,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.312 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.16,0.066 -0.371,0.094 -0.774,0.098 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath402)"
+             id="path861" />
+          <path
+             d="m 432.742,386.699 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 4.434,0.387 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.539 h -3.227 v 4.808 h 0.614 z m 4.461,-1.207 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 5.23,2.824 h -2.461 c 0.059,-0.394 0.27,-0.644 0.844,-0.996 l 0.66,-0.367 c 0.656,-0.363 0.992,-0.852 0.992,-1.442 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.277,-0.25 -0.617,-0.367 -1.063,-0.367 -0.593,0 -1.035,0.211 -1.293,0.617 -0.164,0.254 -0.238,0.551 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.672 0.152,-0.293 0.457,-0.468 0.805,-0.468 0.527,0 0.926,0.382 0.926,0.898 0,0.383 -0.219,0.711 -0.633,0.949 l -0.61,0.356 c -0.976,0.562 -1.261,1.011 -1.312,2.054 h 3.113 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath403)"
+             id="path862" />
+          <path
+             d="m 432.742,379.258 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.868 0,1.222 -0.5,1.863 -1.449,1.863 z m 5.309,-2.86 v 3.403 h 0.582 v -4.774 h -0.383 c -0.203,0.731 -0.336,0.832 -1.235,0.95 v 0.421 z m 5.035,-1.277 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.324 0.492,-0.438 0.864,-0.438 0.625,0 1.015,0.43 1.015,1.122 0,0.675 -0.39,1.086 -1.023,1.086 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.578 c 0.078,0.383 0.144,0.567 0.281,0.739 0.265,0.355 0.738,0.558 1.269,0.558 0.942,0 1.602,-0.683 1.602,-1.676 0,-0.921 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.305 h 1.95 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath404)"
+             id="path863" />
+          <path
+             d="m 432.742,371.82 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.637 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 5.309,-2.855 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.235,0.949 v 0.426 z m 4.05,2.242 v 1.156 h 0.582 v -1.156 h 0.692 v -0.519 h -0.692 v -3.098 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath405)"
+             id="path864" />
+          <path
+             d="m 432.742,364.379 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.415 -1.485,-1.415 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.356,1.137 0.496,1.445 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 4.914,-2.719 h -3.129 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.567 -1.918,4.106 h 0.621 c 0.254,-1.5 0.844,-2.785 1.899,-4.191 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath406)"
+             id="path865" />
+          <path
+             d="m 432.742,356.938 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.54 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.847 -0.938,0.847 z m 6.356,1.133 0.496,1.446 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 4.769,-1.571 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.512,0 -0.976,0.25 -1.254,0.68 -0.297,0.468 -0.422,1.047 -0.422,1.914 0,0.804 0.114,1.312 0.399,1.734 0.25,0.391 0.66,0.594 1.172,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.496 -1.43,-1.496 -0.465,0 -0.824,0.172 -1.078,0.52 0.008,-1.18 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.265 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.398 0.91,1.031 0,0.602 -0.394,1.035 -0.929,1.035 -0.54,0 -0.95,-0.453 -0.95,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath407)"
+             id="path866" />
+          <path
+             d="m 432.742,349.496 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 6.356,1.133 0.496,1.445 h 0.683 l -1.687,-4.808 h -0.793 l -1.715,4.808 h 0.652 l 0.508,-1.445 z m -0.172,-0.512 h -1.531 l 0.793,-2.191 z m 4.625,-2.723 h -2.418 l -0.348,2.551 h 0.535 c 0.27,-0.324 0.492,-0.437 0.864,-0.437 0.628,0 1.015,0.429 1.015,1.121 0,0.676 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.254 -0.957,-0.785 h -0.578 c 0.078,0.383 0.144,0.57 0.281,0.742 0.266,0.355 0.742,0.559 1.269,0.559 0.942,0 1.602,-0.684 1.602,-1.676 0,-0.922 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.593,0.086 -0.863,0.285 l 0.184,-1.308 h 1.949 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath408)"
+             id="path867" />
+          <path
+             d="m 436.207,341.555 h -2.004 v 0.543 h 1.465 v 0.129 c 0,0.859 -0.633,1.48 -1.512,1.48 -0.488,0 -0.929,-0.18 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.18 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.535 -2.012,-1.535 -0.586,0 -1.063,0.148 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.903,2.512 2.203,2.512 0.653,0 1.168,-0.246 1.645,-0.766 l 0.152,0.637 h 0.387 z m 4.746,-2.27 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.813 h 0.579 v -3.903 l 2.488,3.903 h 0.695 z m 1.004,4.813 h 1.855 c 1.215,0 1.958,-0.914 1.958,-2.41 0,-1.493 -0.739,-2.403 -1.958,-2.403 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.871 0,1.219 -0.5,1.86 -1.449,1.86 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath409)"
+             id="path868" />
+          <path
+             d="m 435.793,331.723 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.578 v -3.898 l 2.489,3.898 h 0.695 z m 4.906,1.492 c -0.191,-1.055 -0.801,-1.57 -1.855,-1.57 -0.649,0 -1.168,0.203 -1.524,0.601 -0.437,0.473 -0.675,1.16 -0.675,1.942 0,0.789 0.246,1.468 0.695,1.937 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.633 1.981,-1.907 h -0.633 c -0.055,0.328 -0.121,0.555 -0.219,0.746 -0.199,0.395 -0.605,0.618 -1.121,0.618 -0.957,0 -1.566,-0.766 -1.566,-1.965 0,-1.235 0.574,-1.992 1.512,-1.992 0.39,0 0.753,0.109 0.953,0.3 0.175,0.168 0.277,0.364 0.347,0.727 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath410)"
+             id="path869" />
+          <path
+             d="m 432.742,327.055 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.531 -0.352,0.848 -0.938,0.848 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.403 0.238,-0.25 0.371,-0.593 0.371,-0.968 0,-0.582 -0.266,-0.93 -0.879,-1.168 0.442,-0.207 0.668,-0.555 0.668,-1.051 0,-0.356 -0.133,-0.66 -0.383,-0.883 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.739 v -1.531 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.332 0.262,0.594 0,0.265 -0.09,0.461 -0.262,0.594 -0.164,0.125 -0.355,0.171 -0.699,0.171 z m 0,2.2 v -1.657 h 1.497 c 0.543,0 0.863,0.309 0.863,0.832 0,0.512 -0.32,0.825 -0.863,0.825 z m 3.653,-0.547 c 0.113,0.777 0.613,1.238 1.328,1.238 0.519,0 0.984,-0.25 1.258,-0.68 0.293,-0.468 0.426,-1.046 0.426,-1.914 0,-0.804 -0.122,-1.312 -0.399,-1.734 -0.258,-0.391 -0.664,-0.594 -1.18,-0.594 -0.89,0 -1.531,0.664 -1.531,1.59 0,0.879 0.594,1.496 1.438,1.496 0.441,0 0.773,-0.156 1.07,-0.519 -0.008,1.187 -0.375,1.839 -1.043,1.839 -0.41,0 -0.695,-0.261 -0.785,-0.722 z m 1.426,-3.176 c 0.543,0 0.949,0.453 0.949,1.07 0,0.586 -0.395,0.996 -0.969,0.996 -0.562,0 -0.91,-0.398 -0.91,-1.031 0,-0.601 0.391,-1.035 0.93,-1.035 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath411)"
+             id="path870" />
+          <path
+             d="m 432.742,319.613 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.129 1.051,-0.402 0.238,-0.254 0.371,-0.598 0.371,-0.973 0,-0.582 -0.266,-0.929 -0.879,-1.168 0.442,-0.203 0.668,-0.554 0.668,-1.051 0,-0.355 -0.133,-0.66 -0.383,-0.882 -0.258,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.742 v -1.531 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.332 0.262,0.593 0,0.266 -0.09,0.465 -0.262,0.594 -0.164,0.129 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.497 c 0.543,0 0.863,0.309 0.863,0.832 0,0.516 -0.32,0.824 -0.863,0.824 z m 5.883,-1.972 c 0.489,-0.297 0.641,-0.536 0.641,-0.985 0,-0.754 -0.574,-1.273 -1.406,-1.273 -0.825,0 -1.407,0.519 -1.407,1.265 0,0.457 0.153,0.688 0.637,0.993 -0.535,0.269 -0.801,0.66 -0.801,1.187 0,0.871 0.641,1.477 1.571,1.477 0.925,0 1.57,-0.606 1.57,-1.477 0,-0.527 -0.262,-0.918 -0.805,-1.187 z m -0.765,-1.743 c 0.496,0 0.812,0.297 0.812,0.77 0,0.449 -0.324,0.746 -0.812,0.746 -0.493,0 -0.813,-0.297 -0.813,-0.758 0,-0.461 0.32,-0.758 0.813,-0.758 z m 0,2.004 c 0.582,0 0.976,0.383 0.976,0.938 0,0.574 -0.387,0.953 -0.988,0.953 -0.566,0 -0.965,-0.391 -0.965,-0.945 0,-0.567 0.391,-0.946 0.977,-0.946 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath412)"
+             id="path871" />
+          <path
+             d="m 432.742,450.062 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.542 v -1.692 h 1.281 c 0.586,0 0.938,0.32 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.871 0,1.219 -0.5,1.86 -1.449,1.86 z m 3.949,-0.547 c 0.113,0.777 0.617,1.242 1.328,1.242 0.524,0 0.985,-0.254 1.262,-0.68 0.289,-0.469 0.422,-1.051 0.422,-1.914 0,-0.808 -0.121,-1.316 -0.395,-1.738 -0.257,-0.391 -0.668,-0.594 -1.183,-0.594 -0.891,0 -1.531,0.668 -1.531,1.59 0,0.879 0.593,1.5 1.437,1.5 0.445,0 0.773,-0.16 1.07,-0.523 -0.007,1.187 -0.375,1.843 -1.043,1.843 -0.41,0 -0.691,-0.265 -0.785,-0.726 z m 1.426,-3.176 c 0.543,0 0.953,0.457 0.953,1.07 0,0.586 -0.398,0.996 -0.973,0.996 -0.558,0 -0.91,-0.394 -0.91,-1.031 0,-0.598 0.391,-1.035 0.93,-1.035 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath413)"
+             id="path872" />
+          <path
+             d="m 432.742,442.621 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 6.184,-1.972 c 0.488,-0.297 0.636,-0.536 0.636,-0.985 0,-0.75 -0.574,-1.273 -1.402,-1.273 -0.828,0 -1.406,0.523 -1.406,1.269 0,0.453 0.148,0.684 0.632,0.989 -0.535,0.269 -0.8,0.66 -0.8,1.187 0,0.871 0.64,1.48 1.574,1.48 0.922,0 1.57,-0.609 1.57,-1.48 0,-0.527 -0.265,-0.918 -0.804,-1.187 z m -0.766,-1.743 c 0.492,0 0.809,0.297 0.809,0.774 0,0.449 -0.321,0.746 -0.809,0.746 -0.496,0 -0.813,-0.297 -0.813,-0.762 0,-0.461 0.317,-0.758 0.813,-0.758 z m 0,2.008 c 0.578,0 0.976,0.383 0.976,0.938 0,0.574 -0.39,0.949 -0.992,0.949 -0.566,0 -0.965,-0.391 -0.965,-0.945 0,-0.567 0.391,-0.942 0.981,-0.942 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath414)"
+             id="path873" />
+          <path
+             d="m 432.742,435.059 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.531 -0.352,0.848 -0.938,0.848 z m 4.434,0.386 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.539 h -3.227 v 4.809 h 0.614 z m 4.461,-1.207 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z m 5.035,-1.281 h -2.418 l -0.348,2.551 h 0.535 c 0.27,-0.324 0.493,-0.438 0.864,-0.438 0.629,0 1.015,0.43 1.015,1.121 0,0.676 -0.386,1.082 -1.023,1.082 -0.508,0 -0.817,-0.254 -0.957,-0.785 h -0.578 c 0.078,0.383 0.144,0.571 0.281,0.742 0.266,0.356 0.742,0.559 1.269,0.559 0.942,0 1.602,-0.684 1.602,-1.676 0,-0.922 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.593,0.086 -0.863,0.285 l 0.184,-1.309 h 1.949 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath415)"
+             id="path874" />
+          <path
+             d="m 432.742,427.621 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.691 h 1.281 c 0.586,0 0.938,0.32 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.333 v 4.812 h 3.454 v -0.543 h -2.84 z m 4.941,-1.211 v 3.402 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.949 v 0.422 z m 3.352,1.203 h 0.316 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.641,0 -0.949,-0.324 -0.988,-1.024 h -0.582 c 0.027,0.383 0.093,0.633 0.207,0.844 0.242,0.461 0.699,0.692 1.34,0.692 0.961,0 1.582,-0.579 1.582,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.133 0.437,-0.179 0.656,-0.507 0.656,-0.992 0,-0.816 -0.535,-1.312 -1.426,-1.312 -0.945,0 -1.445,0.527 -1.465,1.539 h 0.578 c 0.008,-0.293 0.036,-0.457 0.106,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.828,0.312 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.656 -0.156,0.063 -0.367,0.09 -0.769,0.098 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath416)"
+             id="path875" />
+          <path
+             d="m 432.742,420.18 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.227 v 4.813 h 0.614 z m 4.461,-1.207 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.953 v 0.422 z m 4.051,2.242 v 1.157 h 0.582 v -1.157 h 0.691 v -0.519 h -0.691 v -3.098 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.105 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath417)"
+             id="path876" />
+          <path
+             d="m 432.742,412.738 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.262 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 4.434,0.391 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 v -0.539 h -2.84 z m 4.941,-1.207 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 3.602,0 v 3.398 h 0.578 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath418)"
+             id="path877" />
+          <path
+             d="m 432.742,405.297 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.015 0,-0.903 -0.536,-1.411 -1.485,-1.411 h -1.988 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.531 -0.352,0.848 -0.938,0.848 z m 4.434,0.387 h 2.621 v -0.54 h -2.621 v -1.539 h 2.719 v -0.539 h -3.333 v 4.809 h 3.454 v -0.539 h -2.84 z m 3.582,1.105 c 0.113,0.777 0.613,1.238 1.328,1.238 0.519,0 0.984,-0.25 1.258,-0.679 0.293,-0.469 0.426,-1.051 0.426,-1.914 0,-0.805 -0.122,-1.313 -0.399,-1.735 -0.258,-0.39 -0.664,-0.594 -1.18,-0.594 -0.89,0 -1.531,0.664 -1.531,1.59 0,0.879 0.594,1.496 1.438,1.496 0.441,0 0.773,-0.156 1.07,-0.519 -0.008,1.187 -0.375,1.84 -1.043,1.84 -0.41,0 -0.695,-0.262 -0.785,-0.723 z m 1.426,-3.176 c 0.543,0 0.949,0.453 0.949,1.067 0,0.589 -0.395,1 -0.969,1 -0.562,0 -0.91,-0.399 -0.91,-1.032 0,-0.601 0.391,-1.035 0.93,-1.035 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath419)"
+             id="path878" />
+          <path
+             d="m 432.742,397.855 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.339 0.293,-0.266 0.418,-0.575 0.418,-1.02 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.848 0,0.527 -0.352,0.843 -0.938,0.843 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.539 h 2.613 v -0.539 h -3.227 v 4.812 h 0.614 z m 4.461,-1.211 v 3.402 h 0.582 v -4.773 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 3.351,1.203 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.965 -0.961,0.965 -0.64,0 -0.953,-0.324 -0.992,-1.023 h -0.578 c 0.024,0.383 0.09,0.633 0.203,0.843 0.243,0.461 0.7,0.692 1.34,0.692 0.965,0 1.582,-0.578 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.789,-1.132 0.434,-0.18 0.652,-0.512 0.652,-0.992 0,-0.817 -0.535,-1.313 -1.425,-1.313 -0.946,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.004,-0.293 0.031,-0.457 0.105,-0.602 0.129,-0.269 0.422,-0.429 0.785,-0.429 0.512,0 0.825,0.308 0.825,0.824 0,0.336 -0.121,0.543 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.774,0.102 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath420)"
+             id="path879" />
+          <path
+             d="m 432.742,517.383 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.371,-0.594 0.371,-0.969 0,-0.582 -0.266,-0.934 -0.879,-1.168 0.442,-0.207 0.668,-0.555 0.668,-1.051 0,-0.355 -0.133,-0.66 -0.383,-0.887 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.738 v -1.532 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.328 0.262,0.594 0,0.262 -0.09,0.461 -0.262,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.195 v -1.656 h 1.497 c 0.543,0 0.863,0.312 0.863,0.832 0,0.515 -0.32,0.824 -0.863,0.824 z m 5.012,-2.856 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.954 v 0.421 z m 3.602,0 v 3.399 h 0.578 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.954 v 0.421 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath421)"
+             id="path880" />
+          <path
+             d="m 432.742,509.941 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.262 0.418,-0.575 0.418,-1.016 0,-0.902 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.531 -0.352,0.847 -0.938,0.847 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.371,-0.594 0.371,-0.969 0,-0.582 -0.266,-0.929 -0.879,-1.168 0.442,-0.207 0.668,-0.554 0.668,-1.05 0,-0.356 -0.133,-0.661 -0.383,-0.883 -0.258,-0.231 -0.582,-0.34 -1.043,-0.34 h -1.957 z m 0.617,-2.738 v -1.531 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.328 0.262,0.594 0,0.265 -0.09,0.461 -0.262,0.593 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.497 c 0.543,0 0.863,0.309 0.863,0.832 0,0.512 -0.32,0.824 -0.863,0.824 z m 5.012,-2.859 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 3.707,-1.371 c -0.437,0 -0.832,0.195 -1.078,0.519 -0.301,0.422 -0.453,1.055 -0.453,1.942 0,1.609 0.527,2.461 1.531,2.461 0.988,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.144,-1.543 -0.457,-1.981 -0.242,-0.328 -0.632,-0.519 -1.074,-0.519 z m 0,0.512 c 0.625,0 0.938,0.64 0.938,1.937 0,1.36 -0.305,1.992 -0.953,1.992 -0.614,0 -0.922,-0.66 -0.922,-1.972 0,-1.317 0.308,-1.957 0.937,-1.957 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath422)"
+             id="path881" />
+          <path
+             d="m 432.742,502.5 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.536,-1.411 -1.485,-1.411 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.54 h -3.333 v 4.813 h 3.454 V 504 h -2.84 z m 4.941,-1.211 v 3.402 h 0.582 v -4.773 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 5.031,-1.278 h -2.414 l -0.351,2.547 h 0.535 c 0.273,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.016,0.429 1.016,1.121 0,0.676 -0.391,1.086 -1.024,1.086 -0.507,0 -0.82,-0.258 -0.957,-0.789 h -0.582 c 0.082,0.382 0.145,0.57 0.285,0.742 0.266,0.355 0.739,0.558 1.266,0.558 0.945,0 1.606,-0.683 1.606,-1.675 0,-0.922 -0.614,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.304 h 1.945 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath423)"
+             id="path882" />
+          <path
+             d="m 432.742,495.062 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.542 v -1.688 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.813 h 3.454 v -0.543 h -2.84 z m 4.941,-1.207 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.949 v 0.426 z m 4.051,2.242 v 1.157 h 0.578 v -1.157 h 0.695 v -0.519 h -0.695 v -3.098 h -0.426 l -2.129,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath424)"
+             id="path883" />
+          <path
+             d="m 432.742,487.621 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 v -0.543 h -2.84 z m 4.941,-1.207 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 5.231,2.824 h -2.461 c 0.058,-0.395 0.269,-0.648 0.843,-0.996 l 0.661,-0.371 c 0.652,-0.364 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.438,-1.023 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.578 c 0.02,-0.324 0.062,-0.516 0.141,-0.676 0.152,-0.289 0.453,-0.468 0.804,-0.468 0.528,0 0.926,0.382 0.926,0.898 0,0.383 -0.219,0.715 -0.637,0.953 l -0.605,0.356 c -0.977,0.558 -1.262,1.007 -1.313,2.05 h 3.114 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath425)"
+             id="path884" />
+          <path
+             d="m 432.742,480.18 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.848 -0.938,0.848 z m 4.434,0.386 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.333 v 4.813 h 3.454 v -0.539 h -2.84 z m 4.941,-1.207 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.828 -1.234,0.949 v 0.422 z m 3.707,-1.371 c -0.437,0 -0.832,0.196 -1.078,0.52 -0.301,0.422 -0.453,1.054 -0.453,1.941 0,1.61 0.527,2.461 1.531,2.461 0.988,0 1.531,-0.851 1.531,-2.422 0,-0.926 -0.144,-1.543 -0.457,-1.98 -0.242,-0.328 -0.632,-0.52 -1.074,-0.52 z m 0,0.512 c 0.625,0 0.938,0.641 0.938,1.934 0,1.359 -0.305,1.996 -0.953,1.996 -0.614,0 -0.922,-0.661 -0.922,-1.977 0,-1.312 0.308,-1.953 0.937,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath426)"
+             id="path885" />
+          <path
+             d="m 432.742,465.301 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.813 h 3.454 v -0.543 h -2.84 z m 6.664,-2.488 h -3.129 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.567 -1.918,4.106 h 0.621 c 0.254,-1.5 0.844,-2.785 1.899,-4.192 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath427)"
+             id="path886" />
+          <path
+             d="m 432.742,457.859 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 4.434,0.391 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 v -0.543 h -2.84 z m 5.812,-0.324 c 0.489,-0.297 0.641,-0.535 0.641,-0.981 0,-0.754 -0.574,-1.277 -1.406,-1.277 -0.825,0 -1.407,0.523 -1.407,1.27 0,0.453 0.153,0.687 0.637,0.988 -0.535,0.273 -0.801,0.66 -0.801,1.187 0,0.871 0.641,1.481 1.571,1.481 0.925,0 1.57,-0.61 1.57,-1.481 0,-0.527 -0.262,-0.914 -0.805,-1.187 z m -0.765,-1.742 c 0.496,0 0.812,0.297 0.812,0.773 0,0.449 -0.324,0.746 -0.812,0.746 -0.493,0 -0.813,-0.297 -0.813,-0.758 0,-0.464 0.32,-0.761 0.813,-0.761 z m 0,2.007 c 0.582,0 0.976,0.383 0.976,0.938 0,0.574 -0.387,0.949 -0.988,0.949 -0.566,0 -0.965,-0.39 -0.965,-0.945 0,-0.567 0.391,-0.942 0.977,-0.942 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath428)"
+             id="path887" />
+          <path
+             d="m 436.207,472.238 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.929,-0.18 -1.215,-0.489 -0.316,-0.343 -0.507,-0.918 -0.507,-1.511 0,-1.184 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.152 -1.438,0.465 -0.562,0.46 -0.871,1.207 -0.871,2.07 0,1.48 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.808 h 0.579 v -3.898 l 2.488,3.898 h 0.695 z m 1.004,4.808 h 1.855 c 1.215,0 1.958,-0.91 1.958,-2.406 0,-1.492 -0.739,-2.402 -1.958,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath429)"
+             id="path888" />
+          <path
+             d="m 402.234,388.734 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 6.058,-1.976 c 0.489,-0.297 0.641,-0.535 0.641,-0.981 0,-0.754 -0.574,-1.277 -1.406,-1.277 -0.825,0 -1.403,0.523 -1.403,1.269 0,0.454 0.149,0.688 0.633,0.989 -0.535,0.273 -0.801,0.66 -0.801,1.187 0,0.875 0.641,1.481 1.571,1.481 0.925,0 1.574,-0.606 1.574,-1.481 0,-0.527 -0.266,-0.914 -0.809,-1.187 z m -0.765,-1.742 c 0.496,0 0.812,0.296 0.812,0.773 0,0.449 -0.324,0.746 -0.812,0.746 -0.493,0 -0.809,-0.297 -0.809,-0.758 0,-0.465 0.316,-0.761 0.809,-0.761 z m 0,2.007 c 0.582,0 0.98,0.383 0.98,0.938 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.965,-0.391 -0.965,-0.941 0,-0.571 0.391,-0.946 0.977,-0.946 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath430)"
+             id="path889" />
+          <path
+             d="m 402.355,381.293 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 3.949,-0.547 c 0.113,0.777 0.613,1.238 1.324,1.238 0.524,0 0.985,-0.25 1.262,-0.679 0.293,-0.469 0.422,-1.051 0.422,-1.914 0,-0.805 -0.117,-1.313 -0.395,-1.735 -0.258,-0.39 -0.668,-0.594 -1.183,-0.594 -0.891,0 -1.532,0.665 -1.532,1.59 0,0.879 0.598,1.496 1.442,1.496 0.441,0 0.773,-0.156 1.07,-0.519 -0.008,1.187 -0.379,1.84 -1.043,1.84 -0.41,0 -0.695,-0.262 -0.785,-0.723 z m 1.426,-3.176 c 0.539,0 0.949,0.453 0.949,1.071 0,0.586 -0.395,0.996 -0.969,0.996 -0.562,0 -0.91,-0.399 -0.91,-1.032 0,-0.601 0.387,-1.035 0.93,-1.035 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath431)"
+             id="path890" />
+          <path
+             d="m 402.355,373.855 h 1.856 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.73 h 1.136 c 0.95,0 1.45,0.641 1.45,1.871 0,1.219 -0.5,1.859 -1.45,1.859 z m 5.308,-2.859 v 3.402 h 0.582 v -4.773 h -0.382 c -0.207,0.73 -0.34,0.832 -1.235,0.949 v 0.422 z m 3.703,-1.371 c -0.433,0 -0.828,0.199 -1.074,0.52 -0.304,0.425 -0.457,1.058 -0.457,1.941 0,1.609 0.531,2.461 1.531,2.461 0.993,0 1.532,-0.852 1.532,-2.422 0,-0.922 -0.145,-1.543 -0.453,-1.98 -0.247,-0.329 -0.633,-0.52 -1.079,-0.52 z m 0,0.516 c 0.629,0 0.938,0.64 0.938,1.933 0,1.36 -0.301,1.992 -0.949,1.992 -0.614,0 -0.922,-0.66 -0.922,-1.972 0,-1.313 0.308,-1.953 0.933,-1.953 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath432)"
+             id="path891" />
+          <path
+             d="m 402.355,366.414 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.636 1.45,1.867 0,1.218 -0.5,1.859 -1.45,1.859 z m 5.308,-2.855 v 3.398 h 0.582 v -4.773 h -0.382 c -0.207,0.734 -0.34,0.832 -1.235,0.949 v 0.426 z m 3.598,0 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.949 v 0.426 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath433)"
+             id="path892" />
+          <path
+             d="m 402.355,358.973 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.411 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.727 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.86 -1.45,1.86 z m 5.308,-2.856 v 3.399 h 0.582 v -4.774 h -0.382 c -0.207,0.735 -0.34,0.832 -1.235,0.953 v 0.422 z m 5.231,2.824 h -2.461 c 0.058,-0.394 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.395 -0.156,-0.766 -0.434,-1.024 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.032 h 0.582 c 0.02,-0.325 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.469 0.808,-0.469 0.528,0 0.922,0.383 0.922,0.898 0,0.383 -0.218,0.715 -0.633,0.954 l -0.605,0.355 c -0.98,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath434)"
+             id="path893" />
+          <path
+             d="m 402.355,351.531 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.406 -1.957,-2.406 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.308,-2.859 v 3.398 h 0.582 v -4.769 h -0.382 c -0.207,0.73 -0.34,0.828 -1.235,0.949 v 0.422 z m 3.348,1.203 h 0.316 c 0.637,0 0.973,0.297 0.973,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.988,-1.023 h -0.582 c 0.027,0.382 0.094,0.636 0.203,0.847 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.609 -0.231,-0.937 -0.793,-1.137 0.437,-0.175 0.652,-0.507 0.652,-0.988 0,-0.82 -0.535,-1.312 -1.426,-1.312 -0.941,0 -1.445,0.527 -1.464,1.535 h 0.582 c 0.007,-0.289 0.031,-0.453 0.105,-0.598 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.824,0.308 0.824,0.824 0,0.336 -0.117,0.539 -0.375,0.652 -0.16,0.066 -0.371,0.094 -0.773,0.102 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath435)"
+             id="path894" />
+          <path
+             d="m 406.445,341.551 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.859 -0.633,1.48 -1.511,1.48 -0.489,0 -0.93,-0.18 -1.215,-0.488 -0.317,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.183 0.672,-1.961 1.687,-1.961 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.168,-0.976 -0.91,-1.539 -2.012,-1.539 -0.586,0 -1.062,0.153 -1.437,0.465 -0.563,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.242 1.644,-0.765 l 0.153,0.64 h 0.386 z m 4.746,-2.27 h -0.582 v 3.934 l -2.515,-3.934 h -0.664 v 4.809 h 0.578 v -3.899 l 2.488,3.899 h 0.695 z m 1.004,4.809 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath436)"
+             id="path895" />
+          <path
+             d="m 404.895,335.086 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 4.07,1.961 1.672,-4.812 h -0.656 l -1.332,4.074 -1.415,-4.074 h -0.66 l 1.731,4.812 z m 2.32,0 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.949,0 1.449,0.64 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 4.187,0.543 h 1.856 c 1.214,0 1.96,-0.91 1.96,-2.41 0,-1.492 -0.738,-2.402 -1.96,-2.402 h -1.856 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath437)"
+             id="path896" />
+          <path
+             d="m 402.355,329.09 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.489 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.308,-2.86 v 3.399 h 0.582 v -4.77 h -0.382 c -0.207,0.731 -0.34,0.828 -1.235,0.95 v 0.421 z m 4.047,2.243 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.094 h -0.429 l -2.125,3 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath438)"
+             id="path897" />
+          <path
+             d="m 402.355,321.648 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.308,-2.859 v 3.398 h 0.582 v -4.769 h -0.382 c -0.207,0.73 -0.34,0.832 -1.235,0.949 v 0.422 z m 5.032,-1.281 h -2.414 l -0.352,2.551 h 0.535 c 0.27,-0.325 0.496,-0.438 0.863,-0.438 0.629,0 1.02,0.43 1.02,1.121 0,0.676 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.254 -0.958,-0.785 h -0.582 c 0.079,0.383 0.145,0.57 0.286,0.742 0.261,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.617,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.286 l 0.187,-1.309 h 1.946 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath439)"
+             id="path898" />
+          <path
+             d="m 402.355,452.094 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 5.414,-4.231 c -0.438,0 -0.832,0.199 -1.074,0.52 -0.305,0.422 -0.457,1.058 -0.457,1.941 0,1.61 0.527,2.461 1.531,2.461 0.988,0 1.531,-0.851 1.531,-2.422 0,-0.922 -0.144,-1.543 -0.457,-1.98 -0.242,-0.328 -0.633,-0.52 -1.074,-0.52 z m 0,0.516 c 0.625,0 0.937,0.64 0.937,1.933 0,1.36 -0.304,1.993 -0.949,1.993 -0.617,0 -0.926,-0.661 -0.926,-1.973 0,-1.313 0.309,-1.953 0.938,-1.953 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath440)"
+             id="path899" />
+          <path
+             d="m 402.355,444.656 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.636 1.45,1.867 0,1.219 -0.5,1.859 -1.45,1.859 z m 5.308,-2.855 v 3.398 h 0.582 v -4.773 h -0.382 c -0.207,0.734 -0.34,0.832 -1.235,0.949 v 0.426 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath441)"
+             id="path900" />
+          <path
+             d="m 402.355,437.094 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.489 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 6.937,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.997 l 0.66,-0.371 c 0.656,-0.359 0.992,-0.851 0.992,-1.437 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.277,-0.25 -0.621,-0.367 -1.063,-0.367 -0.593,0 -1.035,0.211 -1.293,0.617 -0.164,0.254 -0.238,0.551 -0.25,1.032 h 0.579 c 0.023,-0.325 0.062,-0.516 0.14,-0.672 0.153,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.926,0.383 0.926,0.895 0,0.382 -0.219,0.714 -0.637,0.953 l -0.606,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.055 h 3.113 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath442)"
+             id="path901" />
+          <path
+             d="m 402.355,429.652 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.961 -0.964,0.961 -0.637,0 -0.95,-0.32 -0.989,-1.019 h -0.582 c 0.028,0.382 0.094,0.632 0.207,0.843 0.243,0.461 0.7,0.692 1.34,0.692 0.961,0 1.582,-0.578 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.793,-1.136 0.438,-0.176 0.657,-0.508 0.657,-0.989 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.105,-0.598 0.133,-0.273 0.426,-0.429 0.786,-0.429 0.515,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.77,0.102 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath443)"
+             id="path902" />
+          <path
+             d="m 402.355,422.215 h 1.856 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.871 0,1.219 -0.5,1.86 -1.45,1.86 z m 5.758,-0.613 v 1.156 h 0.578 v -1.156 H 410 v -0.524 h -0.695 v -3.094 h -0.426 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.465 l 1.465,-2.105 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath444)"
+             id="path903" />
+          <path
+             d="m 402.355,414.773 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.219 -0.5,1.859 -1.45,1.859 z m 6.742,-4.136 h -2.418 l -0.348,2.547 h 0.532 c 0.273,-0.325 0.496,-0.434 0.867,-0.434 0.625,0 1.015,0.426 1.015,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.816,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.266,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.593,0.086 -0.863,0.282 l 0.184,-1.305 h 1.949 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath445)"
+             id="path904" />
+          <path
+             d="m 402.355,407.332 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.488 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 6.886,-2.992 c -0.113,-0.778 -0.613,-1.242 -1.328,-1.242 -0.515,0 -0.976,0.253 -1.254,0.683 -0.296,0.465 -0.421,1.047 -0.421,1.914 0,0.805 0.113,1.313 0.394,1.735 0.254,0.39 0.66,0.593 1.176,0.593 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.496 -1.433,-1.496 -0.461,0 -0.825,0.168 -1.075,0.519 0.008,-1.18 0.375,-1.836 1.043,-1.836 0.41,0 0.692,0.266 0.785,0.727 z m -1.406,1.101 c 0.559,0 0.91,0.399 0.91,1.032 0,0.601 -0.394,1.035 -0.929,1.035 -0.543,0 -0.953,-0.453 -0.953,-1.063 0,-0.594 0.398,-1.004 0.972,-1.004 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath446)"
+             id="path905" />
+          <path
+             d="m 402.355,399.891 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.407 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z M 410,395.211 h -3.129 v 0.574 h 2.527 c -1.113,1.594 -1.57,2.57 -1.921,4.106 h 0.621 c 0.257,-1.496 0.847,-2.786 1.902,-4.192 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath447)"
+             id="path906" />
+          <path
+             d="m 402.355,519.418 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.727 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.218 -0.5,1.859 -1.45,1.859 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.601 -0.363,0.965 -0.964,0.965 -0.637,0 -0.95,-0.325 -0.989,-1.024 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.844 0.243,0.465 0.7,0.695 1.34,0.695 0.961,0 1.582,-0.582 1.582,-1.484 0,-0.609 -0.23,-0.938 -0.793,-1.137 0.438,-0.179 0.657,-0.508 0.657,-0.992 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.539 h 0.578 c 0.008,-0.289 0.035,-0.457 0.105,-0.602 0.133,-0.27 0.426,-0.43 0.786,-0.43 0.515,0 0.828,0.313 0.828,0.828 0,0.336 -0.121,0.54 -0.379,0.653 -0.156,0.066 -0.367,0.09 -0.77,0.097 z m 5.282,-2.481 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.324 0.496,-0.433 0.863,-0.433 0.629,0 1.02,0.425 1.02,1.121 0,0.672 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.258 -0.958,-0.785 h -0.582 c 0.079,0.382 0.145,0.566 0.286,0.738 0.261,0.355 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.675 0,-0.926 -0.617,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.281 l 0.187,-1.305 h 1.946 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath448)"
+             id="path907" />
+          <path
+             d="m 402.355,511.977 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.411 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 5.058,-1.661 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.965 -0.964,0.965 -0.637,0 -0.95,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.848 0.243,0.46 0.7,0.691 1.34,0.691 0.961,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.23,-0.938 -0.793,-1.137 0.438,-0.176 0.657,-0.508 0.657,-0.988 0,-0.821 -0.536,-1.317 -1.426,-1.317 -0.946,0 -1.446,0.531 -1.465,1.539 h 0.578 c 0.008,-0.289 0.035,-0.453 0.105,-0.601 0.133,-0.27 0.426,-0.426 0.786,-0.426 0.515,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.539 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.77,0.098 z m 5.426,-1.332 c -0.109,-0.777 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.977,0.254 -1.254,0.68 -0.297,0.469 -0.426,1.051 -0.426,1.914 0,0.808 0.113,1.316 0.399,1.738 0.25,0.391 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.004,-1.18 0.375,-1.836 1.043,-1.836 0.406,0 0.691,0.265 0.785,0.726 z m -1.406,1.102 c 0.562,0 0.914,0.398 0.914,1.031 0,0.602 -0.399,1.035 -0.934,1.035 -0.539,0 -0.949,-0.453 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath449)"
+             id="path908" />
+          <path
+             d="m 402.355,504.535 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.598 -0.363,0.961 -0.964,0.961 -0.637,0 -0.95,-0.32 -0.989,-1.024 h -0.582 c 0.028,0.383 0.094,0.637 0.207,0.848 0.243,0.461 0.7,0.692 1.34,0.692 0.961,0 1.582,-0.583 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.793,-1.137 0.438,-0.175 0.657,-0.507 0.657,-0.988 0,-0.82 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.105,-0.598 0.133,-0.273 0.426,-0.43 0.786,-0.43 0.515,0 0.828,0.309 0.828,0.825 0,0.336 -0.121,0.543 -0.379,0.652 -0.156,0.066 -0.367,0.094 -0.77,0.102 z m 5.571,-2.485 h -3.125 v 0.575 H 413 c -1.117,1.593 -1.57,2.57 -1.922,4.105 h 0.621 c 0.258,-1.496 0.844,-2.785 1.899,-4.191 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath450)"
+             id="path909" />
+          <path
+             d="m 402.355,497.098 h 1.856 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 5.058,-1.657 h 0.317 c 0.633,0 0.968,0.297 0.968,0.872 0,0.601 -0.363,0.964 -0.964,0.964 -0.637,0 -0.95,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.844 0.243,0.461 0.7,0.691 1.34,0.691 0.961,0 1.582,-0.578 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.133 0.438,-0.18 0.657,-0.512 0.657,-0.992 0,-0.817 -0.536,-1.313 -1.426,-1.313 -0.946,0 -1.446,0.528 -1.465,1.539 h 0.578 c 0.008,-0.293 0.035,-0.457 0.105,-0.601 0.133,-0.27 0.426,-0.43 0.786,-0.43 0.515,0 0.828,0.309 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.653 -0.156,0.066 -0.367,0.093 -0.77,0.101 z m 4.719,-0.316 c 0.492,-0.297 0.641,-0.535 0.641,-0.984 0,-0.754 -0.575,-1.274 -1.407,-1.274 -0.824,0 -1.402,0.52 -1.402,1.266 0,0.457 0.149,0.687 0.633,0.992 -0.535,0.27 -0.801,0.66 -0.801,1.188 0,0.871 0.641,1.476 1.57,1.476 0.926,0 1.575,-0.605 1.575,-1.476 0,-0.528 -0.266,-0.918 -0.809,-1.188 z m -0.766,-1.742 c 0.497,0 0.813,0.297 0.813,0.769 0,0.45 -0.32,0.746 -0.813,0.746 -0.492,0 -0.808,-0.296 -0.808,-0.757 0,-0.461 0.316,-0.758 0.808,-0.758 z m 0,2.004 c 0.582,0 0.981,0.383 0.981,0.937 0,0.574 -0.391,0.953 -0.992,0.953 -0.567,0 -0.965,-0.39 -0.965,-0.945 0,-0.566 0.391,-0.945 0.976,-0.945 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath451)"
+             id="path910" />
+          <path
+             d="m 402.355,489.656 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.636 1.45,1.867 0,1.219 -0.5,1.859 -1.45,1.859 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.965 -0.964,0.965 -0.637,0 -0.95,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.382 0.094,0.632 0.207,0.843 0.243,0.461 0.7,0.696 1.34,0.696 0.961,0 1.582,-0.582 1.582,-1.489 0,-0.605 -0.23,-0.933 -0.793,-1.132 0.438,-0.18 0.657,-0.508 0.657,-0.993 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.539 h 0.578 c 0.008,-0.293 0.035,-0.457 0.105,-0.602 0.133,-0.269 0.426,-0.429 0.786,-0.429 0.515,0 0.828,0.312 0.828,0.824 0,0.34 -0.121,0.543 -0.379,0.656 -0.156,0.067 -0.367,0.09 -0.77,0.098 z m 2.489,1.109 c 0.113,0.778 0.617,1.243 1.328,1.243 0.519,0 0.984,-0.254 1.261,-0.68 0.29,-0.469 0.422,-1.051 0.422,-1.914 0,-0.809 -0.121,-1.317 -0.398,-1.738 -0.254,-0.387 -0.664,-0.594 -1.18,-0.594 -0.89,0 -1.531,0.668 -1.531,1.59 0,0.879 0.594,1.5 1.437,1.5 0.446,0 0.774,-0.161 1.071,-0.524 -0.008,1.192 -0.375,1.844 -1.043,1.844 -0.41,0 -0.692,-0.266 -0.785,-0.727 z m 1.425,-3.175 c 0.543,0 0.954,0.457 0.954,1.07 0,0.586 -0.399,0.996 -0.973,0.996 -0.559,0 -0.91,-0.395 -0.91,-1.027 0,-0.602 0.39,-1.039 0.929,-1.039 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath452)"
+             id="path911" />
+          <path
+             d="m 402.355,482.215 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.727 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.86 -1.45,1.86 z m 5.758,-0.613 v 1.156 h 0.578 v -1.156 H 410 v -0.52 h -0.695 v -3.098 h -0.426 l -2.125,3.004 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z m 3.253,-3.098 c -0.433,0 -0.828,0.2 -1.074,0.524 -0.304,0.422 -0.457,1.055 -0.457,1.941 0,1.61 0.531,2.461 1.531,2.461 0.993,0 1.532,-0.851 1.532,-2.422 0,-0.925 -0.145,-1.547 -0.453,-1.98 -0.247,-0.332 -0.633,-0.524 -1.079,-0.524 z m 0,0.516 c 0.629,0 0.938,0.641 0.938,1.934 0,1.359 -0.301,1.996 -0.949,1.996 -0.614,0 -0.922,-0.66 -0.922,-1.977 0,-1.312 0.308,-1.953 0.933,-1.953 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath453)"
+             id="path912" />
+          <path
+             d="m 406.445,472.234 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.481 -1.511,1.481 -0.489,0 -0.93,-0.18 -1.215,-0.492 -0.317,-0.34 -0.508,-0.915 -0.508,-1.508 0,-1.184 0.672,-1.961 1.687,-1.961 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.168,-0.977 -0.91,-1.539 -2.012,-1.539 -0.586,0 -1.062,0.152 -1.437,0.461 -0.563,0.465 -0.871,1.211 -0.871,2.074 0,1.477 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.242 1.644,-0.766 l 0.153,0.641 h 0.386 z m 4.746,-2.273 h -0.582 v 3.934 l -2.515,-3.934 h -0.664 v 4.812 h 0.578 v -3.898 l 2.488,3.898 h 0.695 z m 1.004,4.812 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath454)"
+             id="path913" />
+          <path
+             d="m 402.234,467.332 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.757,-0.613 v 1.152 h 0.583 v -1.152 h 0.691 v -0.524 h -0.691 v -3.094 h -0.43 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.464 l 1.464,-2.105 z m 3.153,-1.722 v 3.398 h 0.578 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.833 -1.234,0.95 v 0.422 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath455)"
+             id="path914" />
+          <path
+             d="m 402.234,459.895 h 1.856 c 1.215,0 1.961,-0.915 1.961,-2.411 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.871 0,1.219 -0.5,1.86 -1.45,1.86 z m 5.757,-0.614 v 1.157 h 0.583 v -1.157 h 0.691 v -0.523 h -0.691 v -3.094 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.464 l 1.464,-2.106 z m 4.782,1.105 h -2.461 c 0.058,-0.398 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.399 -0.156,-0.766 -0.434,-1.024 -0.277,-0.254 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.028 h 0.578 c 0.02,-0.321 0.059,-0.512 0.141,-0.672 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.898 0,0.383 -0.215,0.711 -0.633,0.95 l -0.605,0.355 c -0.977,0.563 -1.262,1.012 -1.313,2.055 h 3.114 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath456)"
+             id="path915" />
+        </g>
+      </g>
+    </g>
+    <path
+       d="m 67.5,173.461 h 460.441 v 0.48 H 67.5 Z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="scale(1.3333333)"
+       clip-path="url(#clipPath460)"
+       id="path917" />
+    <path
+       d="m 527.461,173.699 h 0.48 v 507.242 h -0.48 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="scale(1.3333333)"
+       clip-path="url(#clipPath461)"
+       id="path918" />
+    <path
+       d="M 67.262,680.461 H 527.7 v 0.48 H 67.262 Z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="scale(1.3333333)"
+       clip-path="url(#clipPath462)"
+       id="path919" />
+    <path
+       d="m 67.262,173.461 h 0.477 v 507.238 h -0.477 z"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="scale(1.3333333)"
+       clip-path="url(#clipPath463)"
+       id="path920" />
+  </g>
+</svg>

--- a/doc/doxygen/src/pinouts/nucleo-l4r5zi.svg
+++ b/doc/doxygen/src/pinouts/nucleo-l4r5zi.svg
@@ -1,0 +1,5689 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="614.23865"
+   height="676.71863"
+   viewBox="0 0 614.23865 676.7186"
+   sodipodi:docname="nucleo-l4r5zi.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath2">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path4" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path6" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path8" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath10">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path11" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath12">
+      <path
+         d="M 0,0.02 H 595 V 842 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path12" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13">
+      <path
+         d="M 71.52,737.039 H 99.899 V 752.16 H 71.52 Z"
+         transform="scale(1.3333333)"
+         id="path13" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath14">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path14" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M 0,0.02 H 595 V 842 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path16" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="m 67.262,102.422 h 460.68 V 609.961 H 67.262 Z"
+         transform="scale(1.3333333)"
+         id="path17" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path18" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath19">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path19" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath20">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path20" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath21">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path21" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path22" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath23">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path23" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path24" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath25">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path25" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath26">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path26" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path27" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath28">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path28" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath29">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path29" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath30">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path30" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath31">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path31" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath32">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path32" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path33" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path34" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path35" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path36" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path37" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path38" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path39" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath40">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path40" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath41">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path41" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath42">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path42" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path43" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath44">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path44" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath45">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path45" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath46">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path46" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path47" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath48">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path48" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath49">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path49" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath50">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path50" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath51">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path51" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath52">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path52" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath53">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path53" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath54">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path54" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath55">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path55" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath56">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path56" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath57">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path57" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath58">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path58" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath59">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path59" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath60">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path60" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath61">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path61" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath62">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path62" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath63">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path63" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath64">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path64" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath65">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path65" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath66">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path66" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath67">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path67" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath68">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path68" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath69">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path69" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath70">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path70" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath71">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path71" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath72">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path72" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath73">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path73" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath74">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path74" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath75">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path75" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath76">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path76" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath77">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path77" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath78">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path78" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath79">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path79" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath80">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path80" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath81">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path81" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath82">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path82" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath83">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path83" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath84">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path84" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath85">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path85" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath86">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path86" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath87">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path87" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath88">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path88" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath89">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path89" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath90">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path90" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath91">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path91" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath92">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path92" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath93">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path93" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath94">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path94" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath95">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path95" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath96">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path96" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath97">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path97" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath98">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path98" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath99">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path99" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath100">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path100" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath101">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path101" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath102">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path102" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath103">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path103" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath104">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path104" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath105">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path105" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath106">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path106" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath107">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path107" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath108">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path108" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath109">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path109" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath110">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path110" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath111">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path111" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath112">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path112" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath113">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path113" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath114">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path114" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath115">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path115" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath116">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path116" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath117">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path117" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath118">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path118" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath119">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path119" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath120">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path120" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath121">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path121" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath122">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path122" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath123">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path123" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath124">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path124" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath125">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path125" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath126">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path126" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath127">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path127" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath128">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path128" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath129">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path129" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath130">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path130" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath131">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path131" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath132">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path132" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath133">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path133" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath134">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path134" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath135">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path135" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath136">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path136" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath137">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path137" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath138">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path138" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath139">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path139" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath140">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path140" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath141">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path141" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath142">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path142" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath143">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path143" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path144" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path145" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath146">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path146" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path147" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path148" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path149" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path150" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path151" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path152" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path153" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path154" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path155" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path156" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path157" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path158" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path159" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path160" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path161" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path162" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path163" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path164" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path165" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path166" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path167" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path168" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path169" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path170" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path171" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path172" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path173" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path174" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path175" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path176" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path177" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path178" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path179" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path180" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path181" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path182" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path183" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path184" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path185" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path186" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path187" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path188" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path189" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path190" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path191" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path192" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path193" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path194" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path195" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path196" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path197" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path198" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path199" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path200" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path201" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path202" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path203" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path204" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path205" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path206" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path207" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path208" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path209" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path210" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path211" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path212" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path213" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path214" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path215" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path216" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path217" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path218" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path219" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path220" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path221" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path222" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path223" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path224" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path225" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path226" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path227" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path228" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path229" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path230" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path231" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path232" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path233" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path234" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path235" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path236" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path237" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path238" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path239" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path240" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path241" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path242" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path243" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path244" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path245" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path246" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path247" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path248" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path249" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path250" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path251" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path252" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path253" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path254" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path255" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path256" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path257" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path258" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path259" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path260" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path261" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path262" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path263" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path264" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path265" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path266" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path267" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path268" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path269" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path270" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path271" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path272" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path274" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path275" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path276" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path278" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path279" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path280" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path281" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path282" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path283" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path284" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath286">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path286" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath287">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path287" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath288">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path288" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath289">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath290">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path290" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath291">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path291" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath292">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path292" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath293">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path293" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath294">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path294" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath295">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path295" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath296">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path296" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath297">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path297" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath298">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path298" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath299">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path299" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath300">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path300" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath301">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path301" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath302">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path302" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath303">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path303" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath304">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path304" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath305">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path305" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath306">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path306" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath307">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path307" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath308">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path308" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath309">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path309" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath310">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path310" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath311">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path311" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath312">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path312" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath313">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path313" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath314">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path314" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath315">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path315" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath316">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path316" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath317">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path317" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath318">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path318" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath319">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path319" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath320">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath321">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path321" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath322">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path322" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath323">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path323" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath324">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path324" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath325">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path325" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath326">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path326" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath327">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path327" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath328">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath329">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path329" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath330">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path330" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath331">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path331" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath332">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path332" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath333">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path333" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath334">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path334" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath335">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path335" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath336">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path336" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath337">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path337" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath338">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path338" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath339">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path339" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath340">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path340" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath341">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path341" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath342">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path342" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath343">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path343" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath344">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath345">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path345" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath346">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path346" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath347">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path347" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath348">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path348" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath349">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path349" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath350">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path350" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath351">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path351" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath352">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path352" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath353">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path353" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath354">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath355">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path355" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath356">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path356" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath357">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path357" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath358">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path358" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath359">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path359" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath360">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath361">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path361" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath362">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path362" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath363">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path363" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath364">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path364" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath365">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath366">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path366" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path367" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath368">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path368" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath369">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path369" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath370">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path370" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath371">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath372">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path372" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path373" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath374">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path374" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath375">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path375" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath376">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath377">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path377" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath378">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path378" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath379">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path379" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath380">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path380" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath381">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath382">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path382" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path383" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath384">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path384" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath385">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path385" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath386">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path386" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath387">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath388">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path388" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path389" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath390">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path390" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath391">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path391" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath392">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath393">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path393" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath394">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path394" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath395">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path395" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath396">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path396" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath397">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath398">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path398" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path399" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath400">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path400" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath401">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path401" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath402">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path402" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath403">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path403" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath404">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path404" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path405" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath406">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path406" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath407">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path407" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath408">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath409">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path409" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath410">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path410" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath411">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path411" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath412">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path412" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath413">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path413" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path414" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath415">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path415" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath416">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path416" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath417">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path417" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath418">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path418" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath419">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path419" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath420">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path420" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath421">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path421" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath422">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path422" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath423">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path423" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath424">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath425">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path425" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath426">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path426" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath427">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path427" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath428">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path428" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath429">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path429" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath430">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path430" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath431">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path431" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath432">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path432" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath433">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path433" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath434">
+      <path
+         d="M 0,0.02 H 595 V 842 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath435">
+      <path
+         d="m 67.262,102.422 h 460.68 V 609.961 H 67.262 Z"
+         transform="scale(1.3333333)"
+         id="path435" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath436">
+      <path
+         d="M 120.539,102.422 H 474.66 V 609.961 H 120.539 Z"
+         transform="scale(1.3333333)"
+         id="path436" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath437">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path437" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath438">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path438" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath439">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path439" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath440">
+      <path
+         d="M 0,0 H 595 V 843 H 0 Z"
+         id="path440" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.65290966"
+     inkscape:cx="305.55529"
+     inkscape:cy="425.02051"
+     inkscape:window-width="1680"
+     inkscape:window-height="981"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="614.23865"
+       height="676.71863"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <g
+     id="g1"
+     inkscape:groupmode="layer"
+     inkscape:label="1"
+     transform="translate(-89.682663,-136.56266)">
+    <g
+       id="g874">
+      <g
+         clip-path="url(#clipPath17)"
+         id="g454">
+        <g
+           clip-path="url(#clipPath16)"
+           id="g453">
+          <path
+             d="M 120.539,102.422 H 474.66 V 609.961 H 120.539 Z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath15)"
+             id="path453" />
+        </g>
+      </g>
+      <g
+         clip-path="url(#clipPath436)"
+         id="g871">
+        <g
+           clip-path="url(#clipPath435)"
+           id="g870">
+          <g
+             clip-path="url(#clipPath434)"
+             id="g869">
+            <path
+               d="m 141.477,569.035 h 312.851 c 6.242,0 11.16,-5.039 11.16,-11.277 V 124.297 c 0,-6.238 -4.918,-11.281 -11.16,-11.281 H 141.477 c -6.122,0 -11.161,5.043 -11.161,11.281 v 433.461 c 0,6.238 5.039,11.277 11.161,11.277"
+               style="fill:#dddddd;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath18)"
+               id="path454" />
+            <path
+               d="m 246.086,167.02 h 1.961 v -9.536 h -1.961 v 6.489 l -3.781,-6.489 h -2.016 v 9.536 h 1.965 v -6.594 z m 9.394,-9.536 v 6.461 c 0,1.153 -0.589,1.7 -1.816,1.7 -1.23,0 -1.82,-0.547 -1.82,-1.7 v -6.461 h -1.961 v 6.461 c 0,1.075 0.285,1.832 0.929,2.407 0.692,0.628 1.7,0.968 2.852,0.968 1.148,0 2.156,-0.34 2.852,-0.968 0.64,-0.575 0.925,-1.332 0.925,-2.407 v -6.461 z m 11.817,3.231 c -0.067,-0.824 -0.235,-1.348 -0.641,-1.883 -0.734,-0.969 -1.91,-1.504 -3.336,-1.504 -2.695,0 -4.371,1.922 -4.371,5.008 0,3.074 1.664,4.984 4.317,4.984 2.382,0 3.953,-1.375 4.07,-3.558 h -1.91 c -0.133,1.218 -0.891,1.91 -2.106,1.91 -1.519,0 -2.406,-1.231 -2.406,-3.309 0,-2.105 0.926,-3.363 2.473,-3.363 1.136,0 1.777,0.551 2.039,1.715 z m 3.574,-3.231 h -1.961 v 9.536 h 6.528 v -1.637 h -4.567 z m 8.024,5.43 h 4.562 v -1.637 h -4.562 v -2.16 h 4.929 v -1.633 h -6.894 v 9.536 h 7.129 v -1.637 h -5.164 z m 10.871,-5.586 c -1.332,0 -2.43,0.445 -3.243,1.32 -0.851,0.914 -1.335,2.25 -1.335,3.676 0,1.426 0.484,2.774 1.335,3.676 0.825,0.887 1.895,1.32 3.258,1.32 1.36,0 2.434,-0.433 3.258,-1.32 0.82,-0.879 1.332,-2.266 1.332,-3.609 0,-1.493 -0.484,-2.84 -1.332,-3.743 -0.84,-0.902 -1.887,-1.32 -3.273,-1.32 z m 0.015,1.672 c 1.61,0 2.629,1.309 2.629,3.375 0,1.965 -1.058,3.27 -2.629,3.27 -1.597,0 -2.629,-1.305 -2.629,-3.321 0,-2.015 1.032,-3.324 2.629,-3.324 z m 9.004,3.547 h -3.558 v 1.765 h 3.558 z m 3.508,-5.063 h -1.961 v 9.536 h 6.527 v -1.637 h -4.566 z m 11.855,5.965 h -0.968 v -5.703 h -2.157 l -3.39,5.676 v 1.543 h 3.715 v 2.055 h 1.832 v -2.055 h 0.968 z m -2.8,0 h -2.418 l 2.418,-3.965 z m 6.179,-0.211 h 2.25 c 0.852,0 1.219,0.34 1.219,1.125 v 0.395 c -0.016,0.246 -0.016,0.484 -0.016,0.625 0,0.902 0.055,1.179 0.29,1.637 h 2.105 v -0.352 c -0.301,-0.172 -0.418,-0.367 -0.418,-0.785 -0.051,-2.813 -0.105,-2.945 -1.32,-3.469 1.07,-0.418 1.609,-1.187 1.609,-2.352 0,-0.761 -0.262,-1.453 -0.719,-1.925 -0.433,-0.446 -1.035,-0.653 -1.847,-0.653 h -5.114 v 9.536 h 1.961 z m 0,-1.633 v -2.488 h 2.371 c 0.563,0 0.782,0.055 1.032,0.25 0.234,0.195 0.355,0.524 0.355,0.969 0,0.457 -0.121,0.824 -0.355,1.019 -0.223,0.184 -0.469,0.25 -1.032,0.25 z m 12.989,-3.859 h -4.957 l -0.825,5.168 h 1.649 c 0.195,-0.461 0.617,-0.707 1.176,-0.707 0.929,0 1.492,0.664 1.492,1.789 0,1.086 -0.563,1.754 -1.492,1.754 -0.797,0 -1.243,-0.406 -1.282,-1.152 h -1.804 c 0.027,1.625 1.257,2.722 3.062,2.722 1.988,0 3.348,-1.359 3.348,-3.363 0,-1.91 -1.176,-3.203 -2.891,-3.203 -0.613,0 -1.074,0.156 -1.609,0.562 l 0.301,-1.937 h 3.832 z m 8.367,-0.262 h -7.168 v 1.633 h 4.879 l -4.879,6.266 v 1.637 h 7.168 v -1.637 h -4.867 l 4.867,-6.266 z m 3.265,0 h -1.96 v 9.536 h 1.96 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath19)"
+               id="path455" />
+            <path
+               d="M 466.211,203.98 H 131.035"
+               style="fill:none;stroke:#ffffff;stroke-width:2.838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:110.684, 25.542, 42.571, 25.542, 42.571, 25.542;stroke-dashoffset:0;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath20)"
+               id="path456" />
+            <path
+               d="m 385.148,237.879 c -0.035,-0.414 -0.121,-0.68 -0.324,-0.949 -0.371,-0.489 -0.965,-0.758 -1.683,-0.758 -1.36,0 -2.203,0.969 -2.203,2.527 0,1.551 0.835,2.516 2.175,2.516 1.203,0 1.996,-0.695 2.055,-1.797 h -0.965 c -0.066,0.613 -0.449,0.965 -1.062,0.965 -0.766,0 -1.215,-0.621 -1.215,-1.672 0,-1.063 0.469,-1.695 1.25,-1.695 0.574,0 0.894,0.277 1.027,0.863 z m 3.672,3.183 h 0.989 v -4.812 h -0.989 v 3.273 l -1.91,-3.273 h -1.015 v 4.812 h 0.992 v -3.328 z m 4.793,-4.679 h -3.293 v 0.824 h 2.328 c -0.285,0.305 -0.843,1.156 -1.031,1.566 -0.32,0.68 -0.488,1.293 -0.613,2.289 h 0.93 c 0.086,-1.48 0.57,-2.613 1.679,-3.953 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath21)"
+               id="path457" />
+            <path
+               d="m 383.348,456.051 c -0.032,-0.418 -0.118,-0.68 -0.325,-0.949 -0.367,-0.489 -0.961,-0.762 -1.683,-0.762 -1.36,0 -2.203,0.972 -2.203,2.527 0,1.551 0.84,2.516 2.179,2.516 1.2,0 1.993,-0.692 2.051,-1.793 h -0.965 c -0.062,0.613 -0.445,0.961 -1.062,0.961 -0.766,0 -1.215,-0.621 -1.215,-1.668 0,-1.063 0.469,-1.695 1.25,-1.695 0.574,0 0.898,0.277 1.027,0.863 z m 3.672,3.179 h 0.988 v -4.808 h -0.988 v 3.273 l -1.907,-3.273 h -1.019 v 4.808 h 0.992 v -3.324 z m 2.878,-3.226 v 3.226 h 0.922 v -4.679 h -0.613 c -0.145,0.554 -0.625,0.84 -1.43,0.84 v 0.613 z m 3.832,-1.551 c -0.503,0 -0.929,0.211 -1.214,0.602 -0.27,0.363 -0.399,0.957 -0.399,1.867 0,0.832 0.11,1.414 0.332,1.769 0.278,0.45 0.735,0.692 1.281,0.692 0.508,0 0.922,-0.203 1.215,-0.594 0.262,-0.363 0.395,-0.965 0.395,-1.84 0,-0.859 -0.106,-1.441 -0.328,-1.804 -0.278,-0.446 -0.735,-0.692 -1.282,-0.692 z m 0,0.746 c 0.239,0 0.43,0.133 0.54,0.375 0.093,0.199 0.144,0.707 0.144,1.356 0,0.527 -0.043,1.043 -0.117,1.234 -0.106,0.277 -0.305,0.426 -0.567,0.426 -0.246,0 -0.429,-0.125 -0.542,-0.363 -0.09,-0.196 -0.145,-0.684 -0.145,-1.313 0,-0.555 0.047,-1.082 0.117,-1.273 0.102,-0.286 0.305,-0.442 0.57,-0.442 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath22)"
+               id="path458" />
+            <path
+               d="m 208.262,262.84 c -0.035,-0.414 -0.121,-0.68 -0.324,-0.949 -0.372,-0.489 -0.965,-0.758 -1.684,-0.758 -1.359,0 -2.207,0.969 -2.207,2.527 0,1.551 0.84,2.516 2.18,2.516 1.203,0 1.992,-0.696 2.054,-1.797 h -0.965 c -0.066,0.613 -0.449,0.965 -1.062,0.965 -0.766,0 -1.215,-0.621 -1.215,-1.672 0,-1.063 0.469,-1.695 1.246,-1.695 0.574,0 0.899,0.277 1.031,0.863 z m 3.668,3.183 h 0.992 v -4.812 h -0.992 v 3.273 l -1.907,-3.273 h -1.015 v 4.812 h 0.988 v -3.328 z m 4.008,-2.546 c 0.16,-0.086 0.23,-0.133 0.304,-0.2 0.192,-0.179 0.305,-0.461 0.305,-0.765 0,-0.735 -0.633,-1.266 -1.5,-1.266 -0.871,0 -1.504,0.531 -1.504,1.274 0,0.449 0.184,0.73 0.605,0.957 -0.539,0.296 -0.765,0.644 -0.765,1.199 0,0.886 0.679,1.5 1.664,1.5 0.976,0 1.656,-0.614 1.656,-1.5 0,-0.555 -0.223,-0.903 -0.765,-1.199 z m -0.883,-1.485 c 0.41,0 0.691,0.25 0.691,0.613 0,0.356 -0.289,0.614 -0.691,0.614 -0.418,0 -0.7,-0.25 -0.7,-0.621 0,-0.356 0.282,-0.606 0.7,-0.606 z m -0.016,1.852 c 0.457,0 0.742,0.304 0.742,0.793 0,0.449 -0.293,0.746 -0.742,0.746 -0.445,0 -0.73,-0.297 -0.73,-0.758 0,-0.477 0.285,-0.781 0.73,-0.781 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath23)"
+               id="path459" />
+            <path
+               d="m 208.262,456.051 c -0.035,-0.418 -0.121,-0.68 -0.324,-0.949 -0.372,-0.489 -0.965,-0.762 -1.684,-0.762 -1.359,0 -2.207,0.972 -2.207,2.527 0,1.551 0.84,2.516 2.18,2.516 1.203,0 1.992,-0.692 2.054,-1.793 h -0.965 c -0.066,0.613 -0.449,0.961 -1.062,0.961 -0.766,0 -1.215,-0.621 -1.215,-1.668 0,-1.063 0.469,-1.695 1.246,-1.695 0.574,0 0.899,0.273 1.031,0.863 z m 3.668,3.179 h 0.992 v -4.808 h -0.992 v 3.273 l -1.907,-3.273 h -1.015 v 4.808 h 0.988 v -3.324 z m 1.558,-1.085 c 0.02,0.718 0.629,1.246 1.434,1.246 0.601,0 1.055,-0.25 1.332,-0.727 0.246,-0.414 0.391,-1.121 0.391,-1.875 0,-0.687 -0.106,-1.215 -0.325,-1.57 -0.297,-0.5 -0.758,-0.766 -1.32,-0.766 -0.938,0 -1.574,0.672 -1.574,1.649 0,0.964 0.566,1.625 1.398,1.625 0.238,0 0.461,-0.067 0.606,-0.172 0.086,-0.059 0.14,-0.117 0.293,-0.289 0,0.902 -0.254,1.332 -0.774,1.332 -0.332,0 -0.547,-0.18 -0.566,-0.453 z m 1.489,-2.938 c 0.445,0 0.722,0.34 0.722,0.895 0,0.515 -0.281,0.859 -0.711,0.859 -0.422,0 -0.687,-0.328 -0.687,-0.871 0,-0.543 0.258,-0.883 0.676,-0.883 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath24)"
+               id="path460" />
+            <path
+               d="m 379.688,311.984 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath25)"
+               id="path461" />
+            <path
+               d="m 379.688,304.543 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath26)"
+               id="path462" />
+            <path
+               d="m 379.688,297.105 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath27)"
+               id="path463" />
+            <path
+               d="m 379.688,289.664 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath28)"
+               id="path464" />
+            <path
+               d="m 379.688,282.223 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath29)"
+               id="path465" />
+            <path
+               d="m 379.688,274.785 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath30)"
+               id="path466" />
+            <path
+               d="m 379.688,267.344 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath31)"
+               id="path467" />
+            <path
+               d="m 379.688,259.902 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath32)"
+               id="path468" />
+            <path
+               d="m 379.688,252.344 h 7.438 v 7.559 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath33)"
+               id="path469" />
+            <path
+               d="m 379.688,244.902 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath34)"
+               id="path470" />
+            <path
+               d="m 387.129,311.984 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath35)"
+               id="path471" />
+            <path
+               d="m 387.129,304.543 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath36)"
+               id="path472" />
+            <path
+               d="m 387.129,297.105 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath37)"
+               id="path473" />
+            <path
+               d="m 387.129,289.664 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath38)"
+               id="path474" />
+            <path
+               d="m 387.129,282.223 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath39)"
+               id="path475" />
+            <path
+               d="m 387.129,274.785 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath40)"
+               id="path476" />
+            <path
+               d="m 387.129,267.344 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath41)"
+               id="path477" />
+            <path
+               d="m 387.129,259.902 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath42)"
+               id="path478" />
+            <path
+               d="m 387.129,252.344 h 7.438 v 7.559 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath43)"
+               id="path479" />
+            <path
+               d="m 387.129,244.902 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath44)"
+               id="path480" />
+            <path
+               d="m 383.223,248.082 v 2.582 h 0.738 v -3.746 h -0.488 c -0.118,0.445 -0.504,0.672 -1.149,0.672 v 0.492 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath45)"
+               id="path481" />
+            <path
+               d="m 383.113,256.43 c 0.285,0 0.301,0 0.434,0.035 0.246,0.07 0.406,0.285 0.406,0.562 0,0.332 -0.234,0.563 -0.555,0.563 -0.347,0 -0.539,-0.199 -0.562,-0.586 h -0.715 c 0.004,0.75 0.488,1.219 1.262,1.219 0.797,0 1.308,-0.469 1.308,-1.196 0,-0.441 -0.191,-0.726 -0.613,-0.929 0.344,-0.219 0.492,-0.457 0.492,-0.797 0,-0.625 -0.465,-1.02 -1.187,-1.02 -0.547,0 -0.961,0.235 -1.125,0.645 -0.07,0.179 -0.09,0.301 -0.09,0.609 h 0.687 c 0.004,-0.199 0.02,-0.301 0.055,-0.394 0.07,-0.164 0.238,-0.266 0.457,-0.266 0.293,0 0.465,0.18 0.465,0.492 0,0.379 -0.219,0.567 -0.656,0.567 h -0.063 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath46)"
+               id="path482" />
+            <path
+               d="m 384.547,261.801 h -2 l -0.332,2.086 h 0.664 c 0.082,-0.188 0.25,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.722 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.5,-0.164 -0.519,-0.465 h -0.727 c 0.012,0.657 0.508,1.098 1.235,1.098 0.804,0 1.351,-0.547 1.351,-1.355 0,-0.774 -0.472,-1.293 -1.164,-1.293 -0.25,0 -0.433,0.062 -0.652,0.226 L 383,262.461 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath47)"
+               id="path483" />
+            <path
+               d="m 384.754,269.238 h -2.633 v 0.66 h 1.863 c -0.226,0.247 -0.675,0.926 -0.824,1.254 -0.258,0.543 -0.39,1.036 -0.492,1.832 h 0.746 c 0.066,-1.183 0.453,-2.093 1.34,-3.164 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath48)"
+               id="path484" />
+            <path
+               d="m 382.168,279.551 c 0.016,0.578 0.5,1 1.144,1 0.481,0 0.844,-0.199 1.067,-0.582 0.195,-0.332 0.312,-0.899 0.312,-1.5 0,-0.547 -0.086,-0.969 -0.257,-1.254 -0.239,-0.403 -0.61,-0.613 -1.059,-0.613 -0.75,0 -1.262,0.539 -1.262,1.32 0,0.769 0.457,1.297 1.121,1.297 0.192,0 0.368,-0.051 0.485,-0.137 0.07,-0.047 0.113,-0.094 0.234,-0.23 0,0.722 -0.203,1.066 -0.617,1.066 -0.266,0 -0.441,-0.145 -0.457,-0.367 z m 1.187,-2.348 c 0.36,0 0.583,0.274 0.583,0.719 0,0.41 -0.231,0.683 -0.571,0.683 -0.34,0 -0.551,-0.261 -0.551,-0.695 0,-0.433 0.207,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath49)"
+               id="path485" />
+            <path
+               d="m 381.785,285.402 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.446 -0.5,0.672 -1.144,0.672 v 0.492 z m 2.879,0 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.446 -0.5,0.672 -1.144,0.672 v 0.492 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath50)"
+               id="path486" />
+            <path
+               d="m 381.785,292.844 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.492 z m 2.766,0.906 c 0.285,0 0.301,0 0.433,0.039 0.25,0.066 0.407,0.285 0.407,0.559 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.718 c 0.007,0.75 0.492,1.223 1.261,1.223 0.797,0 1.313,-0.473 1.313,-1.199 0,-0.438 -0.192,-0.723 -0.613,-0.93 0.343,-0.215 0.488,-0.453 0.488,-0.797 0,-0.625 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.613 h 0.688 c 0.004,-0.203 0.023,-0.3 0.059,-0.398 0.07,-0.164 0.238,-0.262 0.453,-0.262 0.297,0 0.465,0.18 0.465,0.489 0,0.382 -0.215,0.566 -0.653,0.566 h -0.066 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath51)"
+               id="path487" />
+            <path
+               d="m 381.785,300.281 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.441 -0.5,0.672 -1.144,0.672 v 0.488 z m 4.203,-1.16 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.184 0.246,-0.285 0.477,-0.285 0.375,0 0.601,0.269 0.601,0.723 0,0.437 -0.226,0.707 -0.601,0.707 -0.324,0 -0.504,-0.164 -0.52,-0.465 h -0.726 c 0.008,0.656 0.504,1.097 1.234,1.097 0.801,0 1.352,-0.546 1.352,-1.355 0,-0.77 -0.477,-1.293 -1.168,-1.293 -0.246,0 -0.434,0.062 -0.649,0.226 l 0.121,-0.781 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath52)"
+               id="path488" />
+            <path
+               d="m 381.785,307.723 v 2.582 h 0.738 v -3.743 h -0.492 c -0.117,0.442 -0.5,0.668 -1.144,0.668 v 0.493 z m 4.41,-1.161 h -2.636 v 0.661 h 1.863 c -0.227,0.242 -0.676,0.922 -0.82,1.25 -0.262,0.543 -0.391,1.035 -0.493,1.832 h 0.743 c 0.07,-1.184 0.457,-2.09 1.343,-3.164 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath53)"
+               id="path489" />
+            <path
+               d="m 381.785,315.164 v 2.582 h 0.738 V 314 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.492 z m 1.82,1.711 c 0.016,0.574 0.504,0.996 1.149,0.996 0.48,0 0.844,-0.199 1.066,-0.578 0.196,-0.336 0.313,-0.898 0.313,-1.5 0,-0.551 -0.086,-0.973 -0.262,-1.258 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.77 0.453,1.301 1.117,1.301 0.191,0 0.371,-0.055 0.488,-0.141 0.067,-0.047 0.11,-0.093 0.231,-0.23 0,0.723 -0.2,1.066 -0.618,1.066 -0.261,0 -0.437,-0.144 -0.453,-0.363 z m 1.192,-2.352 c 0.355,0 0.578,0.274 0.578,0.719 0,0.41 -0.227,0.688 -0.57,0.688 -0.336,0 -0.547,-0.266 -0.547,-0.7 0,-0.433 0.203,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath54)"
+               id="path490" />
+            <path
+               d="m 392.23,250.004 h -1.589 c 0.101,-0.203 0.214,-0.313 0.765,-0.711 0.649,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.5,-1.187 -1.285,-1.187 -0.773,0 -1.227,0.457 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.661 0.535,-0.661 0.325,0 0.528,0.227 0.528,0.602 0,0.418 -0.129,0.57 -0.961,1.16 -0.633,0.434 -0.832,0.762 -0.863,1.461 h 2.546 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath55)"
+               id="path491" />
+            <path
+               d="m 392.281,256.66 h -0.39 v -2.301 h -0.871 l -1.368,2.293 v 0.621 h 1.5 v 0.829 h 0.739 v -0.829 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.598 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath56)"
+               id="path492" />
+            <path
+               d="m 392.203,262.648 c -0.035,-0.242 -0.082,-0.363 -0.18,-0.5 -0.195,-0.269 -0.539,-0.429 -0.945,-0.429 -0.465,0 -0.844,0.207 -1.07,0.582 -0.223,0.363 -0.313,0.781 -0.313,1.461 0,0.644 0.078,1.047 0.27,1.347 0.215,0.348 0.605,0.555 1.051,0.555 0.746,0 1.25,-0.555 1.25,-1.371 0,-0.719 -0.442,-1.215 -1.086,-1.215 -0.305,0 -0.512,0.09 -0.746,0.332 l 0.007,-0.078 c 0.008,-0.352 0.024,-0.461 0.079,-0.602 0.101,-0.277 0.281,-0.414 0.539,-0.414 0.238,0 0.363,0.094 0.457,0.332 z m -1.207,1.016 c 0.348,0 0.57,0.262 0.57,0.68 0,0.398 -0.246,0.687 -0.57,0.687 -0.34,0 -0.57,-0.273 -0.57,-0.676 0,-0.406 0.23,-0.691 0.57,-0.691 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath57)"
+               id="path493" />
+            <path
+               d="m 391.688,270.945 c 0.124,-0.07 0.183,-0.105 0.242,-0.16 0.152,-0.14 0.242,-0.367 0.242,-0.609 0,-0.586 -0.508,-1.016 -1.199,-1.016 -0.696,0 -1.203,0.43 -1.203,1.02 0,0.359 0.148,0.586 0.484,0.765 -0.43,0.239 -0.609,0.516 -0.609,0.961 0,0.707 0.543,1.199 1.328,1.199 0.781,0 1.324,-0.492 1.324,-1.199 0,-0.445 -0.176,-0.722 -0.609,-0.961 z m -0.708,-1.187 c 0.325,0 0.551,0.199 0.551,0.492 0,0.281 -0.23,0.488 -0.551,0.488 -0.335,0 -0.562,-0.199 -0.562,-0.496 0,-0.285 0.227,-0.484 0.562,-0.484 z m -0.011,1.484 c 0.363,0 0.59,0.242 0.59,0.633 0,0.359 -0.231,0.598 -0.59,0.598 -0.36,0 -0.586,-0.239 -0.586,-0.61 0,-0.379 0.226,-0.621 0.586,-0.621 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath58)"
+               id="path494" />
+            <path
+               d="m 389.344,277.84 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.488 z m 3.062,-1.238 c -0.398,0 -0.742,0.168 -0.968,0.48 -0.219,0.289 -0.317,0.766 -0.317,1.492 0,0.668 0.082,1.133 0.262,1.418 0.222,0.356 0.586,0.555 1.023,0.555 0.41,0 0.742,-0.164 0.973,-0.477 0.211,-0.289 0.316,-0.769 0.316,-1.472 0,-0.688 -0.082,-1.153 -0.261,-1.442 -0.223,-0.359 -0.586,-0.554 -1.028,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.156 0.117,0.562 0.117,1.082 0,0.422 -0.035,0.832 -0.094,0.984 -0.086,0.223 -0.242,0.344 -0.457,0.344 -0.195,0 -0.34,-0.098 -0.429,-0.289 -0.075,-0.16 -0.118,-0.551 -0.118,-1.051 0,-0.445 0.036,-0.867 0.094,-1.019 0.078,-0.227 0.242,-0.352 0.453,-0.352 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath59)"
+               id="path495" />
+            <path
+               d="m 389.344,285.402 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.446 -0.5,0.672 -1.145,0.672 v 0.492 z m 4.328,1.922 h -1.59 c 0.098,-0.203 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.129 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.164 -0.632,0.434 -0.828,0.758 -0.859,1.457 h 2.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath60)"
+               id="path496" />
+            <path
+               d="m 389.344,292.844 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.492 z m 4.379,1.14 h -0.391 v -2.304 h -0.871 l -1.367,2.293 v 0.621 h 1.5 v 0.832 h 0.738 v -0.832 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.601 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath61)"
+               id="path497" />
+            <path
+               d="m 389.344,300.281 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.441 -0.5,0.672 -1.145,0.672 v 0.488 z m 4.301,-0.308 c -0.04,-0.246 -0.086,-0.368 -0.18,-0.504 -0.195,-0.27 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.203 -1.075,0.578 -0.218,0.367 -0.308,0.781 -0.308,1.465 0,0.644 0.078,1.043 0.269,1.344 0.215,0.351 0.606,0.554 1.051,0.554 0.742,0 1.25,-0.554 1.25,-1.371 0,-0.718 -0.445,-1.215 -1.086,-1.215 -0.309,0 -0.516,0.09 -0.746,0.332 l 0.004,-0.078 c 0.012,-0.347 0.027,-0.461 0.078,-0.601 0.102,-0.274 0.281,-0.414 0.539,-0.414 0.238,0 0.367,0.097 0.461,0.336 z m -1.211,1.011 c 0.347,0 0.57,0.266 0.57,0.68 0,0.398 -0.242,0.688 -0.57,0.688 -0.336,0 -0.571,-0.274 -0.571,-0.676 0,-0.406 0.235,-0.692 0.571,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath62)"
+               id="path498" />
+            <path
+               d="m 389.344,307.723 v 2.582 h 0.738 v -3.743 h -0.492 c -0.113,0.442 -0.5,0.668 -1.145,0.668 v 0.493 z m 3.781,0.543 c 0.129,-0.067 0.187,-0.106 0.242,-0.157 0.156,-0.144 0.246,-0.371 0.246,-0.613 0,-0.586 -0.508,-1.016 -1.199,-1.016 -0.699,0 -1.203,0.43 -1.203,1.02 0,0.359 0.144,0.586 0.484,0.766 -0.433,0.238 -0.613,0.519 -0.613,0.961 0,0.707 0.543,1.199 1.332,1.199 0.781,0 1.324,-0.492 1.324,-1.199 0,-0.442 -0.179,-0.723 -0.613,-0.961 z m -0.707,-1.188 c 0.328,0 0.555,0.199 0.555,0.492 0,0.285 -0.231,0.489 -0.555,0.489 -0.332,0 -0.559,-0.2 -0.559,-0.497 0,-0.285 0.227,-0.484 0.559,-0.484 z m -0.012,1.484 c 0.367,0 0.594,0.243 0.594,0.633 0,0.36 -0.234,0.598 -0.594,0.598 -0.355,0 -0.586,-0.238 -0.586,-0.609 0,-0.379 0.231,-0.622 0.586,-0.622 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath63)"
+               id="path499" />
+            <path
+               d="m 390.789,317.086 h -1.59 c 0.102,-0.203 0.219,-0.313 0.766,-0.707 0.652,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.661 0.535,-0.661 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.632,0.43 -0.828,0.758 -0.859,1.457 h 2.543 z m 1.617,-3.164 c -0.398,0 -0.742,0.168 -0.968,0.48 -0.219,0.289 -0.317,0.766 -0.317,1.496 0,0.664 0.082,1.129 0.262,1.414 0.222,0.36 0.586,0.555 1.023,0.555 0.41,0 0.742,-0.164 0.973,-0.476 0.211,-0.289 0.316,-0.77 0.316,-1.473 0,-0.688 -0.082,-1.152 -0.261,-1.441 -0.223,-0.36 -0.586,-0.555 -1.028,-0.555 z m 0,0.598 c 0.192,0 0.344,0.105 0.434,0.3 0.074,0.157 0.117,0.563 0.117,1.082 0,0.422 -0.035,0.836 -0.094,0.989 -0.086,0.218 -0.242,0.343 -0.457,0.343 -0.195,0 -0.34,-0.101 -0.429,-0.293 -0.075,-0.156 -0.118,-0.546 -0.118,-1.05 0,-0.442 0.036,-0.864 0.094,-1.02 0.078,-0.226 0.242,-0.351 0.453,-0.351 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath64)"
+               id="path500" />
+            <path
+               d="m 202.438,323.145 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath65)"
+               id="path501" />
+            <path
+               d="m 202.438,315.707 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath66)"
+               id="path502" />
+            <path
+               d="m 202.438,308.266 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath67)"
+               id="path503" />
+            <path
+               d="m 202.438,300.824 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath68)"
+               id="path504" />
+            <path
+               d="m 202.438,293.383 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath69)"
+               id="path505" />
+            <path
+               d="m 202.438,285.945 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath70)"
+               id="path506" />
+            <path
+               d="m 202.438,278.504 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath71)"
+               id="path507" />
+            <path
+               d="m 202.438,271.062 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath72)"
+               id="path508" />
+            <path
+               d="m 209.879,323.145 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath73)"
+               id="path509" />
+            <path
+               d="m 209.879,315.707 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath74)"
+               id="path510" />
+            <path
+               d="m 209.879,308.266 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath75)"
+               id="path511" />
+            <path
+               d="m 209.879,300.824 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath76)"
+               id="path512" />
+            <path
+               d="m 209.879,293.383 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath77)"
+               id="path513" />
+            <path
+               d="m 209.879,285.945 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath78)"
+               id="path514" />
+            <path
+               d="m 209.879,278.504 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath79)"
+               id="path515" />
+            <path
+               d="m 209.879,271.062 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath80)"
+               id="path516" />
+            <path
+               d="m 205.977,274.121 v 2.582 h 0.738 v -3.742 h -0.492 c -0.114,0.441 -0.5,0.668 -1.145,0.668 v 0.492 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath81)"
+               id="path517" />
+            <path
+               d="m 205.863,282.469 c 0.285,0 0.301,0 0.434,0.039 0.25,0.066 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.567 -0.555,0.567 -0.347,0 -0.535,-0.203 -0.558,-0.586 h -0.719 c 0.008,0.75 0.492,1.219 1.262,1.219 0.797,0 1.312,-0.469 1.312,-1.2 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.215 0.488,-0.453 0.488,-0.797 0,-0.621 -0.461,-1.02 -1.187,-1.02 -0.543,0 -0.961,0.239 -1.125,0.645 -0.067,0.18 -0.09,0.301 -0.09,0.613 h 0.687 c 0.004,-0.199 0.024,-0.301 0.059,-0.394 0.07,-0.164 0.238,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.563 -0.652,0.563 h -0.067 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath82)"
+               id="path518" />
+            <path
+               d="m 207.301,287.961 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.188 0.246,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.722 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.504,-0.164 -0.519,-0.464 h -0.727 c 0.008,0.656 0.504,1.097 1.235,1.097 0.8,0 1.351,-0.547 1.351,-1.355 0,-0.77 -0.476,-1.293 -1.168,-1.293 -0.246,0 -0.433,0.062 -0.648,0.226 l 0.121,-0.781 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath83)"
+               id="path519" />
+            <path
+               d="m 207.508,295.402 h -2.637 v 0.66 h 1.863 c -0.226,0.243 -0.675,0.922 -0.82,1.25 -0.262,0.543 -0.391,1.036 -0.492,1.833 h 0.742 c 0.07,-1.184 0.457,-2.09 1.344,-3.165 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath84)"
+               id="path520" />
+            <path
+               d="m 204.918,305.715 c 0.016,0.574 0.504,0.996 1.148,0.996 0.481,0 0.844,-0.199 1.067,-0.582 0.195,-0.332 0.312,-0.895 0.312,-1.496 0,-0.551 -0.086,-0.973 -0.261,-1.258 -0.239,-0.402 -0.606,-0.613 -1.055,-0.613 -0.75,0 -1.262,0.539 -1.262,1.32 0,0.77 0.453,1.297 1.117,1.297 0.192,0 0.371,-0.051 0.489,-0.137 0.066,-0.047 0.109,-0.094 0.23,-0.23 0,0.722 -0.199,1.066 -0.617,1.066 -0.262,0 -0.438,-0.144 -0.453,-0.363 z m 1.191,-2.352 c 0.356,0 0.579,0.274 0.579,0.719 0,0.41 -0.227,0.688 -0.571,0.688 -0.336,0 -0.547,-0.266 -0.547,-0.7 0,-0.433 0.203,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath85)"
+               id="path521" />
+            <path
+               d="m 204.535,311.441 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.446 -0.504,0.672 -1.148,0.672 v 0.488 z m 2.883,0 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.446 -0.5,0.672 -1.144,0.672 v 0.488 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath86)"
+               id="path522" />
+            <path
+               d="m 204.535,318.883 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.441 -0.504,0.668 -1.148,0.668 v 0.492 z m 2.77,0.91 c 0.285,0 0.3,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.559 0,0.336 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.719 c 0.004,0.75 0.493,1.219 1.262,1.219 0.797,0 1.309,-0.469 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.61,-0.93 0.34,-0.215 0.489,-0.453 0.489,-0.797 0,-0.621 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.613 h 0.688 c 0.004,-0.199 0.019,-0.3 0.058,-0.394 0.067,-0.164 0.239,-0.266 0.454,-0.266 0.296,0 0.464,0.18 0.464,0.492 0,0.379 -0.214,0.567 -0.656,0.567 h -0.062 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath87)"
+               id="path523" />
+            <path
+               d="m 204.535,326.324 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.672 -1.148,0.672 v 0.492 z m 4.207,-1.164 h -2 l -0.336,2.086 h 0.668 c 0.078,-0.184 0.246,-0.285 0.473,-0.285 0.375,0 0.601,0.269 0.601,0.727 0,0.437 -0.226,0.707 -0.601,0.707 -0.32,0 -0.5,-0.165 -0.516,-0.465 h -0.73 c 0.011,0.652 0.508,1.097 1.238,1.097 0.801,0 1.352,-0.55 1.352,-1.355 0,-0.774 -0.477,-1.297 -1.168,-1.297 -0.25,0 -0.434,0.066 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath88)"
+               id="path524" />
+            <path
+               d="m 215.102,276.043 h -1.586 c 0.097,-0.199 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.836,-0.754 0.836,-1.266 0,-0.726 -0.5,-1.191 -1.281,-1.191 -0.777,0 -1.231,0.461 -1.231,1.254 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.2,-0.661 0.536,-0.661 0.328,0 0.527,0.227 0.527,0.602 0,0.414 -0.125,0.57 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath89)"
+               id="path525" />
+            <path
+               d="m 215.156,282.703 h -0.39 v -2.305 h -0.871 l -1.368,2.293 v 0.625 h 1.5 v 0.829 h 0.739 v -0.829 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.601 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath90)"
+               id="path526" />
+            <path
+               d="m 215.078,288.809 c -0.039,-0.243 -0.086,-0.364 -0.18,-0.5 -0.195,-0.27 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.848,0.203 -1.074,0.578 -0.219,0.367 -0.309,0.781 -0.309,1.465 0,0.644 0.078,1.043 0.266,1.344 0.219,0.351 0.609,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.371 0,-0.719 -0.446,-1.215 -1.09,-1.215 -0.305,0 -0.512,0.09 -0.742,0.332 l 0.003,-0.078 c 0.012,-0.347 0.028,-0.461 0.079,-0.601 0.101,-0.278 0.281,-0.414 0.539,-0.414 0.238,0 0.363,0.097 0.461,0.332 z m -1.211,1.015 c 0.348,0 0.571,0.266 0.571,0.68 0,0.398 -0.243,0.687 -0.571,0.687 -0.336,0 -0.57,-0.273 -0.57,-0.675 0,-0.407 0.234,-0.692 0.57,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath91)"
+               id="path527" />
+            <path
+               d="m 214.559,297.105 c 0.129,-0.066 0.183,-0.105 0.242,-0.156 0.156,-0.144 0.246,-0.371 0.246,-0.613 0,-0.586 -0.508,-1.016 -1.199,-1.016 -0.7,0 -1.207,0.43 -1.207,1.02 0,0.359 0.148,0.586 0.488,0.765 -0.434,0.239 -0.613,0.52 -0.613,0.961 0,0.707 0.543,1.2 1.332,1.2 0.781,0 1.324,-0.493 1.324,-1.2 0,-0.441 -0.18,-0.722 -0.613,-0.961 z m -0.707,-1.187 c 0.328,0 0.554,0.199 0.554,0.492 0,0.285 -0.234,0.488 -0.554,0.488 -0.332,0 -0.559,-0.199 -0.559,-0.496 0,-0.285 0.227,-0.484 0.559,-0.484 z m -0.012,1.484 c 0.367,0 0.594,0.243 0.594,0.633 0,0.36 -0.235,0.598 -0.594,0.598 -0.36,0 -0.586,-0.238 -0.586,-0.61 0,-0.378 0.226,-0.621 0.586,-0.621 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath92)"
+               id="path528" />
+            <path
+               d="m 212.215,304.004 v 2.582 h 0.742 v -3.746 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.492 z m 3.066,-1.242 c -0.402,0 -0.746,0.168 -0.972,0.48 -0.215,0.289 -0.317,0.766 -0.317,1.496 0,0.664 0.086,1.129 0.266,1.414 0.222,0.36 0.586,0.555 1.023,0.555 0.407,0 0.739,-0.164 0.973,-0.477 0.211,-0.289 0.316,-0.769 0.316,-1.472 0,-0.688 -0.086,-1.153 -0.265,-1.442 -0.219,-0.359 -0.586,-0.554 -1.024,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.156 0.117,0.563 0.117,1.082 0,0.422 -0.039,0.832 -0.098,0.988 -0.082,0.219 -0.242,0.344 -0.453,0.344 -0.195,0 -0.343,-0.101 -0.433,-0.293 -0.075,-0.156 -0.118,-0.547 -0.118,-1.051 0,-0.441 0.04,-0.863 0.098,-1.019 0.078,-0.227 0.242,-0.352 0.453,-0.352 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath93)"
+               id="path529" />
+            <path
+               d="m 212.215,311.441 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.446 -0.504,0.672 -1.145,0.672 v 0.488 z m 4.328,1.922 h -1.59 c 0.102,-0.199 0.219,-0.308 0.766,-0.707 0.652,-0.472 0.84,-0.754 0.84,-1.265 0,-0.723 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath94)"
+               id="path530" />
+            <path
+               d="m 212.215,318.883 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.441 -0.504,0.668 -1.145,0.668 v 0.492 z m 4.383,1.14 h -0.391 v -2.3 h -0.871 l -1.371,2.289 v 0.625 h 1.5 v 0.828 h 0.742 v -0.828 h 0.391 z m -1.133,0 h -0.977 l 0.977,-1.601 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath95)"
+               id="path531" />
+            <path
+               d="m 212.215,326.324 v 2.582 h 0.742 v -3.746 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.492 z m 4.301,-0.312 c -0.036,-0.242 -0.082,-0.364 -0.18,-0.5 -0.195,-0.27 -0.535,-0.43 -0.945,-0.43 -0.465,0 -0.844,0.207 -1.071,0.582 -0.222,0.363 -0.312,0.781 -0.312,1.461 0,0.645 0.082,1.047 0.269,1.348 0.219,0.347 0.61,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.375 0,-0.714 -0.445,-1.211 -1.09,-1.211 -0.304,0 -0.512,0.09 -0.742,0.332 l 0.004,-0.082 c 0.012,-0.347 0.027,-0.457 0.078,-0.601 0.102,-0.274 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.093 0.461,0.332 z m -1.207,1.015 c 0.347,0 0.57,0.262 0.57,0.68 0,0.395 -0.242,0.688 -0.57,0.688 -0.34,0 -0.571,-0.278 -0.571,-0.676 0,-0.407 0.231,-0.692 0.571,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath96)"
+               id="path532" />
+            <path
+               d="m 202.438,442.312 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath97)"
+               id="path533" />
+            <path
+               d="m 202.438,434.871 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath98)"
+               id="path534" />
+            <path
+               d="m 202.438,427.43 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath99)"
+               id="path535" />
+            <path
+               d="m 202.438,419.988 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath100)"
+               id="path536" />
+            <path
+               d="m 202.438,412.547 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath101)"
+               id="path537" />
+            <path
+               d="m 202.438,405.109 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath102)"
+               id="path538" />
+            <path
+               d="m 202.438,397.668 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath103)"
+               id="path539" />
+            <path
+               d="m 202.438,390.23 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath104)"
+               id="path540" />
+            <path
+               d="m 202.438,382.789 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath105)"
+               id="path541" />
+            <path
+               d="m 202.438,375.348 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath106)"
+               id="path542" />
+            <path
+               d="m 202.438,367.906 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath107)"
+               id="path543" />
+            <path
+               d="m 202.438,360.465 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath108)"
+               id="path544" />
+            <path
+               d="m 202.438,352.906 h 7.441 v 7.562 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath109)"
+               id="path545" />
+            <path
+               d="m 202.438,345.465 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath110)"
+               id="path546" />
+            <path
+               d="m 202.438,338.027 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath111)"
+               id="path547" />
+            <path
+               d="m 209.879,442.312 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath112)"
+               id="path548" />
+            <path
+               d="m 209.879,434.871 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath113)"
+               id="path549" />
+            <path
+               d="m 209.879,427.43 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath114)"
+               id="path550" />
+            <path
+               d="m 209.879,419.988 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath115)"
+               id="path551" />
+            <path
+               d="m 209.879,412.547 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath116)"
+               id="path552" />
+            <path
+               d="m 209.879,405.109 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath117)"
+               id="path553" />
+            <path
+               d="m 209.879,397.668 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath118)"
+               id="path554" />
+            <path
+               d="m 209.879,390.23 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath119)"
+               id="path555" />
+            <path
+               d="m 209.879,382.789 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath120)"
+               id="path556" />
+            <path
+               d="m 209.879,375.348 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath121)"
+               id="path557" />
+            <path
+               d="m 209.879,367.906 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath122)"
+               id="path558" />
+            <path
+               d="m 209.879,360.465 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath123)"
+               id="path559" />
+            <path
+               d="m 209.879,352.906 h 7.441 v 7.562 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath124)"
+               id="path560" />
+            <path
+               d="m 209.879,345.465 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath125)"
+               id="path561" />
+            <path
+               d="m 209.879,338.027 h 7.441 v 7.438 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath126)"
+               id="path562" />
+            <path
+               d="m 205.977,341.203 v 2.582 h 0.738 v -3.742 h -0.492 c -0.114,0.441 -0.5,0.672 -1.145,0.672 v 0.488 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath127)"
+               id="path563" />
+            <path
+               d="m 205.863,349.555 c 0.285,0 0.301,0 0.434,0.035 0.25,0.07 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.567 -0.555,0.567 -0.347,0 -0.535,-0.199 -0.558,-0.586 h -0.719 c 0.008,0.75 0.492,1.219 1.262,1.219 0.797,0 1.312,-0.469 1.312,-1.2 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.215 0.488,-0.453 0.488,-0.797 0,-0.621 -0.461,-1.02 -1.187,-1.02 -0.543,0 -0.961,0.239 -1.125,0.645 -0.067,0.18 -0.09,0.301 -0.09,0.613 h 0.687 c 0.004,-0.199 0.024,-0.301 0.059,-0.394 0.07,-0.164 0.238,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.563 -0.652,0.563 h -0.067 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath128)"
+               id="path564" />
+            <path
+               d="m 207.301,354.922 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.184 0.246,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.722 0,0.442 -0.227,0.711 -0.602,0.711 -0.324,0 -0.504,-0.164 -0.519,-0.465 h -0.727 c 0.008,0.653 0.504,1.098 1.235,1.098 0.8,0 1.351,-0.551 1.351,-1.359 0,-0.77 -0.476,-1.293 -1.168,-1.293 -0.246,0 -0.433,0.062 -0.648,0.226 l 0.121,-0.781 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath129)"
+               id="path565" />
+            <path
+               d="m 207.508,362.363 h -2.637 v 0.66 h 1.863 c -0.226,0.243 -0.675,0.926 -0.82,1.25 -0.262,0.547 -0.391,1.036 -0.492,1.832 h 0.742 c 0.07,-1.179 0.457,-2.089 1.344,-3.16 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath130)"
+               id="path566" />
+            <path
+               d="m 204.918,372.676 c 0.016,0.574 0.504,1 1.148,1 0.481,0 0.844,-0.203 1.067,-0.582 0.195,-0.332 0.312,-0.899 0.312,-1.5 0,-0.551 -0.086,-0.973 -0.261,-1.258 -0.239,-0.398 -0.606,-0.609 -1.055,-0.609 -0.75,0 -1.262,0.535 -1.262,1.316 0,0.773 0.453,1.301 1.117,1.301 0.192,0 0.371,-0.055 0.489,-0.137 0.066,-0.047 0.109,-0.094 0.23,-0.234 0,0.726 -0.199,1.066 -0.617,1.066 -0.262,0 -0.438,-0.141 -0.453,-0.363 z m 1.191,-2.348 c 0.356,0 0.579,0.274 0.579,0.715 0,0.414 -0.227,0.687 -0.571,0.687 -0.336,0 -0.547,-0.261 -0.547,-0.695 0,-0.433 0.203,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath131)"
+               id="path567" />
+            <path
+               d="m 204.535,378.406 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.442 -0.504,0.668 -1.148,0.668 v 0.492 z m 2.883,0 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.442 -0.5,0.668 -1.144,0.668 v 0.492 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath132)"
+               id="path568" />
+            <path
+               d="m 204.535,385.965 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.441 -0.504,0.672 -1.148,0.672 v 0.488 z m 2.77,0.91 c 0.285,0 0.3,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.563 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.719 c 0.004,0.75 0.493,1.219 1.262,1.219 0.797,0 1.309,-0.469 1.309,-1.195 0,-0.442 -0.188,-0.727 -0.61,-0.93 0.34,-0.219 0.489,-0.457 0.489,-0.797 0,-0.625 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.609 h 0.688 c 0.004,-0.199 0.019,-0.3 0.058,-0.394 0.067,-0.164 0.239,-0.266 0.454,-0.266 0.296,0 0.464,0.18 0.464,0.492 0,0.379 -0.214,0.567 -0.656,0.567 h -0.062 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath133)"
+               id="path569" />
+            <path
+               d="m 204.535,393.406 v 2.582 h 0.738 v -3.742 h -0.488 c -0.117,0.442 -0.504,0.668 -1.148,0.668 v 0.492 z m 4.207,-1.16 h -2 l -0.336,2.086 h 0.668 c 0.078,-0.187 0.246,-0.285 0.473,-0.285 0.375,0 0.601,0.269 0.601,0.723 0,0.437 -0.226,0.707 -0.601,0.707 -0.32,0 -0.5,-0.165 -0.516,-0.465 h -0.73 c 0.011,0.656 0.508,1.097 1.238,1.097 0.801,0 1.352,-0.547 1.352,-1.355 0,-0.774 -0.477,-1.293 -1.168,-1.293 -0.25,0 -0.434,0.062 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath134)"
+               id="path570" />
+            <path
+               d="m 204.535,400.848 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.671 -1.148,0.671 v 0.493 z m 4.414,-1.164 h -2.637 v 0.66 h 1.864 c -0.227,0.246 -0.676,0.926 -0.824,1.254 -0.258,0.543 -0.391,1.035 -0.489,1.832 h 0.742 c 0.071,-1.184 0.454,-2.094 1.344,-3.164 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath135)"
+               id="path571" />
+            <path
+               d="m 204.535,408.289 v 2.582 h 0.738 v -3.746 h -0.488 c -0.117,0.445 -0.504,0.672 -1.148,0.672 v 0.492 z m 1.824,1.707 c 0.016,0.578 0.504,1 1.149,1 0.48,0 0.844,-0.199 1.066,-0.582 0.196,-0.332 0.309,-0.898 0.309,-1.5 0,-0.547 -0.082,-0.969 -0.258,-1.254 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.77 0.453,1.297 1.117,1.297 0.191,0 0.371,-0.051 0.488,-0.137 0.066,-0.047 0.109,-0.093 0.231,-0.23 0,0.723 -0.2,1.066 -0.618,1.066 -0.265,0 -0.437,-0.144 -0.453,-0.367 z m 1.188,-2.348 c 0.359,0 0.582,0.274 0.582,0.719 0,0.41 -0.227,0.688 -0.57,0.688 -0.336,0 -0.551,-0.266 -0.551,-0.7 0,-0.433 0.207,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath136)"
+               id="path572" />
+            <path
+               d="m 205.984,417.648 h -1.589 c 0.097,-0.199 0.214,-0.308 0.765,-0.707 0.649,-0.476 0.84,-0.753 0.84,-1.265 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.777,0 -1.231,0.457 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.226 0.528,0.601 0,0.418 -0.125,0.571 -0.961,1.161 -0.633,0.433 -0.828,0.761 -0.859,1.457 h 2.546 z m 1.434,-1.921 v 2.582 h 0.738 v -3.743 h -0.492 c -0.117,0.442 -0.5,0.672 -1.144,0.672 v 0.489 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath137)"
+               id="path573" />
+            <path
+               d="m 205.984,425.09 h -1.589 c 0.097,-0.199 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.84,-0.754 0.84,-1.27 0,-0.722 -0.504,-1.187 -1.285,-1.187 -0.777,0 -1.231,0.461 -1.231,1.254 v 0.129 h 0.715 v -0.121 c 0,-0.415 0.196,-0.661 0.531,-0.661 0.329,0 0.528,0.231 0.528,0.606 0,0.414 -0.125,0.566 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.546 z m 1.321,-1.016 c 0.285,0 0.3,0 0.433,0.039 0.25,0.067 0.407,0.285 0.407,0.559 0,0.332 -0.231,0.566 -0.555,0.566 -0.348,0 -0.539,-0.203 -0.559,-0.586 h -0.719 c 0.004,0.75 0.493,1.219 1.262,1.219 0.797,0 1.309,-0.469 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.61,-0.93 0.34,-0.215 0.489,-0.453 0.489,-0.797 0,-0.621 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.614 h 0.688 c 0.004,-0.2 0.019,-0.301 0.058,-0.395 0.067,-0.164 0.239,-0.266 0.454,-0.266 0.296,0 0.464,0.18 0.464,0.493 0,0.379 -0.214,0.562 -0.656,0.562 h -0.062 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath138)"
+               id="path574" />
+            <path
+               d="m 205.984,432.531 h -1.589 c 0.097,-0.203 0.214,-0.312 0.765,-0.707 0.649,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.777,0 -1.231,0.461 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.226 0.528,0.601 0,0.418 -0.125,0.571 -0.961,1.164 -0.633,0.43 -0.828,0.758 -0.859,1.457 h 2.546 z m 2.758,-3.086 h -2 l -0.336,2.086 h 0.668 c 0.078,-0.183 0.246,-0.285 0.473,-0.285 0.375,0 0.601,0.27 0.601,0.723 0,0.441 -0.226,0.711 -0.601,0.711 -0.32,0 -0.5,-0.164 -0.516,-0.465 h -0.73 c 0.011,0.652 0.508,1.097 1.238,1.097 0.801,0 1.352,-0.55 1.352,-1.359 0,-0.769 -0.477,-1.293 -1.168,-1.293 -0.25,0 -0.434,0.063 -0.649,0.227 l 0.121,-0.782 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath139)"
+               id="path575" />
+            <path
+               d="m 205.984,439.969 h -1.589 c 0.097,-0.199 0.214,-0.309 0.765,-0.707 0.649,-0.473 0.84,-0.754 0.84,-1.266 0,-0.723 -0.504,-1.187 -1.285,-1.187 -0.777,0 -1.231,0.457 -1.231,1.25 v 0.132 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.227 0.528,0.602 0,0.418 -0.125,0.57 -0.961,1.16 -0.633,0.433 -0.828,0.762 -0.859,1.457 h 2.546 z m 2.965,-3.082 h -2.637 v 0.66 h 1.864 c -0.227,0.242 -0.676,0.926 -0.824,1.25 -0.258,0.547 -0.391,1.035 -0.489,1.832 h 0.742 c 0.071,-1.18 0.454,-2.09 1.344,-3.16 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath140)"
+               id="path576" />
+            <path
+               d="m 205.984,447.41 h -1.589 c 0.097,-0.199 0.214,-0.312 0.765,-0.707 0.649,-0.476 0.84,-0.754 0.84,-1.265 0,-0.727 -0.504,-1.192 -1.285,-1.192 -0.777,0 -1.231,0.461 -1.231,1.254 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.196,-0.66 0.531,-0.66 0.329,0 0.528,0.226 0.528,0.601 0,0.414 -0.125,0.57 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.546 z m 0.375,-0.211 c 0.016,0.574 0.504,1 1.149,1 0.48,0 0.844,-0.203 1.066,-0.582 0.196,-0.332 0.309,-0.898 0.309,-1.5 0,-0.551 -0.082,-0.972 -0.258,-1.258 -0.238,-0.398 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.774 0.453,1.301 1.117,1.301 0.191,0 0.371,-0.055 0.488,-0.137 0.066,-0.046 0.109,-0.097 0.231,-0.234 0,0.727 -0.2,1.066 -0.618,1.066 -0.265,0 -0.437,-0.14 -0.453,-0.363 z m 1.188,-2.347 c 0.359,0 0.582,0.273 0.582,0.714 0,0.414 -0.227,0.688 -0.57,0.688 -0.336,0 -0.551,-0.262 -0.551,-0.695 0,-0.434 0.207,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath141)"
+               id="path577" />
+            <path
+               d="m 215.102,343.125 h -1.586 c 0.097,-0.199 0.214,-0.309 0.765,-0.707 0.649,-0.473 0.836,-0.754 0.836,-1.266 0,-0.722 -0.5,-1.187 -1.281,-1.187 -0.777,0 -1.231,0.457 -1.231,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.2,-0.661 0.536,-0.661 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.16 -0.633,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath142)"
+               id="path578" />
+            <path
+               d="m 215.156,349.785 h -0.39 v -2.301 h -0.871 l -1.368,2.289 v 0.625 h 1.5 v 0.829 h 0.739 v -0.829 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.597 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath143)"
+               id="path579" />
+            <path
+               d="m 215.078,355.773 c -0.039,-0.242 -0.086,-0.363 -0.18,-0.5 -0.195,-0.269 -0.539,-0.429 -0.945,-0.429 -0.465,0 -0.848,0.207 -1.074,0.582 -0.219,0.363 -0.309,0.781 -0.309,1.461 0,0.644 0.078,1.047 0.266,1.347 0.219,0.348 0.609,0.555 1.051,0.555 0.746,0 1.254,-0.555 1.254,-1.371 0,-0.719 -0.446,-1.215 -1.09,-1.215 -0.305,0 -0.512,0.09 -0.742,0.332 l 0.003,-0.078 c 0.012,-0.352 0.028,-0.461 0.079,-0.605 0.101,-0.274 0.281,-0.411 0.539,-0.411 0.238,0 0.363,0.094 0.461,0.332 z m -1.211,1.016 c 0.348,0 0.571,0.262 0.571,0.68 0,0.394 -0.243,0.687 -0.571,0.687 -0.336,0 -0.57,-0.277 -0.57,-0.676 0,-0.406 0.234,-0.691 0.57,-0.691 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath144)"
+               id="path580" />
+            <path
+               d="m 214.559,364.07 c 0.129,-0.07 0.183,-0.105 0.242,-0.16 0.156,-0.14 0.246,-0.367 0.246,-0.609 0,-0.59 -0.508,-1.016 -1.199,-1.016 -0.7,0 -1.207,0.426 -1.207,1.02 0,0.359 0.148,0.586 0.488,0.765 -0.434,0.239 -0.613,0.516 -0.613,0.961 0,0.707 0.543,1.199 1.332,1.199 0.781,0 1.324,-0.492 1.324,-1.199 0,-0.445 -0.18,-0.722 -0.613,-0.961 z m -0.707,-1.187 c 0.328,0 0.554,0.199 0.554,0.488 0,0.285 -0.234,0.492 -0.554,0.492 -0.332,0 -0.559,-0.199 -0.559,-0.496 0,-0.285 0.227,-0.484 0.559,-0.484 z m -0.012,1.484 c 0.367,0 0.594,0.242 0.594,0.633 0,0.359 -0.235,0.598 -0.594,0.598 -0.36,0 -0.586,-0.239 -0.586,-0.61 0,-0.379 0.226,-0.621 0.586,-0.621 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath145)"
+               id="path581" />
+            <path
+               d="m 212.215,370.965 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.488 z m 3.066,-1.238 c -0.402,0 -0.746,0.168 -0.972,0.48 -0.215,0.289 -0.317,0.766 -0.317,1.492 0,0.668 0.086,1.133 0.266,1.418 0.222,0.356 0.586,0.551 1.023,0.551 0.407,0 0.739,-0.16 0.973,-0.473 0.211,-0.293 0.316,-0.773 0.316,-1.472 0,-0.688 -0.086,-1.153 -0.265,-1.442 -0.219,-0.359 -0.586,-0.554 -1.024,-0.554 z m 0,0.593 c 0.192,0 0.344,0.106 0.434,0.305 0.074,0.156 0.117,0.563 0.117,1.082 0,0.422 -0.039,0.832 -0.098,0.984 -0.082,0.223 -0.242,0.344 -0.453,0.344 -0.195,0 -0.343,-0.097 -0.433,-0.289 -0.075,-0.16 -0.118,-0.551 -0.118,-1.051 0,-0.445 0.04,-0.867 0.098,-1.019 0.078,-0.227 0.242,-0.356 0.453,-0.356 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath146)"
+               id="path582" />
+            <path
+               d="m 212.215,378.406 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.442 -0.504,0.668 -1.145,0.668 v 0.492 z m 4.328,1.922 h -1.59 c 0.102,-0.199 0.219,-0.312 0.766,-0.707 0.652,-0.476 0.84,-0.754 0.84,-1.266 0,-0.726 -0.5,-1.191 -1.282,-1.191 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.133 h 0.711 v -0.125 c 0,-0.414 0.195,-0.656 0.535,-0.656 0.328,0 0.527,0.226 0.527,0.601 0,0.414 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath147)"
+               id="path583" />
+            <path
+               d="m 212.215,385.965 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.445 -0.504,0.672 -1.145,0.672 v 0.488 z m 4.383,1.14 h -0.391 v -2.3 h -0.871 l -1.371,2.293 v 0.621 h 1.5 v 0.828 h 0.742 v -0.828 h 0.391 z m -1.133,0 h -0.977 l 0.977,-1.597 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath148)"
+               id="path584" />
+            <path
+               d="m 212.215,393.406 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.442 -0.504,0.672 -1.145,0.672 v 0.488 z m 4.301,-0.312 c -0.036,-0.242 -0.082,-0.364 -0.18,-0.5 -0.195,-0.27 -0.535,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.203 -1.071,0.578 -0.222,0.367 -0.312,0.781 -0.312,1.465 0,0.644 0.082,1.043 0.269,1.344 0.219,0.351 0.61,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.371 0,-0.718 -0.445,-1.215 -1.09,-1.215 -0.304,0 -0.512,0.09 -0.742,0.332 l 0.004,-0.078 c 0.012,-0.347 0.027,-0.461 0.078,-0.601 0.102,-0.278 0.281,-0.414 0.539,-0.414 0.238,0 0.363,0.097 0.461,0.332 z m -1.207,1.015 c 0.347,0 0.57,0.266 0.57,0.68 0,0.399 -0.242,0.688 -0.57,0.688 -0.34,0 -0.571,-0.274 -0.571,-0.676 0,-0.406 0.231,-0.692 0.571,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath149)"
+               id="path585" />
+            <path
+               d="m 212.215,400.848 v 2.582 h 0.742 v -3.742 h -0.492 c -0.117,0.441 -0.504,0.667 -1.145,0.667 v 0.493 z m 3.785,0.543 c 0.125,-0.067 0.184,-0.106 0.242,-0.157 0.153,-0.144 0.242,-0.371 0.242,-0.613 0,-0.586 -0.507,-1.016 -1.199,-1.016 -0.695,0 -1.203,0.43 -1.203,1.02 0,0.359 0.148,0.586 0.488,0.766 -0.433,0.238 -0.613,0.519 -0.613,0.961 0,0.707 0.543,1.199 1.328,1.199 0.781,0 1.328,-0.492 1.328,-1.199 0,-0.442 -0.179,-0.723 -0.613,-0.961 z m -0.707,-1.188 c 0.328,0 0.555,0.199 0.555,0.492 0,0.285 -0.235,0.489 -0.555,0.489 -0.332,0 -0.563,-0.2 -0.563,-0.496 0,-0.286 0.231,-0.485 0.563,-0.485 z m -0.012,1.485 c 0.364,0 0.59,0.242 0.59,0.632 0,0.36 -0.23,0.598 -0.59,0.598 -0.359,0 -0.586,-0.238 -0.586,-0.609 0,-0.379 0.227,-0.621 0.586,-0.621 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath150)"
+               id="path586" />
+            <path
+               d="m 213.664,410.211 h -1.59 c 0.102,-0.203 0.215,-0.313 0.766,-0.707 0.648,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.504,-1.187 -1.285,-1.187 -0.774,0 -1.231,0.461 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.661 0.531,-0.661 0.328,0 0.531,0.227 0.531,0.602 0,0.418 -0.129,0.57 -0.961,1.164 -0.636,0.43 -0.832,0.758 -0.863,1.457 h 2.547 z m 1.617,-3.164 c -0.402,0 -0.746,0.168 -0.972,0.48 -0.215,0.289 -0.317,0.766 -0.317,1.496 0,0.665 0.086,1.129 0.266,1.415 0.222,0.359 0.586,0.554 1.023,0.554 0.407,0 0.739,-0.164 0.973,-0.476 0.211,-0.289 0.316,-0.77 0.316,-1.473 0,-0.688 -0.086,-1.152 -0.265,-1.441 -0.219,-0.36 -0.586,-0.555 -1.024,-0.555 z m 0,0.598 c 0.192,0 0.344,0.105 0.434,0.3 0.074,0.157 0.117,0.563 0.117,1.082 0,0.422 -0.039,0.832 -0.098,0.989 -0.082,0.218 -0.242,0.343 -0.453,0.343 -0.195,0 -0.343,-0.101 -0.433,-0.293 -0.075,-0.156 -0.118,-0.546 -0.118,-1.05 0,-0.442 0.04,-0.864 0.098,-1.02 0.078,-0.226 0.242,-0.351 0.453,-0.351 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath151)"
+               id="path587" />
+            <path
+               d="m 213.664,417.648 h -1.59 c 0.102,-0.199 0.215,-0.308 0.766,-0.707 0.648,-0.472 0.84,-0.753 0.84,-1.265 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.774,0 -1.231,0.457 -1.231,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.226 0.531,0.601 0,0.418 -0.129,0.571 -0.961,1.161 -0.636,0.433 -0.832,0.761 -0.863,1.457 h 2.547 z m 2.879,0 h -1.59 c 0.102,-0.199 0.219,-0.308 0.766,-0.707 0.652,-0.472 0.84,-0.753 0.84,-1.265 0,-0.723 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.161 -0.632,0.433 -0.828,0.761 -0.859,1.457 h 2.543 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath152)"
+               id="path588" />
+            <path
+               d="m 213.664,425.09 h -1.59 c 0.102,-0.199 0.215,-0.313 0.766,-0.707 0.648,-0.477 0.84,-0.754 0.84,-1.266 0,-0.726 -0.504,-1.191 -1.285,-1.191 -0.774,0 -1.231,0.461 -1.231,1.254 v 0.132 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.227 0.531,0.602 0,0.414 -0.129,0.57 -0.961,1.16 -0.636,0.434 -0.832,0.762 -0.863,1.457 h 2.547 z m 2.934,-0.781 h -0.391 v -2.301 h -0.871 l -1.371,2.289 v 0.625 h 1.5 v 0.828 h 0.742 v -0.828 h 0.391 z m -1.133,0 h -0.977 l 0.977,-1.598 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath153)"
+               id="path589" />
+            <path
+               d="m 213.664,432.531 h -1.59 c 0.102,-0.199 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.285,-1.188 -0.774,0 -1.231,0.461 -1.231,1.254 v 0.129 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.226 0.531,0.601 0,0.418 -0.129,0.571 -0.961,1.164 -0.636,0.434 -0.832,0.758 -0.863,1.457 h 2.547 z m 2.852,-2.234 c -0.036,-0.242 -0.082,-0.363 -0.18,-0.5 -0.195,-0.27 -0.535,-0.43 -0.945,-0.43 -0.465,0 -0.844,0.207 -1.071,0.582 -0.222,0.363 -0.312,0.781 -0.312,1.461 0,0.645 0.082,1.047 0.269,1.348 0.219,0.347 0.61,0.554 1.051,0.554 0.746,0 1.254,-0.554 1.254,-1.374 0,-0.715 -0.445,-1.211 -1.09,-1.211 -0.304,0 -0.512,0.089 -0.742,0.332 l 0.004,-0.082 c 0.012,-0.348 0.027,-0.457 0.078,-0.602 0.102,-0.273 0.281,-0.41 0.539,-0.41 0.238,0 0.363,0.094 0.461,0.332 z m -1.207,1.015 c 0.347,0 0.57,0.262 0.57,0.68 0,0.395 -0.242,0.688 -0.57,0.688 -0.34,0 -0.571,-0.278 -0.571,-0.676 0,-0.406 0.231,-0.692 0.571,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath154)"
+               id="path590" />
+            <path
+               d="m 213.664,439.973 h -1.59 c 0.102,-0.203 0.215,-0.313 0.766,-0.711 0.648,-0.473 0.84,-0.754 0.84,-1.266 0,-0.723 -0.504,-1.187 -1.285,-1.187 -0.774,0 -1.231,0.461 -1.231,1.25 v 0.132 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.531,0.227 0.531,0.602 0,0.418 -0.129,0.57 -0.961,1.164 -0.636,0.429 -0.832,0.758 -0.863,1.457 h 2.547 z M 216,438.594 c 0.125,-0.071 0.184,-0.106 0.242,-0.16 0.153,-0.141 0.242,-0.368 0.242,-0.614 0,-0.586 -0.507,-1.011 -1.199,-1.011 -0.695,0 -1.203,0.425 -1.203,1.019 0,0.36 0.148,0.586 0.488,0.766 -0.433,0.238 -0.613,0.515 -0.613,0.961 0,0.707 0.543,1.199 1.328,1.199 0.781,0 1.328,-0.492 1.328,-1.199 0,-0.446 -0.179,-0.723 -0.613,-0.961 z m -0.707,-1.188 c 0.328,0 0.555,0.199 0.555,0.489 0,0.285 -0.235,0.492 -0.555,0.492 -0.332,0 -0.563,-0.199 -0.563,-0.496 0,-0.286 0.231,-0.485 0.563,-0.485 z m -0.012,1.485 c 0.364,0 0.59,0.242 0.59,0.632 0,0.36 -0.23,0.594 -0.59,0.594 -0.359,0 -0.586,-0.234 -0.586,-0.605 0,-0.379 0.227,-0.621 0.586,-0.621 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath155)"
+               id="path591" />
+            <path
+               d="m 212.105,446.398 c 0.286,0 0.301,0 0.434,0.036 0.246,0.07 0.406,0.285 0.406,0.562 0,0.332 -0.234,0.563 -0.554,0.563 -0.348,0 -0.539,-0.2 -0.559,-0.586 h -0.719 c 0.004,0.75 0.492,1.218 1.262,1.218 0.797,0 1.309,-0.468 1.309,-1.195 0,-0.441 -0.188,-0.726 -0.614,-0.93 0.344,-0.218 0.492,-0.457 0.492,-0.796 0,-0.625 -0.464,-1.02 -1.187,-1.02 -0.543,0 -0.961,0.234 -1.125,0.645 -0.07,0.179 -0.09,0.3 -0.09,0.609 h 0.688 c 0.004,-0.199 0.019,-0.301 0.058,-0.395 0.067,-0.164 0.235,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.219,0.566 -0.656,0.566 h -0.063 z m 3.176,-2.148 c -0.402,0 -0.746,0.168 -0.972,0.48 -0.215,0.29 -0.317,0.766 -0.317,1.493 0,0.668 0.086,1.129 0.266,1.414 0.222,0.359 0.586,0.554 1.023,0.554 0.407,0 0.739,-0.164 0.973,-0.472 0.211,-0.293 0.316,-0.774 0.316,-1.473 0,-0.687 -0.086,-1.152 -0.265,-1.441 -0.219,-0.36 -0.586,-0.555 -1.024,-0.555 z m 0,0.594 c 0.192,0 0.344,0.105 0.434,0.301 0.074,0.16 0.117,0.566 0.117,1.085 0,0.422 -0.039,0.832 -0.098,0.985 -0.082,0.223 -0.242,0.344 -0.453,0.344 -0.195,0 -0.343,-0.098 -0.433,-0.289 -0.075,-0.161 -0.118,-0.551 -0.118,-1.051 0,-0.446 0.04,-0.867 0.098,-1.02 0.078,-0.226 0.242,-0.355 0.453,-0.355 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath156)"
+               id="path592" />
+            <path
+               d="m 379.688,442.312 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath157)"
+               id="path593" />
+            <path
+               d="m 379.688,434.871 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath158)"
+               id="path594" />
+            <path
+               d="m 379.688,427.43 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath159)"
+               id="path595" />
+            <path
+               d="m 379.688,419.988 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath160)"
+               id="path596" />
+            <path
+               d="m 379.688,412.547 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath161)"
+               id="path597" />
+            <path
+               d="m 379.688,405.109 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath162)"
+               id="path598" />
+            <path
+               d="m 379.688,397.668 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath163)"
+               id="path599" />
+            <path
+               d="m 379.688,390.23 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath164)"
+               id="path600" />
+            <path
+               d="m 379.688,382.789 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath165)"
+               id="path601" />
+            <path
+               d="m 379.688,375.348 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath166)"
+               id="path602" />
+            <path
+               d="m 379.688,367.906 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath167)"
+               id="path603" />
+            <path
+               d="m 379.688,360.465 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath168)"
+               id="path604" />
+            <path
+               d="m 379.688,352.906 h 7.438 v 7.562 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath169)"
+               id="path605" />
+            <path
+               d="m 379.688,345.465 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath170)"
+               id="path606" />
+            <path
+               d="m 379.688,338.027 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath171)"
+               id="path607" />
+            <path
+               d="m 379.688,330.586 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath172)"
+               id="path608" />
+            <path
+               d="m 379.688,323.145 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath173)"
+               id="path609" />
+            <path
+               d="m 387.129,442.312 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath174)"
+               id="path610" />
+            <path
+               d="m 387.129,434.871 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath175)"
+               id="path611" />
+            <path
+               d="m 387.129,427.43 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath176)"
+               id="path612" />
+            <path
+               d="m 387.129,419.988 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath177)"
+               id="path613" />
+            <path
+               d="m 387.129,412.547 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath178)"
+               id="path614" />
+            <path
+               d="m 387.129,405.109 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath179)"
+               id="path615" />
+            <path
+               d="m 387.129,397.668 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath180)"
+               id="path616" />
+            <path
+               d="m 387.129,390.23 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath181)"
+               id="path617" />
+            <path
+               d="m 387.129,382.789 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath182)"
+               id="path618" />
+            <path
+               d="m 387.129,375.348 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath183)"
+               id="path619" />
+            <path
+               d="m 387.129,367.906 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath184)"
+               id="path620" />
+            <path
+               d="m 387.129,360.465 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath185)"
+               id="path621" />
+            <path
+               d="m 387.129,352.906 h 7.438 v 7.562 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath186)"
+               id="path622" />
+            <path
+               d="m 387.129,345.465 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath187)"
+               id="path623" />
+            <path
+               d="m 387.129,338.027 h 7.438 v 7.438 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath188)"
+               id="path624" />
+            <path
+               d="m 387.129,330.586 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath189)"
+               id="path625" />
+            <path
+               d="m 387.129,323.145 h 7.438 v 7.441 h -7.438 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath190)"
+               id="path626" />
+            <path
+               d="m 383.223,326.324 v 2.582 h 0.738 v -3.742 h -0.488 c -0.118,0.441 -0.504,0.668 -1.149,0.668 v 0.492 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath191)"
+               id="path627" />
+            <path
+               d="m 383.113,334.672 c 0.285,0 0.301,0 0.434,0.039 0.246,0.066 0.406,0.285 0.406,0.559 0,0.332 -0.234,0.566 -0.555,0.566 -0.347,0 -0.539,-0.203 -0.562,-0.59 h -0.715 c 0.004,0.75 0.488,1.223 1.262,1.223 0.797,0 1.308,-0.473 1.308,-1.199 0,-0.438 -0.191,-0.723 -0.613,-0.93 0.344,-0.215 0.492,-0.453 0.492,-0.797 0,-0.625 -0.465,-1.02 -1.187,-1.02 -0.547,0 -0.961,0.239 -1.125,0.645 -0.07,0.18 -0.09,0.301 -0.09,0.613 h 0.687 c 0.004,-0.203 0.02,-0.301 0.055,-0.398 0.07,-0.164 0.238,-0.262 0.457,-0.262 0.293,0 0.465,0.18 0.465,0.488 0,0.383 -0.219,0.567 -0.656,0.567 h -0.063 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath192)"
+               id="path628" />
+            <path
+               d="m 384.547,340.043 h -2 l -0.332,2.086 h 0.664 c 0.082,-0.184 0.25,-0.285 0.476,-0.285 0.375,0 0.602,0.269 0.602,0.722 0,0.438 -0.227,0.707 -0.602,0.707 -0.324,0 -0.5,-0.164 -0.519,-0.464 h -0.727 c 0.012,0.656 0.508,1.097 1.235,1.097 0.804,0 1.351,-0.547 1.351,-1.355 0,-0.77 -0.472,-1.293 -1.164,-1.293 -0.25,0 -0.433,0.062 -0.652,0.226 L 383,340.703 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath193)"
+               id="path629" />
+            <path
+               d="m 384.754,347.484 h -2.633 v 0.661 h 1.863 c -0.226,0.242 -0.675,0.921 -0.824,1.25 -0.258,0.543 -0.39,1.035 -0.492,1.832 h 0.746 c 0.066,-1.184 0.453,-2.09 1.34,-3.165 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath194)"
+               id="path630" />
+            <path
+               d="m 382.168,357.797 c 0.016,0.574 0.5,0.996 1.144,0.996 0.481,0 0.844,-0.199 1.067,-0.578 0.195,-0.336 0.312,-0.899 0.312,-1.5 0,-0.551 -0.086,-0.973 -0.257,-1.258 -0.239,-0.402 -0.61,-0.613 -1.059,-0.613 -0.75,0 -1.262,0.539 -1.262,1.32 0,0.77 0.457,1.301 1.121,1.301 0.192,0 0.368,-0.055 0.485,-0.141 0.07,-0.047 0.113,-0.094 0.234,-0.23 0,0.722 -0.203,1.066 -0.617,1.066 -0.266,0 -0.441,-0.14 -0.457,-0.363 z m 1.187,-2.352 c 0.36,0 0.583,0.278 0.583,0.719 0,0.414 -0.231,0.688 -0.571,0.688 -0.34,0 -0.551,-0.266 -0.551,-0.7 0,-0.429 0.207,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath195)"
+               id="path631" />
+            <path
+               d="m 381.785,363.527 v 2.582 h 0.738 v -3.746 h -0.492 c -0.117,0.446 -0.5,0.672 -1.144,0.672 v 0.492 z m 2.879,0 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.446 -0.5,0.672 -1.144,0.672 v 0.492 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath196)"
+               id="path632" />
+            <path
+               d="m 381.785,370.965 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.441 -0.5,0.672 -1.144,0.672 v 0.488 z m 2.766,0.91 c 0.285,0 0.301,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.563 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.718 c 0.007,0.75 0.492,1.219 1.261,1.219 0.797,0 1.313,-0.469 1.313,-1.195 0,-0.442 -0.192,-0.727 -0.613,-0.93 0.343,-0.219 0.488,-0.457 0.488,-0.801 0,-0.621 -0.465,-1.015 -1.188,-1.015 -0.543,0 -0.961,0.234 -1.125,0.644 -0.066,0.176 -0.09,0.301 -0.09,0.609 h 0.688 c 0.004,-0.199 0.023,-0.3 0.059,-0.394 0.07,-0.164 0.238,-0.266 0.453,-0.266 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.567 -0.653,0.567 h -0.066 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath197)"
+               id="path633" />
+            <path
+               d="m 381.785,378.406 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.442 -0.5,0.668 -1.144,0.668 v 0.492 z m 4.203,-1.16 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.187 0.246,-0.285 0.477,-0.285 0.375,0 0.601,0.265 0.601,0.723 0,0.437 -0.226,0.707 -0.601,0.707 -0.324,0 -0.504,-0.165 -0.52,-0.465 h -0.726 c 0.008,0.656 0.504,1.097 1.234,1.097 0.801,0 1.352,-0.55 1.352,-1.355 0,-0.774 -0.477,-1.297 -1.168,-1.297 -0.246,0 -0.434,0.066 -0.649,0.231 l 0.121,-0.782 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath198)"
+               id="path634" />
+            <path
+               d="m 381.785,385.965 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.445 -0.5,0.672 -1.144,0.672 v 0.488 z m 4.41,-1.16 h -2.636 v 0.66 h 1.863 c -0.227,0.242 -0.676,0.926 -0.82,1.25 -0.262,0.547 -0.391,1.035 -0.493,1.832 h 0.743 c 0.07,-1.18 0.457,-2.09 1.343,-3.16 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath199)"
+               id="path635" />
+            <path
+               d="m 381.785,393.406 v 2.582 h 0.738 v -3.742 h -0.492 c -0.117,0.442 -0.5,0.668 -1.144,0.668 v 0.492 z m 1.82,1.711 c 0.016,0.574 0.504,1 1.149,1 0.48,0 0.844,-0.203 1.066,-0.582 0.196,-0.332 0.313,-0.898 0.313,-1.5 0,-0.551 -0.086,-0.973 -0.262,-1.258 -0.238,-0.398 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.32 0,0.774 0.453,1.301 1.117,1.301 0.191,0 0.371,-0.055 0.488,-0.137 0.067,-0.046 0.11,-0.097 0.231,-0.234 0,0.723 -0.2,1.066 -0.618,1.066 -0.261,0 -0.437,-0.14 -0.453,-0.363 z m 1.192,-2.347 c 0.355,0 0.578,0.273 0.578,0.714 0,0.414 -0.227,0.688 -0.57,0.688 -0.336,0 -0.547,-0.262 -0.547,-0.695 0,-0.434 0.203,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath200)"
+               id="path636" />
+            <path
+               d="m 383.23,402.77 h -1.589 c 0.101,-0.2 0.214,-0.313 0.765,-0.708 0.649,-0.476 0.84,-0.757 0.84,-1.269 0,-0.723 -0.5,-1.188 -1.285,-1.188 -0.773,0 -1.227,0.461 -1.227,1.254 v 0.129 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.227 0.528,0.602 0,0.418 -0.129,0.57 -0.961,1.164 -0.637,0.433 -0.832,0.757 -0.863,1.457 h 2.546 z m 1.434,-1.922 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.445 -0.5,0.671 -1.144,0.671 v 0.493 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath201)"
+               id="path637" />
+            <path
+               d="m 383.23,410.211 h -1.589 c 0.101,-0.203 0.214,-0.313 0.765,-0.711 0.649,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.5,-1.187 -1.285,-1.187 -0.773,0 -1.227,0.461 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.661 0.535,-0.661 0.325,0 0.528,0.227 0.528,0.602 0,0.418 -0.129,0.57 -0.961,1.16 -0.637,0.434 -0.832,0.762 -0.863,1.461 h 2.546 z m 1.321,-1.016 c 0.285,0 0.301,0 0.433,0.039 0.25,0.067 0.407,0.286 0.407,0.559 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.585 h -0.718 c 0.007,0.75 0.492,1.222 1.261,1.222 0.797,0 1.313,-0.472 1.313,-1.199 0,-0.438 -0.192,-0.723 -0.613,-0.93 0.343,-0.218 0.488,-0.453 0.488,-0.797 0,-0.625 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.09,0.301 -0.09,0.614 h 0.688 c 0.004,-0.203 0.023,-0.301 0.059,-0.399 0.07,-0.164 0.238,-0.261 0.453,-0.261 0.297,0 0.465,0.179 0.465,0.488 0,0.383 -0.215,0.566 -0.653,0.566 h -0.066 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath202)"
+               id="path638" />
+            <path
+               d="m 383.23,417.648 h -1.589 c 0.101,-0.199 0.214,-0.308 0.765,-0.707 0.649,-0.472 0.84,-0.753 0.84,-1.265 0,-0.723 -0.5,-1.188 -1.285,-1.188 -0.773,0 -1.227,0.457 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.226 0.528,0.601 0,0.418 -0.129,0.571 -0.961,1.161 -0.637,0.433 -0.832,0.761 -0.863,1.457 h 2.546 z m 2.758,-3.082 h -2 l -0.332,2.086 h 0.664 c 0.078,-0.183 0.246,-0.285 0.477,-0.285 0.375,0 0.601,0.27 0.601,0.723 0,0.437 -0.226,0.707 -0.601,0.707 -0.324,0 -0.504,-0.164 -0.52,-0.465 h -0.726 c 0.008,0.656 0.504,1.098 1.234,1.098 0.801,0 1.352,-0.547 1.352,-1.356 0,-0.769 -0.477,-1.293 -1.168,-1.293 -0.246,0 -0.434,0.063 -0.649,0.227 l 0.121,-0.781 h 1.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath203)"
+               id="path639" />
+            <path
+               d="m 383.23,425.09 h -1.589 c 0.101,-0.199 0.214,-0.313 0.765,-0.707 0.649,-0.477 0.84,-0.754 0.84,-1.266 0,-0.726 -0.5,-1.191 -1.285,-1.191 -0.773,0 -1.227,0.461 -1.227,1.254 v 0.132 h 0.711 v -0.124 c 0,-0.415 0.196,-0.661 0.535,-0.661 0.325,0 0.528,0.231 0.528,0.606 0,0.414 -0.129,0.57 -0.961,1.16 -0.637,0.434 -0.832,0.762 -0.863,1.457 h 2.546 z m 2.965,-3.082 h -2.636 v 0.66 h 1.863 c -0.227,0.242 -0.676,0.922 -0.82,1.25 -0.262,0.543 -0.391,1.035 -0.493,1.832 h 0.743 c 0.07,-1.184 0.457,-2.09 1.343,-3.164 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath204)"
+               id="path640" />
+            <path
+               d="m 383.23,432.531 h -1.589 c 0.101,-0.203 0.214,-0.312 0.765,-0.707 0.649,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.5,-1.188 -1.285,-1.188 -0.773,0 -1.227,0.461 -1.227,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.196,-0.66 0.535,-0.66 0.325,0 0.528,0.226 0.528,0.601 0,0.418 -0.129,0.571 -0.961,1.164 -0.637,0.434 -0.832,0.758 -0.863,1.457 h 2.546 z m 0.375,-0.211 c 0.016,0.575 0.504,0.996 1.149,0.996 0.48,0 0.844,-0.199 1.066,-0.582 0.196,-0.332 0.313,-0.894 0.313,-1.496 0,-0.55 -0.086,-0.972 -0.262,-1.258 -0.238,-0.402 -0.605,-0.613 -1.055,-0.613 -0.75,0 -1.261,0.539 -1.261,1.321 0,0.769 0.453,1.3 1.117,1.3 0.191,0 0.371,-0.054 0.488,-0.14 0.067,-0.047 0.11,-0.094 0.231,-0.231 0,0.723 -0.2,1.067 -0.618,1.067 -0.261,0 -0.437,-0.145 -0.453,-0.364 z m 1.192,-2.351 c 0.355,0 0.578,0.273 0.578,0.719 0,0.41 -0.227,0.687 -0.57,0.687 -0.336,0 -0.547,-0.266 -0.547,-0.699 0,-0.434 0.203,-0.707 0.539,-0.707 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath205)"
+               id="path641" />
+            <path
+               d="m 381.672,438.957 c 0.285,0 0.301,0 0.433,0.035 0.25,0.07 0.407,0.285 0.407,0.563 0,0.332 -0.231,0.562 -0.555,0.562 -0.348,0 -0.539,-0.199 -0.559,-0.586 h -0.718 c 0.004,0.75 0.492,1.223 1.261,1.223 0.797,0 1.309,-0.473 1.309,-1.199 0,-0.438 -0.188,-0.723 -0.613,-0.93 0.343,-0.219 0.492,-0.453 0.492,-0.797 0,-0.625 -0.465,-1.019 -1.188,-1.019 -0.543,0 -0.961,0.238 -1.125,0.644 -0.066,0.18 -0.089,0.301 -0.089,0.613 h 0.687 c 0.004,-0.203 0.02,-0.304 0.059,-0.398 0.066,-0.164 0.238,-0.262 0.453,-0.262 0.297,0 0.465,0.18 0.465,0.489 0,0.382 -0.215,0.566 -0.657,0.566 h -0.062 z m 2.992,-0.91 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.445 -0.5,0.672 -1.144,0.672 v 0.488 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath206)"
+               id="path642" />
+            <path
+               d="m 381.672,446.398 c 0.285,0 0.301,0 0.433,0.036 0.25,0.07 0.407,0.285 0.407,0.558 0,0.336 -0.231,0.567 -0.555,0.567 -0.348,0 -0.539,-0.2 -0.559,-0.586 h -0.718 c 0.004,0.75 0.492,1.218 1.261,1.218 0.797,0 1.309,-0.468 1.309,-1.199 0,-0.437 -0.188,-0.722 -0.613,-0.926 0.343,-0.218 0.492,-0.457 0.492,-0.8 0,-0.621 -0.465,-1.016 -1.188,-1.016 -0.543,0 -0.961,0.234 -1.125,0.641 -0.066,0.179 -0.089,0.304 -0.089,0.613 h 0.687 c 0.004,-0.199 0.02,-0.301 0.059,-0.395 0.066,-0.164 0.238,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.215,0.566 -0.657,0.566 h -0.062 z m 2.879,0 c 0.285,0 0.301,0 0.433,0.036 0.25,0.07 0.407,0.285 0.407,0.558 0,0.336 -0.231,0.567 -0.555,0.567 -0.348,0 -0.539,-0.2 -0.559,-0.586 h -0.718 c 0.007,0.75 0.492,1.218 1.261,1.218 0.797,0 1.313,-0.468 1.313,-1.199 0,-0.437 -0.192,-0.722 -0.613,-0.926 0.343,-0.218 0.488,-0.457 0.488,-0.8 0,-0.621 -0.465,-1.016 -1.188,-1.016 -0.543,0 -0.961,0.234 -1.125,0.641 -0.066,0.179 -0.09,0.304 -0.09,0.613 h 0.688 c 0.004,-0.199 0.023,-0.301 0.059,-0.395 0.07,-0.164 0.238,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.379 -0.215,0.566 -0.653,0.566 h -0.066 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath207)"
+               id="path643" />
+            <path
+               d="m 392.23,328.246 h -1.589 c 0.101,-0.199 0.214,-0.312 0.765,-0.707 0.649,-0.477 0.84,-0.754 0.84,-1.266 0,-0.726 -0.5,-1.191 -1.285,-1.191 -0.773,0 -1.227,0.461 -1.227,1.254 v 0.133 h 0.711 v -0.125 c 0,-0.414 0.196,-0.656 0.535,-0.656 0.325,0 0.528,0.226 0.528,0.601 0,0.414 -0.129,0.57 -0.961,1.16 -0.633,0.434 -0.832,0.762 -0.863,1.457 h 2.546 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath208)"
+               id="path644" />
+            <path
+               d="m 392.281,334.906 h -0.39 v -2.304 h -0.871 l -1.368,2.293 v 0.625 h 1.5 v 0.828 h 0.739 v -0.828 h 0.39 z m -1.129,0 h -0.976 l 0.976,-1.601 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath209)"
+               id="path645" />
+            <path
+               d="m 392.203,340.895 c -0.035,-0.243 -0.082,-0.368 -0.18,-0.504 -0.195,-0.27 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.207 -1.07,0.582 -0.223,0.363 -0.313,0.781 -0.313,1.461 0,0.644 0.078,1.047 0.27,1.347 0.215,0.348 0.605,0.555 1.051,0.555 0.746,0 1.25,-0.555 1.25,-1.375 0,-0.719 -0.442,-1.215 -1.086,-1.215 -0.305,0 -0.512,0.09 -0.746,0.332 l 0.007,-0.078 c 0.008,-0.347 0.024,-0.457 0.079,-0.601 0.101,-0.274 0.281,-0.411 0.539,-0.411 0.238,0 0.363,0.094 0.457,0.333 z m -1.207,1.011 c 0.348,0 0.57,0.266 0.57,0.684 0,0.394 -0.246,0.683 -0.57,0.683 -0.34,0 -0.57,-0.273 -0.57,-0.675 0,-0.407 0.23,-0.692 0.57,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath210)"
+               id="path646" />
+            <path
+               d="m 391.688,349.188 c 0.124,-0.067 0.183,-0.106 0.242,-0.157 0.152,-0.144 0.242,-0.371 0.242,-0.613 0,-0.586 -0.508,-1.012 -1.199,-1.012 -0.696,0 -1.203,0.426 -1.203,1.016 0,0.359 0.148,0.59 0.484,0.766 -0.43,0.238 -0.609,0.519 -0.609,0.96 0,0.711 0.543,1.2 1.328,1.2 0.781,0 1.324,-0.489 1.324,-1.2 0,-0.441 -0.176,-0.722 -0.609,-0.96 z M 390.98,348 c 0.325,0 0.551,0.203 0.551,0.492 0,0.285 -0.23,0.492 -0.551,0.492 -0.335,0 -0.562,-0.203 -0.562,-0.496 0,-0.285 0.227,-0.488 0.562,-0.488 z m -0.011,1.484 c 0.363,0 0.59,0.243 0.59,0.633 0,0.36 -0.231,0.598 -0.59,0.598 -0.36,0 -0.586,-0.238 -0.586,-0.606 0,-0.382 0.226,-0.625 0.586,-0.625 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath211)"
+               id="path647" />
+            <path
+               d="m 389.344,356.086 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.441 -0.5,0.668 -1.145,0.668 v 0.492 z m 3.062,-1.242 c -0.398,0 -0.742,0.172 -0.968,0.48 -0.219,0.293 -0.317,0.766 -0.317,1.496 0,0.664 0.082,1.129 0.262,1.414 0.222,0.36 0.586,0.555 1.023,0.555 0.41,0 0.742,-0.164 0.973,-0.477 0.211,-0.289 0.316,-0.769 0.316,-1.472 0,-0.684 -0.082,-1.149 -0.261,-1.442 -0.223,-0.359 -0.586,-0.554 -1.028,-0.554 z m 0,0.597 c 0.192,0 0.344,0.106 0.434,0.301 0.074,0.16 0.117,0.567 0.117,1.082 0,0.422 -0.035,0.836 -0.094,0.988 -0.086,0.223 -0.242,0.344 -0.457,0.344 -0.195,0 -0.34,-0.101 -0.429,-0.289 -0.075,-0.16 -0.118,-0.551 -0.118,-1.051 0,-0.445 0.036,-0.867 0.094,-1.019 0.078,-0.227 0.242,-0.356 0.453,-0.356 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath212)"
+               id="path648" />
+            <path
+               d="m 389.344,363.527 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.446 -0.5,0.672 -1.145,0.672 v 0.492 z m 4.328,1.922 h -1.59 c 0.098,-0.203 0.215,-0.312 0.766,-0.707 0.648,-0.476 0.84,-0.758 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.164 -0.632,0.43 -0.828,0.758 -0.859,1.457 h 2.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath213)"
+               id="path649" />
+            <path
+               d="m 389.344,370.965 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.488 z m 4.379,1.14 h -0.391 v -2.3 h -0.871 l -1.367,2.293 v 0.621 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.597 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath214)"
+               id="path650" />
+            <path
+               d="m 389.344,378.406 v 2.582 h 0.738 v -3.742 h -0.492 c -0.113,0.442 -0.5,0.668 -1.145,0.668 v 0.492 z m 4.301,-0.312 c -0.04,-0.242 -0.086,-0.364 -0.18,-0.5 -0.195,-0.27 -0.539,-0.43 -0.945,-0.43 -0.465,0 -0.844,0.207 -1.075,0.582 -0.218,0.363 -0.308,0.781 -0.308,1.465 0,0.644 0.078,1.043 0.269,1.344 0.215,0.351 0.606,0.554 1.051,0.554 0.742,0 1.25,-0.554 1.25,-1.371 0,-0.718 -0.445,-1.215 -1.086,-1.215 -0.309,0 -0.516,0.09 -0.746,0.332 l 0.004,-0.078 c 0.012,-0.347 0.027,-0.461 0.078,-0.601 0.102,-0.278 0.281,-0.414 0.539,-0.414 0.238,0 0.367,0.097 0.461,0.332 z m -1.211,1.015 c 0.347,0 0.57,0.266 0.57,0.68 0,0.399 -0.242,0.688 -0.57,0.688 -0.336,0 -0.571,-0.274 -0.571,-0.676 0,-0.406 0.235,-0.692 0.571,-0.692 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath215)"
+               id="path651" />
+            <path
+               d="m 389.344,385.969 v 2.582 h 0.738 v -3.746 h -0.492 c -0.113,0.445 -0.5,0.672 -1.145,0.672 v 0.492 z m 3.781,0.543 c 0.129,-0.071 0.187,-0.106 0.242,-0.16 0.156,-0.141 0.246,-0.368 0.246,-0.614 0,-0.586 -0.508,-1.011 -1.199,-1.011 -0.699,0 -1.203,0.425 -1.203,1.019 0,0.359 0.144,0.586 0.484,0.766 -0.433,0.238 -0.613,0.515 -0.613,0.961 0,0.707 0.543,1.199 1.332,1.199 0.781,0 1.324,-0.492 1.324,-1.199 0,-0.446 -0.179,-0.723 -0.613,-0.961 z m -0.707,-1.188 c 0.328,0 0.555,0.199 0.555,0.488 0,0.286 -0.231,0.493 -0.555,0.493 -0.332,0 -0.559,-0.2 -0.559,-0.496 0,-0.286 0.227,-0.485 0.559,-0.485 z m -0.012,1.481 c 0.367,0 0.594,0.246 0.594,0.636 0,0.36 -0.234,0.594 -0.594,0.594 -0.355,0 -0.586,-0.234 -0.586,-0.605 0,-0.379 0.231,-0.625 0.586,-0.625 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath216)"
+               id="path652" />
+            <path
+               d="m 390.789,395.328 h -1.59 c 0.102,-0.199 0.219,-0.308 0.766,-0.707 0.652,-0.473 0.84,-0.754 0.84,-1.266 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z m 1.617,-3.16 c -0.398,0 -0.742,0.168 -0.968,0.48 -0.219,0.29 -0.317,0.766 -0.317,1.493 0,0.664 0.082,1.129 0.262,1.414 0.222,0.359 0.586,0.554 1.023,0.554 0.41,0 0.742,-0.164 0.973,-0.472 0.211,-0.293 0.316,-0.774 0.316,-1.473 0,-0.687 -0.082,-1.152 -0.261,-1.441 -0.223,-0.36 -0.586,-0.555 -1.028,-0.555 z m 0,0.594 c 0.192,0 0.344,0.105 0.434,0.3 0.074,0.161 0.117,0.567 0.117,1.086 0,0.422 -0.035,0.832 -0.094,0.985 -0.086,0.222 -0.242,0.344 -0.457,0.344 -0.195,0 -0.34,-0.102 -0.429,-0.289 -0.075,-0.161 -0.118,-0.551 -0.118,-1.051 0,-0.446 0.036,-0.867 0.094,-1.02 0.078,-0.226 0.242,-0.355 0.453,-0.355 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath217)"
+               id="path653" />
+            <path
+               d="m 390.789,402.77 h -1.59 c 0.102,-0.2 0.219,-0.313 0.766,-0.708 0.652,-0.476 0.84,-0.753 0.84,-1.269 0,-0.723 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.133 h 0.711 v -0.125 c 0,-0.414 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.231 0.527,0.605 0,0.415 -0.125,0.571 -0.961,1.161 -0.632,0.433 -0.828,0.761 -0.859,1.457 h 2.543 z m 2.883,0 h -1.59 c 0.098,-0.2 0.215,-0.313 0.766,-0.708 0.648,-0.476 0.84,-0.753 0.84,-1.269 0,-0.723 -0.504,-1.188 -1.286,-1.188 -0.777,0 -1.23,0.461 -1.23,1.254 v 0.133 h 0.715 v -0.125 c 0,-0.414 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.231 0.527,0.605 0,0.415 -0.125,0.571 -0.961,1.161 -0.632,0.433 -0.828,0.761 -0.859,1.457 h 2.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath218)"
+               id="path654" />
+            <path
+               d="m 390.789,410.211 h -1.59 c 0.102,-0.203 0.219,-0.313 0.766,-0.707 0.652,-0.477 0.84,-0.758 0.84,-1.27 0,-0.722 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.661 0.535,-0.661 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.632,0.43 -0.828,0.758 -0.859,1.457 h 2.543 z m 2.934,-0.781 h -0.391 v -2.305 h -0.871 l -1.367,2.293 v 0.625 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.602 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath219)"
+               id="path655" />
+            <path
+               d="m 390.789,417.648 h -1.59 c 0.102,-0.199 0.219,-0.308 0.766,-0.707 0.652,-0.472 0.84,-0.753 0.84,-1.265 0,-0.723 -0.5,-1.188 -1.282,-1.188 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.133 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.226 0.527,0.601 0,0.418 -0.125,0.571 -0.961,1.161 -0.632,0.433 -0.828,0.761 -0.859,1.457 h 2.543 z m 2.856,-2.23 c -0.04,-0.242 -0.086,-0.367 -0.18,-0.504 -0.195,-0.269 -0.539,-0.426 -0.945,-0.426 -0.465,0 -0.844,0.207 -1.075,0.578 -0.218,0.368 -0.308,0.786 -0.308,1.465 0,0.645 0.078,1.047 0.269,1.348 0.215,0.348 0.606,0.555 1.051,0.555 0.742,0 1.25,-0.555 1.25,-1.375 0,-0.719 -0.445,-1.215 -1.086,-1.215 -0.309,0 -0.516,0.09 -0.746,0.332 l 0.004,-0.078 c 0.012,-0.348 0.027,-0.461 0.078,-0.602 0.102,-0.273 0.281,-0.41 0.539,-0.41 0.238,0 0.367,0.094 0.461,0.332 z m -1.211,1.012 c 0.347,0 0.57,0.265 0.57,0.683 0,0.395 -0.242,0.684 -0.57,0.684 -0.336,0 -0.571,-0.274 -0.571,-0.676 0,-0.406 0.235,-0.691 0.571,-0.691 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath220)"
+               id="path656" />
+            <path
+               d="m 390.789,425.09 h -1.59 c 0.102,-0.199 0.219,-0.313 0.766,-0.707 0.652,-0.477 0.84,-0.754 0.84,-1.266 0,-0.726 -0.5,-1.187 -1.282,-1.187 -0.777,0 -1.23,0.457 -1.23,1.25 v 0.132 h 0.711 v -0.121 c 0,-0.418 0.195,-0.66 0.535,-0.66 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.16 -0.632,0.434 -0.828,0.762 -0.859,1.457 h 2.543 z m 2.336,-1.379 c 0.129,-0.066 0.187,-0.106 0.242,-0.156 0.156,-0.145 0.246,-0.371 0.246,-0.614 0,-0.586 -0.508,-1.011 -1.199,-1.011 -0.699,0 -1.203,0.425 -1.203,1.015 0,0.36 0.144,0.586 0.484,0.766 -0.433,0.238 -0.613,0.519 -0.613,0.961 0,0.711 0.543,1.199 1.332,1.199 0.781,0 1.324,-0.488 1.324,-1.199 0,-0.442 -0.179,-0.723 -0.613,-0.961 z m -0.707,-1.188 c 0.328,0 0.555,0.204 0.555,0.493 0,0.285 -0.231,0.492 -0.555,0.492 -0.332,0 -0.559,-0.203 -0.559,-0.496 0,-0.285 0.227,-0.489 0.559,-0.489 z m -0.012,1.485 c 0.367,0 0.594,0.242 0.594,0.633 0,0.359 -0.234,0.597 -0.594,0.597 -0.355,0 -0.586,-0.238 -0.586,-0.605 0,-0.383 0.231,-0.625 0.586,-0.625 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath221)"
+               id="path657" />
+            <path
+               d="m 389.234,431.516 c 0.286,0 0.301,0 0.43,0.039 0.25,0.066 0.406,0.285 0.406,0.558 0,0.332 -0.23,0.567 -0.55,0.567 -0.352,0 -0.54,-0.203 -0.563,-0.586 h -0.719 c 0.008,0.75 0.492,1.218 1.262,1.218 0.801,0 1.312,-0.468 1.312,-1.199 0,-0.437 -0.191,-0.722 -0.613,-0.929 0.344,-0.215 0.492,-0.454 0.492,-0.797 0,-0.621 -0.464,-1.02 -1.191,-1.02 -0.543,0 -0.961,0.238 -1.121,0.645 -0.07,0.179 -0.09,0.3 -0.09,0.613 h 0.684 c 0.007,-0.199 0.023,-0.301 0.058,-0.395 0.071,-0.164 0.239,-0.265 0.453,-0.265 0.297,0 0.465,0.18 0.465,0.492 0,0.379 -0.215,0.563 -0.652,0.563 h -0.063 z m 3.172,-2.149 c -0.398,0 -0.742,0.172 -0.968,0.481 -0.219,0.293 -0.317,0.765 -0.317,1.496 0,0.664 0.082,1.129 0.262,1.414 0.222,0.359 0.586,0.554 1.023,0.554 0.41,0 0.742,-0.164 0.973,-0.476 0.211,-0.289 0.316,-0.77 0.316,-1.473 0,-0.687 -0.082,-1.148 -0.261,-1.441 -0.223,-0.36 -0.586,-0.555 -1.028,-0.555 z m 0,0.598 c 0.192,0 0.344,0.105 0.434,0.301 0.074,0.16 0.117,0.566 0.117,1.082 0,0.422 -0.035,0.836 -0.094,0.988 -0.086,0.223 -0.242,0.344 -0.457,0.344 -0.195,0 -0.34,-0.102 -0.429,-0.293 -0.075,-0.157 -0.118,-0.547 -0.118,-1.051 0,-0.441 0.036,-0.863 0.094,-1.016 0.078,-0.23 0.242,-0.355 0.453,-0.355 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath222)"
+               id="path658" />
+            <path
+               d="m 389.234,438.957 c 0.286,0 0.301,0 0.43,0.039 0.25,0.066 0.406,0.285 0.406,0.559 0,0.332 -0.23,0.566 -0.55,0.566 -0.352,0 -0.54,-0.203 -0.563,-0.59 h -0.719 c 0.008,0.75 0.492,1.223 1.262,1.223 0.801,0 1.312,-0.473 1.312,-1.199 0,-0.438 -0.191,-0.723 -0.613,-0.93 0.344,-0.215 0.492,-0.453 0.492,-0.797 0,-0.625 -0.464,-1.019 -1.191,-1.019 -0.543,0 -0.961,0.238 -1.121,0.644 -0.07,0.18 -0.09,0.301 -0.09,0.613 h 0.684 c 0.007,-0.203 0.023,-0.3 0.058,-0.398 0.071,-0.164 0.239,-0.262 0.453,-0.262 0.297,0 0.465,0.18 0.465,0.489 0,0.382 -0.215,0.566 -0.652,0.566 h -0.063 z m 4.438,1.016 h -1.59 c 0.098,-0.203 0.215,-0.313 0.766,-0.707 0.648,-0.477 0.84,-0.758 0.84,-1.27 0,-0.723 -0.504,-1.187 -1.286,-1.187 -0.777,0 -1.23,0.461 -1.23,1.25 v 0.132 h 0.715 v -0.121 c 0,-0.418 0.195,-0.66 0.531,-0.66 0.328,0 0.527,0.227 0.527,0.602 0,0.418 -0.125,0.57 -0.961,1.164 -0.632,0.429 -0.828,0.758 -0.859,1.457 h 2.547 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath223)"
+               id="path659" />
+            <path
+               d="m 389.234,446.398 c 0.286,0 0.301,0 0.43,0.036 0.25,0.07 0.406,0.285 0.406,0.562 0,0.332 -0.23,0.563 -0.55,0.563 -0.352,0 -0.54,-0.2 -0.563,-0.586 h -0.719 c 0.008,0.75 0.492,1.218 1.262,1.218 0.801,0 1.312,-0.468 1.312,-1.195 0,-0.441 -0.191,-0.726 -0.613,-0.93 0.344,-0.218 0.492,-0.457 0.492,-0.796 0,-0.625 -0.464,-1.02 -1.191,-1.02 -0.543,0 -0.961,0.238 -1.121,0.645 -0.07,0.179 -0.09,0.3 -0.09,0.609 h 0.684 c 0.007,-0.199 0.023,-0.301 0.058,-0.395 0.071,-0.164 0.239,-0.265 0.453,-0.265 0.297,0 0.465,0.179 0.465,0.492 0,0.383 -0.215,0.566 -0.652,0.566 h -0.063 z m 4.489,0.231 h -0.391 v -2.301 h -0.871 l -1.367,2.293 v 0.621 h 1.5 v 0.828 h 0.738 v -0.828 h 0.391 z m -1.129,0 h -0.977 l 0.977,-1.598 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath224)"
+               id="path660" />
+            <path
+               d="m 257.777,274.785 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.617 z m 0,-0.543 v -1.687 h 1.278 c 0.59,0 0.937,0.316 0.937,0.843 0,0.528 -0.347,0.844 -0.937,0.844 z m 7.594,-0.738 c -0.191,-1.055 -0.801,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.203 -1.524,0.601 -0.437,0.473 -0.676,1.16 -0.676,1.938 0,0.793 0.246,1.472 0.696,1.941 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.637 1.981,-1.911 h -0.633 c -0.051,0.332 -0.117,0.555 -0.219,0.746 -0.195,0.399 -0.605,0.622 -1.121,0.622 -0.957,0 -1.562,-0.766 -1.562,-1.965 0,-1.235 0.574,-1.996 1.511,-1.996 0.387,0 0.75,0.113 0.95,0.304 0.175,0.164 0.277,0.364 0.347,0.727 z m 2.891,0.805 c 0.488,-0.297 0.64,-0.536 0.64,-0.985 0,-0.75 -0.574,-1.273 -1.406,-1.273 -0.824,0 -1.406,0.523 -1.406,1.269 0,0.453 0.152,0.684 0.633,0.989 -0.532,0.269 -0.797,0.66 -0.797,1.187 0,0.871 0.64,1.481 1.57,1.481 0.926,0 1.57,-0.61 1.57,-1.481 0,-0.527 -0.261,-0.918 -0.804,-1.187 z m -0.766,-1.743 c 0.496,0 0.813,0.297 0.813,0.774 0,0.449 -0.325,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.762 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.008 c 0.582,0 0.977,0.383 0.977,0.938 0,0.574 -0.387,0.949 -0.989,0.949 -0.57,0 -0.964,-0.391 -0.964,-0.945 0,-0.567 0.39,-0.942 0.976,-0.942 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath225)"
+               id="path661" />
+            <path
+               d="m 257.777,326.867 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.617 z m 0,-0.543 v -1.687 h 1.278 c 0.59,0 0.937,0.316 0.937,0.843 0,0.528 -0.347,0.844 -0.937,0.844 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.23 v 4.812 h 0.617 z m 5.891,-2.488 h -2.414 l -0.352,2.546 h 0.535 c 0.274,-0.324 0.496,-0.433 0.867,-0.433 0.625,0 1.016,0.426 1.016,1.121 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.145,0.566 0.286,0.738 0.265,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.614,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.304 h 1.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath226)"
+               id="path662" />
+            <path
+               d="m 257.777,319.426 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.617 z m 0,-0.543 v -1.688 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.527 -0.347,0.844 -0.937,0.844 z m 4.434,0.39 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.543 h -3.23 v 4.813 h 0.617 z m 4.211,-0.007 h 0.316 c 0.633,0 0.969,0.296 0.969,0.871 0,0.601 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.325 -0.988,-1.024 h -0.582 c 0.027,0.383 0.094,0.633 0.207,0.844 0.242,0.465 0.699,0.695 1.34,0.695 0.961,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.231,-0.938 -0.793,-1.137 0.437,-0.18 0.656,-0.508 0.656,-0.988 0,-0.82 -0.535,-1.317 -1.426,-1.317 -0.945,0 -1.445,0.532 -1.465,1.539 h 0.579 c 0.007,-0.289 0.035,-0.453 0.105,-0.601 0.133,-0.27 0.422,-0.426 0.785,-0.426 0.516,0 0.828,0.309 0.828,0.824 0,0.336 -0.121,0.539 -0.379,0.653 -0.156,0.066 -0.367,0.093 -0.769,0.097 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath227)"
+               id="path663" />
+            <path
+               d="m 257.777,311.984 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.343 0.289,-0.262 0.414,-0.575 0.414,-1.016 0,-0.902 -0.535,-1.41 -1.485,-1.41 h -1.988 v 4.808 h 0.617 z m 0,-0.539 v -1.691 h 1.278 c 0.59,0 0.937,0.316 0.937,0.844 0,0.531 -0.347,0.847 -0.937,0.847 z m 3.813,2.578 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.817,-0.035 h -2.461 c 0.058,-0.394 0.269,-0.644 0.843,-0.996 l 0.66,-0.367 c 0.657,-0.363 0.993,-0.852 0.993,-1.441 0,-0.395 -0.16,-0.766 -0.438,-1.024 -0.277,-0.25 -0.617,-0.367 -1.062,-0.367 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.239,0.547 -0.25,1.027 h 0.582 c 0.019,-0.324 0.058,-0.515 0.136,-0.672 0.153,-0.292 0.458,-0.468 0.805,-0.468 0.527,0 0.926,0.383 0.926,0.898 0,0.383 -0.219,0.711 -0.633,0.949 l -0.609,0.356 c -0.977,0.562 -1.262,1.012 -1.313,2.055 h 3.114 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath228)"
+               id="path664" />
+            <path
+               d="m 257.777,304.543 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.903 -0.535,-1.411 -1.485,-1.411 h -1.988 v 4.813 h 0.617 z m 0,-0.539 v -1.692 h 1.278 c 0.59,0 0.937,0.317 0.937,0.848 0,0.528 -0.347,0.844 -0.937,0.844 z m 7.594,-0.738 c -0.191,-1.059 -0.801,-1.571 -1.855,-1.571 -0.645,0 -1.168,0.203 -1.524,0.598 -0.437,0.477 -0.676,1.164 -0.676,1.941 0,0.793 0.246,1.473 0.696,1.942 0.375,0.383 0.851,0.558 1.476,0.558 1.176,0 1.836,-0.632 1.981,-1.906 h -0.633 c -0.051,0.332 -0.117,0.555 -0.219,0.746 -0.195,0.395 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.765 -1.562,-1.968 0,-1.235 0.574,-1.993 1.511,-1.993 0.387,0 0.75,0.114 0.95,0.305 0.175,0.164 0.277,0.363 0.347,0.727 z m 2.02,-0.082 v 3.402 h 0.582 v -4.774 h -0.383 c -0.207,0.735 -0.336,0.833 -1.235,0.95 v 0.422 z m 5.23,2.828 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-1 l 0.66,-0.367 c 0.652,-0.364 0.992,-0.852 0.992,-1.442 0,-0.394 -0.16,-0.765 -0.437,-1.019 -0.278,-0.254 -0.621,-0.372 -1.063,-0.372 -0.594,0 -1.035,0.211 -1.293,0.622 -0.164,0.25 -0.238,0.546 -0.25,1.027 h 0.578 c 0.02,-0.32 0.063,-0.512 0.141,-0.672 0.152,-0.289 0.453,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.383 -0.218,0.711 -0.636,0.949 l -0.606,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.055 h 3.113 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath229)"
+               id="path665" />
+            <path
+               d="m 257.777,297.105 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.617 z m 0,-0.543 v -1.687 h 1.278 c 0.59,0 0.937,0.316 0.937,0.844 0,0.527 -0.347,0.843 -0.937,0.843 z m 7.594,-0.738 c -0.191,-1.054 -0.801,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.203 -1.524,0.601 -0.437,0.473 -0.676,1.161 -0.676,1.938 0,0.793 0.246,1.473 0.696,1.941 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.637 1.981,-1.91 h -0.633 c -0.051,0.332 -0.117,0.554 -0.219,0.746 -0.195,0.398 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.766 -1.562,-1.965 0,-1.234 0.574,-1.996 1.511,-1.996 0.387,0 0.75,0.113 0.95,0.305 0.175,0.164 0.277,0.363 0.347,0.726 z m 2.02,-0.078 v 3.399 h 0.582 v -4.774 h -0.383 c -0.207,0.734 -0.336,0.832 -1.235,0.953 v 0.422 z m 3.601,0 v 3.399 h 0.582 v -4.774 h -0.383 c -0.207,0.734 -0.339,0.832 -1.234,0.953 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath230)"
+               id="path666" />
+            <path
+               d="m 257.777,289.664 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.907 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.617 z m 0,-0.543 v -1.687 h 1.278 c 0.59,0 0.937,0.316 0.937,0.843 0,0.528 -0.347,0.844 -0.937,0.844 z m 7.594,-0.738 c -0.191,-1.055 -0.801,-1.571 -1.855,-1.571 -0.645,0 -1.168,0.204 -1.524,0.602 -0.437,0.473 -0.676,1.16 -0.676,1.941 0,0.79 0.246,1.469 0.696,1.938 0.375,0.383 0.851,0.562 1.476,0.562 1.176,0 1.836,-0.632 1.981,-1.906 h -0.633 c -0.051,0.328 -0.117,0.555 -0.219,0.746 -0.195,0.395 -0.605,0.617 -1.121,0.617 -0.957,0 -1.562,-0.765 -1.562,-1.964 0,-1.235 0.574,-1.993 1.511,-1.993 0.387,0 0.75,0.11 0.95,0.301 0.175,0.168 0.277,0.364 0.347,0.727 z m 2.02,-0.078 v 3.398 h 0.582 v -4.773 h -0.383 c -0.207,0.734 -0.336,0.832 -1.235,0.953 v 0.422 z m 3.707,-1.375 c -0.438,0 -0.832,0.199 -1.078,0.523 -0.301,0.422 -0.454,1.055 -0.454,1.942 0,1.609 0.528,2.46 1.532,2.46 0.988,0 1.531,-0.851 1.531,-2.421 0,-0.926 -0.145,-1.547 -0.457,-1.981 -0.242,-0.332 -0.633,-0.523 -1.074,-0.523 z m 0,0.515 c 0.625,0 0.937,0.641 0.937,1.934 0,1.359 -0.305,1.996 -0.953,1.996 -0.613,0 -0.922,-0.66 -0.922,-1.977 0,-1.312 0.309,-1.953 0.938,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath231)"
+               id="path667" />
+            <path
+               d="m 257.777,282.223 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.535,-1.41 -1.485,-1.41 h -1.988 v 4.809 h 0.617 z m 0,-0.539 v -1.692 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.531 -0.347,0.848 -0.937,0.848 z m 7.594,-0.743 c -0.191,-1.054 -0.801,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.207 -1.524,0.602 -0.437,0.476 -0.676,1.16 -0.676,1.941 0,0.793 0.246,1.473 0.696,1.941 0.375,0.383 0.851,0.559 1.476,0.559 1.176,0 1.836,-0.633 1.981,-1.906 h -0.633 c -0.051,0.328 -0.117,0.554 -0.219,0.746 -0.195,0.394 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.766 -1.562,-1.969 0,-1.234 0.574,-1.992 1.511,-1.992 0.387,0 0.75,0.113 0.95,0.305 0.175,0.164 0.277,0.359 0.347,0.722 z m 0.66,2.235 c 0.114,0.777 0.614,1.238 1.328,1.238 0.52,0 0.981,-0.25 1.258,-0.68 0.293,-0.468 0.426,-1.05 0.426,-1.914 0,-0.804 -0.121,-1.312 -0.398,-1.734 -0.258,-0.391 -0.668,-0.594 -1.18,-0.594 -0.891,0 -1.531,0.664 -1.531,1.59 0,0.879 0.593,1.496 1.437,1.496 0.441,0 0.774,-0.156 1.07,-0.519 -0.007,1.187 -0.379,1.839 -1.043,1.839 -0.41,0 -0.695,-0.261 -0.785,-0.722 z M 267.457,280 c 0.543,0 0.949,0.453 0.949,1.07 0,0.586 -0.394,0.996 -0.968,0.996 -0.563,0 -0.911,-0.398 -0.911,-1.031 0,-0.601 0.387,-1.035 0.93,-1.035 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath232)"
+               id="path668" />
+            <path
+               d="m 261.121,378.566 h -2.008 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.929,-0.18 -1.211,-0.489 -0.32,-0.343 -0.511,-0.918 -0.511,-1.511 0,-1.184 0.676,-1.961 1.691,-1.961 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.91,-1.539 -2.012,-1.539 -0.59,0 -1.063,0.152 -1.441,0.465 -0.559,0.461 -0.872,1.207 -0.872,2.07 0,1.48 0.907,2.508 2.208,2.508 0.652,0 1.167,-0.242 1.64,-0.766 l 0.152,0.641 h 0.391 z m 4.742,-2.269 h -0.578 v 3.933 l -2.515,-3.933 h -0.668 v 4.808 h 0.582 v -3.898 l 2.488,3.898 h 0.691 z m 1.004,4.808 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath233)"
+               id="path669" />
+            <path
+               d="m 257.656,371.629 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.903 -0.532,-1.411 -1.485,-1.411 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.691 h 1.282 c 0.585,0 0.937,0.32 0.937,0.847 0,0.528 -0.352,0.844 -0.937,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.871 0,1.218 -0.5,1.859 -1.449,1.859 z m 4.938,-1.656 h 0.316 c 0.633,0 0.973,0.297 0.973,0.871 0,0.601 -0.364,0.965 -0.965,0.965 -0.641,0 -0.949,-0.325 -0.989,-1.024 h -0.582 c 0.028,0.383 0.09,0.633 0.204,0.844 0.246,0.461 0.699,0.695 1.339,0.695 0.965,0 1.586,-0.582 1.586,-1.488 0,-0.605 -0.23,-0.937 -0.793,-1.133 0.434,-0.179 0.653,-0.508 0.653,-0.992 0,-0.816 -0.535,-1.312 -1.426,-1.312 -0.941,0 -1.445,0.527 -1.465,1.539 h 0.582 c 0.008,-0.293 0.031,-0.457 0.106,-0.602 0.132,-0.27 0.421,-0.43 0.785,-0.43 0.515,0 0.824,0.313 0.824,0.825 0,0.339 -0.117,0.543 -0.375,0.656 -0.16,0.066 -0.371,0.09 -0.773,0.097 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath234)"
+               id="path670" />
+            <path
+               d="m 257.656,364.066 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.262 0.414,-0.575 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.844 0,0.527 -0.352,0.843 -0.937,0.843 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z m 5.637,-0.617 v 1.156 h 0.582 v -1.156 h 0.691 v -0.519 h -0.691 v -3.098 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath235)"
+               id="path671" />
+            <path
+               d="m 257.656,356.625 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.903 -0.532,-1.411 -1.485,-1.411 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.691 h 1.282 c 0.585,0 0.937,0.316 0.937,0.843 0,0.532 -0.352,0.848 -0.937,0.848 z m 3.813,2.578 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.222 -0.5,1.863 -1.449,1.863 z m 6.621,-4.141 h -2.414 l -0.351,2.551 h 0.535 c 0.269,-0.324 0.496,-0.437 0.863,-0.437 0.629,0 1.016,0.429 1.016,1.121 0,0.676 -0.387,1.082 -1.02,1.082 -0.512,0 -0.82,-0.254 -0.957,-0.785 h -0.582 c 0.078,0.382 0.145,0.57 0.285,0.742 0.262,0.355 0.738,0.558 1.266,0.558 0.945,0 1.605,-0.687 1.605,-1.675 0,-0.926 -0.617,-1.559 -1.511,-1.559 -0.333,0 -0.594,0.086 -0.868,0.285 l 0.188,-1.308 h 1.945 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath236)"
+               id="path672" />
+            <path
+               d="m 257.656,349.184 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.289,-0.266 0.414,-0.574 0.414,-1.02 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.848 0,0.527 -0.352,0.844 -0.937,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.915 1.961,-2.411 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.871 0,1.219 -0.5,1.86 -1.449,1.86 z m 6.766,-2.989 c -0.114,-0.781 -0.614,-1.242 -1.325,-1.242 -0.515,0 -0.976,0.25 -1.253,0.68 -0.297,0.469 -0.426,1.051 -0.426,1.914 0,0.805 0.113,1.312 0.398,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.891,0 1.531,-0.664 1.531,-1.594 0,-0.879 -0.597,-1.5 -1.433,-1.5 -0.461,0 -0.825,0.172 -1.078,0.52 0.007,-1.18 0.378,-1.832 1.042,-1.832 0.411,0 0.696,0.261 0.79,0.726 z m -1.407,1.102 c 0.563,0 0.911,0.394 0.911,1.027 0,0.602 -0.395,1.039 -0.93,1.039 -0.539,0 -0.949,-0.457 -0.949,-1.062 0,-0.594 0.394,-1.004 0.968,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath237)"
+               id="path673" />
+            <path
+               d="m 257.656,341.746 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.843 0,0.528 -0.352,0.844 -0.937,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.636 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 6.91,-4.137 h -3.129 v 0.575 h 2.532 c -1.118,1.59 -1.575,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.898,-4.191 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath238)"
+               id="path674" />
+            <path
+               d="m 257.656,446.391 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.527 -0.352,0.844 -0.937,0.844 z m 7.906,0.039 h -2.007 v 0.543 h 1.465 v 0.132 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.18 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.18 0.672,-1.961 1.692,-1.961 0.73,0 1.257,0.379 1.39,0.996 h 0.629 c -0.172,-0.976 -0.91,-1.535 -2.016,-1.535 -0.585,0 -1.062,0.152 -1.437,0.461 -0.563,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.902,2.508 2.203,2.508 0.656,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.39 z m 2.067,-0.856 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.949 v 0.426 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath239)"
+               id="path675" />
+            <path
+               d="m 257.656,438.949 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.843 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.226 v 4.812 h 0.613 z m 3.101,1.101 c 0.114,0.782 0.614,1.243 1.329,1.243 0.519,0 0.98,-0.25 1.257,-0.68 0.293,-0.469 0.422,-1.051 0.422,-1.914 0,-0.805 -0.117,-1.313 -0.394,-1.738 -0.258,-0.387 -0.668,-0.594 -1.18,-0.594 -0.891,0 -1.531,0.668 -1.531,1.594 0,0.875 0.594,1.496 1.437,1.496 0.442,0 0.774,-0.157 1.071,-0.52 -0.008,1.188 -0.379,1.84 -1.043,1.84 -0.411,0 -0.696,-0.262 -0.786,-0.727 z m 1.426,-3.175 c 0.539,0 0.949,0.457 0.949,1.07 0,0.59 -0.394,0.996 -0.968,0.996 -0.563,0 -0.91,-0.394 -0.91,-1.027 0,-0.602 0.386,-1.039 0.929,-1.039 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath240)"
+               id="path676" />
+            <path
+               d="m 257.656,431.508 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.844 0,0.527 -0.352,0.848 -0.937,0.848 z m 4.434,0.386 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.543 h -3.226 v 4.813 h 0.613 z m 6.183,-2.488 h -3.128 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.571 -1.918,4.106 h 0.617 c 0.258,-1.496 0.848,-2.785 1.902,-4.192 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath241)"
+               id="path677" />
+            <path
+               d="m 257.656,424.066 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.339 0.289,-0.266 0.414,-0.575 0.414,-1.02 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.282 c 0.585,0 0.937,0.316 0.937,0.848 0,0.527 -0.352,0.843 -0.937,0.843 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.539 h 2.613 v -0.539 h -3.226 v 4.808 h 0.613 z m 5.332,-0.324 c 0.488,-0.297 0.64,-0.535 0.64,-0.985 0,-0.754 -0.574,-1.273 -1.406,-1.273 -0.824,0 -1.406,0.519 -1.406,1.266 0,0.457 0.152,0.687 0.633,0.992 -0.531,0.269 -0.797,0.66 -0.797,1.187 0,0.871 0.641,1.477 1.57,1.477 0.926,0 1.571,-0.606 1.571,-1.477 0,-0.527 -0.262,-0.918 -0.805,-1.187 z m -0.766,-1.742 c 0.496,0 0.813,0.296 0.813,0.769 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.461 0.316,-0.757 0.812,-0.757 z m 0,2.003 c 0.582,0 0.977,0.383 0.977,0.938 0,0.574 -0.391,0.953 -0.988,0.953 -0.571,0 -0.965,-0.391 -0.965,-0.945 0,-0.567 0.39,-0.946 0.976,-0.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath242)"
+               id="path678" />
+            <path
+               d="m 257.656,416.629 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.415 -1.485,-1.415 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.691 h 1.282 c 0.585,0 0.937,0.32 0.937,0.847 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.54 h -3.332 v 4.813 h 3.449 v -0.543 h -2.836 z m 4.57,-0.008 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.601 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.325 -0.992,-1.024 h -0.578 c 0.024,0.383 0.09,0.633 0.203,0.844 0.246,0.461 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.578 1.586,-1.484 0,-0.605 -0.234,-0.937 -0.793,-1.133 0.434,-0.179 0.652,-0.508 0.652,-0.992 0,-0.816 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.309 0.825,0.825 0,0.335 -0.118,0.543 -0.375,0.656 -0.161,0.062 -0.372,0.09 -0.774,0.097 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath243)"
+               id="path679" />
+            <path
+               d="m 257.656,409.188 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.282 c 0.585,0 0.937,0.316 0.937,0.844 0,0.527 -0.352,0.844 -0.937,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.332 v 4.813 h 3.449 v -0.543 h -2.836 z m 6.398,-1.34 c -0.113,-0.777 -0.613,-1.242 -1.328,-1.242 -0.512,0 -0.976,0.254 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.316 0.399,1.738 0.25,0.387 0.66,0.594 1.172,0.594 0.894,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.461,0 -0.824,0.172 -1.078,0.524 0.008,-1.184 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.265 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.398 0.91,1.031 0,0.598 -0.394,1.035 -0.93,1.035 -0.539,0 -0.949,-0.457 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath244)"
+               id="path680" />
+            <path
+               d="m 257.656,394.305 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.289,-0.266 0.414,-0.574 0.414,-1.02 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.282 c 0.585,0 0.937,0.317 0.937,0.848 0,0.527 -0.352,0.844 -0.937,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.813 h 3.449 v -0.543 h -2.836 z m 5.269,1.035 v 1.157 h 0.582 v -1.157 h 0.692 v -0.523 h -0.692 v -3.094 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.464 l 1.464,-2.106 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath245)"
+               id="path681" />
+            <path
+               d="m 257.656,386.867 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.843 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.332 v 4.812 h 3.449 v -0.543 h -2.836 z m 6.453,1.617 h -2.465 c 0.063,-0.398 0.274,-0.648 0.848,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.852 0.988,-1.438 0,-0.398 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.371 -1.063,-0.371 -0.598,0 -1.039,0.211 -1.297,0.621 -0.164,0.25 -0.234,0.547 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.676 0.152,-0.289 0.457,-0.468 0.805,-0.468 0.531,0 0.925,0.382 0.925,0.898 0,0.383 -0.218,0.715 -0.632,0.949 l -0.61,0.36 c -0.976,0.558 -1.258,1.007 -1.312,2.05 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath246)"
+               id="path682" />
+            <path
+               d="m 257.656,401.746 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.585,0 0.937,0.316 0.937,0.843 0,0.528 -0.352,0.844 -0.937,0.844 z m 4.434,0.391 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.332 v 4.812 h 3.449 v -0.539 h -2.836 z m 6.254,-2.489 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.32 0.496,-0.433 0.864,-0.433 0.628,0 1.015,0.429 1.015,1.121 0,0.672 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.578 c 0.078,0.383 0.144,0.566 0.281,0.738 0.265,0.359 0.742,0.563 1.269,0.563 0.942,0 1.602,-0.688 1.602,-1.676 0,-0.926 -0.613,-1.559 -1.508,-1.559 -0.332,0 -0.598,0.086 -0.867,0.285 l 0.184,-1.308 h 1.949 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath247)"
+               id="path683" />
+            <path
+               d="m 359.395,448.426 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 4.945,-1.657 h 0.317 c 0.632,0 0.968,0.297 0.968,0.872 0,0.601 -0.363,0.964 -0.961,0.964 -0.64,0 -0.953,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.242,0.461 0.699,0.691 1.34,0.691 0.965,0 1.582,-0.578 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.789,-1.133 0.434,-0.18 0.652,-0.512 0.652,-0.992 0,-0.817 -0.535,-1.313 -1.425,-1.313 -0.946,0 -1.446,0.528 -1.465,1.539 h 0.582 c 0.004,-0.293 0.031,-0.457 0.105,-0.601 0.129,-0.274 0.422,-0.43 0.785,-0.43 0.512,0 0.825,0.309 0.825,0.824 0,0.336 -0.122,0.543 -0.375,0.653 -0.161,0.066 -0.372,0.093 -0.774,0.101 z m 4.293,1.043 v 1.153 h 0.578 v -1.153 h 0.696 v -0.523 h -0.696 v -3.094 h -0.426 l -2.128,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath248)"
+               id="path684" />
+            <path
+               d="m 359.395,440.988 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.871 0,1.219 -0.5,1.859 -1.453,1.859 z m 5.058,-1.656 h 0.317 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.364,0.965 -0.965,0.965 -0.637,0 -0.949,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.382 0.094,0.632 0.207,0.843 0.243,0.461 0.7,0.696 1.34,0.696 0.961,0 1.582,-0.582 1.582,-1.489 0,-0.605 -0.23,-0.937 -0.793,-1.132 0.438,-0.18 0.657,-0.508 0.657,-0.993 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.945,0 -1.445,0.527 -1.465,1.539 h 0.578 c 0.008,-0.293 0.035,-0.457 0.106,-0.602 0.132,-0.269 0.421,-0.429 0.785,-0.429 0.515,0 0.828,0.312 0.828,0.824 0,0.34 -0.121,0.543 -0.379,0.656 -0.156,0.067 -0.367,0.09 -0.77,0.098 z m 3.598,0 h 0.316 c 0.633,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.382 0.09,0.632 0.203,0.843 0.246,0.461 0.699,0.696 1.34,0.696 0.965,0 1.586,-0.582 1.586,-1.489 0,-0.605 -0.231,-0.937 -0.793,-1.132 0.434,-0.18 0.652,-0.508 0.652,-0.993 0,-0.816 -0.535,-1.312 -1.426,-1.312 -0.941,0 -1.445,0.527 -1.464,1.539 h 0.582 c 0.007,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.824,0.312 0.824,0.824 0,0.34 -0.117,0.543 -0.374,0.656 -0.161,0.067 -0.372,0.09 -0.774,0.098 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath249)"
+               id="path685" />
+            <path
+               d="m 359.395,433.547 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.218 -0.5,1.859 -1.453,1.859 z m 4.945,-1.656 h 0.317 c 0.632,0 0.968,0.297 0.968,0.871 0,0.601 -0.363,0.965 -0.961,0.965 -0.64,0 -0.953,-0.325 -0.992,-1.024 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.242,0.465 0.699,0.695 1.34,0.695 0.965,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.23,-0.938 -0.789,-1.137 0.434,-0.18 0.652,-0.508 0.652,-0.988 0,-0.82 -0.535,-1.317 -1.425,-1.317 -0.946,0 -1.446,0.528 -1.465,1.539 h 0.582 c 0.004,-0.289 0.031,-0.457 0.105,-0.601 0.129,-0.27 0.422,-0.43 0.785,-0.43 0.512,0 0.825,0.313 0.825,0.828 0,0.336 -0.122,0.539 -0.375,0.653 -0.161,0.066 -0.372,0.093 -0.774,0.097 z m 5.473,1.625 h -2.461 c 0.058,-0.395 0.269,-0.649 0.844,-0.996 l 0.66,-0.372 c 0.652,-0.363 0.992,-0.851 0.992,-1.437 0,-0.398 -0.16,-0.766 -0.438,-1.023 -0.277,-0.25 -0.621,-0.372 -1.062,-0.372 -0.594,0 -1.035,0.211 -1.293,0.622 -0.164,0.25 -0.238,0.546 -0.25,1.031 h 0.578 c 0.02,-0.324 0.063,-0.516 0.141,-0.676 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.926,0.383 0.926,0.899 0,0.382 -0.219,0.715 -0.637,0.949 l -0.605,0.359 c -0.977,0.559 -1.262,1.008 -1.313,2.051 h 3.114 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath250)"
+               id="path686" />
+            <path
+               d="m 360.844,423.566 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.176 -1.215,-0.488 -0.316,-0.34 -0.508,-0.915 -0.508,-1.512 0,-1.18 0.672,-1.957 1.688,-1.957 0.734,0 1.262,0.375 1.394,0.996 h 0.629 c -0.172,-0.977 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.465 -0.871,1.211 -0.871,2.074 0,1.477 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.273 h -0.582 v 3.934 l -2.512,-3.934 h -0.668 v 4.812 h 0.582 v -3.898 l 2.488,3.898 h 0.692 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath251)"
+               id="path687" />
+            <path
+               d="m 359.395,418.664 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 4.945,-1.656 h 0.317 c 0.632,0 0.968,0.297 0.968,0.871 0,0.598 -0.363,0.961 -0.961,0.961 -0.64,0 -0.953,-0.321 -0.992,-1.02 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.242,0.461 0.699,0.691 1.34,0.691 0.965,0 1.582,-0.578 1.582,-1.484 0,-0.605 -0.23,-0.937 -0.789,-1.137 0.434,-0.175 0.652,-0.507 0.652,-0.988 0,-0.82 -0.535,-1.312 -1.425,-1.312 -0.946,0 -1.446,0.527 -1.465,1.535 h 0.582 c 0.004,-0.289 0.031,-0.453 0.105,-0.598 0.129,-0.273 0.422,-0.43 0.785,-0.43 0.512,0 0.825,0.309 0.825,0.825 0,0.335 -0.122,0.543 -0.375,0.652 -0.161,0.066 -0.372,0.094 -0.774,0.101 z m 3.844,-1.203 v 3.398 h 0.578 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.23,0.949 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath252)"
+               id="path688" />
+            <path
+               d="m 359.395,411.227 h 1.851 c 1.215,0 1.961,-0.915 1.961,-2.411 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.86 -1.453,1.86 z m 5.058,-1.657 h 0.317 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.364,0.965 -0.965,0.965 -0.637,0 -0.949,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.844 0.243,0.461 0.7,0.691 1.34,0.691 0.961,0 1.582,-0.578 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.133 0.438,-0.18 0.657,-0.508 0.657,-0.992 0,-0.817 -0.536,-1.313 -1.426,-1.313 -0.945,0 -1.445,0.527 -1.465,1.539 h 0.578 c 0.008,-0.293 0.035,-0.457 0.106,-0.601 0.132,-0.27 0.421,-0.43 0.785,-0.43 0.515,0 0.828,0.309 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.656 -0.156,0.063 -0.367,0.09 -0.77,0.098 z m 3.954,-2.574 c -0.434,0 -0.829,0.199 -1.075,0.52 -0.304,0.425 -0.457,1.058 -0.457,1.941 0,1.609 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.922 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.516 c 0.628,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.993 -0.949,1.993 -0.613,0 -0.926,-0.661 -0.926,-1.973 0,-1.313 0.313,-1.953 0.938,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath253)"
+               id="path689" />
+            <path
+               d="m 359.395,403.785 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.636 1.453,1.867 0,1.219 -0.5,1.859 -1.453,1.859 z m 6.937,-0.031 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-0.996 l 0.66,-0.371 c 0.653,-0.364 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.277,-0.25 -0.621,-0.371 -1.063,-0.371 -0.593,0 -1.035,0.211 -1.292,0.621 -0.165,0.25 -0.239,0.547 -0.25,1.031 h 0.578 c 0.019,-0.324 0.062,-0.516 0.14,-0.676 0.153,-0.289 0.453,-0.468 0.805,-0.468 0.527,0 0.926,0.382 0.926,0.898 0,0.383 -0.219,0.715 -0.637,0.949 l -0.605,0.36 c -0.977,0.558 -1.262,1.007 -1.313,2.05 h 3.113 z m 0.61,-0.516 c 0.113,0.778 0.613,1.243 1.328,1.243 0.519,0 0.984,-0.254 1.262,-0.68 0.289,-0.469 0.421,-1.051 0.421,-1.914 0,-0.809 -0.121,-1.317 -0.398,-1.739 -0.254,-0.386 -0.664,-0.593 -1.18,-0.593 -0.89,0 -1.531,0.668 -1.531,1.59 0,0.878 0.594,1.5 1.438,1.5 0.445,0 0.773,-0.161 1.07,-0.524 -0.008,1.192 -0.375,1.844 -1.043,1.844 -0.41,0 -0.692,-0.266 -0.785,-0.727 z m 1.425,-3.175 c 0.543,0 0.954,0.457 0.954,1.07 0,0.586 -0.399,0.996 -0.973,0.996 -0.559,0 -0.91,-0.395 -0.91,-1.027 0,-0.602 0.39,-1.039 0.929,-1.039 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath254)"
+               id="path690" />
+            <path
+               d="m 359.395,396.344 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.86 -1.453,1.86 z m 6.824,-0.031 h -2.461 c 0.059,-0.395 0.27,-0.649 0.844,-0.997 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.032 h 0.582 c 0.02,-0.325 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.465 0.805,-0.465 0.527,0 0.925,0.383 0.925,0.895 0,0.382 -0.218,0.714 -0.632,0.953 l -0.61,0.355 c -0.976,0.559 -1.261,1.008 -1.312,2.051 h 3.113 z m 2.836,-1.942 c 0.488,-0.297 0.641,-0.535 0.641,-0.98 0,-0.754 -0.575,-1.278 -1.407,-1.278 -0.824,0 -1.406,0.524 -1.406,1.27 0,0.453 0.152,0.687 0.633,0.988 -0.535,0.274 -0.797,0.66 -0.797,1.188 0,0.871 0.641,1.48 1.57,1.48 0.922,0 1.571,-0.609 1.571,-1.48 0,-0.528 -0.266,-0.914 -0.805,-1.188 z m -0.766,-1.742 c 0.496,0 0.813,0.297 0.813,0.773 0,0.45 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.296 -0.812,-0.757 0,-0.465 0.316,-0.762 0.812,-0.762 z m 0,2.008 c 0.582,0 0.977,0.383 0.977,0.937 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.961,-0.39 -0.961,-0.945 0,-0.566 0.386,-0.941 0.976,-0.941 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath255)"
+               id="path691" />
+            <path
+               d="m 360.844,386.363 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.93,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.184 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.394,0.996 h 0.629 c -0.172,-0.977 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.465 -0.871,1.211 -0.871,2.074 0,1.48 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.243 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.273 h -0.582 v 3.937 l -2.512,-3.937 h -0.668 v 4.812 h 0.582 v -3.898 l 2.488,3.898 h 0.692 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.406 -1.961,-2.406 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath256)"
+               id="path692" />
+            <path
+               d="m 359.395,317.738 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.394 0.27,-0.644 0.844,-0.996 l 0.66,-0.367 c 0.656,-0.363 0.992,-0.852 0.992,-1.442 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.367 -1.063,-0.367 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.672 0.152,-0.289 0.457,-0.468 0.805,-0.468 0.527,0 0.925,0.382 0.925,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.261,1.011 -1.312,2.054 h 3.113 z m 3.395,-4.102 h -2.415 l -0.351,2.547 h 0.535 c 0.274,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.016,0.43 1.016,1.121 0,0.676 -0.391,1.086 -1.024,1.086 -0.507,0 -0.82,-0.258 -0.957,-0.789 h -0.582 c 0.082,0.383 0.145,0.57 0.286,0.742 0.265,0.356 0.738,0.559 1.265,0.559 0.945,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.614,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.304 h 1.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath257)"
+               id="path693" />
+            <path
+               d="m 359.395,310.301 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.637 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z m 6.824,-0.031 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-0.997 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.399 -0.16,-0.766 -0.437,-1.024 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.032 h 0.582 c 0.02,-0.325 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.382 -0.218,0.711 -0.632,0.949 l -0.61,0.359 c -0.976,0.559 -1.261,1.008 -1.312,2.051 h 3.113 z m 2.414,-0.582 v 1.156 h 0.578 v -1.156 h 0.696 v -0.52 h -0.696 v -3.098 h -0.426 l -2.128,3.004 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath258)"
+               id="path694" />
+            <path
+               d="m 359.395,302.859 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.859 -1.453,1.859 z m 6.824,-0.031 h -2.461 c 0.059,-0.394 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.676 0.152,-0.289 0.457,-0.468 0.805,-0.468 0.527,0 0.925,0.383 0.925,0.898 0,0.383 -0.218,0.715 -0.632,0.953 l -0.61,0.356 c -0.976,0.558 -1.261,1.008 -1.312,2.051 h 3.113 z m 1.715,-1.625 h 0.316 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.382 0.094,0.632 0.207,0.843 0.242,0.465 0.699,0.696 1.34,0.696 0.961,0 1.582,-0.582 1.582,-1.485 0,-0.609 -0.231,-0.937 -0.793,-1.136 0.437,-0.18 0.656,-0.508 0.656,-0.989 0,-0.82 -0.535,-1.316 -1.426,-1.316 -0.945,0 -1.445,0.531 -1.465,1.539 h 0.579 c 0.007,-0.289 0.035,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.828,0.312 0.828,0.828 0,0.336 -0.121,0.539 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.769,0.098 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath259)"
+               id="path695" />
+            <path
+               d="m 359.395,295.418 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.36 0.992,-0.852 0.992,-1.438 0,-0.394 -0.16,-0.766 -0.437,-1.023 -0.278,-0.25 -0.618,-0.368 -1.063,-0.368 -0.594,0 -1.035,0.211 -1.293,0.618 -0.164,0.254 -0.238,0.55 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.672 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.895 0,0.383 -0.218,0.715 -0.632,0.953 l -0.61,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.055 h 3.113 z m 3.594,0 h -2.461 c 0.058,-0.395 0.269,-0.645 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.36 0.992,-0.852 0.992,-1.438 0,-0.394 -0.16,-0.766 -0.438,-1.023 -0.277,-0.25 -0.621,-0.368 -1.062,-0.368 -0.594,0 -1.035,0.211 -1.293,0.618 -0.164,0.254 -0.238,0.55 -0.25,1.031 h 0.578 c 0.02,-0.324 0.063,-0.516 0.141,-0.672 0.152,-0.293 0.453,-0.469 0.804,-0.469 0.528,0 0.926,0.383 0.926,0.895 0,0.383 -0.219,0.715 -0.637,0.953 l -0.605,0.355 c -0.977,0.563 -1.262,1.012 -1.313,2.055 h 3.114 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath260)"
+               id="path696" />
+            <path
+               d="m 359.395,287.977 h 1.851 c 1.215,0 1.961,-0.911 1.961,-2.407 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 6.824,-0.036 h -2.461 c 0.059,-0.394 0.27,-0.644 0.844,-0.996 l 0.66,-0.367 c 0.656,-0.363 0.992,-0.851 0.992,-1.441 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.278,-0.25 -0.618,-0.367 -1.063,-0.367 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.671 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.261,1.012 -1.312,2.055 h 3.113 z m 1.965,-2.824 v 3.399 h 0.578 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.832 -1.23,0.949 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath261)"
+               id="path697" />
+            <path
+               d="m 359.395,280.539 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.871 0,1.218 -0.5,1.859 -1.453,1.859 z m 6.824,-0.031 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.364 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.278,-0.254 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.32 0.059,-0.512 0.137,-0.672 0.152,-0.289 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.261,1.011 -1.312,2.054 h 3.113 z m 2.07,-4.199 c -0.437,0 -0.832,0.199 -1.078,0.523 -0.301,0.422 -0.453,1.055 -0.453,1.938 0,1.613 0.527,2.464 1.531,2.464 0.989,0 1.532,-0.851 1.532,-2.425 0,-0.922 -0.145,-1.543 -0.457,-1.977 -0.243,-0.332 -0.633,-0.523 -1.075,-0.523 z m 0,0.515 c 0.625,0 0.938,0.641 0.938,1.934 0,1.359 -0.305,1.992 -0.953,1.992 -0.614,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.308,-1.953 0.937,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath262)"
+               id="path698" />
+            <path
+               d="m 359.395,273.098 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z m 5.195,-2.856 v 3.399 h 0.582 v -4.774 h -0.383 c -0.207,0.735 -0.336,0.832 -1.234,0.953 v 0.422 z m 2.235,2.309 c 0.109,0.777 0.613,1.242 1.324,1.242 0.523,0 0.984,-0.25 1.261,-0.68 0.289,-0.468 0.422,-1.05 0.422,-1.914 0,-0.804 -0.117,-1.316 -0.394,-1.738 -0.258,-0.387 -0.668,-0.594 -1.184,-0.594 -0.89,0 -1.531,0.668 -1.531,1.59 0,0.879 0.594,1.5 1.441,1.5 0.442,0 0.77,-0.16 1.067,-0.519 -0.004,1.187 -0.375,1.839 -1.043,1.839 -0.406,0 -0.692,-0.265 -0.785,-0.726 z m 1.425,-3.176 c 0.539,0 0.949,0.457 0.949,1.07 0,0.586 -0.394,0.996 -0.968,0.996 -0.563,0 -0.914,-0.394 -0.914,-1.027 0,-0.601 0.39,-1.039 0.933,-1.039 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath263)"
+               id="path699" />
+            <path
+               d="m 359.395,265.539 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.871 0,1.218 -0.5,1.859 -1.453,1.859 z m 5.195,-2.859 v 3.402 h 0.582 v -4.773 h -0.383 c -0.207,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 4.465,0.886 c 0.488,-0.296 0.641,-0.535 0.641,-0.984 0,-0.754 -0.575,-1.273 -1.407,-1.273 -0.824,0 -1.406,0.519 -1.406,1.265 0,0.457 0.152,0.688 0.633,0.992 -0.535,0.27 -0.797,0.661 -0.797,1.188 0,0.871 0.641,1.477 1.57,1.477 0.922,0 1.571,-0.606 1.571,-1.477 0,-0.527 -0.266,-0.918 -0.805,-1.188 z m -0.766,-1.742 c 0.496,0 0.813,0.297 0.813,0.77 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.004 c 0.582,0 0.977,0.383 0.977,0.938 0,0.574 -0.391,0.953 -0.992,0.953 -0.567,0 -0.961,-0.391 -0.961,-0.946 0,-0.566 0.386,-0.945 0.976,-0.945 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath264)"
+               id="path700" />
+            <path
+               d="m 359.395,258.098 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.637 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z m 5.195,-2.856 v 3.399 h 0.582 v -4.774 h -0.383 c -0.207,0.735 -0.336,0.832 -1.234,0.949 v 0.426 z m 5.317,-1.281 h -3.129 v 0.574 h 2.527 c -1.117,1.59 -1.57,2.567 -1.922,4.106 h 0.621 c 0.258,-1.5 0.844,-2.786 1.903,-4.192 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath265)"
+               id="path701" />
+            <path
+               d="m 359.395,250.656 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.859 -1.453,1.859 z m 5.195,-2.855 v 3.398 h 0.582 v -4.773 h -0.383 c -0.207,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 5.172,-0.133 c -0.113,-0.777 -0.617,-1.242 -1.328,-1.242 -0.516,0 -0.977,0.254 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.915 0,0.808 0.113,1.316 0.395,1.738 0.25,0.387 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.523 0.008,-1.183 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.102 c 0.558,0 0.91,0.398 0.91,1.031 0,0.601 -0.395,1.035 -0.93,1.035 -0.543,0 -0.953,-0.457 -0.953,-1.063 0,-0.593 0.399,-1.003 0.973,-1.003 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath266)"
+               id="path702" />
+            <path
+               d="m 359.395,381.102 h 1.851 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.54 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.394 0.27,-0.644 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.215 -1.293,0.621 -0.164,0.254 -0.238,0.551 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.671 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.894 0,0.383 -0.218,0.715 -0.632,0.954 l -0.61,0.355 c -0.976,0.562 -1.261,1.008 -1.312,2.051 h 3.113 z m 3.688,-4.105 h -3.129 v 0.574 h 2.527 c -1.117,1.59 -1.57,2.566 -1.922,4.106 h 0.621 c 0.258,-1.497 0.844,-2.786 1.903,-4.192 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath267)"
+               id="path703" />
+            <path
+               d="m 359.395,373.66 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.539 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.824,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.996 l 0.66,-0.367 c 0.656,-0.364 0.992,-0.852 0.992,-1.442 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.367 -1.063,-0.367 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.516 0.137,-0.672 0.152,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.925,0.383 0.925,0.899 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.261,1.011 -1.312,2.054 h 3.113 z m 3.543,-2.957 c -0.113,-0.777 -0.617,-1.238 -1.328,-1.238 -0.516,0 -0.977,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.047 -0.422,1.914 0,0.805 0.113,1.313 0.395,1.735 0.25,0.39 0.66,0.593 1.175,0.593 0.891,0 1.532,-0.664 1.532,-1.597 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.519 0.008,-1.179 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.105 c 0.558,0 0.91,0.395 0.91,1.028 0,0.601 -0.395,1.035 -0.93,1.035 -0.543,0 -0.953,-0.453 -0.953,-1.063 0,-0.593 0.399,-1 0.973,-1 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath268)"
+               id="path704" />
+            <path
+               d="m 365.895,364.656 0.496,1.446 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 3.945,-0.555 c 0.488,-0.297 0.641,-0.535 0.641,-0.984 0,-0.75 -0.575,-1.274 -1.407,-1.274 -0.824,0 -1.406,0.524 -1.406,1.27 0,0.453 0.152,0.683 0.633,0.988 -0.535,0.269 -0.797,0.66 -0.797,1.187 0,0.872 0.641,1.481 1.57,1.481 0.922,0 1.571,-0.609 1.571,-1.481 0,-0.527 -0.266,-0.918 -0.805,-1.187 z m -0.766,-1.742 c 0.496,0 0.813,0.297 0.813,0.773 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.761 0,-0.461 0.316,-0.758 0.812,-0.758 z m 0,2.008 c 0.582,0 0.977,0.382 0.977,0.937 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.961,-0.39 -0.961,-0.945 0,-0.566 0.386,-0.941 0.976,-0.941 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath269)"
+               id="path705" />
+            <path
+               d="m 365.895,357.215 0.496,1.445 h 0.683 l -1.687,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 4.797,-2.719 h -3.129 v 0.575 h 2.527 c -1.117,1.59 -1.57,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.903,-4.191 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath270)"
+               id="path706" />
+            <path
+               d="m 365.895,349.773 0.496,1.446 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 4.652,-1.57 c -0.113,-0.778 -0.617,-1.239 -1.328,-1.239 -0.516,0 -0.977,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.047 -0.422,1.914 0,0.805 0.113,1.312 0.395,1.734 0.25,0.391 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.878 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.52 0.008,-1.18 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.101 c 0.558,0 0.91,0.399 0.91,1.031 0,0.602 -0.395,1.035 -0.93,1.035 -0.543,0 -0.953,-0.453 -0.953,-1.062 0,-0.594 0.399,-1.004 0.973,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath271)"
+               id="path707" />
+            <path
+               d="m 360.844,341.238 h -2.004 v 0.543 h 1.465 v 0.129 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.93,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.184 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.394,0.996 h 0.629 c -0.172,-0.977 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.465 -0.562,0.46 -0.871,1.207 -0.871,2.07 0,1.48 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 h -0.582 v 3.933 l -2.512,-3.933 h -0.668 v 4.808 h 0.582 v -3.898 l 2.488,3.898 h 0.692 z m 1.004,4.808 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath272)"
+               id="path708" />
+            <path
+               d="m 354.973,334.895 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.789 l -1.719,4.813 h 0.656 l 0.508,-1.445 z m -0.168,-0.516 h -1.532 l 0.789,-2.191 z m 6.16,-0.582 h -2.008 v 0.543 h 1.465 v 0.133 c 0,0.855 -0.633,1.476 -1.512,1.476 -0.488,0 -0.93,-0.179 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.179 0.675,-1.961 1.691,-1.961 0.73,0 1.262,0.379 1.391,0.996 h 0.628 c -0.171,-0.976 -0.91,-1.535 -2.011,-1.535 -0.59,0 -1.063,0.153 -1.442,0.461 -0.558,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.906,2.508 2.207,2.508 0.653,0 1.168,-0.246 1.641,-0.765 l 0.152,0.636 h 0.391 z m 4.625,-2.27 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.813 h 0.578 v -3.902 l 2.489,3.902 h 0.695 z m 1.125,4.813 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.403 -1.957,-2.403 h -1.855 z m 0.613,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.872 0,1.218 -0.5,1.859 -1.453,1.859 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath273)"
+               id="path709" />
+            <path
+               d="m 355.695,327.453 0.496,1.445 h 0.684 l -1.687,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 4.071,1.96 1.668,-4.812 h -0.653 l -1.336,4.074 -1.41,-4.074 h -0.66 l 1.731,4.812 z m 2.316,0 h 1.856 c 1.214,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.859 -1.453,1.859 z m 4.188,0.543 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.859 -1.453,1.859 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath274)"
+               id="path710" />
+            <path
+               d="m 331.699,446.383 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.536,-1.41 -1.489,-1.41 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.809 h 3.449 v -0.539 h -2.836 z m 4.926,-2.582 c -0.434,0 -0.829,0.2 -1.075,0.52 -0.304,0.422 -0.457,1.058 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.922 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.516 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.309,-1.953 0.934,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath275)"
+               id="path711" />
+            <path
+               d="m 331.699,438.945 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.489,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.691 h 1.281 c 0.586,0 0.938,0.32 0.938,0.848 0,0.527 -0.352,0.843 -0.938,0.843 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.254 0.367,-0.594 0.367,-0.973 0,-0.578 -0.262,-0.929 -0.875,-1.168 0.442,-0.203 0.664,-0.554 0.664,-1.046 0,-0.36 -0.129,-0.661 -0.383,-0.887 -0.257,-0.231 -0.578,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.742 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.703,0.172 0.172,0.133 0.262,0.332 0.262,0.594 0,0.265 -0.09,0.464 -0.262,0.597 -0.168,0.125 -0.359,0.168 -0.703,0.168 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.309 0.863,0.832 0,0.516 -0.324,0.824 -0.863,0.824 z m 5,-4.23 c -0.434,0 -0.829,0.199 -1.075,0.523 -0.304,0.422 -0.457,1.055 -0.457,1.938 0,1.613 0.532,2.465 1.532,2.465 0.992,0 1.531,-0.852 1.531,-2.426 0,-0.922 -0.145,-1.543 -0.453,-1.977 -0.246,-0.332 -0.633,-0.523 -1.078,-0.523 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.972 0,-1.313 0.309,-1.953 0.934,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath276)"
+               id="path712" />
+            <path
+               d="m 331.699,431.504 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.415 -1.489,-1.415 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.356,1.137 0.492,1.445 h 0.687 l -1.687,-4.813 h -0.793 l -1.719,4.813 h 0.656 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.789,-2.191 z m 3.176,-2.812 c -0.434,0 -0.829,0.199 -1.075,0.523 -0.304,0.422 -0.457,1.055 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.925 -0.145,-1.546 -0.453,-1.98 -0.246,-0.332 -0.633,-0.523 -1.078,-0.523 z m 0,0.515 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.309,-1.953 0.934,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath277)"
+               id="path713" />
+            <path
+               d="m 333.004,423.562 h -2.008 v 0.54 h 1.465 v 0.132 c 0,0.86 -0.633,1.477 -1.508,1.477 -0.488,0 -0.933,-0.176 -1.215,-0.488 -0.316,-0.34 -0.508,-0.914 -0.508,-1.512 0,-1.18 0.672,-1.957 1.688,-1.957 0.734,0 1.262,0.375 1.394,0.996 h 0.626 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.59,0 -1.063,0.152 -1.442,0.461 -0.558,0.465 -0.871,1.211 -0.871,2.074 0,1.477 0.907,2.508 2.207,2.508 0.653,0 1.168,-0.242 1.641,-0.766 l 0.152,0.641 h 0.391 z m 4.746,-2.273 h -0.582 v 3.934 l -2.516,-3.934 h -0.668 v 4.813 h 0.582 v -3.899 l 2.489,3.899 h 0.695 z m 1.004,4.813 h 1.851 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.54 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath278)"
+               id="path714" />
+            <path
+               d="m 328.098,416.621 h 1.511 c 0.379,0 0.676,-0.109 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.808 h 0.614 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.937,0.316 0.937,0.843 0,0.532 -0.351,0.848 -0.937,0.848 z m 4.433,0.387 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.539 h -3.332 v 4.808 h 3.453 v -0.539 h -2.84 z m 4.824,-1.207 v 3.398 h 0.579 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.235,0.949 v 0.422 z m 4.047,2.246 v 1.152 h 0.582 v -1.152 h 0.692 v -0.524 h -0.692 v -3.093 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.524 h -1.464 l 1.464,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath279)"
+               id="path715" />
+            <path
+               d="m 327.98,409.18 h 1.508 c 0.379,0 0.676,-0.11 0.934,-0.34 0.289,-0.266 0.414,-0.574 0.414,-1.02 0,-0.902 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.813 h 0.617 z m 0,-0.539 v -1.692 h 1.278 c 0.59,0 0.937,0.317 0.937,0.848 0,0.527 -0.347,0.844 -0.937,0.844 z m 4.43,0.39 h 2.621 v -0.543 h -2.621 v -1.539 h 2.723 v -0.539 h -3.336 v 4.813 h 3.453 v -0.543 h -2.84 z m 4.824,-1.211 v 3.403 h 0.582 v -4.774 h -0.382 c -0.207,0.735 -0.34,0.832 -1.235,0.949 v 0.422 z m 5.231,2.828 h -2.461 c 0.058,-0.398 0.269,-0.648 0.844,-1 l 0.66,-0.367 c 0.652,-0.363 0.988,-0.851 0.988,-1.441 0,-0.395 -0.156,-0.766 -0.434,-1.02 -0.277,-0.254 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.25,1.028 h 0.578 c 0.02,-0.321 0.059,-0.512 0.141,-0.672 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.898 0,0.383 -0.214,0.711 -0.632,0.95 l -0.606,0.355 c -0.976,0.563 -1.262,1.012 -1.316,2.055 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath280)"
+               id="path716" />
+            <path
+               d="m 331.699,401.742 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.25 0.367,-0.594 0.367,-0.973 0,-0.578 -0.262,-0.929 -0.875,-1.168 0.442,-0.203 0.664,-0.554 0.664,-1.047 0,-0.359 -0.133,-0.66 -0.383,-0.886 -0.257,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.738 v -1.531 h 1.187 c 0.344,0 0.535,0.043 0.699,0.172 0.172,0.128 0.266,0.328 0.266,0.593 0,0.262 -0.094,0.461 -0.266,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.195 v -1.656 h 1.5 c 0.539,0 0.863,0.313 0.863,0.832 0,0.516 -0.324,0.824 -0.863,0.824 z m 5,-4.23 c -0.434,0 -0.832,0.199 -1.075,0.523 -0.304,0.422 -0.457,1.055 -0.457,1.938 0,1.613 0.528,2.465 1.532,2.465 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.547 -0.453,-1.981 -0.246,-0.332 -0.637,-0.523 -1.078,-0.523 z m 0,0.515 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.305,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.972 0,-1.313 0.313,-1.954 0.938,-1.954 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath281)"
+               id="path717" />
+            <path
+               d="m 328.098,394.301 h 1.511 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.527 -0.351,0.844 -0.937,0.844 z m 4.433,0.39 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.332 v 4.813 h 3.453 v -0.539 h -2.84 z m 4.824,-1.207 v 3.399 h 0.579 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.235,0.954 v 0.421 z m 5.032,-1.281 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.32 0.496,-0.434 0.864,-0.434 0.628,0 1.015,0.43 1.015,1.122 0,0.671 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.578 c 0.078,0.383 0.144,0.567 0.281,0.739 0.265,0.359 0.742,0.562 1.269,0.562 0.942,0 1.602,-0.687 1.602,-1.676 0,-0.925 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.184,-1.309 h 1.949 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath282)"
+               id="path718" />
+            <path
+               d="m 333.004,386.359 h -2.008 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.481 -1.512,1.481 -0.488,0 -0.929,-0.18 -1.215,-0.489 -0.316,-0.343 -0.507,-0.918 -0.507,-1.511 0,-1.184 0.675,-1.961 1.691,-1.961 0.73,0 1.262,0.375 1.391,0.996 h 0.629 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.59,0 -1.063,0.152 -1.442,0.465 -0.558,0.461 -0.871,1.207 -0.871,2.07 0,1.48 0.907,2.508 2.207,2.508 0.653,0 1.168,-0.242 1.641,-0.766 l 0.152,0.641 h 0.391 z m 4.742,-2.269 h -0.578 v 3.933 l -2.516,-3.933 h -0.668 v 4.808 h 0.582 V 385 l 2.489,3.898 h 0.691 z m 1.004,4.808 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.73 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath283)"
+               id="path719" />
+            <path
+               d="m 331.699,315.695 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.129 1.051,-0.406 0.234,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.929 -0.875,-1.168 0.442,-0.203 0.664,-0.554 0.664,-1.05 0,-0.356 -0.133,-0.661 -0.383,-0.883 -0.257,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.742 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.266,0.332 0.266,0.593 0,0.266 -0.094,0.465 -0.266,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.309 0.863,0.832 0,0.516 -0.324,0.824 -0.863,0.824 z m 5.343,-0.613 v 1.156 h 0.582 v -1.156 h 0.692 v -0.523 h -0.692 v -3.094 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.464 l 1.464,-2.106 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath284)"
+               id="path720" />
+            <path
+               d="m 331.699,308.258 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 6.352,1.137 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.789 l -1.719,4.813 h 0.656 l 0.508,-1.445 z m -0.168,-0.516 h -1.531 l 0.789,-2.191 z m 3.519,0.805 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.098 h -0.429 l -2.125,3.004 v 0.614 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath285)"
+               id="path721" />
+            <path
+               d="m 331.699,300.816 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.266 0.414,-0.575 0.414,-1.016 0,-0.906 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.933 -0.875,-1.172 0.442,-0.203 0.664,-0.55 0.664,-1.046 0,-0.356 -0.133,-0.661 -0.383,-0.887 -0.257,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.738 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.266,0.328 0.266,0.594 0,0.261 -0.094,0.46 -0.266,0.593 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.195 v -1.656 h 1.5 c 0.539,0 0.863,0.313 0.863,0.832 0,0.516 -0.324,0.824 -0.863,0.824 z m 4.644,-1.656 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.843 0.246,0.465 0.699,0.696 1.34,0.696 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.609 -0.234,-0.937 -0.793,-1.136 0.434,-0.18 0.652,-0.508 0.652,-0.989 0,-0.82 -0.535,-1.316 -1.425,-1.316 -0.942,0 -1.446,0.531 -1.465,1.539 h 0.582 c 0.008,-0.289 0.031,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.312 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.161,0.067 -0.372,0.094 -0.774,0.098 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath286)"
+               id="path722" />
+            <path
+               d="m 331.699,293.375 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.903 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.848 -0.938,0.848 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.234,-0.25 0.367,-0.594 0.367,-0.969 0,-0.582 -0.262,-0.93 -0.875,-1.168 0.442,-0.207 0.664,-0.555 0.664,-1.051 0,-0.355 -0.133,-0.66 -0.383,-0.883 -0.257,-0.234 -0.582,-0.339 -1.043,-0.339 h -1.953 z m 0.614,-2.738 v -1.531 h 1.187 c 0.344,0 0.535,0.046 0.699,0.171 0.172,0.133 0.266,0.329 0.266,0.594 0,0.266 -0.094,0.461 -0.266,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.308 0.863,0.828 0,0.515 -0.324,0.828 -0.863,0.828 z m 6.328,-4.141 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.32 0.496,-0.433 0.864,-0.433 0.628,0 1.015,0.429 1.015,1.121 0,0.676 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.578 c 0.078,0.382 0.144,0.57 0.281,0.738 0.265,0.359 0.742,0.562 1.269,0.562 0.942,0 1.602,-0.687 1.602,-1.675 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.184,-1.308 h 1.949 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath287)"
+               id="path723" />
+            <path
+               d="m 331.699,285.934 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.532,-1.41 -1.485,-1.41 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.403 0.234,-0.25 0.367,-0.593 0.367,-0.968 0,-0.582 -0.262,-0.93 -0.875,-1.168 0.442,-0.204 0.664,-0.555 0.664,-1.051 0,-0.356 -0.133,-0.66 -0.383,-0.883 -0.257,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.739 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.266,0.332 0.266,0.594 0,0.265 -0.094,0.465 -0.266,0.593 -0.164,0.126 -0.355,0.172 -0.699,0.172 z m 0,2.2 v -1.657 h 1.5 c 0.539,0 0.863,0.309 0.863,0.832 0,0.516 -0.324,0.825 -0.863,0.825 z m 5.343,-0.614 v 1.153 h 0.582 v -1.153 h 0.692 v -0.523 h -0.692 v -3.094 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.464 l 1.464,-2.106 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath288)"
+               id="path724" />
+            <path
+               d="m 331.699,278.496 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.532,-1.414 -1.485,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.691 h 1.281 c 0.586,0 0.938,0.32 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.352,1.137 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.789 l -1.719,4.812 h 0.656 l 0.508,-1.445 z m -0.168,-0.516 h -1.531 l 0.789,-2.191 z m 3.519,0.805 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath289)"
+               id="path725" />
+            <path
+               d="m 327.98,271.055 h 1.508 c 0.379,0 0.676,-0.114 0.934,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.617 z m 0,-0.543 v -1.688 h 1.278 c 0.59,0 0.937,0.317 0.937,0.844 0,0.527 -0.347,0.844 -0.937,0.844 z m 3.747,2.582 h 2.171 c 0.454,0 0.79,-0.125 1.047,-0.403 0.239,-0.25 0.371,-0.593 0.371,-0.972 0,-0.578 -0.265,-0.93 -0.878,-1.168 0.441,-0.203 0.667,-0.555 0.667,-1.047 0,-0.356 -0.132,-0.66 -0.382,-0.887 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.953 z m 0.613,-2.739 v -1.531 h 1.187 c 0.344,0 0.535,0.047 0.7,0.172 0.171,0.129 0.265,0.328 0.265,0.594 0,0.262 -0.094,0.461 -0.265,0.594 -0.165,0.125 -0.356,0.171 -0.7,0.171 z m 0,2.196 v -1.656 h 1.496 c 0.543,0 0.867,0.312 0.867,0.832 0,0.515 -0.324,0.824 -0.867,0.824 z m 4.894,-2.856 v 3.399 h 0.582 v -4.774 h -0.382 c -0.207,0.735 -0.34,0.832 -1.235,0.953 v 0.422 z m 5.231,2.825 h -2.461 c 0.058,-0.395 0.269,-0.649 0.844,-0.997 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.399 -0.156,-0.766 -0.434,-1.024 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.25,1.032 h 0.578 c 0.02,-0.325 0.059,-0.516 0.141,-0.676 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.382 -0.214,0.714 -0.632,0.953 l -0.606,0.355 c -0.976,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath290)"
+               id="path726" />
+            <path
+               d="m 328.098,263.492 h 1.511 c 0.379,0 0.676,-0.109 0.93,-0.34 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.812 h 0.614 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.937,0.316 0.937,0.847 0,0.528 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.129 1.05,-0.402 0.239,-0.254 0.372,-0.598 0.372,-0.973 0,-0.582 -0.266,-0.93 -0.879,-1.168 0.441,-0.203 0.668,-0.554 0.668,-1.051 0,-0.355 -0.133,-0.66 -0.383,-0.882 -0.258,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.742 v -1.531 h 1.187 c 0.344,0 0.536,0.047 0.7,0.172 0.172,0.132 0.261,0.332 0.261,0.593 0,0.266 -0.089,0.465 -0.261,0.594 -0.164,0.129 -0.356,0.172 -0.7,0.172 z m 0,2.199 v -1.656 h 1.496 c 0.543,0 0.867,0.309 0.867,0.832 0,0.516 -0.324,0.824 -0.867,0.824 z m 4.894,-2.859 v 3.402 h 0.579 v -4.773 h -0.383 c -0.203,0.73 -0.336,0.832 -1.235,0.949 v 0.422 z m 3.348,1.203 h 0.317 c 0.636,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.024 h -0.582 c 0.027,0.383 0.094,0.633 0.203,0.844 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.579 1.586,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.133 0.437,-0.179 0.652,-0.507 0.652,-0.992 0,-0.816 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.308 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.656 -0.161,0.062 -0.372,0.09 -0.774,0.098 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath291)"
+               id="path727" />
+            <path
+               d="m 328.098,256.055 h 1.511 c 0.379,0 0.676,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.527 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.05,-0.403 0.239,-0.25 0.372,-0.593 0.372,-0.972 0,-0.578 -0.266,-0.93 -0.879,-1.168 0.441,-0.203 0.668,-0.555 0.668,-1.047 0,-0.359 -0.133,-0.66 -0.383,-0.887 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.739 v -1.531 h 1.187 c 0.344,0 0.536,0.043 0.7,0.172 0.172,0.129 0.261,0.328 0.261,0.594 0,0.262 -0.089,0.461 -0.261,0.594 -0.164,0.125 -0.356,0.171 -0.7,0.171 z m 0,2.196 v -1.656 h 1.496 c 0.543,0 0.867,0.312 0.867,0.832 0,0.515 -0.324,0.824 -0.867,0.824 z m 4.894,-2.856 v 3.399 h 0.579 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.235,0.95 v 0.425 z m 5.032,-1.281 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.324 0.496,-0.434 0.864,-0.434 0.628,0 1.019,0.426 1.019,1.121 0,0.672 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.257 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.567 0.285,0.739 0.261,0.355 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.68 0,-0.921 -0.617,-1.554 -1.512,-1.554 -0.332,0 -0.594,0.086 -0.867,0.281 l 0.187,-1.305 h 1.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath292)"
+               id="path728" />
+            <path
+               d="m 331.34,248.613 h 1.512 c 0.375,0 0.671,-0.113 0.929,-0.343 0.289,-0.266 0.414,-0.575 0.414,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.934,0.316 0.934,0.844 0,0.527 -0.348,0.843 -0.934,0.843 z m 7.594,-0.738 c -0.192,-1.055 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.601 -0.438,0.473 -0.672,1.16 -0.672,1.942 0,0.789 0.242,1.468 0.691,1.937 0.375,0.383 0.852,0.563 1.477,0.563 1.176,0 1.836,-0.633 1.98,-1.907 h -0.633 c -0.05,0.329 -0.117,0.555 -0.218,0.747 -0.196,0.394 -0.606,0.617 -1.121,0.617 -0.957,0 -1.563,-0.766 -1.563,-1.965 0,-1.235 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.109 0.949,0.3 0.18,0.168 0.277,0.364 0.352,0.727 z m 3.597,-0.211 c -0.113,-0.777 -0.613,-1.242 -1.328,-1.242 -0.512,0 -0.976,0.254 -1.254,0.68 -0.297,0.468 -0.422,1.05 -0.422,1.914 0,0.808 0.114,1.316 0.399,1.738 0.25,0.391 0.66,0.594 1.172,0.594 0.894,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.465,0 -0.824,0.172 -1.078,0.523 0.008,-1.183 0.379,-1.835 1.043,-1.835 0.41,0 0.695,0.265 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.398 0.91,1.031 0,0.601 -0.394,1.035 -0.93,1.035 -0.539,0 -0.949,-0.453 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath293)"
+               id="path729" />
+            <path
+               d="m 328.098,379.059 h 1.511 c 0.379,0 0.676,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.813 h 0.614 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.527 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.05,-0.403 0.239,-0.25 0.372,-0.593 0.372,-0.968 0,-0.582 -0.266,-0.934 -0.879,-1.168 0.441,-0.207 0.668,-0.555 0.668,-1.051 0,-0.356 -0.133,-0.66 -0.383,-0.883 -0.258,-0.234 -0.582,-0.34 -1.043,-0.34 h -1.957 z m 0.617,-2.739 v -1.531 h 1.187 c 0.344,0 0.536,0.047 0.7,0.172 0.172,0.133 0.261,0.328 0.261,0.594 0,0.265 -0.089,0.461 -0.261,0.594 -0.164,0.124 -0.356,0.171 -0.7,0.171 z m 0,2.2 v -1.661 h 1.496 c 0.543,0 0.867,0.313 0.867,0.832 0,0.516 -0.324,0.829 -0.867,0.829 z m 4.894,-2.86 v 3.399 h 0.579 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.828 -1.235,0.949 v 0.422 z m 3.704,-1.371 c -0.434,0 -0.829,0.195 -1.075,0.52 -0.304,0.422 -0.457,1.054 -0.457,1.941 0,1.609 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.512 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.997 -0.949,1.997 -0.613,0 -0.922,-0.661 -0.922,-1.977 0,-1.313 0.309,-1.953 0.934,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath294)"
+               id="path730" />
+            <path
+               d="m 331.699,371.617 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.536,-1.41 -1.489,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 6.356,1.133 0.492,1.445 h 0.687 l -1.687,-4.808 h -0.793 l -1.719,4.808 h 0.656 l 0.508,-1.445 z m -0.172,-0.512 h -1.531 l 0.789,-2.191 z m 4.703,1.383 h -2.461 c 0.059,-0.394 0.27,-0.644 0.844,-0.996 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.622,-0.367 -1.063,-0.367 -0.594,0 -1.039,0.211 -1.297,0.621 -0.164,0.25 -0.234,0.547 -0.25,1.027 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.672 0.152,-0.293 0.457,-0.468 0.809,-0.468 0.527,0 0.921,0.382 0.921,0.898 0,0.383 -0.218,0.711 -0.632,0.949 l -0.61,0.356 c -0.976,0.562 -1.258,1.011 -1.312,2.054 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath295)"
+               id="path731" />
+            <path
+               d="m 331.699,364.059 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.489,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 6.356,1.136 0.492,1.446 h 0.687 l -1.687,-4.813 h -0.793 l -1.719,4.813 h 0.656 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 3.07,-1.438 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.953 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath296)"
+               id="path732" />
+            <path
+               d="m 331.34,356.617 h 1.512 c 0.375,0 0.671,-0.113 0.929,-0.344 0.289,-0.261 0.418,-0.574 0.418,-1.015 0,-0.906 -0.535,-1.414 -1.488,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 7.594,-0.738 c -0.192,-1.055 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.601 -0.434,0.473 -0.672,1.16 -0.672,1.942 0,0.789 0.242,1.468 0.691,1.937 0.375,0.383 0.852,0.563 1.481,0.563 1.172,0 1.832,-0.633 1.98,-1.907 h -0.637 c -0.05,0.328 -0.117,0.555 -0.214,0.746 -0.2,0.395 -0.61,0.618 -1.125,0.618 -0.957,0 -1.563,-0.766 -1.563,-1.965 0,-1.235 0.574,-1.992 1.512,-1.992 0.39,0 0.75,0.109 0.949,0.3 0.18,0.168 0.277,0.364 0.352,0.727 z m 3.652,2.746 h -2.461 c 0.059,-0.394 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.852 0.988,-1.438 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.622,-0.371 -1.063,-0.371 -0.594,0 -1.039,0.215 -1.297,0.621 -0.164,0.25 -0.234,0.551 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.672 0.152,-0.293 0.457,-0.468 0.809,-0.468 0.527,0 0.921,0.382 0.921,0.894 0,0.383 -0.218,0.715 -0.632,0.953 l -0.61,0.356 c -0.976,0.562 -1.258,1.007 -1.312,2.05 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath297)"
+               id="path733" />
+            <path
+               d="m 331.699,349.176 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.489,-1.41 h -1.984 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.531 -0.352,0.848 -0.938,0.848 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.403 0.238,-0.25 0.367,-0.593 0.367,-0.968 0,-0.582 -0.262,-0.93 -0.875,-1.168 0.442,-0.207 0.664,-0.555 0.664,-1.051 0,-0.355 -0.129,-0.66 -0.383,-0.883 -0.257,-0.23 -0.578,-0.336 -1.043,-0.336 h -1.953 z m 0.614,-2.738 v -1.532 h 1.187 c 0.344,0 0.535,0.047 0.703,0.172 0.172,0.133 0.262,0.328 0.262,0.594 0,0.266 -0.09,0.461 -0.262,0.594 -0.168,0.125 -0.359,0.172 -0.703,0.172 z m 0,2.199 v -1.656 h 1.5 c 0.539,0 0.863,0.308 0.863,0.832 0,0.511 -0.324,0.824 -0.863,0.824 z m 4.894,-2.86 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.832 -1.234,0.95 v 0.421 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath298)"
+               id="path734" />
+            <path
+               d="m 333.004,341.234 h -2.008 v 0.543 h 1.465 v 0.129 c 0,0.86 -0.633,1.481 -1.508,1.481 -0.488,0 -0.933,-0.18 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.184 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.394,0.996 h 0.626 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.59,0 -1.063,0.152 -1.442,0.465 -0.558,0.461 -0.871,1.207 -0.871,2.07 0,1.48 0.907,2.508 2.207,2.508 0.653,0 1.168,-0.242 1.641,-0.766 l 0.152,0.641 h 0.391 z m 4.746,-2.269 h -0.582 v 3.933 l -2.516,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.695 z m 1.004,4.812 h 1.851 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.851 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath299)"
+               id="path735" />
+            <path
+               d="m 327.012,334.891 0.496,1.445 h 0.687 l -1.691,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.512,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 6.164,-0.582 h -2.008 v 0.543 h 1.465 v 0.133 c 0,0.855 -0.633,1.476 -1.512,1.476 -0.488,0 -0.929,-0.179 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.179 0.675,-1.961 1.691,-1.961 0.73,0 1.258,0.379 1.391,0.996 h 0.629 c -0.172,-0.976 -0.911,-1.535 -2.016,-1.535 -0.586,0 -1.063,0.153 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.907,2.508 2.203,2.508 0.657,0 1.168,-0.246 1.645,-0.765 l 0.152,0.64 h 0.391 z m 4.621,-2.27 h -0.578 v 3.934 l -2.516,-3.934 h -0.668 v 4.813 h 0.582 v -3.902 l 2.489,3.902 h 0.691 z m 1.129,4.813 h 1.851 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.851 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.637 1.453,1.868 0,1.218 -0.5,1.859 -1.453,1.859 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath300)"
+               id="path736" />
+            <path
+               d="m 327.734,327.449 0.493,1.446 h 0.687 l -1.687,-4.813 h -0.793 l -1.719,4.813 h 0.656 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 4.067,1.961 1.672,-4.813 h -0.653 l -1.336,4.074 -1.41,-4.074 h -0.66 l 1.727,4.813 z m 2.32,0 h 1.856 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.86 -1.453,1.86 z m 4.188,0.543 h 1.855 c 1.211,0 1.957,-0.911 1.957,-2.411 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.86 -1.453,1.86 z m -111.98,0.543 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,328.352 v -3.727 h 1.137 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.86 -1.453,1.86 z m 6.629,-4.137 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.324 0.497,-0.434 0.864,-0.434 0.629,0 1.019,0.43 1.019,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.566 0.285,0.738 0.262,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.332,0 -0.593,0.086 -0.867,0.286 l 0.188,-1.309 h 1.945 z m 2.266,-0.094 c -0.434,0 -0.833,0.199 -1.075,0.524 -0.304,0.421 -0.457,1.054 -0.457,1.941 0,1.609 0.528,2.461 1.532,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.145,-1.547 -0.453,-1.98 -0.246,-0.333 -0.633,-0.524 -1.078,-0.524 z m 0,0.516 c 0.628,0 0.937,0.64 0.937,1.933 0,1.36 -0.301,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.976 0,-1.313 0.313,-1.953 0.938,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath301)"
+               id="path737" />
+            <path
+               d="m 227.387,321.453 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,320.914 v -3.73 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.222 -0.504,1.863 -1.453,1.863 z m 5.645,-0.613 v 1.152 h 0.582 v -1.152 h 0.695 v -0.524 h -0.695 v -3.093 h -0.43 l -2.125,3 v 0.617 z m 0,-0.524 h -1.465 l 1.465,-2.105 z m 1.785,0.586 c 0.113,0.782 0.613,1.242 1.328,1.242 0.519,0 0.984,-0.25 1.262,-0.679 0.289,-0.469 0.421,-1.051 0.421,-1.914 0,-0.805 -0.121,-1.313 -0.398,-1.735 -0.258,-0.39 -0.664,-0.593 -1.18,-0.593 -0.89,0 -1.531,0.664 -1.531,1.589 0,0.879 0.594,1.497 1.438,1.497 0.441,0 0.773,-0.157 1.07,-0.52 -0.008,1.188 -0.375,1.84 -1.043,1.84 -0.41,0 -0.692,-0.262 -0.785,-0.727 z m 1.425,-3.172 c 0.543,0 0.95,0.454 0.95,1.067 0,0.59 -0.395,1 -0.969,1 -0.563,0 -0.91,-0.399 -0.91,-1.031 0,-0.602 0.39,-1.036 0.929,-1.036 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath302)"
+               id="path738" />
+            <path
+               d="m 227.387,314.012 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.407 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,313.473 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 5.645,-0.614 v 1.153 h 0.582 v -1.153 h 0.695 v -0.523 h -0.695 v -3.094 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.106 z m 4.015,-0.836 c 0.488,-0.297 0.641,-0.535 0.641,-0.984 0,-0.754 -0.574,-1.274 -1.406,-1.274 -0.825,0 -1.407,0.52 -1.407,1.266 0,0.457 0.153,0.687 0.637,0.992 -0.535,0.27 -0.801,0.66 -0.801,1.188 0,0.871 0.641,1.476 1.571,1.476 0.925,0 1.57,-0.605 1.57,-1.476 0,-0.528 -0.262,-0.918 -0.805,-1.188 z m -0.765,-1.742 c 0.496,0 0.812,0.297 0.812,0.769 0,0.45 -0.324,0.746 -0.812,0.746 -0.493,0 -0.813,-0.296 -0.813,-0.757 0,-0.461 0.32,-0.758 0.813,-0.758 z m 0,2.004 c 0.582,0 0.976,0.383 0.976,0.937 0,0.574 -0.387,0.953 -0.988,0.953 -0.567,0 -0.965,-0.39 -0.965,-0.945 0,-0.566 0.391,-0.945 0.977,-0.945 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath303)"
+               id="path739" />
+            <path
+               d="m 227.387,306.574 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,306.031 v -3.73 h 1.137 c 0.949,0 1.453,0.64 1.453,1.871 0,1.219 -0.504,1.859 -1.453,1.859 z m 5.645,-0.613 v 1.156 h 0.582 v -1.156 h 0.695 v -0.52 h -0.695 v -3.097 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.465 l 1.465,-2.105 z m 4.867,-3.003 h -3.129 v 0.574 h 2.531 c -1.117,1.59 -1.574,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.899,-4.191 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath304)"
+               id="path740" />
+            <path
+               d="m 227.387,299.133 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z M 228,298.59 v -3.727 h 1.137 c 0.949,0 1.453,0.641 1.453,1.867 0,1.219 -0.504,1.86 -1.453,1.86 z m 5.645,-0.613 v 1.156 h 0.582 v -1.156 h 0.695 v -0.52 h -0.695 v -3.098 h -0.43 l -2.125,3.004 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z m 4.722,-1.855 c -0.113,-0.778 -0.613,-1.243 -1.328,-1.243 -0.512,0 -0.977,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.317 0.399,1.738 0.25,0.387 0.66,0.594 1.172,0.594 0.894,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.461,0 -0.824,0.171 -1.078,0.523 0.008,-1.184 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.266 0.785,0.727 z m -1.406,1.101 c 0.562,0 0.91,0.399 0.91,1.031 0,0.598 -0.394,1.036 -0.93,1.036 -0.539,0 -0.949,-0.458 -0.949,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath305)"
+               id="path741" />
+            <path
+               d="m 227.387,291.691 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,291.152 v -3.73 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 5.645,-0.617 v 1.156 h 0.582 v -1.156 h 0.695 v -0.519 h -0.695 v -3.094 h -0.43 l -2.125,3 v 0.613 z m 0,-0.519 h -1.465 l 1.465,-2.106 z m 4.578,-3.004 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.321 0.496,-0.434 0.863,-0.434 0.629,0 1.016,0.43 1.016,1.121 0,0.672 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.579 c 0.079,0.383 0.145,0.566 0.282,0.738 0.265,0.36 0.742,0.563 1.269,0.563 0.942,0 1.602,-0.688 1.602,-1.676 0,-0.926 -0.613,-1.559 -1.508,-1.559 -0.332,0 -0.598,0.086 -0.867,0.286 l 0.183,-1.309 h 1.95 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath306)"
+               id="path742" />
+            <path
+               d="m 227.387,284.25 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.855 z M 228,283.711 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.868 0,1.222 -0.504,1.863 -1.453,1.863 z m 5.645,-0.613 v 1.152 h 0.582 v -1.152 h 0.695 v -0.524 h -0.695 v -3.094 h -0.43 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.465 l 1.465,-2.105 z m 3.593,0.524 v 1.152 h 0.582 v -1.152 h 0.692 v -0.524 h -0.692 v -3.094 h -0.429 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.465 l 1.465,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath307)"
+               id="path743" />
+            <path
+               d="m 227.387,276.812 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z M 228,276.27 v -3.731 h 1.137 c 0.949,0 1.453,0.641 1.453,1.871 0,1.219 -0.504,1.86 -1.453,1.86 z m 5.645,-0.614 v 1.156 h 0.582 v -1.156 h 0.695 v -0.523 h -0.695 v -3.094 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.106 z m 2.894,-0.52 h 0.316 c 0.633,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.633 0.203,0.844 0.246,0.46 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.578 1.586,-1.484 0,-0.606 -0.234,-0.938 -0.793,-1.133 0.433,-0.18 0.652,-0.508 0.652,-0.992 0,-0.817 -0.535,-1.313 -1.426,-1.313 -0.941,0 -1.445,0.527 -1.464,1.539 h 0.582 c 0.007,-0.293 0.031,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.312 0.825,0.824 0,0.336 -0.118,0.543 -0.376,0.656 -0.16,0.063 -0.371,0.09 -0.773,0.098 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath308)"
+               id="path744" />
+            <path
+               d="m 231.359,378.555 h -2.007 v 0.543 h 1.464 v 0.129 c 0,0.859 -0.632,1.48 -1.507,1.48 -0.493,0 -0.934,-0.18 -1.215,-0.488 -0.317,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.184 0.672,-1.961 1.687,-1.961 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.91,-1.539 -2.012,-1.539 -0.59,0 -1.062,0.152 -1.441,0.465 -0.559,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.906,2.508 2.207,2.508 0.652,0 1.168,-0.242 1.64,-0.766 l 0.153,0.641 h 0.39 z m 4.746,-2.27 h -0.582 v 3.934 l -2.515,-3.934 h -0.668 v 4.813 h 0.582 v -3.903 l 2.488,3.903 h 0.695 z m 1.004,4.813 h 1.852 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.852 z m 0.614,-0.543 v -3.731 h 1.132 c 0.954,0 1.454,0.641 1.454,1.867 0,1.223 -0.5,1.864 -1.454,1.864 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath309)"
+               id="path745" />
+            <path
+               d="m 227.266,373.656 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.726 h 1.133 c 0.949,0 1.453,0.636 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z m 6.625,-4.136 h -2.414 l -0.348,2.546 h 0.531 c 0.274,-0.324 0.496,-0.437 0.868,-0.437 0.625,0 1.015,0.43 1.015,1.125 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.265,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.68 0,-0.922 -0.613,-1.555 -1.512,-1.555 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.304 h 1.946 z m 3.594,0 h -2.414 l -0.352,2.546 h 0.535 c 0.27,-0.324 0.496,-0.437 0.863,-0.437 0.629,0 1.02,0.43 1.02,1.125 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.079,0.383 0.145,0.566 0.286,0.738 0.261,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.68 0,-0.922 -0.614,-1.555 -1.512,-1.555 -0.332,0 -0.594,0.086 -0.867,0.281 l 0.187,-1.304 h 1.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath310)"
+               id="path746" />
+            <path
+               d="m 227.266,366.094 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.489 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.539 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 6.625,-4.141 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.32 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.43 1.015,1.121 0,0.676 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.257 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.571 0.285,0.739 0.265,0.359 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.676 0,-0.925 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.946 z m 2.609,3.527 v 1.153 h 0.582 v -1.153 h 0.696 v -0.523 h -0.696 v -3.094 h -0.429 l -2.125,3 v 0.617 z m 0,-0.523 h -1.465 l 1.465,-2.106 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath311)"
+               id="path747" />
+            <path
+               d="m 227.266,358.652 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.73 h 1.133 c 0.949,0 1.453,0.64 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 6.625,-4.14 h -2.414 l -0.348,2.55 h 0.531 c 0.274,-0.324 0.496,-0.437 0.868,-0.437 0.625,0 1.015,0.43 1.015,1.121 0,0.676 -0.39,1.086 -1.023,1.086 -0.508,0 -0.817,-0.258 -0.957,-0.789 h -0.582 c 0.082,0.383 0.148,0.57 0.285,0.742 0.265,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.308 h 1.946 z m 1.91,2.484 h 0.316 c 0.637,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.382 0.094,0.632 0.203,0.843 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.578 1.586,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.132 0.437,-0.18 0.652,-0.512 0.652,-0.993 0,-0.816 -0.531,-1.312 -1.426,-1.312 -0.941,0 -1.445,0.527 -1.464,1.539 h 0.582 c 0.007,-0.293 0.031,-0.457 0.105,-0.602 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.824,0.308 0.824,0.824 0,0.336 -0.117,0.543 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.773,0.102 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath312)"
+               id="path748" />
+            <path
+               d="m 227.266,351.215 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.871 0,1.219 -0.504,1.86 -1.453,1.86 z m 6.625,-4.137 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.324 0.496,-0.437 0.868,-0.437 0.625,0 1.015,0.429 1.015,1.125 0,0.671 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.582 c 0.082,0.383 0.148,0.567 0.285,0.739 0.265,0.355 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.679 0,-0.922 -0.613,-1.555 -1.512,-1.555 -0.328,0 -0.594,0.086 -0.863,0.281 l 0.183,-1.305 h 1.946 z m 3.793,4.106 h -2.461 c 0.058,-0.399 0.269,-0.649 0.844,-0.996 l 0.66,-0.372 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.398 -0.156,-0.766 -0.434,-1.024 -0.277,-0.253 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.028 h 0.582 c 0.02,-0.32 0.059,-0.512 0.141,-0.672 0.148,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.382 -0.218,0.711 -0.633,0.949 l -0.605,0.355 c -0.977,0.563 -1.262,1.012 -1.316,2.055 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath313)"
+               id="path749" />
+            <path
+               d="m 227.266,343.773 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.726 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z m 6.625,-4.136 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.325 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.426 1.015,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.265,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.282 l 0.183,-1.305 h 1.946 z m 2.164,1.281 v 3.398 h 0.578 V 339 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath314)"
+               id="path750" />
+            <path
+               d="m 227.266,448.418 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.727 h 1.133 c 0.949,0 1.453,0.641 1.453,1.868 0,1.218 -0.504,1.859 -1.453,1.859 z m 6.773,-2.988 c -0.113,-0.778 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.317 0.395,1.739 0.25,0.386 0.66,0.593 1.176,0.593 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.523 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.101 c 0.559,0 0.91,0.395 0.91,1.032 0,0.597 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.457 -0.953,-1.063 0,-0.594 0.399,-1.004 0.973,-1.004 z m 3.867,1.274 v 1.156 h 0.582 v -1.156 h 0.696 v -0.52 h -0.696 v -3.097 h -0.429 l -2.125,3.003 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath315)"
+               id="path751" />
+            <path
+               d="m 227.266,440.977 h 1.855 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.488 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.864 -1.453,1.864 z m 6.773,-2.993 c -0.113,-0.777 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.254 -1.254,0.684 -0.297,0.465 -0.422,1.047 -0.422,1.914 0,0.804 0.114,1.312 0.395,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.168 -1.074,0.52 0.008,-1.18 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.265 0.785,0.726 z m -1.406,1.102 c 0.559,0 0.91,0.398 0.91,1.031 0,0.602 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.453 -0.953,-1.062 0,-0.594 0.399,-1.004 0.973,-1.004 z m 3.168,0.23 h 0.316 c 0.637,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.633 0.203,0.848 0.246,0.46 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.61 -0.231,-0.938 -0.793,-1.137 0.437,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.531,-1.317 -1.426,-1.317 -0.941,0 -1.445,0.531 -1.464,1.539 h 0.582 c 0.007,-0.289 0.031,-0.453 0.105,-0.601 0.133,-0.27 0.422,-0.426 0.785,-0.426 0.516,0 0.824,0.308 0.824,0.824 0,0.336 -0.117,0.539 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.773,0.098 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath316)"
+               id="path752" />
+            <path
+               d="m 227.266,433.535 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.539 v -3.73 h 1.133 c 0.949,0 1.453,0.64 1.453,1.867 0,1.222 -0.504,1.863 -1.453,1.863 z m 6.773,-2.992 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.516,0 -0.976,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.047 -0.422,1.914 0,0.805 0.114,1.313 0.395,1.735 0.25,0.39 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.665 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.519 0.008,-1.179 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.105 c 0.559,0 0.91,0.395 0.91,1.028 0,0.601 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.453 -0.953,-1.063 0,-0.593 0.399,-1 0.973,-1 z m 5.051,1.852 h -2.461 c 0.058,-0.395 0.269,-0.645 0.844,-0.996 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.434,-1.023 -0.277,-0.25 -0.621,-0.367 -1.062,-0.367 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.027 h 0.582 c 0.02,-0.324 0.059,-0.516 0.141,-0.672 0.148,-0.293 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.383 -0.218,0.711 -0.633,0.949 l -0.605,0.356 c -0.977,0.562 -1.262,1.011 -1.316,2.054 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath317)"
+               id="path753" />
+            <path
+               d="m 227.266,426.098 h 1.855 c 1.215,0 1.961,-0.914 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.731 h 1.133 c 0.949,0 1.453,0.641 1.453,1.871 0,1.219 -0.504,1.86 -1.453,1.86 z m 6.773,-2.989 c -0.113,-0.781 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.312 0.395,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.664 1.531,-1.594 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.52 0.008,-1.18 0.375,-1.832 1.043,-1.832 0.41,0 0.691,0.262 0.785,0.726 z m -1.406,1.102 c 0.559,0 0.91,0.394 0.91,1.027 0,0.602 -0.394,1.039 -0.93,1.039 -0.542,0 -0.953,-0.457 -0.953,-1.062 0,-0.594 0.399,-1.004 0.973,-1.004 z m 3.422,-0.973 v 3.403 h 0.578 v -4.774 h -0.383 c -0.203,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath318)"
+               id="path754" />
+            <path
+               d="m 227.266,418.656 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.855 z m 0.617,-0.543 v -3.726 h 1.133 c 0.949,0 1.453,0.636 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z m 6.773,-2.988 c -0.113,-0.781 -0.613,-1.242 -1.328,-1.242 -0.516,0 -0.976,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.915 0,0.804 0.114,1.312 0.395,1.738 0.25,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.523 0.008,-1.183 0.375,-1.836 1.043,-1.836 0.41,0 0.691,0.266 0.785,0.727 z m -1.406,1.102 c 0.559,0 0.91,0.394 0.91,1.031 0,0.597 -0.394,1.035 -0.93,1.035 -0.542,0 -0.953,-0.457 -0.953,-1.063 0,-0.593 0.399,-1.003 0.973,-1.003 z m 3.527,-2.344 c -0.437,0 -0.832,0.199 -1.078,0.523 -0.304,0.422 -0.453,1.055 -0.453,1.938 0,1.613 0.527,2.465 1.531,2.465 0.989,0 1.532,-0.852 1.532,-2.422 0,-0.926 -0.149,-1.547 -0.457,-1.981 -0.247,-0.332 -0.633,-0.523 -1.075,-0.523 z m 0,0.515 c 0.625,0 0.934,0.641 0.934,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.614,0 -0.922,-0.66 -0.922,-1.972 0,-1.313 0.308,-1.954 0.937,-1.954 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath319)"
+               id="path755" />
+            <path
+               d="m 227.266,411.215 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.727 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.86 -1.453,1.86 z m 6.625,-4.137 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.324 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.43 1.015,1.122 0,0.671 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.582 c 0.082,0.383 0.148,0.567 0.285,0.739 0.265,0.355 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.676 0,-0.925 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.946 z m 0.801,3.59 c 0.113,0.781 0.617,1.242 1.328,1.242 0.523,0 0.984,-0.25 1.261,-0.679 0.29,-0.469 0.422,-1.051 0.422,-1.915 0,-0.804 -0.117,-1.312 -0.394,-1.738 -0.258,-0.387 -0.668,-0.594 -1.184,-0.594 -0.89,0 -1.531,0.668 -1.531,1.594 0,0.875 0.594,1.496 1.437,1.496 0.446,0 0.774,-0.156 1.071,-0.519 -0.008,1.187 -0.375,1.84 -1.043,1.84 -0.41,0 -0.692,-0.266 -0.785,-0.727 z m 1.425,-3.176 c 0.543,0 0.954,0.457 0.954,1.071 0,0.589 -0.399,0.996 -0.973,0.996 -0.559,0 -0.91,-0.395 -0.91,-1.028 0,-0.601 0.39,-1.039 0.929,-1.039 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath320)"
+               id="path756" />
+            <path
+               d="m 227.266,403.773 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.406 -1.961,-2.406 h -1.855 z m 0.617,-0.539 v -3.73 h 1.133 c 0.949,0 1.453,0.641 1.453,1.867 0,1.223 -0.504,1.863 -1.453,1.863 z m 6.625,-4.14 h -2.414 l -0.348,2.547 h 0.531 c 0.274,-0.321 0.496,-0.434 0.868,-0.434 0.625,0 1.015,0.43 1.015,1.121 0,0.676 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.57 0.285,0.738 0.265,0.36 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.286 l 0.183,-1.309 h 1.946 z m 3.035,2.164 c 0.488,-0.297 0.637,-0.531 0.637,-0.981 0,-0.754 -0.575,-1.273 -1.403,-1.273 -0.828,0 -1.406,0.519 -1.406,1.266 0,0.457 0.152,0.687 0.633,0.988 -0.535,0.273 -0.801,0.66 -0.801,1.191 0,0.871 0.641,1.477 1.574,1.477 0.922,0 1.571,-0.606 1.571,-1.477 0,-0.531 -0.266,-0.918 -0.805,-1.191 z m -0.766,-1.742 c 0.493,0 0.809,0.296 0.809,0.773 0,0.449 -0.32,0.746 -0.809,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.465 0.316,-0.761 0.812,-0.761 z m 0,2.007 c 0.578,0 0.977,0.383 0.977,0.938 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.965,-0.387 -0.965,-0.941 0,-0.571 0.391,-0.946 0.98,-0.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath321)"
+               id="path757" />
+            <path
+               d="M 227.148,396.332 H 229 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.852 z m 0.614,-0.539 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.863 -1.453,1.863 z m 6.738,-4.141 h -2.414 l -0.352,2.551 h 0.536 c 0.273,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.015,0.429 1.015,1.121 0,0.675 -0.39,1.086 -1.023,1.086 -0.508,0 -0.82,-0.258 -0.957,-0.789 h -0.582 c 0.082,0.382 0.144,0.57 0.285,0.742 0.266,0.355 0.738,0.558 1.266,0.558 0.945,0 1.605,-0.683 1.605,-1.675 0,-0.922 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.593,0.086 -0.863,0.285 l 0.184,-1.308 h 1.945 z m 3.895,0 h -3.129 v 0.575 h 2.527 c -1.117,1.593 -1.57,2.57 -1.922,4.105 h 0.621 c 0.258,-1.496 0.844,-2.785 1.903,-4.187 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath322)"
+               id="path758" />
+            <path
+               d="M 227.148,388.895 H 229 c 1.215,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.738,-2.402 -1.961,-2.402 h -1.852 z m 0.614,-0.543 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.871 0,1.219 -0.5,1.86 -1.453,1.86 z m 6.738,-4.137 h -2.414 l -0.352,2.547 h 0.536 c 0.273,-0.324 0.496,-0.438 0.867,-0.438 0.625,0 1.015,0.43 1.015,1.125 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.144,0.566 0.285,0.738 0.266,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.68 0,-0.922 -0.613,-1.555 -1.512,-1.555 -0.328,0 -0.593,0.086 -0.863,0.282 l 0.184,-1.305 h 1.945 z m 3.746,1.148 c -0.109,-0.781 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.977,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.109,1.312 0.395,1.734 0.25,0.391 0.66,0.598 1.175,0.598 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.004,-1.184 0.375,-1.836 1.043,-1.836 0.406,0 0.691,0.261 0.785,0.726 z m -1.406,1.102 c 0.562,0 0.914,0.394 0.914,1.027 0,0.602 -0.399,1.039 -0.934,1.039 -0.539,0 -0.949,-0.457 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath323)"
+               id="path759" />
+            <path
+               d="m 237.488,584.617 0.496,1.445 h 0.684 l -1.688,-4.812 h -0.792 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 1.938,-1.497 v 3.457 h 0.555 v -1.796 c 0.007,-0.832 0.351,-1.2 1.109,-1.18 v -0.563 c -0.09,-0.011 -0.145,-0.019 -0.211,-0.019 -0.355,0 -0.625,0.211 -0.945,0.726 v -0.625 z m 4.973,-1.355 h -0.547 v 1.789 c -0.231,-0.351 -0.602,-0.535 -1.063,-0.535 -0.898,0 -1.484,0.719 -1.484,1.824 0,1.168 0.566,1.887 1.504,1.887 0.476,0 0.804,-0.18 1.101,-0.61 v 0.457 h 0.489 z m -1.516,1.77 c 0.594,0 0.969,0.519 0.969,1.351 0,0.801 -0.383,1.328 -0.965,1.328 -0.606,0 -1.008,-0.535 -1.008,-1.34 0,-0.804 0.402,-1.339 1.004,-1.339 z m 5.031,3.042 v -3.457 h -0.547 v 1.957 c 0,0.708 -0.371,1.168 -0.945,1.168 -0.434,0 -0.711,-0.261 -0.711,-0.679 v -2.446 h -0.551 v 2.665 c 0,0.574 0.43,0.945 1.106,0.945 0.508,0 0.828,-0.18 1.152,-0.633 v 0.48 z m 1.528,-3.457 h -0.547 v 3.457 h 0.547 z m 0,-1.355 h -0.555 v 0.695 h 0.555 z m 0.902,1.355 v 3.457 h 0.555 v -1.906 c 0,-0.707 0.371,-1.168 0.937,-1.168 0.438,0 0.715,0.262 0.715,0.68 v 2.394 h 0.547 v -2.613 c 0,-0.574 -0.43,-0.945 -1.094,-0.945 -0.516,0 -0.848,0.199 -1.148,0.68 v -0.579 z m 4.933,-0.101 c -0.976,0 -1.554,0.695 -1.554,1.855 0,1.168 0.578,1.856 1.562,1.856 0.977,0 1.567,-0.695 1.567,-1.828 0,-1.203 -0.571,-1.883 -1.575,-1.883 z m 0.008,0.508 c 0.621,0 0.992,0.508 0.992,1.367 0,0.82 -0.382,1.328 -0.992,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.839 0.375,-1.347 0.988,-1.347 z m 6.61,0.554 c -0.008,-0.679 -0.453,-1.062 -1.254,-1.062 -0.805,0 -1.328,0.418 -1.328,1.058 0,0.54 0.277,0.797 1.097,0.997 l 0.516,0.125 c 0.383,0.089 0.535,0.23 0.535,0.472 0,0.332 -0.324,0.551 -0.809,0.551 -0.296,0 -0.546,-0.086 -0.683,-0.23 -0.086,-0.102 -0.125,-0.2 -0.16,-0.446 h -0.582 c 0.027,0.801 0.476,1.184 1.383,1.184 0.871,0 1.425,-0.43 1.425,-1.098 0,-0.515 -0.293,-0.797 -0.976,-0.961 l -0.532,-0.129 c -0.449,-0.105 -0.64,-0.25 -0.64,-0.492 0,-0.324 0.285,-0.523 0.734,-0.523 0.442,0 0.68,0.191 0.692,0.554 z m 3.558,2.496 v -3.457 h -0.551 v 1.957 c 0,0.708 -0.367,1.168 -0.941,1.168 -0.437,0 -0.715,-0.261 -0.715,-0.679 v -2.446 h -0.547 v 2.665 c 0,0.574 0.43,0.945 1.102,0.945 0.508,0 0.832,-0.18 1.156,-0.633 v 0.48 z m 0.895,-4.812 v 4.812 h 0.492 v -0.441 c 0.266,0.402 0.613,0.594 1.098,0.594 0.91,0 1.504,-0.746 1.504,-1.895 0,-1.121 -0.563,-1.816 -1.477,-1.816 -0.477,0 -0.813,0.18 -1.07,0.566 v -1.82 z m 1.512,1.77 c 0.613,0 1.007,0.535 1.007,1.359 0,0.785 -0.41,1.32 -1.007,1.32 -0.59,0 -0.965,-0.527 -0.965,-1.34 0,-0.812 0.375,-1.339 0.965,-1.339 z m 4.621,0.546 c -0.008,-0.679 -0.454,-1.062 -1.254,-1.062 -0.805,0 -1.325,0.418 -1.325,1.058 0,0.54 0.274,0.797 1.094,0.997 l 0.516,0.125 c 0.383,0.089 0.535,0.23 0.535,0.472 0,0.332 -0.324,0.551 -0.805,0.551 -0.3,0 -0.55,-0.086 -0.687,-0.23 -0.086,-0.102 -0.125,-0.2 -0.16,-0.446 h -0.578 c 0.023,0.801 0.472,1.184 1.378,1.184 0.872,0 1.426,-0.43 1.426,-1.098 0,-0.515 -0.293,-0.797 -0.976,-0.961 l -0.532,-0.129 c -0.445,-0.105 -0.636,-0.25 -0.636,-0.492 0,-0.324 0.281,-0.523 0.73,-0.523 0.442,0 0.68,0.191 0.692,0.554 z m 3.855,0.954 c 0,-0.532 -0.039,-0.848 -0.137,-1.106 -0.226,-0.566 -0.754,-0.91 -1.402,-0.91 -0.961,0 -1.582,0.734 -1.582,1.875 0,1.141 0.594,1.836 1.57,1.836 0.793,0 1.34,-0.449 1.481,-1.203 h -0.555 c -0.152,0.457 -0.465,0.695 -0.906,0.695 -0.348,0 -0.645,-0.16 -0.832,-0.449 -0.133,-0.199 -0.176,-0.399 -0.184,-0.738 z m -2.535,-0.45 c 0.047,-0.64 0.437,-1.058 0.992,-1.058 0.559,0 0.949,0.437 0.949,1.058 z m 4.426,-1.465 h -0.567 v -0.953 h -0.547 v 0.953 h -0.468 v 0.446 h 0.468 v 2.617 c 0,0.355 0.235,0.547 0.664,0.547 0.145,0 0.266,-0.016 0.45,-0.047 v -0.461 c -0.078,0.02 -0.153,0.023 -0.262,0.023 -0.238,0 -0.305,-0.062 -0.305,-0.308 v -2.371 h 0.567 z m 3.718,-0.101 c -0.976,0 -1.558,0.695 -1.558,1.855 0,1.168 0.582,1.856 1.566,1.856 0.977,0 1.563,-0.695 1.563,-1.828 0,-1.203 -0.567,-1.883 -1.571,-1.883 z m 0.008,0.508 c 0.621,0 0.989,0.508 0.989,1.367 0,0.82 -0.383,1.328 -0.989,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.839 0.375,-1.347 0.988,-1.347 z m 3.621,-0.407 h -0.574 v -0.543 c 0,-0.23 0.125,-0.351 0.383,-0.351 0.047,0 0.066,0 0.191,0.008 v -0.453 c -0.125,-0.028 -0.199,-0.036 -0.308,-0.036 -0.512,0 -0.813,0.29 -0.813,0.786 v 0.589 h -0.465 v 0.45 h 0.465 v 3.007 h 0.547 v -3.007 h 0.574 z m 5.731,-1.355 h -3.465 v 0.543 h 2.707 l -2.891,3.727 v 0.542 h 3.664 v -0.542 h -2.89 l 2.875,-3.715 z m 1.238,1.355 h -0.551 v 3.457 h 0.551 z m 0,-1.355 h -0.555 v 0.695 h 0.555 z m 2.242,1.254 c -0.976,0 -1.554,0.695 -1.554,1.855 0,1.168 0.578,1.856 1.562,1.856 0.977,0 1.567,-0.695 1.567,-1.828 0,-1.203 -0.571,-1.883 -1.575,-1.883 z m 0.008,0.508 c 0.621,0 0.992,0.508 0.992,1.367 0,0.82 -0.383,1.328 -0.992,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.839 0.375,-1.347 0.988,-1.347 z m 7.125,0.718 h -3.195 v 0.465 h 3.195 z m 0,1.137 h -3.195 v 0.461 h 3.195 z m 14.344,-0.25 0.492,1.445 h 0.688 l -1.688,-4.812 h -0.793 l -1.719,4.812 h 0.657 l 0.507,-1.445 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 3.297,-2.813 c -0.434,0 -0.832,0.199 -1.074,0.523 -0.305,0.422 -0.457,1.055 -0.457,1.942 0,1.609 0.527,2.461 1.531,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.144,-1.547 -0.457,-1.981 -0.242,-0.332 -0.633,-0.523 -1.074,-0.523 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.304,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.972 0,-1.313 0.313,-1.953 0.938,-1.953 z m 5.383,0.8 h -0.567 v -0.953 h -0.551 v 0.953 h -0.468 v 0.446 h 0.468 v 2.617 c 0,0.355 0.239,0.547 0.668,0.547 0.145,0 0.266,-0.016 0.45,-0.047 v -0.461 c -0.078,0.02 -0.153,0.023 -0.266,0.023 -0.238,0 -0.301,-0.062 -0.301,-0.308 v -2.371 h 0.567 z m 1.918,-0.101 c -0.977,0 -1.559,0.695 -1.559,1.855 0,1.168 0.582,1.856 1.566,1.856 0.977,0 1.563,-0.695 1.563,-1.828 0,-1.203 -0.566,-1.883 -1.57,-1.883 z m 0.007,0.508 c 0.622,0 0.989,0.508 0.989,1.367 0,0.82 -0.383,1.328 -0.989,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.839 0.375,-1.347 0.988,-1.347 z m 6.848,1.605 0.492,1.445 h 0.688 l -1.688,-4.812 h -0.793 l -1.718,4.812 h 0.656 l 0.508,-1.445 z m -0.172,-0.515 h -1.531 l 0.789,-2.192 z m 4.504,-2.719 h -2.414 l -0.351,2.547 h 0.535 c 0.269,-0.325 0.496,-0.434 0.863,-0.434 0.629,0 1.019,0.426 1.019,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.145,0.566 0.285,0.738 0.262,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.617,-1.559 -1.511,-1.559 -0.333,0 -0.594,0.086 -0.868,0.282 l 0.188,-1.305 h 1.945 z m 5.91,4.355 c -0.058,0.012 -0.086,0.012 -0.117,0.012 -0.191,0 -0.297,-0.098 -0.297,-0.27 v -2.031 c 0,-0.613 -0.449,-0.945 -1.301,-0.945 -0.507,0 -0.91,0.144 -1.148,0.402 -0.16,0.18 -0.227,0.379 -0.238,0.719 h 0.554 c 0.047,-0.422 0.297,-0.613 0.813,-0.613 0.5,0 0.769,0.187 0.769,0.515 v 0.145 c -0.003,0.238 -0.125,0.324 -0.574,0.383 -0.777,0.101 -0.894,0.125 -1.109,0.211 -0.403,0.172 -0.606,0.476 -0.606,0.925 0,0.625 0.438,1.024 1.137,1.024 0.434,0 0.785,-0.153 1.172,-0.508 0.043,0.355 0.211,0.508 0.57,0.508 0.117,0 0.192,-0.016 0.375,-0.059 z m -0.965,-0.765 c 0,0.183 -0.05,0.297 -0.214,0.449 -0.227,0.203 -0.496,0.308 -0.821,0.308 -0.429,0 -0.679,-0.203 -0.679,-0.554 0,-0.36 0.238,-0.547 0.832,-0.633 0.586,-0.078 0.699,-0.105 0.882,-0.191 z m 1.497,-2.368 v 3.457 h 0.554 v -1.906 c 0,-0.707 0.371,-1.168 0.938,-1.168 0.433,0 0.711,0.262 0.711,0.68 v 2.394 h 0.55 v -2.613 c 0,-0.574 -0.429,-0.945 -1.097,-0.945 -0.516,0 -0.844,0.199 -1.149,0.68 v -0.579 z m 6.523,-1.355 h -0.547 v 1.789 c -0.23,-0.351 -0.601,-0.535 -1.062,-0.535 -0.899,0 -1.485,0.719 -1.485,1.824 0,1.168 0.567,1.887 1.504,1.887 0.477,0 0.805,-0.18 1.102,-0.61 v 0.457 h 0.488 z m -1.516,1.77 c 0.594,0 0.969,0.519 0.969,1.351 0,0.801 -0.383,1.328 -0.961,1.328 -0.609,0 -1.012,-0.535 -1.012,-1.34 0,-0.804 0.403,-1.339 1.004,-1.339 z m 4.36,3.042 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.542 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z m 5.293,-4.231 c -0.434,0 -0.832,0.199 -1.074,0.523 -0.305,0.422 -0.457,1.055 -0.457,1.942 0,1.609 0.527,2.461 1.531,2.461 0.992,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.144,-1.547 -0.453,-1.981 -0.246,-0.332 -0.637,-0.523 -1.078,-0.523 z m 0,0.516 c 0.629,0 0.937,0.64 0.937,1.933 0,1.36 -0.304,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.972 0,-1.313 0.313,-1.953 0.938,-1.953 z m 5.262,0.8 h -0.567 v -0.953 h -0.547 v 0.953 h -0.468 v 0.446 h 0.468 v 2.617 c 0,0.355 0.235,0.547 0.664,0.547 0.145,0 0.266,-0.016 0.45,-0.047 v -0.461 c -0.078,0.02 -0.153,0.023 -0.262,0.023 -0.238,0 -0.305,-0.062 -0.305,-0.308 v -2.371 h 0.567 z m 1.922,-0.101 c -0.981,0 -1.559,0.695 -1.559,1.855 0,1.168 0.578,1.856 1.562,1.856 0.977,0 1.567,-0.695 1.567,-1.828 0,-1.203 -0.57,-1.883 -1.57,-1.883 z m 0.003,0.508 c 0.622,0 0.993,0.508 0.993,1.367 0,0.82 -0.383,1.328 -0.993,1.328 -0.613,0 -0.988,-0.508 -0.988,-1.348 0,-0.839 0.375,-1.347 0.988,-1.347 z m 4.305,3.05 h 1.856 c 1.214,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.856 z m 0.617,-0.542 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z m 5.309,-2.856 v 3.398 h 0.578 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 5.031,-1.281 h -2.414 l -0.351,2.547 h 0.535 c 0.269,-0.325 0.496,-0.434 0.863,-0.434 0.629,0 1.016,0.426 1.016,1.121 0,0.672 -0.387,1.082 -1.02,1.082 -0.512,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.145,0.566 0.285,0.738 0.262,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.617,-1.559 -1.511,-1.559 -0.332,0 -0.594,0.086 -0.868,0.282 l 0.188,-1.305 h 1.945 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath324)"
+               id="path760" />
+            <path
+               d="m 219.719,579.957 h 7.441 v 7.559 h -7.441 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath325)"
+               id="path761" />
+            <path
+               d="m 219.719,593.035 h 7.441 v 7.441 h -7.441 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath326)"
+               id="path762" />
+            <path
+               d="m 238.676,593.984 h -3.465 v 0.543 h 2.707 l -2.895,3.727 v 0.543 h 3.665 v -0.543 h -2.891 l 2.879,-3.715 z m 1.113,1.356 h -0.547 v 3.457 h 0.547 z m 0,-1.356 h -0.555 v 0.696 h 0.555 z m 2.367,1.254 c -0.976,0 -1.558,0.696 -1.558,1.856 0,1.168 0.582,1.855 1.566,1.855 0.977,0 1.563,-0.695 1.563,-1.828 0,-1.203 -0.567,-1.883 -1.571,-1.883 z m 0.008,0.508 c 0.621,0 0.988,0.508 0.988,1.367 0,0.821 -0.382,1.328 -0.988,1.328 -0.613,0 -0.992,-0.507 -0.992,-1.347 0,-0.84 0.379,-1.348 0.992,-1.348 z m 6.984,1.508 c 0,-0.531 -0.039,-0.848 -0.14,-1.106 -0.223,-0.566 -0.75,-0.91 -1.399,-0.91 -0.964,0 -1.582,0.735 -1.582,1.875 0,1.141 0.594,1.836 1.571,1.836 0.789,0 1.34,-0.449 1.476,-1.203 h -0.554 c -0.153,0.457 -0.461,0.695 -0.903,0.695 -0.351,0 -0.648,-0.16 -0.832,-0.449 -0.133,-0.199 -0.18,-0.398 -0.183,-0.738 z m -2.535,-0.449 c 0.047,-0.641 0.434,-1.059 0.989,-1.059 0.562,0 0.953,0.438 0.953,1.059 z m 4.797,0.203 1.16,-1.668 h -0.621 l -0.832,1.254 -0.832,-1.254 h -0.625 l 1.156,1.695 -1.222,1.762 h 0.629 l 0.875,-1.328 0.867,1.328 h 0.637 z m 2.988,-1.668 h -0.566 v -0.953 h -0.551 v 0.953 h -0.469 v 0.445 h 0.469 v 2.617 c 0,0.356 0.239,0.547 0.668,0.547 0.145,0 0.266,-0.015 0.449,-0.047 v -0.461 c -0.078,0.02 -0.152,0.024 -0.265,0.024 -0.235,0 -0.301,-0.063 -0.301,-0.309 v -2.371 h 0.566 z m 3.512,1.914 c 0,-0.531 -0.039,-0.848 -0.137,-1.106 -0.226,-0.566 -0.753,-0.91 -1.402,-0.91 -0.961,0 -1.582,0.735 -1.582,1.875 0,1.141 0.594,1.836 1.57,1.836 0.793,0 1.34,-0.449 1.477,-1.203 h -0.555 c -0.148,0.457 -0.461,0.695 -0.902,0.695 -0.352,0 -0.649,-0.16 -0.832,-0.449 -0.133,-0.199 -0.18,-0.398 -0.184,-0.738 z m -2.535,-0.449 c 0.047,-0.641 0.437,-1.059 0.992,-1.059 0.559,0 0.949,0.438 0.949,1.059 z m 3.332,-1.465 v 3.457 h 0.555 v -1.906 c 0,-0.707 0.367,-1.168 0.937,-1.168 0.434,0 0.711,0.261 0.711,0.679 v 2.395 h 0.547 v -2.613 c 0,-0.575 -0.426,-0.946 -1.094,-0.946 -0.515,0 -0.843,0.2 -1.148,0.68 v -0.578 z m 6.027,0.961 c -0.007,-0.68 -0.453,-1.063 -1.254,-1.063 -0.804,0 -1.324,0.418 -1.324,1.059 0,0.539 0.278,0.797 1.094,0.996 l 0.516,0.125 c 0.382,0.09 0.535,0.23 0.535,0.473 0,0.332 -0.324,0.55 -0.805,0.55 -0.297,0 -0.551,-0.086 -0.687,-0.23 -0.086,-0.102 -0.125,-0.199 -0.161,-0.445 h -0.578 c 0.024,0.8 0.473,1.183 1.379,1.183 0.871,0 1.426,-0.429 1.426,-1.097 0,-0.512 -0.293,-0.797 -0.977,-0.961 l -0.527,-0.125 c -0.449,-0.106 -0.641,-0.254 -0.641,-0.496 0,-0.325 0.282,-0.524 0.731,-0.524 0.441,0 0.68,0.192 0.695,0.555 z m 1.461,-0.961 h -0.547 v 3.457 h 0.547 z m 0,-1.356 h -0.554 v 0.696 h 0.554 z m 2.239,1.254 c -0.977,0 -1.559,0.696 -1.559,1.856 0,1.168 0.582,1.855 1.566,1.855 0.977,0 1.563,-0.695 1.563,-1.828 0,-1.203 -0.566,-1.883 -1.57,-1.883 z m 0.007,0.508 c 0.618,0 0.989,0.508 0.989,1.367 0,0.821 -0.383,1.328 -0.989,1.328 -0.617,0 -0.992,-0.507 -0.992,-1.347 0,-0.84 0.375,-1.348 0.992,-1.348 z m 2.258,-0.406 v 3.457 h 0.555 v -1.906 c 0,-0.707 0.371,-1.168 0.937,-1.168 0.438,0 0.715,0.261 0.715,0.679 v 2.395 h 0.547 v -2.613 c 0,-0.575 -0.43,-0.946 -1.098,-0.946 -0.511,0 -0.843,0.2 -1.148,0.68 v -0.578 z m 8.582,1.129 h -3.191 v 0.461 h 3.191 z m 0,1.133 h -3.191 v 0.46 h 3.191 z m 36.188,-0.25 0.492,1.445 h 0.687 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 4.769,-1.57 c -0.113,-0.778 -0.613,-1.243 -1.328,-1.243 -0.515,0 -0.976,0.254 -1.254,0.68 -0.296,0.469 -0.422,1.051 -0.422,1.914 0,0.809 0.114,1.317 0.395,1.738 0.254,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.464,0 -0.828,0.171 -1.078,0.523 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.696,0.266 0.785,0.727 z m -1.406,1.101 c 0.563,0 0.91,0.399 0.91,1.031 0,0.602 -0.394,1.036 -0.929,1.036 -0.543,0 -0.95,-0.457 -0.95,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 5.317,-1.027 h -0.567 v -0.953 h -0.551 v 0.953 h -0.468 v 0.445 h 0.468 v 2.617 c 0,0.356 0.239,0.547 0.668,0.547 0.145,0 0.266,-0.015 0.45,-0.047 v -0.461 c -0.079,0.02 -0.153,0.024 -0.266,0.024 -0.238,0 -0.301,-0.063 -0.301,-0.309 v -2.371 h 0.567 z m 1.921,-0.102 c -0.976,0 -1.558,0.696 -1.558,1.856 0,1.168 0.582,1.855 1.562,1.855 0.981,0 1.567,-0.695 1.567,-1.828 0,-1.203 -0.567,-1.883 -1.571,-1.883 z m 0.008,0.508 c 0.617,0 0.989,0.508 0.989,1.367 0,0.821 -0.383,1.328 -0.989,1.328 -0.617,0 -0.992,-0.507 -0.992,-1.347 0,-0.84 0.375,-1.348 0.992,-1.348 z m 6.844,1.606 0.496,1.445 h 0.688 l -1.692,-4.813 h -0.793 l -1.715,4.813 h 0.653 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 3.945,-0.555 c 0.489,-0.297 0.641,-0.535 0.641,-0.984 0,-0.75 -0.574,-1.274 -1.406,-1.274 -0.824,0 -1.406,0.524 -1.406,1.27 0,0.453 0.152,0.684 0.632,0.988 -0.535,0.27 -0.796,0.66 -0.796,1.188 0,0.871 0.64,1.48 1.57,1.48 0.922,0 1.57,-0.609 1.57,-1.48 0,-0.528 -0.266,-0.918 -0.805,-1.188 z m -0.765,-1.742 c 0.496,0 0.812,0.297 0.812,0.773 0,0.45 -0.324,0.747 -0.812,0.747 -0.496,0 -0.813,-0.297 -0.813,-0.762 0,-0.461 0.317,-0.758 0.813,-0.758 z m 0,2.008 c 0.582,0 0.976,0.383 0.976,0.937 0,0.575 -0.39,0.95 -0.992,0.95 -0.566,0 -0.961,-0.391 -0.961,-0.946 0,-0.566 0.387,-0.941 0.977,-0.941 z m 7.234,1.926 c -0.058,0.015 -0.086,0.015 -0.117,0.015 -0.191,0 -0.297,-0.101 -0.297,-0.273 v -2.031 c 0,-0.614 -0.449,-0.946 -1.301,-0.946 -0.507,0 -0.91,0.145 -1.148,0.403 -0.156,0.179 -0.223,0.379 -0.238,0.718 h 0.554 c 0.047,-0.421 0.297,-0.613 0.813,-0.613 0.5,0 0.773,0.188 0.773,0.516 v 0.144 c -0.008,0.239 -0.125,0.324 -0.574,0.383 -0.781,0.102 -0.898,0.125 -1.109,0.211 -0.403,0.172 -0.61,0.477 -0.61,0.926 0,0.625 0.438,1.023 1.137,1.023 0.437,0 0.785,-0.152 1.176,-0.508 0.039,0.356 0.211,0.508 0.566,0.508 0.121,0 0.192,-0.015 0.375,-0.058 z m -0.961,-0.766 c 0,0.184 -0.054,0.297 -0.219,0.449 -0.222,0.203 -0.496,0.309 -0.82,0.309 -0.426,0 -0.68,-0.203 -0.68,-0.551 0,-0.363 0.239,-0.551 0.833,-0.637 0.589,-0.078 0.699,-0.105 0.886,-0.191 z m 1.492,-2.367 v 3.457 h 0.555 v -1.906 c 0,-0.707 0.371,-1.168 0.938,-1.168 0.437,0 0.714,0.261 0.714,0.679 v 2.395 h 0.547 v -2.613 c 0,-0.575 -0.429,-0.946 -1.093,-0.946 -0.516,0 -0.848,0.2 -1.149,0.68 v -0.578 z m 6.528,-1.356 h -0.547 v 1.789 c -0.234,-0.347 -0.602,-0.535 -1.063,-0.535 -0.898,0 -1.488,0.719 -1.488,1.824 0,1.168 0.57,1.887 1.508,1.887 0.473,0 0.805,-0.179 1.101,-0.609 v 0.457 h 0.489 z m -1.52,1.77 c 0.594,0 0.973,0.523 0.973,1.351 0,0.801 -0.383,1.329 -0.965,1.329 -0.609,0 -1.012,-0.536 -1.012,-1.34 0,-0.805 0.403,-1.34 1.004,-1.34 z m 4.36,3.043 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.727 h 1.137 c 0.949,0 1.453,0.641 1.453,1.868 0,1.222 -0.504,1.859 -1.453,1.859 z m 5.187,-2.856 v 3.399 h 0.582 v -4.774 h -0.382 c -0.203,0.735 -0.336,0.832 -1.235,0.954 v 0.421 z m 5.18,-0.132 c -0.113,-0.778 -0.613,-1.243 -1.328,-1.243 -0.516,0 -0.977,0.254 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.809 0.113,1.317 0.395,1.738 0.254,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.465,0 -0.828,0.171 -1.078,0.523 0.008,-1.184 0.375,-1.836 1.043,-1.836 0.41,0 0.695,0.266 0.785,0.727 z m -1.406,1.101 c 0.562,0 0.91,0.399 0.91,1.031 0,0.602 -0.395,1.036 -0.93,1.036 -0.543,0 -0.949,-0.457 -0.949,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 5.316,-1.027 h -0.57 v -0.953 h -0.547 v 0.953 h -0.469 v 0.445 h 0.469 v 2.617 c 0,0.356 0.238,0.547 0.668,0.547 0.145,0 0.262,-0.015 0.449,-0.047 v -0.461 c -0.082,0.02 -0.152,0.024 -0.265,0.024 -0.239,0 -0.305,-0.063 -0.305,-0.309 v -2.371 h 0.57 z m 1.922,-0.102 c -0.98,0 -1.558,0.696 -1.558,1.856 0,1.168 0.578,1.855 1.562,1.855 0.977,0 1.566,-0.695 1.566,-1.828 0,-1.203 -0.57,-1.883 -1.57,-1.883 z m 0.004,0.508 c 0.621,0 0.992,0.508 0.992,1.367 0,0.821 -0.383,1.328 -0.992,1.328 -0.613,0 -0.988,-0.507 -0.988,-1.347 0,-0.84 0.375,-1.348 0.988,-1.348 z m 4.305,3.051 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.738,-2.403 -1.961,-2.403 h -1.855 z m 0.617,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.868 0,1.222 -0.5,1.859 -1.453,1.859 z m 6.91,-4.137 h -3.129 v 0.574 h 2.528 c -1.114,1.59 -1.571,2.567 -1.922,4.106 h 0.621 c 0.258,-1.5 0.847,-2.785 1.902,-4.192 z m 3.508,4.106 h -2.461 c 0.059,-0.395 0.269,-0.649 0.844,-0.996 l 0.66,-0.372 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.398 -0.156,-0.766 -0.433,-1.023 -0.278,-0.25 -0.622,-0.372 -1.063,-0.372 -0.594,0 -1.035,0.211 -1.293,0.622 -0.168,0.25 -0.238,0.546 -0.254,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.141,-0.676 0.148,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.899 0,0.382 -0.214,0.715 -0.632,0.953 l -0.606,0.355 c -0.976,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath327)"
+               id="path763" />
+            <path
+               d="m 205.559,543.113 h 40.922 v 26.281 h -40.922 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.577;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath328)"
+               id="path764" />
+            <path
+               d="m 222.41,548.141 v 4.054 c 0,0.778 -0.562,1.254 -1.488,1.254 -0.426,0 -0.777,-0.105 -1.051,-0.301 -0.285,-0.222 -0.422,-0.515 -0.422,-0.953 v -4.054 h -0.738 v 4.054 c 0,1.172 0.84,1.903 2.211,1.903 1.355,0 2.226,-0.746 2.226,-1.903 v -4.054 z m 5.988,1.695 c 0,-0.395 -0.023,-0.508 -0.148,-0.777 -0.316,-0.664 -0.992,-1.012 -1.965,-1.012 -1.265,0 -2.051,0.648 -2.051,1.695 0,0.703 0.371,1.149 1.133,1.344 l 1.434,0.383 c 0.734,0.187 1.062,0.48 1.062,0.933 0,0.309 -0.168,0.625 -0.414,0.801 -0.23,0.164 -0.594,0.246 -1.062,0.246 -0.633,0 -1.051,-0.152 -1.328,-0.484 -0.215,-0.254 -0.309,-0.531 -0.301,-0.887 h -0.699 c 0.007,0.531 0.113,0.879 0.339,1.195 0.399,0.547 1.063,0.825 1.942,0.825 0.691,0 1.254,-0.16 1.625,-0.446 0.387,-0.308 0.633,-0.824 0.633,-1.32 0,-0.715 -0.442,-1.238 -1.227,-1.449 l -1.449,-0.391 c -0.699,-0.187 -0.953,-0.41 -0.953,-0.855 0,-0.586 0.515,-0.973 1.293,-0.973 0.918,0 1.433,0.41 1.441,1.172 z m 1.188,4.078 h 2.605 c 0.547,0 0.95,-0.148 1.258,-0.48 0.285,-0.301 0.446,-0.715 0.446,-1.164 0,-0.7 -0.317,-1.118 -1.055,-1.403 0.531,-0.246 0.801,-0.668 0.801,-1.262 0,-0.425 -0.157,-0.793 -0.461,-1.058 -0.309,-0.277 -0.696,-0.406 -1.25,-0.406 h -2.344 z m 0.738,-3.285 v -1.84 h 1.426 c 0.41,0 0.641,0.059 0.836,0.207 0.207,0.16 0.32,0.395 0.32,0.715 0,0.316 -0.113,0.555 -0.32,0.711 -0.195,0.152 -0.426,0.207 -0.836,0.207 z m 0,2.637 v -1.989 h 1.797 c 0.649,0 1.035,0.371 1.035,1 0,0.618 -0.386,0.989 -1.035,0.989 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath329)"
+               id="path765" />
+            <path
+               d="m 220.641,557.527 c -1.657,0 -2.782,1.219 -2.782,3.024 0,1.816 1.118,3.027 2.789,3.027 0.704,0 1.325,-0.215 1.79,-0.609 0.624,-0.531 1,-1.426 1,-2.367 0,-1.864 -1.102,-3.075 -2.797,-3.075 z m 0,0.649 c 1.25,0 2.058,0.941 2.058,2.406 0,1.395 -0.832,2.348 -2.051,2.348 -1.234,0 -2.05,-0.953 -2.05,-2.379 0,-1.426 0.816,-2.375 2.043,-2.375 z m 5.843,0.094 h 1.895 v -0.649 h -4.531 v 0.649 h 1.902 v 5.125 h 0.734 z m 7.61,2.078 h -2.406 v 0.648 h 1.757 v 0.156 c 0,1.032 -0.757,1.778 -1.812,1.778 -0.586,0 -1.117,-0.215 -1.457,-0.586 -0.383,-0.414 -0.61,-1.102 -0.61,-1.817 0,-1.418 0.809,-2.351 2.028,-2.351 0.879,0 1.511,0.453 1.672,1.195 h 0.75 c -0.207,-1.172 -1.094,-1.844 -2.414,-1.844 -0.707,0 -1.278,0.18 -1.727,0.555 -0.676,0.555 -1.047,1.449 -1.047,2.484 0,1.778 1.086,3.012 2.645,3.012 0.785,0 1.402,-0.293 1.972,-0.918 l 0.184,0.766 h 0.465 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath330)"
+               id="path766" />
+            <path
+               d="m 350.766,112.777 h 41.043 v 26.16 h -41.043 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.577;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath331)"
+               id="path767" />
+            <path
+               d="m 367.617,117.805 v 4.054 c 0,0.778 -0.562,1.25 -1.488,1.25 -0.43,0 -0.777,-0.101 -1.055,-0.3 -0.285,-0.223 -0.418,-0.516 -0.418,-0.95 v -4.054 h -0.738 v 4.054 c 0,1.172 0.84,1.899 2.211,1.899 1.355,0 2.226,-0.742 2.226,-1.899 v -4.054 z m 5.988,1.695 c 0,-0.398 -0.023,-0.508 -0.148,-0.777 -0.316,-0.664 -0.992,-1.016 -1.965,-1.016 -1.269,0 -2.051,0.652 -2.051,1.695 0,0.707 0.371,1.149 1.133,1.348 l 1.434,0.379 c 0.734,0.191 1.058,0.484 1.058,0.937 0,0.309 -0.164,0.625 -0.41,0.797 -0.23,0.168 -0.594,0.246 -1.062,0.246 -0.633,0 -1.051,-0.148 -1.328,-0.48 -0.215,-0.254 -0.313,-0.531 -0.301,-0.891 h -0.699 c 0.007,0.532 0.109,0.883 0.339,1.2 0.399,0.546 1.063,0.82 1.942,0.82 0.687,0 1.25,-0.156 1.625,-0.442 0.387,-0.308 0.633,-0.824 0.633,-1.324 0,-0.711 -0.446,-1.234 -1.227,-1.449 l -1.449,-0.387 c -0.699,-0.191 -0.953,-0.41 -0.953,-0.855 0,-0.586 0.515,-0.973 1.293,-0.973 0.918,0 1.433,0.41 1.441,1.172 z m 1.188,4.078 h 2.605 c 0.547,0 0.95,-0.152 1.258,-0.484 0.285,-0.301 0.446,-0.711 0.446,-1.164 0,-0.696 -0.317,-1.118 -1.055,-1.403 0.531,-0.246 0.801,-0.664 0.801,-1.257 0,-0.43 -0.16,-0.793 -0.461,-1.063 -0.309,-0.277 -0.696,-0.402 -1.25,-0.402 h -2.344 z m 0.734,-3.289 v -1.836 h 1.426 c 0.414,0 0.645,0.055 0.84,0.207 0.207,0.156 0.316,0.395 0.316,0.711 0,0.317 -0.109,0.555 -0.316,0.715 -0.195,0.148 -0.426,0.203 -0.84,0.203 z m 0,2.641 v -1.989 h 1.801 c 0.649,0 1.035,0.371 1.035,0.997 0,0.617 -0.386,0.992 -1.035,0.992 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath332)"
+               id="path768" />
+            <path
+               d="m 361.004,128.859 c 0,-0.398 -0.024,-0.507 -0.149,-0.777 -0.316,-0.664 -0.988,-1.012 -1.964,-1.012 -1.266,0 -2.051,0.649 -2.051,1.696 0,0.703 0.371,1.148 1.133,1.343 l 1.433,0.383 c 0.735,0.188 1.063,0.481 1.063,0.934 0,0.308 -0.168,0.625 -0.414,0.801 -0.231,0.164 -0.594,0.242 -1.063,0.242 -0.633,0 -1.051,-0.149 -1.328,-0.481 -0.215,-0.254 -0.309,-0.531 -0.301,-0.886 h -0.699 c 0.008,0.531 0.113,0.878 0.344,1.195 0.394,0.547 1.058,0.824 1.937,0.824 0.692,0 1.254,-0.16 1.625,-0.445 0.387,-0.309 0.633,-0.824 0.633,-1.321 0,-0.714 -0.441,-1.238 -1.226,-1.449 l -1.45,-0.39 c -0.699,-0.192 -0.949,-0.411 -0.949,-0.856 0,-0.586 0.512,-0.972 1.289,-0.972 0.918,0 1.434,0.41 1.442,1.171 z m 3.336,-1.047 h 1.894 v -0.648 h -4.531 v 0.648 h 1.902 v 5.126 h 0.735 z m 4.254,2.653 h -1.887 v 0.57 h 1.887 z m 1.64,-3.301 h -0.738 v 5.774 h 3.59 v -0.649 h -2.852 z m 4.606,0 h -0.742 v 5.774 h 0.742 z m 5.75,0 h -0.695 v 4.719 l -3.02,-4.719 h -0.797 v 5.774 h 0.695 v -4.68 l 2.985,4.68 h 0.832 z m 1.887,3.754 0.941,-0.941 2.035,2.961 h 0.875 l -2.379,-3.422 2.352,-2.352 h -0.949 l -2.875,2.922 v -2.922 h -0.735 v 5.774 h 0.735 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath333)"
+               id="path769" />
+            <path
+               d="m 182.266,448.43 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.407 0,-1.492 -0.742,-2.406 -1.961,-2.406 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z m 6.773,-2.993 c -0.109,-0.777 -0.613,-1.238 -1.324,-1.238 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.426,1.047 -0.426,1.914 0,0.805 0.114,1.312 0.399,1.734 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.078,0.52 0.008,-1.18 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.266 0.789,0.726 z M 188.246,446 c 0.563,0 0.914,0.398 0.914,1.031 0,0.602 -0.398,1.035 -0.933,1.035 -0.539,0 -0.95,-0.453 -0.95,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z m 4.856,-2.25 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.32 0.492,-0.434 0.863,-0.434 0.629,0 1.016,0.43 1.016,1.121 0,0.676 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.257 -0.957,-0.785 h -0.579 c 0.079,0.383 0.145,0.571 0.282,0.739 0.265,0.359 0.738,0.562 1.269,0.562 0.942,0 1.602,-0.687 1.602,-1.676 0,-0.926 -0.614,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.95 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath334)"
+               id="path770" />
+            <path
+               d="m 182.387,440.988 h 1.855 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z M 183,440.449 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.867 0,1.223 -0.5,1.863 -1.453,1.863 z m 6.773,-2.992 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.511,0 -0.976,0.25 -1.254,0.679 -0.296,0.469 -0.421,1.051 -0.421,1.914 0,0.805 0.113,1.313 0.398,1.735 0.25,0.391 0.66,0.594 1.172,0.594 0.89,0 1.531,-0.664 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.43,-1.496 -0.464,0 -0.828,0.172 -1.078,0.519 0.008,-1.179 0.379,-1.832 1.043,-1.832 0.41,0 0.696,0.262 0.785,0.723 z m -1.406,1.105 c 0.563,0 0.91,0.395 0.91,1.028 0,0.601 -0.394,1.039 -0.929,1.039 -0.543,0 -0.95,-0.457 -0.95,-1.067 0,-0.593 0.395,-1 0.969,-1 z m 5,-1.105 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.516,0 -0.977,0.25 -1.254,0.679 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.313 0.395,1.735 0.25,0.391 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.664 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.172 -1.074,0.519 0.008,-1.179 0.375,-1.832 1.043,-1.832 0.41,0 0.691,0.262 0.785,0.723 z m -1.406,1.105 c 0.559,0 0.91,0.395 0.91,1.028 0,0.601 -0.394,1.039 -0.93,1.039 -0.543,0 -0.953,-0.457 -0.953,-1.067 0,-0.593 0.399,-1 0.973,-1 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath335)"
+               id="path771" />
+            <path
+               d="m 182.266,433.551 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.871 0,1.219 -0.5,1.86 -1.449,1.86 z m 6.773,-2.988 c -0.109,-0.782 -0.613,-1.243 -1.324,-1.243 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.426,1.051 -0.426,1.914 0,0.805 0.114,1.313 0.399,1.734 0.25,0.391 0.66,0.598 1.176,0.598 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.878 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.078,0.524 0.008,-1.184 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.262 0.789,0.727 z m -1.406,1.101 c 0.563,0 0.914,0.395 0.914,1.027 0,0.602 -0.398,1.04 -0.933,1.04 -0.539,0 -0.95,-0.458 -0.95,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 5.145,-2.25 h -3.129 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.567 -1.918,4.106 h 0.617 c 0.258,-1.5 0.848,-2.785 1.903,-4.192 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath336)"
+               id="path772" />
+            <path
+               d="m 183.836,423.566 h -2.004 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.176 -1.215,-0.489 -0.316,-0.343 -0.508,-0.918 -0.508,-1.511 0,-1.18 0.672,-1.961 1.692,-1.961 0.73,0 1.258,0.379 1.391,1 h 0.628 c -0.171,-0.981 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.476 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 H 188 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.691 z m 1.004,4.812 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath337)"
+               id="path773" />
+            <path
+               d="m 182.266,418.668 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.868 0,1.222 -0.5,1.863 -1.449,1.863 z m 6.773,-2.992 c -0.109,-0.778 -0.613,-1.239 -1.324,-1.239 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.426,1.047 -0.426,1.914 0,0.805 0.114,1.313 0.399,1.735 0.25,0.39 0.66,0.593 1.176,0.593 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.496 -1.434,-1.496 -0.461,0 -0.824,0.168 -1.078,0.519 0.008,-1.18 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.266 0.789,0.727 z m -1.406,1.101 c 0.563,0 0.914,0.399 0.914,1.032 0,0.601 -0.398,1.035 -0.933,1.035 -0.539,0 -0.95,-0.453 -0.95,-1.063 0,-0.594 0.395,-1.004 0.969,-1.004 z m 4.293,-0.086 c 0.488,-0.297 0.641,-0.531 0.641,-0.98 0,-0.754 -0.575,-1.274 -1.407,-1.274 -0.824,0 -1.406,0.52 -1.406,1.266 0,0.457 0.153,0.688 0.633,0.988 -0.531,0.274 -0.797,0.66 -0.797,1.192 0,0.871 0.641,1.476 1.57,1.476 0.926,0 1.571,-0.605 1.571,-1.476 0,-0.532 -0.262,-0.918 -0.805,-1.192 z m -0.766,-1.742 c 0.497,0 0.813,0.297 0.813,0.774 0,0.449 -0.324,0.746 -0.813,0.746 -0.496,0 -0.812,-0.297 -0.812,-0.758 0,-0.465 0.316,-0.762 0.812,-0.762 z m 0,2.008 c 0.582,0 0.977,0.383 0.977,0.937 0,0.575 -0.387,0.95 -0.988,0.95 -0.571,0 -0.965,-0.387 -0.965,-0.942 0,-0.57 0.391,-0.945 0.976,-0.945 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath338)"
+               id="path774" />
+            <path
+               d="m 182.387,411.227 h 1.855 c 1.211,0 1.957,-0.911 1.957,-2.407 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z M 183,410.688 v -3.731 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.223 -0.5,1.864 -1.453,1.864 z m 6.773,-2.993 c -0.113,-0.777 -0.613,-1.238 -1.328,-1.238 -0.511,0 -0.976,0.25 -1.254,0.68 -0.296,0.468 -0.421,1.047 -0.421,1.914 0,0.804 0.113,1.312 0.398,1.734 0.25,0.391 0.66,0.594 1.172,0.594 0.89,0 1.531,-0.664 1.531,-1.598 0,-0.875 -0.594,-1.496 -1.43,-1.496 -0.464,0 -0.828,0.172 -1.078,0.52 0.008,-1.18 0.379,-1.832 1.043,-1.832 0.41,0 0.696,0.261 0.785,0.722 z m -1.406,1.106 c 0.563,0 0.91,0.394 0.91,1.027 0,0.602 -0.394,1.035 -0.929,1.035 -0.543,0 -0.95,-0.453 -0.95,-1.062 0,-0.594 0.395,-1 0.969,-1 z m 2.063,1.34 c 0.109,0.777 0.613,1.238 1.324,1.238 0.523,0 0.984,-0.25 1.262,-0.68 0.289,-0.469 0.422,-1.047 0.422,-1.914 0,-0.805 -0.118,-1.312 -0.395,-1.734 -0.258,-0.391 -0.668,-0.594 -1.184,-0.594 -0.89,0 -1.531,0.664 -1.531,1.59 0,0.879 0.594,1.496 1.442,1.496 0.441,0 0.769,-0.156 1.066,-0.52 -0.004,1.188 -0.375,1.84 -1.039,1.84 -0.41,0 -0.695,-0.261 -0.789,-0.722 z m 1.425,-3.176 c 0.54,0 0.95,0.453 0.95,1.07 0,0.586 -0.395,0.996 -0.969,0.996 -0.563,0 -0.914,-0.398 -0.914,-1.031 0,-0.602 0.39,-1.035 0.933,-1.035 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath339)"
+               id="path775" />
+            <path
+               d="m 182.387,403.789 h 1.855 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z M 183,403.246 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.871 0,1.218 -0.5,1.859 -1.453,1.859 z m 6.918,-4.137 h -3.129 v 0.575 h 2.527 c -1.113,1.589 -1.57,2.566 -1.918,4.105 h 0.622 c 0.253,-1.5 0.843,-2.785 1.898,-4.191 z m 1.977,-0.093 c -0.438,0 -0.833,0.199 -1.079,0.519 -0.3,0.426 -0.453,1.059 -0.453,1.942 0,1.609 0.528,2.461 1.532,2.461 0.988,0 1.531,-0.852 1.531,-2.422 0,-0.922 -0.145,-1.543 -0.457,-1.981 -0.242,-0.328 -0.633,-0.519 -1.074,-0.519 z m 0,0.515 c 0.625,0 0.937,0.641 0.937,1.934 0,1.359 -0.305,1.992 -0.953,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.312 0.309,-1.953 0.938,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath340)"
+               id="path776" />
+            <path
+               d="m 182.266,396.348 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.543 v -3.727 h 1.137 c 0.949,0 1.449,0.637 1.449,1.867 0,1.219 -0.5,1.86 -1.449,1.86 z m 6.918,-4.137 h -3.129 v 0.574 h 2.531 c -1.117,1.59 -1.574,2.567 -1.922,4.106 h 0.621 c 0.258,-1.5 0.844,-2.786 1.899,-4.192 z m 1.871,1.281 v 3.399 h 0.582 v -4.774 h -0.383 c -0.207,0.735 -0.336,0.832 -1.234,0.949 v 0.426 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath341)"
+               id="path777" />
+            <path
+               d="m 182.266,388.906 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.223 -0.5,1.859 -1.449,1.859 z m 6.918,-4.136 h -3.129 v 0.574 h 2.531 c -1.117,1.59 -1.574,2.566 -1.922,4.105 h 0.621 c 0.258,-1.5 0.844,-2.785 1.899,-4.191 z m 3.5,4.105 h -2.461 c 0.059,-0.394 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.852 0.992,-1.438 0,-0.394 -0.16,-0.765 -0.437,-1.023 -0.278,-0.25 -0.618,-0.371 -1.063,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.676 0.152,-0.289 0.457,-0.464 0.804,-0.464 0.528,0 0.926,0.382 0.926,0.894 0,0.383 -0.218,0.715 -0.633,0.953 l -0.609,0.356 c -0.976,0.558 -1.262,1.007 -1.312,2.05 h 3.113 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath342)"
+               id="path778" />
+            <path
+               d="m 185.344,328.902 1.672,-4.808 h -0.653 l -1.336,4.07 -1.41,-4.07 h -0.66 l 1.727,4.808 z m 3.133,-4.808 h -0.618 v 4.808 h 0.618 z m 4.785,0 h -0.582 v 3.933 l -2.512,-3.933 H 189.5 v 4.808 h 0.582 v -3.898 l 2.488,3.898 h 0.692 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath343)"
+               id="path779" />
+            <path
+               d="m 183.836,318.922 h -2.004 v 0.543 h 1.465 v 0.129 c 0,0.859 -0.633,1.48 -1.512,1.48 -0.488,0 -0.93,-0.179 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.183 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.535 -2.012,-1.535 -0.586,0 -1.063,0.149 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.765 l 0.152,0.64 h 0.387 z m 4.746,-2.27 H 188 v 3.934 l -2.516,-3.934 h -0.664 v 4.813 h 0.578 v -3.903 l 2.489,3.903 h 0.695 z m 1.004,4.813 h 1.855 c 1.215,0 1.957,-0.914 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.855 z m 0.613,-0.543 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.871 0,1.219 -0.5,1.86 -1.449,1.86 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath344)"
+               id="path780" />
+            <path
+               d="m 183.836,311.48 h -2.004 v 0.543 h 1.465 v 0.133 c 0,0.856 -0.633,1.477 -1.512,1.477 -0.488,0 -0.93,-0.176 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.18 0.672,-1.961 1.688,-1.961 0.734,0 1.262,0.379 1.395,0.996 h 0.625 c -0.172,-0.977 -0.911,-1.535 -2.012,-1.535 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.246 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.269 H 188 v 3.934 l -2.516,-3.934 h -0.664 v 4.812 h 0.578 v -3.902 l 2.489,3.902 h 0.695 z m 1.004,4.812 h 1.855 c 1.215,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.855 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath345)"
+               id="path781" />
+            <path
+               d="m 185.32,304.82 h -1.363 v -1.367 h -0.465 v 1.367 h -1.363 v 0.461 h 1.363 v 1.367 h 0.465 v -1.367 h 1.363 z m 3.461,-2.918 h -2.418 l -0.347,2.547 h 0.531 c 0.273,-0.32 0.496,-0.433 0.867,-0.433 0.625,0 1.016,0.429 1.016,1.121 0,0.672 -0.391,1.082 -1.024,1.082 -0.508,0 -0.816,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.382 0.149,0.566 0.285,0.738 0.266,0.359 0.739,0.562 1.266,0.562 0.945,0 1.605,-0.687 1.605,-1.675 0,-0.926 -0.613,-1.559 -1.511,-1.559 -0.328,0 -0.594,0.086 -0.864,0.285 l 0.184,-1.308 h 1.949 z m 3.164,4.68 1.668,-4.812 h -0.652 l -1.332,4.074 -1.414,-4.074 h -0.66 l 1.73,4.812 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath346)"
+               id="path782" />
+            <path
+               d="m 181.723,297.379 h -1.368 v -1.367 h -0.46 v 1.367 h -1.368 v 0.461 h 1.368 v 1.367 h 0.46 v -1.367 h 1.368 z m 1.773,-0.434 h 0.316 c 0.633,0 0.969,0.297 0.969,0.871 0,0.598 -0.363,0.961 -0.961,0.961 -0.64,0 -0.953,-0.32 -0.992,-1.023 h -0.578 c 0.023,0.383 0.09,0.637 0.203,0.848 0.242,0.46 0.699,0.691 1.34,0.691 0.965,0 1.582,-0.582 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.789,-1.137 0.434,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.313 -1.426,-1.313 -0.945,0 -1.445,0.527 -1.464,1.535 h 0.582 c 0.004,-0.289 0.031,-0.453 0.105,-0.597 0.129,-0.274 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.309 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.652 -0.161,0.067 -0.372,0.094 -0.774,0.102 z m 4.731,2.196 1.668,-4.809 h -0.653 l -1.336,4.07 -1.41,-4.07 h -0.66 l 1.73,4.809 z m 3.308,-2.196 h 0.317 c 0.636,0 0.972,0.297 0.972,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.637 0.203,0.848 0.246,0.46 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.137 0.437,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.531,-1.313 -1.425,-1.313 -0.942,0 -1.446,0.527 -1.465,1.535 h 0.582 c 0.008,-0.289 0.031,-0.453 0.105,-0.597 0.133,-0.274 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.309 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.652 -0.161,0.067 -0.371,0.094 -0.774,0.102 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath347)"
+               id="path783" />
+            <path
+               d="m 173.066,289.629 h 1.582 c 0.547,0 0.793,0.266 0.793,0.859 l -0.007,0.426 c 0,0.297 0.054,0.59 0.14,0.789 h 0.742 v -0.152 c -0.23,-0.16 -0.273,-0.332 -0.289,-0.973 -0.007,-0.789 -0.132,-1.027 -0.652,-1.254 0.539,-0.269 0.758,-0.594 0.758,-1.148 0,-0.832 -0.516,-1.285 -1.465,-1.285 h -2.219 v 4.812 h 0.613 z m 0,-0.543 v -1.656 h 1.485 c 0.344,0 0.539,0.054 0.691,0.187 0.164,0.137 0.25,0.356 0.25,0.641 0,0.574 -0.289,0.828 -0.941,0.828 z m 4.782,0.426 h 2.621 v -0.543 h -2.621 v -1.539 h 2.718 v -0.539 h -3.332 v 4.812 h 3.45 v -0.543 h -2.836 z m 7.047,-1.211 c 0,-0.328 -0.02,-0.422 -0.125,-0.645 -0.266,-0.554 -0.829,-0.847 -1.641,-0.847 -1.055,0 -1.707,0.543 -1.707,1.414 0,0.586 0.308,0.957 0.941,1.121 l 1.196,0.316 c 0.613,0.16 0.886,0.402 0.886,0.781 0,0.258 -0.14,0.52 -0.343,0.664 -0.192,0.141 -0.497,0.207 -0.887,0.207 -0.527,0 -0.875,-0.124 -1.106,-0.402 -0.179,-0.211 -0.257,-0.441 -0.254,-0.738 h -0.578 c 0.004,0.441 0.09,0.73 0.282,0.996 0.332,0.453 0.886,0.684 1.617,0.684 0.574,0 1.043,-0.129 1.355,-0.368 0.321,-0.257 0.528,-0.687 0.528,-1.101 0,-0.594 -0.371,-1.031 -1.024,-1.211 l -1.207,-0.32 c -0.582,-0.161 -0.793,-0.344 -0.793,-0.715 0,-0.489 0.43,-0.813 1.074,-0.813 0.766,0 1.196,0.344 1.203,0.977 z m 1.71,1.211 h 2.622 v -0.543 h -2.622 v -1.539 h 2.719 v -0.539 h -3.332 v 4.812 h 3.453 v -0.543 h -2.84 z m 5.45,-2.082 h 1.578 v -0.539 h -3.778 v 0.539 h 1.586 v 4.273 h 0.614 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath348)"
+               id="path784" />
+            <path
+               d="m 174.918,279.449 h -0.621 v 4.813 h 0.621 z m 3.086,-0.078 c -1.379,0 -2.316,1.016 -2.316,2.52 0,1.511 0.929,2.523 2.324,2.523 0.586,0 1.101,-0.18 1.492,-0.508 0.519,-0.445 0.832,-1.191 0.832,-1.976 0,-1.551 -0.918,-2.559 -2.332,-2.559 z m 0,0.539 c 1.043,0 1.715,0.785 1.715,2.008 0,1.16 -0.692,1.953 -1.707,1.953 -1.032,0 -1.711,-0.793 -1.711,-1.98 0,-1.188 0.679,-1.981 1.703,-1.981 z m 3.82,2.278 h 1.586 c 0.547,0 0.789,0.265 0.789,0.859 l -0.004,0.43 c 0,0.296 0.051,0.585 0.137,0.785 h 0.746 v -0.153 c -0.23,-0.16 -0.277,-0.332 -0.289,-0.968 -0.008,-0.793 -0.133,-1.032 -0.656,-1.258 0.543,-0.27 0.762,-0.594 0.762,-1.149 0,-0.828 -0.516,-1.285 -1.465,-1.285 h -2.219 v 4.813 h 0.613 z m 0,-0.54 v -1.656 h 1.485 c 0.343,0 0.543,0.051 0.695,0.184 0.164,0.136 0.25,0.355 0.25,0.64 0,0.575 -0.289,0.832 -0.945,0.832 z m 4.66,0.422 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.332 v 4.813 h 3.453 v -0.543 h -2.84 z m 4.442,0 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.227 v 4.813 h 0.614 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath349)"
+               id="path785" />
+            <path
+               d="m 188.461,272.008 h -0.582 v 3.933 l -2.512,-3.933 h -0.668 v 4.812 h 0.582 v -3.902 l 2.489,3.902 h 0.691 z m 4.906,1.492 c -0.191,-1.055 -0.797,-1.57 -1.855,-1.57 -0.645,0 -1.168,0.203 -1.524,0.601 -0.437,0.473 -0.672,1.16 -0.672,1.938 0,0.793 0.243,1.472 0.692,1.941 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.633 1.981,-1.907 h -0.633 c -0.051,0.329 -0.117,0.551 -0.219,0.743 -0.195,0.398 -0.605,0.621 -1.121,0.621 -0.957,0 -1.562,-0.766 -1.562,-1.965 0,-1.235 0.574,-1.992 1.511,-1.992 0.387,0 0.75,0.109 0.95,0.3 0.179,0.165 0.277,0.364 0.347,0.727 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath350)"
+               id="path786" />
+            <path
+               d="m 188.766,379.66 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 4.625,-2.719 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.325 0.496,-0.434 0.864,-0.434 0.628,0 1.019,0.426 1.019,1.121 0,0.672 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.566 0.285,0.738 0.261,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.282 L 191.273,377 h 1.946 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath351)"
+               id="path787" />
+            <path
+               d="m 188.766,372.219 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 3.64,0.805 v 1.156 h 0.582 v -1.156 h 0.696 v -0.52 h -0.696 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath352)"
+               id="path788" />
+            <path
+               d="m 188.766,364.66 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 2.941,-0.239 h 0.317 c 0.636,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.383 0.094,0.633 0.203,0.843 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.578 1.586,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.133 0.437,-0.18 0.652,-0.508 0.652,-0.992 0,-0.817 -0.531,-1.313 -1.425,-1.313 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.293 0.031,-0.457 0.105,-0.601 0.133,-0.27 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.308 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.656 -0.161,0.063 -0.371,0.09 -0.774,0.098 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath353)"
+               id="path789" />
+            <path
+               d="m 188.766,357.219 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 4.824,1.387 h -2.461 c 0.059,-0.399 0.27,-0.649 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.364 0.988,-0.852 0.988,-1.438 0,-0.398 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.371 -1.063,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.031 h 0.582 c 0.02,-0.324 0.059,-0.516 0.141,-0.676 0.148,-0.289 0.453,-0.469 0.805,-0.469 0.527,0 0.921,0.383 0.921,0.899 0,0.383 -0.218,0.715 -0.632,0.949 l -0.606,0.359 c -0.98,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath354)"
+               id="path790" />
+            <path
+               d="m 188.766,349.777 0.496,1.446 h 0.687 l -1.691,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.532 l 0.793,-2.192 z m 3.195,-1.438 v 3.399 h 0.578 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.953 v 0.422 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath355)"
+               id="path791" />
+            <path
+               d="m 188.766,342.336 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 3.301,-2.808 c -0.438,0 -0.833,0.195 -1.079,0.519 -0.304,0.422 -0.453,1.055 -0.453,1.942 0,1.609 0.528,2.461 1.532,2.461 0.988,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.149,-1.543 -0.457,-1.981 -0.246,-0.328 -0.633,-0.519 -1.074,-0.519 z m 0,0.511 c 0.625,0 0.933,0.641 0.933,1.938 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.922,-0.66 -0.922,-1.973 0,-1.316 0.309,-1.957 0.938,-1.957 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath356)"
+               id="path792" />
+            <path
+               d="m 153.852,446.387 h 1.511 c 0.375,0 0.672,-0.114 0.93,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.902 -0.531,-1.414 -1.484,-1.414 h -1.985 v 4.813 h 0.614 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.933,0.317 0.933,0.844 0,0.527 -0.347,0.848 -0.933,0.848 z m 7.902,0.039 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.859 -0.633,1.48 -1.512,1.48 -0.488,0 -0.93,-0.18 -1.215,-0.488 -0.316,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.184 0.672,-1.961 1.692,-1.961 0.73,0 1.258,0.375 1.39,0.996 h 0.629 c -0.171,-0.976 -0.914,-1.539 -2.015,-1.539 -0.586,0 -1.063,0.153 -1.438,0.461 -0.562,0.465 -0.871,1.211 -0.871,2.074 0,1.481 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 2.176,-2.231 c -0.434,0 -0.832,0.196 -1.075,0.52 -0.304,0.422 -0.457,1.054 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.926 -0.145,-1.543 -0.453,-1.98 -0.246,-0.328 -0.633,-0.52 -1.078,-0.52 z m 0,0.512 c 0.629,0 0.937,0.641 0.937,1.934 0,1.363 -0.301,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.973 0,-1.316 0.313,-1.957 0.938,-1.957 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath357)"
+               id="path793" />
+            <path
+               d="m 154.211,438.945 h 1.512 c 0.375,0 0.672,-0.109 0.929,-0.34 0.289,-0.265 0.414,-0.574 0.414,-1.019 0,-0.902 -0.531,-1.41 -1.484,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.812,2.578 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.187,-2.859 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.335,0.832 -1.234,0.949 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath358)"
+               id="path794" />
+            <path
+               d="m 154.211,431.508 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.344 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.692 h 1.281 c 0.586,0 0.938,0.321 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.812,2.582 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.872 0,1.218 -0.5,1.859 -1.45,1.859 z m 5.293,-4.231 c -0.434,0 -0.832,0.2 -1.075,0.524 -0.304,0.422 -0.457,1.055 -0.457,1.937 0,1.614 0.532,2.465 1.532,2.465 0.992,0 1.531,-0.851 1.531,-2.426 0,-0.921 -0.145,-1.543 -0.453,-1.976 -0.246,-0.332 -0.633,-0.524 -1.078,-0.524 z m 0,0.516 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.992 -0.949,1.992 -0.613,0 -0.926,-0.66 -0.926,-1.973 0,-1.312 0.313,-1.953 0.938,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath359)"
+               id="path795" />
+            <path
+               d="m 155.875,423.562 h -2.008 v 0.543 h 1.469 v 0.133 c 0,0.856 -0.637,1.477 -1.512,1.477 -0.488,0 -0.933,-0.176 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.18 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.379 1.395,1 h 0.625 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.246 1.645,-0.766 l 0.148,0.641 h 0.391 z m 4.746,-2.269 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.812 h 0.579 v -3.902 l 2.488,3.902 h 0.695 z m 1.004,4.812 h 1.852 c 1.214,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.852 z m 0.613,-0.543 v -3.726 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.219 -0.5,1.859 -1.453,1.859 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath360)"
+               id="path796" />
+            <path
+               d="m 154.93,416.625 h 1.511 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.907 -0.535,-1.414 -1.484,-1.414 h -1.989 v 4.812 h 0.614 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.937,0.316 0.937,0.843 0,0.528 -0.351,0.844 -0.937,0.844 z m 4.433,0.391 h 2.297 v -0.539 h -2.297 v -1.539 h 2.614 v -0.543 h -3.227 v 4.812 h 0.613 z m 4.567,-2.578 c -0.434,0 -0.832,0.195 -1.075,0.519 -0.304,0.422 -0.457,1.055 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.421 0,-0.926 -0.145,-1.543 -0.453,-1.981 -0.246,-0.328 -0.633,-0.519 -1.078,-0.519 z m 0,0.511 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.996 -0.949,1.996 -0.613,0 -0.926,-0.66 -0.926,-1.977 0,-1.312 0.313,-1.953 0.938,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath361)"
+               id="path797" />
+            <path
+               d="m 154.93,409.184 h 1.511 c 0.375,0 0.672,-0.11 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.809 h 0.614 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.937,0.317 0.937,0.844 0,0.531 -0.351,0.848 -0.937,0.848 z m 4.433,0.386 h 2.297 v -0.539 h -2.297 v -1.539 h 2.614 v -0.539 h -3.227 v 4.809 h 0.613 z m 4.461,-1.207 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.731 -0.335,0.832 -1.234,0.949 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath362)"
+               id="path798" />
+            <path
+               d="m 154.93,401.742 h 1.511 c 0.375,0 0.672,-0.109 0.93,-0.34 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.535,-1.41 -1.484,-1.41 h -1.989 v 4.812 h 0.614 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.937,0.316 0.937,0.847 0,0.528 -0.351,0.844 -0.937,0.844 z m 4.433,0.391 h 2.297 v -0.543 h -2.297 v -1.539 h 2.614 v -0.539 h -3.227 v 4.812 h 0.613 z m 6.094,1.617 h -2.465 c 0.063,-0.399 0.274,-0.649 0.848,-1 l 0.66,-0.367 c 0.652,-0.364 0.988,-0.852 0.988,-1.442 0,-0.394 -0.156,-0.765 -0.433,-1.019 -0.278,-0.254 -0.621,-0.371 -1.063,-0.371 -0.594,0 -1.039,0.211 -1.297,0.621 -0.164,0.25 -0.234,0.547 -0.25,1.027 h 0.582 c 0.02,-0.32 0.059,-0.512 0.137,-0.672 0.152,-0.289 0.457,-0.468 0.809,-0.468 0.527,0 0.922,0.382 0.922,0.898 0,0.383 -0.219,0.711 -0.633,0.949 l -0.61,0.356 c -0.976,0.562 -1.257,1.011 -1.312,2.054 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath363)"
+               id="path799" />
+            <path
+               d="m 154.57,394.305 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.282 c 0.586,0 0.937,0.317 0.937,0.844 0,0.527 -0.351,0.844 -0.937,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.403 0.238,-0.25 0.371,-0.593 0.371,-0.972 0,-0.578 -0.265,-0.93 -0.879,-1.168 0.442,-0.203 0.664,-0.555 0.664,-1.047 0,-0.359 -0.129,-0.66 -0.383,-0.887 -0.253,-0.23 -0.578,-0.336 -1.042,-0.336 h -1.954 z m 0.614,-2.739 v -1.531 h 1.191 c 0.34,0 0.531,0.043 0.699,0.172 0.172,0.129 0.262,0.328 0.262,0.594 0,0.262 -0.09,0.461 -0.262,0.594 -0.168,0.125 -0.359,0.171 -0.699,0.171 z m 0,2.196 v -1.656 h 1.5 c 0.543,0 0.863,0.312 0.863,0.832 0,0.515 -0.32,0.824 -0.863,0.824 z m 6.472,-2.989 c -0.109,-0.781 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.11,1.313 0.395,1.738 0.25,0.387 0.66,0.594 1.176,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.878 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.004,-1.184 0.375,-1.836 1.043,-1.836 0.406,0 0.691,0.266 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.914,0.395 0.914,1.031 0,0.598 -0.398,1.035 -0.933,1.035 -0.539,0 -0.95,-0.457 -0.95,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath364)"
+               id="path800" />
+            <path
+               d="m 154.57,386.863 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.262 0.418,-0.575 0.418,-1.016 0,-0.906 -0.535,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.282 c 0.586,0 0.937,0.316 0.937,0.844 0,0.527 -0.351,0.843 -0.937,0.843 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.371,-0.594 0.371,-0.969 0,-0.582 -0.265,-0.933 -0.879,-1.168 0.442,-0.207 0.664,-0.554 0.664,-1.051 0,-0.355 -0.129,-0.66 -0.383,-0.886 -0.253,-0.231 -0.578,-0.336 -1.042,-0.336 h -1.954 z m 0.614,-2.738 v -1.531 h 1.191 c 0.34,0 0.531,0.047 0.699,0.172 0.172,0.133 0.262,0.328 0.262,0.593 0,0.262 -0.09,0.461 -0.262,0.594 -0.168,0.125 -0.359,0.172 -0.699,0.172 z m 0,2.199 v -1.66 h 1.5 c 0.543,0 0.863,0.313 0.863,0.832 0,0.516 -0.32,0.828 -0.863,0.828 z m 6.527,-0.035 h -2.461 c 0.059,-0.394 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.852 0.988,-1.438 0,-0.394 -0.156,-0.765 -0.433,-1.023 -0.278,-0.25 -0.621,-0.371 -1.063,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.141,-0.676 0.148,-0.289 0.453,-0.464 0.805,-0.464 0.527,0 0.922,0.382 0.922,0.894 0,0.383 -0.219,0.715 -0.633,0.953 l -0.606,0.356 c -0.976,0.562 -1.261,1.008 -1.316,2.051 h 3.117 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath365)"
+               id="path801" />
+            <path
+               d="m 157.383,328.898 1.672,-4.808 h -0.657 l -1.332,4.07 -1.41,-4.07 h -0.66 l 1.727,4.808 z m 3.133,-4.808 h -0.621 v 4.808 h 0.621 z m 4.785,0 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.808 h 0.578 V 325 l 2.488,3.898 h 0.696 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath366)"
+               id="path802" />
+            <path
+               d="m 155.875,318.918 h -2.008 v 0.543 h 1.469 v 0.129 c 0,0.859 -0.637,1.48 -1.512,1.48 -0.488,0 -0.933,-0.179 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.183 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.535 -2.012,-1.535 -0.586,0 -1.063,0.149 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.071 0,1.48 0.903,2.507 2.203,2.507 0.653,0 1.168,-0.242 1.645,-0.765 l 0.148,0.64 h 0.391 z m 4.746,-2.27 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.813 h 0.579 v -3.902 l 2.488,3.902 h 0.695 z m 1.004,4.813 h 1.852 c 1.214,0 1.961,-0.914 1.961,-2.41 0,-1.492 -0.739,-2.403 -1.961,-2.403 h -1.852 z m 0.613,-0.543 v -3.73 h 1.133 c 0.953,0 1.453,0.64 1.453,1.871 0,1.218 -0.5,1.859 -1.453,1.859 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath367)"
+               id="path803" />
+            <path
+               d="m 155.875,311.477 h -2.008 v 0.543 h 1.469 v 0.132 c 0,0.856 -0.637,1.477 -1.512,1.477 -0.488,0 -0.933,-0.176 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.18 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.379 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.535 -2.012,-1.535 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.461 -0.871,1.207 -0.871,2.074 0,1.477 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.246 1.645,-0.766 l 0.148,0.641 h 0.391 z m 4.746,-2.27 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.813 h 0.579 v -3.903 l 2.488,3.903 h 0.695 z m 1.004,4.813 h 1.852 c 1.214,0 1.961,-0.911 1.961,-2.411 0,-1.492 -0.739,-2.402 -1.961,-2.402 h -1.852 z m 0.613,-0.543 v -3.727 h 1.133 c 0.953,0 1.453,0.641 1.453,1.867 0,1.219 -0.5,1.86 -1.453,1.86 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath368)"
+               id="path804" />
+            <path
+               d="m 157.359,304.816 h -1.363 v -1.367 h -0.465 v 1.367 h -1.363 v 0.461 h 1.363 v 1.368 h 0.465 v -1.368 h 1.363 z m 3.457,-2.918 h -2.414 l -0.351,2.547 h 0.535 c 0.273,-0.32 0.496,-0.433 0.867,-0.433 0.625,0 1.016,0.429 1.016,1.121 0,0.672 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.382 0.145,0.566 0.285,0.738 0.262,0.359 0.739,0.562 1.266,0.562 0.945,0 1.605,-0.687 1.605,-1.675 0,-0.926 -0.613,-1.559 -1.511,-1.559 -0.332,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.308 h 1.945 z m 3.168,4.68 1.668,-4.812 H 165 l -1.332,4.074 -1.414,-4.074 h -0.66 l 1.73,4.812 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath369)"
+               id="path805" />
+            <path
+               d="m 153.762,297.375 h -1.367 v -1.367 h -0.461 v 1.367 h -1.368 v 0.461 h 1.368 v 1.367 h 0.461 v -1.367 h 1.367 z m 1.773,-0.434 h 0.317 c 0.632,0 0.968,0.297 0.968,0.871 0,0.598 -0.363,0.961 -0.961,0.961 -0.64,0 -0.953,-0.32 -0.992,-1.023 h -0.582 c 0.027,0.383 0.094,0.637 0.207,0.848 0.242,0.461 0.699,0.691 1.34,0.691 0.965,0 1.582,-0.582 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.789,-1.137 0.434,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.313 -1.425,-1.313 -0.946,0 -1.446,0.528 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.109,-0.597 0.129,-0.274 0.422,-0.43 0.785,-0.43 0.512,0 0.825,0.309 0.825,0.824 0,0.336 -0.122,0.543 -0.379,0.653 -0.157,0.066 -0.367,0.093 -0.77,0.101 z m 4.727,2.196 1.672,-4.809 h -0.653 l -1.336,4.07 -1.41,-4.07 h -0.66 l 1.727,4.809 z m 3.312,-2.196 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.992,-1.023 h -0.578 c 0.027,0.383 0.09,0.637 0.203,0.848 0.246,0.461 0.699,0.691 1.34,0.691 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.137 0.434,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.313 -1.425,-1.313 -0.942,0 -1.446,0.528 -1.465,1.535 h 0.582 c 0.008,-0.289 0.031,-0.453 0.105,-0.597 0.133,-0.274 0.422,-0.43 0.785,-0.43 0.516,0 0.825,0.309 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.653 -0.16,0.066 -0.371,0.093 -0.774,0.101 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath370)"
+               id="path806" />
+            <path
+               d="m 145.102,289.625 h 1.586 c 0.546,0 0.792,0.266 0.792,0.859 l -0.007,0.426 c 0,0.301 0.05,0.59 0.136,0.789 h 0.746 v -0.152 c -0.23,-0.16 -0.277,-0.332 -0.289,-0.973 -0.007,-0.789 -0.132,-1.027 -0.652,-1.254 0.539,-0.269 0.758,-0.593 0.758,-1.148 0,-0.832 -0.516,-1.285 -1.465,-1.285 h -2.219 v 4.812 h 0.614 z m 0,-0.543 v -1.656 h 1.488 c 0.34,0 0.539,0.054 0.691,0.187 0.164,0.137 0.25,0.356 0.25,0.641 0,0.574 -0.289,0.828 -0.941,0.828 z m 4.785,0.426 h 2.617 v -0.543 h -2.617 v -1.539 h 2.718 v -0.539 h -3.335 v 4.812 h 3.453 v -0.543 h -2.836 z m 7.043,-1.211 c 0,-0.328 -0.02,-0.422 -0.125,-0.645 -0.262,-0.554 -0.825,-0.847 -1.637,-0.847 -1.055,0 -1.707,0.543 -1.707,1.414 0,0.586 0.309,0.957 0.941,1.121 l 1.196,0.316 c 0.613,0.16 0.886,0.406 0.886,0.782 0,0.257 -0.14,0.519 -0.343,0.664 -0.192,0.14 -0.496,0.207 -0.887,0.207 -0.527,0 -0.875,-0.125 -1.109,-0.403 -0.176,-0.211 -0.254,-0.441 -0.25,-0.738 h -0.579 c 0.004,0.441 0.09,0.73 0.282,0.996 0.332,0.453 0.886,0.684 1.617,0.684 0.574,0 1.043,-0.129 1.355,-0.368 0.321,-0.257 0.528,-0.687 0.528,-1.101 0,-0.594 -0.371,-1.031 -1.024,-1.211 l -1.207,-0.32 c -0.582,-0.16 -0.793,-0.344 -0.793,-0.715 0,-0.488 0.43,-0.813 1.074,-0.813 0.766,0 1.196,0.344 1.204,0.977 z m 1.715,1.211 h 2.621 v -0.543 h -2.621 v -1.539 h 2.718 v -0.539 h -3.332 v 4.812 h 3.453 v -0.543 h -2.839 z m 5.449,-2.082 h 1.578 v -0.539 h -3.777 v 0.539 h 1.585 v 4.273 h 0.614 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath371)"
+               id="path807" />
+            <path
+               d="m 146.957,279.445 h -0.621 v 4.813 h 0.621 z m 3.086,-0.078 c -1.379,0 -2.316,1.016 -2.316,2.52 0,1.511 0.929,2.523 2.324,2.523 0.586,0 1.101,-0.18 1.492,-0.508 0.519,-0.445 0.828,-1.191 0.828,-1.976 0,-1.551 -0.914,-2.559 -2.328,-2.559 z m 0,0.539 c 1.043,0 1.715,0.785 1.715,2.008 0,1.16 -0.692,1.953 -1.707,1.953 -1.031,0 -1.711,-0.793 -1.711,-1.98 0,-1.188 0.68,-1.981 1.703,-1.981 z m 3.82,2.278 h 1.582 c 0.551,0 0.793,0.265 0.793,0.859 l -0.008,0.43 c 0,0.297 0.055,0.586 0.141,0.785 h 0.746 v -0.153 c -0.23,-0.16 -0.277,-0.332 -0.289,-0.968 -0.008,-0.793 -0.133,-1.032 -0.656,-1.258 0.543,-0.27 0.762,-0.594 0.762,-1.149 0,-0.828 -0.516,-1.285 -1.469,-1.285 h -2.215 v 4.813 h 0.613 z m 0,-0.539 v -1.657 h 1.485 c 0.343,0 0.543,0.051 0.695,0.184 0.164,0.137 0.25,0.355 0.25,0.64 0,0.575 -0.293,0.833 -0.945,0.833 z m 4.66,0.421 h 2.622 v -0.543 h -2.622 v -1.535 h 2.719 v -0.543 h -3.332 v 4.813 h 3.453 v -0.543 h -2.84 z m 4.442,0 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.226 v 4.813 h 0.613 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath372)"
+               id="path808" />
+            <path
+               d="m 160.621,272.004 h -0.582 v 3.934 l -2.516,-3.934 h -0.664 v 4.812 h 0.579 v -3.902 l 2.488,3.902 h 0.695 z m 4.906,1.492 c -0.191,-1.055 -0.8,-1.57 -1.855,-1.57 -0.649,0 -1.168,0.203 -1.524,0.601 -0.437,0.473 -0.675,1.161 -0.675,1.938 0,0.793 0.246,1.473 0.695,1.941 0.375,0.383 0.852,0.563 1.477,0.563 1.175,0 1.835,-0.633 1.98,-1.907 h -0.633 c -0.054,0.329 -0.121,0.551 -0.219,0.743 -0.199,0.398 -0.605,0.621 -1.121,0.621 -0.957,0 -1.566,-0.766 -1.566,-1.965 0,-1.234 0.574,-1.992 1.512,-1.992 0.39,0 0.754,0.109 0.953,0.301 0.176,0.164 0.277,0.363 0.347,0.726 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath373)"
+               id="path809" />
+            <path
+               d="m 154.211,379.062 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.343 0.289,-0.266 0.414,-0.574 0.414,-1.016 0,-0.906 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.542 v -1.688 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 7.594,-0.739 c -0.192,-1.054 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.601 -0.434,0.473 -0.672,1.161 -0.672,1.938 0,0.793 0.242,1.473 0.691,1.941 0.375,0.383 0.852,0.563 1.481,0.563 1.172,0 1.832,-0.633 1.976,-1.91 h -0.632 c -0.051,0.332 -0.118,0.554 -0.215,0.746 -0.2,0.398 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.766 -1.563,-1.965 0,-1.234 0.574,-1.996 1.512,-1.996 0.387,0 0.75,0.113 0.949,0.305 0.18,0.164 0.277,0.363 0.352,0.726 z m 3.453,-1.359 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.324 0.496,-0.434 0.864,-0.434 0.629,0 1.015,0.426 1.015,1.121 0,0.672 -0.386,1.082 -1.019,1.082 -0.512,0 -0.821,-0.258 -0.957,-0.785 h -0.582 c 0.078,0.383 0.144,0.567 0.285,0.738 0.262,0.356 0.738,0.563 1.265,0.563 0.946,0 1.606,-0.688 1.606,-1.676 0,-0.926 -0.617,-1.558 -1.512,-1.558 -0.332,0 -0.594,0.085 -0.867,0.281 l 0.187,-1.305 h 1.946 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath374)"
+               id="path810" />
+            <path
+               d="m 154.211,371.621 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.344 0.289,-0.261 0.414,-0.574 0.414,-1.015 0,-0.907 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 7.594,-0.738 c -0.192,-1.055 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.601 -0.434,0.473 -0.672,1.16 -0.672,1.941 0,0.79 0.242,1.469 0.691,1.938 0.375,0.383 0.852,0.562 1.481,0.562 1.172,0 1.832,-0.632 1.976,-1.906 h -0.632 c -0.051,0.328 -0.118,0.555 -0.215,0.746 -0.2,0.395 -0.61,0.618 -1.125,0.618 -0.957,0 -1.563,-0.766 -1.563,-1.965 0,-1.235 0.574,-1.993 1.512,-1.993 0.387,0 0.75,0.11 0.949,0.301 0.18,0.168 0.277,0.364 0.352,0.727 z m 2.468,2.164 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.097 h -0.429 l -2.125,3.004 v 0.613 z m 0,-0.52 h -1.464 l 1.464,-2.105 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath375)"
+               id="path811" />
+            <path
+               d="m 154.211,364.059 h 1.512 c 0.375,0 0.672,-0.11 0.929,-0.34 0.289,-0.266 0.414,-0.574 0.414,-1.02 0,-0.902 -0.531,-1.41 -1.484,-1.41 h -1.984 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 7.594,-0.739 c -0.192,-1.058 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.598 -0.434,0.476 -0.672,1.164 -0.672,1.941 0,0.793 0.242,1.473 0.691,1.941 0.375,0.383 0.852,0.559 1.481,0.559 1.172,0 1.832,-0.633 1.976,-1.906 h -0.632 c -0.051,0.332 -0.118,0.554 -0.215,0.746 -0.2,0.394 -0.61,0.621 -1.125,0.621 -0.957,0 -1.563,-0.766 -1.563,-1.969 0,-1.234 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.113 0.949,0.305 0.18,0.164 0.277,0.363 0.352,0.726 z m 2.019,-0.082 v 3.403 h 0.582 v -4.774 h -0.383 c -0.203,0.734 -0.335,0.832 -1.234,0.949 v 0.422 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath376)"
+               id="path812" />
+            <path
+               d="m 154.211,356.621 h 1.512 c 0.375,0 0.672,-0.113 0.929,-0.344 0.289,-0.265 0.414,-0.574 0.414,-1.015 0,-0.907 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 7.594,-0.738 c -0.192,-1.055 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.601 -0.434,0.473 -0.672,1.16 -0.672,1.938 0,0.793 0.242,1.472 0.691,1.941 0.375,0.383 0.852,0.562 1.481,0.562 1.172,0 1.832,-0.636 1.976,-1.91 h -0.632 c -0.051,0.332 -0.118,0.555 -0.215,0.746 -0.2,0.399 -0.61,0.622 -1.125,0.622 -0.957,0 -1.563,-0.766 -1.563,-1.965 0,-1.235 0.574,-1.996 1.512,-1.996 0.387,0 0.75,0.113 0.949,0.304 0.18,0.164 0.277,0.364 0.352,0.727 z m 1.769,1.121 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.992,-1.024 h -0.578 c 0.027,0.383 0.09,0.633 0.203,0.844 0.246,0.465 0.699,0.695 1.34,0.695 0.965,0 1.586,-0.582 1.586,-1.484 0,-0.609 -0.23,-0.937 -0.793,-1.137 0.434,-0.179 0.652,-0.507 0.652,-0.992 0,-0.816 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.539 h 0.582 c 0.008,-0.289 0.031,-0.457 0.105,-0.602 0.133,-0.269 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.312 0.825,0.828 0,0.336 -0.118,0.539 -0.375,0.652 -0.16,0.066 -0.371,0.09 -0.774,0.098 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath377)"
+               id="path813" />
+            <path
+               d="m 154.211,349.18 h 1.512 c 0.375,0 0.672,-0.114 0.929,-0.344 0.289,-0.262 0.414,-0.574 0.414,-1.016 0,-0.906 -0.531,-1.414 -1.484,-1.414 h -1.984 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 7.594,-0.739 c -0.192,-1.054 -0.797,-1.57 -1.856,-1.57 -0.644,0 -1.168,0.203 -1.523,0.602 -0.434,0.472 -0.672,1.16 -0.672,1.941 0,0.789 0.242,1.469 0.691,1.938 0.375,0.382 0.852,0.562 1.481,0.562 1.172,0 1.832,-0.633 1.976,-1.906 h -0.632 c -0.051,0.328 -0.118,0.555 -0.215,0.746 -0.2,0.394 -0.61,0.617 -1.125,0.617 -0.957,0 -1.563,-0.766 -1.563,-1.965 0,-1.234 0.574,-1.992 1.512,-1.992 0.387,0 0.75,0.109 0.949,0.301 0.18,0.168 0.277,0.363 0.352,0.726 z m 2.125,-1.453 c -0.434,0 -0.832,0.2 -1.075,0.524 -0.304,0.422 -0.457,1.054 -0.457,1.941 0,1.61 0.532,2.461 1.532,2.461 0.992,0 1.531,-0.851 1.531,-2.422 0,-0.926 -0.145,-1.547 -0.453,-1.98 -0.246,-0.332 -0.633,-0.524 -1.078,-0.524 z m 0,0.516 c 0.629,0 0.937,0.641 0.937,1.934 0,1.359 -0.301,1.996 -0.949,1.996 -0.613,0 -0.926,-0.661 -0.926,-1.977 0,-1.312 0.313,-1.953 0.938,-1.953 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath378)"
+               id="path814" />
+            <path
+               d="m 154.57,341.738 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.289,-0.262 0.418,-0.575 0.418,-1.016 0,-0.902 -0.535,-1.41 -1.489,-1.41 h -1.984 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.282 c 0.586,0 0.937,0.316 0.937,0.844 0,0.531 -0.351,0.847 -0.937,0.847 z m 6.356,1.133 0.492,1.445 h 0.687 l -1.691,-4.808 h -0.789 l -1.719,4.808 h 0.656 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.789,-2.191 z m 2.82,-0.234 h 0.317 c 0.632,0 0.972,0.297 0.972,0.871 0,0.598 -0.363,0.961 -0.965,0.961 -0.64,0 -0.949,-0.32 -0.992,-1.023 h -0.578 c 0.027,0.382 0.09,0.636 0.203,0.847 0.246,0.461 0.699,0.692 1.34,0.692 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.605 -0.23,-0.937 -0.793,-1.136 0.434,-0.176 0.652,-0.508 0.652,-0.989 0,-0.82 -0.535,-1.312 -1.425,-1.312 -0.942,0 -1.446,0.527 -1.465,1.535 h 0.582 c 0.008,-0.289 0.031,-0.453 0.105,-0.598 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.825,0.308 0.825,0.824 0,0.336 -0.118,0.543 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.774,0.102 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath379)"
+               id="path815" />
+            <path
+               d="m 432.742,315.699 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 4.434,0.391 h 2.297 v -0.543 h -2.297 v -1.535 h 2.613 v -0.543 h -3.227 v 4.812 h 0.614 z m 4.461,-1.207 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 5.23,2.824 h -2.461 c 0.059,-0.398 0.27,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.437,-1.023 -0.277,-0.25 -0.617,-0.371 -1.063,-0.371 -0.593,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.582 c 0.02,-0.324 0.059,-0.515 0.137,-0.676 0.152,-0.289 0.457,-0.468 0.805,-0.468 0.527,0 0.926,0.382 0.926,0.898 0,0.383 -0.219,0.715 -0.633,0.949 l -0.61,0.36 c -0.976,0.558 -1.261,1.008 -1.312,2.05 h 3.113 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath380)"
+               id="path816" />
+            <path
+               d="m 432.742,308.258 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.868 0,1.222 -0.5,1.863 -1.449,1.863 z m 5.309,-2.86 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.235,0.954 v 0.421 z m 5.035,-1.281 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.32 0.492,-0.434 0.864,-0.434 0.625,0 1.015,0.43 1.015,1.122 0,0.671 -0.39,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.786 h -0.578 c 0.078,0.383 0.144,0.567 0.281,0.739 0.265,0.359 0.738,0.562 1.269,0.562 0.942,0 1.602,-0.687 1.602,-1.676 0,-0.925 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.309 h 1.95 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath381)"
+               id="path817" />
+            <path
+               d="m 432.742,300.816 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.262 0.418,-0.575 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.531 -0.352,0.847 -0.938,0.847 z m 3.813,2.578 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z m 5.309,-2.859 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.235,0.949 v 0.422 z m 4.05,2.246 v 1.152 h 0.582 v -1.152 h 0.692 v -0.523 h -0.692 v -3.094 h -0.429 l -2.125,3 v 0.617 z m 0,-0.523 h -1.465 l 1.465,-2.106 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath382)"
+               id="path818" />
+            <path
+               d="m 432.742,293.375 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.536,-1.411 -1.485,-1.411 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.356,1.137 0.496,1.445 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 4.914,-2.719 h -3.129 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.567 -1.918,4.106 h 0.621 c 0.254,-1.5 0.844,-2.785 1.899,-4.191 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath383)"
+               id="path819" />
+            <path
+               d="m 432.742,285.938 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 6.356,1.136 0.496,1.446 h 0.683 l -1.687,-4.813 h -0.793 l -1.715,4.813 h 0.652 l 0.508,-1.446 z m -0.172,-0.515 h -1.531 l 0.793,-2.192 z m 4.769,-1.571 c -0.113,-0.781 -0.613,-1.242 -1.328,-1.242 -0.512,0 -0.976,0.25 -1.254,0.68 -0.297,0.469 -0.422,1.051 -0.422,1.914 0,0.805 0.114,1.312 0.399,1.738 0.25,0.387 0.66,0.594 1.172,0.594 0.89,0 1.531,-0.668 1.531,-1.598 0,-0.879 -0.594,-1.5 -1.43,-1.5 -0.465,0 -0.824,0.172 -1.078,0.524 0.008,-1.184 0.379,-1.836 1.043,-1.836 0.41,0 0.695,0.265 0.785,0.726 z m -1.406,1.102 c 0.563,0 0.91,0.394 0.91,1.031 0,0.598 -0.394,1.035 -0.929,1.035 -0.54,0 -0.95,-0.457 -0.95,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath384)"
+               id="path820" />
+            <path
+               d="m 432.742,278.496 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 6.356,1.137 0.496,1.445 h 0.683 l -1.687,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.531 l 0.793,-2.191 z m 4.625,-2.719 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.324 0.492,-0.433 0.864,-0.433 0.628,0 1.015,0.429 1.015,1.121 0,0.672 -0.387,1.082 -1.023,1.082 -0.508,0 -0.817,-0.258 -0.957,-0.785 h -0.578 c 0.078,0.383 0.144,0.566 0.281,0.738 0.266,0.355 0.742,0.563 1.269,0.563 0.942,0 1.602,-0.688 1.602,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.593,0.086 -0.863,0.285 l 0.184,-1.308 h 1.949 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath385)"
+               id="path821" />
+            <path
+               d="m 436.207,270.555 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.859 -0.633,1.48 -1.512,1.48 -0.488,0 -0.929,-0.18 -1.215,-0.488 -0.316,-0.344 -0.507,-0.918 -0.507,-1.512 0,-1.184 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.976 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.465 -0.871,1.211 -0.871,2.074 0,1.481 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.274 h -0.582 v 3.938 l -2.516,-3.938 h -0.664 v 4.813 h 0.579 v -3.899 l 2.488,3.899 h 0.695 z m 1.004,4.813 h 1.855 c 1.215,0 1.958,-0.91 1.958,-2.406 0,-1.493 -0.739,-2.407 -1.958,-2.407 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath386)"
+               id="path822" />
+            <path
+               d="m 435.793,260.723 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.578 v -3.902 l 2.489,3.902 h 0.695 z m 4.906,1.492 c -0.191,-1.055 -0.801,-1.57 -1.855,-1.57 -0.649,0 -1.168,0.203 -1.524,0.601 -0.437,0.473 -0.675,1.16 -0.675,1.938 0,0.793 0.246,1.472 0.695,1.941 0.375,0.383 0.851,0.563 1.476,0.563 1.176,0 1.836,-0.633 1.981,-1.911 h -0.633 c -0.055,0.332 -0.121,0.555 -0.219,0.746 -0.199,0.399 -0.605,0.622 -1.121,0.622 -0.957,0 -1.566,-0.766 -1.566,-1.965 0,-1.235 0.574,-1.996 1.512,-1.996 0.39,0 0.753,0.113 0.953,0.304 0.175,0.164 0.277,0.364 0.347,0.727 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath387)"
+               id="path823" />
+            <path
+               d="m 432.742,256.055 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.403 0.238,-0.25 0.371,-0.593 0.371,-0.968 0,-0.582 -0.266,-0.934 -0.879,-1.168 0.442,-0.207 0.668,-0.555 0.668,-1.051 0,-0.356 -0.133,-0.66 -0.383,-0.883 -0.258,-0.234 -0.582,-0.34 -1.043,-0.34 h -1.957 z m 0.617,-2.739 v -1.531 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.328 0.262,0.594 0,0.262 -0.09,0.461 -0.262,0.594 -0.164,0.125 -0.355,0.171 -0.699,0.171 z m 0,2.2 v -1.66 h 1.497 c 0.543,0 0.863,0.312 0.863,0.832 0,0.515 -0.32,0.828 -0.863,0.828 z m 3.653,-0.551 c 0.113,0.781 0.613,1.242 1.328,1.242 0.519,0 0.984,-0.25 1.258,-0.68 0.293,-0.468 0.426,-1.05 0.426,-1.914 0,-0.804 -0.122,-1.312 -0.399,-1.734 -0.258,-0.391 -0.664,-0.598 -1.18,-0.598 -0.89,0 -1.531,0.668 -1.531,1.594 0,0.875 0.594,1.496 1.438,1.496 0.441,0 0.773,-0.156 1.07,-0.519 -0.008,1.187 -0.375,1.839 -1.043,1.839 -0.41,0 -0.695,-0.261 -0.785,-0.726 z m 1.426,-3.172 c 0.543,0 0.949,0.453 0.949,1.066 0,0.59 -0.395,0.997 -0.969,0.997 -0.562,0 -0.91,-0.395 -0.91,-1.028 0,-0.601 0.391,-1.035 0.93,-1.035 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath388)"
+               id="path824" />
+            <path
+               d="m 432.742,248.613 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.343 0.293,-0.262 0.418,-0.575 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.531 -0.352,0.847 -0.938,0.847 z m 3.746,2.578 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.371,-0.594 0.371,-0.969 0,-0.582 -0.266,-0.929 -0.879,-1.168 0.442,-0.207 0.668,-0.554 0.668,-1.051 0,-0.355 -0.133,-0.66 -0.383,-0.882 -0.258,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.738 v -1.531 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.332 0.262,0.593 0,0.266 -0.09,0.461 -0.262,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.199 v -1.656 h 1.497 c 0.543,0 0.863,0.309 0.863,0.832 0,0.512 -0.32,0.824 -0.863,0.824 z m 5.883,-1.972 c 0.489,-0.297 0.641,-0.536 0.641,-0.985 0,-0.754 -0.574,-1.273 -1.406,-1.273 -0.825,0 -1.407,0.519 -1.407,1.265 0,0.457 0.153,0.688 0.637,0.993 -0.535,0.269 -0.801,0.66 -0.801,1.187 0,0.871 0.641,1.477 1.571,1.477 0.925,0 1.57,-0.606 1.57,-1.477 0,-0.527 -0.262,-0.918 -0.805,-1.187 z m -0.765,-1.743 c 0.496,0 0.812,0.297 0.812,0.77 0,0.449 -0.324,0.746 -0.812,0.746 -0.493,0 -0.813,-0.297 -0.813,-0.758 0,-0.461 0.32,-0.758 0.813,-0.758 z m 0,2.004 c 0.582,0 0.976,0.383 0.976,0.938 0,0.574 -0.387,0.949 -0.988,0.949 -0.566,0 -0.965,-0.387 -0.965,-0.941 0,-0.571 0.391,-0.946 0.977,-0.946 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath389)"
+               id="path825" />
+            <path
+               d="m 432.742,379.059 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.809 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.813,2.578 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.407 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.539 v -3.731 h 1.137 c 0.949,0 1.449,0.641 1.449,1.867 0,1.223 -0.5,1.864 -1.449,1.864 z m 3.949,-0.547 c 0.113,0.777 0.617,1.238 1.328,1.238 0.524,0 0.985,-0.25 1.262,-0.68 0.289,-0.468 0.422,-1.047 0.422,-1.914 0,-0.804 -0.121,-1.312 -0.395,-1.734 -0.257,-0.391 -0.668,-0.594 -1.183,-0.594 -0.891,0 -1.531,0.664 -1.531,1.59 0,0.879 0.593,1.5 1.437,1.5 0.445,0 0.773,-0.16 1.07,-0.523 -0.007,1.187 -0.375,1.843 -1.043,1.843 -0.41,0 -0.691,-0.265 -0.785,-0.726 z m 1.426,-3.176 c 0.543,0 0.953,0.457 0.953,1.07 0,0.586 -0.398,0.996 -0.973,0.996 -0.558,0 -0.91,-0.398 -0.91,-1.031 0,-0.601 0.391,-1.035 0.93,-1.035 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath390)"
+               id="path826" />
+            <path
+               d="m 432.742,371.621 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.019 0,-0.903 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.691 h 1.281 c 0.586,0 0.938,0.32 0.938,0.847 0,0.528 -0.352,0.844 -0.938,0.844 z m 3.813,2.582 h 1.855 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.855 z m 0.613,-0.543 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.871 0,1.219 -0.5,1.859 -1.449,1.859 z m 6.184,-1.972 c 0.488,-0.297 0.636,-0.536 0.636,-0.985 0,-0.75 -0.574,-1.273 -1.402,-1.273 -0.828,0 -1.406,0.523 -1.406,1.265 0,0.457 0.148,0.688 0.632,0.993 -0.535,0.269 -0.8,0.66 -0.8,1.187 0,0.871 0.64,1.48 1.574,1.48 0.922,0 1.57,-0.609 1.57,-1.48 0,-0.527 -0.265,-0.918 -0.804,-1.187 z m -0.766,-1.743 c 0.492,0 0.809,0.297 0.809,0.774 0,0.445 -0.321,0.742 -0.809,0.742 -0.496,0 -0.813,-0.297 -0.813,-0.758 0,-0.461 0.317,-0.758 0.813,-0.758 z m 0,2.004 c 0.578,0 0.976,0.387 0.976,0.938 0,0.574 -0.39,0.953 -0.992,0.953 -0.566,0 -0.965,-0.391 -0.965,-0.945 0,-0.567 0.391,-0.946 0.981,-0.946 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath391)"
+               id="path827" />
+            <path
+               d="m 432.742,364.059 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.543 h -3.227 v 4.813 h 0.614 z m 4.461,-1.207 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.828 -1.234,0.949 v 0.422 z m 5.035,-1.281 h -2.418 l -0.348,2.547 h 0.535 c 0.27,-0.32 0.493,-0.434 0.864,-0.434 0.629,0 1.015,0.43 1.015,1.121 0,0.672 -0.386,1.082 -1.023,1.082 -0.508,0 -0.817,-0.257 -0.957,-0.785 h -0.578 c 0.078,0.383 0.144,0.567 0.281,0.739 0.266,0.359 0.742,0.562 1.269,0.562 0.942,0 1.602,-0.688 1.602,-1.676 0,-0.926 -0.613,-1.558 -1.512,-1.558 -0.328,0 -0.593,0.086 -0.863,0.285 l 0.184,-1.309 h 1.949 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath392)"
+               id="path828" />
+            <path
+               d="m 432.742,356.617 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.808 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 4.434,0.387 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.539 h -3.333 v 4.808 h 3.454 v -0.539 h -2.84 z m 4.941,-1.207 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 3.352,1.203 h 0.316 c 0.633,0 0.969,0.297 0.969,0.871 0,0.602 -0.363,0.961 -0.965,0.961 -0.641,0 -0.949,-0.32 -0.988,-1.02 h -0.582 c 0.027,0.383 0.093,0.633 0.207,0.844 0.242,0.461 0.699,0.692 1.34,0.692 0.961,0 1.582,-0.579 1.582,-1.485 0,-0.605 -0.231,-0.937 -0.793,-1.136 0.437,-0.176 0.656,-0.508 0.656,-0.989 0,-0.82 -0.535,-1.312 -1.426,-1.312 -0.945,0 -1.445,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.036,-0.453 0.106,-0.598 0.133,-0.273 0.422,-0.429 0.785,-0.429 0.516,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.769,0.102 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath393)"
+               id="path829" />
+            <path
+               d="m 432.742,349.176 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.297 v -0.543 h -2.297 v -1.539 h 2.613 v -0.539 h -3.227 v 4.813 h 0.614 z m 4.461,-1.211 v 3.403 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.95 v 0.421 z m 4.051,2.246 v 1.157 h 0.582 v -1.157 h 0.691 v -0.523 h -0.691 v -3.094 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.105 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath394)"
+               id="path830" />
+            <path
+               d="m 432.742,341.738 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 v -0.543 h -2.84 z m 4.941,-1.207 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 3.602,0 v 3.398 h 0.578 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath395)"
+               id="path831" />
+            <path
+               d="m 432.742,334.297 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.262 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.415 -1.485,-1.415 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.528 -0.352,0.844 -0.938,0.844 z m 4.434,0.391 h 2.621 v -0.54 h -2.621 v -1.539 h 2.719 v -0.543 h -3.333 v 4.813 h 3.454 v -0.539 h -2.84 z m 3.582,1.101 c 0.113,0.781 0.613,1.242 1.328,1.242 0.519,0 0.984,-0.25 1.258,-0.679 0.293,-0.469 0.426,-1.051 0.426,-1.914 0,-0.805 -0.122,-1.313 -0.399,-1.739 -0.258,-0.386 -0.664,-0.594 -1.18,-0.594 -0.89,0 -1.531,0.668 -1.531,1.594 0,0.875 0.594,1.496 1.438,1.496 0.441,0 0.773,-0.156 1.07,-0.519 -0.008,1.187 -0.375,1.84 -1.043,1.84 -0.41,0 -0.695,-0.262 -0.785,-0.727 z m 1.426,-3.172 c 0.543,0 0.949,0.453 0.949,1.067 0,0.589 -0.395,0.996 -0.969,0.996 -0.562,0 -0.91,-0.395 -0.91,-1.028 0,-0.601 0.391,-1.035 0.93,-1.035 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath396)"
+               id="path832" />
+            <path
+               d="m 432.742,326.855 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.262 0.418,-0.574 0.418,-1.016 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.809 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.531 -0.352,0.847 -0.938,0.847 z m 4.434,0.387 h 2.297 v -0.539 h -2.297 v -1.539 h 2.613 v -0.539 h -3.227 v 4.809 h 0.614 z m 4.461,-1.207 v 3.399 h 0.582 v -4.77 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 3.351,1.203 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.598 -0.363,0.961 -0.961,0.961 -0.64,0 -0.953,-0.32 -0.992,-1.023 h -0.578 c 0.024,0.383 0.09,0.637 0.203,0.847 0.243,0.461 0.7,0.692 1.34,0.692 0.965,0 1.582,-0.582 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.789,-1.136 0.434,-0.176 0.652,-0.508 0.652,-0.988 0,-0.821 -0.535,-1.313 -1.425,-1.313 -0.946,0 -1.446,0.527 -1.465,1.535 h 0.582 c 0.004,-0.289 0.031,-0.453 0.105,-0.598 0.129,-0.273 0.422,-0.429 0.785,-0.429 0.512,0 0.825,0.308 0.825,0.824 0,0.336 -0.121,0.543 -0.375,0.652 -0.16,0.067 -0.371,0.094 -0.774,0.102 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath397)"
+               id="path833" />
+            <path
+               d="m 432.742,446.383 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.371,-0.594 0.371,-0.973 0,-0.578 -0.266,-0.93 -0.879,-1.168 0.442,-0.203 0.668,-0.555 0.668,-1.047 0,-0.359 -0.133,-0.66 -0.383,-0.887 -0.258,-0.23 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.738 v -1.532 h 1.188 c 0.344,0 0.535,0.043 0.699,0.172 0.172,0.129 0.262,0.328 0.262,0.594 0,0.262 -0.09,0.461 -0.262,0.594 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.195 v -1.656 h 1.497 c 0.543,0 0.863,0.312 0.863,0.832 0,0.515 -0.32,0.824 -0.863,0.824 z m 5.012,-2.856 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.95 v 0.425 z m 3.602,0 v 3.399 h 0.578 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.95 v 0.425 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath398)"
+               id="path834" />
+            <path
+               d="m 432.742,438.941 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 3.746,2.582 h 2.172 c 0.457,0 0.793,-0.125 1.051,-0.402 0.238,-0.25 0.371,-0.594 0.371,-0.969 0,-0.582 -0.266,-0.933 -0.879,-1.168 0.442,-0.207 0.668,-0.554 0.668,-1.05 0,-0.356 -0.133,-0.661 -0.383,-0.887 -0.258,-0.231 -0.582,-0.336 -1.043,-0.336 h -1.957 z m 0.617,-2.738 v -1.531 h 1.188 c 0.344,0 0.535,0.047 0.699,0.172 0.172,0.133 0.262,0.328 0.262,0.594 0,0.261 -0.09,0.461 -0.262,0.593 -0.164,0.125 -0.355,0.172 -0.699,0.172 z m 0,2.196 v -1.657 h 1.497 c 0.543,0 0.863,0.313 0.863,0.832 0,0.516 -0.32,0.825 -0.863,0.825 z m 5.012,-2.856 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.953 v 0.422 z m 3.707,-1.375 c -0.437,0 -0.832,0.199 -1.078,0.523 -0.301,0.422 -0.453,1.055 -0.453,1.942 0,1.609 0.527,2.461 1.531,2.461 0.988,0 1.531,-0.852 1.531,-2.422 0,-0.926 -0.144,-1.547 -0.457,-1.981 -0.242,-0.332 -0.632,-0.523 -1.074,-0.523 z m 0,0.516 c 0.625,0 0.938,0.64 0.938,1.933 0,1.36 -0.305,1.996 -0.953,1.996 -0.614,0 -0.922,-0.66 -0.922,-1.976 0,-1.313 0.308,-1.953 0.937,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath399)"
+               id="path835" />
+            <path
+               d="m 432.742,431.5 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.261 0.418,-0.574 0.418,-1.015 0,-0.903 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.539 v -1.691 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.532 -0.352,0.848 -0.938,0.848 z m 4.434,0.387 h 2.621 v -0.539 h -2.621 v -1.539 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 V 433 h -2.84 z m 4.941,-1.207 v 3.398 h 0.582 v -4.769 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z m 5.031,-1.282 h -2.414 l -0.351,2.551 h 0.535 c 0.273,-0.324 0.496,-0.437 0.867,-0.437 0.625,0 1.016,0.429 1.016,1.121 0,0.676 -0.391,1.082 -1.024,1.082 -0.507,0 -0.82,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.382 0.145,0.57 0.285,0.742 0.266,0.355 0.739,0.558 1.266,0.558 0.945,0 1.606,-0.687 1.606,-1.675 0,-0.926 -0.614,-1.559 -1.512,-1.559 -0.328,0 -0.594,0.086 -0.863,0.285 l 0.183,-1.308 h 1.945 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath400)"
+               id="path836" />
+            <path
+               d="m 432.742,424.059 h 1.512 c 0.375,0 0.672,-0.11 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.02 0,-0.902 -0.536,-1.41 -1.485,-1.41 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.333 v 4.813 h 3.454 v -0.543 h -2.84 z m 4.941,-1.211 v 3.403 h 0.582 v -4.774 h -0.383 c -0.203,0.731 -0.336,0.832 -1.234,0.949 v 0.422 z m 4.051,2.246 v 1.157 h 0.578 v -1.157 h 0.695 v -0.523 h -0.695 v -3.094 h -0.426 l -2.129,3.004 v 0.613 z m 0,-0.523 h -1.465 l 1.465,-2.106 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath401)"
+               id="path837" />
+            <path
+               d="m 432.742,416.621 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.344 0.293,-0.265 0.418,-0.574 0.418,-1.015 0,-0.907 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.843 0,0.528 -0.352,0.844 -0.938,0.844 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 v -0.543 h -2.84 z m 4.941,-1.207 v 3.398 h 0.582 v -4.773 h -0.383 c -0.203,0.734 -0.336,0.832 -1.234,0.949 v 0.426 z m 5.231,2.824 h -2.461 c 0.058,-0.398 0.269,-0.648 0.843,-0.996 l 0.661,-0.371 c 0.652,-0.364 0.992,-0.852 0.992,-1.438 0,-0.398 -0.16,-0.765 -0.438,-1.023 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.031 h 0.578 c 0.02,-0.324 0.062,-0.516 0.141,-0.676 0.152,-0.289 0.453,-0.468 0.804,-0.468 0.528,0 0.926,0.382 0.926,0.898 0,0.383 -0.219,0.711 -0.637,0.949 l -0.605,0.36 c -0.977,0.558 -1.262,1.007 -1.313,2.05 h 3.114 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath402)"
+               id="path838" />
+            <path
+               d="m 432.742,409.18 h 1.512 c 0.375,0 0.672,-0.114 0.93,-0.344 0.293,-0.266 0.418,-0.574 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.813 h 0.613 z m 0,-0.543 v -1.688 h 1.281 c 0.586,0 0.938,0.317 0.938,0.844 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.813 h 3.454 v -0.543 h -2.84 z m 4.941,-1.207 v 3.399 h 0.582 v -4.774 h -0.383 c -0.203,0.735 -0.336,0.832 -1.234,0.953 v 0.422 z m 3.707,-1.375 c -0.437,0 -0.832,0.2 -1.078,0.524 -0.301,0.422 -0.453,1.054 -0.453,1.941 0,1.61 0.527,2.461 1.531,2.461 0.988,0 1.531,-0.851 1.531,-2.422 0,-0.926 -0.144,-1.547 -0.457,-1.98 -0.242,-0.332 -0.632,-0.524 -1.074,-0.524 z m 0,0.516 c 0.625,0 0.938,0.641 0.938,1.934 0,1.359 -0.305,1.992 -0.953,1.992 -0.614,0 -0.922,-0.657 -0.922,-1.973 0,-1.312 0.308,-1.953 0.937,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath403)"
+               id="path839" />
+            <path
+               d="m 432.742,394.297 h 1.512 c 0.375,0 0.672,-0.109 0.93,-0.34 0.293,-0.266 0.418,-0.574 0.418,-1.019 0,-0.903 -0.536,-1.411 -1.485,-1.411 h -1.988 v 4.813 h 0.613 z m 0,-0.539 v -1.692 h 1.281 c 0.586,0 0.938,0.317 0.938,0.848 0,0.527 -0.352,0.844 -0.938,0.844 z m 4.434,0.39 h 2.621 v -0.543 h -2.621 v -1.539 h 2.719 v -0.539 h -3.333 v 4.813 h 3.454 v -0.543 h -2.84 z m 6.664,-2.488 h -3.129 v 0.574 h 2.527 c -1.113,1.59 -1.57,2.567 -1.918,4.106 h 0.621 c 0.254,-1.5 0.844,-2.785 1.899,-4.192 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath404)"
+               id="path840" />
+            <path
+               d="m 432.742,386.859 h 1.512 c 0.375,0 0.672,-0.113 0.93,-0.343 0.293,-0.266 0.418,-0.575 0.418,-1.016 0,-0.906 -0.536,-1.414 -1.485,-1.414 h -1.988 v 4.812 h 0.613 z m 0,-0.543 v -1.687 h 1.281 c 0.586,0 0.938,0.316 0.938,0.844 0,0.527 -0.352,0.843 -0.938,0.843 z m 4.434,0.391 h 2.621 v -0.543 h -2.621 v -1.535 h 2.719 v -0.543 h -3.333 v 4.812 h 3.454 v -0.543 h -2.84 z m 5.812,-0.324 c 0.489,-0.297 0.641,-0.535 0.641,-0.985 0,-0.75 -0.574,-1.273 -1.406,-1.273 -0.825,0 -1.407,0.523 -1.407,1.27 0,0.453 0.153,0.683 0.637,0.988 -0.535,0.269 -0.801,0.66 -0.801,1.187 0,0.871 0.641,1.481 1.571,1.481 0.925,0 1.57,-0.61 1.57,-1.481 0,-0.527 -0.262,-0.918 -0.805,-1.187 z m -0.765,-1.742 c 0.496,0 0.812,0.297 0.812,0.773 0,0.449 -0.324,0.746 -0.812,0.746 -0.493,0 -0.813,-0.297 -0.813,-0.762 0,-0.46 0.32,-0.757 0.813,-0.757 z m 0,2.007 c 0.582,0 0.976,0.383 0.976,0.938 0,0.574 -0.387,0.949 -0.988,0.949 -0.566,0 -0.965,-0.39 -0.965,-0.945 0,-0.567 0.391,-0.942 0.977,-0.942 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath405)"
+               id="path841" />
+            <path
+               d="m 436.207,401.238 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.477 -1.512,1.477 -0.488,0 -0.929,-0.176 -1.215,-0.489 -0.316,-0.339 -0.507,-0.914 -0.507,-1.507 0,-1.184 0.671,-1.961 1.687,-1.961 0.734,0 1.262,0.375 1.395,0.996 h 0.625 c -0.172,-0.977 -0.911,-1.539 -2.012,-1.539 -0.586,0 -1.063,0.152 -1.438,0.461 -0.562,0.464 -0.871,1.211 -0.871,2.074 0,1.476 0.903,2.508 2.203,2.508 0.653,0 1.168,-0.242 1.645,-0.766 l 0.152,0.641 h 0.387 z m 4.746,-2.273 h -0.582 v 3.933 l -2.516,-3.933 h -0.664 v 4.812 h 0.579 v -3.898 l 2.488,3.898 h 0.695 z m 1.004,4.812 h 1.855 c 1.215,0 1.958,-0.91 1.958,-2.41 0,-1.488 -0.739,-2.402 -1.958,-2.402 h -1.855 z m 0.613,-0.539 v -3.73 h 1.137 c 0.949,0 1.449,0.64 1.449,1.867 0,1.223 -0.5,1.863 -1.449,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath406)"
+               id="path842" />
+            <path
+               d="m 402.234,317.734 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.219 -0.5,1.859 -1.45,1.859 z m 6.058,-1.972 c 0.489,-0.297 0.641,-0.535 0.641,-0.985 0,-0.75 -0.574,-1.273 -1.406,-1.273 -0.825,0 -1.403,0.523 -1.403,1.269 0,0.454 0.149,0.684 0.633,0.989 -0.535,0.269 -0.801,0.66 -0.801,1.187 0,0.871 0.641,1.481 1.571,1.481 0.925,0 1.574,-0.61 1.574,-1.481 0,-0.527 -0.266,-0.918 -0.809,-1.187 z m -0.765,-1.742 c 0.496,0 0.812,0.296 0.812,0.773 0,0.449 -0.324,0.746 -0.812,0.746 -0.493,0 -0.809,-0.297 -0.809,-0.762 0,-0.461 0.316,-0.757 0.809,-0.757 z m 0,2.007 c 0.582,0 0.98,0.383 0.98,0.938 0,0.574 -0.391,0.949 -0.992,0.949 -0.567,0 -0.965,-0.391 -0.965,-0.945 0,-0.567 0.391,-0.942 0.977,-0.942 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath407)"
+               id="path843" />
+            <path
+               d="m 402.355,310.293 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.488 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 3.949,-0.551 c 0.113,0.781 0.613,1.242 1.324,1.242 0.524,0 0.985,-0.25 1.262,-0.679 0.293,-0.469 0.422,-1.051 0.422,-1.914 0,-0.805 -0.117,-1.313 -0.395,-1.735 -0.258,-0.39 -0.668,-0.597 -1.183,-0.597 -0.891,0 -1.532,0.668 -1.532,1.593 0,0.875 0.598,1.496 1.442,1.496 0.441,0 0.773,-0.156 1.07,-0.519 -0.008,1.187 -0.379,1.84 -1.043,1.84 -0.41,0 -0.695,-0.262 -0.785,-0.727 z m 1.426,-3.172 c 0.539,0 0.949,0.453 0.949,1.067 0,0.59 -0.395,0.996 -0.969,0.996 -0.562,0 -0.91,-0.395 -0.91,-1.028 0,-0.601 0.387,-1.035 0.93,-1.035 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath408)"
+               id="path844" />
+            <path
+               d="m 402.355,302.852 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.407 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.54 v -3.73 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.308,-2.859 v 3.399 h 0.582 v -4.77 h -0.382 c -0.207,0.73 -0.34,0.832 -1.235,0.949 v 0.422 z m 3.703,-1.371 c -0.433,0 -0.828,0.195 -1.074,0.52 -0.304,0.421 -0.457,1.058 -0.457,1.941 0,1.609 0.531,2.461 1.531,2.461 0.993,0 1.532,-0.852 1.532,-2.422 0,-0.922 -0.145,-1.543 -0.453,-1.98 -0.247,-0.329 -0.633,-0.52 -1.079,-0.52 z m 0,0.516 c 0.629,0 0.938,0.636 0.938,1.933 0,1.36 -0.301,1.992 -0.949,1.992 -0.614,0 -0.922,-0.66 -0.922,-1.972 0,-1.317 0.308,-1.953 0.933,-1.953 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath409)"
+               id="path845" />
+            <path
+               d="m 402.355,295.414 h 1.856 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.871 0,1.218 -0.5,1.859 -1.45,1.859 z m 5.308,-2.859 v 3.402 h 0.582 v -4.773 h -0.382 c -0.207,0.73 -0.34,0.832 -1.235,0.949 v 0.422 z m 3.598,0 v 3.402 h 0.582 v -4.773 h -0.383 c -0.203,0.73 -0.336,0.832 -1.234,0.949 v 0.422 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath410)"
+               id="path846" />
+            <path
+               d="m 402.355,287.973 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.411 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.727 h 1.136 c 0.95,0 1.45,0.637 1.45,1.867 0,1.219 -0.5,1.86 -1.45,1.86 z m 5.308,-2.856 v 3.399 h 0.582 v -4.774 h -0.382 c -0.207,0.735 -0.34,0.832 -1.235,0.949 v 0.426 z m 5.231,2.824 h -2.461 c 0.058,-0.398 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.399 -0.156,-0.766 -0.434,-1.024 -0.277,-0.25 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.039,0.211 -1.293,0.621 -0.168,0.25 -0.238,0.547 -0.254,1.032 h 0.582 c 0.02,-0.325 0.059,-0.516 0.137,-0.676 0.152,-0.289 0.457,-0.469 0.808,-0.469 0.528,0 0.922,0.383 0.922,0.898 0,0.383 -0.218,0.715 -0.633,0.95 l -0.605,0.359 c -0.98,0.559 -1.262,1.008 -1.316,2.051 h 3.117 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath411)"
+               id="path847" />
+            <path
+               d="m 402.355,280.531 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.859 -1.45,1.859 z m 5.308,-2.855 v 3.398 h 0.582 v -4.773 h -0.382 c -0.207,0.734 -0.34,0.832 -1.235,0.953 v 0.422 z m 3.348,1.199 h 0.316 c 0.637,0 0.973,0.297 0.973,0.871 0,0.602 -0.363,0.965 -0.965,0.965 -0.64,0 -0.949,-0.324 -0.988,-1.023 h -0.582 c 0.027,0.382 0.094,0.632 0.203,0.843 0.246,0.465 0.699,0.696 1.34,0.696 0.965,0 1.586,-0.582 1.586,-1.485 0,-0.609 -0.231,-0.937 -0.793,-1.137 0.437,-0.179 0.652,-0.507 0.652,-0.988 0,-0.82 -0.535,-1.316 -1.426,-1.316 -0.941,0 -1.445,0.531 -1.464,1.539 h 0.582 c 0.007,-0.289 0.031,-0.453 0.105,-0.602 0.133,-0.269 0.422,-0.425 0.785,-0.425 0.516,0 0.824,0.308 0.824,0.824 0,0.336 -0.117,0.539 -0.375,0.652 -0.16,0.066 -0.371,0.094 -0.773,0.098 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath412)"
+               id="path848" />
+            <path
+               d="m 406.445,270.551 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.859 -0.633,1.48 -1.511,1.48 -0.489,0 -0.93,-0.18 -1.215,-0.488 -0.317,-0.344 -0.508,-0.918 -0.508,-1.512 0,-1.183 0.672,-1.961 1.687,-1.961 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.168,-0.976 -0.91,-1.539 -2.012,-1.539 -0.586,0 -1.062,0.153 -1.437,0.465 -0.563,0.461 -0.871,1.207 -0.871,2.07 0,1.481 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.242 1.644,-0.765 l 0.153,0.64 h 0.386 z m 4.746,-2.27 h -0.582 v 3.934 l -2.515,-3.934 h -0.664 v 4.809 h 0.578 v -3.899 l 2.488,3.899 h 0.695 z m 1.004,4.809 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.493 -0.742,-2.403 -1.961,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath413)"
+               id="path849" />
+            <path
+               d="m 404.895,264.086 0.496,1.445 h 0.687 l -1.691,-4.812 h -0.793 l -1.715,4.812 h 0.652 l 0.508,-1.445 z m -0.172,-0.516 h -1.532 l 0.793,-2.191 z m 4.07,1.961 1.672,-4.812 h -0.656 l -1.332,4.074 -1.415,-4.074 h -0.66 l 1.731,4.812 z m 2.32,0 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.949,0 1.449,0.64 1.449,1.867 0,1.219 -0.5,1.859 -1.449,1.859 z m 4.187,0.543 h 1.856 c 1.214,0 1.96,-0.91 1.96,-2.41 0,-1.492 -0.738,-2.402 -1.96,-2.402 h -1.856 z m 0.613,-0.543 v -3.726 h 1.137 c 0.949,0 1.453,0.64 1.453,1.867 0,1.219 -0.504,1.859 -1.453,1.859 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath414)"
+               id="path850" />
+            <path
+               d="m 402.355,258.09 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.489 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.308,-2.86 v 3.399 h 0.582 v -4.77 h -0.382 c -0.207,0.731 -0.34,0.828 -1.235,0.95 v 0.421 z m 4.047,2.243 v 1.156 h 0.582 v -1.156 h 0.692 v -0.52 h -0.692 v -3.094 h -0.429 l -2.125,3 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath415)"
+               id="path851" />
+            <path
+               d="m 402.355,250.648 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.308,-2.859 v 3.398 h 0.582 v -4.769 h -0.382 c -0.207,0.73 -0.34,0.832 -1.235,0.949 v 0.422 z m 5.032,-1.281 h -2.414 l -0.352,2.551 h 0.535 c 0.27,-0.325 0.496,-0.438 0.863,-0.438 0.629,0 1.02,0.43 1.02,1.121 0,0.676 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.254 -0.958,-0.785 h -0.582 c 0.079,0.383 0.145,0.57 0.286,0.742 0.261,0.356 0.738,0.559 1.265,0.559 0.946,0 1.606,-0.684 1.606,-1.676 0,-0.922 -0.617,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.286 l 0.187,-1.309 h 1.946 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath416)"
+               id="path852" />
+            <path
+               d="m 402.355,381.094 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 5.414,-4.231 c -0.438,0 -0.832,0.199 -1.074,0.52 -0.305,0.422 -0.457,1.058 -0.457,1.941 0,1.61 0.527,2.461 1.531,2.461 0.988,0 1.531,-0.851 1.531,-2.422 0,-0.922 -0.144,-1.543 -0.457,-1.98 -0.242,-0.328 -0.633,-0.52 -1.074,-0.52 z m 0,0.516 c 0.625,0 0.937,0.64 0.937,1.933 0,1.36 -0.304,1.993 -0.949,1.993 -0.617,0 -0.926,-0.661 -0.926,-1.973 0,-1.313 0.309,-1.953 0.938,-1.953 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath417)"
+               id="path853" />
+            <path
+               d="m 402.355,373.656 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.871 0,1.219 -0.5,1.859 -1.45,1.859 z m 5.308,-2.855 v 3.398 h 0.582 v -4.773 h -0.382 c -0.207,0.734 -0.34,0.832 -1.235,0.949 v 0.426 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath418)"
+               id="path854" />
+            <path
+               d="m 402.355,366.094 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.489 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 6.937,-0.035 h -2.461 c 0.059,-0.395 0.27,-0.645 0.844,-0.997 l 0.66,-0.371 c 0.656,-0.363 0.992,-0.851 0.992,-1.437 0,-0.395 -0.16,-0.766 -0.437,-1.024 -0.277,-0.25 -0.621,-0.367 -1.063,-0.367 -0.593,0 -1.035,0.211 -1.293,0.617 -0.164,0.254 -0.238,0.551 -0.25,1.032 h 0.579 c 0.023,-0.325 0.062,-0.516 0.14,-0.672 0.153,-0.293 0.457,-0.469 0.805,-0.469 0.527,0 0.926,0.383 0.926,0.895 0,0.382 -0.219,0.714 -0.637,0.953 l -0.606,0.355 c -0.976,0.563 -1.261,1.012 -1.312,2.051 h 3.113 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath419)"
+               id="path855" />
+            <path
+               d="m 402.355,358.652 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.961 -0.964,0.961 -0.637,0 -0.95,-0.32 -0.989,-1.019 h -0.582 c 0.028,0.382 0.094,0.632 0.207,0.843 0.243,0.461 0.7,0.692 1.34,0.692 0.961,0 1.582,-0.578 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.793,-1.136 0.438,-0.176 0.657,-0.508 0.657,-0.989 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.105,-0.598 0.133,-0.273 0.426,-0.429 0.786,-0.429 0.515,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.77,0.102 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath420)"
+               id="path856" />
+            <path
+               d="m 402.355,351.215 h 1.856 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.871 0,1.219 -0.5,1.86 -1.45,1.86 z m 5.758,-0.613 v 1.156 h 0.578 v -1.156 H 410 v -0.524 h -0.695 v -3.094 h -0.426 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.465 l 1.465,-2.105 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath421)"
+               id="path857" />
+            <path
+               d="m 402.355,343.773 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.219 -0.5,1.859 -1.45,1.859 z m 6.742,-4.136 h -2.418 l -0.348,2.547 h 0.532 c 0.273,-0.325 0.496,-0.434 0.867,-0.434 0.625,0 1.015,0.426 1.015,1.121 0,0.672 -0.39,1.082 -1.023,1.082 -0.508,0 -0.816,-0.258 -0.957,-0.785 h -0.582 c 0.082,0.383 0.148,0.566 0.285,0.738 0.266,0.356 0.738,0.563 1.266,0.563 0.945,0 1.605,-0.688 1.605,-1.676 0,-0.926 -0.613,-1.559 -1.512,-1.559 -0.328,0 -0.593,0.086 -0.863,0.282 l 0.184,-1.305 h 1.949 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath422)"
+               id="path858" />
+            <path
+               d="m 402.355,336.332 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 6.886,-2.992 c -0.113,-0.778 -0.613,-1.242 -1.328,-1.242 -0.515,0 -0.976,0.253 -1.254,0.679 -0.296,0.469 -0.421,1.051 -0.421,1.918 0,0.805 0.113,1.313 0.394,1.735 0.254,0.39 0.66,0.593 1.176,0.593 0.89,0 1.531,-0.668 1.531,-1.597 0,-0.879 -0.594,-1.5 -1.433,-1.5 -0.461,0 -0.825,0.172 -1.075,0.523 0.008,-1.18 0.375,-1.836 1.043,-1.836 0.41,0 0.692,0.266 0.785,0.727 z m -1.406,1.101 c 0.559,0 0.91,0.399 0.91,1.032 0,0.601 -0.394,1.035 -0.929,1.035 -0.543,0 -0.953,-0.453 -0.953,-1.063 0,-0.594 0.398,-1.004 0.972,-1.004 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath423)"
+               id="path859" />
+            <path
+               d="m 402.355,328.891 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.407 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z M 410,324.211 h -3.129 v 0.574 h 2.527 c -1.113,1.594 -1.57,2.57 -1.921,4.106 h 0.621 c 0.257,-1.496 0.847,-2.786 1.902,-4.192 z"
+               style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath424)"
+               id="path860" />
+            <path
+               d="m 402.355,448.418 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.727 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.218 -0.5,1.859 -1.45,1.859 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.601 -0.363,0.965 -0.964,0.965 -0.637,0 -0.95,-0.325 -0.989,-1.024 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.844 0.243,0.465 0.7,0.695 1.34,0.695 0.961,0 1.582,-0.582 1.582,-1.484 0,-0.609 -0.23,-0.938 -0.793,-1.137 0.438,-0.179 0.657,-0.508 0.657,-0.992 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.539 h 0.578 c 0.008,-0.289 0.035,-0.457 0.105,-0.602 0.133,-0.27 0.426,-0.43 0.786,-0.43 0.515,0 0.828,0.313 0.828,0.828 0,0.336 -0.121,0.54 -0.379,0.653 -0.156,0.066 -0.367,0.09 -0.77,0.097 z m 5.282,-2.481 h -2.414 l -0.352,2.547 h 0.535 c 0.27,-0.324 0.496,-0.433 0.863,-0.433 0.629,0 1.02,0.425 1.02,1.121 0,0.672 -0.391,1.082 -1.023,1.082 -0.508,0 -0.821,-0.258 -0.958,-0.785 h -0.582 c 0.079,0.382 0.145,0.566 0.286,0.738 0.261,0.355 0.738,0.562 1.265,0.562 0.946,0 1.606,-0.687 1.606,-1.675 0,-0.926 -0.617,-1.559 -1.512,-1.559 -0.332,0 -0.594,0.086 -0.867,0.281 l 0.187,-1.305 h 1.946 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath425)"
+               id="path861" />
+            <path
+               d="m 402.355,440.977 h 1.856 c 1.211,0 1.957,-0.911 1.957,-2.411 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 5.058,-1.661 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.965 -0.964,0.965 -0.637,0 -0.95,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.848 0.243,0.46 0.7,0.691 1.34,0.691 0.961,0 1.582,-0.582 1.582,-1.484 0,-0.61 -0.23,-0.938 -0.793,-1.137 0.438,-0.176 0.657,-0.508 0.657,-0.988 0,-0.821 -0.536,-1.317 -1.426,-1.317 -0.946,0 -1.446,0.531 -1.465,1.539 h 0.578 c 0.008,-0.289 0.035,-0.453 0.105,-0.601 0.133,-0.27 0.426,-0.426 0.786,-0.426 0.515,0 0.828,0.308 0.828,0.824 0,0.336 -0.121,0.539 -0.379,0.652 -0.156,0.067 -0.367,0.094 -0.77,0.098 z m 5.426,-1.332 c -0.109,-0.777 -0.613,-1.242 -1.324,-1.242 -0.516,0 -0.977,0.254 -1.254,0.68 -0.297,0.469 -0.426,1.051 -0.426,1.914 0,0.808 0.113,1.316 0.399,1.738 0.25,0.391 0.66,0.594 1.175,0.594 0.891,0 1.532,-0.668 1.532,-1.598 0,-0.879 -0.594,-1.5 -1.434,-1.5 -0.461,0 -0.824,0.172 -1.074,0.524 0.004,-1.18 0.375,-1.836 1.043,-1.836 0.406,0 0.691,0.265 0.785,0.726 z m -1.406,1.102 c 0.562,0 0.914,0.398 0.914,1.031 0,0.602 -0.399,1.035 -0.934,1.035 -0.539,0 -0.949,-0.453 -0.949,-1.062 0,-0.594 0.395,-1.004 0.969,-1.004 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath426)"
+               id="path862" />
+            <path
+               d="m 402.355,433.535 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.406 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.64 1.45,1.867 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.598 -0.363,0.961 -0.964,0.961 -0.637,0 -0.95,-0.32 -0.989,-1.024 h -0.582 c 0.028,0.383 0.094,0.637 0.207,0.848 0.243,0.461 0.7,0.692 1.34,0.692 0.961,0 1.582,-0.583 1.582,-1.485 0,-0.605 -0.23,-0.937 -0.793,-1.137 0.438,-0.175 0.657,-0.507 0.657,-0.988 0,-0.82 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.535 h 0.578 c 0.008,-0.289 0.035,-0.453 0.105,-0.598 0.133,-0.273 0.426,-0.43 0.786,-0.43 0.515,0 0.828,0.309 0.828,0.825 0,0.336 -0.121,0.543 -0.379,0.652 -0.156,0.066 -0.367,0.094 -0.77,0.102 z m 5.571,-2.485 h -3.125 v 0.575 H 413 c -1.117,1.593 -1.57,2.57 -1.922,4.105 h 0.621 c 0.258,-1.496 0.844,-2.785 1.899,-4.191 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath427)"
+               id="path863" />
+            <path
+               d="m 402.355,426.098 h 1.856 c 1.211,0 1.957,-0.914 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.864 -1.45,1.864 z m 5.058,-1.657 h 0.317 c 0.633,0 0.968,0.297 0.968,0.872 0,0.601 -0.363,0.964 -0.964,0.964 -0.637,0 -0.95,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.383 0.094,0.633 0.207,0.844 0.243,0.461 0.7,0.691 1.34,0.691 0.961,0 1.582,-0.578 1.582,-1.484 0,-0.606 -0.23,-0.938 -0.793,-1.133 0.438,-0.18 0.657,-0.512 0.657,-0.992 0,-0.817 -0.536,-1.313 -1.426,-1.313 -0.946,0 -1.446,0.528 -1.465,1.539 h 0.578 c 0.008,-0.293 0.035,-0.457 0.105,-0.601 0.133,-0.27 0.426,-0.43 0.786,-0.43 0.515,0 0.828,0.309 0.828,0.824 0,0.336 -0.121,0.543 -0.379,0.653 -0.156,0.066 -0.367,0.093 -0.77,0.101 z m 4.719,-0.316 c 0.492,-0.297 0.641,-0.535 0.641,-0.984 0,-0.754 -0.575,-1.274 -1.407,-1.274 -0.824,0 -1.402,0.52 -1.402,1.266 0,0.457 0.149,0.687 0.633,0.992 -0.535,0.27 -0.801,0.66 -0.801,1.188 0,0.871 0.641,1.476 1.57,1.476 0.926,0 1.575,-0.605 1.575,-1.476 0,-0.528 -0.266,-0.918 -0.809,-1.188 z m -0.766,-1.742 c 0.497,0 0.813,0.297 0.813,0.769 0,0.45 -0.32,0.746 -0.813,0.746 -0.492,0 -0.808,-0.296 -0.808,-0.757 0,-0.461 0.316,-0.758 0.808,-0.758 z m 0,2.004 c 0.582,0 0.981,0.383 0.981,0.937 0,0.574 -0.391,0.953 -0.992,0.953 -0.567,0 -0.965,-0.39 -0.965,-0.945 0,-0.566 0.391,-0.945 0.976,-0.945 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath428)"
+               id="path864" />
+            <path
+               d="m 402.355,418.656 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.492 -0.738,-2.402 -1.957,-2.402 h -1.856 z m 0.614,-0.543 v -3.726 h 1.136 c 0.95,0 1.45,0.636 1.45,1.867 0,1.219 -0.5,1.859 -1.45,1.859 z m 5.058,-1.656 h 0.317 c 0.633,0 0.968,0.297 0.968,0.871 0,0.602 -0.363,0.965 -0.964,0.965 -0.637,0 -0.95,-0.324 -0.989,-1.023 h -0.582 c 0.028,0.382 0.094,0.632 0.207,0.843 0.243,0.461 0.7,0.696 1.34,0.696 0.961,0 1.582,-0.582 1.582,-1.489 0,-0.605 -0.23,-0.933 -0.793,-1.132 0.438,-0.18 0.657,-0.508 0.657,-0.993 0,-0.816 -0.536,-1.312 -1.426,-1.312 -0.946,0 -1.446,0.527 -1.465,1.539 h 0.578 c 0.008,-0.293 0.035,-0.457 0.105,-0.602 0.133,-0.269 0.426,-0.429 0.786,-0.429 0.515,0 0.828,0.312 0.828,0.824 0,0.34 -0.121,0.543 -0.379,0.656 -0.156,0.067 -0.367,0.09 -0.77,0.098 z m 2.489,1.109 c 0.113,0.778 0.617,1.243 1.328,1.243 0.519,0 0.984,-0.254 1.261,-0.68 0.29,-0.469 0.422,-1.051 0.422,-1.914 0,-0.809 -0.121,-1.317 -0.398,-1.738 -0.254,-0.387 -0.664,-0.594 -1.18,-0.594 -0.89,0 -1.531,0.668 -1.531,1.59 0,0.879 0.594,1.5 1.437,1.5 0.446,0 0.774,-0.161 1.071,-0.524 -0.008,1.192 -0.375,1.844 -1.043,1.844 -0.41,0 -0.692,-0.266 -0.785,-0.727 z m 1.425,-3.175 c 0.543,0 0.954,0.457 0.954,1.07 0,0.586 -0.399,0.996 -0.973,0.996 -0.559,0 -0.91,-0.395 -0.91,-1.027 0,-0.602 0.39,-1.039 0.929,-1.039 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath429)"
+               id="path865" />
+            <path
+               d="m 402.355,411.215 h 1.856 c 1.211,0 1.957,-0.91 1.957,-2.41 0,-1.493 -0.738,-2.403 -1.957,-2.403 h -1.856 z m 0.614,-0.543 v -3.727 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.86 -1.45,1.86 z m 5.758,-0.613 v 1.156 h 0.578 v -1.156 H 410 v -0.52 h -0.695 v -3.098 h -0.426 l -2.125,3.004 v 0.614 z m 0,-0.52 h -1.465 l 1.465,-2.105 z m 3.253,-3.098 c -0.433,0 -0.828,0.2 -1.074,0.524 -0.304,0.422 -0.457,1.055 -0.457,1.941 0,1.61 0.531,2.461 1.531,2.461 0.993,0 1.532,-0.851 1.532,-2.422 0,-0.925 -0.145,-1.547 -0.453,-1.98 -0.247,-0.332 -0.633,-0.524 -1.079,-0.524 z m 0,0.516 c 0.629,0 0.938,0.641 0.938,1.934 0,1.359 -0.301,1.996 -0.949,1.996 -0.614,0 -0.922,-0.66 -0.922,-1.977 0,-1.312 0.308,-1.953 0.933,-1.953 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath430)"
+               id="path866" />
+            <path
+               d="m 406.445,401.234 h -2.004 v 0.539 h 1.465 v 0.133 c 0,0.86 -0.633,1.481 -1.511,1.481 -0.489,0 -0.93,-0.18 -1.215,-0.492 -0.317,-0.34 -0.508,-0.915 -0.508,-1.508 0,-1.184 0.672,-1.961 1.687,-1.961 0.735,0 1.262,0.375 1.395,0.996 h 0.625 c -0.168,-0.977 -0.91,-1.539 -2.012,-1.539 -0.586,0 -1.062,0.152 -1.437,0.461 -0.563,0.465 -0.871,1.211 -0.871,2.074 0,1.477 0.902,2.508 2.203,2.508 0.652,0 1.168,-0.242 1.644,-0.766 l 0.153,0.641 h 0.386 z m 4.746,-2.273 h -0.582 v 3.934 l -2.515,-3.934 h -0.664 v 4.812 h 0.578 v -3.898 l 2.488,3.898 h 0.695 z m 1.004,4.812 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.41 0,-1.488 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.539 v -3.73 h 1.136 c 0.95,0 1.45,0.641 1.45,1.867 0,1.223 -0.5,1.863 -1.45,1.863 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath431)"
+               id="path867" />
+            <path
+               d="m 402.234,396.332 h 1.856 c 1.215,0 1.961,-0.91 1.961,-2.406 0,-1.492 -0.742,-2.403 -1.961,-2.403 h -1.856 z m 0.614,-0.539 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.868 0,1.222 -0.5,1.863 -1.45,1.863 z m 5.757,-0.613 v 1.152 h 0.583 v -1.152 h 0.691 v -0.524 h -0.691 v -3.094 h -0.43 l -2.125,3.004 v 0.614 z m 0,-0.524 h -1.464 l 1.464,-2.105 z m 3.153,-1.722 v 3.398 h 0.578 v -4.77 h -0.383 c -0.203,0.731 -0.336,0.833 -1.234,0.95 v 0.422 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath432)"
+               id="path868" />
+            <path
+               d="m 402.234,388.895 h 1.856 c 1.215,0 1.961,-0.915 1.961,-2.411 0,-1.492 -0.742,-2.402 -1.961,-2.402 h -1.856 z m 0.614,-0.543 v -3.731 h 1.136 c 0.95,0 1.45,0.641 1.45,1.871 0,1.219 -0.5,1.86 -1.45,1.86 z m 5.757,-0.614 v 1.157 h 0.583 v -1.157 h 0.691 v -0.523 h -0.691 v -3.094 h -0.43 l -2.125,3.004 v 0.613 z m 0,-0.523 h -1.464 l 1.464,-2.106 z m 4.782,1.105 h -2.461 c 0.058,-0.398 0.269,-0.648 0.844,-0.996 l 0.66,-0.371 c 0.652,-0.363 0.988,-0.851 0.988,-1.437 0,-0.399 -0.156,-0.766 -0.434,-1.024 -0.277,-0.254 -0.621,-0.371 -1.062,-0.371 -0.594,0 -1.035,0.211 -1.293,0.621 -0.164,0.25 -0.238,0.547 -0.25,1.028 h 0.578 c 0.02,-0.321 0.059,-0.512 0.141,-0.672 0.152,-0.289 0.453,-0.469 0.804,-0.469 0.528,0 0.922,0.383 0.922,0.898 0,0.383 -0.215,0.711 -0.633,0.95 l -0.605,0.355 c -0.977,0.563 -1.262,1.012 -1.313,2.055 h 3.114 z"
+               style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               transform="scale(1.3333333)"
+               clip-path="url(#clipPath433)"
+               id="path869" />
+          </g>
+        </g>
+      </g>
+      <path
+         d="m 67.5,102.48 h 460.441 v 0.48 H 67.5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath437)"
+         id="path871" />
+      <path
+         d="m 527.461,102.719 h 0.48 v 507.242 h -0.48 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath438)"
+         id="path872" />
+      <path
+         d="M 67.262,609.48 H 527.7 v 0.48 H 67.262 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath439)"
+         id="path873" />
+      <path
+         d="m 67.262,102.48 h 0.477 v 507.238 h -0.477 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath440)"
+         id="path874" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
### Contribution description

This PR adds pinout diagrams from MB1312 for RIOT supported boards:
- nucleo-l4r5zi,
- nucleo-l496zg.

### Testing procedure

Generate doc and see if everything is fine.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l4r5zi.html
xdg-open doc/doxygen/html/group__boards__nucleo-l496zg.html
```

### Issues/PRs references

None