### PR TITLE
static_tests: Add test for Rust code formatting rules

### DIFF
--- a/dist/tools/cargo-checks/check.sh
+++ b/dist/tools/cargo-checks/check.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+FAILURES=""
+
+# This is a Make based environment, therefore we don't have funny names to take
+# care of, and anyone who can cause commands to be run by injecting files can
+# just as well modify the scripts being run. (Otherwise we'd need to go through
+# a less readable print0 / read).
+for CARGOTOML in `find -name Cargo.toml`
+do
+    if cargo fmt --quiet --check --manifest-path "${CARGOTOML}"; then
+        continue
+    else
+        FAILURES="${FAILURES} ${CARGOTOML%Cargo.toml}"
+    fi
+done
+
+if [ x"" != x"${FAILURES}" ]; then
+    echo "Some Rust files are following rustfmt, in particular in:"
+    echo "${FAILURES}"
+    echo "You can format the code locally using:"
+    echo
+    echo "find -name Cargo.toml -exec cargo fmt --manifest-path '{}' ';'"
+    if [ ! -z "${GITHUB_RUN_ID:-}" ]; then
+        echo
+        echo "The author of this test regrets not knowing how to provide an easy way to just click a button here that provides the right fixup commits."
+    fi
+    exit 1
+fi

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -128,6 +128,7 @@ run ./dist/tools/buildsystem_sanity_check/check.sh
 run ./dist/tools/feature_resolution/check.sh
 run ./dist/tools/boards_supported/check.sh
 run ./dist/tools/codespell/check.sh
+run ./dist/tools/cargo-checks/check.sh
 if [ -z "${GITHUB_RUN_ID}" ]; then
     run ./dist/tools/uncrustify/uncrustify.sh --check
 else


### PR DESCRIPTION
### Contribution description

It is common for projects with Rust code to just enforce the code style suggested by Rust.

This adds a check to the static tests, and 

### Testing procedure

This PR should fail with a sensible message on the first run, and be green when I push the second commit fixing all the formatting errors (through the provided command).

### Issues/PRs references

Thanks @Teufelchen1 for spotting the formatting errors.