### PR TITLE
boards/weact-g030f6: fix use with stdio_rtt

### DIFF
--- a/boards/weact-g030f6/Makefile.include
+++ b/boards/weact-g030f6/Makefile.include
@@ -1,18 +1,13 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
+# setup programmer
+PROGRAMMERS_SUPPORTED += openocd
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink
-
-# openocd programmer is supported
-PROGRAMMERS_SUPPORTED += openocd
-
-# this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk
+
+# setup serial terminal
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+include $(RIOTMAKE)/tools/serial.inc.mk


### PR DESCRIPTION
### Contribution description

Running

    USEMODULE=stdio_rtt make BOARD=weact-g030f6 -C ... flash term

failed due the programmer not being specified by the time the serial is configured:

    makefiles/tools/serial.inc.mk:44: "Warning: No RIOT_TERMINAL set,
    but using stdio_rtt: The default terminal is likely not to work."

This reorders the setup of the board to first configure the programmer and then the serial, so that using stdio_rtt now works out of the box.

### Testing procedure

    USEMODULE=stdio_rtt make BOARD=weact-g030f6 -C examples/default flash term

should now work

### Issues/PRs references

None