### PR TITLE
sys/crypto: fix OCB mode

### DIFF
--- a/sys/crypto/modes/ocb.c
+++ b/sys/crypto/modes/ocb.c
@@ -179,7 +179,7 @@ static void init_ocb(const cipher_t *cipher, uint8_t tag_len,
     memcpy(nonce_padded + 16 - nonce_len, nonce, nonce_len);
 
     /* bottom = str2num(Nonce[123..128])*/
-    uint8_t bottom = (nonce_padded[15] << 2) >> 2;
+    uint8_t bottom = nonce_padded[15] & 0x3F;
     /* Ktop = ENCIPHER(K, Nonce[1..122] || zeros(6)) */
     nonce_padded[15] = nonce_padded[15] & 0xC0;
     uint8_t ktop[16];

--- a/tests/sys/crypto/tests-crypto-modes-ocb.c
+++ b/tests/sys/crypto/tests-crypto-modes-ocb.c
@@ -149,6 +149,50 @@ static size_t TEST_4_EXPECTED_LEN = sizeof(TEST_4_EXPECTED);
 
 static uint8_t TEST_4_TAG_LEN = 16;
 
+/* Test 4A:
+
+    Variation of Test 4 to uncover a RIOT specific bug.
+
+    N: BBAA9988776655443322FFFF
+    A:
+    P: 0001020304050607
+    C: 8E4547845BBA5203750B97FC5C97E839B8C346EEA2F6508E
+
+    Test vector generated using PyCryptodome:
+    >>> from Crypto.Cipher import AES
+    >>> key = bytearray.fromhex('000102030405060708090A0B0C0D0E0F')
+    >>> nonce = bytearray.fromhex('BBAA9988776655443322FFFF')
+    >>> plaintext = bytearray.fromhex('0001020304050607')
+    >>> cipher = AES.new(key, AES.MODE_OCB, nonce=nonce)
+    >>> ciphertext,tag = cipher.encrypt_and_digest(plaintext)
+    >>> print((ciphertext+tag).hex())
+*/
+static uint8_t *TEST_4A_KEY = TEST_KEY;
+
+static uint8_t TEST_4A_NONCE[] = {
+    0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44,
+    0x33, 0x22, 0xFF, 0xFF,
+};
+static size_t TEST_4A_NONCE_LEN = 12;
+
+static uint8_t TEST_4A_INPUT[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07
+};
+static size_t TEST_4A_INPUT_LEN = sizeof(TEST_4A_INPUT);
+
+static uint8_t *TEST_4A_ADATA;
+
+static size_t TEST_4A_ADATA_LEN = 0;
+
+static uint8_t TEST_4A_EXPECTED[] = {
+    0x8E, 0x45, 0x47, 0x84, 0x5B, 0xBA, 0x52, 0x03,
+    0x75, 0x0B, 0x97, 0xFC, 0x5C, 0x97, 0xE8, 0x39,
+    0xB8, 0xC3, 0x46, 0xEE, 0xA2, 0xF6, 0x50, 0x8E
+};
+static size_t TEST_4A_EXPECTED_LEN = sizeof(TEST_4A_EXPECTED);
+
+static uint8_t TEST_4A_TAG_LEN = 16;
+
 /* Test 16:
     N: BBAA9988776655443322110F
     A:
@@ -301,6 +345,7 @@ static void test_crypto_modes_ocb_encrypt(void)
     do_test_encrypt_op(2);
     do_test_encrypt_op(3);
     do_test_encrypt_op(4);
+    do_test_encrypt_op(4A);
     do_test_encrypt_op(16);
     do_test_encrypt_op(17);
 }
@@ -395,6 +440,7 @@ static void test_crypto_modes_ocb_decrypt(void)
     do_test_decrypt_op(2);
     do_test_decrypt_op(3);
     do_test_decrypt_op(4);
+    do_test_decrypt_op(4A);
     do_test_decrypt_op(16);
     do_test_decrypt_op(17);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes the Offset_0 calculation in OCB mode. There was a failed attempt to discard the upper two bits of `nonce_padded[15]`. The tests did not catch this because all nonces have zeros in those positions.

Perhaps we should just remove OCB mode, as it has apparently never been used by anyone (including its authors) since it was merged 5 years ago.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make -C tests/sys/crypto all test`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
