### PR TITLE
boards/adafruit-grand-central-m4-express: provide arduino features

### DIFF
--- a/boards/adafruit-grand-central-m4-express/Makefile.features
+++ b/boards/adafruit-grand-central-m4-express/Makefile.features
@@ -17,4 +17,8 @@ FEATURES_PROVIDED += periph_usbdev
 # other board features
 FEATURES_PROVIDED += arduino_analog
 FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_shield_isp
+FEATURES_PROVIDED += arduino_shield_mega
+FEATURES_PROVIDED += arduino_shield_uno
+FEATURES_PROVIDED += arduino_spi
 FEATURES_PROVIDED += sdcard_spi

--- a/boards/adafruit-grand-central-m4-express/include/arduino_iomap.h
+++ b/boards/adafruit-grand-central-m4-express/include/arduino_iomap.h
@@ -85,6 +85,16 @@ extern "C" {
 #define ARDUINO_ANALOG_PIN_LAST 5
 /** @} */
 
+/**
+ * @name    Arduino's default SPI device
+ * @{
+ */
+/**
+ * @brief   SPI_DEV(0) is connected to the ISP header *AND* the SD card reader
+ */
+#define ARDUINO_SPI_ISP         SPI_DEV(0)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/adafruit-grand-central-m4-express/include/periph_conf.h
+++ b/boards/adafruit-grand-central-m4-express/include/periph_conf.h
@@ -204,7 +204,7 @@ static const tc32_conf_t timer_config[] = {
  * @{
  */
 static const spi_conf_t spi_config[] = {
-    {   /* SPI on XIO connector */
+    {   /* SPI on XIO connector *AND* SPI on ISP */
         .dev      = &(SERCOM7->SPI),
         .miso_pin = GPIO_PIN(PD, 11),   /* D50 MISO */
         .mosi_pin = GPIO_PIN(PD, 8),    /* D51 MOSI */


### PR DESCRIPTION
### Contribution description

The board is compatible with Arduino UNO and Arduino MEGA shields and has an ISP connector, so this adds the corresponding features.

This adds the Arduino I/O-mapping for the ISP SPI and provides the corresponding feature.

It appears that the SPI on D11/D12/D13 cannot be provided by a SERCOM, this is under clarification at [1]. For now, no I/O mapping for that SPI bus is provided.

[1]: https://forums.adafruit.com/viewtopic.php?t=214093

### Testing procedure

An Arduino Shield that uses the ISP SPI bus (the older ones targeting the AVR based Arduinos still do that) should now work out of the box.

E.g.

```
USEMODULE=shield_w5100 make -C examples/gnrc_networking BOARD=adafruit-grand-central-m4-express flash term
[...]

2024-10-10 10:28:28,746 # ifconfig
2024-10-10 10:28:28,747 # Iface  6  HWaddr: A6:45:6B:D7:7E:41 
2024-10-10 10:28:28,747 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2024-10-10 10:28:28,747 #           RTR_ADV  
2024-10-10 10:28:28,748 #           Source address length: 6
2024-10-10 10:28:28,748 #           Link type: wired
2024-10-10 10:28:28,748 #           inet6 addr: fe80::a445:6bff:fed7:7e41  scope: link  VAL
2024-10-10 10:28:28,748 #           inet6 group: ff02::2
2024-10-10 10:28:28,750 #           inet6 group: ff02::1
2024-10-10 10:28:28,750 #           inet6 group: ff02::1:ffd7:7e41
2024-10-10 10:28:28,750 #           inet6 group: ff02::1a
2024-10-10 10:28:28,751 #           
2024-10-10 10:28:28,751 #           Statistics for Layer 2
2024-10-10 10:28:28,751 #             RX packets 0  bytes 0
2024-10-10 10:28:28,751 #             TX packets 1 (Multicast: 1)  bytes 78
2024-10-10 10:28:28,751 #             TX succeeded 0 errors 0
2024-10-10 10:28:28,752 #           Statistics for IPv6
2024-10-10 10:28:28,752 #             RX packets 0  bytes 0
2024-10-10 10:28:28,752 #             TX packets 1 (Multicast: 1)  bytes 64
2024-10-10 10:28:28,752 #             TX succeeded 1 errors 0
```

### Issues/PRs references

None