### PR TITLE
drivers/led: add LED_NUMOF and convenience inline functions

### DIFF
--- a/boards/adafruit-grand-central-m4-express/include/board.h
+++ b/boards/adafruit-grand-central-m4-express/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/adafruit-itsybitsy-m4/include/board.h
+++ b/boards/adafruit-itsybitsy-m4/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/arduino-mkr1000/include/board.h
+++ b/boards/arduino-mkr1000/include/board.h
@@ -24,6 +24,7 @@
 #include "periph_conf.h"
 #include "board_common.h"
 #include "arduino_pinmap.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/arduino-mkrfox1200/include/board.h
+++ b/boards/arduino-mkrfox1200/include/board.h
@@ -24,6 +24,7 @@
 #include "periph_conf.h"
 #include "board_common.h"
 #include "arduino_pinmap.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/arduino-mkrwan1300/include/board.h
+++ b/boards/arduino-mkrwan1300/include/board.h
@@ -25,6 +25,7 @@
 #include "periph_conf.h"
 #include "board_common.h"
 #include "arduino_pinmap.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/arduino-mkrzero/include/board.h
+++ b/boards/arduino-mkrzero/include/board.h
@@ -24,6 +24,7 @@
 #include "periph_conf.h"
 #include "board_common.h"
 #include "arduino_pinmap.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/arduino-nano-33-iot/include/board.h
+++ b/boards/arduino-nano-33-iot/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/bastwan/include/board.h
+++ b/boards/bastwan/include/board.h
@@ -25,6 +25,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 #include "periph/pm.h"
 
 #ifdef __cplusplus

--- a/boards/common/arduino-due/include/board.h
+++ b/boards/common/arduino-due/include/board.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "arduino_pinmap.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/common/arduino-zero/include/board.h
+++ b/boards/common/arduino-zero/include/board.h
@@ -25,6 +25,7 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 #include "arduino_pinmap.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -23,6 +23,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -23,6 +23,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/gd32vf103c-start/include/board.h
+++ b/boards/gd32vf103c-start/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -24,6 +24,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/samd10-xmini/include/board.h
+++ b/boards/samd10-xmini/include/board.h
@@ -23,6 +23,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/samd20-xpro/include/board.h
+++ b/boards/samd20-xpro/include/board.h
@@ -23,6 +23,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/samd21-xpro/include/board.h
+++ b/boards/samd21-xpro/include/board.h
@@ -26,6 +26,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/saml21-xpro/include/board.h
+++ b/boards/saml21-xpro/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -24,6 +24,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -22,6 +22,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/seeedstudio-gd32/include/board.h
+++ b/boards/seeedstudio-gd32/include/board.h
@@ -22,6 +22,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/seeeduino_xiao/include/board.h
+++ b/boards/seeeduino_xiao/include/board.h
@@ -24,6 +24,7 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -25,6 +25,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/serpente/include/board.h
+++ b/boards/serpente/include/board.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sipeed-longan-nano/include/board.h
+++ b/boards/sipeed-longan-nano/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sodaq-autonomo/include/board.h
+++ b/boards/sodaq-autonomo/include/board.h
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sodaq-explorer/include/board.h
+++ b/boards/sodaq-explorer/include/board.h
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sodaq-one/include/board.h
+++ b/boards/sodaq-one/include/board.h
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sodaq-sara-aff/include/board.h
+++ b/boards/sodaq-sara-aff/include/board.h
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/sodaq-sara-sff/include/board.h
+++ b/boards/sodaq-sara-sff/include/board.h
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/led.h
+++ b/drivers/include/led.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    drivers_led Control on-board LEDs
  * @ingroup     drivers_actuators
- * @brief       Access macros to control the on-board LEDs
+ * @brief       Access macros and functions to control the on-board LEDs
  *
  * This header contains a set of macros for controlling the on-board LEDs of
  * a board. The LEDs are enumerated, starting from LED0 to LED7. As most
