### PR TITLE
cpu/native: Support native CPU on arm64 Linux

### DIFF
--- a/cpu/native/include/util/ucontext.h
+++ b/cpu/native/include/util/ucontext.h
@@ -43,7 +43,9 @@ static inline uintptr_t _context_get_fptr(ucontext_t *context) {
 # if defined(__FreeBSD__) /* FreeBSD */
     return (uintptr_t)((struct sigcontext *)context)->sc_eip;
 # elif defined(__linux__) /* Linux */
-#  if defined(__arm__)
+#  if defined(__arm64__) || defined(__aarch64__)
+    return (uintptr_t)((ucontext_t *)context)->uc_mcontext.pc;
+#  elif defined(__arm__)
     return (uintptr_t)((ucontext_t *)context)->uc_mcontext.arm_pc;
 #  elif defined(__x86_64__)
     return (uintptr_t)((ucontext_t *)context)->uc_mcontext.gregs[REG_RIP];
@@ -66,7 +68,9 @@ static inline void _context_set_fptr(ucontext_t *context, uintptr_t func) {
 # if defined(__FreeBSD__) /* FreeBSD */
     ((struct sigcontext *)context)->sc_eip = (unsigned int)func;
 # elif defined(__linux__) /* Linux */
-#  if defined(__arm__)
+#  if defined(__arm64__) || defined(__aarch64__)
+    ((ucontext_t *)context)->uc_mcontext.pc = func;
+#  elif defined(__arm__)
     ((ucontext_t *)context)->uc_mcontext.arm_lr = func;
     ((ucontext_t *)context)->uc_mcontext.arm_pc = func;
 #  elif defined(__x86_64__)
@@ -117,6 +121,11 @@ static inline void makecontext64(ucontext_t *context, void (*func)(void), void* 
 #   if defined(__linux__)
      context->uc_mcontext.gregs[REG_R14] = (greg_t)func;
      context->uc_mcontext.gregs[REG_R15] = (greg_t)arg;
+#   endif
+#  elif defined(__arm64__) || defined(__aarch64__)
+#   if defined(__linux__)
+     context->uc_mcontext.regs[27] = (greg_t)func;
+     context->uc_mcontext.regs[28] = (greg_t)arg;
 #   endif
 #  endif
 

--- a/cpu/native/native.S
+++ b/cpu/native/native.S
@@ -1,11 +1,25 @@
 /*
  * Copyright (C) 2013, 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  * Copyright (C) 2014 Thomas Eichinger <thomas.eichinger1@gmail.com>
+ * Copyright (C) 2025 carl-tud
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+/* arm64e/ARMv8.3 */
+#if defined(__ARM_FEATURE_PAC_DEFAULT) || defined(__ARM_FEATURE_PAUTH)
+# define NATIVE_HAS_PTRAUTH_RETURNS 1
+#elif defined(__has_feature)
+# if __has_feature(ptrauth_returns)
+#  define NATIVE_HAS_PTRAUTH_RETURNS 1
+# endif
+#endif
+
+#if !defined(NATIVE_HAS_PTRAUTH_RETURNS)
+#  define NATIVE_HAS_PTRAUTH_RETURNS 0
+#endif
 
 /**
  * @brief Generates platform-dependent symbol name
@@ -94,6 +108,125 @@ GLOBAL_SYMBOL _native_isr_leave
     ldmia     sp!, {r0-r12}
     ldmia     sp!, {pc}
 
+#elif defined(__arm64__) || defined(__aarch64__)
+
+.macro ARM64_RETURN_WITH_PTRAUTH
+# if NATIVE_HAS_PTRAUTH_RETURNS
+    /* arm64e/ARMv8.3 */
+    retab
+# else
+    ret
+# endif
+.endm
+
+GLOBAL_SYMBOL _native_sig_leave_tramp
+    sub      sp, sp, #240
+    /* Preserve general-purpose registers */
+    stp      x0, x1, [sp]
+    stp      x2, x3, [sp, #0x10]
+    stp      x4, x5, [sp, #0x20]
+    stp      x6, x7, [sp, #0x30]
+    stp      x8, x9, [sp, #0x40]
+    stp      x10, x11, [sp, #0x50]
+    stp      x12, x13, [sp, #0x60]
+    stp      x14, x15, [sp, #0x70]
+    stp      x16, x17, [sp, #0x80]
+    stp      x18, x19, [sp, #0x90]
+    stp      x20, x21, [sp, #0xA0]
+    stp      x22, x23, [sp, #0xB0]
+    stp      x24, x25, [sp, #0xC0]
+    stp      x26, x27, [sp, #0xD0]
+    stp      x28, x29, [sp, #0xE0]
+    /* Don't need to preserve x30 (= LR), we modify LR below */
+
+    /* call swapcontext(_native_current_context, _native_isr_context) */
+    LOADMEM  x0, SYMBOL(_native_current_context)
+    LOADMEM  x1, SYMBOL(_native_isr_context)
+    /* branch and link (set LR to @here0, branch to swapcontext) */
+    bl       SYMBOL(swapcontext)
+
+    /* @here0: */
+    /* reenable interrupts */
+    bl       SYMBOL(irq_enable)
+
+    /* _native_in_isr = 0
+     *
+     * _native_in_isr is an int, not a full word-width pointer.
+     * Must not write 64-bit value to &_native_in_isr as this would also overwrite whatever
+     * comes after _native_in_isr in memory.
+     *
+     * w0 (rather than x0) is the 32-bit version we need to use. */
+    mov      w0, #0x0
+    STOREMEM w0, x1, SYMBOL(_native_in_isr)
+
+    /* restore registers, jump to (saved) _native_user_fptr */
+    ldp      x0, x1, [sp]
+    ldp      x2, x3, [sp, #0x10]
+    ldp      x4, x5, [sp, #0x20]
+    ldp      x6, x7, [sp, #0x30]
+    ldp      x8, x9, [sp, #0x40]
+    ldp      x10, x11, [sp, #0x50]
+    ldp      x12, x13, [sp, #0x60]
+    ldp      x14, x15, [sp, #0x70]
+    ldp      x16, x18, [sp, #0x80]
+    ldp      x18, x19, [sp, #0x90]
+    ldp      x20, x21, [sp, #0xA0]
+    ldp      x22, x23, [sp, #0xB0]
+    ldp      x24, x25, [sp, #0xC0]
+    ldp      x26, x27, [sp, #0xD0]
+    ldp      x28, x29, [sp, #0xE0]
+    /* Don't need to restore x30 (= LR), we modify LR below */
+    add      sp, sp, #240
+
+    /* return to _native_user_fptr. See comments below. */
+    LOADMEM  lr, SYMBOL(_native_user_fptr)
+    ARM64_RETURN_WITH_PTRAUTH
+
+GLOBAL_SYMBOL _native_isr_leave
+    /* Save registers we use to reset _native_in_isr. */
+    sub      sp, sp, #16
+    stp      x0, x1, [sp]
+
+    /* _native_in_isr = 0
+     *
+     * _native_in_isr is an int, not a full word-width pointer.
+     * Must not write 64-bit value to &_native_in_isr as this would also overwrite whatever
+     * comes after _native_in_isr in memory.
+     *
+     * w0 (rather than x0) is the 32-bit version we need to use. */
+    mov      w0, #0x0
+    STOREMEM w0, x1, SYMBOL(_native_in_isr)
+
+    /* Restore registers used above. */
+    ldp      x0, x1, [sp]
+    add      sp, sp, #16
+
+    /* Return to _native_user_fptr.
+     * This is the return address of the call to getcontext in userspace. We captured that
+     * that before in the buffer where the user thread stack also lives (_native_user_context()).
+     *
+     * Modifying LR is fine as the context is applied with setcontext and we manipulate LR directly
+     * in util/ucontext.h. (With makecontext that would work properly due to _ctx_start).
+     */
+    LOADMEM  lr, SYMBOL(_native_user_fptr)
+
+    /* In _isr_switch_to_user, we set _native_user_fptr to the presigned value of the [return
+     * address in the call to getcontext (that was used to capture the machine state when
+     * switching to kernel space (ISR))]. That return address was stored in LR and has been
+     * signed by getcontext.
+     *
+     * ret/retab will read LR and set PC to that value.
+     * PC isn't mutable on arm64 (not a register) */
+    ARM64_RETURN_WITH_PTRAUTH
+
+GLOBAL_SYMBOL _start_task_func64
+    /* Use x27 and x28 as scratch registers. */
+    /* x19 and x20 are used by glibc and libplatform on arm64 */
+    /* This is the 64-bit function argument. RIOT threads can only receive one argument. */
+    mov     x0, x28
+    /* Branch there. */
+    br      x27
+
 #elif defined(__x86_64__)
 
 GLOBAL_SYMBOL _native_sig_leave_tramp
@@ -164,7 +297,7 @@ GLOBAL_SYMBOL _native_isr_leave
 
 GLOBAL_SYMBOL _start_task_func64
     /* Use r14 and r15 as scratch registers. */
-    /* r8, r9 / r12 are used by glibc / libplatform on arm64 */
+    /* r8, r9 / r12 are used by glibc / libplatform on x86_64 */
     /* This is the 64-bit function argument. RIOT threads can only receive one argument. */
     /* System V ABI says: first argument in RDI.
      * See: https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf

--- a/makefiles/arch/native.inc.mk
+++ b/makefiles/arch/native.inc.mk
@@ -32,12 +32,17 @@ ifeq (,$(filter -std=%, $(CFLAGS)))
   CFLAGS += -std=gnu11
 endif
 
+HOST_BIT := $(shell getconf LONG_BIT)
 ifeq ($(NATIVE_ARCH_BIT),64)
-  CFLAGS += -m64
-  LINKFLAGS += -m64
+  ifneq ($(HOST_BIT),64)
+    CFLAGS += -m64
+    LINKFLAGS += -m64
+  endif
 else ifeq ($(NATIVE_ARCH_BIT),32)
-  CFLAGS += -m32
-  LINKFLAGS += -m32
+  ifneq ($(HOST_BIT),32)
+    CFLAGS += -m32
+    LINKFLAGS += -m32
+  endif
 else
   $(error Unsupported native architecture)
 endif


### PR DESCRIPTION
**Update 10 April 2025**:
#21283 is merged.

**Update 10 March 2025**:
_This PR now builds upon #21283. The next PR will revive macOS support which this PR is the basis for._
_You may look at the first approach here: [`native64-arm-old`](/carl-tud/RIOT-Pull-Requests/tree/native64-arm-old)_

### Contribution Description.
This PR adds support for the `native64` board on arm64/aarch64[^1] Linux platforms (e.g., Raspberry Pi, Mac)

- ISR functionality has been extended to work on 64-bit ARMv8[^2]
- Since gcc cannot be compiled to support the `-m32` and `-m64` flags on ARM (?) (hence `gcc-multilib` is unavailable on ARM), `-mXX` flags are omitted when they would match `getconf LONG_BIT`

### Testing procedure (GNU/Linux)
Compile and run on an ARM 64-bit CPU on Linux.

[^1]: **Why?** E.g., with 64-bit ARM support, you can use the native board on Apple Silicon Macs in a Linux-based virtualized environment (i.e., multipass (or qemu directly), Docker, Virtualization.framework or Hypervisor.framework), without having to resort to emulating a 32-bit ARM or x86 CPU.

[^2]: For anyone else also wondering how the PC can be set on ARM 64-bit, v8, while preserving all general-purpose registers: You simply can’t. On ARMv8, `PC` cannot be written to anymore, and branch instructions (and friends) either require a static address (which isn't available to us (stored in `_native_saved_eip`) or a register containing the destination address. If you look at the glibc implementation of `setcontext` (which lets you set the instruction pointer) in glibc's `setcontext.S`, you'll notice `x16` is used as the register for the `br` instruction. This PR adopts the same technique. **Edit 10 March 2025**: You can set LR and `ret` there, so actually don't even need `x16`. This is also consistent with _setcontext.s in libplatform.