### PR TITLE
sys/net/app/cord: update doc

### DIFF
--- a/examples/cord_ep/README.md
+++ b/examples/cord_ep/README.md
@@ -4,7 +4,7 @@ CoRE Resource Directory: Endpoint Example
 This example application demonstrates the usage of RIOT's Resource Directory
 (RD) endpoint module, called `cord_ep`. This module supports the registration,
 update, and removal procedures as defined in
-[draft-ietf-core-resource-directory-27](https://tools.ietf.org/html/draft-ietf-core-resource-directory-27).
+[RFC 9176](https://datatracker.ietf.org/doc/html/rfc9176).
 
 Usage
 =====

--- a/examples/cord_epsim/README.md
+++ b/examples/cord_epsim/README.md
@@ -3,7 +3,7 @@ CoRE Resource Directory: Simple Endpoint Example
 
 This example shows how a node can register with a CoRE resource directory using
 the simple registration procedure as described in
-draft-ietf-core-resource-directory-27, section 5.1.
+RFC 9176, section 5.1.
 
 When running this example, you **must** define the RD server's IPv6 address
 statically, using the `RD_ADDR` environment variable:

--- a/examples/cord_lc/README.md
+++ b/examples/cord_lc/README.md
@@ -4,7 +4,7 @@ CoRE Resource Directory: Lookup Example
 This example application demonstrates the usage of RIOT's Resource Directory
 (RD) lookup module, called `cord_lc`. This module supports the lookup of
 resources and endpoints as defined in
-[draft-ietf-core-resource-directory-27](https://tools.ietf.org/html/draft-ietf-core-resource-directory-27).
+[RFC 9176](https://datatracker.ietf.org/doc/html/rfc9176).
 The lookup can be done in two modes: a) raw: result of the lookup is returned
 as is. b) pre-parsed: result of the lookup is parsed and only one link is
 returned for each call.

--- a/sys/include/net/cord/ep.h
+++ b/sys/include/net/cord/ep.h
@@ -14,7 +14,7 @@
  * This module implements a CoRE Resource Directory endpoint library, that
  * allows RIOT nodes to register themselves with resource directories.
  * It implements the standard endpoint functionality as defined in
- * draft-ietf-core-resource-directory-27.
+ * RFC 9176.
  * @see https://datatracker.ietf.org/doc/html/rfc9176
  *
  * # Design Decisions

--- a/sys/include/net/cord/lc.h
+++ b/sys/include/net/cord/lc.h
@@ -15,8 +15,8 @@
  * allows RIOT nodes to lookup resources, endpoints and groups with resource
  * directories.
  * It implements the standard lookup functionality as defined in
- * draft-ietf-core-resource-directory-27.
- * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-27
+ * RFC 9176.
+ * @see https://datatracker.ietf.org/doc/html/rfc9176
  *
  * ## Lookup modes
  *

--- a/sys/net/application_layer/cord/doc.txt
+++ b/sys/net/application_layer/cord/doc.txt
@@ -56,8 +56,7 @@
  * - `cord_epsim`:  endpoint implementation following the simple registration
  *                  procedure as defined in section 5.3.1
  * - `cord_lc`:     lookup client implementation for querying information from
- *                  an RD using the lookup and group interfaces (**NOT
- *                  YET IMPLEMENTED**)
+ *                  an RD using the lookup interfaces
  * - `cord_config`: header file collection (default) configuration values used
  *                  throughout this module
  * - `cord_common`: shared functionality used by the above submodules

--- a/sys/net/application_layer/cord/doc.txt
+++ b/sys/net/application_layer/cord/doc.txt
@@ -15,11 +15,11 @@
  * # About
  * The `cord` ([Co]RE [R]esource [D]irectory) module provides endpoint and
  * lookup client functionality for interacting with CoRE Resource Directories
- * (RDs) as defined in `draft-ietf-core-resource-directory-27`.
+ * (RDs) as defined in `RFC 9176`.
  *
- * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-27
+ * @see https://datatracker.ietf.org/doc/html/rfc9176
  *
- * `draft-ietf-core-resource-directory-27` defines two types different roles for
+ * `RFC 9176` defines two types different roles for
  * nodes when interacting with a RD:
  * - `endpoint`: registers and manages entries at the RD
  * - `client`: performs different kind of lookups
@@ -39,7 +39,7 @@
  *   | EP |----      |                 |
  *   +----+
  * ```
- * Figure copied form `draft-ietf-core-resource-directory-27`.
+ * Figure copied form `RFC 9176`.
  *
  * @note In the context of this module, we refer to these roles as `endpoint
  *       (ep)` and `lookup client (lc)`. This should hopefully prevent some
@@ -49,7 +49,7 @@
  * # Structure
  *
  * This module is structured in a number of submodules with goal to reflect the
- * different roles described in `draft-ietf-core-resource-directory-27`:
+ * different roles described in `RFC 9176`:
  *
  * - `cord_ep`:     standard endpoint implementation following the rules as
  *                  defined i.a. in sections 5.2, 5.3, A.1, and A.2


### PR DESCRIPTION

### Contribution description

This PR updates the doc file of the `CORD` module and examples in RIOT. Updates:

- Update of the references to **RFC 9176**.
- Removal of the label **Not Yet Implemented** in the doc file of the `CORD` module, since it is obsolete.



### Testing procedure

- The **draft-ietf-core-resource-directory-27** was compared with the **RFC 9176** and no necessary changes in the implementation were found.
- An experimental Lookup Client was built, to test if the functions from the `cord_lc` of the `CORD` module in RIOT were implemented. Lookup requests were sent to an `aiocoap` Resource Directory implementation. All the functions in the `cord_lc` returned the expected results.


### Issues/PRs references

- [Comparison draft-ietf-core-resource-directory-27 vs RFC 9176](https://author-tools.ietf.org/iddiff?url1=draft-ietf-core-resource-directory-27&url2=rfc9176&difftype=--html)
- [aiocoap Resource Directory](https://aiocoap.readthedocs.io/en/latest/module/aiocoap.resourcedirectory.html#module-aiocoap.resourcedirectory)
- [RIOT Lookup Client](https://doc.riot-os.org/group__net__cord__lc.html)
