### PR TITLE
core/panic: don't use LOG_ functions in panic handler

### DIFF
--- a/core/lib/panic.c
+++ b/core/lib/panic.c
@@ -21,12 +21,12 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <stdio.h>
 #include "kernel_defines.h"
 #include "cpu.h"
 #include "irq.h"
 #include "panic.h"
 #include "periph/pm.h"
-#include "log.h"
 
 #if defined(DEVELHELP) && defined(MODULE_PS)
 #include "ps.h"
@@ -64,16 +64,16 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
 
         /* Call back app in case it wants to store some context */
         panic_app(crash_code, message);
-        LOG_ERROR("*** RIOT kernel panic:\n%s\n\n", message);
+        printf("*** RIOT kernel panic:\n%s\n\n", message);
 #ifdef DEVELHELP
 #ifdef MODULE_PS
         ps();
-        LOG_ERROR("\n");
+        printf("\n");
 #endif
 
-        LOG_ERROR("*** halted.\n\n");
+        printf("*** halted.\n\n");
 #else
-        LOG_ERROR("*** rebooting...\n\n");
+        printf("*** rebooting...\n\n");
 #endif
     }
     /* disable watchdog and all possible sources of interrupts */

--- a/cpu/cortexm_common/panic.c
+++ b/cpu/cortexm_common/panic.c
@@ -20,8 +20,8 @@
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
 
+#include <stdio.h>
 #include "cpu.h"
-#include "log.h"
 
 #ifdef DEVELHELP
 static void print_ipsr(void)
@@ -31,7 +31,7 @@ static void print_ipsr(void)
     if (ipsr) {
         /* if you get here, you might have forgotten to implement the isr
          * for the printed interrupt number */
-        LOG_ERROR("Inside isr %d\n", ((int)ipsr) - 16);
+        printf("Inside isr %d\n", ((int)ipsr) - 16);
     }
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The LOG_ functions can be overwritten to log e.g. to network or file system.
Calling them in the panic handler will just lead to another panic, obfuscating the original source of the panic.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
