### PR TITLE
cpu/sam0_common: avoid bitfield usage

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -681,8 +681,13 @@ typedef enum {
 static inline void sam0_set_voltage_regulator(sam0_supc_t src)
 {
 #ifdef REG_SUPC_VREG
-    SUPC->VREG.bit.SEL = src;
-    while (!SUPC->STATUS.bit.VREGRDY) {}
+    if (src == SAM0_VREG_BUCK) {
+        SUPC->VREG.reg |= (1 << SUPC_VREG_SEL_Pos);
+    }
+    else {
+        SUPC->VREG.reg &= ~(1 << SUPC_VREG_SEL_Pos);
+    }
+    while (!(SUPC->STATUS.reg & SUPC_STATUS_VREGRDY)) {}
 #else
     (void) src;
     assert(0);
@@ -867,7 +872,7 @@ static inline void sercom_set_gen(void *sercom, uint8_t gclk)
 static inline bool cpu_woke_from_backup(void)
 {
 #ifdef RSTC_RCAUSE_BACKUP
-    return RSTC->RCAUSE.bit.BACKUP;
+    return RSTC->RCAUSE.reg & RSTC_RCAUSE_BACKUP;
 #else
     return false;
 #endif

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -190,10 +190,12 @@ static int _adc_configure(Adc *dev, adc_res_t res)
     /* Set ADC resolution */
 #ifdef ADC_CTRLC_RESSEL
     /* Reset resolution bits in CTRLC */
-    dev->CTRLC.bit.RESSEL = res & 0x3;
+    uint32_t ctrlc = dev->CTRLC.reg;
+    dev->CTRLC.reg = ((ctrlc & ~ADC_CTRLC_RESSEL_Msk) | ADC_CTRLC_RESSEL(res));
 #else
     /* Reset resolution bits in CTRLB */
-    dev->CTRLB.bit.RESSEL = res & 0x3;
+    uint32_t ctrlb = dev->CTRLB.reg;
+    dev->CTRLB.reg = ((ctrlb & ~ADC_CTRLB_RESSEL_Msk) | ADC_CTRLB_RESSEL(res));
 #endif
 
     /* Set Voltage Reference */
@@ -317,7 +319,12 @@ static int32_t _sample(adc_t line)
                        | adc_channels[line].inputctrl
                        | (diffmode ? 0 : ADC_NEG_INPUT);
 #ifdef ADC_CTRLB_DIFFMODE
-    dev->CTRLB.bit.DIFFMODE = diffmode;
+    if (diffmode) {
+        dev->CTRLB.reg |= ADC_CTRLB_DIFFMODE;
+    }
+    else {
+        dev->CTRLB.reg &= ~ADC_CTRLB_DIFFMODE;
+    }
 #endif
     _wait_syncbusy(dev);
 

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -59,7 +59,7 @@ static inline void _sync(void)
 #ifdef DAC_SYNCBUSY_MASK
     while (DAC->SYNCBUSY.reg) {}
 #else
-    while (DAC->STATUS.bit.SYNCBUSY) {}
+    while (DAC->STATUS.reg & DAC_STATUS_SYNCBUSY) {}
 #endif
 }
 
@@ -110,7 +110,7 @@ int8_t dac_init(dac_t line)
     _dac_init_clock(line);
 
     /* Settings can only be changed when DAC is disabled */
-    DAC->CTRLA.bit.ENABLE = 0;
+    DAC->CTRLA.reg &= ~DAC_CTRLA_ENABLE;
     _sync();
 
 #ifdef DAC_DACCTRL_ENABLE
@@ -125,7 +125,7 @@ int8_t dac_init(dac_t line)
 #endif
                    ;
 
-    DAC->CTRLA.bit.ENABLE = 1;
+    DAC->CTRLA.reg |= DAC_CTRLA_ENABLE;
     _sync();
 
 #ifdef DAC_STATUS_READY

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -90,7 +90,7 @@ void dma_init(void)
     NVIC_EnableIRQ(DMAC_IRQn);
 #endif
 
-    DMAC->CTRL.bit.DMAENABLE = 1;
+    DMAC->CTRL.reg |= DMAC_CTRL_DMAENABLE;
 }
 
 dma_t dma_acquire_channel(void)
@@ -255,11 +255,11 @@ void dma_start(dma_t dma)
 
 #ifdef REG_DMAC_CHID
     unsigned state = irq_disable();
-    DMAC->CHID.bit.ID = dma;
+    DMAC->CHID.reg = DMAC_CHID_ID(dma);
     DMAC->CHCTRLA.reg = DMAC_CHCTRLA_ENABLE;
     irq_restore(state);
 #else
-    DMAC->Channel[dma].CHCTRLA.bit.ENABLE = 1;
+    DMAC->Channel[dma].CHCTRLA.reg |= DMAC_CHCTRLA_ENABLE;
 #endif
 }
 
