### PR TITLE
dist/tools/tapsetup: make compatible with doas

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -13,6 +13,10 @@ BRIDGE_ROUTES=""
 DEFAULT_PREFIX_LEN=128
 UPLINK=""
 
+# doas uses the DOAS_USER variable instead of SUDO_USER. For compatibility with
+# both, we populate SUDO_USER with DOAS_USER, if SUDO_USER is not existing.
+: "${SUDO_USER:="$DOAS_USER"}"
+
 usage() {
     echo "usage: ${PROGRAM} [arguments]" >&2
     echo "" >&2


### PR DESCRIPTION
### Contribution description

`doas` doesn't set `SUDO_USER`, but `DOAS_USER`. This populates `SUDO_USER` with `DOAS_USER` if it is empty, so the script works with both doas and sudo.

### Testing procedure

`sudo dist/tools/tapsetup/tapsetup` should still work on systems where `sudo` is not the [`doas-sudo-shim`](https://github.com/jirutka/doas-sudo-shim) but in fact the real legacy sudo tool.

### Issues/PRs references

None