### PR TITLE
drivers/led: Allow LEDn_ON to be disabled by other modules

### DIFF
--- a/boards/common/particle-mesh/include/board.h
+++ b/boards/common/particle-mesh/include/board.h
@@ -95,6 +95,18 @@ extern "C" {
 #define LED2_MASK           (1 << 15)
 #define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK)
 
+/* The typical SAUL setup for this board uses PWM to make the LEDs (really a
+ * single RGB LED) into a PWM controlled RGB LED entry. As a consequence of the
+ * PWM configuration, toggling the GPIO has no effect any more, and thus we do
+ * not define the macros so that no LEDs get picked up for LEDn_IS_PROVIDED.
+ * (The LEDn_ON etc macros will still be present and no-op as usual, but those
+ * explicitly checking for IS_PROVIDED will get an accurate picture).
+ *
+ * Both conditions are typically true when saul_default is on, but strictly, it
+ * is those two that in combination make LEDs effectively unavailable to users.
+ * */
+#if !(IS_USED(MODULE_AUTO_INIT_SAUL) && IS_USED(MODULE_SAUL_PWM))
+
 #define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
 #define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
 #define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
@@ -106,6 +118,9 @@ extern "C" {
 #define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK)
 #define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK)
 #define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK)
+
+#endif /* !(IS_USED(MODULE_AUTO_INIT_SAUL) && IS_USED(MODULE_SAUL_PWM)) */
+
 /** @} */
 
 /**

--- a/drivers/periph_common/init_leds.c
+++ b/drivers/periph_common/init_leds.c
@@ -17,7 +17,7 @@
  * @}
  */
 
-#include "board.h"
+#include "led.h"
 #include "periph/gpio.h"
 #include "kernel_defines.h"
 
@@ -35,28 +35,32 @@ void led_init(void)
         return;
     }
 
-#ifdef LED0_PIN
+    /* The condition is dual: We don't init if the LED is absent (eg. when a
+     * LEDn_PIN is defined, but there is a higher level driver such as SAUL PWM that makes the
+     * direct use impossible), but we also don't init if there is no pin (eg.
+     * on native where there is a different mechanism for LEDs). */
+#if defined(LED0_IS_PRESENT) && defined(LED0_PIN)
     LED_INIT(0);
 #endif
-#ifdef LED1_PIN
+#if defined(LED1_IS_PRESENT) && defined(LED1_PIN)
     LED_INIT(1);
 #endif
-#ifdef LED2_PIN
+#if defined(LED2_IS_PRESENT) && defined(LED2_PIN)
     LED_INIT(2);
 #endif
-#ifdef LED3_PIN
+#if defined(LED3_IS_PRESENT) && defined(LED3_PIN)
     LED_INIT(3);
 #endif
-#ifdef LED4_PIN
+#if defined(LED4_IS_PRESENT) && defined(LED4_PIN)
     LED_INIT(4);
 #endif
-#ifdef LED5_PIN
+#if defined(LED5_IS_PRESENT) && defined(LED5_PIN)
     LED_INIT(5);
 #endif
-#ifdef LED6_PIN
+#if defined(LED6_IS_PRESENT) && defined(LED6_PIN)
     LED_INIT(6);
 #endif
-#ifdef LED7_PIN
+#if defined(LED7_IS_PRESENT) && defined(LED7_PIN)
     LED_INIT(7);
 #endif
 }


### PR DESCRIPTION
### Contribution description

On the particle-xenon and similar boards, once SAUL is active, LED[012]_ON will not do anything, even though LED[012]_IS_PROVIDED is set. This may not surprise users of LEDn_ON (because it's the established behavior of those to no-op), but when explicitly inspecting LEDn_IS_PROVIDED (like Rust users [<del>will</del> do](https://github.com/RIOT-OS/rust-riot-wrappers/pull/113)), this behavior is confusing.

The cause of this is that SAUL's use of the LED pins is through PWM, and (at least on that family) that completely overrides GPIO input.

The change is two-fold:

* On the particle-mesh family, the condition for when something else grabs the LED pins is written out as `!(IS_ACTIVE(SAUL_AUTO_INIT) && IS_ACTIVE(SAUL_PWM))`. If that is the case, LED0_ON is not defined, and consequently, led.h does not set LED0_IS_PRESENT.
* The setup in init_leds.c checks for whether LEDn_PIN is set, and then sets up the GPIO and runs LEDn_OFF. That criterion is no longer accurate, and is changed to LEDn_IS_PRESENT. (Funnily, this required us to include led.h, and by the time that happened, LEDn_OFF is defined as a no-op -- but still going for the LEDn_IS_PRESENT condition because when something else uses the pin, the LED module should keep its hands off the pins).

### Testing procedure

* Run leds_shell -- and everything is as it always was.
* USEMODULE+=saul_default and then run leds_shell -- and the LEDs are not shown any more.

### Alternatives

* LEDn_ON could be altered in the PWM case to set it to 100%. I have not chosen this path because the expectation with the LEDn functions is that they are very very fast.
* Rather than doing the change in init_leds.c to LED0_IS_PRESENT, we could extend the is-used-by-SAUL guard to also disable LED0_PIN. This was not done because LED0_PIN is also used at the definition of the PWM channels. We could still do that, and either spell out the pins in the PWM setup, or use a new define (but it's in board.h and thus widely seen) for the channel pins. (That definition would then be used both to conditionally define LEDn_PIN and to set up the PWM).