### PR TITLE
event_periodic_callback: add event_periodic_callback_oneshot()

### DIFF
--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -175,6 +175,29 @@ static inline void event_periodic_callback_stop(event_periodic_callback_t *event
     event_periodic_stop(&event->periodic);
 }
 
+/**
+ * @brief   Initialize and start a periodic callback event that will be executed once
+ *
+ * This is a convenience function that combines @ref event_periodic_callback_init
+ * and @ref event_periodic_callback_start
+ *
+ * @param[out]  event           event_periodic_callback object to initialize
+ * @param[in]   queue           queue that the timed-out event will be added to
+ * @param[in]   clock           the clock to configure this timer on
+ * @param[in]   timeout         time after which the event should be executed
+ * @param[in]   callback        callback to set up
+ * @param[in]   arg             callback argument to set up
+ */
+static inline void event_periodic_callback_oneshot(event_periodic_callback_t *event,
+                                                   event_queue_t *queue,
+                                                   ztimer_clock_t *clock, uint32_t timeout,
+                                                   void (*callback)(void *), void *arg)
+{
+    event_periodic_callback_init(event, clock, queue, callback, arg);
+    event->periodic.count = 1;
+    event_periodic_callback_start(event, timeout);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/sys/event_periodic_callback/main.c
+++ b/tests/sys/event_periodic_callback/main.c
@@ -32,8 +32,15 @@ int main(void)
 {
     event_periodic_callback_t a, b, c;
 
+    /* event is executed immediately */
     event_callback_t oneshot;
     event_callback_oneshot(&oneshot, EVENT_PRIO_MEDIUM, _event_cb, "event 0");
+
+    /* event is executed after 750 ms */
+    event_periodic_callback_t oneshot_deferred;
+    event_periodic_callback_oneshot(&oneshot_deferred, EVENT_PRIO_MEDIUM,
+                                    ZTIMER_MSEC, 750,
+                                    _event_cb, "event 1");
 
     event_periodic_callback_init(&a, ZTIMER_MSEC, EVENT_PRIO_MEDIUM, _event_cb, "event A");
     event_periodic_callback_init(&b, ZTIMER_MSEC, EVENT_PRIO_MEDIUM, _event_cb, "event B");

--- a/tests/sys/event_periodic_callback/tests/01-run.py
+++ b/tests/sys/event_periodic_callback/tests/01-run.py
@@ -7,6 +7,7 @@ from testrunner import run
 def testfunc(child):
     child.expect_exact("event 0")
     child.expect_exact("event A")
+    child.expect_exact("event 1")
     child.expect_exact("event B")
     child.expect_exact("event A")
     child.expect_exact("event C")


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Often there is a need to execute an event once after a delay.
This adds a convenience helper function for it.

### Testing procedure

A test for the new function has been added to `tests/sys/event_periodic_callback`
 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
