### PR TITLE
sys/nanocoap: add coap_pkt_set_code()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -688,6 +688,17 @@ static inline void coap_hdr_set_code(coap_hdr_t *hdr, uint8_t code)
 }
 
 /**
+ * @brief   Write the given raw message code to given CoAP pkt
+ *
+ * @param[out]  pkt     CoAP packet to write to
+ * @param[in]   code    raw message code
+ */
+static inline void coap_pkt_set_code(coap_pkt_t *pkt, uint8_t code)
+{
+    coap_hdr_set_code(pkt->hdr, code);
+}
+
+/**
  * @brief   Set the message type for the given CoAP header
  *
  * @pre     (type := [0-3])

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -585,7 +585,7 @@ static void _process_coap_pdu(gcoap_socket_t *sock, sock_udp_ep_t *remote, sock_
 
     if (messagelayer_emptyresponse_type != NO_IMMEDIATE_REPLY) {
         coap_hdr_set_type(pdu.hdr, (uint8_t)messagelayer_emptyresponse_type);
-        coap_hdr_set_code(pdu.hdr, COAP_CODE_EMPTY);
+        coap_pkt_set_code(&pdu, COAP_CODE_EMPTY);
         /* Set the token length to 0, preserving the CoAP version as it was and
          * the empty message type that was just set.
          *

--- a/sys/net/application_layer/nanocoap/fileserver.c
+++ b/sys/net/application_layer/nanocoap/fileserver.c
@@ -292,7 +292,7 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 
 late_err:
     vfs_close(fd);
-    coap_hdr_set_code(pdu->hdr, COAP_CODE_INTERNAL_SERVER_ERROR);
+    coap_pkt_set_code(pdu, COAP_CODE_INTERNAL_SERVER_ERROR);
     return coap_get_total_hdr_len(pdu);
 }
 


### PR DESCRIPTION
### Contribution description

This adds a small convenience function to set the CoAP code of a packet and converts users of coap_hdr_set_code() where applicable.

### Testing procedure

No regressions should be introduced (the CI will tell).

### Issues/PRs references

Relevant to https://github.com/RIOT-OS/rust-riot-wrappers/pull/130