### PR TITLE
core/sched.c: fix _runqueue_pop() removing wrong thread

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -252,7 +252,7 @@ static inline __attribute__((always_inline)) void _runqueue_pop(thread_t *thread
 {
     DEBUG("sched_set_status: removing thread %" PRIkernel_pid " from runqueue %" PRIu8 ".\n",
           thread->pid, thread->priority);
-    clist_lpop(&sched_runqueues[thread->priority]);
+    clist_remove(&sched_runqueues[thread->priority], &thread->rq_entry);
 
     if (!sched_runqueues[thread->priority].next) {
         _clear_runqueue_bit(thread->priority);

--- a/tests/drivers/xbee/Makefile.ci
+++ b/tests/drivers/xbee/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f334r8 \
     nucleo-l011k4 \
+    nucleo-l031k6 \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`_runqueue_pop()` calls `clist_lpop()`, which pops the leftmost entry in the thread's priority runqueue, but not necessarily the one passed as argument. 

I understand the original logic behind this: if a thread is to be removed, then it is so because it is about to block on something or exit. And a thread can only block or exit if it's currently running. As a result, it must be the leftmost entry on the runqueue. But this isn't always true. Consider `sched_change_priority()`, which does the following:

```c
    if (thread_is_active(thread)) { 
        _runqueue_pop(thread);
        _runqueue_push(thread, priority);
    }
```

`thread_is_active()` returns true if a thread is either running or queued to be running. So the `_runqueue_pop()` might retrieve any thread. Let's extend `_runqueue_pop()` with the following assertion:
```c
    ...
    clist_node_t *removed = clist_lpop(&sched_runqueues[thread->priority]);
    assume(container_of(removed, thread_t, rq_entry) == thread);
    ...
```

Running this will trigger the assertion:

```c
    int thread_ids[WAITERS_CNT];
    for (unsigned i = 0; i < WAITERS_CNT; i++) {
       // set a lower priority than the current thread's to make sure they are all in the runqueue when
       // changing priorities below
        thread_ids[i] = thread_create(stacks[i], sizeof(stacks[0]), THREAD_PRIORITY_MAIN + 1,
                      THREAD_CREATE_STACKTEST, waiter, NULL, "waiter");
    }

    thread_t *thread2 = thread_get(thread_ids[1]);

    irq_disable(); // sched_change_priority() wants interrupts disabled
    sched_change_priority(thread2, THREAD_PRIORITY_MAIN);
    irq_enable();

```

If we change `_runqueue_pop()` to search for the specific thread:

```c
    ...
    clist_node_t *removed = clist_remove(&sched_runqueues[thread->priority], &thread->rq_entry);
    assume(container_of(removed, thread_t, rq_entry) == thread);
    ....
```

Then everything is all right.

The only ugly thing is that, when the thread is indeed running (vast majority of cases), due to how `clist`s are implemented the whole list is walked to remove the thread.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I briefly tested this code on a SAM0 board.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


