### PR TITLE
boards/nucleo144: add pinout source

### DIFF
--- a/boards/nucleo-f207zg/doc.txt
+++ b/boards/nucleo-f207zg/doc.txt
@@ -15,7 +15,7 @@ STM32F207ZG microcontroller with 128KiB of SRAM and 1MiB of ROM Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the nucleo-f207zg (from STM board manual)" width=50%
+@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the Nucleo-F207ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f303ze/doc.txt
+++ b/boards/nucleo-f303ze/doc.txt
@@ -14,7 +14,7 @@ STM32F303ZE microcontroller with 64KiB of RAM and 512KiB of ROM.
 
 ## Pinout
 
-@image html pinouts/nucleo-f303ze.svg "Pinout for the nucleo-f303ze (from STM board manual)" width=55%
+@image html pinouts/nucleo-f303ze.svg "Pinout for the Nucleo-F303ZE (from STM user board manual, M1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 33)" width=55%
 
 ### MCU
 | MCU        | STM32F303ZE       |

--- a/boards/nucleo-f412zg/doc.txt
+++ b/boards/nucleo-f412zg/doc.txt
@@ -10,7 +10,7 @@ STM32F412ZG microcontroller with 256KiB of RAM and 1MiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f412zg-and-f413zh.svg "Pinout for the nucleo-f412zg (from STM board manual)" width=50%
+@image html pinouts/nucleo-f412zg-and-f413zh.svg "Pinout for the Nucleo-F412ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50%
 
 ## Flashing the Board Using ST-LINK Removable Media
 

--- a/boards/nucleo-f413zh/doc.txt
+++ b/boards/nucleo-f413zh/doc.txt
@@ -10,7 +10,7 @@ STM32F413ZH microcontroller with 256KiB of RAM and 1MiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f412zg-and-f413zh.svg "Pinout for the nucleo-f413zh (from STM board manual)" width=50%
+@image html pinouts/nucleo-f412zg-and-f413zh.svg "Pinout for the nucleo-f413zh (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50%
 
 ## Flashing the Board Using ST-LINK Removable Media
 

--- a/boards/nucleo-f429zi/doc.txt
+++ b/boards/nucleo-f429zi/doc.txt
@@ -14,7 +14,7 @@ STM32F429ZI microcontroller with 256KiB of RAM and 2MiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the nucleo-f429zi (from STM board manual)" width=50%
+@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the Nucleo-F429ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f439zi/doc.txt
+++ b/boards/nucleo-f439zi/doc.txt
@@ -10,7 +10,7 @@ STM32F439ZI microcontroller with, 256KiB of RAM and 2MiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the nucleo-f439zi (from STM board manual)" width=50%
+@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the Nucleo-F439ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f446ze/doc.txt
+++ b/boards/nucleo-f446ze/doc.txt
@@ -14,7 +14,7 @@ STM32F446ZE microcontroller with 128KiB of RAM and 512KiB of ROM Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f446ze-and-f722ze.svg "Pinout for the nucleo-f446ze (from STM board manual)" width=50%
+@image html pinouts/nucleo-f446ze-and-f722ze.svg "Pinout for the Nucleo-F446ZE (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f722ze/doc.txt
+++ b/boards/nucleo-f722ze/doc.txt
@@ -10,7 +10,7 @@ STM32F722ZE microcontroller with 256KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f446ze-and-f722ze.svg "Pinout for the nucleo-f722ze (from STM board manual)" width=50%
+@image html pinouts/nucleo-f446ze-and-f722ze.svg "Pinout for the Nucleo-F722ZE (from STM ser manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -10,7 +10,7 @@ STM32F767ZI microcontroller with 512KiB of RAM and 2 MiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the nucleo-f767zi (from STM board manual)" width=50%
+@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the Nucleo-F767ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-l496zg/doc.txt
+++ b/boards/nucleo-l496zg/doc.txt
@@ -10,7 +10,7 @@ STM32L496ZG ultra-low-pawer microcontroller with 320KiB of RAM and 1 MiB of Flas
 
 ## Pinout
 
-@image html pinouts/nucleo-l496zg.svg "Pinout for the nucleo-l496zg (from STM board manual)" width=55%
+@image html pinouts/nucleo-l496zg.svg "Pinout for the Nucleo-L496ZG (from STM user manual, UM2179, https://www.st.com/resource/en/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf, page 31)" width=55%
 
 ### MCU
 

--- a/boards/nucleo-l4r5zi/doc.txt
+++ b/boards/nucleo-l4r5zi/doc.txt
@@ -14,7 +14,7 @@ STM32L4R5ZI microcontroller with 640KiB of RAM and 2MiB of ROM Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-l4r5zi.svg "Pinout for the nucleo-l4r5zi (from STM board manual)" width=55%
+@image html pinouts/nucleo-l4r5zi.svg "Pinout for the Nucleo-L4R5ZI (from STM user manual, UM2179, http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf, page 35)" width=55%
 
 ### MCU
 
@@ -36,7 +36,7 @@ STM32L4R5ZI microcontroller with 640KiB of RAM and 2MiB of ROM Flash.
 | Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l4r5zi.pdf)|
 | Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0432-stm32l4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
 | Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
-| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics-1.pdf)|
+| Board Manual | [Board Manual](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf)|
 
 ## Flashing the device
 


### PR DESCRIPTION
### Contribution description

This PR adds detailed pinout source (UM number, link and page) to all pinouts for nucleo-144 boards. 
The issue was mentioned in the comments for PR #20832.

### Testing procedure

Generate doc and see if everything is fine.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f207zg.html
 . . .
```

### Issues/PRs references

PR #20832