### PR TITLE
sys/event: add API to start periodic event without initial delay

### DIFF
--- a/sys/event/periodic.c
+++ b/sys/event/periodic.c
@@ -25,7 +25,6 @@
 static bool _event_periodic_callback(void *arg)
 {
     event_periodic_t *event_periodic = (event_periodic_t *)arg;
-
     event_post(event_periodic->queue, event_periodic->event);
 
     if (event_periodic->count && --event_periodic->count == 0) {

--- a/sys/include/event/periodic.h
+++ b/sys/include/event/periodic.h
@@ -73,6 +73,28 @@ void event_periodic_init(event_periodic_t *event_periodic, ztimer_clock_t *clock
                          event_queue_t *queue, event_t *event);
 
 /**
+ * @brief   Starts a periodic timeout without delay for the first occurrence
+ *
+ * This will make the event as configured in @p event_periodic be triggered
+ * at every interval ticks (based on event_periodic->clock).
+ *
+ * @note: the used event_periodic struct must stay valid until after the timeout
+ *        event has been processed!
+ *
+ * @note: this function does not touch the current count value.
+ *
+ * @note: the periodic event will start without delay.
+ *
+ * @param[in]   event_periodic   event_timout context object to use
+ * @param[in]   interval         period length for the event
+ */
+static inline void event_periodic_start_now(event_periodic_t *event_periodic, uint32_t interval)
+{
+    event_periodic->timer.interval = interval;
+    ztimer_periodic_start_now(&event_periodic->timer);
+}
+
+/**
  * @brief   Starts a periodic timeout
  *
  * This will make the event as configured in @p event_periodic be triggered

--- a/sys/include/ztimer/periodic.h
+++ b/sys/include/ztimer/periodic.h
@@ -131,6 +131,19 @@ void ztimer_periodic_init(ztimer_clock_t *clock, ztimer_periodic_t *timer,
 void ztimer_periodic_start(ztimer_periodic_t *timer);
 
 /**
+ * @brief    Start or restart a periodic timer without initial timer delay
+ *
+ * When called on a newly initialized timer, the timer will start.
+ *
+ * When called on an already running timer, the current interval is reset to its
+ * start (thus the next callback will be called after the configured interval
+ * has passed).
+ *
+ * @param[in]   timer   periodic timer object to work on
+ */
+void ztimer_periodic_start_now(ztimer_periodic_t *timer);
+
+/**
  * @brief   Stop a periodic timer
  *
  * The periodic timer will not trigger anymore.

--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -75,6 +75,11 @@ void ztimer_periodic_start(ztimer_periodic_t *timer)
     timer->last = ztimer_set(timer->clock, &timer->timer, timer->interval) + timer->interval;
 }
 
+void ztimer_periodic_start_now(ztimer_periodic_t *timer)
+{
+    timer->last = ztimer_set(timer->clock, &timer->timer, 0);
+}
+
 void ztimer_periodic_stop(ztimer_periodic_t *timer)
 {
     ztimer_remove(timer->clock, &timer->timer);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Depending on what you want, a periodic event could happen the first time after the first interval, or without initial delay.
Only the first variant is implemented in RIOT so far. This adds an API to start it without delay.

Currently I am misusing the timed events for that. I initialize them with 0 delay and in their callback I re-initialize and add them again with actual delay. The reinit is an invitation for race conditions if the event could also be added from another thread as the event thread.  

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I added a call to the new API in `tests/sys/event_ztimer`.

```
Help: Press s to start test, r to print it is ready
s
START
main(): This is RIOT! (Version: 2024.10-devel-292-gb6d800-pr/event_periodic_no_delay)
posting periodic timed callback with timeout 1sec
waiting for periodic callback to be triggered 4 times
trigger 1 of periodic timeout, elapsed time: 1000547 us
trigger 2 of periodic timeout, elapsed time: 1000076 us
stop periodic event
resume periodic event, 2 triggers remaining
trigger 3 of periodic timeout, elapsed time: 663 us
trigger 4 of periodic timeout, elapsed time: 999972 us
posting periodic timed callback with timeout 1sec and no delay
waiting for periodic callback to be triggered 4 times
trigger 1 of periodic timeout, elapsed time: 406 us
trigger 2 of periodic timeout, elapsed time: 1000223 us
stop periodic event
resume periodic event, 2 triggers remaining
trigger 3 of periodic timeout, elapsed time: 682 us
trigger 4 of periodic timeout, elapsed time: 1000017 us
posting timed callback with timeout 0.5sec, clear right after
posting timed callback with timeout 1sec
waiting for timed callback to trigger
triggered timed callback after 1000794us
[SUCCESS]
{ "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 600 }]}
{ "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2452 }]}
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
