### PR TITLE
Fido2 update tests

### DIFF
--- a/pkg/fido2_tests/Makefile
+++ b/pkg/fido2_tests/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=fido2_tests
-PKG_URL=https://github.com/solokeys/fido2-tests
-PKG_VERSION=3f7893d8d1a39b009cddad7913d3808ca664d3b7
+PKG_URL=https://github.com/trussed-dev/fido2-tests
+PKG_VERSION=591d3d2279949e08de0766897f24bcfd39af1339
 PKG_LICENSE=Apache-2.0 OR MIT
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/fido2_tests/patches/0001-Adaptions-for-RIOT-FIDO2-CTAP.patch
+++ b/pkg/fido2_tests/patches/0001-Adaptions-for-RIOT-FIDO2-CTAP.patch
@@ -1,17 +1,16 @@
-From 445c1fe93f6d0edbd1c59f318703b070c8ee445f Mon Sep 17 00:00:00 2001
+From 21f07dc85160512086c5836214f396f2e334d7df Mon Sep 17 00:00:00 2001
 From: Ollrogge <nils-ollrogge@outlook.de>
-Date: Tue, 7 Sep 2021 19:12:31 +0200
-Subject: [PATCH] Adaptions for RIOT FIDO2 CTAP
+Date: Fri, 27 Sep 2024 18:16:53 +0200
+Subject: [PATCH] [PATCH] Adaptions for RIOT FIDO2 CTAP
 
 ---
  Makefile                                      | 15 ++++++------
  tests/conftest.py                             |  2 +-
  tests/standard/fido2/pin/test_pin.py          | 24 ++++++++++++++++---
  tests/standard/fido2/test_reset.py            |  5 ++++
- tests/standard/fido2/test_resident_key.py     |  4 ++--
  .../fido2/user_presence/test_user_presence.py | 10 +++++++-
  tests/standard/transport/test_hid.py          | 11 +++++++++
