### PR TITLE
core/sched_switch: fix crash with no active thread

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -281,6 +281,14 @@ void sched_set_status(thread_t *process, thread_status_t status)
 void sched_switch(uint16_t other_prio)
 {
     thread_t *active_thread = thread_get_active();
+
+    /* If a thread exists and no other thread is runnable, we may end up in
+     * a situation with no active thread. This can not occur if there is an
+     * idle thread, which is always runnable, though */
+    if (!IS_USED(MODULE_CORE_IDLE_THREAD) && unlikely(active_thread == NULL)) {
+        thread_yield_higher();
+    }
+
     uint16_t current_prio = active_thread->priority;
     int on_runqueue = (active_thread->status >= STATUS_ON_RUNQUEUE);
 


### PR DESCRIPTION
### Contribution description

The function `sched_switch()` was implemented with the assumption that there will always be an active thread. This was true until threadless idle was implemented for Cortex M MCUs: If no thread is runnable and the running thread exists, there will be no active thread. If from ISR a thread is then unblocked, `sched_switch()` will be called without an active thread.

This handles the corner case explicitly when the module `core_idle_thread` is not used (in other words: for threadless idle).

#### Implementation choice

I first wanted to avoid adding the check for this very unlikely corner case to this hot path, and rather have in `cpu_switch_context_exit()` of the only offender to make sure to set the active thread to something reasonable. However, switching to a non-runnable thread without running it is something that I have no elegant, simple and maintainable solution for. So I decided to rather add a simple and maintainable check into a hot path.

### Testing procedure

See https://github.com/RIOT-OS/RIOT/issues/20812

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/20812