### PR TITLE
sys/net/gcoap: reduce insanity of hack

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1454,10 +1454,9 @@ static ssize_t _cache_build_response(nanocoap_cache_entry_t *ce, coap_pkt_t *pdu
 
 static void _copy_hdr_from_req_memo(coap_pkt_t *pdu, gcoap_request_memo_t *memo)
 {
-    coap_pkt_t req_pdu;
-
-    req_pdu.hdr = gcoap_request_memo_get_hdr(memo);
-    memcpy(pdu->hdr, req_pdu.hdr, coap_get_total_hdr_len(&req_pdu));
+    const coap_hdr_t *hdr = gcoap_request_memo_get_hdr(memo);
+    size_t hdr_len = coap_hdr_len(hdr);
+    memcpy(pdu->hdr, hdr, hdr_len);
 }
 
 static void _receive_from_cache_cb(void *ctx)


### PR DESCRIPTION
### Contribution description

gcoap contains a hack where a `coap_pkt_t` is pulled out of thin air, parts of the members are left uninitialized and a function is called on that mostly uninitialized data while crossing fingers hard that the result will be correct. (With the current implementation of the used function this hack does actually work.)

Estimated level of insanity: 😱😱😱😱😱

This adds to insane functions to get the length of a token and the length of a header of a CoAP packet while crossing fingers hard that the packet is valid and that the functions do not overread.

Estimated level of insanity: 😱😱😱

The newly introduced insane functions are used to replace the old insane hack, resulting in an estimated reduction of insanity of 😱😱.

> [!NOTE]
> This actually does fix a bug, as the old code did not take into account the length of the extended TKL field in case of RFC 8974 being used. But that is a bug in the abused API, and not in the caller abusing the API.

### Testing procedure

gcoap unit tests should still pass.

### Issues/PRs references

None