@@ -274,15 +274,15 @@ void dma_cancel(dma_t dma)
     DEBUG("[DMA]: Cancelling active transfer: %u\n", dma);
 #ifdef REG_DMAC_CHID
     unsigned state = irq_disable();
-    DMAC->CHID.bit.ID = dma;
+    DMAC->CHID.reg = DMAC_CHID_ID(dma);
     /* Write zero to the enable bit */
     DMAC->CHCTRLA.reg = 0;
     /* Wait until the active beat is finished */
-    while (DMAC->CHCTRLA.bit.ENABLE) {}
+    while (DMAC->CHCTRLA.reg & DMAC_CHCTRLA_ENABLE) {}
     irq_restore(state);
 #else
-    DMAC->Channel[dma].CHCTRLA.bit.ENABLE = 0;
-    while (DMAC->Channel[dma].CHCTRLA.bit.ENABLE) {}
+    DMAC->Channel[dma].CHCTRLA.reg &= ~DMAC_CHCTRLA_ENABLE;
+    while (DMAC->Channel[dma].CHCTRLA.reg & DMAC_CHCTRLA_ENABLE) {}
 #endif
 }
 

--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -132,7 +132,7 @@ unsigned sam0_read_phy(uint8_t phy, uint8_t addr)
                   | GMAC_MAN_OP(PHY_READ_OP);
 
     /* Wait for operation completion */
-    while (!GMAC->NSR.bit.IDLE) {}
+    while (!(GMAC->NSR.reg & GMAC_NSR_IDLE)) {}
     /* return content of shift register */
     return (GMAC->MAN.reg & GMAC_MAN_DATA_Msk);
 }
@@ -148,7 +148,7 @@ void sam0_write_phy(uint8_t phy, uint8_t addr, uint16_t data)
                   | GMAC_MAN_CLTTO      | GMAC_MAN_DATA(data);
 
     /* Wait for operation completion */
-    while (!GMAC->NSR.bit.IDLE) {}
+    while (!(GMAC->NSR.reg & GMAC_NSR_IDLE)) {}
 }
 
 void sam0_eth_poweron(void)

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -58,9 +58,9 @@
 static inline void wait_nvm_is_ready(void)
 {
 #ifdef NVMCTRL_STATUS_READY
-    while (!_NVMCTRL->STATUS.bit.READY) {}
+    while (!(_NVMCTRL->STATUS.reg & NVMCTRL_STATUS_READY)) {}
 #else
-    while (!_NVMCTRL->INTFLAG.bit.READY) {}
+    while (!(_NVMCTRL->INTFLAG.reg & NVMCTRL_INTFLAG_READY)) {}
 #endif
 }
 
@@ -89,7 +89,7 @@ static void _lock(unsigned state)
 
     /* cached flash contents may have changed - invalidate cache */
 #ifdef CMCC
-    CMCC->MAINT0.bit.INVALL = 1;
+    CMCC->MAINT0.reg |= CMCC_MAINT0_INVALL;
 #endif
 
     irq_restore(state);

