### PR TITLE
pkg/littlefs: make use of RIOT's log module instead of pkg provided macros

### DIFF
--- a/pkg/littlefs/Makefile
+++ b/pkg/littlefs/Makefile
@@ -8,10 +8,8 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-format
 
-# Disable debug printing
-ifneq ($(DEVELHELP),1)
-  CFLAGS += -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR
-endif
+# replace pkg supplied logging macros with RIOT's
+CFLAGS += -include $(PKG_DIR)/lfs_log.h
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/littlefs/lfs_log.h
+++ b/pkg/littlefs/lfs_log.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Joshua DeWeese <josh.deweese@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_littlefs
+ * @{
+ *
+ * @file
+ * @brief       littlefs logging macro overrides
+ *
+ * This header provides re-implementations of the logging and debugging macros
+ * used in littlefs. This is to allow the package to make use of RIOT's own
+ * modules for logging and debugging.
+ *
+ * @author      Joshua DeWeese <josh.deweese@gmail.com>
+ *
+ */
+
+#ifndef LFS_LOG_H
+#define LFS_LOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "log.h"
+
+/**
+ * @brief Private macro for routing littlefs log msgs to RIOT's log module.
+ *
+ * @param[in] level             log level of this log message
+ * @param[in] fmt               printf style format string
+ * @param[inout] ...            printf style variadic args
+ */
+#define _LFS_LOG(level, fmt, ...)\
+    LOG(level, "lfs: " fmt "%s\n", __VA_ARGS__)
+
+/**  */
+/**
+ * @name littlefs overrides
+ * @{
+ * @brief Re-implementation of littlefs's logging and debugging macros.
+ */
+
+/** override of littlefs's `LFS_DEBUG()` */
+#ifndef LFS_NO_DEBUG
+#  define LFS_DEBUG(...) _LFS_LOG(LOG_DEBUG, __VA_ARGS__, "")
+#else
+#  define LFS_DEBUG(...)
+#endif
+
+/** override of littlefs's `LFS_WARN()` */
+#ifndef LFS_NO_WARN
+#  define LFS_WARN(...) _LFS_LOG(LOG_WARNING, __VA_ARGS__, "")
+#else
+#  define LFS_WARN(...)
+#endif
+
+/** override of littlefs's `LFS_ERROR()` */
+#ifndef LFS_NO_ERROR
+#  define LFS_ERROR(...) _LFS_LOG(LOG_ERROR, __VA_ARGS__, "")
+#else
+#  define LFS_ERROR(...)
+#endif
+
+/** @} */
+
+#endif /* LFS_LOG_H */
+/** @} */

--- a/pkg/littlefs/patches/0001-remove-pkg-supplied-logging-macros.patch
+++ b/pkg/littlefs/patches/0001-remove-pkg-supplied-logging-macros.patch
@@ -1,0 +1,45 @@
+From 0a1aaadaa6c2e58c7c7e60d28130b77d0e9ac382 Mon Sep 17 00:00:00 2001
+From: Joshua DeWeese <jdeweese@primecontrols.com>
+Date: Mon, 7 Oct 2024 12:20:59 -0400
+Subject: [PATCH] remove pkg supplied logging macros
+
+---
+ lfs_util.h | 22 ----------------------
+ 1 file changed, 22 deletions(-)
+
+diff --git a/lfs_util.h b/lfs_util.h
+index b2dc237..fcc4a00 100644
+--- a/lfs_util.h
++++ b/lfs_util.h
+@@ -44,28 +44,6 @@ extern "C"
+ // macros must not have side-effects as the macros can be removed for a smaller
+ // code footprint
+ 
+-// Logging functions
+-#ifndef LFS_NO_DEBUG
+-#define LFS_DEBUG(fmt, ...) \
+-    printf("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+-#else
+-#define LFS_DEBUG(fmt, ...)
+-#endif
+-
+-#ifndef LFS_NO_WARN
+-#define LFS_WARN(fmt, ...) \
+-    printf("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+-#else
+-#define LFS_WARN(fmt, ...)
+-#endif
+-
+-#ifndef LFS_NO_ERROR
+-#define LFS_ERROR(fmt, ...) \
+-    printf("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+-#else
+-#define LFS_ERROR(fmt, ...)
+-#endif
+-
+ // Runtime assertions
+ #ifndef LFS_NO_ASSERT
+ #define LFS_ASSERT(test) assert(test)
+-- 
+2.34.1
+

--- a/pkg/littlefs2/Makefile
+++ b/pkg/littlefs2/Makefile
@@ -8,10 +8,8 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-format
 
-# Disable debug printing
-ifneq ($(DEVELHELP),1)
-  CFLAGS += -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR
-endif
+# replace pkg supplied logging macros with RIOT's
+CFLAGS += -include $(PKG_DIR)/lfs_log.h
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/littlefs2/lfs_log.h
+++ b/pkg/littlefs2/lfs_log.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Joshua DeWeese <josh.deweese@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_littlefs2
+ * @{
+ *
+ * @file
+ * @brief       littlefs v2 logging macro overrides
+ *
+ * This header provides re-implementations of the logging and debugging macros
+ * used in littlefs. This is to allow the package to make use of RIOT's own
+ * modules for logging and debugging.
+ *
+ * @author      Joshua DeWeese <josh.deweese@gmail.com>
+ *
+ */
+
+#ifndef LFS_LOG_H
+#define LFS_LOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "log.h"
+
+#ifdef LFS_YES_TRACE
+#  define ENABLE_DEBUG 1
+#endif
+#include "debug.h"
+
+/**
+ * @brief Private macro for routing littlefs trace msgs to RIOT's DEBUG macro.
+ *
+ * @param[in] fmt               printf style format string
+ * @param[inout] ...            printf style variadic args
+ */
+#define _LFS_TRACE(fmt, ...) \
+    DEBUG("%s:%d: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+
+/**
+ * @brief Private macro for routing littlefs log msgs to RIOT's log module.
+ *
+ * @param[in] level             log level of this log message
+ * @param[in] fmt               printf style format string
+ * @param[inout] ...            printf style variadic args
+ */
+#define _LFS_LOG(level, fmt, ...)\
+    LOG(level, "lfs: " fmt "%s\n", __VA_ARGS__)
+
+/**  */
+/**
+ * @name littlefs overrides
+ * @{
+ * @brief Re-implementation of littlefs's logging and debugging macros.
+ */
+
+/** override of littlefs's `LFS_TRACE()` */
+#ifdef LFS_YES_TRACE
+#  define LFS_TRACE(...) _LFS_TRACE(__VA_ARGS__, "")
+#else
+#  define LFS_TRACE(...)
+#endif
+
+/** override of littlefs's `LFS_DEBUG()` */
+#ifndef LFS_NO_DEBUG
+#  define LFS_DEBUG(...) _LFS_LOG(LOG_DEBUG, __VA_ARGS__, "")
+#else
+#  define LFS_DEBUG(...)
+#endif
+
+/** override of littlefs's `LFS_WARN()` */
+#ifndef LFS_NO_WARN
+#  define LFS_WARN(...) _LFS_LOG(LOG_WARNING, __VA_ARGS__, "")
+#else
+#  define LFS_WARN(...)
+#endif
+
+/** override of littlefs's `LFS_ERROR()` */
+#ifndef LFS_NO_ERROR
+#  define LFS_ERROR(...) _LFS_LOG(LOG_ERROR, __VA_ARGS__, "")
+#else
+#  define LFS_ERROR(...)
+#endif
+
+/** @} */
+
+#endif /* LFS_LOG_H */
+/** @} */

--- a/tests/pkg/littlefs/Makefile
+++ b/tests/pkg/littlefs/Makefile
@@ -4,4 +4,7 @@ USEMODULE += littlefs
 USEMODULE += embunit
 USEMODULE += mtd_emulated
 
+# silence expected errors
+CFLAGS += -DLOG_LEVEL=LOG_NONE
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg/littlefs2/Makefile
+++ b/tests/pkg/littlefs2/Makefile
@@ -4,4 +4,7 @@ USEPKG += littlefs2
 USEMODULE += embunit
 USEMODULE += mtd_emulated
 
+# silence expected errors
+CFLAGS += -DLOG_LEVEL=LOG_NONE
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This patch replaces littlefs's logging with RIOT's own logging module.


### Testing procedure

``` sh
make -C tests/pkg/littlefs all term
make -C tests/pkg/littlefs2 all term
```

### Issues/PRs references

Some log messages in the tests needed to be silenced due to this patch also fixing broken support of logging in the package. See #20889.
