### PR TITLE
examples/gcoap-rust: Expose more functionality

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -658,6 +658,9 @@ name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -777,6 +780,7 @@ dependencies = [
  "coap-handler",
  "coap-message",
  "coap-numbers",
+ "critical-section",
  "cstr",
  "embedded-graphics",
  "embedded-hal 0.2.7",
@@ -802,6 +806,7 @@ version = "0.1.0"
 dependencies = [
  "coap-handler-implementations",
  "coap-message-demos",
+ "portable-atomic",
  "riot-coap-handler-demos",
  "riot-wrappers",
  "rust_riotmodules",
@@ -973,8 +978,10 @@ dependencies = [
 [[package]]
 name = "try-lock"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+source = "git+https://github.com/seanmonstar/try-lock?rev=45c39685b56a4dba1b71bdbbbe5f731c3c77dc50#45c39685b56a4dba1b71bdbbbe5f731c3c77dc50"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "typenum"

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex 1.3.0",
+ "shlex",
  "syn 1.0.109",
  "which",
 ]
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "coap-handler-implementations"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2aeab8575ae5b10c04ce5649cd30113c7c2d0d085c393b79a638fd36a854"
+checksum = "be078e893f1f88cab31e2af83bbbb90cd5f8e9e95384cbbb4b45c8d537dffe35"
 dependencies = [
  "ciborium-io",
  "coap-handler",
@@ -173,7 +173,8 @@ dependencies = [
  "crc",
  "document-features",
  "embedded-io",
- "minicbor",
+ "minicbor 0.19.1",
+ "minicbor 0.24.4",
  "serde",
  "serde_cbor",
  "windowed-infinity",
@@ -212,7 +213,7 @@ dependencies = [
  "coap-message",
  "coap-numbers",
  "document-features",
- "minicbor",
+ "minicbor 0.19.1",
 ]
 
 [[package]]
@@ -334,10 +335,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-nal"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9efecb57ab54fa918730f2874d7d37647169c50fa1357fecb81abee840b113"
+dependencies = [
+ "heapless 0.7.17",
+ "nb 1.1.0",
+ "no-std-net",
+]
+
+[[package]]
+name = "embedded-nal-tcpextensions"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2e746f564378f553ee88d860885d74eaa85f462bbd87db348a3e27cfc36230"
+dependencies = [
+ "embedded-nal",
+ "heapless 0.7.17",
+]
 
 [[package]]
 name = "errno"
@@ -511,19 +542,25 @@ name = "minicbor"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+
+[[package]]
+name = "minicbor"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+checksum = "297ad6022c004a6c54f0fb28bbd2306314d5a4edc767e56b4b4cc48fc2371654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -554,6 +591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "no-std-net"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "peeking_take_while"
@@ -609,6 +652,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "proc-macro2"
@@ -666,7 +715,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.2.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#ab8e8e596fdbfd89c519e848cc7970b1c8410fea"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#9252de4b8cd844e788dc3ebbd0f35f79c5e4edc9"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -678,9 +727,11 @@ dependencies = [
  "document-features",
  "embedded-graphics",
  "embedded-hal 1.0.0",
+ "embedded-hal-async",
  "heapless 0.7.17",
  "hex",
- "minicbor",
+ "minicbor 0.24.4",
+ "no-std-net",
  "riot-shell-commands",
  "riot-sys",
  "riot-wrappers",
@@ -688,12 +739,13 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "switch-hal",
+ "try-lock",
 ]
 
 [[package]]
 name = "riot-shell-commands"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#ab8e8e596fdbfd89c519e848cc7970b1c8410fea"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#9252de4b8cd844e788dc3ebbd0f35f79c5e4edc9"
 dependencies = [
  "document-features",
  "heapless 0.7.17",
@@ -713,13 +765,13 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shlex 1.3.0",
+ "shlex",
 ]
 
 [[package]]
 name = "riot-wrappers"
-version = "0.9.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#3d280a4f453fe655e1cfdeb773dff1972025cd04"
+version = "0.9.1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#d7858f5dc84e188f063773008888abff20916856"
 dependencies = [
  "bare-metal",
  "coap-handler",
@@ -729,18 +781,19 @@ dependencies = [
  "embedded-graphics",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
+ "embedded-nal",
+ "embedded-nal-tcpextensions",
  "heapless 0.8.0",
  "hex",
  "mutex-trait",
  "nb 0.1.3",
+ "no-std-net",
  "num-traits",
  "pin-project",
  "pin-utils",
  "rand_core",
  "riot-sys",
- "shlex 0.1.1",
  "switch-hal",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -752,6 +805,7 @@ dependencies = [
  "riot-coap-handler-demos",
  "riot-wrappers",
  "rust_riotmodules",
+ "static_cell",
 ]
 
 [[package]]
@@ -775,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -857,12 +911,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-
-[[package]]
-name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
@@ -881,6 +929,15 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_cell"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89b0684884a883431282db1e4343f34afc2ff6996fe1f4a1664519b66e14c1e"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "switch-hal"
@@ -912,6 +969,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -951,15 +1014,16 @@ dependencies = [
 
 [[package]]
 name = "windowed-infinity"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9487d1d565a9db59e1fd0b3c2d3f0c277bc375d348a6c46ff2b322917fbc035"
+checksum = "ceb9fe94789e0552a8f626fddfa2c074e74ddf61db8c4ccd19eb8cfa4cdbb1bc"
 dependencies = [
  "ciborium-io",
  "crc",
  "digest",
  "embedded-io",
- "minicbor",
+ "minicbor 0.19.1",
+ "minicbor 0.24.4",
  "serde",
  "serde_cbor",
 ]

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "coap-handler-implementations"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2735f53da500caae442466ba2126d62458e86116ec1e273919880410f7e187b"
+checksum = "fbcd2aeab8575ae5b10c04ce5649cd30113c7c2d0d085c393b79a638fd36a854"
 dependencies = [
  "ciborium-io",
  "coap-handler",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "coap-message"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e126d86a35f4c5dfcf454da6c9c58a6e703150989e536945ef3813f2bc60565"
+checksum = "5ccab4ff10bcaab1d7f017c34ea598e9f21d187c32f6f086d7abd580b0412096"
 dependencies = [
  "num-traits",
 ]
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "coap-message-utils"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc625b0d10d99c012e83dfc68265231c2a9ae4f2e02e1a72dfef266133e9a09"
+checksum = "c3ba07600e8cd4a6bf7ee0df249fc66bb89b8c6deedcce5b4e93b192e14b3306"
 dependencies = [
  "coap-message",
  "coap-numbers",
@@ -666,7 +666,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.2.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#5f83cbdb3be5f5a9d74703bcdd0de14fa122fb16"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#ab8e8e596fdbfd89c519e848cc7970b1c8410fea"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -675,8 +675,9 @@ dependencies = [
  "coap-message",
  "coap-message-utils",
  "coap-numbers",
+ "document-features",
  "embedded-graphics",
- "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
  "heapless 0.7.17",
  "hex",
  "minicbor",
@@ -686,13 +687,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
+ "switch-hal",
 ]
 
 [[package]]
 name = "riot-shell-commands"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#5f83cbdb3be5f5a9d74703bcdd0de14fa122fb16"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#ab8e8e596fdbfd89c519e848cc7970b1c8410fea"
 dependencies = [
+ "document-features",
  "heapless 0.7.17",
  "riot-sys",
  "riot-wrappers",
@@ -700,8 +703,8 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.12"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#a3752271062299f68c5f6ba3c6e503ac725722c4"
+version = "0.7.13"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#0b53c15cc171ce2a95b89b1c34e3dfd0ef7e90e2"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -716,7 +719,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.0"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b8933a2b7c60423a63b614e6f8933c489b46833f"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#3d280a4f453fe655e1cfdeb773dff1972025cd04"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -23,10 +23,11 @@ riot-wrappers = { version = "^0.9.0", features = [ "set_panic_handler", "panic_h
 
 coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
 coap-handler-implementations = "0.5"
-riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples/", features = [ "vfs", "saul" ] }
+riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples/", features = [ "vfs", "saul", "nib", "ping" ] }
 
 # While currently this exmple does not use any RIOT modules implemented in
 # Rust, that may change; it is best practice for any RIOT application that has
 # its own top-level Rust crate to include rust_riotmodules from inside
 # RIOTBASE.
 rust_riotmodules = { path = "../../sys/rust_riotmodules/" }
+static_cell = "2.1.0"

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -19,7 +19,8 @@ codegen-units = 1
 opt-level = "s"
 
 [dependencies]
-riot-wrappers = { version = "^0.9.0", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
+riot-wrappers = { version = "^0.9.0", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler", "provide_critical_section_1_0" ] }
+portable-atomic = { version = "1", features = [ "critical-section" ] }
 
 coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
 coap-handler-implementations = "0.5"
@@ -31,3 +32,9 @@ riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-exampl
 # RIOTBASE.
 rust_riotmodules = { path = "../../sys/rust_riotmodules/" }
 static_cell = "2.1.0"
+
+[patch.crates-io]
+# from https://github.com/seanmonstar/try-lock/pull/11, necessary for those
+# platforms without atomics (which also needs provide_critical_section_1_0 from
+# riot-wrappers, and portable-atomic/critical-section to bridge the gap)
+try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "45c39685b56a4dba1b71bdbbbe5f731c3c77dc50" }

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -36,12 +36,12 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-# Add 16k extra stack: The Rust examples take more of it than gcoap expects,
+# Add 12k extra stack: The Rust examples take more of it than gcoap expects,
 # for reasons that are not fully understood (it's not the string formatter).
-CFLAGS += -DGCOAP_STACK_SIZE='(THREAD_STACKSIZE_DEFAULT+DEBUG_EXTRA_STACKSIZE+sizeof(coap_pkt_t)+16384)'
+CFLAGS += -DGCOAP_STACK_SIZE='(THREAD_STACKSIZE_DEFAULT+DEBUG_EXTRA_STACKSIZE+sizeof(coap_pkt_t)+12288)'
 # This thread needs some more stack for printing the addresses, once more being
 # hit by string formatting.
-CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF+2048)'
+CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF+1024)'
 
 # The name of crate (as per Cargo.toml package name, but with '-' replaced with '_')
 APPLICATION_RUST_MODULE = rust_gcoap

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -19,6 +19,8 @@ USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec
 USEMODULE += ztimer_sec
 
+USEMODULE += gnrc_netapi_callbacks
+
 # for the "vfs" feature of riot-coap-handler-demos (and vfs.c)
 USEMODULE += vfs
 USEMODULE += constfs

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -34,10 +34,9 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-# Add 8k extra stack: The Rust examples take more of it than gcoap expects,
-# presumably because the example use the standard library's sting formatting
-# instead of one of the more optimized formatters.
-CFLAGS += -DGCOAP_STACK_SIZE='(THREAD_STACKSIZE_DEFAULT+DEBUG_EXTRA_STACKSIZE+sizeof(coap_pkt_t)+8192)'
+# Add 16k extra stack: The Rust examples take more of it than gcoap expects,
+# for reasons that are not fully understood (it's not the string formatter).
+CFLAGS += -DGCOAP_STACK_SIZE='(THREAD_STACKSIZE_DEFAULT+DEBUG_EXTRA_STACKSIZE+sizeof(coap_pkt_t)+16384)'
 # This thread needs some more stack for printing the addresses, once more being
 # hit by string formatting.
 CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF+2048)'

--- a/examples/rust-gcoap/Makefile.ci
+++ b/examples/rust-gcoap/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
+    arduino-mkr1000 \
     b-l072z-lrwan1 \
     blackpill-stm32f103c8 \
     blackpill-stm32f103cb \
@@ -12,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     cc2650stk \
     e104-bt5010a-tb \
     e104-bt5011a-tb \
+    feather-m0-wifi \
     gd32vf103c-start \
     hifive1 \
     hifive1b \
@@ -21,7 +23,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     lsn50 \
     maple-mini \
     microbit \
-    microbit-v2 \
     nrf51dongle \
     nrf6310 \
     nucleo-c031c6 \
@@ -34,10 +35,15 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-f410rb \
+    nucleo-g070rb \
+    nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \
+    nucleo-l412kb \
     olimexino-stm32 \
     opencm904 \
     samd10-xmini \

--- a/examples/rust-gcoap/README.md
+++ b/examples/rust-gcoap/README.md
@@ -51,3 +51,7 @@ Once that is ready, in a parallel shell, run:
 ```
 $ aiocoap-client 'coap://[2a02:0b18:c13b:8018:1234:56ff:fe78:90ab]/.well-known/core'
 ```
+
+Note that no security is enabled by default so far; this is considered a bug.
+To mitigate this, no controls that are expected to be harmful are exposed in this example.
+(For example, while LEDs are exposed, GPIO pins are not, for they might not tolerate driving to some level depending on the hardware connected to them).

--- a/examples/rust-gcoap/src/lib.rs
+++ b/examples/rust-gcoap/src/lib.rs
@@ -26,6 +26,7 @@ fn main() {
         .below(&["led"], riot_coap_handler_demos::led::all_leds())
         .below(&["vfs"], riot_coap_handler_demos::vfs::vfs(""))
         .below(&["saul"], riot_coap_handler_demos::saul::SaulHandler::new(&["saul"]))
+        .below(&["netif"], riot_coap_handler_demos::netif::netif())
         .with_wkc()
         ;
     let mut handler = riot_wrappers::coap_handler::v0_2::GcoapHandler(handler);

--- a/examples/rust-gcoap/src/lib.rs
+++ b/examples/rust-gcoap/src/lib.rs
@@ -23,6 +23,7 @@ fn main() {
 
     let handler = coap_message_demos::full_application_tree(None)
         .below(&["ps"], riot_coap_handler_demos::ps::ps_tree())
+        .below(&["led"], riot_coap_handler_demos::led::all_leds())
         .below(&["vfs"], riot_coap_handler_demos::vfs::vfs(""))
         .below(&["saul"], riot_coap_handler_demos::saul::SaulHandler::new(&["saul"]))
         .with_wkc()

--- a/examples/rust-gcoap/src/lib.rs
+++ b/examples/rust-gcoap/src/lib.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 use riot_wrappers::{riot_main, println};
-use riot_wrappers::{gcoap, thread, ztimer, gnrc};
+use riot_wrappers::{gcoap, ztimer, gnrc};
 
 use coap_handler_implementations::{ReportingHandlerBuilder, HandlerBuilder};
 
@@ -21,17 +21,29 @@ fn main() {
 
     unsafe { do_vfs_init() };
 
+    static PINGS: riot_coap_handler_demos::ping::PingPool = riot_coap_handler_demos::ping::PingPool::new();
+    static PING_PASSIVE: riot_coap_handler_demos::ping_passive::PingHistoryMutex<{ riot_coap_handler_demos::ping_passive::DEFAULT_SIZE }> = riot_coap_handler_demos::ping_passive::PingHistoryMutex::new();
+
     let handler = coap_message_demos::full_application_tree(None)
         .below(&["ps"], riot_coap_handler_demos::ps::ps_tree())
         .below(&["led"], riot_coap_handler_demos::led::all_leds())
         .below(&["vfs"], riot_coap_handler_demos::vfs::vfs(""))
         .below(&["saul"], riot_coap_handler_demos::saul::SaulHandler::new(&["saul"]))
         .below(&["netif"], riot_coap_handler_demos::netif::netif())
+        .below(&["nib", "neigh"], riot_coap_handler_demos::nib::neighbor_cache())
+        .below(&["ping"], riot_coap_handler_demos::ping::ping_tree(&PINGS))
+        .at(&["pinged"], riot_coap_handler_demos::ping_passive::resource(&PING_PASSIVE))
         .with_wkc()
         ;
     let mut handler = riot_wrappers::coap_handler::v0_2::GcoapHandler(handler);
 
     let mut listener = gcoap::SingleHandlerListener::new_catch_all(&mut handler);
+
+    static SLOT: static_cell::StaticCell<gnrc::netreg::callback::Slot<riot_coap_handler_demos::ping::PingCallback>> = static_cell::StaticCell::new();
+    PINGS.register(SLOT.init(Default::default()));
+
+    static PASSIVE_SLOT: static_cell::StaticCell<gnrc::netreg::callback::Slot<&'static riot_coap_handler_demos::ping_passive::PingHistoryMutex<{ riot_coap_handler_demos::ping_passive::DEFAULT_SIZE }>>> = static_cell::StaticCell::new();
+    PING_PASSIVE.register(PASSIVE_SLOT.init(Default::default()));
 
     gcoap::scope(|greg| {
         greg.register(&mut listener);
@@ -57,6 +69,9 @@ fn main() {
 
         // Sending main thread to sleep; can't return or the Gcoap handler would need to be
         // deregistered (which it can't).
-        loop { thread::sleep(); }
+        loop {
+            PINGS.tick();
+            sectimer.sleep(ztimer::Ticks(1));
+        }
     })
 }


### PR DESCRIPTION
### Contribution description

The riot-coap-handler-demos has a few ready-made components that were not shown off in examples/rust-gcoap before. I think they are useful to have, as they point users to more example code and to things they can explore with safe Rust bindings. The added resources don't make the example's source code more complex (effectively they're all just adding a line), but obviously they increase code size.

Concretely, this exposes any board LEDs as individual resources (PUT CBOR values false or true, or POST (see maturity)), and also exposes /netif which roughly contains data from `ifconfig` (only MAC address and IP addresses so far).

Two non-src/lib.rs changes are an added note in the README on security (none is there, thus we only expose harmless things), updating various riot-wrappers related dependencies (so for example LEDs are properly wrapped in the first place), and a stack size increase.

The CoAP thread's stack size gets increased from 8k to 16k. This fixes an actual bug, where on the particle-xenon the stack usage of the /ps/ handler (that was already active) was around 11k. I've done some digging into it (with terrible methodology, a mix of interactive gdb, attempts to read the stack usage from a Python script in gdb, and eventually resorting to calling ps() over and over in various places because that's faster than breakpoints), and what I can tell so far is that it's not so much related to serialization (I've tried switching CBOR libraries but the effect was present but miniomal) but that a lot of stack is used already in request parsing. Clearly something to investigate further, but for now, easy to fix.

### Testing procedure

* Run the examples/rust-gcoap program and note the IP address it shows
* `pipx run --spec 'aiocoap[prettyprint]' aiocoap-client coap://[fe80::the-address-shown%relevant-netif]/.well-known/core` (or just aiocoap-client if you have aiocoap installed) and from there interact with the other resources advertised

The prettyprinting will make sure you see the returned CBOR in a reasonable form; very recent (I think unpublished) versions even give you readable IP addesses such as this:

```
./aiocoap-client coap://'[fe80::a41b:b9ff:fe1f:0894%enxa61bb91f1494]'/netif
# CBOR message shown in Diagnostic Notation
[_ [6, h'a61bb91f0894', [54([ip'fe80::a41b:b9ff:fe1f:894', null, 6])]]]
```

(which would be a lot more readable even if tag 54's text notation had the capability of expressing zone identifiers).

### Maturity

<del>The LED resources are a bit weird so far in that toggling them requires sending a null value rather than an empty payload; I'd like to fix that before merging.</del>