--- a/cpu/sam0_common/periph/gpio_ll.c
+++ b/cpu/sam0_common/periph/gpio_ll.c
@@ -62,12 +62,12 @@ void gpio_ll_mux(gpio_port_t port, uint8_t pin, gpio_mux_t mux)
 
     unsigned irq_state = irq_disable();
     if (mux == GPIO_MUX_DISABLED) {
-        apb->PINCFG[pin].bit.PMUXEN = 0;
+        apb->PINCFG[pin].reg &= ~PORT_PINCFG_PMUXEN;
     }
     else {
         unsigned pmux_reg = pin >> 1;
         unsigned pmux_pos = (pin & 0x01) << 2;
-        apb->PINCFG[pin].bit.PMUXEN = 1;
+        apb->PINCFG[pin].reg |= PORT_PINCFG_PMUXEN;
         unsigned pmux = apb->PMUX[pmux_reg].reg;
         pmux &= ~(PORT_PMUX_PMUXE_Msk << pmux_pos);
         pmux |= (unsigned)mux << pmux_pos;

--- a/cpu/sam0_common/periph/gpio_ll_irq.c
+++ b/cpu/sam0_common/periph/gpio_ll_irq.c
@@ -121,10 +121,10 @@ static void disable_trigger(unsigned exti_num)
 static void eic_sync(void)
 {
 #ifdef EIC_STATUS_SYNCBUSY
-    while (EIC_SEC->STATUS.bit.SYNCBUSY) { }
+    while (EIC_SEC->STATUS.reg & EIC_STATUS_SYNCBUSY) {}
 #endif
 #ifdef EIC_SYNCBUSY_ENABLE
-    while (EIC_SEC->SYNCBUSY.bit.ENABLE) { }
+    while (EIC_SEC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
 #endif
 }
 
@@ -136,7 +136,7 @@ static void eic_enable_clock(void)
     GCLK->CLKCTRL.reg = EIC_GCLK_ID
                       | GCLK_CLKCTRL_CLKEN
                       | GCLK_CLKCTRL_GEN(CONFIG_SAM0_GCLK_GPIO);
-    while (GCLK->STATUS.bit.SYNCBUSY) {}
+    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 #endif
 #ifdef MCLK_APBAMASK_EIC
     MCLK->APBAMASK.reg |= MCLK_APBAMASK_EIC;

--- a/cpu/sam0_common/periph/hwrng.c
+++ b/cpu/sam0_common/periph/hwrng.c
@@ -26,15 +26,16 @@
 void hwrng_init(void)
 {
     /* Enable the MCLK */
-    MCLK->APBCMASK.bit.TRNG_ = 1;
+    MCLK->APBCMASK.reg |= MCLK_APBCMASK_TRNG;
 
     /* Enable the TRNG */
-    TRNG->CTRLA.bit.ENABLE = 1;
+    TRNG->CTRLA.reg |= TRNG_CTRLA_ENABLE;
+
 }
 
 uint32_t hwrand(void)
 {
-    while (!TRNG->INTFLAG.bit.DATARDY) {}
+    while (!(TRNG->INTFLAG.reg & TRNG_INTFLAG_DATARDY)) {}
     return TRNG->DATA.reg;
 }
 

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -76,7 +76,7 @@ static inline SercomI2cm *bus(i2c_t dev)
 static void _syncbusy(SercomI2cm *dev)
 {
 #ifdef SERCOM_I2CM_STATUS_SYNCBUSY
-    while (dev->STATUS.bit.SYNCBUSY) {}
+    while (dev->STATUS.reg & SERCOM_I2CM_STATUS_SYNCBUSY) {}
 #else
     while (dev->SYNCBUSY.reg) {}
 #endif
@@ -88,9 +88,9 @@ static void _reset(SercomI2cm *dev)
     while (dev->CTRLA.reg & SERCOM_SPI_CTRLA_SWRST) {}
 
 #ifdef SERCOM_I2CM_STATUS_SYNCBUSY
-    while (dev->STATUS.bit.SYNCBUSY) {}
+    while (dev->STATUS.reg & SERCOM_I2CM_STATUS_SYNCBUSY) {}
 #else
-    while (dev->SYNCBUSY.bit.SWRST) {}
+    while (dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_SWRST) {}
 #endif
 }
 
@@ -311,7 +311,7 @@ void _i2c_poweron(i2c_t dev)
     if (bus(dev) == NULL) {
         return;
     }
-    bus(dev)->CTRLA.bit.ENABLE = 1;
+    bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_ENABLE;
     _syncbusy(bus(dev));
 }
 
@@ -322,7 +322,7 @@ void _i2c_poweroff(i2c_t dev)
     if (bus(dev) == NULL) {
         return;
     }
-    bus(dev)->CTRLA.bit.ENABLE = 0;
+    bus(dev)->CTRLA.reg &= ~SERCOM_I2CM_CTRLA_ENABLE;
     _syncbusy(bus(dev));
 }
 

