### PR TITLE
examples/leds_shell: use periph_gpio_mock on native

### DIFF
--- a/examples/leds_shell/Makefile
+++ b/examples/leds_shell/Makefile
@@ -19,4 +19,10 @@ QUIET ?= 1
 USEMODULE += shell
 USEMODULE += periph_gpio
 
+# Prevents native and native64 program from segfault when gpio set/clear are
+# used without a gpiochip
+ifneq (,$(filter native native64,$(BOARD)))
+ USEMODULE += periph_gpio_mock
+endif
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

In current version of the `leds_shell` when user uses `gpio set` or `gpio clear` command in the `native` program ends with **_segmentation fault_** error. This PR solves this problem by adding `periph_gpio_mock` module. Now, when user in `native` uses these commands program works without crach - of course as this is mockup - nothing really happens. I tested this PR in few real boards and everything works fine.

### Testing procedure

Output from `examples/leds_shell` for `native` without this PR:

```
main(): This is RIOT! (Version: 2021.07-devel-10924-g4612c)
This board has 2 LEDs
> gpio set 0 0
gpio set 0 0
Set HIGH to PORT 0, PIN 0
Segmentation fault
```

and with this PR:

```
main(): This is RIOT! (Version: 2021.07-devel-10924-g4612c-examples-leds_shell-fix-segfault)
This board has 2 LEDs
> gpio set 0 0
gpio set 0 0
Set HIGH to PORT 0, PIN 0
> 
```
### Issues/PRs references

See also #20431
