### PR TITLE
makefiles: add OPENOCD_DEBUG_ADAPTER and SLOT_AUX_LEN to riotboot build environment

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -87,10 +87,12 @@ riotboot/bootloader/%: $$(if $$(filter riotboot/bootloader/clean,$$@),,$$(BUILDD
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)" USER="$(USER)"\
 		INCLUDES="$(INCLUDES)"\
-		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
+		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD) \
+		OPENOCD_DEBUG_ADAPTER=$(OPENOCD_DEBUG_ADAPTER) \
 		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID) \
 		IOTLAB_NODE=$(IOTLAB_NODE) \
 		PROGRAMMER=$(PROGRAMMER) PROGRAMMER_QUIET=$(PROGRAMMER_QUIET) \
+		SLOT_AUX_LEN=$(SLOT_AUX_LEN) \
 			$(MAKE) --no-print-directory -C $(RIOTBOOT_DIR) $*
 
 # Generate a binary file from the bootloader which fills all the


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When using the auxiliary flash slot, the image slot size shrinks.
This must be known to the firmware image AND the bootloader.
Else slot 1 will not be booted after a SUIT update.
This PR adds the `SLOT_AUX_LEN` variable to the build environment of the bootloader

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Without this fix, check the `riotbuild.h` in the `bin` folder of an application with `SLOT_AUX_LEN = 0x10000` and in `bootloaders/riotboot/bin`. You will see that for example `SLOT0_LEN` is different.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
