### PR TITLE
periph_common/init.c: unblock i2c bus

### DIFF
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -26,6 +26,9 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
 #ifdef MODULE_PERIPH_INIT
 #ifdef MODULE_PERIPH_INIT_I2C
 #include "periph/i2c.h"
@@ -60,6 +63,52 @@
 #ifdef MODULE_PERIPH_INIT_SDMMC
 #include "sdmmc/sdmmc.h"
 #endif
+
+#if IS_USED(MODULE_PERIPH_INIT_I2C)
+#include "periph/gpio.h"
+#include "busy_wait.h"
+
+static void _i2c_sync_devices(i2c_t dev)
+{
+    /* Recover possible bus hangup by clocking peripheral
+     * i2c device state machines into idle.
+     * Hangup can occur if a transaction was interrupted
+     * by a reset of the MCU.
+     * Badly designed hardware can also cause a hangup
+     * due to glitches on the bus during operation which
+     * we do not aim to mitigate here.
+     */
+    gpio_init(i2c_config[dev].sda_pin, GPIO_IN);
+    gpio_init(i2c_config[dev].scl_pin, GPIO_OUT);
+    gpio_set(i2c_config[dev].scl_pin);
+    if (IS_ACTIVE(ENABLE_DEBUG)) {
+        if (!gpio_read(i2c_config[dev].sda_pin)) {
+            DEBUG("periph_init: i2c bus hangup detected for bus #%u,"
+                " recovering...\n", dev);
+        }
+        else {
+            DEBUG("periph_init: i2c bus #%u is ok\n", dev);
+        }
+    }
+    int max_cycles = 10; /* 9 clock cycles should be enough for making
+                          * any device that holds the SDA line in low
+                          * release the line. Actual number of cyccles may
+                          * vary depending on the device state.
+                          * The 10th cycle was added in case the first cycle
+                          * was not accepted by a device.
+                          */
+    while (gpio_read(i2c_config[dev].sda_pin) == 0 && max_cycles--) {
+        gpio_clear(i2c_config[dev].scl_pin);
+        busy_wait_us(100);
+        gpio_set(i2c_config[dev].scl_pin);
+        busy_wait_us(100);
+    }
+    if (IS_ACTIVE(ENABLE_DEBUG) && gpio_read(i2c_config[dev].sda_pin) == 0) {
+        DEBUG("periph_init: i2c recovery failed for bus #%u\n", dev);
+    }
+}
+#endif /* MODULE_PERIPH_INIT_I2C */
+
 #endif /* MODULE_PERIPH_INIT */
 
 void periph_init(void)
@@ -73,6 +122,7 @@ void periph_init(void)
     /* initialize configured I2C devices */
 #ifdef MODULE_PERIPH_INIT_I2C
     for (unsigned i = 0; i < I2C_NUMOF; i++) {
+        _i2c_sync_devices(i);
         i2c_init(I2C_DEV(i));
     }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a transaction is interrupted an external i2c device can remain in an unwanted state where it drives the bus to low
and will not release it without action. This can happen whenever a MCU has a software reset but no power cycle
is done on any part of the board.

This PR suggests a bus recovery at upstart, before `i2c_init`, assuming that any other cause for blocking
i2c devices will either be a software bug or a hardware issue and should be handled differently.

