### PR TITLE
Makefile: add .DEFAULT target to further guide new users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ include makefiles/tools/riotgen.inc.mk
 
 include makefiles/color.inc.mk
 
-welcome:
+# Prints a welcome message
+define welcome_message
 	@echo "Welcome to RIOT - The friendly OS for IoT!"
 	@echo ""
 	@echo "You executed 'make' from the base directory."
@@ -70,3 +71,13 @@ welcome:
 	@echo "==> tl;dr Try running:"
 	@echo "    cd examples/default"
 	@echo "    make BOARD=<INSERT_BOARD_NAME>"
+endef
+
+welcome:
+	$(call welcome_message)
+
+.DEFAULT:
+	@echo '*** ERROR: unrecognized target "$@"'
+	@echo ""
+	$(call welcome_message)
+	@exit 1


### PR DESCRIPTION
### Contribution description

With #20187, running `make` or `make all` in the RIOT base directory prints the welcome message including a list of available targets to be called from there. However, when the user enters an unknown target such as `make unknown`, Make only outputs a generic error.

This PR fixes this and shows the welcome message instead.

### Testing procedure

on `master`:
```
$ make unknown
make: *** No rule to make target 'unknown'.  Stop.
```

with this PR:
```
$ make unknown         
*** ERROR: unrecognized target "unknown"

Welcome to RIOT - The friendly OS for IoT!

You executed 'make' from the base directory.
Usually, you should run 'make' in your application's directory instead.

Please see our Quick Start Guide at:
    https://doc.riot-os.org/getting-started.html
You can ask questions or discuss with other users on our forum:
    https://forum.riot-os.org

Available targets for the RIOT base directory include:
 generate-{board,driver,example,module,pkg,test,features}
 info-{applications,boards,emulated-boards} info-applications-supported-boards
 print-versions
 clean distclean pkg-clean
 doc doc-{man,latex}

==> tl;dr Try running:
    cd examples/default
    make BOARD=<INSERT_BOARD_NAME>
make: *** [Makefile:83: unknown] Error 1
```


### Issues/PRs references

#20187
