### PR TITLE
boards/stm32l476g-disco: add ADC support

### DIFF
--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l476vg
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -80,6 +80,19 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC12_IN5  */
+    {GPIO_PIN(PORT_A, 5), 0, 10}, /*< ADC12_IN10 */
+    {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC12_IN6  */
+    {GPIO_PIN(PORT_A, 2), 0, 7},  /*< ADC12_IN7  */
+    {GPIO_PIN(PORT_A, 3), 0, 8},  /*< ADC12_IN8  */
+    {GPIO_UNDEF, 0, 18}, /* VBAT */
+};
+
+#define VBAT_ADC            ADC_LINE(5) /**< VBAT ADC line */
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -80,6 +80,35 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @brief    ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32L476VG order. Instead, we
+ * just define 5 ADC channels, for the next adjacent
+ * 5 pins, from 10 to 14, in the header P1 and the
+ * internal VBAT channel.
+ *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC12_IN10 is device 0 or device 1,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC12_IN10 is channel 10
+ *
+ * For STM32L476VG this information is in MCU datasheet,
+ * Table 16, page 73.
+ *
+ * VBAT is connected ADC1_IN18 or ADC3_IN18 and a voltage divider
+ * is used, so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For STM32L476VG more information is provided in MCU datasheet,
+ * in section 3.15.3 - Vbat battery voltage monitoring, page 42.
+ * @{
+ */
 static const adc_conf_t adc_config[] = {
     {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC12_IN5  */
     {GPIO_PIN(PORT_A, 5), 0, 10}, /*< ADC12_IN10 */
@@ -89,9 +118,16 @@ static const adc_conf_t adc_config[] = {
     {GPIO_UNDEF, 0, 18}, /* VBAT */
 };
 
-#define VBAT_ADC            ADC_LINE(5) /**< VBAT ADC line */
+/**
+ * @brief VBAT ADC line
+ */
+#define VBAT_ADC            ADC_LINE(5)
 
+/**
+ * @brief Number of ADC devices
+ */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -37,10 +37,10 @@ extern "C" {
 #error "Can't determine the number of ADC devices"
 #endif
 
-#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG) || \
-    defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC) || \
-    defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI) || \
-    defined(CPU_MODEL_STM32L496AG)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L476VG) || \
+    defined(CPU_MODEL_STM32L475VG) || defined(CPU_MODEL_STM32L452RE) || \
+    defined(CPU_MODEL_STM32L432KC) || defined(CPU_MODEL_STM32L496ZG) || \
+    defined(CPU_MODEL_STM32L4R5ZI) || defined(CPU_MODEL_STM32L496AG)
 /**
  * @brief   ADC voltage regulator start-up time [us]
  */


### PR DESCRIPTION
### Contribution description

This PR adds to the stm32l476g-disco ADC support.

### Testing procedure

Flash the board using `tests/periph_adc` program. Check if measured values changes when A0-A4 pins are
connected to the 3,3V, GND or to the potentiometer. 

### Issues/PRs references

None