### PR TITLE
boards/nucleo-f722: fix typo in documentation

### DIFF
--- a/boards/nucleo-f722ze/doc.txt
+++ b/boards/nucleo-f722ze/doc.txt
@@ -10,7 +10,7 @@ STM32F722ZE microcontroller with 256KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f446ze-and-f722ze.svg "Pinout for the Nucleo-F722ZE (from STM ser manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50%
+@image html pinouts/nucleo-f446ze-and-f722ze.svg "Pinout for the Nucleo-F722ZE (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50%
 
 ### MCU
 


### PR DESCRIPTION
### Contribution description

This PR fix typo in `nucleo-f722ze` documentation page. 
Currently there is "STM ser manual" should be "STM user manual".

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f722ze.html
```

### Issues/PRs references

None.