### PR TITLE
CI: fix true and false positives by newer codespell version

### DIFF
--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -114,6 +114,6 @@ Pin mapping in RIOT
 The following image shows RIOT's static pin mapping chosen for this board.
 This mapping is completely arbitrary, it can be adjusted in
 `boards/spark-core/include/periph_conf.h`
-![Pin Mappin](http://docs.spark.io/assets/images/spark-pinout.png)
+![Pin Mapping](http://docs.spark.io/assets/images/spark-pinout.png)
 
  */

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -577,7 +577,7 @@ For more information on `esptool.py`, please refer to the
 
 Once the toolchain is installed either as RIOT docker build image or as local
 installation, a RIOT application can be compiled and flashed for an ESP32x
-boards. For that purpuse change to RIOT's root directory and execute the make
+boards. For that purpose change to RIOT's root directory and execute the make
 command, for example:
 
 - RIOT Docker build image installation

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -174,3 +174,15 @@ fram
 
 # MIS (mask interrupt register)
 mis
+
+# assertIn (python test framework method)
+assertIn
+
+# bootup (common spelling of boot-up)
+bootup
+
+# shiftIn (Arduino function name)
+shiftIn
+
+# <b>e</b>lements (used in Congure documentation)
+lements

--- a/dist/tools/zep_dispatch/main.c
+++ b/dist/tools/zep_dispatch/main.c
@@ -200,7 +200,7 @@ static void _print_help(const char *progname)
     fprintf(stderr, "\tport\t\tlocal port to bind to\n");
 
     fprintf(stderr, "\noptional arguments:\n");
-    fprintf(stderr, "\t-t <file>\tLoad toplogy from file\n");
+    fprintf(stderr, "\t-t <file>\tLoad topology from file\n");
     fprintf(stderr, "\t-p <file>\tStore PID in file\n");
     fprintf(stderr, "\t-s <seed>\tRandom seed used to simulate packet loss\n");
     fprintf(stderr, "\t-g <file>\tFile to dump topology as Graphviz visualisation on SIGUSR1\n");

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -150,7 +150,7 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
                           const uint8_t *data, size_t len);
 #endif
 /**
- * @brief   Start a read transcation internal frame buffer of the given device
+ * @brief   Start a read transaction internal frame buffer of the given device
  *
  * Reading the frame buffer returns some extra bytes that are not accessible
  * through reading the RAM directly. This locks the used SPI.
@@ -182,7 +182,7 @@ static inline void at86rf2xx_fb_read(const at86rf2xx_t *dev, uint8_t *data, size
 void at86rf2xx_fb_read(const at86rf2xx_t *dev, uint8_t *data, size_t len);
 #endif
 /**
- * @brief   Stop a read transcation internal frame buffer of the given device
+ * @brief   Stop a read transaction internal frame buffer of the given device
  *
  * Release the SPI device and unlock frame buffer protection.
  *

--- a/drivers/atwinc15x0/doc.txt
+++ b/drivers/atwinc15x0/doc.txt
@@ -49,7 +49,7 @@ The WiFi module ATWINC15x0 is connected via SPI and supports SPI clock speeds
 of up to 48 MHz. Although the module also has an I2C and a UART interface,
 these interfaces are only used for debugging.
 
-The ATWINC15x0 WiFi module implements a complete TCP/IP procotol stack which is
+The ATWINC15x0 WiFi module implements a complete TCP/IP protocol stack which is
 not used in RIOT.
 
 ### Driver Details

--- a/drivers/include/enc28j60.h
+++ b/drivers/include/enc28j60.h
@@ -48,7 +48,7 @@ typedef struct {
  */
 typedef struct {
     netdev_t netdev;        /**< pull in the netdev fields */
-    enc28j60_params_t p;    /**< SPI and pin confiuration */
+    enc28j60_params_t p;    /**< SPI and pin configuration */
     mutex_t lock;           /**< lock the device on access */
     uint32_t tx_time;       /**< last transmission time for timeout handling */
 } enc28j60_t;

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -239,7 +239,7 @@ extern const ltc4150_recorder_t ltc4150_last_minute;
  * @brief             Initialize the LTC4150 driver
  *
  * @param  dev        Device to initialize
- * @param  params     Information on how the LTC4150 is conntected
+ * @param  params     Information on how the LTC4150 is connected
  *
  * @retval  0         Success
  * @retval -EINVAL    Called with invalid argument(s)

--- a/drivers/sdmmc/sdmmc_sdhc.c
+++ b/drivers/sdmmc/sdmmc_sdhc.c
@@ -484,7 +484,7 @@ static int _xfer_prepare(sdmmc_dev_t *dev, sdmmc_xfer_desc_t *xfer)
     /* TODO: at the moment only 32-bit words supported */
     assert((xfer->block_size % sizeof(uint32_t)) == 0);
 
-    /* indicate that a data transfer is perpared */
+    /* indicate that a data transfer is prepared */
     sdhc_dev->data_transfer = true;
 
     uint32_t tmr;

--- a/pkg/tlsf/contrib/native.c
+++ b/pkg/tlsf/contrib/native.c
@@ -15,7 +15,7 @@
  * @brief   Definitions to use tlsf as malloc on native.
  * @author  Juan I Carrano
  *
- * This assumes glibc is bein used.
+ * This assumes glibc is being used.
  * see: https://www.gnu.org/software/libc/manual/html_node/Replacing-malloc.html
  *
  */

--- a/pkg/uwb-core/include/dpl/dpl_eventq.h
+++ b/pkg/uwb-core/include/dpl/dpl_eventq.h
@@ -33,7 +33,7 @@ extern "C" {
  * @brief dpl event wrapper
  */
 struct dpl_event {
-    struct os_event ev;     /**< the envent */
+    struct os_event ev;     /**< the event */
 };
 
 /**

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -556,7 +556,7 @@ Here are some of the highlights:
 + RIOT boots on two newly added boards:
     + The Nintendo Game Boy Advance (#19519)
     + Native on 64-bit Linux / x86_64 (#20315, #20335, #20339)
-+ The documentation features a new guide to help you set up a RIOT develpoment environment on Windows (#20426)
++ The documentation features a new guide to help you set up a RIOT development environment on Windows (#20426)
 + To accommodate the ever growing RAM sizes in the IoT, RIOT can now monitor your `malloc` usage (#20363)
 - Dependency modelling via Kconfig is no longer part of RIOT. A big step forward towards having only one source of truth for configurations (#20438)
 
@@ -7088,7 +7088,7 @@ FIDO2 support
 -------------
 
 We now have an implementation of the Fast Identity Online 2 (FIDO2) specification.
-With this you can use any RIOT device with USB support as an authenticaton token
+With this you can use any RIOT device with USB support as an authentication token
 similar to the YubiKey.
 
 RPL-over-BLE

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -91,7 +91,7 @@ extern "C" {
  *   passing stdin (`isrpipe_t stdin_isrpipe`) does not support backpressure
  *   and overflows silently. As a consequence, commands through such terminals
  *   appear to be truncated at @ref STDIO_RX_BUFSIZE bytes (defaulting to 64)
- *   unless the command is sent in parts (on many terminals, by presing Ctrl-D
+ *   unless the command is sent in parts (on many terminals, by pressing Ctrl-D
  *   half way through the command).
  *
  *   For example, this affects systems with direct USB stdio (@ref

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_fsm.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_fsm.h
@@ -12,7 +12,7 @@
  * @{
  *
  * @file
- * @brief       TCP finite state maschine declarations.
+ * @brief       TCP finite state machine declarations.
  *
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
@@ -64,7 +64,7 @@ typedef enum {
 } _gnrc_tcp_fsm_event_t;
 
 /**
- * @brief TCP finite state maschine
+ * @brief TCP finite state machine
  *
  * @param[in,out] tcb     TCB holding the connection information.
  * @param[in]     event   Current event that triggers FSM transition.


### PR DESCRIPTION
### Contribution description

The static tests have been failing on `master` for some time due to codespell findings: https://github.com/RIOT-OS/RIOT/actions/workflows/static-test.yml
That happened probably after some update to the `riot/riotbuild` docker image, which presumably lead to a version bump of codespell.

This PR adds some new false positives to the ignored-words list and fixes several found true positives throughout the codebase.


### Testing procedure

Review typo corrections and newly added false positives.

Static tests in this PR will probably run through anyway as for all the other recent PRs. I'm wondering if the static-test workflow somehow uses a cached version of `riot/static-test-tools:latest`, since pulling that and executing the codespell check locally there also fails.
