### PR TITLE
cpu/sam0_common/periph_dma: Fix API mismatch

### DIFF
--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -170,7 +170,7 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
 }
 
 void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst,
-                 size_t num, uint8_t incr)
+                 size_t num, dma_incr_t incr)
 {
     DEBUG("[DMA]: Prepare %u, num: %u\n", dma, (unsigned)num);
     DmacDescriptor *descr = &descriptors[dma];


### PR DESCRIPTION
### Contribution description

Match the signature of the implementation of the dma_prepare() with the declaration to fix:

    /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common/periph/dma.c:172:6: error: conflicting types for 'dma_prepare' due to enum/integer mismatch; have 'void(dma_t,  uint8_t,  const void *, void *, size_t,  uint8_t)' {aka 'void(unsigned int,  unsigned char,  const void *, void *, unsigned int,  unsigned char)'} [-Werror=enum-int-mismatch]
      172 | void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst,
          |      ^~~~~~~~~~~
    In file included from /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/samd5x/include/periph_cpu.h:26,
                     from /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common/periph/dma.c:21:
    /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common/include/periph_cpu_common.h:1186:6: note: previous declaration of 'dma_prepare' with type void(dma_t,  uint8_t,  const void *, void *, size_t,  dma_incr_t)' {aka 'void(unsigned int,  unsigned char,  const void *, void *, unsigned int,  dma_incr_t)'}
     1186 | void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst,
          |      ^~~~~~~~~~~


### Testing procedure

The following should now compile with GCC 13.2.1 (as shipped by Ubuntu 24.04.1 LTS):

- `make BOARD=same54-xpro -C tests/periph/spi_dma`
- `make BOARD=same54-xpro -C tests/periph/dma`

### Issues/PRs references

None