### PR TITLE
doc: Clarify that our CPU ID is not ARM's CPUID

### DIFF
--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -13,6 +13,10 @@
  *
  * Provides access the CPU's serial number
  *
+ * @note This is *distinct* from what is called CPUID in ARM CPUs (which only
+ * covers variation down to silicon revisions, not down to individual instances
+ * of a CPU).
+ *
  * # (Low-) Power Implications
  *
  * The implementation **should** make sure, that calling cpuid_get() does not


### PR DESCRIPTION
### Contribution description

Pulling in prior art around https://github.com/future-proof-iot/RIOT-rs/pull/444, I hurt myself in confusion.

### Testing procedure

Look the built docs, they now have a note to prevent that confusion.