### PR TITLE
boards/nucleo64: add pinout source

### DIFF
--- a/boards/nucleo-c031c6/doc.txt
+++ b/boards/nucleo-c031c6/doc.txt
@@ -10,7 +10,7 @@ Cortex-M0+ STM32C031C6 microcontroller with 12KiB of RAM and 32KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-c031c6.svg "Pinout for the Nucleo-C031C6 (from STM board manual)" width=50%
+@image html pinouts/nucleo-c031c6.svg "Pinout for the Nucleo-C031C6 (from STM user manual UM2953, https://www.st.com/resource/en/user_manual/um2953-stm32-nucleo64-board-mb1717-stmicroelectronics.pdf, page 19)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f030r8/doc.txt
+++ b/boards/nucleo-f030r8/doc.txt
@@ -14,7 +14,7 @@ STM32F030R8 microcontroller with 8KiB of RAM and 64KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f030r8.svg "Pinout for the nucleo-f030r8" width=50%
+@image html pinouts/nucleo-f030r8.svg "Pinout for the Nucleo-F030R8 from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 28)" width=50%
 
 ### MCU
 | MCU        | STM32F030R8                                                          |

--- a/boards/nucleo-f070rb/doc.txt
+++ b/boards/nucleo-f070rb/doc.txt
@@ -14,7 +14,7 @@ STM32F070RB microcontroller with 16KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f070rb.svg "Pinout for the nucleo-f070rb" width=50%
+@image html pinouts/nucleo-f070rb.svg "Pinout for the Nucleo-F070RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 28)" width=50%
 
 ### MCU
 | MCU                   | STM32F070RB                                                                           |

--- a/boards/nucleo-f072rb/doc.txt
+++ b/boards/nucleo-f072rb/doc.txt
@@ -14,7 +14,7 @@ STM32F072RB microcontroller with 16KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f072rb.svg "Pinout for the nucleo-f072rb" width=50%
+@image html pinouts/nucleo-f072rb.svg "Pinout for the Nucleo-F072RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 29)" width=50%
 
 ### MCU
 | MCU        | STM32F072RB       |

--- a/boards/nucleo-f091rc/doc.txt
+++ b/boards/nucleo-f091rc/doc.txt
@@ -14,7 +14,7 @@ STM32F091RC microcontroller with 32KiB of RAM and 256KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f091rc.svg "Pinout for the nucleo-f091rc" width=50%
+@image html pinouts/nucleo-f091rc.svg "Pinout for the Nucleo-F091RC (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 29)" width=50%
 
 ### MCU
 | MCU        | STM32F091RC       |

--- a/boards/nucleo-f103rb/doc.txt
+++ b/boards/nucleo-f103rb/doc.txt
@@ -14,7 +14,7 @@ STM32F103RB microcontroller with 20KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f103rb.svg "Pinout for the nucleo-f103rb" width=50%
+@image html pinouts/nucleo-f103rb.svg "Pinout for the Nucleo-F103RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 30)" width=50%
 
 ### MCU
 | MCU        | STM32F103RB       |

--- a/boards/nucleo-f302r8/doc.txt
+++ b/boards/nucleo-f302r8/doc.txt
@@ -16,7 +16,7 @@ microcontroller with 16KiB of RAM and 64KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f302r8.svg "Pinout for the nucleo-f302r8" width=50%
+@image html pinouts/nucleo-f302r8.svg "Pinout for the Nucleo-F302R8 (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 30)" width=50%
 
 ### MCU
 | MCU        | STM32F302R8           |

--- a/boards/nucleo-f303re/doc.txt
+++ b/boards/nucleo-f303re/doc.txt
@@ -15,7 +15,7 @@ STM32F303RE microcontroller with 64KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f303re.svg "Pinout for the nucleo-f303re" width=50%
+@image html pinouts/nucleo-f303re.svg "Pinout for the Nucleo-F303RE (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 31)" width=50%
 
 ### MCU
 | MCU        | STM32F303RE       |

--- a/boards/nucleo-f334r8/doc.txt
+++ b/boards/nucleo-f334r8/doc.txt
@@ -15,7 +15,7 @@ STM32F334R8 microcontroller with 12KiB of RAM and 64KiB or Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f334r8.svg "Pinout for the nucleo-f334r8" width=50%
+@image html pinouts/nucleo-f334r8.svg "Pinout for the nucleo-F334R8 (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 31)" width=50%
 
 ### MCU
 | MCU        | STM32F334R8       |

