### PR TITLE
release-tests.yaml: remove (always failing) matrix notification

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -130,7 +130,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install lib32asan6
     - name: Run release tests
-      id: tests
       timeout-minutes: 350
       run: |
         RIOTBASE="$GITHUB_WORKSPACE/RIOT"
@@ -182,27 +181,6 @@ jobs:
         mkdir test-reports/
         junit2html ${REPORT_XML} ${REPORT_NAME}.html
         cp ${REPORT_XML} ${REPORT_NAME}.xml
-    - name: Generate result message
-      if: always()
-      id: generate_results
-      run: |
-        if [ "${{ steps.tests.conclusion }}" == "success" ]; then
-          nice_str="&#x2705; **PASSED**"
-        elif [ "${{ steps.tests.conclusion }}" == "failure" ]; then
-          nice_str="&#x274C; **FAILED**"
-        fi
-        echo "nice_str=${nice_str}" >> ${GITHUB_OUTPUT}
-    - name: Report to Matrix channel
-      if: ${{ always() && steps.generate_results.outputs.nice_str != '' }}
-      uses: s3krit/matrix-message-action@v0.0.3
-      with:
-        room_id: ${{ secrets.RIOT_CI_RELEASE_REPORT_CHANNEL }}
-        access_token: ${{ secrets.MATRIX_RIOT_CI_ACCESS_TOKEN }}
-        server: "matrix.org"
-        message: >
-          ${{ steps.generate_results.outputs.nice_str}}: Release tests
-          `[${{ join(matrix.*, ', ') }}]` on `${{ github.event_name }}`:
-          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     - uses: actions/upload-artifact@v2
       if: always()
       with:


### PR DESCRIPTION


### Contribution description

For some reason, enabling matrix notifications for release test results does not seem to work: Last example is [here](https://github.com/RIOT-OS/RIOT/actions/runs/9425685944/job/25967687520#step:16:3683).

As discussed with @miri64, this removes the matrix notifications until we find a working setup again.

### Testing procedure

Compare changes to reverted commits (below). Merge and wait for next scheduled release test.


### Issues/PRs references

This reverts commit aafb9abb8bc7f332f6b2e8cb7a17771c0cf8c621 and 7e6a46465d63f15eb7ca0d741deecdf98bd6c85e from #20424.
