### PR TITLE
drivers/dht: fix null deref with saul

### DIFF
--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -272,8 +272,12 @@ int dht_read(dht_t *dev, int16_t *temp, int16_t *hum)
         return ret;
     }
 
-    *hum = dev->last_val.humidity;
-    *temp = dev->last_val.temperature;
+    if (hum != NULL) {
+        *hum = dev->last_val.humidity;
+    }
+    if (temp != NULL) {
+        *temp = dev->last_val.temperature;
+    }
 
     return 0;
 }

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -107,14 +107,16 @@ typedef struct {
 int dht_init(dht_t *dev, const dht_params_t *params);
 
 /**
- * @brief   get a new temperature and humidity value from the device
+ * @brief   get a new temperature and/or humidity value from the device
  *
  * @note    if reading fails or checksum is invalid, no new values will be
  *          written into the result values
  *
  * @param[in]  dev      device descriptor of a DHT device
- * @param[out] temp     temperature value [in °C * 10^-1]
- * @param[out] hum      relative humidity value [in percent * 10^-1]
+ * @param[out] temp     temperature value [in °C * 10^-1],
+ *                      may be NULL if not needed
+ * @param[out] hum      relative humidity value [in percent * 10^-1],
+ *                      may be NULL if not needed
  *
  * @retval 0            Success
  * @retval -ENODEV      The sensor did not respond to the transmission of a

--- a/tests/drivers/dht/main.c
+++ b/tests/drivers/dht/main.c
@@ -52,7 +52,15 @@ int main(void)
         ztimer_sleep(ZTIMER_USEC, DELAY);
 
         if (dht_read(&dev, &temp, &hum) != DHT_OK) {
-            puts("Error reading values");
+            puts("Error reading both values");
+            continue;
+        }
+        if (dht_read(&dev, &temp, NULL) != DHT_OK) {
+            puts("Error reading just temperature");
+            continue;
+        }
+        if (dht_read(&dev, NULL, &hum) != DHT_OK) {
+            puts("Error reading just humidity");
             continue;
         }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The SAUL interface exposes two sensors for humidity and temperature, while the internal `dht` driver exposes a single `dht_read` function with two pointers to store humidity and temperature results. The SAUL wrappers pass NULL for the value they're not interested in, but `dht_read` does not check for that and tries to store both values all the time, causing a segfault.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The initial bug and its fix have been observed with a DHT11 on a Wemos D1 Mini with the `saul` shell command.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
N/A