### PR TITLE
tree wide: compilation fixes for `native64` on musl systems

### DIFF
--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -30,6 +30,7 @@ extern "C" {
 #ifdef CPU_NATIVE
 #include <stdio.h>
 
+#if __GLIBC__
 /*
  * Required to use some C++11 headers with g++ on the native board.
  */
@@ -39,6 +40,7 @@ typedef unsigned long int __cpu_mask;
 typedef struct {
     __cpu_mask __bits[__CPU_SETSIZE / __NCPUBITS];
 } cpu_set_t;
+#endif
 
 /**
  * @brief In all test the function has never been called, hence it is empty for now.

--- a/cpu/native/include/c11_atomics_compat_cpu.hpp
+++ b/cpu/native/include/c11_atomics_compat_cpu.hpp
@@ -63,24 +63,24 @@
 #define ATOMIC_UINT_FAST8_T_SIZE                        (1U)
 #define ATOMIC_UINT_FAST8_T_SAME_SIZED_TYPE             uint8_t
 #endif
-#ifdef __x86_64__
-#define ATOMIC_INT_FAST16_T_SIZE                        (8U)
-#define ATOMIC_INT_FAST16_T_SAME_SIZED_TYPE             uint64_t
-#define ATOMIC_UINT_FAST16_T_SIZE                       (8U)
-#define ATOMIC_UINT_FAST16_T_SAME_SIZED_TYPE            uint64_t
-#define ATOMIC_INT_FAST32_T_SIZE                        (8U)
-#define ATOMIC_INT_FAST32_T_SAME_SIZED_TYPE             uint64_t
-#define ATOMIC_UINT_FAST32_T_SIZE                       (8U)
-#define ATOMIC_UINT_FAST32_T_SAME_SIZED_TYPE            uint64_t
+#if defined(__x86_64__) && defined(__GLIBC__)
+#  define ATOMIC_INT_FAST16_T_SIZE                     (8U)
+#  define ATOMIC_INT_FAST16_T_SAME_SIZED_TYPE          uint64_t
+#  define ATOMIC_UINT_FAST16_T_SIZE                    (8U)
+#  define ATOMIC_UINT_FAST16_T_SAME_SIZED_TYPE         uint64_t
+#  define ATOMIC_INT_FAST32_T_SIZE                     (8U)
+#  define ATOMIC_INT_FAST32_T_SAME_SIZED_TYPE          uint64_t
+#  define ATOMIC_UINT_FAST32_T_SIZE                    (8U)
+#  define ATOMIC_UINT_FAST32_T_SAME_SIZED_TYPE         uint64_t
 #else
-#define ATOMIC_INT_FAST16_T_SIZE                        (4U)
-#define ATOMIC_INT_FAST16_T_SAME_SIZED_TYPE             uint32_t
-#define ATOMIC_UINT_FAST16_T_SIZE                       (4U)
-#define ATOMIC_UINT_FAST16_T_SAME_SIZED_TYPE            uint32_t
-#define ATOMIC_INT_FAST32_T_SIZE                        (4U)
-#define ATOMIC_INT_FAST32_T_SAME_SIZED_TYPE             uint32_t
-#define ATOMIC_UINT_FAST32_T_SIZE                       (4U)
-#define ATOMIC_UINT_FAST32_T_SAME_SIZED_TYPE            uint32_t
+#  define ATOMIC_INT_FAST16_T_SIZE                     (4U)
+#  define ATOMIC_INT_FAST16_T_SAME_SIZED_TYPE          uint32_t
+#  define ATOMIC_UINT_FAST16_T_SIZE                    (4U)
+#  define ATOMIC_UINT_FAST16_T_SAME_SIZED_TYPE         uint32_t
+#  define ATOMIC_INT_FAST32_T_SIZE                     (4U)
+#  define ATOMIC_INT_FAST32_T_SAME_SIZED_TYPE          uint32_t
+#  define ATOMIC_UINT_FAST32_T_SIZE                    (4U)
+#  define ATOMIC_UINT_FAST32_T_SAME_SIZED_TYPE         uint32_t
 #endif
 #define ATOMIC_INT_FAST64_T_SIZE                        (8U)
 #define ATOMIC_INT_FAST64_T_SAME_SIZED_TYPE             uint64_t

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -37,7 +37,7 @@
 #define min(a, b) ((a) > (b) ? (b) : (a))
 #endif
 
-#define PAGE_SIZE   (dev->params.page_size)
+#define AT25_PAGE_SIZE   (dev->params.page_size)
 #define ADDR_LEN    (AT25XXX_PARAM_ADDR_LEN)
 #define ADDR_MSK    ((1UL << ADDR_LEN) - 1)
 
@@ -85,12 +85,12 @@ static inline int _wait_until_eeprom_ready(const at25xxx_t *dev)
 
 static int _at25xxx_write_page(const at25xxx_t *dev, uint32_t page, uint32_t offset, const void *data, size_t len)
 {
-    assert(offset < PAGE_SIZE);
+    assert(offset < AT25_PAGE_SIZE);
 
     /* write no more than to the end of the current page to prevent wrap-around */
-    size_t remaining = PAGE_SIZE - offset;
+    size_t remaining = AT25_PAGE_SIZE - offset;
     len = min(len, remaining);
-    uint32_t pos = _pos(CMD_WRITE, page * PAGE_SIZE + offset);
+    uint32_t pos = _pos(CMD_WRITE, page * AT25_PAGE_SIZE + offset);
 
     /* wait for previous write to finish - may take up to 5 ms */
     int res = _wait_until_eeprom_ready(dev);
@@ -136,8 +136,8 @@ int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t l
     }
 
     /* page size is always a power of two */
