### PR TITLE
examples/rust: Update CoAP example modules

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -735,7 +735,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.2.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#26a7d27b4c0d518be1d26d07403f57261ee37cd5"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#0994301d597a39d66bcc7de07149c06b59d0e4ba"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "riot-shell-commands"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#26a7d27b4c0d518be1d26d07403f57261ee37cd5"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#0994301d597a39d66bcc7de07149c06b59d0e4ba"
 dependencies = [
  "heapless 0.7.17",
  "riot-sys",


### PR DESCRIPTION
### Contribution description

This updates the use of two deprecated items to the latest idioms in riot-wrappers 0.8.

### Testing procedure

Green CI should suffice.

### Issues/PRs references

This unblocks testing of https://github.com/RIOT-OS/rust-riot-wrappers/pull/90: riot-wrappers 0.9 is developed and tested as 0.8.999, because its claim is that if all deprecation warnings of latest 0.8 are resolved, and you don't do something weird[^1], all can still run.

[^1]: Such as assigning the error from a known can-not-err result to a `!` type rather than to `Infallible` – that is a breaking API change, but practical breakage is not expected, and at worst fixed by implementing some conversion to do the same when going from `!` as for `Infallible`.