### PR TITLE
bluetil: Ensure advertisement length does not exceed pkt len

### DIFF
--- a/sys/net/ble/bluetil/bluetil_ad/bluetil_ad.c
+++ b/sys/net/ble/bluetil/bluetil_ad/bluetil_ad.c
@@ -44,8 +44,12 @@ int bluetil_ad_find(const bluetil_ad_t *ad, uint8_t type,
 
     unsigned pos = 0;
 
-    while ((pos + POS_TYPE) < ad->pos) {
+    while ((pos + POS_DATA) < ad->pos) {
         uint8_t len = ad->buf[pos];
+
+        if (pos + len >= ad->pos) {
+            return BLUETIL_AD_NOMEM;
+        }
 
         if (ad->buf[pos + POS_TYPE] == type) {
             data->data = ad->buf + pos + POS_DATA;


### PR DESCRIPTION


### Contribution description

Hey 🦪

this fixes an erroneous advertisement parsing, in which the length of the adv. was inherently trusted.

### Testing procedure

Good review should be sufficient. 

