### PR TITLE
cpu/stm32: implement `periph_gpio_ll_switch_dir`

### DIFF
--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -25,6 +25,7 @@ FEATURES_PROVIDED += periph_uart_nonblocking
 
 ifneq (f1,$(CPU_FAM))
   FEATURES_PROVIDED += periph_gpio_ll_open_drain_pull_up
+  FEATURES_PROVIDED += periph_gpio_ll_switch_dir
 endif
 
 ifneq (,$(filter $(CPU_FAM),c0 f0 f1 f3 g0 g4 l0 l1 l4 l5 u5 wb wl))

--- a/cpu/stm32/include/gpio_ll_arch.h
+++ b/cpu/stm32/include/gpio_ll_arch.h
@@ -142,6 +142,31 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t value)
     p->ODR = value;
 }
 
+#ifdef MODULE_PERIPH_GPIO_LL_SWITCH_DIR
+static inline uword_t gpio_ll_prepare_switch_dir(uword_t mask)
+{
+    /* implementation too large to always inline */
+    extern uword_t gpio_ll_prepare_switch_dir_impl(uword_t mask);
+    return gpio_ll_prepare_switch_dir_impl(mask);
+}
+
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    p->MODER |= pins;
+    irq_restore(irq_state);
+}
+
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    p->MODER &= ~pins;
+    irq_restore(irq_state);
+}
+#endif
+
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
     return pin & 0xfffffff0LU;

--- a/cpu/stm32/include/periph/cpu_gpio_ll.h
+++ b/cpu/stm32/include/periph/cpu_gpio_ll.h
@@ -31,6 +31,11 @@ extern "C" {
  * public view on type */
 #ifndef DOXYGEN
 
+#if !defined(CPU_FAM_STM32F1)
+/* For the STM32F1 GPIO peripheral, the gpio_ll_switch_dir is not supported */
+#  define HAVE_GPIO_LL_PREPARE_SWITCH_DIR
+#endif
+
 #define HAVE_GPIO_PULL_STRENGTH_T
 typedef enum {
     GPIO_PULL_WEAKEST = 0,

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -731,29 +731,39 @@ static inline uword_t gpio_ll_prepare_write(gpio_port_t port, uword_t mask,
 }
 #endif
 
+#if defined(DOXYGEN) || !defined(HAVE_GPIO_LL_PREPARE_SWITCH_DIR)
 /**
- * @brief       Turn GPIO pins specified by the bitmask @p outputs to outputs
+ * @brief       Prepare bitmask for use with @ref gpio_ll_switch_dir_output
+ *              and @ref gpio_ll_switch_dir_input
+ * @param[in]   mask    bitmask specifying the pins to switch the direction of
+ *
+ * @return      Value to use in @ref gpio_ll_switch_dir_output or
+ *              @ref gpio_ll_switch_dir_input
+ */
+static inline uword_t gpio_ll_prepare_switch_dir(uword_t mask)
+{
+    return mask;
+}
+#endif
+
+/**
+ * @brief       Turn GPIO pins specified by @p pins (obtained from
+ *              @ref gpio_ll_prepare_switch_dir) to outputs
  *
  * @param[in]   port        GPIO port to modify
- * @param[in]   outputs     Bitmask specifying the GPIO pins to set in output
- *                          mode
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_dir
  * @pre         The feature `gpio_ll_switch_dir` is available
  * @pre         Each affected GPIO pin is either configured as input or as
  *              push-pull output.
- *
- * @note        This is a makeshift solution to implement bit-banging of
- *              bidirectional protocols on less sophisticated GPIO peripherals
- *              that do not support open drain mode.
- * @warning     Use open drain mode instead, if supported.
  */
-static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs);
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t pins);
 
 /**
- * @brief       Turn GPIO pins specified by the bitmask @p inputs to inputs
+ * @brief       Turn GPIO pins specified by @p pins (obtained from
+ *              @ref gpio_ll_prepare_switch_dir) to inputs
  *
  * @param[in]   port        GPIO port to modify
- * @param[in]   inputs      Bitmask specifying the GPIO pins to set in input
- *                          mode
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_dir
  * @pre         The feature `gpio_ll_switch_dir` is available
  * @pre         Each affected GPIO pin is either configured as input or as
  *              push-pull output.
@@ -765,12 +775,8 @@ static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs);
  *              resistor is enabled). Hence, the bits in the output
  *              register of the pins switched to input should be restored
  *              just after this call.
- * @note        This is a makeshift solution to implement bit-banging of
- *              bidirectional protocols on less sophisticated GPIO peripherals
- *              that do not support open drain mode.
- * @warning     Use open drain mode instead, if supported.
  */
