### PR TITLE
nanocoap: always write at least 1 byte in coap_block2_finish()

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1339,6 +1339,11 @@ bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
     uint32_t blkopt = _slicer2blkopt(slicer, more);
     size_t olen = _encode_uint(&blkopt);
 
+    /* ensure that we overwrite the dummy value set by coap_block2_init() */
+    if (!olen) {
+        olen = 1;
+    }
+
     coap_put_option(slicer->opt, option - delta, option, (uint8_t *)&blkopt, olen);
     return more;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The CoAP block option gets written twice:
First a 'dummy' value is written by `coap_opt_add_block2()`, later this gets overwritten by the real option value by `coap_block2_finish()`.

The problem arises when the size of the option changes. If the option ends up smaller than the dummy, we have garbage bytes after the real option value, corrupting the packet.

To mitigate this, always write at least one option byte (which will be a 0 byte) to ensure the dummy data is overwritten.



### Testing procedure

 - run `examples/gcoap_fileserver`:

       make -C examples/gcoap_fileserver PORT=tap1 all term

 - create a dummy file

       echo "Hello World!" > examples/gcoap_fileserver/native/me

 - Try to access the file via e.g. `ncget` with a 16 byte block size

        CFLAGS=-DCONFIG_NANOCOAP_BLOCKSIZE_DEFAULT=COAP_BLOCKSIZE_16 make -C tests/net/nanocoap_cli all term
        > ncget coap://[fe80::d07c:7cff:fe6d:9441]/vfs/me -


```
2024-09-07 16:07:09,198 # ncget coap://[fe80::d07c:7cff:fe6d:9441]/vfs/me -
2024-09-07 16:07:09,199 # Hello World!
```


### Issues/PRs references

fixes #20686
alternative to #20688
