### PR TITLE
gnrc/ipv6/nib: don't queue packets on 6lo neighbors and drop/flush if…

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -282,6 +282,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief Per-neighbor packet queue capacity
+ *
+ * If @ref CONFIG_GNRC_IPV6_NIB_QUEUE_PKT enabled, this is the maximum number
+ * of packets, per neighbor, awaiting packet resolution.
+ *
+ * @attention This MUST be leq UINT8_MAX
+ */
+#ifndef CONFIG_GNRC_IPV6_NIB_NBR_QUEUE_CAP
+#define CONFIG_GNRC_IPV6_NIB_NBR_QUEUE_CAP          (16)
+#endif
+
+/**
  * @brief   Number of off-link entries in NIB
  *
  * @attention   This number is equal to the maximum number of forwarding table

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
@@ -174,13 +174,21 @@ void _handle_adv_l2(gnrc_netif_t *netif, _nib_onl_entry_t *nce,
 void _recalc_reach_time(gnrc_netif_ipv6_t *netif);
 
 /**
- * @brief   Sets a neighbor cache entry reachable and starts the required
+ * @brief   Sets a neighbor cache entry REACHABLE and starts the required
  *          event timers
  *
  * @param[in] netif Interface to the NCE
- * @param[in] nce   The neighbor cache entry to set reachable
+ * @param[in] nce   The neighbor cache entry to set REACHABLE
  */
 void _set_reachable(gnrc_netif_t *netif, _nib_onl_entry_t *nce);
+
+/**
+ * @brief   Sets a neighbor cache entry UNREACHABLE and flushes its packet queue
+ *
+ * @param[in] netif Interface to the NCE
+ * @param[in] nce   The neighbor cache entry to set UNREACHABLE
+ */
+void _set_unreachable(gnrc_netif_t *netif, _nib_onl_entry_t *nce);
 
 /**
  * @brief   Initializes interface for address registration state machine

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -276,18 +276,7 @@ void _nib_nc_remove(_nib_onl_entry_t *node)
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LR)
     evtimer_del((evtimer_t *)&_nib_evtimer, &node->addr_reg_timeout.event);
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LR */
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_QUEUE_PKT)
-    gnrc_pktqueue_t *tmp;
-    for (gnrc_pktqueue_t *ptr = node->pktqueue;
-         (ptr != NULL) && (tmp = (ptr->next), 1);
-         ptr = tmp) {
-        gnrc_pktqueue_t *entry = gnrc_pktqueue_remove(&node->pktqueue, ptr);
-        gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
-                                       entry->pkt);
-        gnrc_pktbuf_release_error(entry->pkt, EHOSTUNREACH);
-        entry->pkt = NULL;
-    }
-#endif  /* CONFIG_GNRC_IPV6_NIB_QUEUE_PKT */
+    _nbr_flush_pktqueue(node);
     /* remove from cache-out procedure */
     clist_remove(&_next_removable, (clist_node_t *)node);
     _nib_onl_clear(node);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -180,6 +180,9 @@ typedef struct _nib_onl_entry {
      */
     uint8_t l2addr_len;
 #endif
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_QUEUE_PKT) || defined(DOXYGEN)
+    uint8_t pktqueue_len; /**< Number of queued packets (in pktqueue) */
+#endif
 } _nib_onl_entry_t;
 
 /**
@@ -871,6 +874,41 @@ void _nib_ft_get(const _nib_offl_entry_t *dst, gnrc_ipv6_nib_ft_t *fte);
  */
 int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *ctx,
                    gnrc_ipv6_nib_ft_t *entry);
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_QUEUE_PKT) || DOXYGEN
+/**
+ * @brief Flush the packet queue of a on-link neighbor.
+ *
+ * @param node neighbor entry to be flushed
+ */
+void _nbr_flush_pktqueue(_nib_onl_entry_t *node);
+
+/**
+ * @brief Remove oldest packet from a on-link neighbor's packet queue.
+ *
+ * @param node neighbor entry
+ *
+ * @retval pointer to the packet entry or NULL if the queue is empty
+ */
+gnrc_pktqueue_t *_nbr_pop_pkt(_nib_onl_entry_t *node);
+
+/**
+ * @brief Push packet to a on-link neighbor's packet queue.
+ *
+ * If there are already @ref CONFIG_GNRC_IPV6_NIB_NBR_QUEUE_CAP packets queued,
+ * the oldest will be dropped silently.
+ *
+ * @pre Neighbor is INCOMPLETE.
+ *
+ * @param node neighbor entry
+ * @param pkt packet to be pushed
+ */
+void _nbr_push_pkt(_nib_onl_entry_t *node, gnrc_pktqueue_t *pkt);
+#else
+#define _nbr_flush_pktqueue(node) ((void)node)
+#define _nbr_pop_pkt(node) ((void)node, NULL)
+#define _nbr_push_pkt(node, pkt) ((void)node, (void)pkt)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This following fix only applies for `CONFIG_GNRC_IPV6_NIB_QUEUE_PKT == 1` (default config).  

