### PR TITLE
sys/net/application_layer/nanocoap: add `nanocoap_sock_get_non()`

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -384,7 +384,7 @@ static inline void nanocoap_sock_close(nanocoap_sock_t *sock)
  * @param[in]   len     length of @p buffer
  *
  * @returns     length of response payload on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf,
                           size_t len);
@@ -398,7 +398,7 @@ ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf,
  * @param[in]   len_max length of @p response
  *
  * @returns     length of response payload on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_get_non(nanocoap_sock_t *sock, const char *path,
                               void *response, size_t len_max);
@@ -414,7 +414,7 @@ ssize_t nanocoap_sock_get_non(nanocoap_sock_t *sock, const char *path,
  * @param[in]   len_max length of @p response
  *
  * @returns     length of response payload on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_put(nanocoap_sock_t *sock, const char *path,
                           const void *request, size_t len,
@@ -433,7 +433,7 @@ ssize_t nanocoap_sock_put(nanocoap_sock_t *sock, const char *path,
  * @returns     length of response payload on success
  * @returns     0 if the request was sent and no response buffer was provided,
  *              independently of success (because no response is requested in that case)
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_put_non(nanocoap_sock_t *sock, const char *path,
                               const void *request, size_t len,
@@ -466,7 +466,7 @@ ssize_t nanocoap_sock_put_url(const char *url,
  * @param[in]   len_max length of @p response
  *
  * @returns     length of response payload on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
                            const void *request, size_t len,
@@ -485,7 +485,7 @@ ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
  * @returns     length of response payload on success
  * @returns     0 if the request was sent and no response buffer was provided,
  *              independently of success (because no response is requested in that case)
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_post_non(nanocoap_sock_t *sock, const char *path,
                                const void *request, size_t len,
@@ -519,7 +519,7 @@ ssize_t nanocoap_sock_post_url(const char *url,
  * @param[in]   len_max length of @p response
  *
  * @returns     length of response payload on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_fetch(nanocoap_sock_t *sock, const char *path,
                             const void *request, size_t len,
@@ -539,7 +539,7 @@ ssize_t nanocoap_sock_fetch(nanocoap_sock_t *sock, const char *path,
  * @returns     length of response payload on success
  * @returns     0 if the request was sent and no response buffer was provided,
  *              independently of success (because no response is requested in that case)
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_fetch_non(nanocoap_sock_t *sock, const char *path,
                                 const void *request, size_t len,
@@ -569,7 +569,7 @@ ssize_t nanocoap_sock_fetch_url(const char *url,
  * @param[in]   path    remote path (with query) to delete
  *
  * @returns     0 on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_sock_delete(nanocoap_sock_t *sock, const char *path);
 
@@ -716,7 +716,15 @@ ssize_t nanocoap_sock_request(nanocoap_sock_t *sock, coap_pkt_t *pkt, size_t len
  * @param[in]       arg     Optional callback argumnent
  *
  * @returns     length of response on success
- * @returns     <0 on error
+ * @returns     0 for a request for which no response is expected, indicated by @p cb == NULL,
+ *              or for a 2.xx response
+ * @returns     -ETIMEDOUT, if no matching ACK or no response was received
+ * @returns     -EBADMSG, if a matching RST was received
+ * @returns     -ENXIO, if @p cb == NULL and the response indicates a 4.xx client error
+ * @returns     -ENETRESET, if @p cb == NULL and the response indicates a 5.xx server error
+ * @returns     any error on @see sock_udp_sendv or @see sock_dtls_sendv
+ * @returns     any error on @see sock_udp_recv_buf or @see sock_dtls_recv_buf
+ * @returns     any return value of @p cb for a matching response
  */
 ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                                  coap_request_cb_t cb, void *arg);
@@ -732,7 +740,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
  *                          request
  *
  * @returns     length of response on success
- * @returns     <0 on error
+ * @returns     @see nanocoap_sock_request_cb on error
  */
 ssize_t nanocoap_request(coap_pkt_t *pkt, const sock_udp_ep_t *local,
                          const sock_udp_ep_t *remote, size_t len);

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -390,6 +390,20 @@ ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf,
                           size_t len);
 
 /**
+ * @brief   Simple non-confirmable GET
+ *
+ * @param[in]   sock    socket to use for the request
+ * @param[in]   path    remote path and query
+ * @param[out]  response buffer for the response, may be NULL
+ * @param[in]   len_max length of @p response
+ *
+ * @returns     length of response payload on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_get_non(nanocoap_sock_t *sock, const char *path,
+                              void *response, size_t len_max);
+
+/**
  * @brief   Simple synchronous CoAP (confirmable) PUT
  *
  * @param[in]   sock    socket to use for the request

--- a/tests/net/nanocoap_cli/main.c
+++ b/tests/net/nanocoap_cli/main.c
@@ -53,6 +53,7 @@ extern int nanotest_client_url_cmd(int argc, char **argv);
 extern int nanotest_server_cmd(int argc, char **argv);
 extern int nanotest_client_put_cmd(int argc, char **argv);
 extern int nanotest_client_put_non_cmd(int argc, char **argv);
+extern int nanotest_client_get_non_cmd(int argc, char **argv);
 static int _list_all_inet6(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
@@ -60,6 +61,7 @@ static const shell_command_t shell_commands[] = {
     { "url", "CoAP client URL request", nanotest_client_url_cmd },
     { "put", "experimental put", nanotest_client_put_cmd },
     { "put_non", "non-confirmable put", nanotest_client_put_non_cmd },
+    { "get_non", "non-confirmable get", nanotest_client_get_non_cmd },
     { "server", "CoAP server", nanotest_server_cmd },
     { "inet6", "IPv6 addresses", _list_all_inet6 },
     { NULL, NULL, NULL }

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -322,3 +322,29 @@ int nanotest_client_put_non_cmd(int argc, char **argv)
 
     return res;
 }
+
+int nanotest_client_get_non_cmd(int argc, char **argv)
+{
+    int res;
+
+    uint8_t response[CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT];
+
+    if (argc < 2) {
+        printf("usage: %s <url>\n", argv[0]);
+        return 1;
+    }
+
+    nanocoap_sock_t sock;
+    nanocoap_sock_url_connect(argv[1], &sock);
+
+    res = nanocoap_sock_get_non(&sock, sock_urlpath(argv[1]), response, sizeof(response));
+    nanocoap_sock_close(&sock);
+
+    if (res >= 0) {
+        od_hex_dump(response, res, OD_WIDTH_DEFAULT);
+    }
+    else {
+        printf("error: %d\n", res);
+    }
+    return res;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

We have NON-Confirmable versions for PUT, POST, and FETCH, but non for GET so far.
This PR adds it in a straight forward manner.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`tapsetup`
Two `native` instances of `tests/net/nanocoap_cli`.
One starts the server:
```
2024-09-05 15:48:28,576 # server start
2024-09-05 15:48:28,576 # starting server on port 5683
```

The other one GETs a resource:
```
> get_non coap://[fe80::a0ae:a2ff:fe2f:af16]/value
2024-09-05 15:48:32,316 # get_non coap://[fe80::a0ae:a2ff:fe2f:af16]/value
2024-09-05 15:48:32,318 # 00000000  30
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
