### PR TITLE
sys/event: add assertion that event has a handler

### DIFF
--- a/examples/twr_aloha/control.c
+++ b/examples/twr_aloha/control.c
@@ -146,7 +146,7 @@ static bool _complete_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs)
     if (inst->fctrl != FCNTL_IEEE_RANGE_16 &&
         inst->fctrl != (FCNTL_IEEE_RANGE_16 | UWB_FCTRL_ACK_REQUESTED)) {
         /* on completion of a range request setup an event to keep listening */
-        event_post(uwb_core_get_eventq(), &_rng_listen_event.super);
+        event_callback_post(uwb_core_get_eventq(), &_rng_listen_event);
         return false;
     }
 
@@ -163,7 +163,7 @@ static bool _complete_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs)
     if (IS_ACTIVE(CONFIG_TWR_PRINTF_INITIATOR_ONLY) &&
         ((frame->code < UWB_DATA_CODE_DS_TWR && frame->src_address != _udev->uid) ||
          (frame->code >= UWB_DATA_CODE_DS_TWR && frame->dst_address != _udev->uid))) {
-        event_post(uwb_core_get_eventq(), &_rng_listen_event.super);
+        event_callback_post(uwb_core_get_eventq(), &_rng_listen_event);
         return true;
     }
 
@@ -183,9 +183,9 @@ static bool _complete_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs)
 #endif
     /* offload range data printing */
     memcpy(&_rng_data, &data, sizeof(uwb_core_rng_data_t));
-    event_post(uwb_core_get_eventq(), &_print_rng_data_event.super);
+    event_callback_post(uwb_core_get_eventq(), &_print_rng_data_event);
     /* on completion of a range request setup an event to keep listening */
-    event_post(uwb_core_get_eventq(), &_rng_listen_event.super);
+    event_callback_post(uwb_core_get_eventq(), &_rng_listen_event);
     return true;
 }
 
@@ -201,7 +201,7 @@ static bool _rx_timeout_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs)
 {
     (void)inst;
     (void)cbs;
-    event_post(uwb_core_get_eventq(), &_rng_listen_event.super);
+    event_callback_post(uwb_core_get_eventq(), &_rng_listen_event);
     return true;
 }
 
@@ -238,7 +238,7 @@ void uwb_core_rng_listen_enable(void)
 {
     _status |= TWR_STATUS_RESPONDER;
     /* post event to start listening */
-    event_post(uwb_core_get_eventq(), &_rng_listen_event.super);
+    event_callback_post(uwb_core_get_eventq(), &_rng_listen_event);
 }
 
 void uwb_core_rng_listen_disable(void)

--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -36,6 +36,7 @@
 void event_post(event_queue_t *queue, event_t *event)
 {
     assert(queue && event);
+    assert(event->handler);
 
     unsigned state = irq_disable();
     if (!event->list_node.next) {

--- a/sys/include/event/callback.h
+++ b/sys/include/event/callback.h
@@ -36,6 +36,7 @@
 #ifndef EVENT_CALLBACK_H
 #define EVENT_CALLBACK_H
 
+#include <assert.h>
 #include "event.h"
 
 #ifdef __cplusplus
@@ -59,6 +60,25 @@ typedef struct {
  * @param[in]   arg             callback argument to set up
  */
 void event_callback_init(event_callback_t *event_callback, void (*callback)(void *), void *arg);
+
+/**
+ * @brief   Queue an event
+ *
+ * The given event will be posted on the given @p queue. If the event is already
+ * queued when calling this function, the event will not be touched and remain
+ * in the previous position on the queue. So reposting an event while it is
+ * already on the queue will have no effect.
+ *
+ * @pre     queue should be initialized
+ *
+ * @param[in]   queue   event queue to queue event in
+ * @param[in]   event   event to queue in event queue
+ */
+static inline void event_callback_post(event_queue_t *queue, event_callback_t *event)
+{
+    assert(event->callback);
+    event_post(queue, &event->super);
+}
 
 /**
  * @brief   Generate a one-shot callback event on @p queue

--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -25,6 +25,7 @@
 #ifndef EVENT_PERIODIC_CALLBACK_H
 #define EVENT_PERIODIC_CALLBACK_H
 
+#include <assert.h>
 #include "event/callback.h"
 #include "event/periodic.h"
 
@@ -94,6 +95,7 @@ static inline void event_periodic_callback_init(event_periodic_callback_t *event
 static inline void event_periodic_callback_start(event_periodic_callback_t *event,
                                                  uint32_t interval)
 {
+    assert(event->event.callback);
     event_periodic_start(&event->periodic, interval);
 }
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1842,7 +1842,7 @@ ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
             event_callback_init(&_receive_from_cache,
                                 _receive_from_cache_cb,
                                 memo);
-            event_post(&_queue, &_receive_from_cache.super);
+            event_callback_post(&_queue, &_receive_from_cache);
             return len;
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When an uninitialized event is added, we will dereference a NULL pointer.
It can then be a bit tricky to find out which event caused this - so add an assertion when queuing the event that a callback is set.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