The basic mechanism for unblocking the bus is to "clock" it free until the state machine of the
corresponding device goes to idle and releases the bus. According to [this reference](https://ww1.microchip.com/downloads/en/devicedoc/atmel-8766-seeprom-at24cs04-08-datasheet.pdf) (Section "2-wire software reset"),
a maximum of 9 clock cycles should be able to do this. The additional start and stop conditions might not be
required as other sources [like this one](https://pebblebay.com/i2c-lock-up-prevention-and-recovery/)
do not mention it. As they interfere with the error condition where a device has control over SDA by pulling it low,
this PR chooses only to use SDA as an input and intends to make a blocking i2c device release the bus.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

Reproduction was possible using a SAME54-XPRO, using `tests/drivers/at24cxxx` with the following changes applied:

```diff
 % git diff
diff --git a/drivers/at24cxxx/at24cxxx.c b/drivers/at24cxxx/at24cxxx.c
index b3b9e8824d..be75fd9410 100644
--- a/drivers/at24cxxx/at24cxxx.c
+++ b/drivers/at24cxxx/at24cxxx.c
@@ -28,7 +28,7 @@
 #include "at24cxxx_defines.h"
 #include "at24cxxx.h"
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 #include "debug.h"
 
 /**
diff --git a/drivers/periph_common/init.c b/drivers/periph_common/init.c
index 8e7ff533a5..a45030de26 100644
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -26,7 +26,7 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 #include "debug.h"
 
 #ifdef MODULE_PERIPH_INIT
diff --git a/tests/drivers/at24cxxx/Makefile b/tests/drivers/at24cxxx/Makefile
index 36df791a5a..8d9c8d5e7f 100644
--- a/tests/drivers/at24cxxx/Makefile
+++ b/tests/drivers/at24cxxx/Makefile
@@ -1,7 +1,11 @@
 include ../Makefile.drivers_common
 
-AT24CXXX_DEV ?= at24c256
+AT24CXXX_DEV ?= at24cxxx
 
-USEMODULE += $(AT24CXXX_DEV)
+USEMODULE += stdin
+USEMODULE += at24mac
+USEMODULE += at24cxxx
+
+FEATURES_REQUIRED += periph_pm
 
 include $(RIOTBASE)/Makefile.include
diff --git a/tests/drivers/at24cxxx/main.c b/tests/drivers/at24cxxx/main.c
index 8f06fc3001..11a4b0c022 100644
--- a/tests/drivers/at24cxxx/main.c
+++ b/tests/drivers/at24cxxx/main.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "periph/pm.h"
 #include "xtimer.h"
 
 #include "at24cxxx.h"
@@ -42,10 +43,24 @@
 #define SET_POSITION            (AT24CXXX_EEPROM_SIZE - \
                                 7 * AT24CXXX_PAGE_SIZE - 4)
 #define SET_CHARACTER           'G'
-#define SET_LEN                 (20U)
+#define SET_LEN                 (100U)
+
+void do_reboot(void *arg)
+{
+    (void)arg;
+    pm_reboot();
+}
 
 int main(void)
 {
+    while (1) {
+        uint8_t c = getchar();
+        if (c == 's') {
+            puts("STARTING");
+            break;
+        }
+    }
+
     puts("Starting tests for module at24cxxx");
 
     at24cxxx_t at24cxxx_dev;
@@ -150,6 +165,11 @@ int main(void)
 
     uint8_t actual_set_data[sizeof(expected_set_data)];
 
+    xtimer_t reboot_timer = {
+        .callback = do_reboot,
+        .arg = NULL
+    };
+    xtimer_set(&reboot_timer, 550); // FIDDLED AROUND WITH THIS UNTIL IT WORKED
     check = at24cxxx_set(&at24cxxx_dev, SET_POSITION, SET_CHARACTER, SET_LEN);
     if (check != AT24CXXX_OK) {
         printf("[FAILURE] at24cxxx_set: %d (size = %u)\n", check, SET_LEN);

```

With the proposed changes, the program will reset during a write transaction on the EEPROM, but recover access during initilization and is able to execute the test repeatedly:

```text
2024-07-15 16:18:37,244 # periph_init: i2c bus #0 is ok
2024-07-15 16:18:37,254 # periph_init: i2c bus #1 is ok
2024-07-15 16:18:37,267 # main(): This is RIOT! (Version: 2024.04-devel-610-gc06da)
s
2024-07-15 16:18:41,699 # STARTING
2024-07-15 16:18:41,702 # Starting tests for module at24cxxx
2024-07-15 16:18:41,704 # EEPROM size: 256 byte
2024-07-15 16:18:41,706 # Page size  : 16 byte
2024-07-15 16:18:41,708 # [SUCCESS] at24cxxx_init
2024-07-15 16:18:41,712 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:41,715 # [SUCCESS] at24cxxx_write_byte
2024-07-15 16:18:41,719 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:18:41,721 # [SUCCESS] at24cxxx_read_byte
2024-07-15 16:18:41,724 # [SUCCESS] write_byte/read_byte
2024-07-15 16:18:41,728 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:41,732 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:41,735 # [SUCCESS] at24cxxx_write
2024-07-15 16:18:41,740 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:18:41,742 # [SUCCESS] at24cxxx_read
2024-07-15 16:18:41,743 # [SUCCESS] write/read
2024-07-15 16:18:41,753 # periph_init: i2c bus #0 is ok
2024-07-15 16:18:41,765 # periph_init: i2c bus hangup detected for bus #1, recovering...
2024-07-15 16:18:41,778 # main(): This is RIOT! (Version: 2024.04-devel-610-gc06da)
s
2024-07-15 16:18:46,107 # STARTING
2024-07-15 16:18:46,110 # Starting tests for module at24cxxx
2024-07-15 16:18:46,113 # EEPROM size: 256 byte
2024-07-15 16:18:46,115 # Page size  : 16 byte
2024-07-15 16:18:46,117 # [SUCCESS] at24cxxx_init
2024-07-15 16:18:46,120 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:46,122 # [SUCCESS] at24cxxx_write_byte
2024-07-15 16:18:46,126 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:18:46,129 # [SUCCESS] at24cxxx_read_byte
2024-07-15 16:18:46,131 # [SUCCESS] write_byte/read_byte
2024-07-15 16:18:46,135 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:46,142 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:46,142 # [SUCCESS] at24cxxx_write
2024-07-15 16:18:46,147 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:18:46,149 # [SUCCESS] at24cxxx_read
2024-07-15 16:18:46,151 # [SUCCESS] write/read
2024-07-15 16:18:46,160 # periph_init: i2c bus #0 is ok
2024-07-15 16:18:46,173 # periph_init: i2c bus hangup detected for bus #1, recovering...
2024-07-15 16:18:46,185 # main(): This is RIOT! (Version: 2024.04-devel-610-gc06da)
s
2024-07-15 16:18:51,811 # STARTING
2024-07-15 16:18:51,815 # Starting tests for module at24cxxx
2024-07-15 16:18:51,817 # EEPROM size: 256 byte
2024-07-15 16:18:51,818 # Page size  : 16 byte
2024-07-15 16:18:51,820 # [SUCCESS] at24cxxx_init
2024-07-15 16:18:51,826 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:51,827 # [SUCCESS] at24cxxx_write_byte
2024-07-15 16:18:51,831 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:18:51,834 # [SUCCESS] at24cxxx_read_byte
2024-07-15 16:18:51,836 # [SUCCESS] write_byte/read_byte
2024-07-15 16:18:51,840 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:51,844 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:18:51,846 # [SUCCESS] at24cxxx_write
2024-07-15 16:18:51,851 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:18:51,854 # [SUCCESS] at24cxxx_read
2024-07-15 16:18:51,855 # [SUCCESS] write/read
```

When returning directly after the debug output for the startup bus state in `drivers/periph_common/init.c`

```C
static void _i2c_sync_devices(i2c_t dev)
{
    /* ... */
        else {
            DEBUG("periph_init: i2c bus #%u is ok\n", dev);
        }
    }
    return; /* EARLY RETURN AFTER DETECTION BUT WITHOUT RECOVERY */
    int max_cycles = 10; /* 9 clock cycles should be enough for making
    /* ... */
```

the test will fail after the reset during a transaction:

```text
2024-07-15 16:19:10,093 # periph_init: i2c bus #0 is ok
2024-07-15 16:19:10,103 # periph_init: i2c bus #1 is ok
2024-07-15 16:19:10,115 # main(): This is RIOT! (Version: 2024.04-devel-610-gc06da)
s
2024-07-15 16:19:14,050 # STARTING
2024-07-15 16:19:14,054 # Starting tests for module at24cxxx
2024-07-15 16:19:14,055 # EEPROM size: 256 byte
2024-07-15 16:19:14,057 # Page size  : 16 byte
2024-07-15 16:19:14,060 # [SUCCESS] at24cxxx_init
2024-07-15 16:19:14,063 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:19:14,066 # [SUCCESS] at24cxxx_write_byte
2024-07-15 16:19:14,070 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:19:14,073 # [SUCCESS] at24cxxx_read_byte
2024-07-15 16:19:14,077 # [SUCCESS] write_byte/read_byte
2024-07-15 16:19:14,079 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:19:14,084 # [at24cxxx] i2c_write_regs(): 0; polls: 6
2024-07-15 16:19:14,086 # [SUCCESS] at24cxxx_write
2024-07-15 16:19:14,097 # [at24cxxx] i2c_read_regs(): 0; polls: 6
2024-07-15 16:19:14,098 # [SUCCESS] at24cxxx_read
2024-07-15 16:19:14,098 # [SUCCESS] write/read
2024-07-15 16:19:14,104 # periph_init: i2c bus #0 is ok
2024-07-15 16:19:14,117 # periph_init: i2c bus hangup detected for bus #1, recovering...
2024-07-15 16:19:14,130 # main(): This is RIOT! (Version: 2024.04-devel-610-gc06da)
s
2024-07-15 16:19:18,045 # STARTING
2024-07-15 16:19:18,052 # Starting tests for module at24cxxx
2024-07-15 16:19:18,053 # EEPROM size: 256 byte
2024-07-15 16:19:18,053 # Page size  : 16 byte
2024-07-15 16:19:18,054 # [SUCCESS] at24cxxx_init
2024-07-15 16:19:18,067 # [at24cxxx] i2c_write_regs(): -116; polls: 6
2024-07-15 16:19:18,068 # [FAILURE] at24cxxx_write_byte: -116
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
