### PR TITLE
Rust: Add `make cargo-command` and refactoring around it

### DIFF
--- a/makefiles/cargo-settings.inc.mk
+++ b/makefiles/cargo-settings.inc.mk
@@ -30,7 +30,7 @@ CARGO_TARGET_DIR = $(BINDIR)/target
 # directory with the same name as the profile".
 CARGO_LIB = $(CARGO_TARGET_DIR)/$(RUST_TARGET)/$(patsubst test,debug,$(patsubst dev,debug,$(patsubst bench,release,${CARGO_PROFILE})))/lib$(APPLICATION_RUST_MODULE).a
 
-# Options passed into all Cargo commands, in particular to the build command.
+# Options passed into the Cargo build command.
 #
 # Most of these are populated by RIOT modules that are backed by Rust. Popular
 # options added by the user are `-Zbuild-std=core` (only available on nightly)

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -39,8 +39,7 @@ $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 	        -e 's/"riscv64-elf"/"riscv32"/g' \
 	  | $(LAZYSPONGE) $@
 
-
-$(CARGO_LIB): $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS) FORCE
+cargo-preflight: FORCE
 	@command -v cargo >/dev/null || ($(COLOR_ECHO) \
 		'$(COLOR_RED)Error: `cargo` command missing to build Rust modules.$(COLOR_RESET) Please install as described on <https://doc.riot-os.org/using-rust.html>.' ;\
 		exit 1)
@@ -58,7 +57,9 @@ $(CARGO_LIB): $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS
 		($(COLOR_ECHO) \
 		'$(COLOR_RED)Error: No Rust libraries are installed for the board'"'"'s CPU.$(COLOR_RESET) Run\n    $(COLOR_GREEN)$$$(COLOR_RESET) rustup target add $(RUST_TARGET)\nor set `CARGO_OPTIONS=-Zbuild-std=core`.'; \
 		exit 1)
-	@# finally call out to cargo. mind the "+" to pass down make's jobserver.
+
+$(CARGO_LIB): cargo-preflight $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS) FORCE
+	@# mind the "+" to pass down make's jobserver.
 	$(Q)+ CC= CFLAGS= CPPFLAGS= CXXFLAGS= \
 		RIOT_COMPILE_COMMANDS_JSON="$(CARGO_COMPILE_COMMANDS)" \
 		cargo \

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -62,9 +62,9 @@ $(CARGO_LIB): cargo-preflight $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_
 	@# mind the "+" to pass down make's jobserver.
 	$(Q)+ CC= CFLAGS= CPPFLAGS= CXXFLAGS= \
 		RIOT_COMPILE_COMMANDS_JSON="$(CARGO_COMPILE_COMMANDS)" \
+		CARGO_BUILD_TARGET="$(RUST_TARGET)" \
 		cargo \
 			build \
-			--target $(RUST_TARGET) \
 			--profile $(CARGO_PROFILE) \
 			$(CARGO_OPTIONS)
 

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -68,6 +68,15 @@ $(CARGO_LIB): cargo-preflight $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_
 			--profile $(CARGO_PROFILE) \
 			$(CARGO_OPTIONS)
 
+cargo-command: cargo-preflight $(RIOTBUILD_CONFIG_HEADER_C) $(CARGO_COMPILE_COMMANDS) FORCE
+	@[ x"$(CARGO_COMMAND)" != x"" ] || ($(COLOR_ECHO) "$(COLOR_RED)Error: Running cargo-command requires a CARGO_COMMAND to be set.$(COLOR_RESET) Set CARGO_COMMAND=\"cargo clippy --release --fix\" or any other cargo command to run with the right RIOT environment."; exit 1)
+	@# mind the "+" to pass down make's jobserver.
+	$(Q)+ CC= CFLAGS= CPPFLAGS= CXXFLAGS= \
+		RIOT_COMPILE_COMMANDS_JSON="$(CARGO_COMPILE_COMMANDS)" \
+		CARGO_BUILD_TARGET="$(RUST_TARGET)" \
+		PROFILE="$(CARGO_PROFILE)" \
+		$(CARGO_COMMAND)
+
 $(APPLICATION_RUST_MODULE).module: $(CARGO_LIB) FORCE
 	$(Q)# Ensure no old object files persist. These would lead to duplicate
 	$(Q)# symbols, or worse, lingering behaivor of XFA entries.

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -254,3 +254,4 @@ info-rust:
 	@echo "and export these environment variables:"
 	@echo "    RIOT_COMPILE_COMMANDS_JSON=\"$(CARGO_COMPILE_COMMANDS)\""
 	@echo "    RIOTBUILD_CONFIG_HEADER_C=\"$(RIOTBUILD_CONFIG_HEADER_C)\""
