### PR TITLE
boards/nucleo-f103rb: add ADC configuration

### DIFF
--- a/boards/nucleo-f103rb/Makefile.features
+++ b/boards/nucleo-f103rb/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32f103rb
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-f103rb/doc.txt
+++ b/boards/nucleo-f103rb/doc.txt
@@ -46,7 +46,7 @@ STM32F103RB microcontroller with 20KiB of RAM and 128KiB of Flash.
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | yes (4 pins available)  |  |
 |        | UART      | 2 UARTs       | USART2 via STLink/USB or D0(RX)/D1(TX), USART1 on PA10(RX)/PA09(TX) and USART3 on PB11(RX)/PB10(TX) |
-|        | ADC       | no        | |
+|        | ADC       | yes       | Pins A0 - A5 |
 |        | I2C       | yes (I2C1 and I2C2)       | |
 |        | SPI       | yes (SPI1 and SPI2)       | |
 |        | USB       | no        | |

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -172,6 +172,22 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name   ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan = 0 },  /* ADC12_IN0 */
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan = 1 },  /* ADC12_IN1 */
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },  /* ADC12_IN4 */
+    { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 8 },  /* ADC12_IN8 */
+    { .pin = GPIO_PIN(PORT_C, 1), .dev = 0, .chan = 11 }, /* ADC12_IN11 */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 0, .chan = 10 }, /* ADC12_IN10 */
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description
This adds the ADC configuration and feature for the `nucleo-f103rb` board.

### Testing procedure
- Run the `tests/periph/adc` application (make sure to set the resolution to 12 bits).

### Issues/PRs references
None