-static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs);
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t pins);
 
 /**
  * @brief   Perform a masked write operation on the I/O register of the port

--- a/features.yaml
+++ b/features.yaml
@@ -567,9 +567,9 @@ groups:
         help: The GPIO LL driver allows switching the direction between input
               and (push-pull) output in an efficient manner. The main use case
               is bit-banging bidirectional protocols when open-drain / open-source
-              mode is not supported. GPIO LL drivers for peripherals that do
-              support open drain mode typically do not bother implementing this,
-              even if the hardware would allow it.
+              mode is not supported. Another use case is controlling GPIOs
+              at high speed with three output states (high, low, high impedance),
+              as e.g. needed for Charlieplexing
 
   - title: Serial Interfaces
     help: Features related to serial interfaces

--- a/tests/periph/gpio_ll/main.c
+++ b/tests/periph/gpio_ll/main.c
@@ -933,8 +933,10 @@ static void test_switch_dir(void)
     expect(test_passed);
 
     gpio_ll_clear(port_out, mask_out);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = (0 == (gpio_ll_read(port_in) & mask_in));
     gpio_ll_set(port_out, mask_out);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = test_passed && (gpio_ll_read(port_in) & mask_in);
     printf_optional("Pin behaves as output after switched to output mode: %s\n",
                     noyes[test_passed]);
@@ -965,8 +967,10 @@ static void test_switch_dir(void)
     expect(0 == gpio_ll_init(port_in, PIN_IN_0, gpio_ll_out));
 
     gpio_ll_clear(port_in, mask_in);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = (0 == (gpio_ll_read(port_out) & mask_out));
     gpio_ll_set(port_in, mask_in);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = test_passed && (gpio_ll_read(port_out) & mask_out);
     printf_optional("Pin behaves as input after switched back to input mode: %s\n",
                     noyes[test_passed]);

--- a/tests/periph/gpio_ll/main.c
+++ b/tests/periph/gpio_ll/main.c
@@ -905,6 +905,7 @@ static void test_switch_dir(void)
          "===========================\n");
 
     uword_t mask_out = 1U << PIN_OUT_0;
+    uword_t pins_out = gpio_ll_prepare_switch_dir(mask_out);
     uword_t mask_in = 1U << PIN_IN_0;
 
     /* floating input must be supported by every MCU */
@@ -924,7 +925,7 @@ static void test_switch_dir(void)
     uword_t out_state = gpio_ll_read_output(port_out);
 
     /* now, switch to output mode and verify the switch */
