### PR TITLE
cpu/native/periph_timer: add missing -lrt to linker flags

### DIFF
--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -7,6 +7,11 @@ ifneq (,$(filter periph_can,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter periph_timer,$(USEMODULE)))
+  # using timer_settime requires -lrt
+  LINKFLAGS += -lrt
+endif
+
 TOOLCHAINS_SUPPORTED = gnu llvm afl
 
 # Platform triple as used by Rust


### PR DESCRIPTION
### Contribution description

This (hopefully) fixes https://github.com/RIOT-OS/RIOT/pull/20009#issuecomment-2294803168

### Testing procedure

E.g. `make BOARD=native64 -C tests/periph/timer` should now work on Debian 11.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/20009#issuecomment-2294803168