### PR TITLE
Makefile.include: place compile_commands.json by rule target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -718,11 +718,12 @@ endif # BUILDOSXNATIVE
 COMPILE_COMMANDS_PATH ?= $(if $(findstring $(RIOTBASE),$(APPDIR)),$(RIOTBASE)/compile_commands.json, $(APPDIR)/compile_commands.json)
 COMPILE_COMMANDS_FLAGS ?= --clangd
 .PHONY: compile-commands
-compile-commands: $(BUILDDEPS)
+compile-commands: $(COMPILE_COMMANDS_PATH)
+%/compile_commands.json: $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" APPLICATION_BLOBS="$(BLOBS)" \
 	  "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk compile-commands
 	$(Q)$(RIOTTOOLS)/compile_commands/compile_commands.py $(COMPILE_COMMANDS_FLAGS) $(BINDIR) \
-	  > $(COMPILE_COMMANDS_PATH)
+	  > $@
 
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container


### PR DESCRIPTION
### Contribution description

place `compile_commands.json` by rule target

### Testing procedure

`make compile-commands` should result in the current `compile_commands.json` placement:
 RIOTBASE if the app if in a subdirectory of that  or APPDIR if not
 
`make <somewhere>/compile_commands.json` should place it `<somewhere>`

as i often have separate app an riot but they share a common path its usually 

`make ../../compile_commands.json` or something like that 

or 

`<somewhere>$ make -D <whatever to build> ./compile_commands.json`

### Issues/PRs references

#19869