### PR TITLE
boards/adafruit-metro-m4-express: initial port

### DIFF
--- a/boards/adafruit-metro-m4-express/Kconfig
+++ b/boards/adafruit-metro-m4-express/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (C) 2024 ML!PA Consulting GmbH
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "adafruit-metro-m4-express" if BOARD_ADAFRUIT_METRO_M4_EXPRESS
+
+config BOARD_ADAFRUIT_METRO_M4_EXPRESS
+    bool
+    default y
+    select CPU_MODEL_SAMD51J19

--- a/boards/adafruit-metro-m4-express/Makefile
+++ b/boards/adafruit-metro-m4-express/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/samdx1-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/adafruit-metro-m4-express/Makefile.dep
+++ b/boards/adafruit-metro-m4-express/Makefile.dep
@@ -1,0 +1,17 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# default to using littlefs2 on QSPI flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi_on_qspi
+  USEMODULE += mtd_spi_nor
+endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.dep

--- a/boards/adafruit-metro-m4-express/Makefile.features
+++ b/boards/adafruit-metro-m4-express/Makefile.features
@@ -1,0 +1,24 @@
+CPU = samd5x
+CPU_MODEL = samd51j19a
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# other board features
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_shield_isp
+FEATURES_PROVIDED += arduino_shield_uno
+FEATURES_PROVIDED += arduino_spi
+
+FEATURES_CONFLICT += periph_uart:periph_spi
+FEATURES_CONFLICT_MSG += "SERCOM3 is needed by both periph_uart and periph_spi on the Metro M4 Express"

