### PR TITLE
doc: Point out common problem installing c2rust

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -151,6 +151,12 @@ as this is using some recent fixes, it is best installed as:
 $ cargo install c2rust --git https://github.com/immunant/c2rust
 ```
 
+If multiple versions of LLVM are installed locally, it may be necessary to prefix it with the selected LLVM version:
+
+```
+$ LLVM_CONFIG_PATH=/usr/bin/llvm-config-16 cargo install …
+```
+
 [cargo]: https://doc.rust-lang.org/cargo/
 [**rustup**, installed as described on its website]: https://rustup.rs/
 


### PR DESCRIPTION
### Contribution description

This is a simple doc update to point users in the right direction when they see something like:

```
  -- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES) 
  -- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES) 
  -- Configuring incomplete, errors occurred!

  --- stderr
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.


  CMake Error at /usr/lib/llvm-14/lib/cmake/clang/ClangTargets.cmake:756 (message):
    The imported target "clangBasic" references the file

       "/usr/lib/llvm-14/lib/libclangBasic.a"

    but this file does not exist.  Possible reasons include:

    * The file was deleted, renamed, or moved to another location.

    * An install or uninstall procedure did not complete successfully.

    * The installation package was faulty and contained

       "/usr/lib/llvm-14/lib/cmake/clang/ClangTargets.cmake"

    but not all the files it references.

  Call Stack (most recent call first):
    /usr/lib/cmake/clang-14/ClangConfig.cmake:19 (include)
    CMakeLists.txt:62 (find_package)


  thread 'main' panicked at /home/chrysn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.51/src/lib.rs:1100:5:

  command did not execute successfully, got: exit status: 1

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


### Testing procedure

Look at the documentation.

### More context

After c2rust newer than 0.18 is released, `cargo install c2rust` without git should work -- but that may take some more time on the part of the maintainers (and while it worked until a few weeks ago, when both the published and the git version broke, I didn't even update the docs before).