### PR TITLE
sys/posix/pthread: Add pthread_attr_getstack and pthread_attr_setstack

### DIFF
--- a/sys/posix/pthread/include/pthread_threading_attr.h
+++ b/sys/posix/pthread/include/pthread_threading_attr.h
@@ -202,6 +202,33 @@ int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
  */
 int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
 
+/**
+ * @brief           Query set stacksize for new pthread.
+ * @param[in]       attr        Attribute set to query.
+ * @param[out]      stackaddr   Pointer to previously assigned stack, or `NULL` for dynamic allocation.
+ * @param[out]      stacksize   Assigned or default stack size, resp.
+ * @returns         0, this invocation cannot fail
+ */
+int pthread_attr_getstack(pthread_attr_t *attr, void **stackaddr, size_t *stacksize);
+
+/**
+ * @brief           Set address and stack size of the stack to use for the new pthread.
+ * @details         This function requires setting the address as well as the size
+ *                  since only setting the address will make the implementation
+ *                  on some architectures impossible.
+ *                  If `*stackaddr == NULL`, then the stack is dynamically allocated with malloc().
+ *                  No two running threads may operate on the same stack.
+ *                  The stack of a zombie thread (i.e. a non-detached thread that exited but was not yet joined)
+ *                  may in theory be reused even before joining, though there might be problems
+ *                  if the stack was preempted before pthread_exit() completed.
+ * @param[in,out]   attr        Attribute set to operate on.
+ * @param[in]       stackaddr   Static stack to use, or `NULL` for dynamic allocation.
+ * @param[in]       stacksize   Size of the stack of the new thread.
+ *                              Supply `0` to use the default value.
+ * @returns         0, this invocation cannot fail
+ */
+int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr, size_t stacksize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/posix/pthread/pthread_attr.c
+++ b/sys/posix/pthread/pthread_attr.c
@@ -158,3 +158,23 @@ int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize)
     attr->ss_size = stacksize;
     return 0;
 }
+
+int pthread_attr_getstack(pthread_attr_t *attr, void **stackaddr, size_t *stacksize)
+{
+    int res = pthread_attr_getstackaddr(attr, stackaddr);
+    if (res != 0) {
+        return res;
+    }
+
+    return pthread_attr_getstacksize(attr, stacksize);
+}
+
+int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr, size_t stacksize)
+{
+    int res = pthread_attr_setstackaddr(attr, stackaddr);
+    if (res != 0) {
+        return res;
+    }
+
+    return pthread_attr_setstacksize(attr, stacksize);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the missing `pthread_attr_setstack` and `pthread_attr_getstack` functions to the `posix-pthread wrappers`.

### Motivation
'pthread_attr_setstackaddr' and `pthread_attr_getstackaddr` are deprecated and it is recommended to use use `pthread_attr_getstack` and `pthread_attr_setstack` instead.