### PR TITLE
boards/nucleo-f439zi: add ADC support

### DIFF
--- a/boards/nucleo-f439zi/Makefile.features
+++ b/boards/nucleo-f439zi/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32f439zi
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c

--- a/boards/nucleo-f439zi/include/periph_conf.h
+++ b/boards/nucleo-f439zi/include/periph_conf.h
@@ -198,9 +198,43 @@ static const eth_conf_t eth_config = {
 #define ETH_DMA_ISR        isr_dma2_stream0
 /** @} */
 
-static const adc_conf_t adc_config[] = {{}};
+/**
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F439ZI order. Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5 and the internal VBAT channel.
+ *
+ * To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC12_IN10 is device 0 or device 1,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC12_IN10 is channel 10
+ *
+ * For STM32F439ZI this information is in MCU datasheet,
+ * Table 10, page 53 or in Nucleo-f439ZI board manual,
+ * Table 17, page 52.
+
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3),  .dev = 2, .chan = 3},  /* ADC123_IN3 */
+    {GPIO_PIN(PORT_C, 0),  .dev = 2, .chan = 10}, /* ADC123_IN10 */
+    {GPIO_PIN(PORT_C, 3),  .dev = 2, .chan = 13}, /* ADC123_IN13 */
+    {GPIO_PIN(PORT_F, 3),  .dev = 2, .chan = 9},  /* ADC3_IN9    */
+    {GPIO_PIN(PORT_F, 5),  .dev = 2, .chan = 15}, /* ADC3_IN15   */
+    {GPIO_PIN(PORT_F, 10), .dev = 2, .chan = 8},  /* ADC3_IN8    */
+    {GPIO_UNDEF,           .dev = 0, .chan = 18}, /* VBAT */
+};
+
+#define VBAT_ADC            ADC_LINE(6) /**< VBAT ADC line */
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-f439zi/include/periph_conf.h
+++ b/boards/nucleo-f439zi/include/periph_conf.h
@@ -198,6 +198,10 @@ static const eth_conf_t eth_config = {
 #define ETH_DMA_ISR        isr_dma2_stream0
 /** @} */
 
+static const adc_conf_t adc_config[] = {{}};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/include/periph/f4/periph_cpu.h
+++ b/cpu/stm32/include/periph/f4/periph_cpu.h
@@ -32,8 +32,8 @@ extern "C" {
 #define ADC_DEVS            (1U)
 #elif defined(CPU_LINE_STM32F405xx)  || defined(CPU_LINE_STM32F407xx) \
     || defined(CPU_LINE_STM32F415xx) || defined(CPU_LINE_STM32F429xx) \
-    || defined(CPU_LINE_STM32F437xx) || defined(CPU_LINE_STM32F446xx) \
-    || defined(CPU_LINE_STM32F469xx)
+    || defined(CPU_LINE_STM32F439xx) || defined(CPU_LINE_STM32F437xx) \
+    || defined(CPU_LINE_STM32F446xx) || defined(CPU_LINE_STM32F469xx)
 #define ADC_DEVS            (3U)
 #endif
 


### PR DESCRIPTION
### Contribution description

This PR adds to the nucleo-f439zi ADC support.

### Testing procedure

Flash the board using `tests/periph/adc` program. Check if measured values changes when A0-A5 pins are
connected to the 3,3V, GND or to the potentiometer.

### Issues/PRs references

None