### PR TITLE
drivers/periph_wdt: fix auto starting of watchdog timer

### DIFF
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -107,8 +107,10 @@ void periph_init(void)
     usbdev_init_lowlevel();
 #endif
 
-#if defined(MODULE_PERIPH_INIT_WDT) && WDT_HAS_INIT
-    wdt_init();
+#if defined(MODULE_PERIPH_INIT_WDT)
+    if (WDT_HAS_INIT) {
+        wdt_init();
+    }
 
     if (IS_ACTIVE(MODULE_PERIPH_WDT_AUTO_START)) {
         wdt_setup_reboot(CONFIG_PERIPH_WDT_WIN_MIN_MS, CONFIG_PERIPH_WDT_WIN_MAX_MS);


### PR DESCRIPTION
### Contribution description

When `WDT_HAS_INIT` is non-zero (which it is for all but two supported CPUs). The watchdog timer was not automatically started on boot when the `periph_wdt_auto_start` module was enabled. This patch fixes this.

I would like to add a test to prevent future breakage, but lack the time and python experience to do so. Perhaps somebody else could contribute this?


### Testing procedure

I manually tested by hand by inserting an infinite loop in the main thread to starve the watchdog thread. The CPU hangs without this patch and resets with this patch applied.


### Issues/PRs references

- non known
