### PR TITLE
boards/saml10-xpro: enable ATECC508A

### DIFF
--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -30,12 +30,11 @@ extern "C" {
 #endif
 
 /**
- * @brief ATCA device type on SAML11 XPro boards
+ * @brief ATCA device type on SAML1x XPro boards
  * @{
  */
-#ifdef BOARD_SAML11_XPRO
-#define ATCA_DEVTYPE    (ATECC508A)
-#endif
+#define ATCA_DEVTYPE        ATECC508A
+#define ATCA_PARAM_I2C      I2C_DEV(0)      /**< I2C bus device is connected to */
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Both `saml10-xpro` and `saml11-xpro` come with the ATECC508A chuip, so don't guard it for one board.


### Testing procedure

I ran `tests/pkg/cryptoauthlib_compare_sha256` on `saml10-xpro`

```
2024-10-16 15:36:28,700 # main(): This is RIOT! (Version: 2024.10-devel-303-g79dc90-boards/saml10-xpro_cryptoauthlib)
2024-10-16 15:36:28,703 # RIOT SHA256: Success
2024-10-16 15:36:28,728 # ATCA SHA256: Success
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
