### PR TITLE
boards/nucleo-g071rb: add MCU table to doc page

### DIFF
--- a/boards/nucleo-g071rb/doc.txt
+++ b/boards/nucleo-g071rb/doc.txt
@@ -12,6 +12,26 @@ Cortex-M0+ STM32G071RB microcontroller with 36KiB of RAM and 128KiB of Flash.
 
 @image html pinouts/nucleo-g070rb-and-g071rb.svg "Pinout for the nucleo-g071rg (from STM board manual)" width=50%
 
+### MCU
+
+| MCU          | STM32G071RB
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M0+      |
+| Vendor       | ST Microelectronics |
+| RAM          | 36KiB               |
+| Flash        | 128KiB              |
+| Frequency    | up to 64 MHz        |
+| Timers       | 14 (2x watchdog, 1 SysTick, 10x 16-bit and 1 32-bit) |
+| ADCs         | 1x 12 bit (up to 16 channels) |
+| UARTs        | 5 (four USARTs and one Low-Power UART) |
+| I2Cs         | 2                   |
+| SPIs         | 2                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g071rb.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0454-stm32g0x0-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf)|
+
 ## Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.


### PR DESCRIPTION
### Contribution description

PR adds MCU table to the `nucleo-g071rb` board doc page.

### Testing procedure

Generate documentation and see if everything is OK.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-g071rb.html 
```

### Issues/PRs references

None