### PR TITLE
net/gcoap: fix guards around defines

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -622,11 +622,12 @@ extern "C" {
  * @brief Stack size for module thread
  * @{
  */
-#ifndef GCOAP_STACK_SIZE
+#ifndef GCOAP_DTLS_EXTRA_STACKSIZE
 #if IS_USED(MODULE_GCOAP_DTLS)
 #define GCOAP_DTLS_EXTRA_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
 #else
 #define GCOAP_DTLS_EXTRA_STACKSIZE  (0)
+#endif
 #endif
 
 /**
@@ -639,6 +640,7 @@ extern "C" {
 #define GCOAP_VFS_EXTRA_STACKSIZE   (0)
 #endif
 
+#ifndef GCOAP_STACK_SIZE
 #define GCOAP_STACK_SIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE \
                           + sizeof(coap_pkt_t) + GCOAP_DTLS_EXTRA_STACKSIZE \
                           + GCOAP_VFS_EXTRA_STACKSIZE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The guards were wrong, leading to compilation issues with the modules enabled. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
