### PR TITLE
sys/event: add `event_loop_debug` pseudo-module

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -384,6 +384,10 @@ ifneq (,$(filter event_periodic_callback,$(USEMODULE)))
   USEMODULE += event_periodic
 endif
 
+ifneq (,$(filter event_loop_debug,$(USEMODULE)))
+  USEMODULE += ztimer_usec
+endif
+
 ifneq (,$(filter emcute,$(USEMODULE)))
   USEMODULE += core_thread_flags
   USEMODULE += sock_udp

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -96,6 +96,7 @@
 #ifndef EVENT_H
 #define EVENT_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -106,10 +107,7 @@
 #include "thread.h"
 #include "thread_flags.h"
 #include "ptrtag.h"
-
-#if IS_USED(MODULE_ZTIMER)
 #include "ztimer.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -429,6 +427,9 @@ event_t *event_wait_timeout_ztimer(event_queue_t *queue,
  * @pre     The queue must have a waiter (i.e. it should have been claimed, or
  *          initialized using @ref event_queue_init, @ref event_queues_init)
  *
+ * @note    Enable the `event_loop_debug` module to print the execution times of
+ *          the event handler functions.
+ *
  * @param[in]   queues      Event queues to process
  * @param[in]   n_queues    Number of queues passed with @p queues
  */
@@ -437,7 +438,22 @@ static inline void event_loop_multi(event_queue_t *queues, size_t n_queues)
     event_t *event;
 
     while ((event = event_wait_multi(queues, n_queues))) {
-        event->handler(event);
+        if (IS_USED(MODULE_EVENT_LOOP_DEBUG)) {
+            uint32_t now;
+            ztimer_acquire(ZTIMER_USEC);
+            printf("event: executing %p->%p\n",
+                   (void *)event, (void *)(uintptr_t)event->handler);
+            now = ztimer_now(ZTIMER_USEC);
+
+            event->handler(event);
+
+            printf("event: %p took %" PRIu32 " µs\n",
+                   (void *)event, ztimer_now(ZTIMER_USEC) - now);
+            ztimer_release(ZTIMER_USEC);
+        }
+        else {
+            event->handler(event);
+        }
     }
 }
 
@@ -457,6 +473,9 @@ static inline void event_loop_multi(event_queue_t *queues, size_t n_queues)
  *
  * @pre     The queue must have a waiter (i.e. it should have been claimed, or
  *          initialized using @ref event_queue_init, @ref event_queues_init)
+ *
+ * @note    Enable the `event_loop_debug` module to print the execution times of
+ *          the event handler functions.
  *
  * @param[in]   queue   event queue to process
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a pseudo-module that prints execution times of event handlers.
This can be useful to find out which event handler is hogging the event thread. 


### Testing procedure

Enable the `event_loop_debug` module

```
2025-04-03 11:45:49,355 # main(): This is RIOT! (Version: 2024.10-devel-138-gf3a9392-event_loop_debug)
2025-04-03 11:45:49,361 # event: executing 0x8059dfc->0x804cc0a
2025-04-03 11:45:49,362 # event 0
2025-04-03 11:45:49,362 # event: 0x8059dfc took 6 µs
2025-04-03 11:45:49,864 # event: executing 0x8059e3c->0x804cc0a
2025-04-03 11:45:49,864 # event A
2025-04-03 11:45:49,865 # event: 0x8059e3c took 6 µs
2025-04-03 11:45:50,363 # event: executing 0x8059e7c->0x804cc0a
2025-04-03 11:45:50,364 # event B
2025-04-03 11:45:50,365 # event: 0x8059e7c took 5 µs
2025-04-03 11:45:50,366 # event: executing 0x8059e3c->0x804cc0a
2025-04-03 11:45:50,366 # event A
2025-04-03 11:45:50,367 # event: 0x8059e3c took 5 µs
2025-04-03 11:45:50,862 # event: executing 0x8059ebc->0x804cc0a
2025-04-03 11:45:50,862 # event C
2025-04-03 11:45:50,863 # event: 0x8059ebc took 6 µs
2025-04-03 11:45:50,868 # event: executing 0x8059e3c->0x804cc0a
2025-04-03 11:45:50,868 # event A
2025-04-03 11:45:50,869 # event: 0x8059e3c took 7 µs
2025-04-03 11:45:51,364 # event: executing 0x8059e7c->0x804cc0a
2025-04-03 11:45:51,365 # event B
2025-04-03 11:45:51,366 # event: 0x8059e7c took 6 µs
2025-04-03 11:45:51,369 # event: executing 0x8059e3c->0x804cc0a
2025-04-03 11:45:51,370 # event A
2025-04-03 11:45:51,371 # event: 0x8059e3c took 6 µs
2025-04-03 11:45:51,872 # event: executing 0x8059e3c->0x804cc0a
2025-04-03 11:45:51,872 # event A
2025-04-03 11:45:51,873 # event: 0x8059e3c took 5 µs
2025-04-03 11:45:52,362 # event: executing 0x8059ebc->0x804cc0a
2025-04-03 11:45:52,362 # event C
2025-04-03 11:45:52,363 # event: 0x8059ebc took 6 µs
2025-04-03 11:45:52,365 # event: executing 0x8059e7c->0x804cc0a
2025-04-03 11:45:52,365 # event B
2025-04-03 11:45:52,366 # event: 0x8059e7c took 6 µs
2025-04-03 11:45:52,374 # event: executing 0x8059e3c->0x804cc0a
2025-04-03 11:45:52,374 # event A
2025-04-03 11:45:52,375 # event: 0x8059e3c took 6 µs
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