**This PR is an alternative solution for #20781:**

> There is currently the case that a on-link neighbor's packet queue might never be emptied. Specifically: if a neighbor is unreachable, the packets queued to be later send (i.e. once the neighbor is resolved) will never be de-queued if the neighbor is never resolved. On a typical link (e.g. ethernet), this is less of a problem, as the NIB subsystem actively tries to resolve the host, and in case of failure the neighbor entry is removed and the packets in it's queue get released. However, on e.g. 6LoWPANs, there is no active discovery going on, so the code path for removing the neighbor never gets executed.

This PR adds following changes:
 - packets are not enqueued on 6lo neighbors, as this is not required by specification: https://www.rfc-editor.org/rfc/rfc6775.html#section-5.6
 - once a neighbor's status switches to UNREACHABLE, flush it's packet queue
 - ~for UNREACHABLE neighbors: drop packets instead of queuing~
 - neighbor packet queue length is capped

### Tests

Spun up this thread:
```c
void *udp_send(void *arg)
{
    (void)arg;

    sock_udp_t sock;
    sock_udp_ep_t remote;
    sock_udp_ep_t remote2;

    assert(res == 0);
    res = sock_udp_str2ep(&remote, "[fdf7:0:0:1::2]:777");
    assert(res == 0);
    res = sock_udp_str2ep(&remote2, "[fdf7:0:0:1::3]:777");
    assert(res == 0);

    res = sock_udp_create(&sock, NULL, NULL, 0);
    assert(res == 0);

    static char const to_send[] = "I Receive you receive he/she receives we receive you receive they receive.";

    while (1) {
        res = sock_udp_send(&sock, to_send, sizeof(to_send), &remote);
        res = sock_udp_send(&sock, to_send, sizeof(to_send), &remote2);
        (void) to_send;
        if (res < 0) {
            printf("%s: send error: %d\n", __func__, res);
        } 
        ztimer_sleep(ZTIMER_MSEC, 50);
    }
    return NULL;
}
```

Both remote points are on-link (ethernet) but unreachable. The `sock_udp_send()` should never fail because we drop silently. By enabling debugging in `ipv6/nib/nib.c`, following is printed:

```
2024-10-08 08:02:53,474 # nib: get next hop link-layer address of fdf7:0:0:1::3%0
2024-10-08 08:02:53,489 # nib: fdf7:0:0:1::3 is in NC, start address resolution
2024-10-08 08:02:53,489 # nib: resolve address fdf7:0:0:1::3 by probing neighbors
2024-10-08 08:02:53,490 # nib: no free pktqueue entries, popping from fdf7:0:0:1::2 hogging 3
2024-10-08 08:02:53,490 # nib: host unreachable
2024-10-08 08:02:53,505 # nib: get next hop link-layer address of fdf7:0:0:1::2%0
2024-10-08 08:02:53,506 # nib: fdf7:0:0:1::2 is in NC, start address resolution
2024-10-08 08:02:53,521 # nib: resolve address fdf7:0:0:1::2 by probing neighbors
2024-10-08 08:02:53,522 # nib: no free pktqueue entries, popping from fdf7:0:0:1::3 hogging 3
2024-10-08 08:02:53,522 # nib: host unreachable
2024-10-08 08:02:53,536 # nib: get next hop link-layer address of fdf7:0:0:1::3%0
2024-10-08 08:02:53,537 # nib: fdf7:0:0:1::3 is in NC, start address resolution
2024-10-08 08:02:53,537 # nib: resolve address fdf7:0:0:1::3 by probing neighbors
2024-10-08 08:02:53,538 # nib: no free pktqueue entries, popping from fdf7:0:0:1::2 hogging 3
2024-10-08 08:02:53,552 # nib: host unreachable
2024-10-08 08:02:53,553 # nib: get next hop link-layer address of fdf7:0:0:1::2%0
2024-10-08 08:02:53,568 # nib: fdf7:0:0:1::2 is in NC, start address resolution
2024-10-08 08:02:53,569 # nib: resolve address fdf7:0:0:1::2 by probing neighbors
2024-10-08 08:02:53,570 # nib: no free pktqueue entries, popping from fdf7:0:0:1::3 hogging 3
2024-10-08 08:02:53,570 # nib: host unreachable
```
i.e. packets are dropped from whichever nieghbor has the most in its queue.

### Issues/PRs references
#20781
