### PR TITLE
make: export DEVELHELP

### DIFF
--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -116,7 +116,7 @@ export HEXFILE               # The 'intel hex' stripped result of the compilatio
 # DEBUGSERVER_FLAGS          # The parameters to supply to DEBUGSERVER.
 # DEBUGCLIENT                # The command to call on "make debug-client", usually a script starting the GDB client.
 # DEBUGCLIENT_FLAGS          # The parameters to supply to DEBUGCLIENT.
-# DEVELHELP                  # Set to 1 to spend ROM, RAM and CPU time for help during development (e.g. enable asserts())
+export DEVELHELP             # Set to 1 to spend ROM, RAM and CPU time for help during development (e.g. enable asserts())
 # RESET                      # The command to call on "make reset", this command resets/reboots the target.
 # RESET_FLAGS                # The parameters to supply to RESET.
 # PROGRAMMER                 # The programmer to use when flashing, resetting or debugging


### PR DESCRIPTION
### Contribution description

This patch exports the make macro `DEVELHELP`. Without this patch, use of the macro in the following files does not work when the macro is set in a makefile (such as in Makefile.local or an application's makefile as demonstrated in dist/Makefile). Inside these files `DEVELHELP` is not defined under these conditions.

 - pkg/littlefs/Makefile
 - pkg/littlefs2/Makefile
 - sys/stdio_null/Makefile

Note that use of the macro does work in these files when the macro is set from the command line, without the patch. For example:

``` sh
$make DEVELHELP=1 all
```

### Testing procedure

1. run: `make -C examples/hello-world/ USEMODULE+=stdio_null`
2. observe the warning `Makefile:2: STDIO disabled via stdio_null, but DEVELHELP enabled` is seen with this patch, and is not seen without the patch. The warning is being emmited from the file `sys/stdio_null/Makefile`


### Issues/PRs references

- none known
