### PR TITLE
drivers/ws281x: Fix SAUL writes

### DIFF
--- a/drivers/ws281x/ws281x_saul.c
+++ b/drivers/ws281x/ws281x_saul.c
@@ -33,7 +33,6 @@ static int set_rgb_led(const void *dev, const phydat_t *res)
         .b = res->val[2]
     };
     for (unsigned idx = 0; idx < ws281x->params.numof; idx++) {
-        puts("Setting LED");
         ws281x_set(ws281x, idx, color);
     }
     ws281x_write(ws281x);

--- a/drivers/ws281x/ws281x_saul.c
+++ b/drivers/ws281x/ws281x_saul.c
@@ -36,7 +36,7 @@ static int set_rgb_led(const void *dev, const phydat_t *res)
         ws281x_set(ws281x, idx, color);
     }
     ws281x_write(ws281x);
-    return 1;
+    return 3;
 }
 
 const saul_driver_t ws281x_saul_driver = {


### PR DESCRIPTION
### Contribution description

This fixes a few nits around the ws281x driver, which impact the Rust tutorial experience (because the Rust wrappers do check more strictly for whether the SAUL API is upheld)

### Testing procedure

* `$ make -C examples/saul BOARD=feather-nrf52840-sense all flash term`
* patch sys/shell/cmds/saul_reg.c to report dim in line 149, confirm with [saul_reg_write docs](https://doc.riot-os.org/group__sys__saul__reg.html#ga6ca94b517c5c162187b656fcee03ae26) that it needs to return the number of elements written (which the CLI generally ignores, as do many users)
* `> saul write 15 1 0 0`
