### PR TITLE
tests/pkg/emlearn: drop model.h from builddep

### DIFF
--- a/tests/pkg/emlearn/Makefile
+++ b/tests/pkg/emlearn/Makefile
@@ -4,8 +4,6 @@ USEPKG += emlearn
 
 BLOBS += digit
 
-BUILDDEPS += model.h
-
 include $(RIOTBASE)/Makefile.include
 
 model_head.h:


### PR DESCRIPTION
### Contribution description

Now that model.h is in the repo, it no longer is a build dependency. This allows compilation of the test without having emlearn installed, which is useful e.g. for build testing.

### Testing procedure

Uninstall emlearn and run `make -C tests/pkg/emlearn`. It should now work.

### Issues/PRs references

I should have done so in https://github.com/RIOT-OS/RIOT/pull/20841 already
