### PR TITLE
ci: disable esp32-wroom-32 tests

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -25,7 +25,7 @@ stm32f429i-disc1"
 # this configures boards that are available via pifleet
 case "${CI_MURDOCK_PROJECT}" in
     riot)
-        : ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 samr21-xpro"}
+        : ${TEST_BOARDS_AVAILABLE:="samr21-xpro"}
         ;;
     riot-staging)
         : ${TEST_BOARDS_AVAILABLE:=""}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The last working `esp32-wroom-32` is not responsive. Let's disable them to un-break nightlies.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
