### PR TITLE
makesfiles/jlink: fix exports for flashing

### DIFF
--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -15,13 +15,21 @@ JLINK_SERIAL ?= $(DEBUG_ADAPTER_ID)
 JLINK_IF ?=
 JLINK_RESET_FILE ?=
 JLINK_PRE_FLASH ?=
+JLINK_POST_FLASH ?=
+
+JLINK_FLASH_TARGETS = flash flash%
+JLINK_TARGETS = debug% $(JLINK_FLASH_TARGETS) reset term-rtt
 
 # Export JLINK_SERIAL to required targets
-JLINK_TARGETS = debug% flash% reset term-rtt
 $(call target-export-variables,$(JLINK_TARGETS),JLINK_SERIAL)
 
 # Export JLINK_DEVICE to required targets
 $(call target-export-variables,$(JLINK_TARGETS),JLINK_DEVICE)
+
+ifneq (,$(JLINK))
+  # Export JLINK to required targets if not empty
+  $(call target-export-variables,$(JLINK_TARGETS),JLINK)
+endif
 
 ifneq (,$(JLINK_IF))
   # Export JLINK_IF to required targets if not empty
@@ -35,5 +43,10 @@ endif
 
 # Export JLINK_PRE_FLASH to flash targets only if not empty
 ifneq (,$(JLINK_PRE_FLASH))
-  $(call target-export-variables,flash%,JLINK_PRE_FLASH)
+  $(call target-export-variables,JLINK_FLASH_TARGETS,JLINK_PRE_FLASH)
+endif
+
+# Export JLINK_POST_FLASH to flash targets only if not empty
+ifneq (,$(JLINK_POST_FLASH))
+  $(call target-export-variables,JLINK_FLASH_TARGETS,JLINK_POST_FLASH)
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Most details of this PR are detailed in #20775. tl;dr: In the `makefiles/tools/jlink.inc.mk` file, a `%` wildcard is used for the flash targets that includes all variants of `flash...` but not `flash` itself. Therefore important environment variables are not exported as they should be and others  like `JLINK_PRE_FLASH` and `JLINK_POST_FLASH` do not work.

Additionally, the `JLINK` and `JLINK_POST_FLASH` variables were not exported at all. The former did not have an effect because the `JLINK` variable has a backup in `dist/tools/jlink/jlink.sh`. However it _is_ defined in multiple places, for example in `boards/common/nrf52/Makefile.include`, so it would be good to actually use the defined value and not the fallback value.
The latter is not currently used by any boards, so it did not have an effect. However I want to use it, so this PR creates the basis for that.

The `debug%` wildcard seems to call another target as well, so it is not affected? But I could add `JLINK_DEBUG_TARGETS` in a similar way to `JLINK_FLASH_TARGETS` and also add `debug debug%`.

### Testing procedure

Of course, everything should still work as it should. Only very few boards use the `JLINK_PRE_FLASH` variable, but one that does is `stk3200`.
To test that this PR has the effect it should, you can compile for example `examples/default` with `BOARD=stk3200 make flash` (even if you don't have one, we don't need to actually flash it) and check the content of `examples/default/bin/stk3200/burn.seg`.

Without the PR, this is the content of `burn.seg`. The `JLINK_PRE_FLASH = r` from `boards/stk3200/Makefile.include` was ignored.

```
chris@ThinkPias:~/flashdev-riot/RIOT/examples/default$ cat bin/stk3200/burn.seg 
loadfile /home/chris/flashdev-riot/RIOT/examples/default/bin/stk3200/default.elf
r
g
exit
```

With the PR applied the output should look like this:
```
chris@ThinkPias:~/flashdev-riot/RIOT/examples/default$ cat bin/stk3200/burn.seg 
r
loadfile /home/chris/flashdev-riot/RIOT/examples/default/bin/stk3200/default.elf
r
g
exit
```

<hr/>

To test if the `JLINK` variable is properly exported, you can temporarily modify the `boards/common/nrf52/Makefile.include` and insert a random command for `JLINK`, in this case `uname`. It has to run successfully, otherwise the script will select `openocd`.
```diff
# set list of supported programmers
PROGRAMMERS_SUPPORTED += openocd bmp
# keep name of `JLINK` in sync with script jlink.sh in $(RIOTTOOLS)/jlink
- JLINK ?= JLinkExe
+ JLINK ?= uname
ifneq (,$(shell command -v $(JLINK)))
  PROGRAMMER ?= jlink
else
  PROGRAMMER ?= openocd
endif
```

Before applying the PR, the change of command does not have any effect and it should call `JLinkExe` anyway:

```
chris@ThinkPias:~/flashdev-riot/RIOT/examples/default$ BOARD=nrf52840dk make flash
Building application "default" for "nrf52840dk" with CPU "nrf52".

"make" -C /home/chris/flashdev-riot/RIOT/pkg/cmsis/ 
...
"make" -C /home/chris/flashdev-riot/RIOT/sys/net/gnrc/netif/pktq
   text	   data	    bss	    dec	    hex	filename
  45900	    172	   6452	  52524	   cd2c	/home/chris/flashdev-riot/RIOT/examples/default/bin/nrf52840dk/default.elf
/home/chris/flashdev-riot/RIOT/dist/tools/jlink/jlink.sh flash /home/chris/flashdev-riot/RIOT/examples/default/bin/nrf52840dk/default.elf
### Flashing Target ###
### Flashing elf file ###
SEGGER J-Link Commander V7.96e (Compiled Apr 17 2024 16:28:22)
DLL version V7.96e, compiled Apr 17 2024 16:27:56
...
```

After applying the PR, the error message `Error: J-Link appears not to be installed on your PATH` should be reported, because the `dist/tools/jlink/jlink.sh` script interprets the output of `JLinkExe` and obviously `uname` does not produce the correct output.

```
chris@ThinkPias:~/flashdev-riot/RIOT/examples/default$ BOARD=nrf52840dk make flash
Building application "default" for "nrf52840dk" with CPU "nrf52".

"make" -C /home/chris/flashdev-riot/RIOT/pkg/cmsis/ 
...
"make" -C /home/chris/flashdev-riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  45932	    172	   6452	  52556	   cd4c	/home/chris/flashdev-riot/RIOT/examples/default/bin/nrf52840dk/default.elf
/home/chris/flashdev-riot/RIOT/dist/tools/jlink/jlink.sh flash /home/chris/flashdev-riot/RIOT/examples/default/bin/nrf52840dk/default.elf
### Flashing Target ###
### Flashing elf file ###
Error: J-Link appears not to be installed on your PATH
make: *** [/home/chris/flashdev-riot/RIOT/examples/default/../../Makefile.include:844: flash] Fehler 1
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

See also #20775.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