--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -42,6 +42,7 @@
 typedef TcCount8 Tcc;
 #define TCC_CTRLA_ENABLE TC_CTRLA_ENABLE
 #define TCC_SYNCBUSY_CC0 TC_SYNCBUSY_CC0
+#define TCC_STATUS_SYNCBUSY TC_STATUS_SYNCBUSY
 #ifdef TC_SYNCBUSY_MASK
 #define TCC_SYNCBUSY_MASK TC_SYNCBUSY_MASK
 #endif
@@ -216,8 +217,8 @@ static void poweroff(pwm_t dev)
 static void _tc_init(Tc *tc, pwm_mode_t mode, uint8_t prescaler, uint8_t res)
 {
     /* reset TC module */
-    tc->COUNT8.CTRLA.bit.SWRST = 1;
-    while (tc->COUNT8.CTRLA.bit.SWRST) {}
+    tc->COUNT8.CTRLA.reg |= TC_CTRLA_SWRST;
+    while (tc->COUNT8.CTRLA.reg & TC_CTRLA_SWRST) {}
 
     /* set PWM mode */
     switch (mode) {
@@ -250,7 +251,7 @@ static void _tc_init(Tc *tc, pwm_mode_t mode, uint8_t prescaler, uint8_t res)
     tc->COUNT8.PER.reg = (res - 1);
 
 #ifdef TC_STATUS_SYNCBUSY
-    while (tc->COUNT8.STATUS.bit.SYNCBUSY) {}
+    while (tc->COUNT8.STATUS.reg & TC_STATUS_SYNCBUSY) {}
 #else
     while (tc->COUNT8.SYNCBUSY.reg) {}
 #endif
@@ -361,7 +362,7 @@ static void _tc_set(Tc *tc, uint8_t chan, uint16_t value)
     tc->COUNT8.CC[chan].reg = value;
 
 #ifdef TC_STATUS_SYNCBUSY
-    while (tc->COUNT8.STATUS.bit.SYNCBUSY) {}
+    while (tc->COUNT8.STATUS.reg & TC_STATUS_SYNCBUSY) {}
 #else
     while (tc->COUNT8.SYNCBUSY.reg & (TC_SYNCBUSY_CC0 << chan)) {}
 #endif
@@ -375,7 +376,7 @@ static void _tcc_set(Tcc *tcc, uint8_t chan, uint16_t value)
 #ifdef TCC_SYNCBUSY_MASK
     while (tcc->SYNCBUSY.reg & (TCC_SYNCBUSY_CC0 << chan)) {}
 #else
-    while (tcc->STATUS.bit.SYNCBUSY) {}
+    while (tcc->STATUS.reg & TCC_STATUS_SYNCBUSY) {}
 #endif
 }
 

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -82,7 +82,7 @@ static inline void _syncbusy(SercomUsart *dev)
 #ifdef SERCOM_USART_SYNCBUSY_MASK
     while (dev->SYNCBUSY.reg) {}
 #else
-    while (dev->STATUS.bit.SYNCBUSY) {}
+    while (dev->STATUS.reg & SERCOM_USART_STATUS_SYNCBUSY) {}
 #endif
 }
 
