### PR TITLE
boards/b-l072z-lrwan1: add missing adc feature

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l072cz
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -14,6 +14,7 @@
  * @brief       Peripheral MCU configuration for the ST B-L072Z-LRWAN1 board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Thibault Tisserand <gzordrai@gmail.com>
  */
 
 #ifndef PERIPH_CONF_H
@@ -145,6 +146,21 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 2), 2 },
+    { GPIO_PIN(PORT_A, 3), 3 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_A, 5), 5 }
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description
This pull request adds the missing ADC feature for the b-l072z-lrwan1 board.

### Testing procedure
I took a boards/b-l072z-lrwan1 board and added USEMODULE += periph_adc to the Makefile.
I connected an analog sensor to the A0, A2, and PA5 ports (ADCIN_0, ADCIN_4 and ADCIN_5) and checked if I could read values correctly.
 ADCIN_2 and ADCIN_3 are used by ST-Link, but I can still read values from them.

```c
#include <stdio.h>
#include <string.h>

#include "periph/adc.h"

#define NUM_LINES 5

int main(void)
{
    adc_t lines[NUM_LINES];
    int sample;

    for (int i = 0; i < NUM_LINES; i++)
        lines[i] = ADC_LINE(i);

    while (1)
    {
        for (int i = 0; i < NUM_LINES; i++) {
            sample = adc_sample(lines[i], ADC_RES_12BIT);

            printf("Sample (%i): %i\n", i, sample);
        }
    }

    return 0;
}
```

Output:
```
2024-06-06 02:02:08,260 # Sample (0): 2374
2024-06-06 02:02:08,261 # Sample (1): 4095
2024-06-06 02:02:08,263 # Sample (2): 4047
2024-06-06 02:02:08,264 # Sample (3): 372
2024-06-06 02:02:08,266 # Sample (4): 45
2024-06-06 02:02:08,267 # Sample (0): 2373
2024-06-06 02:02:08,269 # Sample (1): 4095
2024-06-06 02:02:08,270 # Sample (2): 4050
2024-06-06 02:02:08,272 # Sample (3): 370
2024-06-06 02:02:08,273 # Sample (4): 48
```
### Issues/PRs references
Resolve [20732](https://github.com/RIOT-OS/RIOT/issues/20732).
