### PR TITLE
tests/sys/psa_crypto_ecdsa: fix stacksize determination

### DIFF
--- a/tests/sys/psa_crypto_ecdsa/Makefile
+++ b/tests/sys/psa_crypto_ecdsa/Makefile
@@ -13,6 +13,8 @@ USEMODULE += psa_asymmetric_ecc_p256r1
 CFLAGS += -DCONFIG_PSA_ASYMMETRIC_KEYPAIR_COUNT=1
 CFLAGS += -DCONFIG_PSA_SINGLE_KEY_COUNT=1
 
+include $(RIOTBASE)/Makefile.include
+
 ifneq (,$(filter psa_asymmetric_ecc_p256r1_backend_microecc,$(USEMODULE)))
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=4096
 endif
@@ -20,5 +22,3 @@ endif
 ifneq (,$(filter psa_asymmetric_ecc_p256r1_backend_periph,$(USEMODULE)))
   CFLAGS += -DTHREAD_STACKSIZE_MAIN=7000
 endif
-
-include $(RIOTBASE)/Makefile.include

--- a/tests/sys/psa_crypto_ecdsa/Makefile.ci
+++ b/tests/sys/psa_crypto_ecdsa/Makefile.ci
@@ -6,7 +6,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
+    nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \
+    stk3200 \
     stm32f030f4-demo \
     #


### PR DESCRIPTION
### Contribution description

We tried to specify the stacksize according to the used backend in `tests/sys/psa_crypto_ecdsa` but failed to do so, if the backend is auto-selected.

This PR moves the stacksize determination to after the default-makefile include.

### Testing procedure

```
make -C tests/sys/psa_crypto_ecdsa BOARD=nrf52840dk flash test
```

Without this patch, the application crashes.


### Issues/PRs references

Introduced in #20545
