### PR TITLE
pkg/lvgl: Increase default LV_MEM_SIZE for 64 bit and enable tests for native64

### DIFF
--- a/pkg/lvgl/include/lv_conf.h
+++ b/pkg/lvgl/include/lv_conf.h
@@ -65,13 +65,20 @@ extern "C" {
 #define LV_MEM_CUSTOM      0
 #if LV_MEM_CUSTOM == 0
 /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-#if IS_USED(MODULE_LVGL_EXTRA_THEME_DEFAULT_GROW)
-#  ifndef LV_MEM_SIZE
-#  define LV_MEM_SIZE    (6U * 1024U)          /*[bytes]*/
-#  endif
-#else
-#  ifndef LV_MEM_SIZE
-#  define LV_MEM_SIZE    (5U * 1024U)          /*[bytes]*/
+#ifndef LV_MEM_SIZE
+#  if (__SIZEOF_POINTER__ > 4)
+/*64-bit platforms require additional space because a lot of pointers are stored on the lvgl heap.*/
+#    if IS_USED(MODULE_LVGL_EXTRA_THEME_DEFAULT_GROW)
+#    define LV_MEM_SIZE    (9U * 1024U)          /*[bytes]*/
+#    else
+#    define LV_MEM_SIZE    (8U * 1024U)          /*[bytes]*/
+#    endif
+#  else
+#    if IS_USED(MODULE_LVGL_EXTRA_THEME_DEFAULT_GROW)
+#    define LV_MEM_SIZE    (6U * 1024U)          /*[bytes]*/
+#    else
+#    define LV_MEM_SIZE    (5U * 1024U)          /*[bytes]*/
+#    endif
 #  endif
 #endif
 

--- a/tests/pkg/lvgl/Makefile
+++ b/tests/pkg/lvgl/Makefile
@@ -12,9 +12,6 @@ USEMODULE += lvgl_extra_layout_flex
 USEMODULE += lvgl_extra_theme_default
 USEMODULE += lvgl_extra_theme_default_dark
 
-# blacklist native64 until https://github.com/RIOT-OS/riotdocker/pull/241 is resolved
-BOARD_BLACKLIST += native64
-
 include $(RIOTBASE)/Makefile.include
 
 # SDL requires more stack

--- a/tests/pkg/lvgl_touch/Makefile
+++ b/tests/pkg/lvgl_touch/Makefile
@@ -17,9 +17,6 @@ USEMODULE += lvgl_extra_theme_default
 
 USEMODULE += random
 
-# blacklist native64 until https://github.com/RIOT-OS/riotdocker/pull/241 is resolved
-BOARD_BLACKLIST += native64
-
 include $(RIOTBASE)/Makefile.include
 
 # SDL requires more stack


### PR DESCRIPTION
### Contribution description

Now that we have the `libsdl2-dev:amd64` package in the CI image (RIOT-OS/riotdocker#241), we can remove `native64` from the blacklist and build the lvgl tests in the CI.

The CI doesn't run the GUI program, but if we run the executable directly, we can see that the lvgl heap size chosen for RIOT is too small for a 64-bit system, since lvgl allocates a lot of space for pointers and the current limits seem to be as small as possible to make the examples run on 32-bit platforms.
I changed the default lvgl heap sizes in `pkg/lvgl/include/lv_conf.h` for 64-bit systems so that the examples can run.

The correct heap size is very application and platform specific. Simply extending the header to include a variety of different default heap sizes to run the examples may not be the most elegant way to go about it. 
Another option include:
- set different heap sizes in the Makefile.
- set a larger default in board.h for some boards
- use `LV_MEM_CUSTOM`
- choose a larger default heap size (such as the recommended >48 kB), which would fix most run-time crashes, but would probably result in quite a few build failures due to insufficient memory.

If you have an opinion on how to handle the default heap size for lvgl, let me know.

### Testing procedure

Check that you have the  `libsdl2-dev:amd64` package installed and run the tests, e.g.:
- `BOARD=native64 make all term -C tests/pkg/lvgl`
- `BOARD=native64 make all term -C tests/pkg/lvgl_touch`