@@ -92,9 +92,9 @@ static inline void _reset(SercomUsart *dev)
     while (dev->CTRLA.reg & SERCOM_SPI_CTRLA_SWRST) {}
 
 #ifdef SERCOM_USART_SYNCBUSY_MASK
-    while (dev->SYNCBUSY.bit.SWRST) {}
+    while (dev->SYNCBUSY.reg & SERCOM_USART_SYNCBUSY_SWRST) {}
 #else
-    while (dev->STATUS.bit.SYNCBUSY) {}
+    while (dev->STATUS.reg & SERCOM_USART_STATUS_SYNCBUSY) {}
 #endif
 }
 
@@ -187,13 +187,13 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 #if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
     /* clear previously blocked power modes */
-    if (dev(uart)->CTRLA.bit.ENABLE) {
+    if (dev(uart)->CTRLA.reg & SERCOM_USART_CTRLA_ENABLE) {
         /* RX IRQ is enabled */
-        if (dev(uart)->INTENSET.bit.RXC) {
+        if (dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_RXC) {
             pm_unblock(SAM0_UART_PM_BLOCK);
         }
         /* data reg empty IRQ is enabled -> sending data was in progress */
-        if (dev(uart)->INTENSET.bit.DRE) {
+        if (dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_DRE) {
             pm_unblock(SAM0_UART_PM_BLOCK);
         }
     }
@@ -363,7 +363,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         return;
     }
 
-    if (!dev(uart)->CTRLA.bit.ENABLE) {
+    if (!(dev(uart)->CTRLA.reg & SERCOM_USART_CTRLA_ENABLE)) {
         return;
     }
 
@@ -372,7 +372,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         if (irq_is_in() || __get_PRIMASK()) {
             /* if ring buffer is full free up a spot */
             if (tsrb_full(&uart_tx_rb[uart])) {
-                while (!dev(uart)->INTFLAG.bit.DRE) {}
+                while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_DRE)) {}
                 dev(uart)->DATA.reg = tsrb_get_one(&uart_tx_rb[uart]);
             }
             tsrb_add_one(&uart_tx_rb[uart], *data);
@@ -386,7 +386,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         /* tsrb_add_one() is blocking the thread. It may happen that
          * the corresponding ISR has turned off DRE IRQs and, thus,
          * unblocked the corresponding power mode. */
-        if (!dev(uart)->INTENSET.bit.DRE) {
+        if (!(dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_DRE)) {
             pm_block(SAM0_UART_PM_BLOCK);
         }
         dev(uart)->INTENSET.reg = SERCOM_USART_INTENSET_DRE;
@@ -397,10 +397,10 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     }
 #else
     for (const void* end = data + len; data != end; ++data) {
-        while (!dev(uart)->INTFLAG.bit.DRE) {}
+        while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_DRE)) {}
         dev(uart)->DATA.reg = *data;
     }
-    while (!dev(uart)->INTFLAG.bit.TXC) {}
+    while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_TXC)) {}
 #endif
 }
 
@@ -412,13 +412,13 @@ void uart_poweron(uart_t uart)
     unsigned state = irq_disable();
 #if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
     /* block required power modes */
