### PR TITLE
gnrc/ipv6: `nib route`: hide off-link PLEs

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/ft.h
+++ b/sys/include/net/gnrc/ipv6/nib/ft.h
@@ -112,7 +112,8 @@ void gnrc_ipv6_nib_ft_del(const ipv6_addr_t *dst, unsigned dst_len);
  *
  * The iteration over all forwarding table entries in the NIB includes all
  * entries added via @p gnrc_ipv6_nib_ft_add() and entries that are currently
- * in the Destination Cache, in the Prefix List, and in the Default Router List.
+ * in the Destination Cache, in the Prefix List (only if they're on-link),
+ * and in the Default Router List.
  *
  * Usage example:
  *

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -133,6 +133,7 @@ bool gnrc_ipv6_nib_ft_iter(const ipv6_addr_t *next_hop, unsigned iface,
         while ((offl = _nib_offl_iter(offl))) {
             assert(offl->mode != 0);
             if ((offl->next_hop != NULL) &&
+                (offl->mode != _PL || offl->flags & _PFX_ON_LINK) &&
                 ((iface == 0) || (iface == _nib_onl_get_if(offl->next_hop))) &&
                 ((next_hop == NULL) || ipv6_addr_equal(&offl->next_hop->ipv6,
                                                        next_hop))) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -132,15 +132,26 @@ bool gnrc_ipv6_nib_ft_iter(const ipv6_addr_t *next_hop, unsigned iface,
 
         while ((offl = _nib_offl_iter(offl))) {
             assert(offl->mode != 0);
-            if ((offl->next_hop != NULL) &&
-                (offl->mode != _PL || offl->flags & _PFX_ON_LINK) &&
-                ((iface == 0) || (iface == _nib_onl_get_if(offl->next_hop))) &&
-                ((next_hop == NULL) || ipv6_addr_equal(&offl->next_hop->ipv6,
-                                                       next_hop))) {
-                _nib_ft_get(offl, fte);
-                *state = offl;
-                return true;
+            if (offl->next_hop == NULL) {
+                /* 'holey' NIB / dangling reference.
+                 * there is no next hop (not even an interface) */
+                continue;
             }
+            if (offl->mode == _PL && !(offl->flags & _PFX_ON_LINK)) {
+                /* prefix list entry is off-link */
+                continue;
+            }
+            if (iface && iface != _nib_onl_get_if(offl->next_hop)) {
+                /* interface does not match */
+                continue;
+            }
+            if (next_hop && !ipv6_addr_equal(&offl->next_hop->ipv6, next_hop)) {
+                /* next hop does not match */
+                continue;
+            }
+            _nib_ft_get(offl, fte);
+            *state = offl;
+            return true;
         }
         *state = NULL;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

An off-link prefix with SLAAC (i.e. RA PIO: L flag = 0, A flag = 1):
- is listed in `nib prefix`. Listing it here only means it’s a "managed" prefix (for SLAAC lifetimes), no indication about whether it’s on-link.
- `nib route`
❌ Currently **falsely displays it as on-link** (e.g. `2001:db8::/32 dev #6`)
Should not list it, to reflect the actually used routing logic [1]
https://github.com/RIOT-OS/RIOT/blob/0e7636a463894c177a2982fd08f7e02cef83aa89/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c#L653

This PR removes it from the `nib route` output.

[1] which is correct ("forward the packet to a default router" - https://datatracker.ietf.org/doc/html/rfc4861#section-6.3.4)

### Testing procedure

<details>
  <summary>Expand</summary>

`sudo dist/tools/tapsetup/tapsetup`

In any directory:
Set file content of `radvd-offl.conf` to:
```
interface tapbr0 {
    AdvSendAdvert on;
    prefix 2001:db8::/32 {
        AdvOnLink off;
    };
};
```
Run
`sudo radvd --nodaemon --config=radvd-offl.conf`

```
cd examples/gnrc_networking/
make && make term
```
In RIOT terminal: command `nib route`
In command output, observe unexpected line `2001:db8::/32 dev #6`.
</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#20757 revealed this bug by adding a feature