### PR TITLE
gcoap: the name of the gcoap thread should be gcoap

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1497,7 +1497,7 @@ kernel_pid_t gcoap_init(void)
         return -EEXIST;
     }
     _pid = thread_create(_msg_stack, sizeof(_msg_stack), THREAD_PRIORITY_MAIN - 1,
-                            0, _event_loop, NULL, "coap");
+                            0, _event_loop, NULL, "gcoap");
 
     mutex_init(&_coap_state.lock);
     /* Blank lists so we know if an entry is available. */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Naming the `gcoap` thread `gcoap` makes it easier to tell where the thread comes from.


### Testing procedure

```
2024-08-26 15:43:52,704 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2024-08-26 15:43:52,705 # 	  - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) |  0x8081ee0 |  0x8081ee0
2024-08-26 15:43:52,706 # 	  1 | idle                 | pending  Q |  15 |   8192 (  436) ( 7756) |  0x807c7e0 |  0x807e63c 
2024-08-26 15:43:52,708 # 	  2 | main                 | running  Q |   7 |  12288 ( 2792) ( 9496) |  0x807e7e0 |  0x808163c 
2024-08-26 15:43:52,709 # 	  3 | ipv6                 | bl rx    _ |   4 |   8128 ( 1864) ( 6264) |  0x8086640 |  0x808845c 
2024-08-26 15:43:52,710 # 	  4 | udp                  | bl rx    _ |   5 |   4032 (  976) ( 3056) |  0x808c2c0 |  0x808d0dc 
2024-08-26 15:43:52,711 # 	  5 | gcoap                | bl anyfl _ |   6 |   8280 ( 1112) ( 7168) |  0x80845a0 |  0x8086454 
2024-08-26 15:43:52,712 # 	  6 | gnrc_netdev_tap      | bl anyfl _ |   2 |   8064 ( 2216) ( 5848) |  0x8088aa0 |  0x808a87c 
2024-08-26 15:43:52,714 # 	    | SUM                  |            |     |  57176 ( 9396) (47780)
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