+	@echo "You can also call cargo related commands with \`make cargo-command CARGO_COMMAND="cargo check"\`; beware that the way the profile is passed in is not consistent across cargo commands, and adding \`--profile $(CARGO_PROFILE)\` as part of CARGO_COMMAND may be necessary."

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -250,8 +250,9 @@ info-rust:
 	cargo version
 	c2rust --version
 	@echo "To use this setup of Rust in an IDE, add these command line arguments to the \`cargo check\` or \`rust-analyzer\`:"
-	@echo "    --target $(RUST_TARGET) --profile $(CARGO_PROFILE)"
+	@echo "    --target $(RUST_TARGET) --profile $(CARGO_PROFILE) $(CARGO_OPTIONS)"
 	@echo "and export these environment variables:"
 	@echo "    RIOT_COMPILE_COMMANDS_JSON=\"$(CARGO_COMPILE_COMMANDS)\""
 	@echo "    RIOTBUILD_CONFIG_HEADER_C=\"$(RIOTBUILD_CONFIG_HEADER_C)\""
-	@echo "You can also call cargo related commands with \`make cargo-command CARGO_COMMAND="cargo check"\`; beware that the way the profile is passed in is not consistent across cargo commands, and adding \`--profile $(CARGO_PROFILE)\` as part of CARGO_COMMAND may be necessary."
+	@echo "You can also call cargo related commands with \`make cargo-command CARGO_COMMAND=\"cargo check\"\`."
+	@echo "Beware that the way the profile and other flags are passed in is not consistent across cargo commands, so adding \`--profile $(CARGO_PROFILE)\` or other flags from above as part of CARGO_COMMAND may be necessary."

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -250,9 +250,10 @@ info-rust:
 	cargo version
 	c2rust --version
 	@echo "To use this setup of Rust in an IDE, add these command line arguments to the \`cargo check\` or \`rust-analyzer\`:"
-	@echo "    --target $(RUST_TARGET) --profile $(CARGO_PROFILE) $(CARGO_OPTIONS)"
+	@echo "    --profile $(CARGO_PROFILE) $(CARGO_OPTIONS)"
 	@echo "and export these environment variables:"
+	@echo "    CARGO_BUILD_TARGET=\"$(RUST_TARGET)\""
 	@echo "    RIOT_COMPILE_COMMANDS_JSON=\"$(CARGO_COMPILE_COMMANDS)\""
 	@echo "    RIOTBUILD_CONFIG_HEADER_C=\"$(RIOTBUILD_CONFIG_HEADER_C)\""
 	@echo "You can also call cargo related commands with \`make cargo-command CARGO_COMMAND=\"cargo check\"\`."
-	@echo "Beware that the way the profile and other flags are passed in is not consistent across cargo commands, so adding \`--profile $(CARGO_PROFILE)\` or other flags from above as part of CARGO_COMMAND may be necessary."
+	@echo "Beware that the way command line arguments are passed in is not consistent across cargo commands, so adding \`--profile $(CARGO_PROFILE)\` or other flags from above as part of CARGO_COMMAND may be necessary."


### PR DESCRIPTION
### Contribution description

Users who want to do more than just use cargo to build their RIOT application (say, run the linter `cargo check` with the right settings, run `cargo fix`, the advanced linter `clippy`, or build documentation) previously had to extract the relevant environment variables and command line extras from `make info-rust`.

In particular, that was hard to integrate in CI – for example, to run the linter in strict mode on your application.

The newly introduced `make cargo-command CARGO_COMMAND="cargo clippy"` family (where the content for CARGO_COMMAND is run with all the right setup) closes this gap.

### Testing procedure

* CI still passes
* `make -C examples/rust-gcoap cargo-command CARGO_COMMAND="cargo check --release"` may show warnings, but completes successfully.

### Issues/PRs references

This may also contribute to https://github.com/RIOT-OS/RIOT/issues/20088 (thus CC'ing @derMihai).

It also helps with the follow-up of https://github.com/RIOT-OS/rust-riot-wrappers/pull/105, making the warnings easier to show, and even to fix by picking `cargo fix` or `cargo clippy --fix`.