### PR TITLE
core/thread: "fix" valgrind erros in thread_measure_stack_free() 

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -35,6 +35,15 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#if defined(HAVE_VALGRIND_H)
+#  include <valgrind.h>
+#elif defined(HAVE_VALGRIND_VALGRIND_H)
+#  include <valgrind/valgrind.h>
+#else
+#  define   VALGRIND_DISABLE_ERROR_REPORTING    (void)0
+#  define   VALGRIND_ENABLE_ERROR_REPORTING     (void)0
+#endif
+
 thread_status_t thread_getstatus(kernel_pid_t pid)
 {
     thread_t *thread = thread_get(pid);
@@ -178,10 +187,22 @@ uintptr_t measure_stack_free_internal(const char *stack, size_t size)
     uintptr_t *stackp = (uintptr_t *)(uintptr_t)stack;
     uintptr_t end = (uintptr_t)stack + size;
 
+    /* HACK: This will affect native/native64 only.
+     *
+     * The dark magic used here is frowned upon by valgrind. E.g. valgrind may
+     * deduce that a specific value was at some point allocated on the stack,
+     * but has gone out of scope. When that value is now read again to
+     * estimate stack usage, it does look a lot like someone passed a pointer
+     * to a stack allocated value, and that pointer is referenced after that
+     * value has gone out of scope. */
+    VALGRIND_DISABLE_ERROR_REPORTING;
+
     /* assume that the stack grows "downwards" */
     while (((uintptr_t)stackp < end) && (*stackp == (uintptr_t)stackp)) {
         stackp++;
     }
+
+    VALGRIND_ENABLE_ERROR_REPORTING;
 
     uintptr_t space_free = (uintptr_t)stackp - (uintptr_t)stack;
 


### PR DESCRIPTION
### Contribution description

The dark magic used used in thread_measure_stack_free() is frowned upon by valgrind. E.g. valgrind may deduce (by monitoring the stack pointer) that a specific value was at some point allocated on the stack, but has gone out of scope. When that value is now read again to estimate stack
usage, it does look a lot like someone passed a pointer to a stack allocated value, and that pointer is referenced after that value has gone out of scope.

This is "fixed" by temporarily disabling valgrind error reporting while iterating over the stack.


### Testing procedure

#### Testing that this indeed "fixes" the warning

With this PR:

```
 make BOARD=native64 all-valgrind -C tests/core/thread_basic && valgrind tests/core/thread_basic/bin/native64/tests_thread_basic.elf
[...]
==2283== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

With https://github.com/RIOT-OS/RIOT/pull/20723 (with current `master` the function is broken and doesn't iterate over the stack - hence, no errors):

```
[...]
==2742== ERROR SUMMARY: 34 errors from 1 contexts (suppressed: 0 from 0)
```

(That one context is `thread_measure_stack_free()`.)

#### Confirming that suppression is reasonable

Double check my reasoning why, in this specific instance, the access of stack memory is not an error.

### Issues/PRs references

Depends upon and includes:

- [ ] https://github.com/RIOT-OS/RIOT/pull/20723