--- a/boards/adafruit-metro-m4-express/Makefile.include
+++ b/boards/adafruit-metro-m4-express/Makefile.include
@@ -1,0 +1,6 @@
+CFLAGS += -DBOOTLOADER_UF2
+
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
+# Include handling of serial and non-bossa programmers (if selected by user)
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/adafruit-metro-m4-express/board.c
+++ b/boards/adafruit-metro-m4-express/board.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-metro-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Adafruit Metro M4 Express
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+#include "timex.h"
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+#endif
+
+#ifdef MODULE_MTD_SPI_NOR
+
+#include "mtd_spi_nor.h"
+
+/* GD25Q16C */
+static const mtd_spi_nor_params_t _samd51_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 25 * US_PER_SEC,
+    .wait_32k_erase = 150 * US_PER_MS,
+    .wait_64k_erase = 200 * US_PER_MS,
+    .wait_sector_erase = 50 * US_PER_MS,
+    .wait_chip_wake_up = 10 * US_PER_MS,
+    .clk  = MHZ(54),
+    .flag = SPI_NOR_F_SECT_4K
+          | SPI_NOR_F_SECT_32K
+          | SPI_NOR_F_SECT_64K,
+    .spi  = SPI_DEV(2),
+    .mode = SPI_MODE_0,
+    .cs   = SAM0_QSPI_PIN_CS,
+    .wp   = SAM0_QSPI_PIN_DATA_2,
+    .hold = SAM0_QSPI_PIN_DATA_3,
+};
+
+static mtd_spi_nor_t samd51_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .sector_count = 512,
+        .page_size = 256,
+        .pages_per_sector = 16,
+    },
+    .params = &_samd51_nor_params,
+};
+
+MTD_XFA_ADD(samd51_nor_dev, 0);
+
+#ifdef MODULE_VFS_DEFAULT
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(samd51_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
+
+#endif /* MODULE_MTD_SPI_NOR */

--- a/boards/adafruit-metro-m4-express/dist/openocd.cfg
+++ b/boards/adafruit-metro-m4-express/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find target/atsame5x.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/adafruit-metro-m4-express/doc.txt
+++ b/boards/adafruit-metro-m4-express/doc.txt
@@ -1,0 +1,60 @@
+/**
+@defgroup    boards_adafruit-metro-m4-express Adafruit Metro M4 Express
+@ingroup     boards
+@brief       Support for the Adafruit Metro M4 Express
+
+General information
+===================
+
+@image html https://cdn-learn.adafruit.com/assets/assets/000/085/521/large1024/adafruit_products_metro-m4-top.jpg "Picture of the Adafruit Metro M4 Express"
+
+The main features of the board are:
+- ATSAMD51 Cortex M4 running at 120 MHz
+- Hardware DSP and floating point support
+- 512 MiB Flash
+- 192 KiB KiB RAM
+- external 2 MiB QSPI Flash storage
+- WS281x RGB LED (NeoPixel)
+- 32-bit, 3.3V logic and power
+- native USB
+
+Pinout
+------
+
+@image html https://cdn-learn.adafruit.com/assets/assets/000/111/183/original/adafruit_products_Adafruit_Metro_M4_Express_Pinout.png "Official Pinout of the Metro M4 Express" width=100%
+
+Links
+=====
+
+- [Official Board Documentation](https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51)
+
+Schematics
+==========
+
+@image html https://cdn-learn.adafruit.com/assets/assets/000/053/093/original/adafruit_products_schem.png "Original Board Schematics"
+
+Flash the board
+===============
+
+The board is flashed using its on-board
+[boot loader](https://github.com/adafruit/uf2-samdx1).
+
+The process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU
+and enter the bootloader. If some other firmware is running or RIOT crashed,
+you need to enter the bootloader manually by double tapping the board's reset
+button.
+
+Readiness of the bootloader is indicated by LED pulsing in red.
+
+@note   You may need to pass `MOST_RECENT_PORT=0` and manually pass the `PORT`
+        if you enter the bootloader by hand.
+
+Accessing STDIO
+---------------
+
+The usual way to obtain a console on this board is using an emulated USB serial
+port.
+
+ */

--- a/boards/adafruit-metro-m4-express/include/arduino_iomap.h
+++ b/boards/adafruit-metro-m4-express/include/arduino_iomap.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-metro-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef ARDUINO_IOMAP_H
+#define ARDUINO_IOMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PA, 23)
+#define ARDUINO_PIN_1           GPIO_PIN(PA, 22)
+#define ARDUINO_PIN_2           GPIO_PIN(PB, 17)
+#define ARDUINO_PIN_3           GPIO_PIN(PB, 16)
+#define ARDUINO_PIN_4           GPIO_PIN(PB, 13)
+#define ARDUINO_PIN_5           GPIO_PIN(PB, 14)
+#define ARDUINO_PIN_6           GPIO_PIN(PB, 15)
+#define ARDUINO_PIN_7           GPIO_PIN(PB, 12)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 21)
+#define ARDUINO_PIN_9           GPIO_PIN(PA, 20)
+#define ARDUINO_PIN_10          GPIO_PIN(PA, 18)
+#define ARDUINO_PIN_11          GPIO_PIN(PA, 19)
+#define ARDUINO_PIN_12          GPIO_PIN(PA, 17)
+#define ARDUINO_PIN_13          GPIO_PIN(PA, 16)
+
+/* SDA and SCL */
+#define ARDUINO_PIN_14          GPIO_PIN(PB, 2) /* SDA */
+#define ARDUINO_PIN_15          GPIO_PIN(PB, 3) /* SCL */
+
+/* Analog pins as digital pins: */
+#define ARDUINO_PIN_16          GPIO_PIN(PA, 2) /* A0 */
+#define ARDUINO_PIN_17          GPIO_PIN(PA, 5) /* A1 */
+#define ARDUINO_PIN_18          GPIO_PIN(PA, 6) /* A2 */
+#define ARDUINO_PIN_19          GPIO_PIN(PA, 4) /* A3 */
+#define ARDUINO_PIN_20          GPIO_PIN(PB, 8) /* A4 */
+#define ARDUINO_PIN_21          GPIO_PIN(PB, 9) /* A5 */
+
+#define ARDUINO_PIN_LAST        21
+/** @} */
+
+/**
+ * @name    Aliases for non-digital pins as digital pins
+ * @{
+ */
+#define ARDUINO_PIN_SDA         ARDUINO_PIN_14
+#define ARDUINO_PIN_SCL         ARDUINO_PIN_15
+#define ARDUINO_PIN_A0          ARDUINO_PIN_16
+#define ARDUINO_PIN_A1          ARDUINO_PIN_17
+#define ARDUINO_PIN_A2          ARDUINO_PIN_18
+#define ARDUINO_PIN_A3          ARDUINO_PIN_19
+#define ARDUINO_PIN_A4          ARDUINO_PIN_20
+#define ARDUINO_PIN_A5          ARDUINO_PIN_21
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+
+#define ARDUINO_ANALOG_PIN_LAST 5
+/** @} */
+
+/**
+ * @name    Arduino's default SPI device
+ * @{
+ */
+/**
+ * @brief   SPI_DEV(0) is connected to the ISP header
+ */
+#define ARDUINO_SPI_ISP         SPI_DEV(0)
+/**
+ * @brief   SPI_DEV(1) is connected to D11/D12/D13
+ */
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_IOMAP_H */
+/** @} */

--- a/boards/adafruit-metro-m4-express/include/board.h
+++ b/boards/adafruit-metro-m4-express/include/board.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-metro-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Adafruit Metro M4 Express
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "arduino_iomap.h"
+#include "cpu.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+
+#define LED0_PIN    GPIO_PIN(PA, 16)    /**< User LED red (D13) */
+#define LED1_PIN    GPIO_PIN(PA, 27)    /**< TX LED yellow */
+#define LED2_PIN    GPIO_PIN(PB, 6)     /**< RX LED yellow */
+
+#define LED0_PORT   PORT->Group[PA]     /**< Port of User LED red (D13) */
+#define LED0_MASK   (1U << 16)          /**< Mask of User LED red (D13) */
+#define LED1_PORT   PORT->Group[PA]     /**< Port of TX LED yellow */
+#define LED1_MASK   (1U << 27)          /**< Mask of TX LED yellow */
+#define LED2_PORT   PORT->Group[PB]     /**< Port of RX LED yellow */
+#define LED2_MASK   (1U << 6)           /**< Mask of RX LED yellow */
+
+#define LED0_ON     (LED0_PORT.OUTSET.reg = LED0_MASK)  /**< Switch on User LED red (D13) */
+#define LED0_OFF    (LED0_PORT.OUTCLR.reg = LED0_MASK)  /**< Switch off User LED red (D13) */
+#define LED0_TOGGLE (LED0_PORT.OUTTGL.reg = LED0_MASK)  /**< Toggle User LED red (D13) */
+
+#define LED1_ON     (LED1_PORT.OUTCLR.reg = LED1_MASK)  /**< Switch on TX LED yellow */
+#define LED1_OFF    (LED1_PORT.OUTSET.reg = LED1_MASK)  /**< Switch off TX LED yellow */
+#define LED1_TOGGLE (LED1_PORT.OUTTGL.reg = LED1_MASK)  /**< Toggle TX LED yellow */
+
+#define LED2_ON     (LED2_PORT.OUTCLR.reg = LED2_MASK)  /**< Switch on RX LED yellow */
+#define LED2_OFF    (LED2_PORT.OUTSET.reg = LED2_MASK)  /**< Switch off RX LED yellow */
+#define LED2_TOGGLE (LED2_PORT.OUTTGL.reg = LED2_MASK)  /**< Toggle User RX LED yellow */
+
+#ifndef WS281X_PARAM_PIN
+#define WS281X_PARAM_PIN    GPIO_PIN(PB, 22)    /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)                /**< Number of LEDs chained */
+#endif
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+#define MTD_0 mtd_dev_get(0)    /**< MTD device for the 8 MiB QSPI Flash */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/adafruit-metro-m4-express/include/gpio_params.h
+++ b/boards/adafruit-metro-m4-express/include/gpio_params.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-metro-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED User (red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "LED TX (yellow)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name = "LED RX (yellow)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/adafruit-metro-m4-express/include/periph_conf.h
+++ b/boards/adafruit-metro-m4-express/include/periph_conf.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2024 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-metro-m4-express
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Adafruit Metro M4 Express
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Core clock frequency
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+#define CLOCK_CORECLOCK     MHZ(120)
+#endif
+/** @} */
+
+/**
+ * @name    32kHz Oscillator configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                   1
+#define INTERNAL_OSC32_SOURCE                   0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE     0
+/** @} */
+
+/**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with L_EXT (L1) of 10uH at VSW pin.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+#define ADC_PRESCALER                       ADC_CTRLA_PRESCALER_DIV128
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos, dev */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA02, .dev = ADC0 }, /* A0 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA05, .dev = ADC0 }, /* A1 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA06, .dev = ADC0 }, /* A2 */
+    { .inputctrl = ADC0_INPUTCTRL_MUXPOS_PA04, .dev = ADC0 }, /* A3 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB08, .dev = ADC1 }, /* A4 */
+    { .inputctrl = ADC1_INPUTCTRL_MUXPOS_PB09, .dev = ADC1 }, /* A5 */
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+                            /* Must not exceed 12 MHz */
+#define DAC_CLOCK           SAM0_GCLK_TIMER
+                            /* Use external reference voltage on PA03 */
+                            /* (A solder jumper connects PA03 to 3V3 on the
+                             * back of the board. We assume the jumper has
+                             * not been cut.) */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VREFPU
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM5->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PB, 3),   /* D: SERCOM5.1 */
+        .sda_pin  = GPIO_PIN(PB, 2),   /* D: SERCOM5.0 */
+        .mux      = GPIO_MUX_D,
+        .gclk_src = SAM0_GCLK_PERIPH,
+        .flags    = I2C_FLAG_NONE
+    },
+};
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC0,
+        .irq            = TC0_IRQn,
+        .mclk           = &MCLK->APBAMASK.reg,
+        .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
+        .gclk_id        = TC0_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {   /* Timer 1 */
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
+        .mclk           = &MCLK->APBBMASK.reg,
+        .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
+        .gclk_id        = TC2_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_ISR         isr_tc0
+
+/* Timer 1 configuration */
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_ISR         isr_tc2
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* SPI on ISP */
+        .dev      = &(SERCOM2->SPI),
+        .miso_pin = GPIO_PIN(PA, 14), /* C: SERCOM2.2, D: SERCOM4.2 */
+        .mosi_pin = GPIO_PIN(PA, 12), /* C: SERCOM2.0, D: SERCOM4.1 */
+        .clk_pin  = GPIO_PIN(PA, 13), /* C: SERCOM2.1, D: SERCOM4.0 */
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_2,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM2_DMAC_ID_TX,
+        .rx_trigger = SERCOM2_DMAC_ID_RX,
+#endif
+    },
+    {   /* D11=MOSI, D12=MISO, D13=SCK */
+        .dev      = &(SERCOM3->SPI),
+        .miso_pin = GPIO_PIN(PA, 17), /* C: SERCOM1.1, D: SERCOM3.0 */
+        .mosi_pin = GPIO_PIN(PA, 19), /* C: SERCOM1.3, D: SERCOM3.3 */
+        .clk_pin  = GPIO_PIN(PA, 16), /* C: SERCOM1.0, D: SERCOM3.1 */
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_3_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM3_DMAC_ID_TX,
+        .rx_trigger = SERCOM3_DMAC_ID_RX,
+#endif
+    },
+#ifdef MODULE_PERIPH_SPI_ON_QSPI
+    {    /* QSPI in SPI mode */
+        .dev      = QSPI,
+        .miso_pin = SAM0_QSPI_PIN_DATA_1,
+        .mosi_pin = SAM0_QSPI_PIN_DATA_0,
+        .clk_pin  = SAM0_QSPI_PIN_CLK,
+        .miso_mux = SAM0_QSPI_MUX,
+        .mosi_mux = SAM0_QSPI_MUX,
+        .clk_mux  = SAM0_QSPI_MUX,
+        .miso_pad = SPI_PAD_MISO_0,         /* unused */
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,   /* unused */
+        .gclk_src = SAM0_GCLK_MAIN,         /* unused */
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = QSPI_DMAC_ID_TX,
+        .rx_trigger = QSPI_DMAC_ID_RX,
+#endif
+    },
+#endif
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_H,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    }
+};
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+/* The UART pins can be routed to SERCOM3 (used by SPI) or
+ * SERCOM5 (used by I2C). The pad configuration for SERCOM5
+ * is impossible, as TXD cannot be routed to pad 1.
+ * Hence, we let periph_spi and periph_uart conflict in
+ * Makefile.features.
+ */
+    /* D0 = RXD, D1 = TXD */
+    {
+        .dev      = &SERCOM3->USART,
+        .rx_pin   = GPIO_PIN(PA, 23),   /* C: SERCOM3.1, D: SERCOM5.0 */
+        .tx_pin   = GPIO_PIN(PA, 22),   /* C: SERCOM3.0, D: SERCOM5.1 */
+  #ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+  #endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom3_2
+#define UART_0_ISR_TX       isr_sercom3_0
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This adds the board specification of the Adafruit Metro M4 Express [1]. The significance of this board is that it is compatible with both classical SPI Arduino Shields using the ISP header for SPI (such as `shield_w5100`) and more recent shields using D11/D12/D13 as SPI (such as `shield_llcc68`).

[1]: https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51/overview

### Testing procedure

```
USEMODULE=shield_w5100 make -C examples/gnrc_networking BOARD=adafruit-metro-m4-express flash term MOST_RECENT_PORT=0
[...]
2024-10-15 20:44:18,578 # ifconfig
2024-10-15 20:44:18,579 # Iface  6  HWaddr: A6:99:B8:23:96:3C 
2024-10-15 20:44:18,579 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2024-10-15 20:44:18,579 #           RTR_ADV  
2024-10-15 20:44:18,580 #           Source address length: 6
2024-10-15 20:44:18,580 #           Link type: wired
2024-10-15 20:44:18,580 #           inet6 addr: fe80::a499:b8ff:fe23:963c  scope: link  VAL
2024-10-15 20:44:18,580 #           inet6 group: ff02::2
2024-10-15 20:44:18,580 #           inet6 group: ff02::1
2024-10-15 20:44:18,581 #           inet6 group: ff02::1:ff23:963c
2024-10-15 20:44:18,581 #           inet6 group: ff02::1a
2024-10-15 20:44:18,581 #           
2024-10-15 20:44:18,581 #           Statistics for Layer 2
2024-10-15 20:44:18,581 #             RX packets 0  bytes 0
2024-10-15 20:44:18,582 #             TX packets 1 (Multicast: 1)  bytes 78
2024-10-15 20:44:18,582 #             TX succeeded 0 errors 0
2024-10-15 20:44:18,582 #           Statistics for IPv6
2024-10-15 20:44:18,582 #             RX packets 0  bytes 0
2024-10-15 20:44:18,582 #             TX packets 1 (Multicast: 1)  bytes 64
2024-10-15 20:44:18,583 #             TX succeeded 1 errors 0
```

```
USEMODULE=shield_llcc68 make -C examples/gnrc_networking BOARD=adafruit-metro-m4-express flash term MOST_RECENT_PORT=0
[...]
2024-10-15 20:46:18,178 # ifconfig
2024-10-15 20:46:18,179 # Iface  6  Frequency: 868300000Hz  RSSI: -128  BW: 125kHz  SF: 7  CR: 4/5 
2024-10-15 20:46:18,179 #            State: STANDBY 
2024-10-15 20:46:18,180 #           MTU:65535  HL:64  RTR  
2024-10-15 20:46:18,180 #           RTR_ADV  
2024-10-15 20:46:18,180 #           Link type: wireless
2024-10-15 20:46:18,180 #           inet6 group: ff02::2
2024-10-15 20:46:18,180 #           inet6 group: ff02::1
2024-10-15 20:46:18,180 #           inet6 group: ff02::1a
2024-10-15 20:46:18,181 #           
2024-10-15 20:46:18,181 #           Statistics for Layer 2
2024-10-15 20:46:18,181 #             RX packets 0  bytes 0
2024-10-15 20:46:18,181 #             TX packets 0 (Multicast: 0)  bytes 0
2024-10-15 20:46:18,181 #             TX succeeded 0 errors 0
2024-10-15 20:46:18,181 #           Statistics for IPv6
2024-10-15 20:46:18,182 #             RX packets 0  bytes 0
2024-10-15 20:46:18,182 #             TX packets 0 (Multicast: 0)  bytes 0
2024-10-15 20:46:18,182 #             TX succeeded 0 errors 0
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
