### PR TITLE
boards/nucleo-l432kc: enable CAN support

### DIFF
--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l432kc
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/cpu/stm32/include/can_params.h
+++ b/cpu/stm32/include/can_params.h
@@ -54,9 +54,16 @@ static const can_conf_t candev_conf[] = {
         .rx_pin = GPIO_PIN(PORT_A, 11),
         .tx_pin = GPIO_PIN(PORT_A, 12),
 #elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F4)
+
+#if defined(CPU_MODEL_STM32L432KC)
+        .rx_pin = GPIO_PIN(PORT_A, 11),
+        .tx_pin = GPIO_PIN(PORT_A, 12),
+        .af = GPIO_AF9,
+#else
         .rx_pin = GPIO_PIN(PORT_B, 8),
         .tx_pin = GPIO_PIN(PORT_B, 9),
         .af = GPIO_AF9,
+#endif
 #else
         .rx_pin = GPIO_PIN(PORT_D, 0),
         .tx_pin = GPIO_PIN(PORT_D, 1),


### PR DESCRIPTION
### Contribution description

This PR adds CAN support to the `nucleo-l432kc`board (see issue #20837) .

### Testing procedure

The testing procedure requires one Nucleo L432KC board, one Nucleo board having CAN interface (F446RE for instance) and 2 CAN drivers (such as [ST L9616](https://www.st.com/en/automotive-analog-and-power/l9616.html)).

```bash
cd tests/sys/conn_can
make BOARD=nucleo-l432kc flash term
```

Nucleo 1 (receiver)
```
init 0
set_mode 0 0
test_can recv 1 0 10000000 100 500
```

Nucleo 2 (sender)
```
init 0
set_mode 0 0
test_can send 0 100 01 02
```

### Issues/PRs references

fixes #20837.
