### PR TITLE
boards/nucleo-g431rb: add MCU table to documentation

### DIFF
--- a/boards/nucleo-g431rb/doc.txt
+++ b/boards/nucleo-g431rb/doc.txt
@@ -12,6 +12,26 @@ Cortex-M4 STM32G431RB microcontroller with 32KiB of RAM and 128KiB of Flash.
 
 @image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G431RB (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
 
+### MCU
+
+| MCU          | STM32G431RB
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M4       |
+| Vendor       | ST Microelectronics |
+| RAM          | 32KiB               |
+| Flash        | 128KiB              |
+| Frequency    | up to 170 MHz       |
+| Timers       | 14 (2x watchdog, 1 SysTick, 10x 16-bit and 1 32-bit) |
+| ADCs         | 2x 12 bit (up to 23 channels) |
+| UARTs        | 5 (one UART, three USARTs and one Low-Power UART) |
+| I2Cs         | 3                   |
+| SPIs         | 3                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g431rb.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf)|
+
 ## Flashing the device
 
 ### Flashing the Board Using OpenOCD

--- a/boards/nucleo-g431rb/doc.txt
+++ b/boards/nucleo-g431rb/doc.txt
@@ -10,7 +10,7 @@ Cortex-M4 STM32G431RB microcontroller with 32KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the nucleo-g431rg (from STM board manual)" width=50%
+@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G431RB (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
 
 ## Flashing the device
 


### PR DESCRIPTION
### Contribution description

This PR adds MCU table for `nucleo-g431rb` board. Moreover, accordingly to comments from PR #20832 detailed source of pinout is added.

### Testing procedure

Generate doc and see if everything is fine.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-g431rb.html
```

### Issues/PRs references

pinout source issue PR #20832