### PR TITLE
rust: bump rust-riot-{sys,wrappers} version

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -769,8 +769,8 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.11"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#3fcd2c1ac196795496be9962bc31919743a60d9a"
+version = "0.7.12"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#a3752271062299f68c5f6ba3c6e503ac725722c4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -784,8 +784,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
+version = "0.8.4"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#7fb661c976c47d8228d4cefdcfaf247c74f316df"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -558,8 +558,8 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.11"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#3fcd2c1ac196795496be9962bc31919743a60d9a"
+version = "0.7.12"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#a3752271062299f68c5f6ba3c6e503ac725722c4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -573,8 +573,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
+version = "0.8.4"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#7fb661c976c47d8228d4cefdcfaf247c74f316df"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -584,8 +584,8 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.11"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#3fcd2c1ac196795496be9962bc31919743a60d9a"
+version = "0.7.12"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#a3752271062299f68c5f6ba3c6e503ac725722c4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -599,8 +599,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
+version = "0.8.4"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#7fb661c976c47d8228d4cefdcfaf247c74f316df"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -558,8 +558,8 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.11"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#3fcd2c1ac196795496be9962bc31919743a60d9a"
+version = "0.7.12"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#a3752271062299f68c5f6ba3c6e503ac725722c4"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -573,8 +573,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.8.3"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#87ba1141e093a97d1999e3c48ab276dd0e9c6529"
+version = "0.8.4"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#7fb661c976c47d8228d4cefdcfaf247c74f316df"
 dependencies = [
  "bare-metal",
  "coap-handler 0.1.6",


### PR DESCRIPTION
### Contribution description

Changes generated with `find -name Cargo.toml -exec cargo update --manifest-path "{}" --package riot-wrappers --package riot-sys ";"` on RIOT master

both `rust-riot-sys` and `rust-riot-wrappers` only bumped the version number with no functional changes


### Testing procedure

CI should suffice.
