### PR TITLE
core: add stdio.h to replace stdout functions with stdio_null

### DIFF
--- a/core/include/stdio.h
+++ b/core/include/stdio.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_stdio_null
+ *
+ * This module a wrapper for the stdio.h header intended to remove all calls
+ * to stdout when stdio_null is used.
+ *
+ * This needs to reside in `core/` so it gets included early.
+ *
+ * @{
+ *
+ * @file
+ * @brief       stdio wrapper to replace the C libs stdio
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef CORE_STDIO_H
+#define CORE_STDIO_H
+#include_next "stdio.h"
+
+#ifdef MODULE_STDIO_NULL
+
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+static inline int printf_null(const char *__restrict__ format, ...)
+{
+    (void)format;
+    return 0;
+}
+
+static inline int vprintf_null(const char *__restrict__ format, va_list ap)
+{
+    (void)format;
+    (void)ap;
+    return 0;
+}
+
+#undef perror
+#undef putchar
+#undef puts
+#undef printf
+#undef vprintf
+
+#define perror(s)   (void)s
+#define puts(s)     (void)s
+#define putchar(c)  (void)c
+#define printf(...) printf_null(__VA_ARGS__)
+#define vprintf(format, ap) vprintf_null(format, ap)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* MODULE_STDIO_NULL */
+
+#endif  /* CORE_STDIO_H */
+/** @} */

--- a/cpu/avr8_common/avr_libc_extra/posix_unistd.c
+++ b/cpu/avr8_common/avr_libc_extra/posix_unistd.c
@@ -177,9 +177,11 @@ ssize_t write(int fd, const void *src, size_t count)
 #endif
 }
 
+#ifndef MODULE_STDIO_NULL
 void perror(const char *s)
 {
     printf("%s: %s\n", s, strerror(errno));
 }
+#endif
 
 /** @} */

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -226,16 +226,11 @@ ssize_t _native_writev(int fd, const struct iovec *iov, int iovcnt)
 #if defined(__FreeBSD__)
 #undef putchar
 #endif
+#ifndef MODULE_STDIO_NULL
 int putchar(int c)
 {
     char tmp = c;
     return _native_write(STDOUT_FILENO, &tmp, sizeof(tmp));
-}
-
-int putc(int c, FILE *fp)
-{
-    char tmp = c;
-    return _native_write(fileno(fp), &tmp, sizeof(tmp));
 }
 
 int puts(const char *s)
@@ -244,6 +239,13 @@ int puts(const char *s)
     r = _native_write(STDOUT_FILENO, (char*)s, strlen(s));
     putchar('\n');
     return r;
+}
+#endif
+
+int putc(int c, FILE *fp)
+{
+    char tmp = c;
+    return _native_write(fileno(fp), &tmp, sizeof(tmp));
 }
 
 int fgetc(FILE *fp)
@@ -308,6 +310,7 @@ char *make_message(const char *format, va_list argp)
     }
 }
 
+#ifndef MODULE_STDIO_NULL
 int printf(const char *format, ...)
 {
     int r;
@@ -324,6 +327,7 @@ int vprintf(const char *format, va_list argp)
 {
     return vfprintf(stdout, format, argp);
 }
+#endif
 
 int fprintf(FILE *fp, const char *format, ...)
 {

--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -43,6 +43,7 @@ def fix_headerguard(filename):
     tmp.seek(0)
 
     guard_found = 0
+    include_next_found = 0
     guard_name = ""
     ifstack = 0
     for line in inlines:
@@ -66,14 +67,17 @@ def fix_headerguard(filename):
                 else:
                     guard_found += 1
                     line = "#endif /* %s */\n" % supposed
+            elif line.startswith("#include_next"):
+                include_next_found = 1
 
         tmp.write(line)
 
     tmp.seek(0)
     if guard_found == 3:
-        for line in difflib.unified_diff(inlines, tmp.readlines(),
-                                         "%s" % filename, "%s" % filename):
-            sys.stdout.write(line)
+        if include_next_found == 0:
+            for line in difflib.unified_diff(inlines, tmp.readlines(),
+                                             "%s" % filename, "%s" % filename):
+                sys.stdout.write(line)
     else:
         print("%s: no / broken header guard" % filename, file=sys.stderr)
         return False

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -13,6 +13,7 @@ JERRY_GC_LIMIT ?= 0  # Use default value, e.g. 1/32 of total heap size
 JERRY_GC_MARK_LIMIT ?= 8  # maximum recursion depth during GC mark phase
 
 EXT_CFLAGS := -D__TARGET_RIOT
+EXT_CFLAGS += -Wno-pedantic
 CFLAGS += -Wno-cast-align
 
 # disable warnings when compiling with LLVM for board native


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

So far `stdio_null` would just drop the stdio backend, all the expensive stdio formatting functions were still included.

This PR replaces all calls to `printf()` and friends with a no-op.


### Testing procedure

Build e.g. `tests/minimal` which uses `stdio_null`:

#### master

```
   text	   data	    bss	    dec	    hex	filename
   9256	    108	   1312	  10676	   29b4	/home/benpicco/dev/RIOT-2/tests/minimal/bin/same54-xpro/tests_minimal.elf
```

#### this PR

```
   text	   data	    bss	    dec	    hex	filename
   5140	    108	   1312	   6560	   19a0	/home/benpicco/dev/RIOT/tests/minimal/bin/same54-xpro/tests_minimal.elf
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
