### PR TITLE
doc/doxygen: print link to generated documentation

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -18,6 +18,8 @@ doc: $(DOCUMENTATION_FORMAT)
 .PHONY: html
 html: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
+	@echo ""
+	@echo "RIOT documentation successfully generated at file://$(RIOTBASE)/doc/doxygen/html/index.html"
 
 .PHONY: check
 check: src/changelog.md


### PR DESCRIPTION
### Contribution description

It can be confusing for new users where to find the HTML documentation generated with `make doc`. This PR prints the link to the `index.html` after successful generation.

### Testing procedure

`make doc`

also, CI should not be confused with these changes
