### PR TITLE
sys/net/sock_udp: Add missing `const` qualifier

### DIFF
--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -58,14 +58,14 @@ void sock_udp_close(sock_udp_t *sock)
     }
 }
 
-int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep)
+int sock_udp_get_local(const sock_udp_t *sock, sock_udp_ep_t *ep)
 {
     assert(sock != NULL);
     return (lwip_sock_get_addr(sock->base.conn, (struct _sock_tl_ep *)ep,
                                1)) ? -EADDRNOTAVAIL : 0;
 }
 
-int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep)
+int sock_udp_get_remote(const sock_udp_t *sock, sock_udp_ep_t *ep)
 {
     assert(sock != NULL);
     return (lwip_sock_get_addr(sock->base.conn, (struct _sock_tl_ep *)ep,

--- a/pkg/openwsn/sock/openwsn_sock_udp.c
+++ b/pkg/openwsn/sock/openwsn_sock_udp.c
@@ -352,7 +352,7 @@ void sock_udp_close(sock_udp_t *sock)
     }
 }
 
-int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep)
+int sock_udp_get_local(const sock_udp_t *sock, sock_udp_ep_t *ep)
 {
     if (sock->gen_sock.local.family == AF_UNSPEC) {
         return -EADDRNOTAVAIL;
@@ -363,7 +363,7 @@ int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep)
     return 0;
 }
 
-int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep)
+int sock_udp_get_remote(const sock_udp_t *sock, sock_udp_ep_t *ep)
 {
     if (sock->gen_sock.remote.family == AF_UNSPEC) {
         return -ENOTCONN;

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -445,7 +445,7 @@ void sock_udp_close(sock_udp_t *sock);
  * @return  0 on success.
  * @return  -EADDRNOTAVAIL, when @p sock has no local end point.
  */
-int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep);
+int sock_udp_get_local(const sock_udp_t *sock, sock_udp_ep_t *ep);
 
 /**
  * @brief   Gets the remote end point of a UDP sock object
@@ -457,7 +457,7 @@ int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep);
  * @return  0 on success.
  * @return  -ENOTCONN, when @p sock has no remote end point bound to it.
  */
-int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
+int sock_udp_get_remote(const sock_udp_t *sock, sock_udp_ep_t *ep);
 
 /**
  * @brief   Receives a UDP message from a remote end point

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -163,7 +163,7 @@ void sock_udp_close(sock_udp_t *sock)
 #endif
 }
 
-int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *local)
+int sock_udp_get_local(const sock_udp_t *sock, sock_udp_ep_t *local)
 {
     assert(sock && local);
     if (sock->local.family == AF_UNSPEC) {
@@ -173,7 +173,7 @@ int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *local)
     return 0;
 }
 
-int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *remote)
+int sock_udp_get_remote(const sock_udp_t *sock, sock_udp_ep_t *remote)
 {
     assert(sock && remote);
     if (sock->remote.family == AF_UNSPEC) {


### PR DESCRIPTION
### Contribution description

The APIs `sock_udp_get_local()` and `sock_udp_get_remote()` are expected to be simple getters that do not modify the socket in any way. Hence, the should use `cost sock_udp_t *` rather than `sock_udp_t *` as first argument.

This fixes the issue.

Note: Since C callers will not be affected by this change, I will not add the API change label.

### Testing procedure

The CI should be green.

### Issues/PRs references

None