### PR TITLE
stdio_udp: allow binding to a specific interface only

### DIFF
--- a/sys/stdio_udp/stdio_udp.c
+++ b/sys/stdio_udp/stdio_udp.c
@@ -30,6 +30,10 @@
 #define CONFIG_STDIO_UDP_PORT       2323
 #endif
 
+#ifndef CONFIG_STDIO_UDP_NETIF
+#define CONFIG_STDIO_UDP_NETIF      SOCK_ADDR_ANY_NETIF
+#endif
+
 #ifndef EOT
 #define EOT 0x4
 #endif
@@ -64,7 +68,7 @@ static void _init(void)
 {
     const sock_udp_ep_t local = {
         .family = AF_INET6,
-        .netif = SOCK_ADDR_ANY_NETIF,
+        .netif = CONFIG_STDIO_UDP_NETIF,
         .port = CONFIG_STDIO_UDP_PORT,
     };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Allow restricting the remote shell to a specific network interface.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
