### PR TITLE
core/mutex: add `mutex_init_locked()`

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -254,6 +254,17 @@ static inline void mutex_init(mutex_t *mutex)
 }
 
 /**
+ * @brief   Initializes a mutex object in a locked state.
+ * @details For initialization of variables use MUTEX_INIT_LOCKED instead.
+ *          Only use the function call for dynamically allocated mutexes.
+ * @param[out]      mutex   pre-allocated mutex structure, must not be NULL.
+ */
+static inline void mutex_init_locked(mutex_t *mutex)
+{
+    *mutex = (mutex_t)MUTEX_INIT_LOCKED;
+}
+
+/**
  * @brief   Initialize a mutex cancellation structure
  * @param   mutex       The mutex that the calling thread wants to lock
  * @return  The cancellation structure for use with @ref mutex_lock_cancelable


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Same as `mutex_init()` and complements `MUTEX_INIT` / `MUTEX_INIT_LOCKED` - I was surprised we did not have this yet.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
