### PR TITLE
makefiles/arch/native: don't be pedantic

### DIFF
--- a/makefiles/arch/native.inc.mk
+++ b/makefiles/arch/native.inc.mk
@@ -16,7 +16,7 @@ export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
 # basic cflags:
-CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG) $(CFLAGS_OPT)
+CFLAGS += -Wall -Wextra $(CFLAGS_DBG) $(CFLAGS_OPT)
 CFLAGS += -U_FORTIFY_SOURCE
 CFLAGS_DBG ?= -g3
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We don't enable this on any other architecture.
`-pedantic` doesn't give us any more beneficial warnings, only warns about language extensions that are implemented by both GCC and Clang anyway.

Since those are the only compilers we are targeting, we can just make use of them to make our lives easier.


### Testing procedure

Code should still compile as before.
We can likely drop all those

```C
typedef int dont_be_pedantic;
```

as a follow-up.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
