### PR TITLE
boards/nucleo-l053r8: MCU table addition to doc page

### DIFF
--- a/boards/nucleo-l053r8/doc.txt
+++ b/boards/nucleo-l053r8/doc.txt
@@ -12,6 +12,27 @@ Cortex-M0+ STM32L053R8 microcontroller with 8KiB of RAM and 32KiB of Flash.
 
 @image html pinouts/nucleo-l053r8.svg "Pinout for the nucleo-l053r8" width=50%
 
+### MCU
+
+| MCU          | STM32L053R8
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M0+      |
+| Vendor       | ST Microelectronics |
+| RAM          | 8KiB                |
+| Flash        | 64KiB               |
+| Frequency    | up to 32 MHz        |
+| Timers       | 9 (2x watchdog, 1 SysTick, 5x 16-bit, 1x RTC) |
+| ADCs         | 1x 12 bit (up to 16 channels) |
+| UARTs        | 3 (two USARTs and one Low-Power UART) |
+| I2Cs         | 2                   |
+| SPIs         | 4                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l053c6.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0367-ultralowpower-stm32l0x3-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um1724-stm32-nucleo64-boards-mb1136-stmicroelectronics.pdf)|
+
+
 ## Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.


### PR DESCRIPTION
### Contribution description

This PR adds MCU table to the `nucleo-l053r8` board doc page.

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l053r8.html 
```

### Issues/PRs references

None