### PR TITLE
riscv_common: Use unsiged long format specifier for printing CSR values

### DIFF
--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -146,8 +146,8 @@ static void handle_trap(uword_t mcause)
 #ifdef DEVELHELP
             printf("Unhandled trap:\n");
             printf("  mcause: 0x%" PRIx32 "\n", trap);
-            printf("  mepc:   0x%" PRIx32 "\n", read_csr(mepc));
-            printf("  mtval:  0x%" PRIx32 "\n", read_csr(mtval));
+            printf("  mepc:   0x%lx\n", read_csr(mepc));
+            printf("  mtval:  0x%lx\n", read_csr(mtval));
 #endif
             /* Unknown trap */
             core_panic(PANIC_GENERAL_ERROR, "Unhandled trap");


### PR DESCRIPTION
### Contribution description

The read_csr macro [returns the CSR value as a `unsigned long`](https://github.com/RIOT-OS/RIOT/blob/2024.07/cpu/riscv_common/include/vendor/riscv_csr.h#L195). However, the format specifier presently treats it as a `uint32_t`. This causes a `-Wformat` compilation error to be emitted by Clang 18:

	cpu/riscv_common/irq_arch.c:149:49: error: format specifies type 'unsigned int'
			   but the argument has type 'unsigned long' [-Werror,-Wformat]
	  149 |             printf("  mepc:   0x%" PRIx32 "\n", read_csr(mepc));


### Testing procedure

```
$ make TOOLCHAIN=llvm BOARD=hifive1 -C examples/hello-world/
```

### Issues/PRs references

None.