### PR TITLE
drivers/periph_gpio_ll: Add periph_gpio_ll_switch_pull

### DIFF
--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -16,6 +16,7 @@ FEATURES_PROVIDED += periph_gpio_ll_irq_edge_triggered_both
 FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_high
 FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_low
 FEATURES_PROVIDED += periph_gpio_ll_open_drain
+FEATURES_PROVIDED += periph_gpio_ll_switch_dir
 FEATURES_PROVIDED += periph_rtt_overflow
 FEATURES_PROVIDED += periph_spi_reconfigure
 FEATURES_PROVIDED += periph_timer_periodic

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -17,6 +17,7 @@ FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_high
 FEATURES_PROVIDED += periph_gpio_ll_irq_level_triggered_low
 FEATURES_PROVIDED += periph_gpio_ll_open_drain
 FEATURES_PROVIDED += periph_gpio_ll_switch_dir
+FEATURES_PROVIDED += periph_gpio_ll_switch_pull
 FEATURES_PROVIDED += periph_rtt_overflow
 FEATURES_PROVIDED += periph_spi_reconfigure
 FEATURES_PROVIDED += periph_timer_periodic

--- a/cpu/stm32/include/gpio_ll_arch.h
+++ b/cpu/stm32/include/gpio_ll_arch.h
@@ -167,6 +167,58 @@ static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t pins)
 }
 #endif
 
+#ifdef MODULE_PERIPH_GPIO_LL_SWITCH_PULL
+static inline uword_t gpio_ll_prepare_switch_pull(uword_t mask)
+{
+    /* implementation too large to always inline */
+    extern uword_t gpio_ll_prepare_switch_pull_impl(uword_t mask);
+    return gpio_ll_prepare_switch_pull_impl(mask);
+}
+
+static inline void gpio_ll_switch_pull_up(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    uint32_t pupdr = p->PUPDR;
+    /* clear the high bit in the two-bit PUPDx fields to disable the pull down,
+     * if needed */
+    pupdr &= ~(pins << 1);
+    /* set the low bit in the two-bit PUPDx fields to enable the pull up */
+    pupdr |= pins;
+    p->PUPDR = pupdr;
+    irq_restore(irq_state);
+}
+
+static inline void gpio_ll_switch_pull_down(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    uint32_t pupdr = p->PUPDR;
+    /* clear the low bit in the two-bit PUPDx fields to disable the pull up,
+     * if needed */
+    pupdr &= ~(pins);
+    /* set the high bit in the two-bit PUPDx fields to enable the pull down */
+    pupdr |= (pins << 1);
+    p->PUPDR = pupdr;
+    irq_restore(irq_state);
+}
+
+static inline void gpio_ll_switch_pull_off(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    uint32_t pupdr = p->PUPDR;
+    /* clear the low bit in the two-bit PUPDx fields to disable the pull up,
+     * if needed */
+    pupdr &= ~(pins);
+    /* clear the high bit in the two-bit PUPDx fields to disable the pull down,
+     * if needed */
+    pupdr &= ~(pins << 1);
+    p->PUPDR = pupdr;
+    irq_restore(irq_state);
+}
+#endif
+
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
     return pin & 0xfffffff0LU;

--- a/cpu/stm32/include/gpio_ll_arch.h
+++ b/cpu/stm32/include/gpio_ll_arch.h
@@ -142,6 +142,31 @@ static inline void gpio_ll_write(gpio_port_t port, uword_t value)
     p->ODR = value;
 }
 
+#ifdef MODULE_PERIPH_GPIO_LL_SWITCH_DIR
+static inline uword_t gpio_ll_prepare_switch_dir(uword_t mask)
+{
+    /* implementation too large to always inline */
+    extern uword_t gpio_ll_prepare_switch_dir_impl(uword_t mask);
+    return gpio_ll_prepare_switch_dir_impl(mask);
+}
+
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    p->MODER |= pins;
+    irq_restore(irq_state);
+}
+
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t pins)
+{
+    GPIO_TypeDef *p = (GPIO_TypeDef *)port;
+    unsigned irq_state = irq_disable();
+    p->MODER &= ~pins;
+    irq_restore(irq_state);
+}
+#endif
+
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
     return pin & 0xfffffff0LU;