-    gpio_ll_switch_dir_output(port_out, mask_out);
+    gpio_ll_switch_dir_output(port_out, pins_out);
     conf = gpio_ll_query_conf(port_out, PIN_OUT_0);
     test_passed = (conf.state == GPIO_OUTPUT_PUSH_PULL);
     printf_optional("Input pin can be switched to output (push-pull) mode: %s\n",
@@ -940,7 +941,7 @@ static void test_switch_dir(void)
     expect(test_passed);
 
     /* switch back to input mode */
-    gpio_ll_switch_dir_input(port_out, mask_out);
+    gpio_ll_switch_dir_input(port_out, pins_out);
     /* restore out state from before the switch */
     gpio_ll_write(port_out, out_state);
     /* verify we are back at the old config */


### PR DESCRIPTION
### Contribution description

This changes the API of the `periph_gpio_ll_switch_dir` feature, so that `gpio_ll_switch_dir_output()` and `gpio_ll_switch_dir_input()` no longer directly take a bitmask indicating with GPIO pins to switch, but the output of `gpio_ll_prepare_switch_dir()` that takes this bitmask.

The reason for this change is that on STM32 (except for F1) the GPIO periphal has no direction register (with one bit per pin), but a mode register (with two bits per pin). This required some non-trivial bit operation to prepare the bitmask to write to the mode register from the bitmask specifying the pins to change. Splitting out the preparation allows to cache the result and switch directions fast anyway.

An implementation for STM32F1 is not provided yet.

A default implementation for `gpio_ll_prepare_switch_dir()` is provided that returns the argument unmodified, so that no overhead is introduced on the platforms already supporting `periph_gpio_ll_switch_dir`.

### Testing procedure

```
git:(cpu/stm32/periph_gpio_ll_periph_gpio_ll_switch_dir) ~/Repos/software/RIOT/stm32_gpio_ll/tests/periph/gpio_ll ➜ make BOARD=nucleo-f303re flash test-with-config 
Building application "tests_gpio_ll" for "nucleo-f303re" with CPU "stm32".

"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/boards/nucleo-f303re
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/boards/common/nucleo
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/core
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/core/lib
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/cpu/stm32
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/cpu/cortexm_common/periph
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/cpu/stm32/periph
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/cpu/stm32/stmclk
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/cpu/stm32/vectors
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/drivers
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/div
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/frac
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll/sys/ztimer
   text	  data	   bss	   dec	   hex	filename
  21880	   176	  2736	 24792	  60d8	/home/maribu/Repos/software/RIOT/stm32_gpio_ll/tests/periph/gpio_ll/bin/nucleo-f303re/tests_gpio_ll.elf
/home/maribu/Repos/software/RIOT/stm32_gpio_ll/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/stm32_gpio_ll/tests/periph/gpio_ll/bin/nucleo-f303re/tests_gpio_ll.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-snapshot (2024-01-17-08:38)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
DEPRECATED! use 'adapter serial' not 'hla_serial'
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : clock speed 1000 kHz
Info : STLINK V2J28M17 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.246873
Info : [stm32f3x.cpu] Cortex-M4 r0p1 processor detected
Info : [stm32f3x.cpu] target has 6 breakpoints, 4 watchpoints
Info : [stm32f3x.cpu] Examination succeed
Info : starting gdb server for stm32f3x.cpu on 0
Info : Listening on port 44059 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f3x.cpu       hla_target little stm32f3x.cpu       unknown
Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
[stm32f3x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08001d70 msp: 0x20000200
Info : device id = 0x10036446
Info : flash size = 512 KiB
Warn : Adding extra erase range, 0x08005628 .. 0x080057ff
auto erase enabled
wrote 22056 bytes from file /home/maribu/Repos/software/RIOT/stm32_gpio_ll/tests/periph/gpio_ll/bin/nucleo-f303re/tests_gpio_ll.elf in 1.199477s (17.957 KiB/s)
verified 22056 bytes in 0.376511s (57.207 KiB/s)
Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
shutdown command invoked
Done flashing
r
/home/maribu/Repos/software/RIOT/stm32_gpio_ll/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-maribu" -rn "2024-08-02_20.05.02-tests_gpio_ll-nucleo-f303re" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2024.10-devel-43-g746981-cpu/stm32/periph_gpio_ll_periph_gpio_ll_switch_dir)
Test / Hardware Details:
========================
Cabling:
(INPUT -- OUTPUT)
  PC0 -- PC8
  PC1 -- PC9
Number of pull resistor values supported: 1
Number of drive strengths supported: 1
Number of slew rates supported: 4
Valid GPIO ports:
- PORT 0 (PORT A)
- PORT 1 (PORT B)
- PORT 2 (PORT C)
- PORT 3 (PORT D)
- PORT 4 (PORT E)
- PORT 5 (PORT F)
- PORT 6 (PORT G)
- PORT 7 (PORT H)

Testing gpio_port_pack_addr()
=============================

All OK

Testing gpip_ng_init()
======================

Testing is_gpio_port_num_valid() is true for PORT_OUT and PORT_IN:

Testing input configurations for PIN_IN_0:
Support for input with pull up: yes
state: in, pull: up, value: on, slew: slowest
Support for input with pull down: yes
state: in, pull: down, value: off, slew: slowest
Support for input with pull to bus level: no
Support for floating input (no pull resistors): yes
state: in, pull: none, value: off, slew: slowest

Testing output configurations for PIN_OUT_0:
Support for output (push-pull) with initial value of LOW: yes
state: out-pp, value: off, slew: slowest
Output is indeed LOW: yes
state: out-pp, value: on, slew: slowest
Output can be pushed HIGH: yes
Support for output (push-pull) with initial value of HIGH: yes
state: out-pp, value: on, slew: slowest
Output is indeed HIGH: yes
Support for output (open drain with pull up) with initial value of LOW: yes
state: out-od, pull: up, value: off, slew: slowest
Output is indeed LOW: yes
Support for output (open drain with pull up) with initial value of HIGH: yes
state: out-od, pull: up, value: on, slew: slowest
Output is indeed HIGH: yes
Support for output (open drain) with initial value of LOW: yes
state: out-od, pull: none, value: off, slew: slowest
Output is indeed LOW: yes
Support for output (open drain) with initial value of HIGH: yes
state: out-od, pull: none, value: on, slew: slowest
state: in, pull: down, value: off, slew: slowest
Output can indeed be pulled LOW: yes
state: in, pull: up, value: on, slew: slowest
Output can indeed be pulled HIGH: yes
Support for output (open source) with initial value of LOW: no
Support for output (open source) with initial value of HIGH: no
Support for output (open source with pull down) with initial value of HIGH: no
Support for output (open source with pull down) with initial value of LOW: no

Support for disconnecting GPIO: yes
state: off, pull: none, value: off, slew: slowest
Output can indeed be pulled LOW: yes
Output can indeed be pulled HIGH: yes

Testing Reading/Writing GPIO Ports
==================================

testing initial value of 0 after init
...OK
testing setting both outputs_optional simultaneously
...OK
testing clearing both outputs_optional simultaneously
...OK
testing toggling first output (0 --> 1)
...OK
testing toggling first output (1 --> 0)
...OK
testing toggling second output (0 --> 1)
...OK
testing toggling second output (1 --> 0)
...OK
testing setting first output and clearing second with write
...OK
testing setting second output and clearing first with write
...OK
All input/output operations worked as expected

Testing External IRQs
=====================

Testing rising edge on PIN_IN_0
... OK
Testing falling edge on PIN_IN_0
... OK
Testing both edges on PIN_IN_0
... OK
Testing masking of IRQs (still both edges on PIN_IN_0)
... OK
Testing level-triggered on HIGH on PIN_IN_0 (when input is LOW when setting up IRQ)
... OK
Testing level-triggered on HIGH on PIN_IN_0 (when input is HIGH when setting up IRQ)
... OK
Testing level-triggered on LOW on PIN_IN_0 (when input is HIGH when setting up IRQ)
... OK
Testing level-triggered on LOW on PIN_IN_0 (when input is LOW when setting up IRQ)
... OK

Testing Switching Direction
===========================

Input pin can be switched to output (push-pull) mode: yes
Pin behaves as output after switched to output mode: yes
Returning back to input had no side effects on config: yes
Pin behaves as input after switched back to input mode: yes


TEST SUCCEEDED
```

### Issues/PRs references

None