### PR TITLE
gnrc/ipv6: Store all SLAAC prefixes

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1643,7 +1643,8 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     if (pio->flags & NDP_OPT_PI_FLAGS_A) {
         _auto_configure_addr(netif, &pio->prefix, pio->prefix_len);
     }
-    if ((pio->flags & NDP_OPT_PI_FLAGS_L) || _multihop_p6c(netif, abr)) {
+    if ((pio->flags & (NDP_OPT_PI_FLAGS_A | NDP_OPT_PI_FLAGS_L))
+        || _multihop_p6c(netif, abr)) {
         _nib_offl_entry_t *pfx;
 
         if (pio->valid_ltime.u32 == 0) {

--- a/tests/net/gnrc_ipv6_nib/main.c
+++ b/tests/net/gnrc_ipv6_nib/main.c
@@ -1180,7 +1180,7 @@ static void test_handle_pkt__rtr_adv__success(uint8_t rtr_adv_flags,
                                 "Address was configured by PIO, "
                                 "but A flag was set");
         }
-        if (pio_flags & NDP_OPT_PI_FLAGS_L) {
+        if (pio_flags & (NDP_OPT_PI_FLAGS_A | NDP_OPT_PI_FLAGS_L)) {
             TEST_ASSERT_MESSAGE(gnrc_ipv6_nib_pl_iter(0, &state, &prefix),
                                 "No prefix list entry found");
             TEST_ASSERT_MESSAGE(ipv6_addr_match_prefix(&_loc_gb,
@@ -1192,7 +1192,7 @@ static void test_handle_pkt__rtr_adv__success(uint8_t rtr_adv_flags,
             TEST_ASSERT((_PIO_PFX_LTIME / MS_PER_SEC) < prefix.pref_until);
         }
     }
-    if (!pio || !(pio_flags & NDP_OPT_PI_FLAGS_L)) {
+    if (!pio || !(pio_flags & (NDP_OPT_PI_FLAGS_A | NDP_OPT_PI_FLAGS_L))) {
         if (!pio) {
             TEST_ASSERT_EQUAL_INT(exp_addr_count,
                                   _netif_addr_count(_mock_netif));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In GNRC's architecture, lifetimes are associated with prefixes (and not to any addresses themselves). The prefixes from a PIO are stored in the prefix list. Even if a prefix is not on-link, it needs to be stored in the prefix list if the A flag (SLAAC) is set, so that auto configured addresses in the prefix have their lifetimes managed. Otherwise these addresses would remain configured possibly longer than what the prefix lifetimes were set for.

This PR stores the prefix in the prefix list as soon as / whenever the A flag is set. The test is modified accordingly.

Background: Generally, by RFC definition (https://datatracker.ietf.org/doc/html/rfc4861#section-5.1) the prefix list only contains on-link prefixes, but in GNRC, this is determined for a prefix list entry by the `_PFX_ON_LINK` flag.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

Receive a RA PIO with A flag but not L flag (e.g. 6LN host). Observe how autoconfigured addresses will not be deprecated and invalidated/removed when preferred resp. valid lifetime expire, since this prefix information is never stored anywhere.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!-- ### Issues/PRs references -->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
