### PR TITLE
sys/random: fix SHAxPRNG init_by_array

### DIFF
--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -78,7 +78,7 @@ void random_init(uint32_t s);
  * slight change for C++, 2004/2/26
  *
  * @param init_key array of keys (seeds) to initialize the PRNG
- * @param key_length number of lements in init_key
+ * @param key_length number of elements in init_key
  */
 void random_init_by_array(uint32_t init_key[], int key_length);
 

--- a/sys/random/shaxprng.c
+++ b/sys/random/shaxprng.c
@@ -149,7 +149,7 @@ void _random_bytes(uint8_t *bytes, size_t size)
 void random_init_by_array(uint32_t init_key[], int key_length)
 {
     _shax_init(&ctx);
-    _shax_update(&ctx, init_key, key_length);
+    _shax_update(&ctx, init_key, key_length * sizeof(uint32_t));
     _shax_final(&ctx, digestdata);
 
     /* copy SHA digestdata to PRNG state */
@@ -161,7 +161,7 @@ void random_init_by_array(uint32_t init_key[], int key_length)
 
 void random_init(uint32_t seed)
 {
-    random_init_by_array((uint32_t *)&seed, sizeof(seed));
+    random_init_by_array((uint32_t *)&seed, 1);
 }
 
 uint32_t random_uint32(void)

--- a/tests/sys/prng_sha1prng/main.c
+++ b/tests/sys/prng_sha1prng/main.c
@@ -57,7 +57,7 @@ static void test_prng_sha1prng_java_u32(void)
     /* seed the generator with 8 bytes similar to the java reference
      * implementation
      */
-    random_init_by_array(seed, sizeof(seed));
+    random_init_by_array(seed, ARRAY_SIZE(seed));
 
     /* request random samples */
     for (unsigned i = 0; i < ARRAY_SIZE(seq_seed1); i++) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes the SHAxPRNG `random_init_by_array` interface. Parameter `key_length` should contain the number of elements, not the number of bytes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make -C tests/sys/prng_sha1prng/ all test`

`make -C tests/sys/prng_sha256prng/ all test`


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
