### PR TITLE
cpu/stm32/periph/timer: prevent spurious IRQs

### DIFF
--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -195,10 +195,12 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
     }
 #endif
 
-    /* clear spurious IRQs */
-    dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
-
     TIM_CHAN(tim, channel) = value;
+
+    /* clear spurious IRQs
+     * note: This might also clear the IRQ just set, but that is handled below
+     * anyway. */
+    dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
 
     /* enable IRQ */
     dev(tim)->DIER |= (TIM_DIER_CC1IE << channel);
@@ -264,7 +266,13 @@ int timer_clear(tim_t tim, int channel)
     }
 
     unsigned irqstate = irq_disable();
+
+    /* disable IRQ */
     dev(tim)->DIER &= ~(TIM_DIER_CC1IE << channel);
+
+    /* clear spurious IRQs */
+    dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
+
     irq_restore(irqstate);
 
 #ifdef MODULE_PERIPH_TIMER_PERIODIC

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -50,7 +50,6 @@ static unsigned channel_numof(tim_t tim)
     return TIMER_CHANNEL_NUMOF;
 }
 
-
 #ifdef MODULE_PERIPH_TIMER_PERIODIC
 
 /**
@@ -238,7 +237,7 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
         dev(tim)->CNT = 0;
 
         /* wait for the interrupt & clear it */
-        while(dev(tim)->SR == 0) {}
+        while (dev(tim)->SR == 0) {}
         dev(tim)->SR = 0;
     }
 


### PR DESCRIPTION
### Contribution description

This patch hardens the STM32 timer driver against some possible causes of spurious IRQs.

I did not actually observe spurious IRQs happening, but this PR comes as the result of a deep dive into the timer code to solve the bug in #20924. This PR is a defensive measure only.

### Testing procedure

Timers should continue to work.

### Issues/PRs references

- #20924
- #20925 
