### PR TITLE
makefiles: change RISC-V GCC -march to rv32imac_zicsr

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -45,22 +45,11 @@ ifeq (,$(TARGET_ARCH))
   $(error No RISC-V toolchain detected. Make sure a RISC-V toolchain is installed.)
 endif
 
-ifeq ($(TOOLCHAIN),gnu)
-  GCC_DEFAULTS_TO_NEW_RISCV_ISA ?= $(shell echo "typedef int dont_be_pedantic;" | $(TARGET_ARCH)-gcc -march=rv32imac -mabi=ilp32 -misa-spec=2.2 -E - > /dev/null 2>&1 && echo 1 || echo 0)
-endif
+CFLAGS_CPU := -march=rv32imac_zicsr -mabi=ilp32
 
-GCC_DEFAULTS_TO_NEW_RISCV_ISA ?= 0
-
-CFLAGS_CPU := -march=rv32imac -mabi=ilp32
-
-# Since RISC-V ISA specifications 20191213 instructions previously included in
-# rv32imac have been moved to the ZICSR extension. See
-# https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf
-#
-# Select the oldest ISA spec in which ZICSR was not yet split out into an
-# extension
-ifeq (1,$(GCC_DEFAULTS_TO_NEW_RISCV_ISA))
-  CFLAGS_CPU += -misa-spec=2.2
+# LLVM<17 does not support Zicsr extension in ISA-string
+ifeq ($(TOOLCHAIN),llvm)
+  CFLAGS_CPU := -march=rv32imac -mabi=ilp32
 endif
 
 # Always use riscv32-none-elf as target triple for clang, as some

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -39,7 +39,9 @@ $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 	        -e 's/"riscv64-elf"/"riscv32"/g' \
 	  | $(LAZYSPONGE) $@
 
-
+# LLVM<17 does not support RISC-V Zicsr extension in ISA-string, so it must
+# be removed when Rust is used with TOOLCHAIN=gnu
+$(CARGO_LIB): CFLAGS := $(subst -march=rv32imac_zicsr,-march=rv32imac,$(CFLAGS))
 $(CARGO_LIB): $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS) FORCE
 	@command -v cargo >/dev/null || ($(COLOR_ECHO) \
 		'$(COLOR_RED)Error: `cargo` command missing to build Rust modules.$(COLOR_RESET) Please install as described on <https://doc.riot-os.org/using-rust.html>.' ;\


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR changes RISC-V GCC `-march` to `rv32imac_zicsr`

See PR #20753. (I may have deleted the PR branch, so I cannot reopen my original PR...)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Same as #20753

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#17951
#18098
#20753

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