--- a/cpu/stm32/include/periph/cpu_gpio_ll.h
+++ b/cpu/stm32/include/periph/cpu_gpio_ll.h
@@ -33,6 +33,8 @@ extern "C" {
 
 #define HAVE_GPIO_LL_PREPARE_SWITCH_DIR
 
+#define HAVE_GPIO_LL_PREPARE_SWITCH_PULL
+
 #define HAVE_GPIO_PULL_STRENGTH_T
 typedef enum {
     GPIO_PULL_WEAKEST = 0,

--- a/cpu/stm32/include/periph/cpu_gpio_ll.h
+++ b/cpu/stm32/include/periph/cpu_gpio_ll.h
@@ -31,6 +31,8 @@ extern "C" {
  * public view on type */
 #ifndef DOXYGEN
 
+#define HAVE_GPIO_LL_PREPARE_SWITCH_DIR
+
 #define HAVE_GPIO_PULL_STRENGTH_T
 typedef enum {
     GPIO_PULL_WEAKEST = 0,

--- a/cpu/stm32/periph/gpio_ll.c
+++ b/cpu/stm32/periph/gpio_ll.c
@@ -405,6 +405,28 @@ uword_t gpio_ll_prepare_switch_dir_impl(uword_t mask)
     return output;
 }
 
+/*
+ * When changing the pull configuration, we need to update the GPIOX->PUPDR,
+ * which for pins 0 to 3 looks like this:
+ *
+ *   7    6    5    4    3    2    1    0
+ * +---------+---------+---------+---------+
+ * |  PUPD3  |  PUPD2  |  PUPD1  |  PUPD0  |
+ * +---------+---------+---------+---------+
+ *
+ * Now we need to write the values `b00` (pull off), `0b01` (pull up), and
+ * `0b10` (pull down). We can prepare the bitmask the same way as for switching
+ * the direction: We use the bitmask as is to control the low bit and shifted
+ * left by one to control the high bit of the pull config.
+ *
+ * Hence, we just create an alias to not waste ROM.
+ *
+ * (Note: Creating a single function, e.g. named gpio_ll_prepare_switch_impl,
+ * will trigger a c2rust bug.)
+ */
+__attribute__((alias("gpio_ll_prepare_switch_dir_impl")))
+uword_t gpio_ll_prepare_switch_pull_impl(uword_t mask);
+
 gpio_conf_t gpio_ll_query_conf(gpio_port_t port, uint8_t pin)
 {
     gpio_conf_t result = { 0 };

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -746,6 +746,22 @@ static inline uword_t gpio_ll_prepare_switch_dir(uword_t mask)
 }
 #endif
 
+#if defined(DOXYGEN) || !defined(HAVE_GPIO_LL_PREPARE_SWITCH_PULL)
+/**
+ * @brief       Prepare bitmask for use with @ref gpio_ll_switch_pull_up ,
+ *              @ref gpio_ll_switch_pull_down and @reg gpio_ll_switch_pull_off
+ * @param[in]   mask    bitmask specifying the pins to switch the direction pull
+ *                      configuration
+ *
+ * @return      Value to use in @ref gpio_ll_switch_pull_up ,
+ *              @ref gpio_ll_switch_pull_down and @ref gpio_ll_switch_pull_off
+ */
+static inline uword_t gpio_ll_prepare_switch_pull(uword_t mask)
+{
+    return mask;
+}
+#endif
+
 /**
  * @brief       Turn GPIO pins specified by @p pins (obtained from
  *              @ref gpio_ll_prepare_switch_dir) to outputs
@@ -777,6 +793,55 @@ static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t pins);
  *              just after this call.
  */
 static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t pins);
+
+/**
+ * @brief       Enables the internal pull up resistors for GPIO pins specified
+ *              by @p pins (obtained from @ref gpio_ll_prepare_switch_pull)
+ *
+ * @param[in]   port        GPIO port to modify
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_pull
+ * @pre         The feature `gpio_ll_switch_pull` is available
+ * @pre         The feature `periph_gpio_ll_input_pull_up` is provided and the
+ *              pins are in input mode. Some MCUs that provide the feature
+ *              `periph_gpio_ll_open_drain_pull_up` may also allow
+ *              enabling pull ups on open drain pins with this function.
+ *
+ * If an MCU would allow enabling both pull up and pull down resistors
+ * at the same time, the driver will make sure to disable the pull
+ * down resistors on the pins specified by @p pins.
+ */
+static inline void gpio_ll_switch_pull_up(gpio_port_t port, uword_t pins);
+
+/**
+ * @brief       Enables the internal pull down resistors for GPIO pins specified
+ *              by @p pins (obtained from @ref gpio_ll_prepare_switch_pull)
+ *
+ * @param[in]   port        GPIO port to modify
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_pull
+ * @pre         The feature `gpio_ll_switch_pull` is available
+ * @pre         The feature `periph_gpio_ll_input_pull_down` is provided and
+ *              the pins are in input mode. Some MCUs that provide the feature
+ *              `periph_gpio_ll_open_source_pull_down` may also allow
+ *              enabling pull downs on open source pins with this function.
+ *
+ * If an MCU would allow enabling both pull up and pull down resistors
+ * at the same time, the driver will make sure to disable the pull
+ * up resistors on the pins specified by @p pins.
+ */
+static inline void gpio_ll_switch_pull_down(gpio_port_t port, uword_t pins);
+
+/**
+ * @brief       Disables the internal pull resistors for GPIO pins specified
+ *              by @p pins (obtained from @ref gpio_ll_prepare_switch_pull)
+ *
+ * @param[in]   port        GPIO port to modify
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_pull
+ * @pre         The feature `gpio_ll_switch_pull` is available
+ * @pre         The pins are in input mode. Some MCUs that allow using pull
+ *              resistors with other modes than input mode may also allow
+ *              disabling the pull resistors with this function.
+ */
+static inline void gpio_ll_switch_pull_off(gpio_port_t port, uword_t pins);
 
 /**
  * @brief   Perform a masked write operation on the I/O register of the port
@@ -889,6 +954,31 @@ static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
 }
 
 #endif /* !MODULE_PERIPH_GPIO_LL_SWITCH_DIR */
+#if !MODULE_PERIPH_GPIO_LL_SWITCH_PULL
+static inline void gpio_ll_switch_pull_up(gpio_port_t port, uword_t pins)
+{
+    (void)port;
+    (void)pins;
+    extern void gpio_ll_switch_pull_up_used_but_feature_gpio_ll_switch_pull_is_not_provided(void);
+    gpio_ll_switch_pull_up_used_but_feature_gpio_ll_switch_pull_is_not_provided();
+}
+
+static inline void gpio_ll_switch_pull_down(gpio_port_t port, uword_t pins)
+{
+    (void)port;
+    (void)pins;
+    extern void gpio_ll_switch_pull_down_used_but_feature_gpio_ll_switch_pull_is_not_provided(void);
+    gpio_ll_switch_pull_down_used_but_feature_gpio_ll_switch_pull_is_not_provided();
+}
+
+static inline void gpio_ll_switch_pull_off(gpio_port_t port, uword_t pins)
+{
+    (void)port;
+    (void)pins;
+    extern void gpio_ll_switch_pull_off_used_but_feature_gpio_ll_switch_pull_is_not_provided(void);
+    gpio_ll_switch_pull_off_used_but_feature_gpio_ll_switch_pull_is_not_provided();
+}
+#endif /* !MODULE_PERIPH_GPIO_LL_SWITCH_PULL */
 #endif /* !DOXYGEN */
 
 #ifdef __cplusplus

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -731,29 +731,39 @@ static inline uword_t gpio_ll_prepare_write(gpio_port_t port, uword_t mask,
 }
 #endif
 
+#if defined(DOXYGEN) || !defined(HAVE_GPIO_LL_PREPARE_SWITCH_DIR)
 /**
- * @brief       Turn GPIO pins specified by the bitmask @p outputs to outputs
+ * @brief       Prepare bitmask for use with @ref gpio_ll_switch_dir_output
+ *              and @ref gpio_ll_switch_dir_input
+ * @param[in]   mask    bitmask specifying the pins to switch the direction of
+ *
+ * @return      Value to use in @ref gpio_ll_switch_dir_output or
+ *              @ref gpio_ll_switch_dir_input
+ */
+static inline uword_t gpio_ll_prepare_switch_dir(uword_t mask)
+{
+    return mask;
+}
+#endif
+
+/**
+ * @brief       Turn GPIO pins specified by @p pins (obtained from
+ *              @ref gpio_ll_prepare_switch_dir) to outputs
  *
  * @param[in]   port        GPIO port to modify
- * @param[in]   outputs     Bitmask specifying the GPIO pins to set in output
- *                          mode
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_dir
  * @pre         The feature `gpio_ll_switch_dir` is available
  * @pre         Each affected GPIO pin is either configured as input or as
  *              push-pull output.
- *
- * @note        This is a makeshift solution to implement bit-banging of
- *              bidirectional protocols on less sophisticated GPIO peripherals
- *              that do not support open drain mode.
- * @warning     Use open drain mode instead, if supported.
  */
-static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs);
+static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t pins);
 
 /**
- * @brief       Turn GPIO pins specified by the bitmask @p inputs to inputs
+ * @brief       Turn GPIO pins specified by @p pins (obtained from
+ *              @ref gpio_ll_prepare_switch_dir) to inputs
  *
  * @param[in]   port        GPIO port to modify
- * @param[in]   inputs      Bitmask specifying the GPIO pins to set in input
- *                          mode
+ * @param[in]   pins        Output of @ref gpio_ll_prepare_switch_dir
  * @pre         The feature `gpio_ll_switch_dir` is available
  * @pre         Each affected GPIO pin is either configured as input or as
  *              push-pull output.
@@ -765,12 +775,8 @@ static inline void gpio_ll_switch_dir_output(gpio_port_t port, uword_t outputs);
  *              resistor is enabled). Hence, the bits in the output
  *              register of the pins switched to input should be restored
  *              just after this call.
- * @note        This is a makeshift solution to implement bit-banging of
- *              bidirectional protocols on less sophisticated GPIO peripherals
- *              that do not support open drain mode.
- * @warning     Use open drain mode instead, if supported.
  */
