### PR TITLE
cpu/sam0_common/periph: fix rtt reset after hibernation

### DIFF
--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -407,29 +407,31 @@ void rtt_init(void)
     _read_gp(backup);
 #endif
 
-    _rtt_reset();
+    if (!cpu_woke_from_backup()) {
+        _rtt_reset();
 
 #ifdef MODULE_PERIPH_RTC_MEM
 #ifdef RTC_MODE2_CTRLB_GP2EN
-    /* RTC driver does not use COMP[1] or ALARM[1] */
-    /* Use second set of Compare registers as general purpose register */
-    RTC->MODE2.CTRLB.reg = RTC_MODE2_CTRLB_GP2EN;
+        /* RTC driver does not use COMP[1] or ALARM[1] */
+        /* Use second set of Compare registers as general purpose register */
+        RTC->MODE2.CTRLB.reg = RTC_MODE2_CTRLB_GP2EN;
 #endif
-    _write_gp(backup);
+        _write_gp(backup);
 #endif /* MODULE_PERIPH_RTC_MEM */
 
-    /* set 32bit counting mode & enable the RTC */
+        /* set 32bit counting mode & enable the RTC */
 #ifdef REG_RTC_MODE0_CTRLA
-    RTC->MODE0.CTRLA.reg = RTC_MODE0_CTRLA_MODE(0)
-                         | RTC_MODE0_CTRLA_ENABLE
-                         | RTC_MODE0_CTRLA_COUNTSYNC
-                         | RTC_MODE0_PRESCALER;
+        RTC->MODE0.CTRLA.reg = RTC_MODE0_CTRLA_MODE(0)
+                            | RTC_MODE0_CTRLA_ENABLE
+                            | RTC_MODE0_CTRLA_COUNTSYNC
+                            | RTC_MODE0_PRESCALER;
 #else
-    RTC->MODE0.CTRL.reg = RTC_MODE0_CTRL_MODE(0)
-                        | RTC_MODE0_CTRL_ENABLE
-                        | RTC_MODE0_PRESCALER;
+        RTC->MODE0.CTRL.reg = RTC_MODE0_CTRL_MODE(0)
+                            | RTC_MODE0_CTRL_ENABLE
+                            | RTC_MODE0_PRESCALER;
 #endif
-    _wait_syncbusy();
+        _wait_syncbusy();
+    }
 
     /* initially clear flag */
     RTC->MODE0.INTFLAG.reg = RTC_MODE0_INTFLAG_CMP0


### PR DESCRIPTION
### Contribution description

This PR fixes the issue with rtt reset after a node hibernation
You may notice an issue when using the **rtt_rtc** module in any RIOT OS example. Specifically, if you use the rtc_gettime() function to get the current time, then set an alarm, put the node into hibernation, and finally retrieve the time again after the node wakes up, you will find that the time is incorrect after hibernation.

I encountered this issue while working with the gcoap example on the same54-xpro board. After adding the rtt_rtc module, I followed the steps mentioned above and observed that the time returned by rtc_gettime() after waking up from hibernation did not match the expected value.

### Testing procedure

The output before the fix, you can notice the time after hibernation is wrong
```
rtc gettime
2024-08-28 17:48:10,774 # rtc gettime
2024-08-28 17:48:10,779 # in _rtc_now: now 151613 and last_alarm 0 and rtc_now 0
2024-08-28 17:48:10,780 # tmp 4s
2024-08-28 17:48:10,782 # 2020-01-01 00:00:04
> rtc setalarm 2020-01-01 00:01:04
2024-08-28 17:48:25,766 # rtc setalarm 2020-01-01 00:01:04
2024-08-28 17:48:25,767 # alarm_time 64
2024-08-28 17:48:25,772 # in _rtc_now: now 642893 and last_alarm 0 and rtc_now 0
2024-08-28 17:48:25,774 # rtc_now in set alarm 19s
2024-08-28 17:48:25,776 # RTT_SECONDS 32768
2024-08-28 17:48:25,777 # RTT_MAX_VALUE -1
2024-08-28 17:48:25,781 # last_alarm in update alarm 622592s and rtc_now 19
2024-08-28 17:48:25,783 # next alarm is 45
> pm set 1
2024-08-28 17:48:31,014 # pm set 1
2024-08-28 17:48:31,017 # CPU is entering power mode 1.
2024-08-28 17:48:31,020 # Now waiting for a wakeup event...
2024-08-28 17:49:10,789 # main(): This is RIOT! (Version: 2024.10-devel-132-gb05606)
2024-08-28 17:49:10,791 # gcoap example app
2024-08-28 17:49:10,793 # All up, running the shell now
rtc gettime
2024-08-28 17:49:15,846 # rtc gettime
2024-08-28 17:49:15,851 # in _rtc_now: now 165913 and last_alarm 622592 and rtc_now 19
2024-08-28 17:49:15,852 # tmp 131077s
2024-08-28 17:49:15,854 # 2020-01-02 12:24:37
```

This is the output after the fix:

```
rtc gettime
2024-08-28 18:14:47,512 # rtc gettime
2024-08-28 18:14:47,517 # in _rtc_now: now 83033 and last_alarm 0 and rtc_now 0
2024-08-28 18:14:47,517 # tmp 2s
2024-08-28 18:14:47,519 # 2020-01-01 00:00:02
rtc setalarm 2020-01-01 00:01:00
2024-08-28 18:14:55,528 # rtc setalarm 2020-01-01 00:01:00
2024-08-28 18:14:55,530 # alarm_time 60
2024-08-28 18:14:55,534 # in _rtc_now: now 345737 and last_alarm 0 and rtc_now 0
2024-08-28 18:14:55,536 # rtc_now in set alarm 10s
2024-08-28 18:14:55,538 # RTT_SECONDS 32768
2024-08-28 18:14:55,540 # RTT_MAX_VALUE -1
2024-08-28 18:14:55,544 # last_alarm in update alarm 327680s and rtc_now 10
2024-08-28 18:14:55,545 # next alarm is 50
> pm set 1
2024-08-28 18:15:01,015 # pm set 1
2024-08-28 18:15:01,018 # CPU is entering power mode 1.
2024-08-28 18:15:01,021 # Now waiting for a wakeup event...
2024-08-28 18:15:45,552 # main(): This is RIOT! (Version: 2024.10-devel-132-gb05606)
2024-08-28 18:15:45,553 # gcoap example app
2024-08-28 18:15:45,556 # All up, running the shell now
> rtc gettime
2024-08-28 18:15:51,254 # rtc gettime
2024-08-28 18:15:51,260 # in _rtc_now: now 2171904 and last_alarm 327680 and rtc_now 10
2024-08-28 18:15:51,260 # tmp 66s
2024-08-28 18:15:51,262 # 2020-01-01 00:01:06

```