### PR TITLE
cpu/thread.c: fix thread_measure_stack_free()

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -179,7 +179,7 @@ uintptr_t measure_stack_free_internal(const char *stack, size_t size)
     uintptr_t end = (uintptr_t)stack + size;
 
     /* better be safe than sorry: align end of stack just in case */
-    end &= (sizeof(uintptr_t) - 1);
+    end &= ~(sizeof(uintptr_t) - 1);
 
     /* assume that the stack grows "downwards" */
     while (((uintptr_t)stackp < end) && (*stackp == (uintptr_t)stackp)) {

--- a/tests/core/thread_stack_alignment/tests/01-run.py
+++ b/tests/core/thread_stack_alignment/tests/01-run.py
@@ -24,6 +24,7 @@ def testfunc(child):
         child.expect(r"(\{[^\n\r]*\})\r\n")
         stats = json.loads(child.match.group(1))["threads"][0]
         assert stats["name"] == "test"
+        assert stats["stack_used"] < stats["stack_size"]
         if stack_used_max < stats["stack_used"]:
             stack_used_max = stats["stack_used"]
         if stack_used_min > stats["stack_used"]:


### PR DESCRIPTION
### Contribution description

This fixes a typo in computation in thread_measure_stack_free, which messed up the computation.

### Testing procedure

Output of `ps` should look sane again.

### Issues/PRs references

Regression of 