### PR TITLE
boards/ek-lm4f120x: Change internal LED macro for C2Rust compatibility

### DIFF
--- a/boards/ek-lm4f120xl/include/board.h
+++ b/boards/ek-lm4f120xl/include/board.h
@@ -46,22 +46,26 @@ extern "C" {
 #define LED1_PIN            GPIO_PIN(5, 2)
 #define LED2_PIN            GPIO_PIN(5, 3)
 
-#define LED_PORT            (GPIO_PORTF_DATA_R)
+/**
+ * @brief Port used for `LED0_ON` and similar implementations
+ * @internal
+ * */
+#define LED_PORT()          (GPIO_PORTF_DATA_R)
 #define LED0_MASK           (1 << 7)
 #define LED1_MASK           (1 << 2)
 #define LED2_MASK           (1 << 1)
 
-#define LED0_ON             (LED_PORT |=  LED0_MASK)
-#define LED0_OFF            (LED_PORT &= ~LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT ^=  LED0_MASK)
+#define LED0_ON             (LED_PORT() |=  LED0_MASK)
+#define LED0_OFF            (LED_PORT() &= ~LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT() ^=  LED0_MASK)
 
-#define LED1_ON             (LED_PORT |=  LED1_MASK)
-#define LED1_OFF            (LED_PORT &= ~LED1_MASK)
-#define LED1_TOGGLE         (LED_PORT ^=  LED1_MASK)
+#define LED1_ON             (LED_PORT() |=  LED1_MASK)
+#define LED1_OFF            (LED_PORT() &= ~LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT() ^=  LED1_MASK)
 
-#define LED2_ON             (LED_PORT |=  LED2_MASK)
-#define LED2_OFF            (LED_PORT &= ~LED2_MASK)
-#define LED2_TOGGLE         (LED_PORT ^=  LED2_MASK)
+#define LED2_ON             (LED_PORT() |=  LED2_MASK)
+#define LED2_OFF            (LED_PORT() &= ~LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT() ^=  LED2_MASK)
 /** @} */
 
 /**

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -48,8 +48,4 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# Currently unknown, something related to the LED_PORT definition that doesn't
-# pass C2Rust's transpilation
-BOARD_BLACKLIST := ek-lm4f120xl
-
 include $(RIOTBASE)/Makefile.include

--- a/examples/rust-hello-world/Makefile
+++ b/examples/rust-hello-world/Makefile
@@ -21,8 +21,4 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# Currently unknown, something related to the LED_PORT definition that doesn't
-# pass C2Rust's transpilation
-BOARD_BLACKLIST := ek-lm4f120xl
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/rust_libs/Makefile
+++ b/tests/rust_libs/Makefile
@@ -6,8 +6,4 @@ USEMODULE += ztimer_msec
 
 FEATURES_REQUIRED += rust_target
 
-# Currently unknown, something related to the LED_PORT definition that doesn't
-# pass C2Rust's transpilation
-BOARD_BLACKLIST := ek-lm4f120xl
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/rust_minimal/Makefile
+++ b/tests/rust_minimal/Makefile
@@ -5,8 +5,4 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
-# Currently unknown, something related to the LED_PORT definition that doesn't
-# pass C2Rust's transpilation
-BOARD_BLACKLIST := ek-lm4f120xl
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

    boards/ek-lm4f120x: Change internal LED macro for C2Rust compatibility
    
    C preprocessor defines in non-function form are assumed by C2Rust to be
    constant if they are an expression and not a statement; the LED_PORT was
    the only place in the code where that was wrong, and led to compiler
    errors due to the value not being constant.
    
    Altering the internal macro to use function form sidesteps that issue.
    The generally preferred alternative of using a `const` is unavailable in
    this case because the dereferencing operator is already part of the
    vendor header file cpu/stellaris_common/include/vendor/cortex-m4-def.h.
    
    The changed macro is documented as required by doccheck. The doccheck
    rule that grandfathered in the LED_PORT macro as allowed undocumented is
    not removed because it is also used in other board.h files.

With that applied, a bunch of BOARD_BLACKLIST entries can be removed (from all Rust Makefiles we have).

### Testing procedure

I did not test LED blinking on that board as I don't have one, but the change should be sufficiently easy to verify on a theoretical level (supported by the compiler passing).