### PR TITLE
examples/lorawan: drop crazy STM32 hack

### DIFF
--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -131,16 +131,6 @@ int main(void)
     puts("LoRaWAN Class A low-power application");
     puts("=====================================");
 
-    /*
-     * Enable deep sleep power mode (e.g. STOP mode on STM32) which
-     * in general provides RAM retention after wake-up.
-     */
-#if IS_USED(MODULE_PM_LAYERED)
-    for (unsigned i = 1; i < PM_NUM_MODES - 1; ++i) {
-        pm_unblock(i);
-    }
-#endif
-
 #ifdef USE_OTAA /* OTAA activation mode */
     /* Convert identifiers and keys strings to byte arrays */
     fmt_hex_bytes(deveui, CONFIG_LORAMAC_DEV_EUI_DEFAULT);


### PR DESCRIPTION
### Contribution description

We cannot just decrement the reference counter of power modes without any coordination. First, this will trigger an `assert()`ion on non STM32 MCUs that have power modes that are not used (the ref count would be decremented below zero). Second, there hopefully is a reason a certain power mode is blocked, e.g. because a periph driver needs a certain clock to function.

Likely the `periph_uart` driver on STM32 boards keeps power modes blocked after TX is completed even when no RX callback is present, which is the waste of power this hack tries to address. But that should be addressed there.

### Testing procedure

With `master` on `wemos-zero` we get:

```
2024-10-01 15:34:30,055 # main(): This is RIOT! (Version: 2024.10-devel-217-g61df1)
2024-10-01 15:34:30,056 # LoRaWAN Class A low-power application
2024-10-01 15:34:30,056 # =====================================
2024-10-01 15:34:30,056 # sys/pm_layered/pm.c:92 => *** RIOT kernel panic:
2024-10-01 15:34:30,056 # FAILED ASSERTION.
2024-10-01 15:34:30,056 # 
2024-10-01 15:34:30,056 # *** halted.
2024-10-01 15:34:30,056 # 
```

With this PR, we get:

```
2024-10-01 15:49:14,045 # main(): This is RIOT! (Version: 2024.10-devel-218-g4b6ad-examples/lorawan/bugfix)
2024-10-01 15:49:14,045 # LoRaWAN Class A low-power application
2024-10-01 15:49:14,045 # =====================================
2024-10-01 15:49:14,045 # Starting join procedure
[...] (No LoRaWAN Gateway close enough...)
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17895