### PR TITLE
sys/string_utils: add string_writer helper

### DIFF
--- a/cpu/atxmega/include/cpu_conf.h
+++ b/cpu/atxmega/include/cpu_conf.h
@@ -64,6 +64,10 @@ extern "C" {
  */
 #define IRQ_API_INLINED                 (1)
 
+#ifndef DOXYGEN
+#define HAS_FLASH_UTILS_ARCH    1
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/libc/string.c
+++ b/sys/libc/string.c
@@ -14,6 +14,8 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
 
+#include <stdarg.h>
+#include <stdio.h>
 #include <errno.h>
 #include "string_utils.h"
 
@@ -48,6 +50,34 @@ const void *memchk(const void *data, uint8_t c, size_t len)
     }
 
     return NULL;
+}
+
+int __swprintf(string_writer_t *sw, FLASH_ATTR const char *restrict format, ...)
+{
+    va_list args;
+    int res;
+
+    va_start(args, format);
+#ifdef __clang__
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"") \
+    res = flash_vsnprintf(sw->position, sw->capacity, format, args);
+    _Pragma("clang diagnostic pop")
+#else
+    res = flash_vsnprintf(sw->position, sw->capacity, format, args);
+#endif
+    va_end(args);
+
+    if (res < (int)sw->capacity) {
+        sw->capacity -= res;
+        sw->position += res;
+    } else {
+        sw->position += sw->capacity;
+        sw->capacity = 0;
+        res = -E2BIG;
+    }
+
+    return res;
 }
 
 /** @} */

--- a/tests/pkg/relic/Makefile
+++ b/tests/pkg/relic/Makefile
@@ -9,6 +9,9 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     atmega256rfr2-xpro \
                     atmega328p \
                     atmega328p-xplained-mini \
+                    atxmega-a1-xplained \
+                    atxmega-a1u-xpro \
+                    atxmega-a3bu-xplained \
                     derfmega128 \
                     derfmega256 \
                     f4vi1 \

--- a/tests/unittests/tests-libc/tests-libc.c
+++ b/tests/unittests/tests-libc/tests-libc.c
@@ -30,6 +30,41 @@ static void test_libc_strscpy(void)
     TEST_ASSERT_EQUAL_INT(strscpy(buffer, "empty", 0), -E2BIG);
 }
 
+static void test_libc_swprintf(void)
+{
+    string_writer_t sw;
+    char buffer[32];
+    int res;
+
+    string_writer_init(&sw, buffer, sizeof(buffer));
+
+    /* check that string can be written completely */
+    res = swprintf(&sw, "Hello World!");
+    TEST_ASSERT_EQUAL_INT(res, 12);
+    TEST_ASSERT_EQUAL_INT(string_writer_len(&sw), 12);
+    TEST_ASSERT_EQUAL_INT(strcmp("Hello World!", string_writer_str(&sw)), 0);
+
+    /* check that we can add to the string */
+    /* Writing 10 characters, returns 10 bytes written */
+    res = swprintf(&sw, "0123456789");
+    TEST_ASSERT_EQUAL_INT(res, 10);
+    TEST_ASSERT_EQUAL_INT(strcmp("Hello World!0123456789", string_writer_str(&sw)), 0);
+
+    /* The string does not fit completely into the buffer, so it gets truncated */
+    res = swprintf(&sw, "01234567891");
+    TEST_ASSERT_EQUAL_INT(res, -E2BIG);
+    TEST_ASSERT_EQUAL_INT(strcmp("Hello World!0123456789012345678", string_writer_str(&sw)), 0);
+
+    /* You can't write to a full buffer */
+    res = swprintf(&sw, "###");
+    TEST_ASSERT_EQUAL_INT(res, -E2BIG);
+
+    /* check if string was truncated as expected */
+    TEST_ASSERT_EQUAL_INT(string_writer_len(&sw), 32);
+    TEST_ASSERT_EQUAL_INT(strcmp("Hello World!0123456789012345678",
+                                 string_writer_str(&sw)), 0);
+}
+
 static void test_libc_memchk(void)
 {
     char buffer[32];
@@ -101,6 +136,7 @@ Test *tests_libc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_libc_strscpy),
+        new_TestFixture(test_libc_swprintf),
         new_TestFixture(test_libc_memchk),
         new_TestFixture(test_libc_endian),
     };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Assembling a string through multiple writes if often open-coded like this

```C
char buffer[64];
size_t len = 0;
for (unsigned i = 0; i < ARRAY_SIZE(names); ++i) {
    len += snprintf(&buffer[len], sizeof(buffer) - len, "%u: %s\n", i, names[i]);
}
```

This is error prone (the above example foregoes any error handling) and ugly.

This introduces a small helper function to achieve the same in a much more convenient fasion:

```C
char buffer[64];
string_writer_t sw;
string_writer_init(&sw, buffer, sizeof(buffer));

for (unsigned i = 0; i < ARRAY_SIZE(names); ++i) {
    swprintf(&sw, "%u: %s\n", i, names[i]);
}
```


### Testing procedure

A new unit test has been added.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
