### PR TITLE
drivers/periph/gpio: make `gpio_write()` take a bool

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -179,7 +179,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio_set(pin);

--- a/cpu/atxmega/periph/gpio.c
+++ b/cpu/atxmega/periph/gpio.c
@@ -306,7 +306,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     DEBUG("gpio_write pin = 0x%04x, value = 0x%02x \n", pin, value);
 

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -142,7 +142,7 @@ void gpio_toggle(gpio_t pin)
     gpio(pin)->DATA ^= _pin_mask(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio(pin)->DATA |= _pin_mask(pin);

--- a/cpu/cc26xx_cc13xx/periph/gpio.c
+++ b/cpu/cc26xx_cc13xx/periph/gpio.c
@@ -81,7 +81,7 @@ void gpio_toggle(gpio_t pin)
     GPIO->DOUTTGL = (1 << pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         GPIO->DOUTSET = (1 << pin);

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -93,7 +93,7 @@ void gpio_toggle(gpio_t pin)
     GPIO_PinOutToggle(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         GPIO_PinOutSet(_port_num(pin), _pin_num(pin));

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -351,7 +351,7 @@ int gpio_read(gpio_t pin)
     return value;
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     DEBUG("%s gpio=%u val=%d\n", __func__, pin, value);
     assert(pin < GPIO_PIN_NUMOF);
@@ -412,7 +412,7 @@ int gpio_read(gpio_t pin)
     return value;
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     DEBUG("%s gpio=%u val=%d\n", __func__, pin, value);
     assert(pin < GPIO_PIN_NUMOF);

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -249,7 +249,7 @@ int gpio_read (gpio_t pin)
     return (GPIO.IN & BIT(pin)) ? 1 : 0;
 }
 
-void gpio_write (gpio_t pin, int value)
+void gpio_write (gpio_t pin, bool value)
 {
     DEBUG("%s: %d %d\n", __func__, pin, value);
 

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -111,7 +111,7 @@ void gpio_toggle(gpio_t pin)
                        __ATOMIC_RELAXED);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         _set_pin_reg(GPIO_OUTPUT_VAL, pin);

--- a/cpu/gd32v/periph/gpio.c
+++ b/cpu/gd32v/periph/gpio.c
@@ -195,7 +195,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio_set(pin);

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -272,7 +272,7 @@ void gpio_toggle(gpio_t pin)
     gpio(pin)->PTOR = (1 << pin_num(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio(pin)->PSOR = (1 << pin_num(pin));

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -157,7 +157,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio_set(pin);

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -120,7 +120,7 @@ void gpio_toggle(gpio_t pin)
     base->FIOPIN ^= (1 << _pin(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 

--- a/cpu/lpc23xx/periph/gpio.c
+++ b/cpu/lpc23xx/periph/gpio.c
@@ -133,13 +133,13 @@ void gpio_toggle(gpio_t dev)
     }
 }
 
-void gpio_write(gpio_t dev, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
-        gpio_set(dev);
+        gpio_set(pin);
     }
     else {
-        gpio_clear(dev);
+        gpio_clear(pin);
     }
 }
 

--- a/cpu/msp430/periph/gpio.c
+++ b/cpu/msp430/periph/gpio.c
@@ -138,7 +138,7 @@ void gpio_toggle(gpio_t pin)
     _port(pin)->OD ^= _pin_mask(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         _port(pin)->OD |= _pin_mask(pin);

--- a/cpu/native/periph/gpio_linux.c
+++ b/cpu/native/periph/gpio_linux.c
@@ -210,7 +210,7 @@ void gpio_toggle(gpio_t pin)
     _set(pin, !gpio_read(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     _set(pin, value);
 }

--- a/cpu/native/periph/gpio_mock.c
+++ b/cpu/native/periph/gpio_mock.c
@@ -92,7 +92,7 @@ __attribute__((weak)) void gpio_toggle(gpio_t pin) {
   }
 }
 
-__attribute__((weak)) void gpio_write(gpio_t pin, int value) {
+__attribute__((weak)) void gpio_write(gpio_t pin, bool value) {
   if (pin) {
     pin->value = value;
   }

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -151,7 +151,7 @@ void gpio_toggle(gpio_t pin)
     port(pin)->OUT ^= (1 << pin_num(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         port(pin)->OUTSET = (1 << pin_num(pin));

--- a/cpu/qn908x/periph/gpio.c
+++ b/cpu/qn908x/periph/gpio.c
@@ -232,7 +232,7 @@ void gpio_toggle(gpio_t pin)
     base->OUTENSET = out_clr & dataout;
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio_set(pin);

--- a/cpu/rpx0xx/periph/gpio.c
+++ b/cpu/rpx0xx/periph/gpio.c
@@ -131,7 +131,7 @@ void gpio_toggle(gpio_t pin)
     SIO->GPIO_OUT_XOR = 1LU << pin;
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio_set(pin);

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -230,7 +230,7 @@ void gpio_toggle(gpio_t pin)
     _port_iobus(pin)->OUTTGL.reg = _pin_mask(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         _port_iobus(pin)->OUTSET.reg = _pin_mask(pin);

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -225,7 +225,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         _port(pin)->PIO_SODR = (1 << _pin_num(pin));

--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -227,7 +227,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         gpio_set(pin);

--- a/cpu/stm32/periph/gpio_f1.c
+++ b/cpu/stm32/periph/gpio_f1.c
@@ -180,7 +180,7 @@ void gpio_toggle(gpio_t pin)
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write(gpio_t pin, bool value)
 {
     if (value) {
         _port(pin)->BSRR = (1 << _pin_num(pin));

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -76,6 +76,7 @@
 #define PERIPH_GPIO_H
 
 #include <limits.h>
+#include <stdbool.h>
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
@@ -258,7 +259,7 @@ void gpio_toggle(gpio_t pin);
  * @param[in] pin       the pin to set
  * @param[in] value     value to set the pin to, 0 for LOW, HIGH otherwise
  */
-void gpio_write(gpio_t pin, int value);
+void gpio_write(gpio_t pin, bool value);
 
 /**
  * @brief   Test if a GPIO pin is equal to another GPIO pin


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There is no reason for `gpio_write()` to take an `int` when a GPIO can only be either on or off.
To avoid confusion, switch to `bool`


### Testing procedure

Since a `bool` is usually just an `int` in disguise, there should be no code or semantic changes. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
