### PR TITLE
Mv event thread flag

### DIFF
--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -104,6 +104,13 @@ extern "C" {
 #define THREAD_FLAG_TIMEOUT         (1u << 14)
 
 /**
+ * @brief Thread flag use to notify available events in an event queue
+ *
+ * This flag is used by the `event` module.
+ */
+#define THREAD_FLAG_EVENT           (1u << 13)
+
+/**
  * @brief Comprehensive set of all predefined flags
  *
  * This bit mask is set for all thread flag bits that are predefined in RIOT.
@@ -114,7 +121,12 @@ extern "C" {
  * When using custom flags, asserting that they are not in this set can help
  * avoid conflict with future additions to the predefined flags.
  */
-#define THREAD_FLAG_PREDEFINED_MASK (THREAD_FLAG_MSG_WAITING | THREAD_FLAG_TIMEOUT)
+#define THREAD_FLAG_PREDEFINED_MASK (\
+    THREAD_FLAG_EVENT |\
+    THREAD_FLAG_MSG_WAITING |\
+    THREAD_FLAG_TIMEOUT\
+    )
+
 /** @} */
 
 /**

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -95,6 +95,7 @@ extern "C" {
  *      }
  */
 #define THREAD_FLAG_MSG_WAITING     (1u << 15)
+
 /**
  * @brief Set by @ref xtimer_set_timeout_flag() when the timer expires
  *

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -115,13 +115,6 @@
 extern "C" {
 #endif
 
-#ifndef THREAD_FLAG_EVENT
-/**
- * @brief   Thread flag use to notify available events in an event queue
- */
-#define THREAD_FLAG_EVENT   (0x1)
-#endif
-
 /**
  * @brief   event_queue_t static initializer
  */


### PR DESCRIPTION
### Contribution description

Move event flag to common area and mark its value as in-use by the OS.


### Testing procedure

`make -C tests/unittests/ test` runs without error


### Issues/PRs references

See issue #20867
