### PR TITLE
boards/adafruit-grand-central-m4-express: minor improvements

### DIFF
--- a/boards/adafruit-grand-central-m4-express/dist/openocd.cfg
+++ b/boards/adafruit-grand-central-m4-express/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find target/atsame5x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/adafruit-grand-central-m4-express/doc.txt
+++ b/boards/adafruit-grand-central-m4-express/doc.txt
@@ -3,26 +3,34 @@
 @ingroup     boards
 @brief       Support for the Adafruit Grand Central M4 Express
 
-### General information
+General information
+===================
 
-![Adafruit Grand Central M4 Expressboard](https://cdn-learn.adafruit.com/assets/assets/000/068/748/medium800/adafruit_products_grand_central_top_angle.jpg?1546734839)
+@image html https://cdn-learn.adafruit.com/assets/assets/000/068/748/medium800/adafruit_products_grand_central_top_angle.jpg "Picture of the Adafruit Grand Central M4 Express"
 
 The main features of the board are:
 - ATSAMD51 Cortex M4 running at 120 MHz
 - Hardware DSP and floating point support
-- 1MB Flash
-- 256 KB RAM
+- 1 MiB Flash
+- 256 KiB RAM
 - external 8 MB QSPI Flash storage
 - 32-bit, 3.3V logic and power
 - Micro SD Card slot connected to SPI
 - native USB
 
-### Links
+Pinout
+------
+
+@image html https://cdn-learn.adafruit.com/assets/assets/000/115/366/original/adafruit_products_Adafruit-Grand-Central-M4-Express-Pinout.png "Official Pinout of the Grand Central M4 Express"
+
+Links
+=====
 
 - [Overview](https://learn.adafruit.com/adafruit-grand-central)
 - [Schematics](https://learn.adafruit.com/assets/69175)
 
-### Flash the board
+Flash the board
+===============
 
 The board is flashed using its on-board
 [boot loader](https://github.com/adafruit/uf2-samdx1).


### PR DESCRIPTION
### Contribution description

- improve the doc
- allow debugging with OpenOCD by adding a config

### Testing procedure

- check the resulting doc
- using e.g. `make BOARD=adafruit-grand-central-m4-express PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink debug` should now work

### Issues/PRs references

None