### PR TITLE
drivers/periph_gpio: let gpio_read() return bool

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -154,7 +154,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     return (_SFR_MEM8(atmega_pin_addr(pin)) & (1 << atmega_pin_num(pin)));
 }

--- a/cpu/atxmega/periph/gpio.c
+++ b/cpu/atxmega/periph/gpio.c
@@ -252,7 +252,7 @@ void gpio_irq_disable(gpio_t pin)
     }
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     PORT_t *port = _port_addr(pin);
     uint8_t pin_mask = _pin_mask(pin);

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -122,7 +122,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     return (int)(gpio(pin)->DATA & _pin_mask(pin));
 }

--- a/cpu/cc26xx_cc13xx/periph/gpio.c
+++ b/cpu/cc26xx_cc13xx/periph/gpio.c
@@ -56,7 +56,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     if (GPIO->DOE & (1 << pin)) {
         return (GPIO->DOUT >> pin) & 1;

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -73,7 +73,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     return GPIO_PinInGet(_port_num(pin), _pin_num(pin));
 }

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -338,7 +338,7 @@ static gpio_hal_context_t _gpio_hal_ctx = {
  */
 static BITFIELD(_output, GPIO_PIN_NUMOF);
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     assert(pin < GPIO_PIN_NUMOF);
 
@@ -394,7 +394,7 @@ void gpio_toggle(gpio_t pin)
 
 #else /* IS_USED(MODULE_ESP_IDF_GPIO_HAL) */
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     assert(pin < GPIO_PIN_NUMOF);
 

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -237,7 +237,7 @@ void gpio_irq_disable (gpio_t pin)
 }
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_read (gpio_t pin)
+bool gpio_read (gpio_t pin)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
 

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -90,7 +90,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     return (GPIO_REG(GPIO_INPUT_VAL) & (1 << pin)) ? 1 : 0;
 }

--- a/cpu/gd32v/periph/gpio.c
+++ b/cpu/gd32v/periph/gpio.c
@@ -160,7 +160,7 @@ void gpio_init_analog(gpio_t pin)
     *pin_reg &= ~(0xfl << (4 * (pin_num - ((pin_num >= 8) * 8))));
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     GPIO_Type *port = _port(pin);
     unsigned pin_num = _pin_num(pin);

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -247,7 +247,7 @@ void gpio_init_port(gpio_t pin, uint32_t pcr)
 #endif /* KINETIS_HAVE_PCR */
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     if (gpio(pin)->PDDR & (1 << pin_num(pin))) {
         return (gpio(pin)->PDOR & (1 << pin_num(pin))) ? 1 : 0;

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -119,7 +119,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -92,7 +92,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 

--- a/cpu/lpc23xx/periph/gpio.c
+++ b/cpu/lpc23xx/periph/gpio.c
@@ -99,7 +99,7 @@ int gpio_init_mux(unsigned pin, unsigned mux)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;

--- a/cpu/msp430/periph/gpio.c
+++ b/cpu/msp430/periph/gpio.c
@@ -112,7 +112,7 @@ void gpio_periph_mode(gpio_t pin, bool enable)
     }
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     msp430_port_t *port = _port(pin);
     if (port->DIR & _pin_mask(pin)) {

--- a/cpu/native/periph/gpio_linux.c
+++ b/cpu/native/periph/gpio_linux.c
@@ -167,7 +167,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     struct gpiohandle_data data;
 

--- a/cpu/native/periph/gpio_mock.c
+++ b/cpu/native/periph/gpio_mock.c
@@ -66,7 +66,7 @@ __attribute__((weak)) void gpio_irq_disable(gpio_t pin)
     (void) pin;
 }
 
-__attribute__((weak)) int gpio_read(gpio_t pin) {
+__attribute__((weak)) bool gpio_read(gpio_t pin) {
   if (pin) {
     return pin->value;
   }

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -126,7 +126,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     if (port(pin)->DIR & (1 << pin_num(pin))) {
         return (port(pin)->OUT & (1 << pin_num(pin))) ? 1 : 0;

--- a/cpu/qn908x/periph/gpio.c
+++ b/cpu/qn908x/periph/gpio.c
@@ -182,7 +182,7 @@ void gpio_irq_disable(gpio_t pin)
 
 #endif /* defined(MODULE_PERIPH_GPIO_IRQ) */
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     return ((GPIO_T_ADDR(pin)->DATA) >> GPIO_T_PIN(pin)) & 1u;
 }

--- a/cpu/rpx0xx/periph/gpio.c
+++ b/cpu/rpx0xx/periph/gpio.c
@@ -106,7 +106,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     if (SIO->GPIO_OE & (1LU << pin)) {
         /* pin is output: */

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -195,7 +195,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     PortGroup *port;
     int mask = _pin_mask(pin);

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -244,7 +244,7 @@ void gpio_irq_disable(gpio_t pin)
     NVIC_DisableIRQ((1 << (_port_num(pin) + PIOA_IRQn)));
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);

--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -203,7 +203,7 @@ void gpio_irq_disable(gpio_t pin)
     EXTI_REG_IMR &= ~(1 << _pin_num(pin));
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     return (_port(pin)->IDR & (1 << _pin_num(pin)));
 }

--- a/cpu/stm32/periph/gpio_f1.c
+++ b/cpu/stm32/periph/gpio_f1.c
@@ -145,7 +145,7 @@ void gpio_init_analog(gpio_t pin)
     *(uint32_t *)(&_port(pin)->CRL + (pin_num >= 8)) &= ~(0xfl << (4 * (pin_num - ((pin_num >= 8) * 8))));
 }
 
