### PR TITLE
scheduling: functions that might reschedule assume interrupts enabled

### DIFF
--- a/core/cond.c
+++ b/core/cond.c
@@ -34,13 +34,14 @@ void cond_init(cond_t *cond)
 
 void cond_wait(cond_t *cond, mutex_t *mutex)
 {
-    unsigned irqstate = irq_disable();
+    assert(irq_is_enabled());
+    irq_disable();
     thread_t *me = thread_get_active();
 
     mutex_unlock(mutex);
     sched_set_status(me, STATUS_COND_BLOCKED);
     thread_add_to_list(&cond->queue, me);
-    irq_restore(irqstate);
+    irq_enable();
     thread_yield_higher();
 
     /*

--- a/core/cond.c
+++ b/core/cond.c
@@ -38,10 +38,11 @@ void cond_wait(cond_t *cond, mutex_t *mutex)
     irq_disable();
     thread_t *me = thread_get_active();
 
-    mutex_unlock(mutex);
     sched_set_status(me, STATUS_COND_BLOCKED);
     thread_add_to_list(&cond->queue, me);
     irq_enable();
+
+    mutex_unlock(mutex);
     thread_yield_higher();
 
     /*

--- a/core/sched.c
+++ b/core/sched.c
@@ -334,13 +334,14 @@ void sched_register_cb(void (*callback)(kernel_pid_t, kernel_pid_t))
 
 void sched_change_priority(thread_t *thread, uint8_t priority)
 {
+    assert(irq_is_enabled());
     assert(thread && (priority < SCHED_PRIO_LEVELS));
 
     if (thread->priority == priority) {
         return;
     }
 
-    unsigned irq_state = irq_disable();
+    irq_disable();
 
     if (thread_is_active(thread)) {
         _runqueue_pop(thread);
@@ -348,7 +349,7 @@ void sched_change_priority(thread_t *thread, uint8_t priority)
     }
     thread->priority = priority;
 
-    irq_restore(irq_state);
+    irq_enable();
 
     thread_t *active = thread_get_active();
 

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -61,16 +61,17 @@ int thread_flags_wake(thread_t *thread)
 static thread_flags_t _thread_flags_clear_atomic(thread_t *thread,
                                                  thread_flags_t mask)
 {
-    unsigned state = irq_disable();
+    assert(irq_is_enabled());
+    irq_disable();
 
     mask &= thread->flags;
     thread->flags &= ~mask;
-    irq_restore(state);
+    irq_enable();
     return mask;
 }
 
 static void _thread_flags_wait(thread_flags_t mask, thread_t *thread,
-                               unsigned threadstate, unsigned irqstate)
+                               unsigned threadstate)
 {
     DEBUG(
         "_thread_flags_wait: me->flags=0x%08x me->mask=0x%08x. going blocked.\n",
@@ -78,7 +79,7 @@ static void _thread_flags_wait(thread_flags_t mask, thread_t *thread,
 
     thread->wait_data = (void *)(uintptr_t)mask;
     sched_set_status(thread, threadstate);
-    irq_restore(irqstate);
+    irq_enable();
     thread_yield_higher();
 }
 
@@ -94,14 +95,15 @@ thread_flags_t thread_flags_clear(thread_flags_t mask)
 
 static void _thread_flags_wait_any(thread_flags_t mask)
 {
+    assert(irq_is_enabled());
     thread_t *me = thread_get_active();
-    unsigned state = irq_disable();
+    irq_disable();
 
     if (!(me->flags & mask)) {
-        _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ANY, state);
+        _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ANY);
     }
     else {
-        irq_restore(state);
+        irq_enable();
     }
 }
 
@@ -126,17 +128,18 @@ thread_flags_t thread_flags_wait_one(thread_flags_t mask)
 
 thread_flags_t thread_flags_wait_all(thread_flags_t mask)
 {
-    unsigned state = irq_disable();
+    assert(irq_is_enabled());
+    irq_disable();
     thread_t *me = thread_get_active();
 
     if (!((me->flags & mask) == mask)) {
         DEBUG(
             "thread_flags_wait_all(): pid %" PRIkernel_pid " waiting for %08x\n",
             thread_getpid(), (unsigned)mask);
-        _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ALL, state);
+        _thread_flags_wait(mask, me, STATUS_FLAG_BLOCKED_ALL);
     }
     else {
-        irq_restore(state);
+        irq_enable();
     }
 
     return _thread_flags_clear_atomic(me, mask);
@@ -144,16 +147,17 @@ thread_flags_t thread_flags_wait_all(thread_flags_t mask)
 
 void thread_flags_set(thread_t *thread, thread_flags_t mask)
 {
+    assert(irq_is_enabled());
     DEBUG("thread_flags_set(): setting 0x%08x for pid %" PRIkernel_pid "\n",
           mask, thread->pid);
-    unsigned state = irq_disable();
+    irq_disable();
 
     thread->flags |= mask;
     if (_thread_flags_wake(thread)) {
-        irq_restore(state);
+        irq_enable();
         thread_yield_higher();
     }
     else {
-        irq_restore(state);
+        irq_enable();
     }
 }

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -125,7 +125,7 @@ static void _update_head_offset(evtimer_t *evtimer)
 
 void evtimer_add(evtimer_t *evtimer, evtimer_event_t *event)
 {
-    unsigned state = irq_disable();
+    irq_disable();
 
     DEBUG("evtimer_add(): adding event with offset %" PRIu32 "\n", event->offset);
 
@@ -134,7 +134,7 @@ void evtimer_add(evtimer_t *evtimer, evtimer_event_t *event)
     if (evtimer->events == event) {
         _set_timer(evtimer);
     }
-    irq_restore(state);
+    irq_enable();
     if (sched_context_switch_request) {
         thread_yield_higher();
     }
@@ -142,14 +142,14 @@ void evtimer_add(evtimer_t *evtimer, evtimer_event_t *event)
 
 void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event)
 {
-    unsigned state = irq_disable();
+    irq_disable();
 
     DEBUG("evtimer_del(): removing event with offset %" PRIu32 "\n", event->offset);
 
     _update_head_offset(evtimer);
     _del_event_from_list(evtimer, event);
     _update_timer(evtimer);
-    irq_restore(state);
+    irq_enable();
 }
 
 static evtimer_event_t *_get_next(evtimer_t *evtimer)

--- a/sys/pipe/pipe.c
+++ b/sys/pipe/pipe.c
@@ -43,7 +43,7 @@ static ssize_t pipe_rw(ringbuffer_t *rb,
     }
 
     while (1) {
-        unsigned old_state = irq_disable();
+        irq_disable();
 
         unsigned count = ringbuffer_op(rb, buf, n);
 
@@ -56,7 +56,7 @@ static ssize_t pipe_rw(ringbuffer_t *rb,
                 sched_set_status(other_thread, STATUS_PENDING);
             }
 
-            irq_restore(old_state);
+            irq_enable();
 
             if (other_prio >= 0) {
                 sched_switch(other_prio);
@@ -65,14 +65,14 @@ static ssize_t pipe_rw(ringbuffer_t *rb,
             return count;
         }
         else if (*this_op_blocked || irq_is_in()) {
-            irq_restore(old_state);
+            irq_enable();
             return 0;
         }
         else {
             *this_op_blocked = thread_get_active();
 
             sched_set_status(thread_get_active(), STATUS_SLEEPING);
-            irq_restore(old_state);
+            irq_enable();
             thread_yield_higher();
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, most functions that might reschedule contain logic that enables them to be called with interrupts disabled. This is not only going against the scope disabling interrupts in the first place, but also doesn't work. All these functions end up calling `thread_yield_higher()`, which will fail to suspend the current thread. 

Depending on the use-case, this can be more or less catastrophic. If the tread doesn't go to sleep, `thread_yield_higher()` will just trigger the switch once the interrupts are enabled (although on some architectures this might be bad due to unflushed instruction caches - see  [the cortex m code](https://github.com/RIOT-OS/RIOT/blob/e5c185b9ebf9054f100092eee19cd7954f8d884b/cpu/cortexm_common/include/thread_arch.h#L40)). But if the thread is set to go to sleep, the current thread will continue execution although it shouldn't. For example, the following assertion will be triggered:

```c
    static cond_t cond = COND_INIT;
    static mutex_t lock = MUTEX_INIT;

    mutex_lock(&lock);
    irq_disable();
    cond_wait(&cond, &lock); // this should block forever
    assert(0); // thread_yield_higher() couldn't trigger the interrupt
```
This breaks both program logic and leaves the scheduler in a messed up state.

:warning: For this PR, I simply grepped for `thread_yield` and removed any IRQ state saving logic wherever `thread_yield*()` was found, so don't expect it to be comprehensive. **There might still be places that I missed and still feature useless IRQ state saving logic.**
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I run a part of tests of the affected subsystems on a cortex M board. I'd like to run all possible tests on both native and the cortex M board but I don't know yet how to automatize this.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/20940

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
