### PR TITLE
boards/common/arduino-zero: Add Arudino SPI mapping

### DIFF
--- a/boards/common/arduino-zero/include/arduino_iomap.h
+++ b/boards/common/arduino-zero/include/arduino_iomap.h
@@ -139,6 +139,20 @@ extern "C" {
 #define ARDUINO_PIN_9_PWM_CHAN  1
 /** @} */
 
+/**
+ * @name    Arduino's SPI buses
+ * @{
+ */
+/**
+ * @brief   SPI_DEV(0) is connected to the ISP
+ */
+#define ARDUINO_SPI_ISP         SPI_DEV(0)
+/**
+ * @brief   SPI_DEV(1) is connected to D11/D12/D13
+ */
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(1)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -241,6 +241,18 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {
+        .dev      = &SERCOM1->SPI,
+        .miso_pin = GPIO_PIN(PA, 19),
+        .mosi_pin = GPIO_PIN(PA, 16),
+        .clk_pin  = GPIO_PIN(PA, 17),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 


### PR DESCRIPTION
### Contribution description

The Arduino Zero based boards already provided the feature `arduino_spi`, but were missing the corresponding mapping. This fixes the issue by adding the SPI bus numbers for the ISP SPI bus and the D11D12D13 SPI bus.

(And in order to actually add the D11D12D13 SPI bus, the `periph_conf.h` was extended to provide an SPI configuration for it.)

### Testing procedure

Add an Arduino Ethernet Shield (the classic one with the W5100 chip) on top of an Arduino Zero board (either original or one of the compatible clones) and run:

```
USEMODULE=shield_w5100 make BOARD=wemos-zero -C examples/gnrc_networking flash term
```

This will fail to compile on `master` (due to the missing SPI defines), but succeed with this PR.

Sadly, this will only test the SPI bus already present in the `periph_conf.h`, not the one added.

### Issues/PRs references

None