-int gpio_read(gpio_t pin)
+bool gpio_read(gpio_t pin)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -74,7 +74,7 @@ static void _wait_for_level(gpio_t pin, bool expected, uint32_t start)
     /* Calls to ztimer_now() can be relatively slow on low end platforms.
      * Mixing in a busy down-counting loop solves issues e.g. on AVR boards. */
     uint8_t pre_timeout = 0;
-    while (((bool)gpio_read(pin) != expected) && (++pre_timeout
+    while ((gpio_read(pin) != expected) && (++pre_timeout
         || ztimer_now(ZTIMER_USEC) < start + SPIN_TIMEOUT)) {}
 }
 

--- a/drivers/epd_bw_spi/epd_bw_spi.c
+++ b/drivers/epd_bw_spi/epd_bw_spi.c
@@ -30,7 +30,7 @@ static void epd_bw_spi_cmd_start(epd_bw_spi_params_t *p, uint8_t cmd, bool cont)
 {
     DEBUG("[epd_bw_spi] cmd_start: command 0x%02x\n", cmd);
     if (gpio_is_valid(p->busy_pin)) {
-        while ((bool)gpio_read(p->busy_pin) == p->busy_value) {}
+        while (gpio_read(p->busy_pin) == p->busy_value) {}
     }
     gpio_clear(p->dc_pin);
     spi_transfer_byte(p->spi, p->cs_pin, cont, (uint8_t)cmd);
@@ -52,7 +52,7 @@ static void epd_bw_spi_wait(epd_bw_spi_params_t *p, uint32_t msec)
 {
     if (gpio_is_valid(p->busy_pin)) {
         DEBUG("[epd_bw_spi] wait: for busy bin\n");
-        while ((bool)gpio_read(p->busy_pin) == p->busy_value) {}
+        while (gpio_read(p->busy_pin) == p->busy_value) {}
     }
     else {
         DEBUG("[epd_bw_spi] wait: for %" PRIu32 " milliseconds\n", msec);

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -227,10 +227,10 @@ void gpio_irq_disable(gpio_t pin);
  *
  * @param[in] pin       the pin to read
  *
- * @return              0 when pin is LOW
- * @return              >0 for HIGH
+ * @retval              false   pin is LOW
+ * @retval              true    pin is HIGH
  */
-int gpio_read(gpio_t pin);
+bool gpio_read(gpio_t pin);
 
 /**
  * @brief   Set the given pin to HIGH

--- a/drivers/lm75/lm75.c
+++ b/drivers/lm75/lm75.c
@@ -244,7 +244,7 @@ int lm75_get_os_pin(lm75_t *dev, bool *os_pin_state) {
         return LM75_ERROR;
     }
 
-    *os_pin_state = !!gpio_read(dev->lm75_params.gpio_alarm) == dev->lm75_params.polarity;
+    *os_pin_state = gpio_read(dev->lm75_params.gpio_alarm) == dev->lm75_params.polarity;
     return LM75_SUCCESS;
 }
 

--- a/examples/rust-async/Cargo.lock
+++ b/examples/rust-async/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#71e854ec4e5e3d187b5f215bd2c8f30ea07b1bd1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#71e854ec4e5e3d187b5f215bd2c8f30ea07b1bd1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#71e854ec4e5e3d187b5f215bd2c8f30ea07b1bd1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#71e854ec4e5e3d187b5f215bd2c8f30ea07b1bd1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#71e854ec4e5e3d187b5f215bd2c8f30ea07b1bd1"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
 dependencies = [
  "bare-metal",
  "coap-handler",


### PR DESCRIPTION
### Contribution description

Since https://github.com/RIOT-OS/RIOT/pull/20935 gpio_write() uses a `bool` instead of an `int`. This does the same treatment for `gpio_read()`.

This does indeed add an instruction to `gpio_read()` implementations. However, users caring about an instruction more are better served with `gpio_ll_read()` anyway. And `gpio_read() == 1` is often seen in newcomer's code, which would now work as expected.

### Testing procedure

This should not cause any regressions.

I cannot find any way to use `int gpio_read()` that won't work with `bool gpio_read()` anymore at the top of my head.

### Issues/PRs references

Same that https://github.com/RIOT-OS/RIOT/pull/20935 did for `gpio_write()`, but for `gpio_read()`.