### PR TITLE
boards/nucleo-l476rg & stm32l476g-disco: fix MCU table

### DIFF
--- a/boards/nucleo-l476rg/doc.txt
+++ b/boards/nucleo-l476rg/doc.txt
@@ -24,8 +24,8 @@ STM32L476RG microcontroller with 128KiB of RAM and 1MiB of Flash.
 | Frequency  | up to 80MHz       |
 | FPU        | yes               |
 | Timers     | 16 (2x watchdog, 1 SysTick, 6x 16-bit, 2x 32-bit [TIM2])  |
-| ADCs       | 1x 12-bit         |
-| UARTs      | 3 (two UARTs and one Low-Power UART)                 |
+| ADCs       | 3x 12-bit (up to 16 channels) |
+| UARTs      | 6 (three USARTs, two UARTs and one Low-Power UART) |
 | SPIs       | 3                 |
 | I2Cs       | 3                 |
 | RTC        | 1                 |

--- a/boards/stm32l476g-disco/doc.txt
+++ b/boards/stm32l476g-disco/doc.txt
@@ -24,8 +24,8 @@ ROM Flash.
 | Frequency  | up to 80MHz        |
 | FPU        | yes                |
 | Timers     | 16 (2x watchdog, 1 SysTick, 6x 16-bit, 2x 32-bit [TIM2])  |
-| ADCs       | 1x 12-bit          |
-| UARTs      | 3 (two UARTs and one Low-Power UART)                 |
+| ADCs       | 3x 12-bit (up to 16 channels) |
+| UARTs      | 6 (three USARTs, two UARTs and one Low-Power UART) |
 | SPIs       | 3                  |
 | I2Cs       | 3                  |
 | RTC        | 1                  |


### PR DESCRIPTION
### Contribution description

During investigation for issue #20748 I found some mistakes in the documentation MCU tables for STM32 L476 MCU.
This PR fixes them.

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l476rg.html 
xdg-open doc/doxygen/html/group__boards__stm32l476g-disco.html
```


### Issues/PRs references

See also Issue #20748.