### PR TITLE
Remove extraneous bitwise assignment operation on NRF5X_common gpio.c

### DIFF
--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -203,7 +203,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 #endif
                              (flank << GPIOTE_CONFIG_POLARITY_Pos));
     /* enable external interrupt */
-    NRF_GPIOTE->INTENSET |= (GPIOTE_INTENSET_IN0_Msk << _pin_index);
+    NRF_GPIOTE->INTENSET = (GPIOTE_INTENSET_IN0_Msk << _pin_index);
 
     return 0;
 }
@@ -213,7 +213,7 @@ void gpio_irq_enable(gpio_t pin)
     for (unsigned int i = 0; i < _gpiote_next_index; i++) {
         if (_exti_pins[i] == pin) {
             NRF_GPIOTE->CONFIG[i] |= GPIOTE_CONFIG_MODE_Event;
-            NRF_GPIOTE->INTENSET |= (GPIOTE_INTENSET_IN0_Msk << i);
+            NRF_GPIOTE->INTENSET = (GPIOTE_INTENSET_IN0_Msk << i);
             break;
         }
     }


### PR DESCRIPTION
### Contribution description

Removing an extraneous bitwise assignment operation for NRF5X_common gpio.c

### Testing procedure

I've been running this on my micro-bit v2 with this fix for a couple of days with no ill effects.  However, it is not expected that the changed the behaviour of the code at all.

On my code base, it saves a whole 16 bytes of code :-).

### Issues/PRs references

Fixes #20736