@@ -24,7 +24,7 @@
  * @{
  *
  * @file
- * @brief       Macros for controlling the on-board LEDs
+ * @brief       Macros and inline functions for controlling the on-board LEDs
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
@@ -106,15 +106,102 @@ extern "C" {
 #define LED7_IS_PRESENT     /**< indicate that LED7 is present */
 #endif
 
+/**
+ * Number of LEDs available on the current board.
+ */
+#if defined(LED7_IS_PRESENT)
+#define LED_NUMOF 8
+#elif defined(LED6_IS_PRESENT)
+#define LED_NUMOF 7
+#elif defined(LED5_IS_PRESENT)
+#define LED_NUMOF 6
+#elif defined(LED4_IS_PRESENT)
+#define LED_NUMOF 5
+#elif defined(LED3_IS_PRESENT)
+#define LED_NUMOF 4
+#elif defined(LED2_IS_PRESENT)
+#define LED_NUMOF 3
+#elif defined(LED1_IS_PRESENT)
+#define LED_NUMOF 2
+#elif defined(LED0_IS_PRESENT)
+#define LED_NUMOF 1
+#else
+#define LED_NUMOF 0
+#endif
+
 /** @} */
 
 /**
- * @name    Convenience LED control macros
+ * @name    Convenience LED control functions and macros
  * @{
  */
-#define LED_ON(x)           LED ## x ##_ON      /**< Turn on led x */
-#define LED_OFF(x)          LED ## x ## _OFF    /**< Turn off led x */
-#define LED_TOGGLE(x)       LED ## x ##_TOGGLE  /**< Toggle led x */
+#define LED_ON(id)           LED ## id ##_ON      /**< Turn on an LED */
+#define LED_OFF(id)          LED ## id ## _OFF    /**< Turn off an LED */
+#define LED_TOGGLE(id)       LED ## id ##_TOGGLE  /**< Toggle an LED */
+
+/**
+ * Turn on an LED.
+ *
+ * @note If id is a compile-time constant, consider using @ref LED_ON(id) instead.
+ *
+ * @param id    id of LED between 0 and 7
+ */
+static inline void led_on(unsigned id)
+{
+    switch (id) {
+        case 0: LED0_ON; break;
+        case 1: LED1_ON; break;
+        case 2: LED2_ON; break;
+        case 3: LED3_ON; break;
+        case 4: LED4_ON; break;
+        case 5: LED5_ON; break;
+        case 6: LED6_ON; break;
+        case 7: LED7_ON; break;
+    }
+}
+
+/**
+ * Turn off an LED.
+ *
+ * @note If id is a compile-time constant, consider using @ref LED_OFF(id) instead.
+ *
+ * @param id    id of LED between 0 and 7
+ */
+static inline void led_off(unsigned id)
+{
+    switch (id) {
+        case 0: LED0_OFF; break;
+        case 1: LED1_OFF; break;
+        case 2: LED2_OFF; break;
+        case 3: LED3_OFF; break;
+        case 4: LED4_OFF; break;
+        case 5: LED5_OFF; break;
+        case 6: LED6_OFF; break;
+        case 7: LED7_OFF; break;
+    }
+}
+
+/**
+ * Toggle an LED.
+ *
+ * @note If id is a compile-time constant, consider using @ref LED_TOGGLE(id) instead.
+ *
+ * @param id    id of LED between 0 and 7
+ */
+static inline void led_toggle(unsigned id)
+{
+    switch (id) {
+        case 0: LED0_TOGGLE; break;
+        case 1: LED1_TOGGLE; break;
+        case 2: LED2_TOGGLE; break;
+        case 3: LED3_TOGGLE; break;
+        case 4: LED4_TOGGLE; break;
+        case 5: LED5_TOGGLE; break;
+        case 6: LED6_TOGGLE; break;
+        case 7: LED7_TOGGLE; break;
+    }
+}
+
 /** @} */
 
 #ifdef __cplusplus

--- a/tests/leds/main.c
+++ b/tests/leds/main.c
@@ -22,8 +22,7 @@
 #include <stdint.h>
 
 #include "clk.h"
-#include "board.h"
-#include "periph_conf.h"
+#include "led.h"
 #include "periph/gpio.h"
 
 #define DELAY_SHORT         (coreclk() / 50)
@@ -38,41 +37,11 @@ void dumb_delay(uint32_t delay)
 
 int main(void)
 {
-    int numof = 0;
-
     /* get the number of available LED's and turn them all off*/
-#ifdef LED0_ON
-    ++numof;
-    LED0_OFF;
-#endif
-#ifdef LED1_ON
-    ++numof;
-    LED1_OFF;
-#endif
-#ifdef LED2_ON
-    ++numof;
-    LED2_OFF;
-#endif
-#ifdef LED3_ON
-    ++numof;
-    LED3_OFF;
-#endif
-#ifdef LED4_ON
-    ++numof;
-    LED4_OFF;
-#endif
-#ifdef LED5_ON
-    ++numof;
-    LED5_OFF;
-#endif
-#ifdef LED6_ON
-    ++numof;
-    LED6_OFF;
-#endif
-#ifdef LED7_ON
-    ++numof;
-    LED7_OFF;
-#endif
+    unsigned numof = LED_NUMOF;
+    for (unsigned i = 0; i < numof; i++) {
+        led_off(i);
+    }
 
     puts("On-board LED test\n");
     /* cppcheck-suppress knownConditionTrueFalse
@@ -86,7 +55,7 @@ int main(void)
     }
 
     for (unsigned i = 0; i < 4; ++i) {
-#ifdef LED0_ON
+#ifdef LED0_IS_PRESENT
         LED0_ON;
         dumb_delay(DELAY_LONG);
         LED0_OFF;
@@ -100,7 +69,7 @@ int main(void)
         LED0_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED1_ON
+#ifdef LED1_IS_PRESENT
         LED1_ON;
         dumb_delay(DELAY_LONG);
         LED1_OFF;
@@ -114,7 +83,7 @@ int main(void)
         LED1_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED2_ON
+#ifdef LED2_IS_PRESENT
         LED2_ON;
         dumb_delay(DELAY_LONG);
         LED2_OFF;
@@ -128,7 +97,7 @@ int main(void)
         LED2_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED3_ON
+#ifdef LED3_IS_PRESENT
         LED3_ON;
         dumb_delay(DELAY_LONG);
         LED3_OFF;
@@ -142,7 +111,7 @@ int main(void)
         LED3_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED4_ON
+#ifdef LED4_IS_PRESENT
         LED4_ON;
         dumb_delay(DELAY_LONG);
         LED4_OFF;
@@ -156,7 +125,7 @@ int main(void)
         LED4_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED5_ON
+#ifdef LED5_IS_PRESENT
         LED5_ON;
         dumb_delay(DELAY_LONG);
         LED5_OFF;
@@ -170,7 +139,7 @@ int main(void)
         LED5_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED6_ON
+#ifdef LED6_IS_PRESENT
         LED6_ON;
         dumb_delay(DELAY_LONG);
         LED6_OFF;
@@ -184,7 +153,7 @@ int main(void)
         LED6_TOGGLE;
         dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED7_ON
+#ifdef LED7_IS_PRESENT
         LED7_ON;
         dumb_delay(DELAY_LONG);
         LED7_OFF;


### PR DESCRIPTION
### Contribution description

While reviewing #20782, I found some expected convenience functions for simple LED usage to be missing from "led.h". This PR adds the following:
- a macro `LED_NUMOF` that provides the number of available LEDs at compile-time
- static inline convenience functions `led_{on,off,toggle}` with the LED id as run-time argument, mirroring the `LED_{ON,OFF,TOGGLE}` compile-time macros

Also adapts `tests/leds` to (partly) use the newly provided functionality.

### Testing procedure

`make -C tests/leds` should still work with the board of your choice.


### Issues/PRs references

Could enable an easier application code for examples like #20782 