-    const uint32_t page_shift = bitarithm_msb(PAGE_SIZE);
-    const uint32_t page_mask = PAGE_SIZE - 1;
+    const uint32_t page_shift = bitarithm_msb(AT25_PAGE_SIZE);
+    const uint32_t page_mask = AT25_PAGE_SIZE - 1;
 
     uint32_t page   = pos >> page_shift;
     uint32_t offset = pos & page_mask;
@@ -214,8 +214,8 @@ int at25xxx_set(const at25xxx_t *dev, uint32_t pos, uint8_t val, size_t len)
     memset(data, val, sizeof(data));
 
     /* page size is always a power of two */
-    const uint32_t page_shift = bitarithm_msb(PAGE_SIZE);
-    const uint32_t page_mask = PAGE_SIZE - 1;
+    const uint32_t page_shift = bitarithm_msb(AT25_PAGE_SIZE);
+    const uint32_t page_mask = AT25_PAGE_SIZE - 1;
 
     uint32_t page   = pos >> page_shift;
     uint32_t offset = pos & page_mask;

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     im880b \
     lobaro-lorabox \
+    maple-mini \
     microbit \
     nrf51dongle \
     nrf6310 \
@@ -35,7 +36,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l412kb \
-    maple-mini \
     olimexino-stm32 \
     opencm904 \
     samd10-xmini \

--- a/sys/posix/include/sys/select.h
+++ b/sys/posix/include/sys/select.h
@@ -29,6 +29,13 @@
 #ifndef SYS_SELECT_H
 #define SYS_SELECT_H
 
+#ifdef CPU_NATIVE
+/* On native, system headers may depend on system's <sys/select.h>. Hence,
+ * include the real sys/select.h here. */
+__extension__
+#include_next <sys/select.h>
+#endif
+
 #include <string.h>
 /* prevent cyclic dependency with newlib/picolibc's `sys/types.h` */
 #if (defined(MODULE_NEWLIB) || defined(MODULE_PICOLIBC)) && !defined(CPU_ESP8266)
@@ -42,6 +49,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief   @ref core_thread_flags for POSIX select
+ */
+#define POSIX_SELECT_THREAD_FLAG    (1U << 3)
+
+#ifndef CPU_NATIVE
 
 /**
  * @addtogroup  config_posix
@@ -58,11 +72,6 @@ extern "C" {
 #define CONFIG_POSIX_FD_SET_SIZE    (16)
 #endif
 /** @} */
-
-/**
- * @brief   @ref core_thread_flags for POSIX select
- */
-#define POSIX_SELECT_THREAD_FLAG    (1U << 3)
 
 /* ESP's newlib has this already defined in `sys/types.h` */
 #if !defined(CPU_ESP8266)
@@ -163,6 +172,8 @@ static inline void FD_ZERO(fd_set *fdsetp)
  */
 int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *errorfds,
            struct timeval *timeout);
+
+#endif /* CPU_NATIVE */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

With this, almost all apps build for `native64` on musl.

### Testing procedure

I abused the insufficient memory tool using

```
./dist/tools/insufficient_memory/update_insufficient_memory_board.sh --no-docker native64
```

on Alpine. I guess `./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` would have been the more canonical tool, but the insufficient memory tool has so fancy colors in the output :)

With this, almost all apps build fine.

### Issues/PRs references

None