### PR TITLE
cpu/saml21: avoid the use of bitfield in register call

### DIFF
--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -54,9 +54,9 @@ void pm_set(unsigned mode)
     }
 
     /* write sleep configuration */
-    PM->SLEEPCFG.bit.SLEEPMODE = _mode;
+    PM->SLEEPCFG.reg = _mode;
     /* make sure value has been set */
-    while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
+    while ((PM->SLEEPCFG.reg & PM_SLEEPCFG_SLEEPMODE_Msk) != _mode) {}
 
     sam0_cortexm_sleep(deep);
 }


### PR DESCRIPTION
### Contribution description

This PR replaces all calls of `foo->bar.bit.xyz = ABCD` to `foo->bar.reg &= ABCD` for instance.
This should not have much impact on the code.
This is the first step of a long serie in order to support new Microchip vendor files.

I plan to do the same to all SAM0-based CPU and boards. 

### Testing procedure
A careful review.
CI should catch most of the failure but feel free to run some tests on hardware.

### Issues/PRs references
see #20457 
