### PR TITLE
test/sys/progress_bar: temporary printout to debug flaky test

### DIFF
--- a/tests/sys/progress_bar/tests/01-run.py
+++ b/tests/sys/progress_bar/tests/01-run.py
@@ -24,6 +24,8 @@ def testfunc(child):
         progress_str += EMPTY_CHARACTER * (LENGTH - ratio)
         check_str = 'Progress bar 0 |{}| {:3}%'.format(
             progress_str, i)
+        # todo: temporary printout for debugging this flaky test
+        print("EXPECTS:", check_str)
         child.expect_exact(check_str)
     child.expect_exact("Done!")
 


### PR DESCRIPTION
### Contribution description

`tests/sys/progress_bar` is apparently flaky on `samr21-xpro` and lets our nightlies fail :(

this PR adds a printout that may help debug the problem by seeing whether it always fails at the same progress value

### Testing procedure

Wait for the next couple of nightlies


### Issues/PRs references

See https://ci.riot-os.org/details/762147886d354ad5ad6308e93898d046/tests for a failed and https://ci.riot-os.org/details/fa7f9c6149fc4e5ba9e3db1627e611a3/tests/tests:sys:progress_bar for the last successful run.
