### PR TITLE
tests/sys/progress_bar: remove debug print

### DIFF
--- a/tests/sys/progress_bar/tests/01-run.py
+++ b/tests/sys/progress_bar/tests/01-run.py
@@ -24,8 +24,6 @@ def testfunc(child):
         progress_str += EMPTY_CHARACTER * (LENGTH - ratio)
         check_str = 'Progress bar 0 |{}| {:3}%'.format(
             progress_str, i)
-        # todo: temporary printout for debugging this flaky test
-        print("EXPECTS:", check_str, "LENGTH:", LENGTH, "ratio:", ratio)
         child.expect_exact(check_str)
     child.expect_exact("Done!")
 


### PR DESCRIPTION
### Contribution description

Remove the temporary printout for debugging purposes after the test has been fixed.


### Testing procedure

Compare with the PRs that introduces the debug print, merge and wait for green nightly.


### Issues/PRs references

Initially introduced in #20763 and bugfix merged with #20764. See successful nightly here: https://ci.riot-os.org/details/4d090795a6a648419641ba286ad8f5a8/tests/tests:sys:progress_bar
