### PR TITLE
pkg/driver_bme680: use mirror of git repo

### DIFF
--- a/pkg/driver_bme680/Makefile
+++ b/pkg/driver_bme680/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME=driver_bme680
-PKG_URL=https://github.com/BoschSensortec/BME680_driver
+PKG_URL=https://github.com/RIOT-OS-pkgmirror/BME680_driver
 PKG_VERSION=63bb5336db4659519860832be2738c685133aa33
 PKG_LICENSE=BSD-3-Clause
 


### PR DESCRIPTION
### Contribution description

The upstream repo has gone, so let's use a mirror for now to avoid build failures.

### Testing procedure

`make -C tests/drivers/bme680` will now succeed. (Note: You may need to remove the `$(BUILD_DIR)/pkg/driver_bme680` folder first to clear the local cache, otherwise the build system will never check the upstream.)

### Issues/PRs references

None