-    if (!dev(uart)->CTRLA.bit.ENABLE) {
+    if (!(dev(uart)->CTRLA.reg & SERCOM_USART_CTRLA_ENABLE)) {
         /* RX IRQ is enabled */
-        if (dev(uart)->INTENSET.bit.RXC) {
+        if (dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_RXC) {
             pm_block(SAM0_UART_PM_BLOCK);
         }
         /* data reg empty IRQ is enabled -> sending data was in progress */
-        if (dev(uart)->INTENSET.bit.DRE) {
+        if (dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_DRE) {
             pm_block(SAM0_UART_PM_BLOCK);
         }
     }
@@ -435,13 +435,13 @@ void uart_poweroff(uart_t uart)
     unsigned state = irq_disable();
 #if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_UART_PM_BLOCK)
     /* clear blocked power modes */
-    if (dev(uart)->CTRLA.bit.ENABLE) {
+    if (dev(uart)->CTRLA.reg & SERCOM_USART_CTRLA_ENABLE) {
         /* RX IRQ is enabled */
-        if (dev(uart)->INTENSET.bit.RXC) {
+        if (dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_RXC) {
             pm_unblock(SAM0_UART_PM_BLOCK);
         }
         /* data reg empty IRQ is enabled -> sending data is in progress */
-        if (dev(uart)->INTENSET.bit.DRE) {
+        if (dev(uart)->INTENSET.reg & SERCOM_USART_INTENSET_DRE) {
             pm_unblock(SAM0_UART_PM_BLOCK);
         }
     }
@@ -461,7 +461,7 @@ bool uart_collision_detected(uart_t uart)
      */
     _syncbusy(dev(uart));
 
-    bool collision = dev(uart)->STATUS.bit.COLL;
+    bool collision = dev(uart)->STATUS.reg & SERCOM_USART_STATUS_COLL;
     dev(uart)->STATUS.reg = SERCOM_USART_STATUS_COLL;
     return collision;
 }
@@ -469,20 +469,20 @@ bool uart_collision_detected(uart_t uart)
 void uart_collision_detect_enable(uart_t uart)
 {
     /* CTRLB is enable protected */
-    dev(uart)->CTRLA.bit.ENABLE = 0;
+    dev(uart)->CTRLA.reg &= ~SERCOM_USART_CTRLA_ENABLE;
     _syncbusy(dev(uart));
 
     /* clear stale collision flag */
     dev(uart)->STATUS.reg = SERCOM_USART_STATUS_COLL;
 
     /* enable collision detection */
-    dev(uart)->CTRLB.bit.COLDEN = 1;
+    dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_COLDEN;
 
     /* disable RX interrupt */
-    dev(uart)->INTENCLR.bit.RXC = 1;
+    dev(uart)->INTENCLR.reg = SERCOM_USART_INTENCLR_RXC;
 
     /* re-enable UART */
-    dev(uart)->CTRLA.bit.ENABLE = 1;
+    dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
 
     /* wait for config to be applied */
     _syncbusy(dev(uart));
@@ -491,7 +491,7 @@ void uart_collision_detect_enable(uart_t uart)
 static void _drain_rxbuf(SercomUsart *dev)
 {
     /* clear readback bytes from receive buffer */
-    while (dev->INTFLAG.bit.RXC) {
+    while (dev->INTFLAG.reg & SERCOM_USART_INTFLAG_RXC) {
         dev->DATA.reg;
     }
 }
@@ -507,13 +507,13 @@ void uart_collision_detect_disable(uart_t uart)
     ctrlb &= ~SERCOM_USART_CTRLB_COLDEN;
 
     /* CTRLB is enable protected */
-    dev(uart)->CTRLA.bit.ENABLE = 0;
+    dev(uart)->CTRLA.reg &= ~SERCOM_USART_CTRLA_ENABLE;
     _syncbusy(dev(uart));
 
     dev(uart)->CTRLB.reg = ctrlb;
 
     /* re-enable UART */
-    dev(uart)->CTRLA.bit.ENABLE = 1;
+    dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
 
     /* wait for config to be applied */
     _syncbusy(dev(uart));
@@ -523,7 +523,7 @@ void uart_collision_detect_disable(uart_t uart)
 
     /* re-enable RX complete IRQ */
     if (uart_ctx[uart].rx_cb) {
-        dev(uart)->INTENSET.bit.RXC = 1;
+        dev(uart)->INTENSET.reg = SERCOM_USART_INTENSET_RXC;
     }
 }
 #endif
@@ -546,23 +546,36 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
     }
 
     /* Disable UART first to remove write protect */
-    dev(uart)->CTRLA.bit.ENABLE = 0;
+    dev(uart)->CTRLA.reg &= ~SERCOM_USART_CTRLA_ENABLE;
     _syncbusy(dev(uart));
 
-    dev(uart)->CTRLB.bit.CHSIZE = data_bits;
+    uint32_t ctrlb = dev(uart)->CTRLB.reg;
 
     if (parity == UART_PARITY_NONE) {
-        dev(uart)->CTRLA.bit.FORM = 0x0;
+        dev(uart)->CTRLA.reg &= ~SERCOM_USART_CTRLA_FORM_Msk;
     }
     else {
-        dev(uart)->CTRLA.bit.FORM = 0x1;
-        dev(uart)->CTRLB.bit.PMODE = (parity == UART_PARITY_ODD) ? 1 : 0;
+        dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_FORM(1);
+        if (parity == UART_PARITY_ODD) {
+            ctrlb |= SERCOM_USART_CTRLB_PMODE;
+        }
+        else {
+            ctrlb &= ~SERCOM_USART_CTRLB_PMODE;
+        }
     }
 
-    dev(uart)->CTRLB.bit.SBMODE = (stop_bits == UART_STOP_BITS_1) ? 0 : 1;
+    if (stop_bits == UART_STOP_BITS_1) {
+        ctrlb &= ~SERCOM_USART_CTRLB_SBMODE;
+    }
+    else {
+        ctrlb |= SERCOM_USART_CTRLB_SBMODE;
+    }
+
+    dev(uart)->CTRLB.reg = ((ctrlb & ~SERCOM_USART_CTRLB_CHSIZE_Msk) |
+                            SERCOM_USART_CTRLB_CHSIZE(data_bits));
 
     /* Enable UART again */
-    dev(uart)->CTRLA.bit.ENABLE = 1;
+    dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
     _syncbusy(dev(uart));
 
     return UART_OK;
@@ -573,7 +586,7 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
 void uart_rxstart_irq_configure(uart_t uart, uart_rxstart_cb_t cb, void *arg)
 {
     /* CTRLB is enable-proteced */
-    dev(uart)->CTRLA.bit.ENABLE = 0;
+    dev(uart)->CTRLA.reg &= ~SERCOM_USART_CTRLA_ENABLE;
 
     /* set start of frame detection enable */
     dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_SFDE;
@@ -582,7 +595,7 @@ void uart_rxstart_irq_configure(uart_t uart, uart_rxstart_cb_t cb, void *arg)
     uart_ctx[uart].rxs_arg = arg;
 
     /* enable UART again */
-    dev(uart)->CTRLA.bit.ENABLE = 1;
+    dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
 }
 
 void uart_rxstart_irq_enable(uart_t uart)
@@ -628,13 +641,15 @@ static inline void irq_handler(unsigned uartnum)
     dev(uartnum)->INTFLAG.reg = status & ~SERCOM_USART_INTFLAG_TXC;
 
 #if !defined(UART_HAS_TX_ISR) && defined(MODULE_PERIPH_UART_NONBLOCKING)
-    if ((status & SERCOM_USART_INTFLAG_DRE) && dev(uartnum)->INTENSET.bit.DRE) {
+    if ((status & SERCOM_USART_INTFLAG_DRE) &&
+        (dev(uartnum)->INTENSET.reg & SERCOM_USART_INTENSET_DRE)) {
         irq_handler_tx(uartnum);
     }
 #endif
 
 #ifdef MODULE_PERIPH_UART_RXSTART_IRQ
-    if (status & SERCOM_USART_INTFLAG_RXS && dev(uartnum)->INTENSET.bit.RXS) {
+    if ((status & SERCOM_USART_INTFLAG_RXS) &&
+        (dev(uartnum)->INTENSET.reg & SERCOM_USART_INTENSET_RXS)) {
         uart_ctx[uartnum].rxs_cb(uart_ctx[uartnum].rxs_arg);
     }
 #endif


### PR DESCRIPTION
### Contribution description

This PR removes all bitfields usage from `cpu/sam0_common/` folder.
I decided to go with a commit per file to allow an easy revert in case something got terribly wrong. Nevertheless, CI should catch most of the issues early. However, I might get sleepy here and there so please, take a careful eyes at this.

/!\ **Breakages are highly probable here** /!\

### Testing procedure
Triple careful review and CI should save us hopefully.

### Issues/PRs references
#20457 
