### PR TITLE
dist/tools/bootterm: bump to 0.5

### DIFF
--- a/dist/tools/bootterm/Makefile
+++ b/dist/tools/bootterm/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=bootterm
 PKG_URL=https://github.com/wtarreau/bootterm
-PKG_VERSION=2d50ab50c3259dbc82d75775c37bbf436d06fb89
+# version 0.5
+PKG_VERSION=02d6a1a0539f696010770a46d1fd52df53400e69
 PKG_LICENSE=MIT
 
 # manually set some RIOT env vars, so this Makefile can be called stand-alone


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Update the tool to the latest upstream version


### Testing procedure

`make RIOT_TERMINAL=bootterm term` is still working

```
Trying port /dev/ttyACM0... Connected to /dev/ttyACM0 at 115200 bps.
Escape character is 'Ctrl-]'. Use escape followed by '?' for help.
> ps
	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
	  - | isr_stack            | -        - |   - |    512 (  172) (  340) | 0x20000000 | 0x200001c8
	  1 | main                 | running  Q |   7 |   1536 (  708) (  828) | 0x200002c0 | 0x200007ac 
	  2 | pktdump              | bl rx    _ |   6 |   1472 (  172) ( 1300) | 0x20001048 | 0x2000155c 
	  3 | sam0_eth             | bl anyfl _ |   2 |    896 (  276) (  620) | 0x20000a5c | 0x20000d1c 
	    | SUM                  |            |     |   4416 ( 1328) ( 3088)
> 
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
