### PR TITLE
doc: note that timer_settime() comes from librt on some systems

### DIFF
--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -16,6 +16,8 @@
  * @brief       Native CPU periph/timer.h implementation
  *
  * Uses POSIX realtime clock and POSIX itimer to mimic hardware.
+ * This is done with the timer_settime(3), timer_create(3)  interfaces, which are
+ * sometimes found only in the -lrt library, and not in glibc.
  *
  * This is based on native's hwtimer implementation by Ludwig Knüpfer.
  * I removed the multiplexing, as ztimer does the same. (kaspar)


### PR DESCRIPTION
### Contribution description

Adds two lines of documentation so point towards -lrt to solve linker issues with timer_create(2)/timer_settime(2) are missing.

### Testing procedure

cd examples/gcoap-rust && make BOARD=native all

### Issues/PRs references

close #20815 