### PR TITLE
gnrc/network_layer/ipv6/nib: fix packet leak with unreachable neighbors

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -243,6 +243,14 @@ extern "C" {
  * @brief   Interface down event
  */
 #define GNRC_IPV6_NIB_IFACE_DOWN            (0x4fd5U)
+
+/**
+ * @brief   Flush neighbor packet queue.
+ *
+ * Event for flushing the packet queue of a on-link entry. The queue is only
+ * flushed if the neighbor is unreachable.
+ */
+#define GNRC_IPV6_NIB_FLUSH_PCK_QUEUE       (0x4fd6U)
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -176,6 +176,23 @@ extern "C" {
 #define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT                1
 #endif
 
+#if CONFIG_GNRC_IPV6_NIB_QUEUE_PKT
+/**
+ * @brief    queue capacity for the packets waiting for address resolution,
+ *           per neighbor
+ */
+#ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT_CAP
+#define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT_CAP            16
+#endif
+
+/**
+ * @brief   timeout for packets waiting for address resolution
+ */
+#ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT_LINGER_MS
+#define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT_LINGER_MS      (5 * MS_PER_SEC)
+#endif
+#endif /* CONFIG_GNRC_IPV6_NIB_QUEUE_PKT */
+
 /**
  * @brief   handle NDP messages according for stateless address
  *          auto-configuration (if activated on interface)

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -242,6 +242,7 @@ static void *_event_loop(void *args)
             case GNRC_IPV6_NIB_REREG_ADDRESS:
             case GNRC_IPV6_NIB_DAD:
             case GNRC_IPV6_NIB_VALID_ADDR:
+            case GNRC_IPV6_NIB_FLUSH_PCK_QUEUE:
                 DEBUG("ipv6: NIB timer event received\n");
                 gnrc_ipv6_nib_handle_timer_event(msg.content.ptr, msg.type);
                 break;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -277,11 +277,9 @@ void _nib_nc_remove(_nib_onl_entry_t *node)
     evtimer_del((evtimer_t *)&_nib_evtimer, &node->addr_reg_timeout.event);
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LR */
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_QUEUE_PKT)
-    gnrc_pktqueue_t *tmp;
-    for (gnrc_pktqueue_t *ptr = node->pktqueue;
-         (ptr != NULL) && (tmp = (ptr->next), 1);
-         ptr = tmp) {
-        gnrc_pktqueue_t *entry = gnrc_pktqueue_remove(&node->pktqueue, ptr);
+    _evtimer_del(&node->flush_queue_timeout);
+    gnrc_pktqueue_t *entry;
+    while ((entry = _nbr_pop_pkt(node)) != NULL) {
         gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
                                        entry->pkt);
         gnrc_pktbuf_release_error(entry->pkt, EHOSTUNREACH);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -100,6 +100,8 @@ typedef struct _nib_onl_entry {
      * @note    Only available if @ref CONFIG_GNRC_IPV6_NIB_QUEUE_PKT != 0.
      */
     gnrc_pktqueue_t *pktqueue;
+    evtimer_msg_event_t flush_queue_timeout;   /**< Event for @ref GNRC_IPV6_NIB_FLUSH_PCK_QUEUE */
+    size_t pktqueue_len;                       /**< Number of queued packets */
 #endif
     /**
      * @brief Neighbors IPv6 address
@@ -871,6 +873,38 @@ void _nib_ft_get(const _nib_offl_entry_t *dst, gnrc_ipv6_nib_ft_t *fte);
  */
 int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *ctx,
                    gnrc_ipv6_nib_ft_t *entry);
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_QUEUE_PKT)
+/**
+ * @brief Event handler for flushing the packet queue of a neighbor
+ *
+ * The queue will only be flushed if the neighbor is unreachable.
+ *
+ * @param node neighbor entry to be flushed
+ */
+void _nbr_flush_pktqueue(_nib_onl_entry_t *node);
+
+/**
+ * @brief Remove oldest packet from the neighbor packet queue.
+ *
+ * @param node neighbor entry
+ *
+ * @retval pointer to the packet entry or NULL if the queue is empty
+ */
+gnrc_pktqueue_t *_nbr_pop_pkt(_nib_onl_entry_t *node);
+
+/**
+ * @brief Push packet to the neighbor packet queue.
+ *
+ * @note If the queue size is @ref CONFIG_GNRC_IPV6_NIB_QUEUE_PKT_CAP,
+ *       this will @ref _nbr_pop_pkt() the oldest packet and release it.
+ *
+ * @param node neighbor entry
+ * @param pkt packet to be pushed
+ */
+void _nbr_push_pkt(_nib_onl_entry_t *node, gnrc_pktqueue_t *pkt);
+
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This following fix only applies for `CONFIG_GNRC_IPV6_NIB_QUEUE_PKT == 1` (default config).  

There is currently the case that a on-link neighbor's packet queue might never be emptied. Specifically: if a neighbor is unreachable, the packets queued to be later send (i.e. once the neighbor is resolved) will never be de-queued if the neighbor is never resolved. On a typical link (e.g. ethernet), this is less of a problem, as the NIB subsystem actively tries to resolve the host, and in case of failure the neighbor entry is removed and the packets in it's queue get released. However, on e.g. 6LoWPANs, there is no active discovery going on, so the code path for removing the neighbor never gets executed.

This PR adds a new event that flushes the packets in a neighbor's queue **if and only if** the neighbor is unreachable.
The flushing event is enqueued only when one of the following events happen:
 - the neighbor is unreachable, it's packet queue is empty, and a packet is enqueued in it's queue
 - the neighbor switches status from reachable to unreachable **and** it's packet queue is **not** empty

Additionally, a neighbor's packet queue is now capped at `CONFIG_GNRC_IPV6_NIB_QUEUE_PKT_CAP`. If this limit is reached before the flushing event is triggered, the oldest packets will get discarded. This is to ensure that packet-flooding a neighbor won't cause a DoS on others, should the packet pool get depleted before the flushing event.

 ### Testing procedure
Here is some example code that triggers the bug:
```c
void udp_send(void)
{
    sock_udp_t sock;
    sock_udp_ep_t local;
    sock_udp_ep_t remote;

    int res = sock_udp_str2ep(&local, "[fdf7:0:0:ff::1]:777");
    assert(res == 0);
    res = sock_udp_str2ep(&remote, "[fdf7:0:0:ff::ff]:777");
    assert(res == 0);

    res = sock_udp_create(&sock, &local, NULL, 0);
    assert(res == 0);

    static char const to_send[] = "I receive, you receive <>";

    while (1) {
        res = sock_udp_send(&sock, to_send, sizeof(to_send), &remote);
        (void) to_send;
        if (res < 0) {
            // once all the packets in the queue pool get used up, it fails with -ENOMEM
            printf("%s: send error: %d\n", __func__, res);
        } else {
            // this works for a while
            printf("%s: sent %d bytes\n", __func__, res);
        }
        ztimer_sleep(ZTIMER_MSEC, 500);
    }
    return NULL;
}

static void config_routes(void)
{
    gnrc_netif_t const *rf_itf = gnrc_netif_get_by_type(NETDEV_AT86RF215, NETDEV_INDEX_ANY);
    assert(rf_itf != NULL);

    ipv6_addr_t subnet;
    ipv6_addr_t *res = ipv6_addr_from_str(&subnet, "fdf7::");
    assert(res != NULL);

    ipv6_addr_t gateway;
    res = ipv6_addr_from_str(&gateway, "fdf7:0:0:ff::ff");
    assert(res != NULL);

    // add a static route, which automatically adds a neighbor entry that never gets resolved
    int resi = gnrc_ipv6_nib_ft_add(&subnet, 64, &gateway, rf_itf->pid, 0);
    assert(resi == 0);

    // if this gets compiled in, the bug is not triggered anymore as the neighbor is then marked as
    // unmanaged and does not count as unresolved
    // uint8_t const l2_addr[] = { 0xE6, 0x41, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6 };
    // resi = gnrc_ipv6_nib_nc_set(&gateway, rf_itf->pid, l2_addr, sizeof(l2_addr));
    // assert(resi == 0);
}

static void config_addresses(void)
{
    gnrc_netif_t *itf = gnrc_netif_get_by_type(NETDEV_AT86RF215, NETDEV_INDEX_ANY);
    assert(itf);

    int res = gnrc_netif_ipv6_addr_add(itf, "fdf7:0:0:ff::1", 64, 0);
    assert(res >= 0);
}

int main(void)
{
    int ret;
    // 8< 
    config_addresses();
    config_routes();
    udp_send();
   // 8< 
}
```

I briefly tested the changes with both `NETDEV_SAM0_ETH` and `NETDEV_AT86RF215`. However, please keep in mind that this is my first time digging in the RIOT network stack, so there might be some edge-cases that I might have missed.