### PR TITLE
sys/net/nanocoap: fix coap_get_total_hdr_len()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -583,18 +583,6 @@ static inline void *coap_get_token(const coap_pkt_t *pkt)
 }
 
 /**
- * @brief   Get the total header length (4-byte header + token length)
- *
- * @param[in]   pkt   CoAP packet
- *
- * @returns     total header length
- */
-static inline unsigned coap_get_total_hdr_len(const coap_pkt_t *pkt)
-{
-    return sizeof(coap_hdr_t) + coap_get_token_len(pkt);
-}
-
-/**
  * @brief   Get the total length of a CoAP packet in the packet buffer
  *
  * @note This does not include possible payload snips.
@@ -674,6 +662,19 @@ static inline uint8_t coap_hdr_tkl_ext_len(const coap_hdr_t *hdr)
 static inline uint8_t *coap_hdr_data_ptr(const coap_hdr_t *hdr)
 {
     return ((uint8_t *)hdr) + sizeof(coap_hdr_t) + coap_hdr_tkl_ext_len(hdr);
+}
+
+/**
+ * @brief   Get the total header length (4-byte header + token length)
+ *
+ * @param[in]   pkt   CoAP packet
+ *
+ * @returns     total header length
+ */
+static inline unsigned coap_get_total_hdr_len(const coap_pkt_t *pkt)
+{
+    return sizeof(coap_hdr_t) + coap_hdr_tkl_ext_len(pkt->hdr) +
+           coap_get_token_len(pkt);
 }
 
 /**

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -182,6 +182,7 @@ static void test_nanocoap__get_multi_path(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
@@ -207,6 +208,7 @@ static void test_nanocoap__get_path_trailing_slash(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
@@ -231,6 +233,7 @@ static void test_nanocoap__get_root_path(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     char uri[10] = {0};
     coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
@@ -254,6 +257,7 @@ static void test_nanocoap__get_max_path(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
@@ -281,6 +285,7 @@ static void test_nanocoap__get_path_too_long(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
@@ -308,6 +313,7 @@ static void test_nanocoap__get_query(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(path_opt_len, len);
@@ -350,6 +356,7 @@ static void test_nanocoap__get_multi_query(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     uint8_t *query_pos = &pkt.payload[0];
     /* first opt header is 2 bytes long */
@@ -406,6 +413,7 @@ static void test_nanocoap__add_uri_query2(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     /* includes key and value */
     char query[20] = {0};
@@ -463,6 +471,7 @@ static void test_nanocoap__option_add_buffer_max(void)
                                  &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
@@ -487,6 +496,7 @@ static void __test_option_remove(uint16_t stride)
                                  &token[0], 2, COAP_METHOD_GET, msgid);
     /* shrink buffer to attempt overfill */
     coap_pkt_init(&pkt, &buf[0], sizeof(buf) - 1, len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     /* add seven options of options 1 to 7 */
     for (uint16_t count = 1; count < 8; count++) {
@@ -647,6 +657,7 @@ static void test_nanocoap__option_remove_no_payload(void)
                                  &token[0], 2, COAP_METHOD_GET, msgid);
     /* shrink buffer to attempt overfill */
     coap_pkt_init(&pkt, &buf[0], sizeof(buf) - 1, len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_uint(&pkt, 1U, 500U);
     TEST_ASSERT_EQUAL_INT(3U, len);
@@ -1004,6 +1015,7 @@ static void test_nanocoap__add_path_unterminated_string(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
     coap_opt_add_chars(&pkt, COAP_OPT_URI_PATH, &path[0], path_len, '/');
 
     char uri[10] = {0};
@@ -1029,6 +1041,7 @@ static void test_nanocoap__add_get_proxy_uri(void)
                                 &token[0], 2, COAP_METHOD_GET, msgid);
 
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+    TEST_ASSERT_EQUAL_INT(len, coap_get_total_hdr_len(&pkt));
 
     len = coap_opt_add_proxy_uri(&pkt, proxy_uri);
 
@@ -1093,6 +1106,7 @@ static void test_nanocoap__token_length_ext_16(void)
     int res = coap_parse(&pkt, buf, 21);
 
     TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(21, coap_get_total_hdr_len(&pkt));
     TEST_ASSERT_EQUAL_INT(204, coap_get_code_decimal(&pkt));
     TEST_ASSERT_EQUAL_INT(23, coap_get_id(&pkt));
     TEST_ASSERT_EQUAL_INT(strlen(token), coap_get_token_len(&pkt));
@@ -1121,6 +1135,7 @@ static void test_nanocoap__token_length_ext_269(void)
     int res = coap_parse(&pkt, buf, 275);
 
     TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(275, coap_get_total_hdr_len(&pkt));
     TEST_ASSERT_EQUAL_INT(204, coap_get_code_decimal(&pkt));
     TEST_ASSERT_EQUAL_INT(23, coap_get_id(&pkt));
     TEST_ASSERT_EQUAL_INT(strlen(token), coap_get_token_len(&pkt));


### PR DESCRIPTION
### Contribution description

Before `coap_get_total_hdr_len()` did not take the extended TKL field (RFC 8974) into account. This fixes the issue.


### Testing procedure

#### Unit tests in `master` (cherry-picking the second commit into `master`):

```
$ make BOARD=native -C tests/unittests all test
[...]

main(): This is RIOT! (Version: 2024.10-devel-370-g00e25)
Help: Press s to start test, r to print it is ready
READY
s
START
.......................==83870==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
.....................................................................................................................................................................................................................==83870==WARNING: ASan is ignoring requested __asan_handle_no_return: stack type: default top: 0xffcd4000; bottom 0xedf02000; size: 0x11dd2000 (299704320)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
nanocoap_tests.test_nanocoap__token_length_ext_16 (tests/unittests/tests-nanocoap/tests-nanocoap.c 1109) exp 21 was 20
.
nanocoap_tests.test_nanocoap__token_length_ext_269 (tests/unittests/tests-nanocoap/tests-nanocoap.c 1138) exp 275 was 273
...........................................................................................................................................................................................................................................................................................................................................................
run 1209 failures 2
```

#### Unit tests in this PR

```
$ make BOARD=native -C tests/unittests all test
[...]
main(): This is RIOT! (Version: 2024.10-devel-372-g2b3da-sys/nanocoap/fix-header-size-computation)
Help: Press s to start test, r to print it is ready
READY
s
START
.......................==81436==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
.....................................................................................................................................................................................................................==81436==WARNING: ASan is ignoring requested __asan_handle_no_return: stack type: default top: 0xfff08000; bottom 0xed502000; size: 0x12a06000 (312500224)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
OK (1209 tests)
```

### Issues/PRs references

None