### PR TITLE
tools/dhcpv6-pd_ia: fix: Add explicit subnet id

### DIFF
--- a/dist/tools/dhcpv6-pd_ia/kea.py
+++ b/dist/tools/dhcpv6-pd_ia/kea.py
@@ -54,6 +54,7 @@ class KeaConfig(object):
                 "renew-timer": int(renew_timer),
                 "rebind-timer": int(rebind_timer),
                 "subnet6": [{
+                    "id": 1,
                     "interface": interface,
                     "subnet": "{}/{}".format(prefix, prefix_len),
                     "pd-pools": [{


### PR DESCRIPTION
Adjust prefix delegation config for Kea 2.6.0

### Contribution description

https://github.com/isc-projects/kea/blob/master/ChangeLog:
```
Kea 2.6.0 (stable) released on May 29, 2024

[...]

2232.	[func]*		fdupont
	Auto-generated subnet identifiers are no longer supported.
	Configurations that contain subnets without explicit subnet
	identifiers (i.e. without an "id" entry) will now be rejected.
	(Gitlab #2961)
```

### Testing procedure

(for reproducability: `sudo killall kea-dhcp6`)
`cd examples/gnrc_border_router/`
`sudo PREFIX_CONF=dhcpv6 IPV6_PREFIX=2001:db8::/64 make all term`
While the application is running, observe that no kea actually runs: `ps -aux | grep kea`

Kea throws an error that the "id" entry is missing and exits. The error is however silenced by the python script.
Having no DHCP server, the `gnrc_border_router` (6LBR) application cannot contact any such server and therefore has no prefix.

<details>
  <summary>Finding the error</summary>


#### Finding the error

##### Find out how kea is started.
Apply this change (patch):
```patch
diff --git a/dist/tools/dhcpv6-pd_ia/base.py b/dist/tools/dhcpv6-pd_ia/base.py
index b68f2d6438..2a93197e96 100644
--- a/dist/tools/dhcpv6-pd_ia/base.py
+++ b/dist/tools/dhcpv6-pd_ia/base.py
@@ -200,4 +200,5 @@ class DHCPv6Server(metaclass=_SingletonMeta):
             # Start the daemon
             self.daemonize()
         self.pre_run()
+        print("command is", self.command)
         subprocess.run(self.command)
```

`sudo PREFIX_CONF=dhcpv6 IPV6_PREFIX=2001:db8::/64 make all term`
> command is ['kea-dhcp6', '-c', '/tmp/tmpsabotu4_']

##### Start kea manually
`sudo kea-dhcp6 -c /tmp/tmpsabotu4_`
```
2024-07-05 10:25:04.238 ERROR [kea-dhcp6.dhcp6/79049.140215599218944] DHCP6_CONFIG_LOAD_FAIL configuration error using file: /tmp/tmpsabotu4_, reason: Unable to open file /tmp/tmpsabotu4_
2024-07-05 10:25:04.238 ERROR [kea-dhcp6.dhcp6/79049.140215599218944] DHCP6_INIT_FAIL failed to initialize Kea server: configuration error using file '/tmp/tmpsabotu4_': Unable to open file /tmp/tmpsabotu4_
```

##### Keep config file
Make the script not delete the file after kea exits, so that the file can be inspected for debugging purposes.
Apply this change (patch):
```patch
diff --git a/dist/tools/dhcpv6-pd_ia/kea.py b/dist/tools/dhcpv6-pd_ia/kea.py
index d9bb6f1d93..567f0ed7ed 100644
--- a/dist/tools/dhcpv6-pd_ia/kea.py
+++ b/dist/tools/dhcpv6-pd_ia/kea.py
@@ -76,7 +89,7 @@ class KeaConfig(object):
 
     def __str__(self):
         if self.config_file is None:
-            self.config_file = tempfile.NamedTemporaryFile(mode="w")
+            self.config_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         self._dump_json()
         return self.config_file.name
```

#### Retry

`sudo PREFIX_CONF=dhcpv6 IPV6_PREFIX=2001:db8::/64 make all term`
> command is ['kea-dhcp6', '-c', '/tmp/tmpq8boziok']

Still: While the application is running, observe that no kea actually runs: `ps -aux | grep kea`

Run kea manually: `sudo kea-dhcp6 -c /tmp/tmpq8boziok`

```
...
2024-06-17 19:07:30.498 ERROR [kea-dhcp6.dhcp6/157063.140048319762688] DHCP6_PARSER_FAIL failed to create or run parser for configuration element subnet6: subnet configuration failed: missing parameter 'id' (/tmp/tmpq8boziok:1:206)
2024-06-17 19:07:30.498 ERROR [kea-dhcp6.dhcp6/157063.140048319762688] DHCP6_CONFIG_LOAD_FAIL configuration error using file: /tmp/tmpq8boziok, reason: subnet configuration failed: missing parameter 'id' (/tmp/tmpq8boziok:1:206)
2024-06-17 19:07:30.498 ERROR [kea-dhcp6.dhcp6/157063.140048319762688] DHCP6_INIT_FAIL failed to initialize Kea server: configuration error using file '/tmp/tmpq8boziok': subnet configuration failed: missing parameter 'id' (/tmp/tmpq8boziok:1:206)
```

https://kea.readthedocs.io/en/kea-2.6.0/arm/dhcp6-srv.html#ipv6-subnet-identifier

</details>