### PR TITLE
cpu/native: fix compilation with GCC 14.1

### DIFF
--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -480,7 +480,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
         const size_t argc_max = 32;
         size_t cmdlen = 0;
         char *cmdline = malloc(bufsize);
-        argv = calloc(sizeof(char *), argc_max);
+        argv = calloc(argc_max, sizeof(char *));
         argc = 0;
         envp = NULL;
         expect(cmdline != NULL);


### PR DESCRIPTION
### Contribution description

The first argument to `calloc()` is the number of members, the second the member size. This fixes an instance where the arguments where switched.

### Testing procedure

Compilation with GCC 14.1 for `native` should work again.

### Issues/PRs references

Offending code merged in https://github.com/RIOT-OS/RIOT/pull/18942