### PR TITLE
pkg/wamr : updated wamr version to v2.1.1

### DIFF
--- a/pkg/wamr/Makefile
+++ b/pkg/wamr/Makefile
@@ -3,8 +3,8 @@ PKG_URL=https://github.com/bytecodealliance/wasm-micro-runtime.git
 ifeq ($(PKG_BLEEDING),1)
   PKG_VERSION=main
 else
-  PKG_VERSION=3f5e2bd23bcb8eb3767c8e17789c6a2e3e912a08
-  #release tag: WAMR-1.3.3
+  PKG_VERSION=8af155076c6c62d9766ede640cf3f29fa73a4b53
+  #release tag: WAMR-2.1.1
 endif
 PKG_LICENSE=Apache-2.0
 


### PR DESCRIPTION
A while ago I added the glue in WAMR to make RIOT works with its most recent version. Since the code is now implemented in the latest release I thought it could be good to update the version RIOT was using. I tested the example and had no particular problem on a DWM1001. 

From what I saw the wamr package is for now only used in the example so that should not cause any extra problem. Feel free to test the example on any other board but be aware that if you are using your own program it may have been broken because of the slight API changes that occurred in wamr between v1.3.3 and v2.1.1 (calling a wasm function does not require the signature anymore if you are not using the iwasm API).

### Contribution description

The only thing that was edited is the pkg/wamr/Makefile with the commit hash.

### Issues/PRs references

Ref : [wamr/PR/3508](https://github.com/bytecodealliance/wasm-micro-runtime/pull/3508)