### PR TITLE
makefiles: fix RISC-V Zicsr attribute with GCC

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -45,22 +45,10 @@ ifeq (,$(TARGET_ARCH))
   $(error No RISC-V toolchain detected. Make sure a RISC-V toolchain is installed.)
 endif
 
-ifeq ($(TOOLCHAIN),gnu)
-  GCC_DEFAULTS_TO_NEW_RISCV_ISA ?= $(shell echo "typedef int dont_be_pedantic;" | $(TARGET_ARCH)-gcc -march=rv32imac -mabi=ilp32 -misa-spec=2.2 -E - > /dev/null 2>&1 && echo 1 || echo 0)
-endif
+CFLAGS_CPU := -march=rv32imac_zicsr -mabi=ilp32
 
-GCC_DEFAULTS_TO_NEW_RISCV_ISA ?= 0
-
-CFLAGS_CPU := -march=rv32imac -mabi=ilp32
-
-# Since RISC-V ISA specifications 20191213 instructions previously included in
-# rv32imac have been moved to the ZICSR extension. See
-# https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf
-#
-# Select the oldest ISA spec in which ZICSR was not yet split out into an
-# extension
-ifeq (1,$(GCC_DEFAULTS_TO_NEW_RISCV_ISA))
-  CFLAGS_CPU += -misa-spec=2.2
+ifeq ($(TOOLCHAIN),llvm)
+  CFLAGS_CPU := -march=rv32imac -mabi=ilp32
 endif
 
 # Always use riscv32-none-elf as target triple for clang, as some


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes RISC-V Zicsr attributes with GCC.

There is a bug with GCC merging RISC-V attributes. RIOT uses the old `rv32i2p0` (`-misa-spec=2.2`), which includes `zicsr`. Newlib was compiled for `rv32i2p1_zicsr`. When GCC links RIOT against newlib, the resulting ELF is `rv32i2p1`, but is missing `zicsr`. Because of this, GDB does not disassemble CSR instructions correctly.

GCC 10 is now deprecated \[1\] and riotbuild was updated to GCC 13 earlier this year \[2\]. So i think we can now remove `-misa-spec=2.2` and set `-march=rv32imac_zicsr` when using GCC.

\[1\]: https://gcc.gnu.org/gcc-10/
\[2\]: https://github.com/RIOT-OS/riotdocker/pull/248

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`BOARD=hifive1b make -C examples/hello-world`

#### Without this PR:

```
$ riscv-none-elf-objdump -s --section=.riscv.attributes examples/hello-world/bin/hifive1b/hello-world.elf
Contents of section .riscv.attributes:
 0000 41370000 00726973 63760001 2d000000  A7...riscv..-...
 0010 04100572 76333269 3270315f 6d327030  ...rv32i2p1_m2p0
 0020 5f613270 315f6332 70305f7a 6d6d756c  _a2p1_c2p0_zmmul
 0030 31703000 08010a0b                    1p0.....
```

```
$ riscv-none-elf-gdb -batch -ex 'disassemble _start' examples/hello-world/bin/hifive1b/hello-world.elf
Dump of assembler code for function _start:
   0x20010000 <+0>:     .4byte  0x30047073
   0x20010004 <+4>:     lui     a0,0x20010
   0x20010008 <+8>:     jr      12(a0) # 0x2001000c <_start_real>
```

#### With this PR:

```
$ riscv-none-elf-objdump -s --section=.riscv.attributes examples/hello-world/bin/hifive1b/hello-world.elf
Contents of section .riscv.attributes:
 0000 41400000 00726973 63760001 36000000  A@...riscv..6...
 0010 04100572 76333269 3270315f 6d327030  ...rv32i2p1_m2p0
 0020 5f613270 315f6332 70305f7a 69637372  _a2p1_c2p0_zicsr
 0030 3270305f 7a6d6d75 6c317030 0008010a  2p0_zmmul1p0....
 0040 0b
```

```
$ riscv-none-elf-gdb -batch -ex 'disassemble _start' examples/hello-world/bin/hifive1b/hello-world.elf
Dump of assembler code for function _start:
   0x20010000 <+0>:     csrc    mstatus,8
   0x20010004 <+4>:     lui     a0,0x20010
   0x20010008 <+8>:     jr      12(a0) # 0x2001000c <_start_real>
```

(This problem still exists with `TOOLCHAIN=llvm` because RIOT uses gcc instead of llvm-ld)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#17951
#18098

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
