### PR TITLE
sys/xtimer: add IWYU pragmas

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -55,9 +55,9 @@
 #include "rmutex.h"
 
 #if IS_USED(MODULE_ZTIMER64_XTIMER_COMPAT)
-#include "ztimer64/xtimer_compat.h"
+#include "ztimer64/xtimer_compat.h" /* IWYU pragma: export */
 #elif IS_USED(MODULE_ZTIMER_XTIMER_COMPAT)
-#include "ztimer/xtimer_compat.h"
+#include "ztimer/xtimer_compat.h" /* IWYU pragma: export */
 #else
 #include "board.h"
 #if !IS_USED(MODULE_XTIMER_ON_ZTIMER)


### PR DESCRIPTION
### Contribution description

This include what you use (IWYU) pragmas so that clang based linters (such as clangd) treat the use of `xtimer_...()` functions as a use of the `xtimer.h` header, even if the implementation of those functions come from a compatibility wrapper.

### Testing procedure

Open e.g. tests/net/gnrc_sock_ip/main.c in an LSP enabled editor (e.g. (neo)vim + ALE, vs codeium, ...) and a recent enough version of clangd, after you ran `make -C tests/net/gnrc_sock_ip compile-commands`. In master, it will complain that both `<assert.h>` and `"xtimer.h"` are unused includes (even though `xtimer_...()` functions are, in fact, used). In this PR, only the include of `<assert.h>` should be considered unused (which is correct).

### Issues/PRs references

None