### PR TITLE
measure_stack_free_internal(): don't try to align end of stack

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -178,9 +178,6 @@ uintptr_t measure_stack_free_internal(const char *stack, size_t size)
     uintptr_t *stackp = (uintptr_t *)(uintptr_t)stack;
     uintptr_t end = (uintptr_t)stack + size;
 
-    /* better be safe than sorry: align end of stack just in case */
-    end &= (sizeof(uintptr_t) - 1);
-
     /* assume that the stack grows "downwards" */
     while (((uintptr_t)stackp < end) && (*stackp == (uintptr_t)stackp)) {
         stackp++;

--- a/tests/core/thread_stack_alignment/tests/01-run.py
+++ b/tests/core/thread_stack_alignment/tests/01-run.py
@@ -24,6 +24,7 @@ def testfunc(child):
         child.expect(r"(\{[^\n\r]*\})\r\n")
         stats = json.loads(child.match.group(1))["threads"][0]
         assert stats["name"] == "test"
+        assert stats["stack_used"] < stats["stack_size"]
         if stack_used_max < stats["stack_used"]:
             stack_used_max = stats["stack_used"]
         if stack_used_min > stats["stack_used"]:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The end-of stack alignment causes the function to fail measuring the stack size.

### Testing procedure

A new test was added to verify the stack measurement. 

`ps` also shows the stack usage again

```
2024-06-04 16:56:22,086 # ps
2024-06-04 16:56:22,089 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2024-06-04 16:56:22,091 # 	  - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) |  0x8085880 |  0x8085880
2024-06-04 16:56:22,093 # 	  1 | idle                 | pending  Q |  15 |   8192 (  436) ( 7756) |  0x8080180 |  0x8081fdc 
2024-06-04 16:56:22,095 # 	  2 | main                 | running  Q |   7 |  12288 ( 2792) ( 9496) |  0x8082180 |  0x8084fdc 
2024-06-04 16:56:22,097 # 	  3 | pktdump              | bl rx    _ |   6 |  12224 (  896) (11328) |  0x808da40 |  0x809085c 
2024-06-04 16:56:22,098 # 	  4 | ipv6                 | bl rx    _ |   4 |   8128 ( 1464) ( 6664) |  0x8087c80 |  0x8089a9c 
2024-06-04 16:56:22,100 # 	  5 | udp                  | bl rx    _ |   5 |   4032 (  960) ( 3072) |  0x8092ce0 |  0x8093afc 
2024-06-04 16:56:22,102 # 	  6 | gnrc_netdev_tap      | bl anyfl _ |   2 |   8064 ( 2216) ( 5848) |  0x808a220 |  0x808bffc 
2024-06-04 16:56:22,105 # 	  7 | RPL                  | bl rx    _ |   5 |   8192 (  896) ( 7296) |  0x8090c80 |  0x8092adc 
2024-06-04 16:56:22,106 # 	    | SUM                  |            |     |  69312 ( 9660) (59652)
```


### Issues/PRs references

fixes the issue from https://github.com/RIOT-OS/RIOT/pull/18942#issuecomment-2147695238
