### PR TITLE
net/dhcpv6: Improve option parsing in dhcpv6 advertise

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -802,6 +802,10 @@ static void _parse_advertise(uint8_t *adv, size_t len)
          len > 0; len -= _opt_len(opt), opt = _opt_next(opt)) {
         switch (byteorder_ntohs(opt->type)) {
             case DHCPV6_OPT_IA_PD:
+                if (_opt_len(opt) < sizeof(dhcpv6_opt_ia_pd_t)) {
+                    DEBUG("DHCPv6 client: IA_PD option underflow minimum size\n");
+                    return;
+                }
                 for (unsigned i = 0;
                      IS_USED(MODULE_DHCPV6_CLIENT_IA_PD) &&
                      (i < CONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX);
@@ -843,6 +847,10 @@ static void _parse_advertise(uint8_t *adv, size_t len)
                 }
                 break;
             case DHCPV6_OPT_IA_NA:
+                if (_opt_len(opt) < sizeof(dhcpv6_opt_ia_na_t)) {
+                    DEBUG("DHCPv6 client: IA_NA option underflows minimum size\n");
+                    return;
+                }
                 for (unsigned i = 0;
                     IS_USED(MODULE_DHCPV6_CLIENT_IA_NA) &&
                     i < CONFIG_DHCPV6_CLIENT_ADDR_LEASE_MAX;
@@ -885,6 +893,10 @@ static void _parse_advertise(uint8_t *adv, size_t len)
                 }
                 break;
             case DHCPV6_OPT_SMR:
+                if (_opt_len(opt) < sizeof(dhcpv6_opt_smr_t)) {
+                    DEBUG("DHCPv6 client: SMR option underflows minimum size\n");
+                    return;
+                }
                 smr = (dhcpv6_opt_smr_t *)opt;
                 break;
             default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Hello 🐿️

This adds missed size checks for the type conversions.
Please note that `dhcpv6_opt_ia_pd_t` and `dhcpv6_opt_ia_na_t` make use of flexible array member - so I am not super sure if the check is enough.

### Testing procedure

A good review by @miri64 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
