### PR TITLE
makefiles/suit: make use of `SUIT_SEC_PASSWORD` optional 

### DIFF
--- a/makefiles/suit.inc.mk
+++ b/makefiles/suit.inc.mk
@@ -32,10 +32,6 @@ SUIT_MANIFEST_SIGNED_LATEST ?= $(BINDIR_SUIT)/$(SUIT_MANIFEST_BASENAME).latest.b
 SUIT_NOTIFY_VERSION ?= latest
 SUIT_NOTIFY_MANIFEST ?= $(SUIT_MANIFEST_BASENAME).$(SUIT_NOTIFY_VERSION).bin
 
-ifneq (,$(SUIT_SEC_PASSWORD))
-  SUIT_TOOL_ARGS += -p $(SUIT_SEC_PASSWORD)
-endif
-
 # Long manifest names require more buffer space when parsing
 export CFLAGS += -DCONFIG_SOCK_URLPATH_MAXLEN=128
 export CFLAGS += -DSUIT_VENDOR_DOMAIN="\"$(SUIT_VENDOR)\""
@@ -58,7 +54,15 @@ $(SUIT_MANIFEST): $(SUIT_MANIFEST_PAYLOADS) $(BINDIR_SUIT)
 	$(Q)rm -f $@.tmp
 
 $(SUIT_MANIFEST_SIGNED): $(SUIT_MANIFEST) $(SUIT_SEC)
-	$(Q)$(SUIT_TOOL) sign $(SUIT_TOOL_ARGS) -k $(SUIT_SEC_SIGN) -m $(SUIT_MANIFEST) -o $@
+	$(Q)(											\
+	if grep -q ENCRYPTED $(SUIT_SEC_SIGN); then						\
+		printf "Enter encryption for key file $(SUIT_SEC_SIGN): ";			\
+		read PASSWORD;									\
+		$(SUIT_TOOL) sign -p $$PASSWORD -k $(SUIT_SEC_SIGN) -m $(SUIT_MANIFEST) -o $@;	\
+	else											\
+		$(SUIT_TOOL) sign -k $(SUIT_SEC_SIGN) -m $(SUIT_MANIFEST) -o $@;		\
+	fi											\
+	)
 
 $(SUIT_MANIFEST_LATEST): $(SUIT_MANIFEST)
 	$(Q)ln -f -s $< $@

--- a/makefiles/suit.inc.mk
+++ b/makefiles/suit.inc.mk
@@ -56,9 +56,13 @@ $(SUIT_MANIFEST): $(SUIT_MANIFEST_PAYLOADS) $(BINDIR_SUIT)
 $(SUIT_MANIFEST_SIGNED): $(SUIT_MANIFEST) $(SUIT_SEC)
 	$(Q)(											\
 	if grep -q ENCRYPTED $(SUIT_SEC_SIGN); then						\
-		printf "Enter encryption for key file $(SUIT_SEC_SIGN): ";			\
-		read PASSWORD;									\
-		$(SUIT_TOOL) sign -p $$PASSWORD -k $(SUIT_SEC_SIGN) -m $(SUIT_MANIFEST) -o $@;	\
+		if [ -z "$(SUIT_SEC_PASSWORD)" ]; then						\
+			printf "Enter encryption for key file $(SUIT_SEC_SIGN): ";		\
+			read PASSWORD;								\
+		else										\
+			PASSWORD="$(SUIT_SEC_PASSWORD)";					\
+		fi;										\
+		$(SUIT_TOOL) sign -p "$$PASSWORD" -k $(SUIT_SEC_SIGN) -m $(SUIT_MANIFEST) -o $@;\
 	else											\
 		$(SUIT_TOOL) sign -k $(SUIT_SEC_SIGN) -m $(SUIT_MANIFEST) -o $@;		\
 	fi											\


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Specifying the password of the SUIT private key on the command line and thereby committing it to shell history is a security issue.

Instead ask for the password interactively when an encrypted private key is used.


### Testing procedure

#### if you don't have an encrypted SUIT key, create one first

```
$ make -C examples/suit_update SUIT_KEY=supersecret 
make: Entering directory '/home/benpicco/dev/RIOT/examples/suit_update'
Building application "suit_update" for "samr21-xpro" with CPU "samd21".

suit: generating key in /home/benpicco/.local/share/RIOT/keys
0) none
1) aes-256-cbc
Choose encryption for key file /home/benpicco/.local/share/RIOT/keys/supersecret.pem: 1
Enter PEM pass phrase:
Verifying - Enter PEM pass phrase:
```

#### sign a manifest with the new key

```
$ make -C examples/suit_update SUIT_KEY=supersecret suit/publish
make: Entering directory '/home/benpicco/dev/RIOT/examples/suit_update'
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
…
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/samr21-xpro/riotboot_files/slot0.1726218363.bin...
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/samr21-xpro/riotboot_files/slot1.1726218363.bin...

Enter encryption for key file /home/benpicco/.local/share/RIOT/keys/supersecret.pem: testtest

published "/home/benpicco/dev/RIOT/examples/suit_update/bin/samr21-xpro/suit_files/riot.suit.1726218363.bin"
       as "coap://localhost/fw/suit_update/samr21-xpro/riot.suit.1726218363.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/samr21-xpro/suit_files/riot.suit.latest.bin"
       as "coap://localhost/fw/suit_update/samr21-xpro/riot.suit.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/samr21-xpro/riotboot_files/slot0.1726218363.bin"
       as "coap://localhost/fw/suit_update/samr21-xpro/slot0.1726218363.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/samr21-xpro/riotboot_files/slot1.1726218363.bin"
       as "coap://localhost/fw/suit_update/samr21-xpro/slot1.1726218363
```

### Issues/PRs references

