### PR TITLE
sys/luid: luid_custom() use fixed width int

### DIFF
--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -180,7 +180,7 @@ void luid_netdev_get_eui64(const netdev_t *netdev, eui64_t *addr);
  * @param[in]  len      length of the LUID in bytes
  * @param[in]  gen      custom LUID generator value
  */
-void luid_custom(void *buf, size_t len, int gen);
+void luid_custom(void *buf, size_t len, uint16_t gen);
 
 /**
  * @brief   Get a LUID base value

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -67,7 +67,7 @@ void luid_get_lb(void *buf, size_t len)
     ((uint8_t *)buf)[len - 1] ^= lastused++;
 }
 
-void luid_custom(void *buf, size_t len, int gen)
+void luid_custom(void *buf, size_t len, uint16_t gen)
 {
     luid_base(buf, len);
 


### PR DESCRIPTION
### Contribution description

This changes the type of the last parameter of `luid_custom()` to a fixed width integer for consistent behavior among different architectures.

### Testing procedure

The unit tests should still pass.

### Issues/PRs references

None