### PR TITLE
pkg/u8g2: add to the displays doc group

### DIFF
--- a/pkg/u8g2/doc.txt
+++ b/pkg/u8g2/doc.txt
@@ -1,6 +1,7 @@
 /**
  * @defgroup pkg_u8g2   U8G2 graphic library for monochome displays
  * @ingroup  pkg
+ * @ingroup  drivers_display
  * @brief    Provides a monochrome graphics library for OLED and LCD displays
  * @see      https://github.com/olikraus/u8g2
  *


### PR DESCRIPTION
### Contribution description

This simply adds the `u8g2` package to the displays doc group.


### Testing procedure

The pkg should show up in these two locations:
- [website drivers page](https://www.riot-os.org/drivers.html) (under the "Display Device Drivers" menu)
- [doxygen "Display Device Drivers" page](https://doc.riot-os.org/group__drivers__display.html)


### Issues/PRs references

- none known
