### PR TITLE
Update docker image (and document the process)

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -148,7 +148,7 @@ In addition to the Rust compiler you'll need to install the C2Rust transpiler;
 as this is using some recent fixes, it is best installed as:
 
 ```shell
-$ cargo install c2rust --git https://github.com/immunant/c2rust
+$ cargo install c2rust --git https://github.com/immunant/c2rust --tag v0.19.0
 ```
 
 [cargo]: https://doc.rust-lang.org/cargo/

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,8 +5,8 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_ID := bbd6bc053ac3eafb173a475e0439376db91b9a88f4b504e1bfa4e0d432204e63
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 52ee7ae8ec4f9b8852aac15cf349d748484cd4d0732b6e030eddf4fff854e799
+DOCKER_TESTED_IMAGE_ID := 488d97b1b8285ca6a9518f177126fc5ab077135648ef40c1ac7867d16ac2d640
+DOCKER_TESTED_IMAGE_REPO_DIGEST := beb980f9ef00e7143fba913f3cb927866f987fe570141e145539c42141a940bd
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 DOCKER_IMAGE_DEFAULT := sha256:$(DOCKER_TESTED_IMAGE_ID)

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -1,6 +1,10 @@
 # This *MUST* be updated in lock-step with the riotbuild image in
 # https://github.com/RIOT-OS/riotdocker. The idea is that when checking out
 # a random RIOT merge commit, `make BUILD_IN_DOCKER=1` should always succeed.
+#
+# When the docker image is updated, checks at
+# dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
+# provide the latest values to verify and fill in.
 DOCKER_TESTED_IMAGE_ID := bbd6bc053ac3eafb173a475e0439376db91b9a88f4b504e1bfa4e0d432204e63
 DOCKER_TESTED_IMAGE_REPO_DIGEST := 52ee7ae8ec4f9b8852aac15cf349d748484cd4d0732b6e030eddf4fff854e799
 


### PR DESCRIPTION
### Contribution description

The docker image now uses c2rust 0.19 and Rust 1.81.

Initially, this only contains the documentation update. That first commit will serve to ask CI to give me the right hashes that'll go in a follow-up commit.

### Testing procedure

CI should suffice.

### Issues/PRs references

https://github.com/RIOT-OS/riotdocker/pull/252