### PR TITLE
sys/usb: Use luid_base for stable USB serials

### DIFF
--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -422,7 +422,7 @@ static void *_usbus_thread(void *args)
                   "USB serial byte length must be at most 63 due to protocol "
                   "limitations");
     uint8_t luid_buf[CONFIG_USB_SERIAL_BYTE_LENGTH];
-    luid_get(luid_buf, sizeof(luid_buf));
+    luid_base(luid_buf, sizeof(luid_buf));
     fmt_bytes_hex(usbus->serial_str, luid_buf, sizeof(luid_buf));
     usbus_add_string_descriptor(usbus, &usbus->serial, usbus->serial_str);
 #endif


### PR DESCRIPTION
### Contribution description

This uses `luid_base()` instead of `luid_get()` to create USB serials in a stable manner. This is useful when having multiple instances of the same board connected via USB CDC ACM and telling the TTYs apart.

### Testing procedure

Two instances of the same board using CDC ACM as default stdio should (if they do have decent CPU IDs) now yield serials that only depend on the board and not on the app flashed.

### Issues/PRs references

None