- 7 files changed, 57 insertions(+), 14 deletions(-)
+ 6 files changed, 55 insertions(+), 12 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 85aa451..c101826 100644
@@ -137,28 +136,6 @@ index 508d755..adb2818 100644
      assert e.value.code == CtapError.ERR.NOT_ALLOWED
 +'''
 \ No newline at end of file
-diff --git a/tests/standard/fido2/test_resident_key.py b/tests/standard/fido2/test_resident_key.py
-index 2c5bece..32fe534 100644
---- a/tests/standard/fido2/test_resident_key.py
-+++ b/tests/standard/fido2/test_resident_key.py
-@@ -45,7 +45,7 @@ class TestResidentKeyPersistance(object):
-     @pytest.mark.parametrize("do_reboot", [False, True])
-     def test_user_info_returned_when_using_allowlist(self, device, MC_RK_Res, GA_RK_Res, do_reboot):
-         assert "id" in GA_RK_Res.user.keys()
--        
-+
-         allow_list = [
-             {
-                 "id": MC_RK_Res.auth_data.credential_data.credential_id[:],
-@@ -66,7 +66,7 @@ class TestResidentKeyPersistance(object):
- class TestResidentKeyAfterReset(object):
-     def test_with_allow_list_after_reset(self, device, MC_RK_Res, GA_RK_Res):
-         assert "id" in GA_RK_Res.user.keys()
--        
-+
-         allow_list = [
-             {
-                 "id": MC_RK_Res.auth_data.credential_data.credential_id[:],
 diff --git a/tests/standard/fido2/user_presence/test_user_presence.py b/tests/standard/fido2/user_presence/test_user_presence.py
 index c9904b2..0b74d24 100644
 --- a/tests/standard/fido2/user_presence/test_user_presence.py
@@ -222,5 +199,5 @@ index c79c933..6203a00 100644
      def test_timeout(self, device):
          device.send_data(CTAPHID.INIT, "\x11\x22\x33\x44\x55\x66\x77\x88")
 -- 
-2.33.0
+2.46.1
 

--- a/sys/fido2/ctap/ctap.c
+++ b/sys/fido2/ctap/ctap.c
@@ -705,6 +705,11 @@ static int _get_assertion(ctap_req_t *req_raw)
         goto done;
     }
 
+    /* CTAP specification (version 20190130) section 5.2, step 9 */
+    if (req.allow_list_len > 0 && _assert_state.count > 1) {
+        _assert_state.count = 1;
+    }
+
     memcpy(_assert_state.client_data_hash, req.client_data_hash,
            SHA256_DIGEST_LENGTH);
 
@@ -749,8 +754,13 @@ static int _get_assertion(ctap_req_t *req_raw)
         }
     }
 
-    /* save current time for get_next_assertion timeout */
-    _assert_state.timer = ztimer_now(ZTIMER_MSEC);
+    /**
+       if more than 1 eligible credential found and no allow list, save current time for
+       get_next_assertion timeout
+     */
+    if (_assert_state.count > 1 && req.allow_list_len == 0) {
+        _assert_state.timer = ztimer_now(ZTIMER_MSEC);
+    }
 
     ret = CTAP2_OK;
 

--- a/sys/fido2/ctap/ctap_utils.c
+++ b/sys/fido2/ctap/ctap_utils.c
@@ -15,8 +15,6 @@
  * @}
  */
 
-#include <string.h>
-
 #include "ztimer.h"
 
 #include "fido2/ctap.h"
@@ -61,9 +59,7 @@ ctap_status_code_t fido2_ctap_utils_user_presence_test(void)
 
     gpio_irq_enable(_pin);
 
-    if (!IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)) {
-        fido2_ctap_utils_led_animation();
-    }
+    fido2_ctap_utils_wait_for_user_presence();
 
     ret = _user_present ? CTAP2_OK : CTAP2_ERR_ACTION_TIMEOUT;
 
@@ -79,39 +75,43 @@ static void _gpio_cb(void *arg)
     _user_present = true;
 }
 
-void fido2_ctap_utils_led_animation(void)
+void fido2_ctap_utils_wait_for_user_presence(void)
 {
     uint32_t start = ztimer_now(ZTIMER_MSEC);
     uint32_t diff = 0;
     uint32_t delay = 500;
 
     while (!_user_present && diff < CTAP_UP_TIMEOUT) {
-#ifdef LED0_TOGGLE
-        LED0_TOGGLE;
-#endif
-#ifdef LED1_TOGGLE
-        LED1_TOGGLE;
-#endif
-#ifdef LED3_TOGGLE
-        LED3_TOGGLE;
-#endif
-#ifdef LED2_TOGGLE
-        LED2_TOGGLE;
-#endif
+        if (!IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)) {
+    #ifdef LED0_TOGGLE
+            LED0_TOGGLE;
+    #endif
+    #ifdef LED1_TOGGLE
+            LED1_TOGGLE;
+    #endif
+    #ifdef LED2_TOGGLE
+            LED2_TOGGLE;
+    #endif
+    #ifdef LED3_TOGGLE
+            LED3_TOGGLE;
+    #endif
+        }
         ztimer_sleep(ZTIMER_MSEC, delay);
         diff = ztimer_now(ZTIMER_MSEC) - start;
     }
 
-#ifdef LED0_TOGGLE
-    LED0_OFF;
-#endif
-#ifdef LED1_TOGGLE
-    LED1_OFF;
-#endif
-#ifdef LED3_TOGGLE
-    LED3_OFF;
-#endif
-#ifdef LED2_TOGGLE
-    LED2_OFF;
-#endif
+    if (!IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)) {
+    #ifdef LED0_TOGGLE
+        LED0_OFF;
+    #endif
+    #ifdef LED1_TOGGLE
+        LED1_OFF;
+    #endif
+    #ifdef LED2_TOGGLE
+        LED2_OFF;
+    #endif
+    #ifdef LED3_TOGGLE
+        LED3_OFF;
+    #endif
+    }
 }

--- a/sys/fido2/ctap/ctap_utils.c
+++ b/sys/fido2/ctap/ctap_utils.c
@@ -16,6 +16,7 @@
  */
 
 #include "ztimer.h"
+#include "led.h"
 
 #include "fido2/ctap.h"
 #include "fido2/ctap/ctap_utils.h"
@@ -83,35 +84,19 @@ void fido2_ctap_utils_wait_for_user_presence(void)
 
     while (!_user_present && diff < CTAP_UP_TIMEOUT) {
         if (!IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)) {
-    #ifdef LED0_TOGGLE
             LED0_TOGGLE;
-    #endif
-    #ifdef LED1_TOGGLE
             LED1_TOGGLE;
-    #endif
-    #ifdef LED2_TOGGLE
             LED2_TOGGLE;
-    #endif
-    #ifdef LED3_TOGGLE
             LED3_TOGGLE;
-    #endif
         }
         ztimer_sleep(ZTIMER_MSEC, delay);
         diff = ztimer_now(ZTIMER_MSEC) - start;
     }
 
     if (!IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)) {
-    #ifdef LED0_TOGGLE
         LED0_OFF;
-    #endif
-    #ifdef LED1_TOGGLE
         LED1_OFF;
-    #endif
-    #ifdef LED2_TOGGLE
         LED2_OFF;
-    #endif
-    #ifdef LED3_TOGGLE
         LED3_OFF;
-    #endif
     }
 }

--- a/sys/include/fido2/ctap/ctap_utils.h
+++ b/sys/include/fido2/ctap/ctap_utils.h
@@ -33,7 +33,7 @@ extern "C" {
 /**
  * @brief LED animation to indicate that user action is required
  */
-void fido2_ctap_utils_led_animation(void);
+void fido2_ctap_utils_wait_for_user_presence(void);
 
 /**
  * @brief Initialize button to be used for user presence test

--- a/tests/sys/fido2_ctap/Makefile
+++ b/tests/sys/fido2_ctap/Makefile
@@ -5,7 +5,8 @@ include ../Makefile.sys_common
 BOARD_WHITELIST = \
   native \
   nrf52840dk \
-  nrf52840dongle
+  nrf52840dongle \
+  feather-nrf52840-sense
 
 # same as CTAP_STACKSIZE
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=15000

--- a/tests/sys/fido2_ctap_hid/Makefile
+++ b/tests/sys/fido2_ctap_hid/Makefile
@@ -26,16 +26,18 @@ CFLAGS += -DCONFIG_FIDO2_CTAP_DISABLE_LED=1
 # compiled natively (x86-64). Therefore we need to clear the flags set by e.g.
 # BOARD = nrf52840dk
 fido2-test:
-	env -i PATH=$(PATH) $(MAKE) -C $(RIOTBASE)/build/pkg/fido2_tests standard-tests
+	env -i PATH=$(PATH) $(MAKE) -C $(PKGDIRBASE)/fido2_tests standard-tests
 
 # FIDO2 user presence tests.
 #
-# Make sure to enable user presence tests by uncommenting CFLAGS += -DCONFIG_FIDO2_CTAP_DISABLE_UP=1
+# Make sure to enable user presence tests by setting CFLAGS += -DCONFIG_FIDO2_CTAP_DISABLE_UP=0.
+# It is also recommended to set CFLAGS += -DCONFIG_FIDO2_CTAP_DISABLE_LED=0 to have
+# an indicator that signals when to press the button.
 #
 # Use env -i because fido2-test has a depedency (pyscard) that needs to be
 # compiled natively (x86-64). Therefore we need to clear the flags set by e.g.
 # BOARD = nrf52840dk
 fido2-test-up:
-	env -i PATH=$(PATH) $(MAKE) -C $(RIOTBASE)/build/pkg/fido2_tests up-tests
+	env -i PATH=$(PATH) $(MAKE) -C $(PKGDIRBASE)/fido2_tests up-tests
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/fido2_ctap_hid/Makefile
+++ b/tests/sys/fido2_ctap_hid/Makefile
@@ -26,7 +26,7 @@ CFLAGS += -DCONFIG_FIDO2_CTAP_DISABLE_LED=1
 # compiled natively (x86-64). Therefore we need to clear the flags set by e.g.
 # BOARD = nrf52840dk
 fido2-test:
-	env -i PATH=$(PATH) $(MAKE) -C $(RIOTBASE)/build/pkg/fido2_tests
+	env -i PATH=$(PATH) $(MAKE) -C $(RIOTBASE)/build/pkg/fido2_tests standard-tests
 
 # FIDO2 user presence tests.
 #

--- a/tests/sys/fido2_ctap_hid/Makefile
+++ b/tests/sys/fido2_ctap_hid/Makefile
@@ -5,7 +5,8 @@ include ../Makefile.sys_common
 
 BOARD_WHITELIST = \
   nrf52840dk \
-  nrf52840dongle
+  nrf52840dongle \
+  feather-nrf52840-sense
 
 USEMODULE += fido2_ctap_transport_hid
 USEPKG += fido2_tests

--- a/tests/sys/fido2_ctap_hid/README.md
+++ b/tests/sys/fido2_ctap_hid/README.md
@@ -37,23 +37,24 @@ Unit testing is based on the `fido2_tests` package.
 There are two test targets (fido2-test, fido2-test-up). The former requires no user
 interaction the latter does.
 
+Before running the tests, you need to first flash the device with this test application. The tests communicate with the authenticator via USB. Therefore, when using a board like the nrf52840dk, you **must** use two USB cables: one for programming the SoC and receiving output and another for direct USB communication with the authenticator through the second USB port.
+
+**fido2-test:**
+
+1. Flash the device with `make flash`.
+2. Run the unit tests by running `make fido2-test`.
+
+**fido2-test-up:**
+
+1. Make sure to enable user interaction by setting `CONFIG_FIDO2_CTAP_DISABLE_UP=0` in the Makefile. Additionally
+it is recommended to also enable LED animations by setting `CONFIG_FIDO2_CTAP_DISABLE_LED=0` to have an indicator that signals when to press the button.
+2. Flash the device with `make flash`.
+3. Run the unit tests by running `make fido2-test-up` and follow the instructions. E.g. when `.ACTIVATE UP ONCE` is displayed, press the configured UP button (default button 1) once. **Important**: The tests will generate credentials on the device before they begin. As user presence tests are enabled, you must press the button twice at the start to initiate the actual test.
+
 Note:
+* Running the tests for the first time will setup a virtual python environment (venv) and install python dependencies of the tests. To check the dependencies please refer to the requirements.txt of the fido2-tests repository.
 * The tests require python 3.6+.
 * The tests require [swig](http://www.swig.org/) to be installed on your host computer.
-* Running the tests for the first time will setup a virtual python environment (venv) and install python dependencies of the tests. To check the dependencies please refer to the `requirements.txt` of the [fido2-tests repository](https://github.com/solokeys/fido2-tests).
+* The tests require [libpcsclite-dev](https://packages.debian.org/de/sid/libpcsclite-dev) to be installed on your host computer.
 * The unit tests will require you to reboot the authenticator multiple times. Be patient before continuing as it takes a few seconds for the connection between OS and authenticator to be re-established.
-* If you keep getting errors while trying to run the tests try changing to another git branch and back e.g. `git checkout branch1 && git checkout -` in order to remove build artifacts. Then re-flash the device with `make flash term` and try to run the tests again with `make fido2-test` or `make fido2-test-up`.
-
-fido2-test
-
-1. To make benchmarking faster disable user presence tests by enabling the CFLAG
-   `CONFIG_FIDO2_CTAP_DISABLE_UP` in the Makefile or through KConfig.
-2. Flash the device with `make flash`.
-3. Run the unit tests by running `make fido2-test`.
-
-fido2-test-up
-
-1. Make sure that the CFLAG `CONFIG_FIDO2_CTAP_DISABLE_UP` is disabled as this test target
-  requires user interaction.
-2. Flash the device with `make flash`.
-3. Run the unit tests by running `make fido2-test-up` and follow the instructions. E.g. when `.ACTIVATE UP ONCE` is displayed, press the configured UP button (default button 1) once.
+* If you keep getting errors while trying to run the tests try `make clean` in order to remove build artifacts. Then re-flash the device with `make flash` and try to run the tests again with `make fido2-test` or `make fido2-test-up`.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Update the fido2 test package to the latest version. Also fix a small bug in the GetAssertion & GetNextAssertion behavior which became apparent because a new test failed.

I ran all tests using the nrf5284dk and reached 100% with the ctap fix.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
+ `/sys/sys/fido2_ctap`




