### PR TITLE
cpu/samd5x/periph_cph.h: drop non-UTF-8 chars

### DIFF
--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -36,8 +36,8 @@ extern "C" {
 #define SAM0_DFLL_FREQ_HZ       MHZ(48)
 
 /**
-￼ * @brief   XOSC is used to generate a fixed frequency of 48 MHz
-￼ */
+ * @brief   XOSC is used to generate a fixed frequency of 48 MHz
+ */
 #define SAM0_XOSC_FREQ_HZ       (XOSC0_FREQUENCY ? XOSC0_FREQUENCY : XOSC1_FREQUENCY)
 
 /**


### PR DESCRIPTION
### Contribution description

There were some bogus chars in a comment. Let's drop them.

### Testing procedure

Only whitespace changes, so this should not change the generated binaries.

### Issues/PRs references

None