### PR TITLE
dist/tools/buildsystem_sanity_check: make shellcheck happy

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -16,42 +16,29 @@
 : "${RIOTBASE:="$(cd "$(dirname "$0")/../../../" || exit; pwd)"}"
 
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
+# not running shellcheck with -x in the CI --> disable SC1091
+# shellcheck disable=SC1091
 . "${RIOTTOOLS}"/ci/github_annotate.sh
 
 SCRIPT_PATH=dist/tools/buildsystem_sanity_check/check.sh
 
-
-tab_indent() {
-    # Ident using 'bashism' to to the tab compatible with 'bsd-sed'
-    sed 's/^/\'$'\t/'
-}
-
-prepend() {
-    # 'i' needs 'i\{newline}' and a newline after for 'bsd-sed'
-    sed '1i\
-'"$1"'
-'
-}
-
 error_with_message() {
-    while read INPUT; do
+    while read -r INPUT; do
+        MESSAGE="${1}"
         if github_annotate_is_on; then
-            MESSAGE="${1}"
             FILE=$(echo "${INPUT}" | cut -d: -f1)
             LINE=$(echo "${INPUT}" | cut -d: -f2)
             MATCH=$(echo "${INPUT}" | cut -d: -f3)
-            if [[ $var =~ ^[0-9]+$ ]] || [  -z "$MATCH" ]; then
+            if [[ ! $LINE =~ ^[0-9]+$ ]] || [  -z "$MATCH" ]; then
                 # line is not provided in grep pattern
                 LINE=0
             fi
             github_annotate_error "$FILE" "$LINE" "$MESSAGE"
         fi
-        # We need to generate non GitHub annotations for this script to fail.
-        # Also, the pure annotate output is not very helpful on its own ;-)
-        echo "${INPUT}" | tab_indent | prepend "${1}:"
+
+        printf "%s:\n\t%s\n\n" "${MESSAGE}" "${INPUT}"
     done
 }
-
 
 # Modules should not check the content of FEATURES_PROVIDED/_REQUIRED/OPTIONAL
 # Handling specific behaviors/dependencies should by checking the content of:
@@ -172,7 +159,7 @@ check_not_exporting_variables() {
     # Only run if there are patterns, otherwise it matches everything
     if [ ${#patterns[@]} -ne 0 ]; then
         git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
-            | error_with_message 'Variables must only be exported in `makefiles/vars.inc.mk`'
+            | error_with_message "Variables must only be exported in \`makefiles/vars.inc.mk\`"
     fi
 }
 
@@ -201,9 +188,7 @@ check_board_do_not_include_cpu_features_dep() {
     local patterns=()
     local pathspec=()
 
-    # shellcheck disable=SC2016
-    # Single quotes are used to not expand expressions
-    patterns+=(-e 'include $(RIOTCPU)/.*/Makefile\..*')
+    patterns+=(-e "include \$(RIOTCPU)/.*/Makefile\..*")
 
     pathspec+=('boards/')
 
@@ -287,14 +272,14 @@ check_files_in_boards_not_reference_board_var() {
     local patterns=()
     local pathspec=()
 
-    patterns+=(-e '/$(BOARD)/')
+    patterns+=(-e "/\$(BOARD)/")
 
     pathspec+=('boards/')
     # boards/common/nrf52 uses a hack to resolve dependencies early
     pathspec+=(':!boards/common/nrf52/Makefile.include')
 
     git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
-        | error_with_message 'Code in boards/ should not use $(BOARDS) to reference files since this breaks external BOARDS changing BOARDSDIR"'
+        | error_with_message "Code in boards/ should not use \$(BOARDS) to reference files since this breaks external BOARDS changing BOARDSDIR"
 }
 
 check_no_pseudomodules_in_makefile_dep() {
@@ -413,15 +398,10 @@ all_checks() {
     check_tests_application_path
 }
 
-main() {
-    all_checks | prepend 'Invalid build system patterns found by '"${0}:" | error_on_input >&2
-    exit $?
-}
-
-
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     github_annotate_setup
-    main
+    all_checks | error_on_input
+    result="$?"
     github_annotate_teardown
-    github_annotate_report_last_run
+    exit "${result}"
 fi


### PR DESCRIPTION
### Contribution description

The build system sanity check test script currently does not pass shellcheck, preventing PRs improving it from getting merged.

This commit fixes the issues pointed out by shellcheck and should not have any functional changes, except for the github annotation teardown now being reached after the call to `main`.

### Testing procedure

The test script should work as before.

### Issues/PRs references

None