### PR TITLE
sys/chunked_ringbuffer: let `crb_end_chunk()` return size of the chunk

### DIFF
--- a/sys/chunked_ringbuffer/chunked_ringbuffer.c
+++ b/sys/chunked_ringbuffer/chunked_ringbuffer.c
@@ -87,13 +87,13 @@ static unsigned _get_cur_len(chunk_ringbuf_t *rb)
     }
 }
 
-bool crb_end_chunk(chunk_ringbuf_t *rb, bool keep)
+unsigned crb_end_chunk(chunk_ringbuf_t *rb, bool keep)
 {
     int idx;
 
     /* no chunk was started */
     if (rb->cur_start == NULL) {
-        return false;
+        return 0;
     }
 
     if (keep) {
@@ -109,7 +109,7 @@ bool crb_end_chunk(chunk_ringbuf_t *rb, bool keep)
         }
         rb->cur = rb->cur_start;
         rb->cur_start = NULL;
-        return false;
+        return 0;
     }
 
     /* store complete chunk */
@@ -117,7 +117,7 @@ bool crb_end_chunk(chunk_ringbuf_t *rb, bool keep)
     rb->chunk_len[idx] = _get_cur_len(rb);
     rb->cur_start = NULL;
 
-    return true;
+    return rb->chunk_len[idx];
 }
 
 bool crb_get_chunk_size(chunk_ringbuf_t *rb, size_t *len)

--- a/sys/include/chunked_ringbuffer.h
+++ b/sys/include/chunked_ringbuffer.h
@@ -82,10 +82,10 @@ void crb_init(chunk_ringbuf_t *rb, void *buffer, size_t len);
  * @param[in] valid     True if the chunk is valid and should be stored
  *                      False if the current chunk should be discarded
  *
- * @return true         If the chunk could be stored in the valid chunk array
- * @return false        If there is no more space in the valid chunk array
+ * @return size of chunk if the chunk could be stored in the valid chunk array
+ * @return 0 if there is no more space in the valid chunk array
  */
-bool crb_end_chunk(chunk_ringbuf_t *rb, bool valid);
+unsigned crb_end_chunk(chunk_ringbuf_t *rb, bool valid);
 
 /**
  * @brief Start a new chunk on the ringbuffer


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It can be handy to know the size of the chunk that we just stored. Since we already have that information, it's very cheap to return that instead of `true`.

### Testing procedure

Technically an API change, but now we already returned 0 in the error case and 1 on success, so changing bool -> int won't need any code changes. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
