### PR TITLE
boards/stm32l476g-disco: add PWM support

### DIFF
--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32l476vg
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -129,6 +129,15 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
+/**
+ * @name    PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {{}};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -132,8 +132,43 @@ static const adc_conf_t adc_config[] = {
 /**
  * @name    PWM configuration
  * @{
+ *
+ * To find appriopate device and channel find in the MCU datasheet table
+ * concerning "Alternate function AF0 to AF7" a text similar to TIM[X]_CH[Y],
+ * where:
+ * TIM[X] - is device,
+ * [Y] - describes used channel (indexed from 0), for example TIM2_CH1 is
+ * channel 0 in configuration structure (cc_chan - field),
+ * Port column in the table describes connected port.
+ *
+ * For stm32l476g-disco this information is in the MCU datasheet,
+ * Table 17, page 88.
+ *
+ * Remark!
+ * PMW device 0 overlaps with ADC.
  */
-static const pwm_conf_t pwm_config[] = {{}};
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR1_TIM2EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 5), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_A, 1), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_A, 2), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_A, 3), .cc_chan = 3} },
+        .af       = GPIO_AF1,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E, 11), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_E, 14), .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    }
+};
 
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR adds PWM configuration for `stm32l476g-disco`.

### Testing procedure

Flash the board using `tests/periph/pwm` program. Check if you could, for example, change LED
intensity using PWM.

### Issues/PRs references

None