### PR TITLE
nib.c: add interface selection rules for static link local address assignment

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -182,6 +182,28 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Select interfaces by driver types for setting static link local
+ *          addresses
+ *
+ * This option allows to explicitly include interfaces by matching their
+ * netdev driver types, encoded in a bitmask.
+ * See @ref netdev_type_t for possible values of netdev driver types.
+ * Matching NETDEV_ANY will include all netdev driver types.
+ *
+ * Example usage, includes AT86RF215 and MRF24J40 driver types:
+ *
+ * @code{.c}
+ * #define CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK \
+ *    ((1UL << NETDEV_AT86RF215) | (1UL << NETDEV_MRF24J40))
+ * @endcode
+ *
+ * A value of 0 will switch this selection feature off.
+ */
+#ifndef CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK
+#define CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK 0ULL
+#endif
+
+/**
  * @brief Message queue size to use for the IPv6 thread.
  */
 #ifndef GNRC_IPV6_MSG_QUEUE_SIZE

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -116,6 +116,23 @@ void gnrc_ipv6_nib_init(void)
 static void _add_static_lladdr(gnrc_netif_t *netif)
 {
 #ifdef CONFIG_GNRC_IPV6_STATIC_LLADDR
+#if (CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK) > 0
+#ifndef MODULE_NETDEV_REGISTER
+#error "Use of CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK requires MODULE_NETDEV_REGISTER"
+#endif
+    if (! (((CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK) & (1ULL << netif->dev->type)) ||
+           ((CONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK) & (1ULL << NETDEV_ANY)))) {
+        DEBUG("nib: interface #%u: not setting static link-local address "
+                "(netdev type %u not included)\n",
+                netif->pid, netif->dev->type);
+        return;
+    }
+#endif
+    DEBUG("nib: interface #%u: adding static link-local address \"%s\"%s\n",
+            netif->pid,
+            CONFIG_GNRC_IPV6_STATIC_LLADDR,
+            IS_ACTIVE(CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED) ?
+                " (fixed)" : " (+ interface number)");
     /* parse addr from string and explicitly set a link local prefix
      * if ifnum > 1 each interface will get its own link local address
      * with CONFIG_GNRC_IPV6_STATIC_LLADDR + i


### PR DESCRIPTION
UPDATED ON: 2024-08-14, 2024-08-15

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Setting static link local addresses is supported in nib.c.
This contribution adds options for applying static link local addresses only on specific interfaces.
Setting the static  link local address can be selected by either netdev driver type or by interface number.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Compile `examples/gnrc_networking` for board `native`, uncommenting the Makefile lines

```Makefile
IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
```

A static link local address will show up in `ifconfig`:

```text
Iface  6  HWaddr: 56:CB:2C:67:4D:F3
          ...
          inet6 addr: fe80::cafe:cafe:cafe:7  scope: link  VAL
          ...
```

You can now play with the include options. Either

```Makefile
CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK="(1ULL << NETDEV_TAP)"
```

or

```Makefile
CFLAGS += -DCONFIG_GNRC_IPV6_STATIC_LLADDR_NETDEV_MASK="(1ULL << NETDEV_ANY)"
```

should leave the netif configuration unaltered, with the static link local address still showing up.

Other values for any of the config variable should make the link local address disappear.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