-static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs);
+static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t pins);
 
 /**
  * @brief   Perform a masked write operation on the I/O register of the port

--- a/drivers/periph_common/Makefile.dep
+++ b/drivers/periph_common/Makefile.dep
@@ -12,3 +12,4 @@ FEATURES_OPTIONAL += periph_gpio_ll_open_drain_pull_up
 FEATURES_OPTIONAL += periph_gpio_ll_open_source
 FEATURES_OPTIONAL += periph_gpio_ll_open_source_pull_down
 FEATURES_OPTIONAL += periph_gpio_ll_switch_dir
+FEATURES_OPTIONAL += periph_gpio_ll_switch_pull

--- a/features.yaml
+++ b/features.yaml
@@ -567,9 +567,9 @@ groups:
         help: The GPIO LL driver allows switching the direction between input
               and (push-pull) output in an efficient manner. The main use case
               is bit-banging bidirectional protocols when open-drain / open-source
-              mode is not supported. GPIO LL drivers for peripherals that do
-              support open drain mode typically do not bother implementing this,
-              even if the hardware would allow it.
+              mode is not supported. Another use case is controlling GPIOs
+              at high speed with three output states (high, low, high impedance),
+              as e.g. needed for Charlieplexing
 
   - title: Serial Interfaces
     help: Features related to serial interfaces

--- a/features.yaml
+++ b/features.yaml
@@ -570,6 +570,9 @@ groups:
               mode is not supported. Another use case is controlling GPIOs
               at high speed with three output states (high, low, high impedance),
               as e.g. needed for Charlieplexing
+      - name: periph_gpio_ll_switch_pull
+        help: The GPIO LL driver allows switching pull resistor configuration
+              in an efficient manner.
 
   - title: Serial Interfaces
     help: Features related to serial interfaces

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -179,6 +179,7 @@ FEATURES_EXISTING := \
     periph_gpio_ll_open_source \
     periph_gpio_ll_open_source_pull_down \
     periph_gpio_ll_switch_dir \
+    periph_gpio_ll_switch_pull \
     periph_gpio_tamper_wake \
     periph_hash_md5 \
     periph_hash_sha3_256 \

--- a/tests/periph/gpio_ll/main.c
+++ b/tests/periph/gpio_ll/main.c
@@ -933,8 +933,10 @@ static void test_switch_dir(void)
     expect(test_passed);
 
     gpio_ll_clear(port_out, mask_out);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = (0 == (gpio_ll_read(port_in) & mask_in));
     gpio_ll_set(port_out, mask_out);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = test_passed && (gpio_ll_read(port_in) & mask_in);
     printf_optional("Pin behaves as output after switched to output mode: %s\n",
                     noyes[test_passed]);
@@ -965,8 +967,10 @@ static void test_switch_dir(void)
     expect(0 == gpio_ll_init(port_in, PIN_IN_0, gpio_ll_out));
 
     gpio_ll_clear(port_in, mask_in);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = (0 == (gpio_ll_read(port_out) & mask_out));
     gpio_ll_set(port_in, mask_in);
+    ztimer_sleep(ZTIMER_USEC, US_PER_MS);
     test_passed = test_passed && (gpio_ll_read(port_out) & mask_out);
     printf_optional("Pin behaves as input after switched back to input mode: %s\n",
                     noyes[test_passed]);

--- a/tests/periph/gpio_ll/main.c
+++ b/tests/periph/gpio_ll/main.c
@@ -905,6 +905,7 @@ static void test_switch_dir(void)
          "===========================\n");
 
     uword_t mask_out = 1U << PIN_OUT_0;
+    uword_t pins_out = gpio_ll_prepare_switch_dir(mask_out);
     uword_t mask_in = 1U << PIN_IN_0;
 
     /* floating input must be supported by every MCU */
