### PR TITLE
cpu/stm32-L4: fix ADC initialization

### DIFF
--- a/cpu/stm32/periph/adc_l4.c
+++ b/cpu/stm32/periph/adc_l4.c
@@ -64,9 +64,6 @@
    This specifies the first channel that goes to SMPR2 instead of SMPR1. */
 #define ADC_SMPR2_FIRST_CHAN (10)
 
-#define ADC_CCR_CKMODE_HCLK_1   (ADC_CCR_CKMODE_0)
-#define ADC_CCR_CKMODE_HCLK_2   (ADC_CCR_CKMODE_1)
-
 /**
  * @brief   Default VBAT undefined value
  */
@@ -144,13 +141,14 @@ int adc_init(adc_t line)
     ADC->CCR &= ~(ADC_CCR_PRESC);
 
     ADC->CCR &= ~(ADC_CCR_CKMODE);
+    /* Setting ADC clock to HCLK/1 is only allowed if AHB clock prescaler is 1*/
     if (!(RCC->CFGR & RCC_CFGR_HPRE_3)) {
-        /* set ADC clock to HCLK/1, only allowed if AHB clock prescaler is 1 */
-        ADC->CCR |= ADC_CCR_CKMODE_HCLK_1 << ADC_CCR_CKMODE_Pos;
+        /* set ADC clock to HCLK/1 */
+        ADC->CCR |= (ADC_CCR_CKMODE_0);
     }
     else {
         /* set ADC clock to HCLK/2 otherwise */
-        ADC->CCR |= ADC_CCR_CKMODE_HCLK_2 << ADC_CCR_CKMODE_Pos;
+        ADC->CCR |= (ADC_CCR_CKMODE_1);
     }
 
     /* configure the pin */


### PR DESCRIPTION
### Contribution description

This PR fixes ADC initialization for `nucleo-l4xxx` boards (more details in issue #20748).
I tested this PR using `nucleo-l476rg`, `nucleo-l496zg` and `nucleo-l4r5zi`.

### Testing procedure

Flash mentioned boards (or maybe other from L4xxx family) using `tests/periph/adc` and observe console.

With this PR you should see new measurements each 100 ms:

```
main(): This is RIOT! (Version: 2021.07-devel-10832-g0ebb6-nucleo-l4xxx-fix-ADC)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
a 10-bit resolution and print the sampled results to STDIO

Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
Successfully initialized ADC_LINE(6)
ADC_LINE(0): 279
ADC_LINE(1): 320
ADC_LINE(2): 393
ADC_LINE(3): 317
ADC_LINE(4): 241
ADC_LINE(5): 278
ADC_LINE(6): 175
ADC_LINE(0): 284
ADC_LINE(1): 342
ADC_LINE(2): 391
ADC_LINE(3): 334
ADC_LINE(4): 246
ADC_LINE(5): 281
ADC_LINE(6): 178
      . . .
```

### Issues/PRs references

Fixes #20748 
