### PR TITLE
cpu/esp32: Improve error descriptions

### DIFF
--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -47,7 +47,7 @@ else ifeq ($(CPU_CORE),cortex-m4f)
 else ifeq ($(CPU_CORE),cortex-m7)
   CPU_ARCH := armv7m
 else
-  $(error Unkwnown cortexm core: $(CPU_CORE))
+  $(error Unknown cortexm core: $(CPU_CORE))
 endif
 
 ifneq (,$(RUST_TARGET))

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -8,7 +8,7 @@ else ifneq (,$(filter esp32s2 esp32s3,$(CPU_FAM)))
   CPU_ARCH = xtensa
   CPU_CORE = xtensa-lx7
 else
-  $(error Unkwnown ESP32x SoC variant (family))
+  $(error Unknown ESP32x SoC variant (family): $(CPU_FAM))
 endif
 
 # MCU defined features that are provided independent on board definitions

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -25,7 +25,7 @@ else ifneq (,$(filter esp32s2,$(CPU_FAM)))
   export FLASH_SIZE ?= 4
   BOOTLOADER_POS = 0x1000
 else
-  $(error Unkwnown ESP32x SoC variant (family))
+  $(error No known flash config for ESP32x SoC variant (family): $(CPU_FAM))
 endif
 
 # RAM configuration
@@ -56,7 +56,7 @@ else ifeq (esp32c3,$(CPU_FAM))
   RAM_LEN = 320K
   RAM_START_ADDR = 0x3FC80000
 else
-  $(error Unkwnown ESP32x SoC variant (family))
+  $(error Missing ram configuration for ESP32x SoC variant (family): $(CPU_FAM))
 endif
 
 ifneq (,$(filter periph_flashpage,$(USEMODULE)))
@@ -103,7 +103,7 @@ ifeq (xtensa,$(CPU_ARCH))
 else ifeq (rv32,$(CPU_ARCH))
   TARGET_ARCH ?= riscv32-esp-elf
 else
-  $(error Unkwnown ESP32x SoC architecture)
+  $(error Unknown ESP32x SoC architecture: $(CPU_ARCH))
 endif
 
 PSEUDOMODULES += esp_ble
@@ -286,7 +286,7 @@ else ifeq (esp32s3,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.version.ld
 else
-  $(error Unkwnown ESP32x SoC variant (family))
+  $(error Unknown link flags for ESP32x SoC variant (family): $(CPU_FAM))
 endif
 
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR improves the error messages of the esp32 common makefiles when adding new esp32 based boards/cpu. 

The previous error messages did not make it clear which part was still missing when adding a new esp32 based board/cpu variant, thus making it needlessly complicated to pinpoint the problem (and also had a minor spelling mistake).

This also fixes the same spelling mistake for the cortexm error message.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I tested the hello_world on both `native`and `esp32c3-devkit` and also while adding a new variant to the `esp32` family. In all three cases everything worked as expected and it helped me to locate issues while adding a new variant.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
