### PR TITLE
boards/nucleo-g474re: add MCU table

### DIFF
--- a/boards/nucleo-g474re/doc.txt
+++ b/boards/nucleo-g474re/doc.txt
@@ -10,7 +10,29 @@ Cortex-M4 STM32G474RE microcontroller with 128KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the nucleo-g4741re (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
+@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G4741RE (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
+
+### MCU
+
+| MCU          | STM32G474RE
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M4       |
+| Vendor       | ST Microelectronics |
+| RAM          | 128KiB              |
+| Flash        | 512KiB              |
+| Frequency    | up to 170 MHz       |
+| Timers       | 17 (2x watchdog, 1 SysTick, 12x 16-bit and 2x 32-bit) |
+| ADCs         | 5x 12 bit (up to 26 channels) |
+| UARTs        | 5 (one UART, three USARTs and one Low-Power UART) |
+| I2Cs         | 4                   |
+| SPIs         | 3                   |
+| CANs         | 3                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g474re.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf)|
+
 
 ## Flashing the device
 

--- a/boards/nucleo-g474re/doc.txt
+++ b/boards/nucleo-g474re/doc.txt
@@ -10,7 +10,7 @@ Cortex-M4 STM32G474RE microcontroller with 128KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the nucleo-g4741re (from STM board manual)" width=50%
+@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the nucleo-g4741re (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
 
 ## Flashing the device
 


### PR DESCRIPTION
### Contribution description

This PR adds MCU table for `nucleo-g474re` board. Moreover, accordingly to comments from PR #20832 detailed source of pinout is added.

### Testing procedure

Generate doc and see if everything is fine.
```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-g474re.html
```
### Issues/PRs references

PR #20832