### PR TITLE
sys/net/nanocoap: fix UB when building hdr

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1946,6 +1946,11 @@ ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,
  * @param[in]    code       CoAP code (e.g., COAP_CODE_204, ...)
  * @param[in]    id         CoAP request id
  *
+ * @pre     @p token is either not overlapping with the memory buffer
+ *          @p hdr points to, or is already at the right offset (e.g.
+ *          when building the response inside the buffer the contained
+ *          the request).
+ *
  * @returns      length of resulting header
  */
 ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, const void *token,


### PR DESCRIPTION
### Contribution description

Some calls to `coap_build_hdr()` were done with the target buffer for the header and the source buffer for the token overlapping: They reuse the buffer that held the request to assemble the response in. We cannot use `memcpy()` in this case to copy the token into the target buffer, as source and destination would (fully) overlap.

This commit makes reusing the request buffer for the response a special case: `memcpy()` is only used to copy the token if source and destination address of the token differ.

An alternative fix would have been to use `memmove()` unconditionally. But `memmove()` does not make any assumption about the layout of target and source buffer, while we know that the token either will already be at the right position (when reusing the request buffer for the response) or be in a non-overlapping buffer (when generating a fresh token). This approach is more efficient than `memmove()`.

### Testing procedure

This did not cause any issues yet, so just testing for regressions should be sufficient. The CI should provide decent test coverage.

### Issues/PRs references

Issue uncovered while debugging https://github.com/RIOT-OS/RIOT/pull/20900
