### PR TITLE
cpu/esp*: fix compilation with GCC 14.1.0

### DIFF
--- a/pkg/esp32_sdk/patches/0034-components-efuse-fix-incorrect-forward-declaration.patch
+++ b/pkg/esp32_sdk/patches/0034-components-efuse-fix-incorrect-forward-declaration.patch
@@ -1,0 +1,25 @@
+From 2957d710a61c11d20e9f9fea10a8fb5d7ef94e15 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Tue, 13 Feb 2024 13:31:10 +0100
+Subject: [PATCH] components/efuse: fix incorrect forward declaration
+
+---
+ components/efuse/private_include/esp_efuse_utility.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/efuse/private_include/esp_efuse_utility.h b/components/efuse/private_include/esp_efuse_utility.h
+index 3016d55d..630a3a32 100644
+--- a/components/efuse/private_include/esp_efuse_utility.h
++++ b/components/efuse/private_include/esp_efuse_utility.h
+@@ -119,7 +119,7 @@ uint32_t esp_efuse_utility_read_reg(esp_efuse_block_t blk, unsigned int num_reg)
+ /**
+  * @brief Writing efuse register with checking of repeated programming of programmed bits.
+  */
+-esp_err_t esp_efuse_utility_write_reg(unsigned int num_reg, esp_efuse_block_t efuse_block, uint32_t reg_to_write);
++esp_err_t esp_efuse_utility_write_reg(esp_efuse_block_t efuse_block, unsigned int num_reg, uint32_t reg_to_write);
+ 
+ /* @brief Reset efuse write registers
+  *
+-- 
+2.43.1
+

--- a/pkg/esp32_sdk/patches/0035-components-wpa_supplicant-add-missing-include.patch
+++ b/pkg/esp32_sdk/patches/0035-components-wpa_supplicant-add-missing-include.patch
@@ -1,0 +1,24 @@
+From a9d2537cb0a3f0967588b625f44a32dcdef2af52 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 1 Jun 2024 09:31:50 +0200
+Subject: [PATCH] components/wpa_supplicant: add missing include
+
+---
+ components/wpa_supplicant/port/include/os.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/wpa_supplicant/port/include/os.h b/components/wpa_supplicant/port/include/os.h
+index d00bd6f6..5a67c4e3 100644
+--- a/components/wpa_supplicant/port/include/os.h
++++ b/components/wpa_supplicant/port/include/os.h
+@@ -18,6 +18,7 @@
+ #include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <time.h>
+ #include "esp_err.h"
+ #include "supplicant_opt.h"
+ 
+-- 
+2.45.1
+

--- a/pkg/esp32_sdk/patches/0036-components-fix-calls-to-calloc.patch
+++ b/pkg/esp32_sdk/patches/0036-components-fix-calls-to-calloc.patch
@@ -1,0 +1,105 @@
+From 3062316cd717b4df3099f40587e37c133195e9ca Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 1 Jun 2024 09:59:40 +0200
+Subject: [PATCH] components: fix calls to calloc()
+
+The first argument is the number of array members, the second the
+member size, not the other way round.
+
+This fixes compilation with `-Werror=calloc-transposed-args`
+---
+ components/app_update/esp_ota_ops.c              |  2 +-
+ components/esp_hw_support/port/esp32/esp_himem.c | 10 +++++-----
+ components/esp_phy/src/phy_init.c                |  2 +-
+ components/spi_flash/partition.c                 |  4 ++--
+ 4 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/components/app_update/esp_ota_ops.c b/components/app_update/esp_ota_ops.c
+index c81dff19..664dd7b3 100644
+--- a/components/app_update/esp_ota_ops.c
++++ b/components/app_update/esp_ota_ops.c
+@@ -156,7 +156,7 @@ esp_err_t esp_ota_begin(const esp_partition_t *partition, size_t image_size, esp
+         }
+     }
+ 
+-    new_entry = (ota_ops_entry_t *) calloc(sizeof(ota_ops_entry_t), 1);
++    new_entry = (ota_ops_entry_t *) calloc(1, sizeof(ota_ops_entry_t));
+     if (new_entry == NULL) {
+         return ESP_ERR_NO_MEM;
+     }
+diff --git a/components/esp_hw_support/port/esp32/esp_himem.c b/components/esp_hw_support/port/esp32/esp_himem.c
+index 061b2661..45d07f6e 100644
+--- a/components/esp_hw_support/port/esp32/esp_himem.c
++++ b/components/esp_hw_support/port/esp32/esp_himem.c
+@@ -144,8 +144,8 @@ void __attribute__((constructor)) esp_himem_init(void)
+     int paddr_end = maxram;
+     s_ramblockcnt = ((paddr_end - paddr_start) / CACHE_BLOCKSIZE);
+     //Allocate data structures
+-    s_ram_descriptor = calloc(sizeof(ramblock_t), s_ramblockcnt);
+-    s_range_descriptor = calloc(sizeof(rangeblock_t), SPIRAM_BANKSWITCH_RESERVE);
++    s_ram_descriptor = calloc(s_ramblockcnt, sizeof(ramblock_t));
++    s_range_descriptor = calloc(SPIRAM_BANKSWITCH_RESERVE, sizeof(rangeblock_t));
+     if (s_ram_descriptor == NULL || s_range_descriptor == NULL) {
+         ESP_EARLY_LOGE(TAG, "Cannot allocate memory for meta info. Not initializing!");
+         free(s_ram_descriptor);
+@@ -188,11 +188,11 @@ esp_err_t esp_himem_alloc(size_t size, esp_himem_handle_t *handle_out)
+         return ESP_ERR_INVALID_SIZE;
+     }
+     int blocks = size / CACHE_BLOCKSIZE;
+-    esp_himem_ramdata_t *r = calloc(sizeof(esp_himem_ramdata_t), 1);
++    esp_himem_ramdata_t *r = calloc(1, sizeof(esp_himem_ramdata_t));
+     if (!r) {
+         goto nomem;
+     }
+-    r->block = calloc(sizeof(uint16_t), blocks);
++    r->block = calloc(blocks, sizeof(uint16_t));
+     if (!r->block) {
+         goto nomem;
+     }
+@@ -239,7 +239,7 @@ esp_err_t esp_himem_alloc_map_range(size_t size, esp_himem_rangehandle_t *handle
+     ESP_RETURN_ON_FALSE(s_ram_descriptor != NULL, ESP_ERR_INVALID_STATE, TAG, "Himem not available!");
+     ESP_RETURN_ON_FALSE(size % CACHE_BLOCKSIZE == 0, ESP_ERR_INVALID_SIZE, TAG, "requested size not aligned to blocksize");
+     int blocks = size / CACHE_BLOCKSIZE;
+-    esp_himem_rangedata_t *r = calloc(sizeof(esp_himem_rangedata_t), 1);
++    esp_himem_rangedata_t *r = calloc(1, sizeof(esp_himem_rangedata_t));
+     if (!r) {
+         return ESP_ERR_NO_MEM;
+     }
+diff --git a/components/esp_phy/src/phy_init.c b/components/esp_phy/src/phy_init.c
+index 5be0fa91..71ece1bb 100644
+--- a/components/esp_phy/src/phy_init.c
++++ b/components/esp_phy/src/phy_init.c
+@@ -625,7 +625,7 @@ void esp_phy_load_cal_and_init(void)
+     phy_eco_version_sel(esp_efuse_get_chip_ver());
+ #endif
+     esp_phy_calibration_data_t* cal_data =
+-            (esp_phy_calibration_data_t*) calloc(sizeof(esp_phy_calibration_data_t), 1);
++            (esp_phy_calibration_data_t*) calloc(1, sizeof(esp_phy_calibration_data_t));
+     if (cal_data == NULL) {
+         ESP_LOGE(TAG, "failed to allocate memory for RF calibration data");
+         abort();
+diff --git a/components/spi_flash/partition.c b/components/spi_flash/partition.c
+index d1140ad0..dcd00324 100644
+--- a/components/spi_flash/partition.c
++++ b/components/spi_flash/partition.c
+@@ -211,7 +211,7 @@ static esp_err_t load_partitions(void)
+ #endif
+ 
+         // allocate new linked list item and populate it with data from partition table
+-        partition_list_item_t* item = (partition_list_item_t*) calloc(sizeof(partition_list_item_t), 1);
++        partition_list_item_t* item = (partition_list_item_t*) calloc(1, sizeof(partition_list_item_t));
+         if (item == NULL) {
+             err = ESP_ERR_NO_MEM;
+             break;
+@@ -326,7 +326,7 @@ esp_err_t esp_partition_register_external(esp_flash_t* flash_chip, size_t offset
+         return err;
+     }
+ 
+-    partition_list_item_t* item = (partition_list_item_t*) calloc(sizeof(partition_list_item_t), 1);
++    partition_list_item_t* item = (partition_list_item_t*) calloc(1, sizeof(partition_list_item_t));
+     if (item == NULL) {
+         return ESP_ERR_NO_MEM;
+     }
+-- 
+2.45.1
+


### PR DESCRIPTION
### Contribution description

This fixes a number of issues when compiling with modern versions of GCC and more recent versions of Espressif's newlib fork. There are still issues during initialization with the newer versions of Espressif's newlib fork. Fixing those is left as follow up; this PR should be trivial to review.

### Testing procedure

I think that this should not change binaries, other than `calloc` called with correct arguments in the SDK.

### Issues/PRs references

None