### PR TITLE
dist/tools/cosy: take BUILD_DIR into account

### DIFF
--- a/dist/tools/cosy/patches/0003-take-BUILD_DIR-environment-variable-into-account.patch
+++ b/dist/tools/cosy/patches/0003-take-BUILD_DIR-environment-variable-into-account.patch
@@ -1,0 +1,34 @@
+From 40e6dfb3ba9c50d0bac3931b981822aaa20375a6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mikolai=20G=C3=BCtschow?= <mikolai.guetschow@tu-dresden.de>
+Date: Tue, 16 Jul 2024 16:48:49 +0200
+Subject: [PATCH] take BUILD_DIR environment variable into account
+
+---
+ cosy.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/cosy.py b/cosy.py
+index 7a15cc5..5d66f6b 100755
+--- a/cosy.py
++++ b/cosy.py
+@@ -17,7 +17,7 @@
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ import sys
+-from os import path
++from os import path, environ
+ from pathlib import Path
+ import argparse
+ import re
+@@ -156,6 +156,8 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
+ 
+     rbase.append("RIOT")
+     rbase.append("riotbuild/riotbase")
++    if "BUILD_DIR" in environ:
++        rbase.append(environ["BUILD_DIR"])
+     riot_base = "|".join([f'{p}/build|{p}' for p in rbase])
+ 
+     c = re.compile(r"(?P<addr>[0-9a-f]+) "
+-- 
+2.39.2
+


### PR DESCRIPTION
### Contribution description

Symbols coming from packages are not properly recognized as soon as the `BUILD_DIR` environment variable is used. This PR changes that.


### Testing procedure

Configure `BUILD_DIR` as per [the documentation](https://doc.riot-os.org/advanced-build-system-tricks.html#out-of-tree-cache-dir).

Start cosy on any app that uses a third-party package, e.g., `dtls-echo`:

```
make -C examples/dtls-echo cosy
```

On master, this shows
> Warning: 893 symbols could not be matched to a path

With this PR, it reduces to
> Warning: 527 symbols could not be matched to a path

and the `tinydtls` symbols are correctly matched.