--- a/boards/nucleo-f401re/doc.txt
+++ b/boards/nucleo-f401re/doc.txt
@@ -14,7 +14,7 @@ STM32F401RE microcontroller with 96KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f401re.svg "Pinout for the nucleo-f401re" width=50%
+@image html pinouts/nucleo-f401re.svg "Pinout for the Nucleo-F401RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 32)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f410rb/doc.txt
+++ b/boards/nucleo-f410rb/doc.txt
@@ -14,7 +14,7 @@ STM32F410RB microcontroller with 32KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f410rb.svg "Pinout for the nucleo-f410rb" width=50%
+@image html pinouts/nucleo-f410rb.svg "Pinout for the Nucleo-F410RB (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 36)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f411re/doc.txt
+++ b/boards/nucleo-f411re/doc.txt
@@ -14,7 +14,7 @@ STM32F411RE microcontroller with 128KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f411re.svg "Pinout for the nucleo-f411re" width=50%
+@image html pinouts/nucleo-f411re.svg "Pinout for the Nucleo-F411RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 32)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-f446re/doc.txt
+++ b/boards/nucleo-f446re/doc.txt
@@ -14,7 +14,7 @@ STM32F446RE microcontroller with 128KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-f446re.svg "Pinout for the nucleo-f446re" width=50%
+@image html pinouts/nucleo-f446re.svg "Pinout for the Nucleo-F446RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 35)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-g070rb/doc.txt
+++ b/boards/nucleo-g070rb/doc.txt
@@ -10,7 +10,7 @@ Cortex-M0+ STM32G070RB microcontroller with 36KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g070rb-and-g071rb.svg "Pinout for the nucleo-g070rg (from STM board manual)" width=50%
+@image html pinouts/nucleo-g070rb-and-g071rb.svg "Pinout for the Nucleo-G070RG (from STM user manual UM2324, https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf, page 34)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-g071rb/doc.txt
+++ b/boards/nucleo-g071rb/doc.txt
@@ -10,7 +10,7 @@ Cortex-M0+ STM32G071RB microcontroller with 36KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g070rb-and-g071rb.svg "Pinout for the nucleo-g071rg (from STM board manual)" width=50%
+@image html pinouts/nucleo-g070rb-and-g071rb.svg "Pinout for the Nucleo-G071RG (from STM user manual UM2324, https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf, page 34)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-l053r8/doc.txt
+++ b/boards/nucleo-l053r8/doc.txt
@@ -10,7 +10,7 @@ Cortex-M0+ STM32L053R8 microcontroller with 8KiB of RAM and 32KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-l053r8.svg "Pinout for the nucleo-l053r8" width=50%
+@image html pinouts/nucleo-l053r8.svg "Pinout for the Nucleo-L053r8 (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 33)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-l073rz/doc.txt
+++ b/boards/nucleo-l073rz/doc.txt
@@ -11,7 +11,7 @@ STM32L073RZT6 microcontroller with 20KiB of RAM and 192KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-l073rz.svg "Pinout for the nucleo-l073rz" width=50%
+@image html pinouts/nucleo-l073rz.svg "Pinout for the Nucleo-L073RZ (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 33)" width=50%
 
 ## Flashing the Board Using ST-LINK Removable Media
 

--- a/boards/nucleo-l152re/doc.txt
+++ b/boards/nucleo-l152re/doc.txt
@@ -14,7 +14,7 @@ Cortex-M3 STM32L152RE microcontroller with 80KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-l152re.svg "Pinout for the nucleo-l152re" width=50%
+@image html pinouts/nucleo-l152re.svg "Pinout for the Nucleo-L152RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 34)" width=50%
 
 ### MCU
 | MCU        | STM32L152RE       |

--- a/boards/nucleo-l452re/doc.txt
+++ b/boards/nucleo-l452re/doc.txt
@@ -10,7 +10,7 @@ STM32L452RE microcontroller with 160KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-l452re.svg "Pinout for the nucleo-l452re (from STM board manual)" width=50%
+@image html pinouts/nucleo-l452re.svg "Pinout for the Nucleo-L452RE (from STM board manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 34)" width=50%
 
 ### MCU
 

--- a/boards/nucleo-l476rg/doc.txt
+++ b/boards/nucleo-l476rg/doc.txt
@@ -11,7 +11,7 @@ STM32L476RG microcontroller with 128KiB of RAM and 1MiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-l476rg.svg "Pinout for the nucleo-l476rg" width=50%
+@image html pinouts/nucleo-l476rg.svg "Pinout for the Nucleo-L476RG (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 35)" width=50%
 
 ### MCU
 


### PR DESCRIPTION
### Contribution description

This PR adds detailed pinout source (UM number, link and page) to all pinouts for nucleo-64 boards.
The issue was mentioned in the comments for PR https://github.com/RIOT-OS/RIOT/pull/20832.

### Testing procedure

Generate doc and check if everything in the doc page is correct.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-c031c6.html
 .   .   .
```

### Issues/PRs references

PR #20832, #20859