### PR TITLE
build system: simplify docker image pinning

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -382,20 +382,12 @@ check_tests_application_path() {
 }
 
 check_pinned_docker_version_is_up_to_date() {
-    local pinned_digest
     local pinned_repo_digest
-    local upstream_digest
     local upstream_repo_digest
-    pinned_digest="$(awk '/^DOCKER_TESTED_IMAGE_ID := (.*)$/ { print substr($0, index($0, $3)); exit }' "$RIOTMAKE/docker.inc.mk")"
     pinned_repo_digest="$(awk '/^DOCKER_TESTED_IMAGE_REPO_DIGEST := (.*)$/ { print substr($0, index($0, $3)); exit }' "$RIOTMAKE/docker.inc.mk")"
     # not using docker and jq here but a python script to not have to install
     # more stuff for the static test docker image
-    IFS=' ' read -r upstream_digest upstream_repo_digest <<< "$("$RIOTTOOLS/buildsystem_sanity_check/get_dockerhub_digests.py" "riot/riotbuild")"
-
-    if [ "$pinned_digest" != "$upstream_digest" ]; then
-        git -C "${RIOTBASE}" grep -n '^DOCKER_TESTED_IMAGE_ID :=' "$RIOTMAKE/docker.inc.mk" \
-            | error_with_message  "Update docker image SHA256 to ${upstream_digest}"
-    fi
+    IFS=' ' read -r upstream_repo_digest <<< "$("$RIOTTOOLS/buildsystem_sanity_check/get_dockerhub_digests.py" "riot/riotbuild")"
 
     if [ "$pinned_repo_digest" != "$upstream_repo_digest" ]; then
         git -C "${RIOTBASE}" grep -n '^DOCKER_TESTED_IMAGE_REPO_DIGEST :=' "$RIOTMAKE/docker.inc.mk" \

--- a/dist/tools/buildsystem_sanity_check/get_dockerhub_digests.py
+++ b/dist/tools/buildsystem_sanity_check/get_dockerhub_digests.py
@@ -87,5 +87,5 @@ if __name__ == '__main__':
     if len(sys.argv) != 2:
         sys.exit(f"Usage {sys.argv[0]} <REPO_NAME>")
 
-    digest, repo_digest = get_upstream_digests(sys.argv[1])
-    print(f"{digest} {repo_digest}")
+    _, repo_digest = get_upstream_digests(sys.argv[1])
+    print(f"{repo_digest}")


### PR DESCRIPTION
### Contribution description

It turns out that the ID mechanics of docker are even more crazy than realized before: On Linux (x86_64) they use a different SHA256 when referring to a locally installed image than when referring to the same image at dockerhub. On Mac OS (Apple Silicon), the use the repo SHA256 also when referring to the local image.

Instead of increasing the complexity of the current solution even more by covering both cases, we now use
`docker.io/riot/riotbuild@sha256:<SHA256_OF_DOCKERHUB_IMAGE>` to refer to a specific docker image, which hopefully works across systems.

Instead of pulling the image explicitly, we now can rely on docker to do so automatically if the pinned image is not found locally. As a result, the knob to disable automatic pulling has been dropped.

### Testing procedure

`make BUILD_IN_DOCKER=1 -C examples/default` should now work on Mac OS on Apple Silicon as well as on Linux machines. It should automatically pull the container, if not locally present.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/20853