### PR TITLE
sys/ztimer: gaurd against spurious ISR

### DIFF
--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -470,10 +470,17 @@ void ztimer_handler(ztimer_clock_t *clock)
 #endif
 
     if (clock->list.next) {
-        clock->list.offset += clock->list.next->offset;
-        clock->list.next->offset = 0;
+        _ztimer_update_head_offset(clock);
 
         ztimer_t *entry = _now_next(clock);
+
+        if (!entry && IS_ACTIVE(ENABLE_DEBUG))
+        {
+            DEBUG("ztimer_handler(): called %" PRIu32 " ticks too early\n"
+                , clock->list.next->offset
+                );
+        }
+
         while (entry) {
             DEBUG("ztimer_handler(): trigger %p->%p at %" PRIu32 "\n",
                   (void *)entry, (void *)entry->base.next, clock->ops->now(


### PR DESCRIPTION
### Contribution description

This patch changes `ztimer_handler()` to properly deal with spurious ISRs. Without the patch, a spurious ISR will potentially cause mutliple timers to fire early. With this patch, these ISRs are properly ignored.

The downside of this PR is that it increases the overhead of the ztimer ISR execution. One option would be to only enable it when `DEVELHELP` is set. Another option is to make this the default behavior, but revert to the old behavior for MCU's where the `periph_timer` is well tested and known the never cause spurious ISRs. This would ease porting of new MCUs where the timer driver may not be as mature yet.

### Testing procedure

Testing procedure is the same as #20924.

### Issues/PRs references

This PR can be used instead of, or together with #20924.
