### PR TITLE
drivers/sx127x: fix link formatting in documentation

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -21,8 +21,7 @@
  * Be careful to configure the device to use a RF frequency allowed in your
  * region.
  * Here is the list of allowed frequencies for your region (see
- * [LoRaWAN regional parameters document available online]
- * (https://www.lora-alliance.org/for-developers)):
+ * [LoRaWAN regional parameters document available online](https://www.lora-alliance.org/for-developers)):
  * - Europe has 2 allowed bands (ETSI):
  *   - EU863-870
  *   - EU433 (from 433.175MHZ to 434.665MHZ exactly)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Browsing through the RIOT documentation, I've noticed a link on the [Semtech SX1272 and SX1276 radios driver](https://doc.riot-os.org/group__drivers__sx127x.html) whose formatting is a bit broken:

<img width="703" alt="image" src="https://github.com/user-attachments/assets/b6fc8612-ffa3-48c9-97bd-6ae3f12e2e68">

This simple PR fixes the problem by slightly rearranging the documentation.

### Testing procedure

1. Run `make doc`.
2. Open the file `doc/doxygen/html/group__drivers__sx127x.html` with a web browser.

The link should now look like this:

<img width="417" alt="image" src="https://github.com/user-attachments/assets/e5da5500-3fc3-4693-86ce-ced3cea1e15e">

### Issues/PRs references

–