@@ -924,7 +925,7 @@ static void test_switch_dir(void)
     uword_t out_state = gpio_ll_read_output(port_out);
 
     /* now, switch to output mode and verify the switch */
-    gpio_ll_switch_dir_output(port_out, mask_out);
+    gpio_ll_switch_dir_output(port_out, pins_out);
     conf = gpio_ll_query_conf(port_out, PIN_OUT_0);
     test_passed = (conf.state == GPIO_OUTPUT_PUSH_PULL);
     printf_optional("Input pin can be switched to output (push-pull) mode: %s\n",
@@ -940,7 +941,7 @@ static void test_switch_dir(void)
     expect(test_passed);
 
     /* switch back to input mode */
-    gpio_ll_switch_dir_input(port_out, mask_out);
+    gpio_ll_switch_dir_input(port_out, pins_out);
     /* restore out state from before the switch */
     gpio_ll_write(port_out, out_state);
     /* verify we are back at the old config */


### PR DESCRIPTION
### Contribution description

This adds a new API with a corresponding feature to GPIO LL that allows to quickly switch the pull configuration between pull-up, pull-down and floating inputs (or the subset of that modes that are actually supported).

The test app was extended accordingly.

And implementation for STM32 was added as well.

### Testing procedure

```
git:(cpu/stm32/periph_gpio_ll_periph_gpio_ll_switch_pull) ~/Repos/software/RIOT/stm32_gpio_ll_pull/tests/periph/gpio_ll ➜ make BOARD=nucleo-f767zi flash test-with-config
Building application "tests_gpio_ll" for "nucleo-f767zi" with CPU "stm32".

"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/pkg/cmsis/ 
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/boards/nucleo-f767zi
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/boards/common/nucleo
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/core
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/core/lib
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/cpu/stm32
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/cpu/cortexm_common
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/cpu/cortexm_common/periph
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/cpu/stm32/periph
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/cpu/stm32/stmclk
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/cpu/stm32/vectors
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/drivers
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/div
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/frac
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/newlib_syscalls_default
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/sys/ztimer
   text	  data	   bss	   dec	   hex	filename
  22916	   180	  2720	 25816	  64d8	/home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/tests/periph/gpio_ll/bin/nucleo-f767zi/tests_gpio_ll.elf
/home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/dist/tools/openocd/openocd.sh flash /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/tests/periph/gpio_ll/bin/nucleo-f767zi/tests_gpio_ll.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-snapshot (2024-01-17-08:38)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
DEPRECATED! use 'adapter serial' not 'hla_serial'
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst
Info : clock speed 2000 kHz
Info : STLINK V2J38M27 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.242520
Info : [stm32f7x.cpu] Cortex-M7 r1p0 processor detected
Info : [stm32f7x.cpu] target has 8 breakpoints, 4 watchpoints
Info : [stm32f7x.cpu] Examination succeed
Info : starting gdb server for stm32f7x.cpu on 0
Info : Listening on port 33317 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f7x.cpu       hla_target little stm32f7x.cpu       unknown
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
[stm32f7x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08001f24 msp: 0x20000200
Info : device id = 0x10016451
Info : flash size = 2048 KiB
Info : Single Bank 2048 kiB STM32F76x/77x found
auto erase enabled
wrote 32768 bytes from file /home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/tests/periph/gpio_ll/bin/nucleo-f767zi/tests_gpio_ll.elf in 0.797893s (40.106 KiB/s)
verified 23096 bytes in 0.177944s (126.752 KiB/s)
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
r
/home/maribu/Repos/software/RIOT/stm32_gpio_ll_pull/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-maribu" -rn "2024-08-08_14.43.02-tests_gpio_ll-nucleo-f767zi" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2024.10-devel-42-g34bac5-cpu/stm32/periph_gpio_ll_periph_gpio_ll_switch_pull)
Test / Hardware Details:
========================
Cabling:
(INPUT -- OUTPUT)
  PD0 -- PG0
  PD1 -- PG1
Number of pull resistor values supported: 1
Number of drive strengths supported: 1
Number of slew rates supported: 4
Valid GPIO ports:
- PORT 0 (PORT A)
- PORT 1 (PORT B)
- PORT 2 (PORT C)
- PORT 3 (PORT D)
- PORT 4 (PORT E)
- PORT 5 (PORT F)
- PORT 6 (PORT G)
- PORT 7 (PORT H)
- PORT 8 (PORT I)
- PORT 9 (PORT J)
- PORT 10 (PORT K)

Testing gpio_port_pack_addr()
=============================

All OK

Testing gpip_ng_init()
======================

Testing is_gpio_port_num_valid() is true for PORT_OUT and PORT_IN:

Testing input configurations for PIN_IN_0:
Support for input with pull up: yes
state: in, pull: up, value: on, slew: slowest
Support for input with pull down: yes
state: in, pull: down, value: off, slew: slowest
Support for input with pull to bus level: no
Support for floating input (no pull resistors): yes
state: in, pull: none, value: off, slew: slowest

Testing output configurations for PIN_OUT_0:
Support for output (push-pull) with initial value of LOW: yes
state: out-pp, value: off, slew: slowest
Output is indeed LOW: yes
state: out-pp, value: on, slew: slowest
Output can be pushed HIGH: yes
Support for output (push-pull) with initial value of HIGH: yes
state: out-pp, value: on, slew: slowest
Output is indeed HIGH: yes
Support for output (open drain with pull up) with initial value of LOW: yes
state: out-od, pull: up, value: off, slew: slowest
Output is indeed LOW: yes
Support for output (open drain with pull up) with initial value of HIGH: yes
state: out-od, pull: up, value: on, slew: slowest
Output is indeed HIGH: yes
Support for output (open drain) with initial value of LOW: yes
state: out-od, pull: none, value: off, slew: slowest
Output is indeed LOW: yes
Support for output (open drain) with initial value of HIGH: yes
state: out-od, pull: none, value: on, slew: slowest
state: in, pull: down, value: off, slew: slowest
Output can indeed be pulled LOW: yes
state: in, pull: up, value: off, slew: slowest
Output can indeed be pulled HIGH: yes
Support for output (open source) with initial value of LOW: no
Support for output (open source) with initial value of HIGH: no
Support for output (open source with pull down) with initial value of HIGH: no
Support for output (open source with pull down) with initial value of LOW: no

Support for disconnecting GPIO: yes
state: off, pull: none, value: off, slew: slowest
Output can indeed be pulled LOW: yes
Output can indeed be pulled HIGH: yes

Testing Reading/Writing GPIO Ports
==================================

testing initial value of 0 after init
...OK
testing setting both outputs_optional simultaneously
...OK
testing clearing both outputs_optional simultaneously
...OK
testing toggling first output (0 --> 1)
...OK
testing toggling first output (1 --> 0)
...OK
testing toggling second output (0 --> 1)
...OK
testing toggling second output (1 --> 0)
...OK
testing setting first output and clearing second with write
...OK
testing setting second output and clearing first with write
...OK
All input/output operations worked as expected

Testing External IRQs
=====================

Testing rising edge on PIN_IN_0
... OK
Testing falling edge on PIN_IN_0
... OK
Testing both edges on PIN_IN_0
... OK
Testing masking of IRQs (still both edges on PIN_IN_0)
... OK
Testing level-triggered on HIGH on PIN_IN_0 (when input is LOW when setting up IRQ)
... OK
Testing level-triggered on HIGH on PIN_IN_0 (when input is HIGH when setting up IRQ)
... OK
Testing level-triggered on LOW on PIN_IN_0 (when input is HIGH when setting up IRQ)
... OK
Testing level-triggered on LOW on PIN_IN_0 (when input is LOW when setting up IRQ)
... OK

Testing Switching Direction
===========================

Input pin can be switched to output (push-pull) mode: yes
Pin behaves as output after switched to output mode: yes
Returning back to input had no side effects on config: yes
Pin behaves as input after switched back to input mode: yes

Testing Switching Pull Config
=============================

Checking if switching to pull up works ...
[OK]
Checking if switching to pull down works ...
[OK]
Checking if switching to floating works ...
[OK]


TEST SUCCEEDED
```

### Issues/PRs references

Depends on and includes:

- [ ] https://github.com/RIOT-OS/RIOT/pull/20805
