### PR TITLE
gnrc_sixlowpan_frag: enable `gnrc_netif_pktq` if `netdev_new_api` is used

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -208,6 +208,12 @@ ifneq (,$(filter gnrc_sixlowpan_border_router_default,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_iphc
 endif
 
+ifneq (,$(filter netdev_new_api,$(USEMODULE)))
+  ifneq (,$(filter gnrc_sixlowpan_frag%,$(USEMODULE)))
+    USEMODULE += gnrc_netif_pktq
+  endif
+endif
+
 ifneq (,$(filter gnrc_sixlowpan_frag,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan
   USEMODULE += gnrc_sixlowpan_frag_fb


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

6lowpan fragmentation is broken on `at86rf215` since #20672. The driver no longer tries to block when a transfer is ongoing, but reports `-EBUSY` to the upper layer when a send is triggered while the previous frame is still being sent.

For this to work (and not drop the 2nd fragment), we need `gnrc_netif_pktq`.

### Testing procedure

6lo fragmented packets are working again

```
2024-09-30 12:00:50,928 # > ping -s 512 fe80::6419:e83f:8e6b:4ce7%7
2024-09-30 12:00:51,042 # 520 bytes from fe80::6419:e83f:8e6b:4ce7%7: icmp_seq=0 ttl=64 rssi=-40 dBm time=108.982 ms
2024-09-30 12:00:52,050 # 520 bytes from fe80::6419:e83f:8e6b:4ce7%7: icmp_seq=1 ttl=64 rssi=-40 dBm time=108.986 ms
2024-09-30 12:00:53,044 # 520 bytes from fe80::6419:e83f:8e6b:4ce7%7: icmp_seq=2 ttl=64 rssi=-39 dBm time=108.983 ms
2024-09-30 12:00:53,045 # 
2024-09-30 12:00:53,058 # --- fe80::6419:e83f:8e6b:4ce7%7 PING statistics ---
2024-09-30 12:00:53,061 # 3 packets transmitted, 3 packets received, 0% packet loss
2024-09-30 12:00:53,063 # round-trip min/avg/max = 108.982/108.983/108.986 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
