### PR TITLE
event/timeout: event_timeout_set() enqueues immediately if timeout is zero

### DIFF
--- a/sys/event/timeout_ztimer.c
+++ b/sys/event/timeout_ztimer.c
@@ -38,7 +38,11 @@ void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *c
 
 void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout)
 {
-    ztimer_set(event_timeout->clock, &event_timeout->timer, timeout);
+    if (timeout == 0) {
+        event_post(event_timeout->queue, event_timeout->event);
+    } else {
+        ztimer_set(event_timeout->clock, &event_timeout->timer, timeout);
+    }
 }
 
 void event_timeout_clear(event_timeout_t *event_timeout)


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, the following can result in `event_B` being executed before `event_A`:
```c
event_timeout_set(event_A, 0);
event_post(event_queue, event_B);
```

I think this is unexpected behavior. Queuing an event with timeout zero should schedule the event for immediate execution. I therefore added a check in `event_timeout_set()` to immediately queue if the timeout is zero.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I briefly tested this on native in the application I'm currently working on.

