### PR TITLE
gnrc/ipv6: Check for overflow

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -111,8 +111,14 @@ static gnrc_pktsnip_t *_offl_to_pio(_nib_offl_entry_t *offl,
     uint8_t flags = 0;
     uint32_t valid_ltime = (offl->valid_until == UINT32_MAX) ? UINT32_MAX :
                            ((offl->valid_until - now) / MS_PER_SEC);
-    uint32_t pref_ltime = (offl->pref_until == UINT32_MAX) ? UINT32_MAX :
-                          ((offl->pref_until - now) / MS_PER_SEC);
+    uint32_t pref_ltime = offl->pref_until;
+    if (pref_ltime != UINT32_MAX) { /* reserved for infinite lifetime */
+        if (pref_ltime >= now) { /* avoid overflow */
+            pref_ltime = (pref_ltime - now) / MS_PER_SEC;
+        } else {
+            pref_ltime = 0; /* deprecated */
+        }
+    }
 
     DEBUG("nib: Build PIO for %s/%u\n",
           ipv6_addr_to_str(addr_str, &offl->pfx, sizeof(addr_str)),

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -158,7 +158,7 @@ void gnrc_ipv6_nib_pl_print(gnrc_ipv6_nib_pl_t *entry)
         printf(" expires %lu sec", (entry->valid_until - now) / MS_PER_SEC);
     }
     if (entry->pref_until < UINT32_MAX) {
-        printf(" deprecates %lu sec", (entry->pref_until - now) / MS_PER_SEC);
+        printf(" deprecates %lu sec", (now >= entry->pref_until ? 0 : entry->pref_until - now) / MS_PER_SEC);
     }
     puts("");
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Avoid overflows when subtracting current time from point in time that is assumed to be in the future, which however sometimes is not the case. For the changed lines of this PR, such an overflow has been encountered. There may still be more cases.

### Testing procedure

Have a 6LN in a state where it has a deprecated prefix (i.e. preferred lifetime = 0) in its prefix list.
- Observe "nib prefix" printing an overflown value for the preferred lifetime, when it should print 0.
- If the 6LN is a 6LR or 6LBR, it sends a Router Advertisement with a Prefix Information Option with an overflown value for the preferred lifetime, when it should be 0.