### PR TITLE
makefiles/serial: better MOST_RECENT_PORT=1 for CDC ACM

### DIFF
--- a/boards/wemos-zero/Makefile.include
+++ b/boards/wemos-zero/Makefile.include
@@ -5,12 +5,4 @@ include $(RIOTBOARD)/common/arduino-zero/Makefile.include
 # Depending on whether the board is running RIOT or the bootloader, it has
 # registers using a different vendor and model. We try to detect either.
 TTY_BOARD_FILTER := --model $(BOARD) --vendor 'RIOT-os\.org'
-PROG_TTY_BOARD_FILTER := --vendor 'Arduino LLC' --model 'Arduino Zero'
-TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
-                  --most-recent \
-                  --format path serial \
-                  $(TTY_BOARD_FILTER) || \
-                  $(RIOTTOOLS)/usb-serial/ttys.py \
-                  --most-recent \
-                  --format path serial \
-                  $(PROG_TTY_BOARD_FILTER_CLONE)
+PROG_TTY_BOARD_FILTER := --vendor 'Arduino LLC' --model '(Arduino|Genuino) Zero'

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,15 +1,29 @@
 # Select the most recently attached tty interface
 ifeq (1,$(MOST_RECENT_PORT))
-  ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
-    TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
-                      --most-recent \
-                      --format path serial \
-                      --model '$(BOARD)' --vendor 'RIOT-os\.org'
-  else
-    TTY_SELECT_CMD ?= $(RIOTTOOLS)/usb-serial/ttys.py \
-                      --most-recent \
-                      --format path serial \
-                      $(TTY_BOARD_FILTER)
+  ifeq (,$(TTY_SELECT_CMD))
+    ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+      TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
+                        --most-recent \
+                        --format path serial \
+                        --model '$(BOARD)' --vendor 'RIOT-os\.org'
+      # Allow matching board by RIOT serial
+      ifneq (,$(SERIAL))
+        TTY_SELECT_CMD += --serial "$(SERIAL)"
+      endif
+      # Allow matching the bootloader TTY as well, if not running RIOT but
+      # but the bootloader
+      ifneq (,$(PROG_TTY_BOARD_FILTER))
+        TTY_SELECT_CMD += || $(RIOTTOOLS)/usb-serial/ttys.py \
+                             --most-recent \
+                             --format path serial \
+                             $(PROG_TTY_BOARD_FILTER)
+      endif
+    else
+      TTY_SELECT_CMD := $(RIOTTOOLS)/usb-serial/ttys.py \
+                        --most-recent \
+                        --format path serial \
+                        $(TTY_BOARD_FILTER)
+    endif
   endif
   TTY_DETECTED := $(shell $(TTY_SELECT_CMD) || echo 'no-tty-detected no-serial-detected')
   PORT_DETECTED := $(firstword $(TTY_DETECTED))


### PR DESCRIPTION
- Allow specifying an alternative board filter for the bootloader TTY, as this will present different vendor, model, and serial than RIOT's USB implementation.
- Allow specifying the serial. This is useful when multiple CDC ACM devices are present.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Connect multiple boards of the same type that use CDC ACM for `stdio` and get their serials:

```
$ make -C examples/default BOARD=wemos-zero list-ttys
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/examples/default'
path         | driver  | vendor      | model      | model_db | serial           | ctime    | iface_num
-------------|---------|-------------|------------|----------|------------------|----------|----------
/dev/ttyACM0 | cdc_acm | RIOT-os.org | wemos-zero | None     | A76A64C0D0458F79 | 13:20:37 | 0        
/dev/ttyACM1 | cdc_acm | RIOT-os.org | wemos-zero | None     | 65C57FC58B0D266F | 13:20:41 | 0        
```

Run `make term` passing `SERIAL=...` for the first board:

```
$ make -C examples/default BOARD=wemos-zero SERIAL=65C57FC58B0D266F term
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/examples/default'
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM1" -b "115200" -ln "/tmp/pyterm-marian.buschsieweke@ml-pa.loc" -rn "2024-11-05_13.20.56-default-wemos-zero"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2024-11-05 13:20:56,101 # Connect to serial port /dev/ttyACM1
```

Same for the second:

```
$ make -C examples/default BOARD=wemos-zero SERIAL=A76A64C0D0458F79 term
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/examples/default'
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-marian.buschsieweke@ml-pa.loc" -rn "2024-11-05_13.21.07-default-wemos-zero"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2024-11-05 13:21:07,813 # Connect to serial port /dev/ttyACM0
```

Check that the correct `/dev/ttyACM<NUM>` devices is selected.

### Issues/PRs references

None