### PR TITLE
cpu/cc2538: use RX FIFO count to determine CRC OK location

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -412,9 +412,9 @@ void cc2538_irq_handler(void)
 
     if (flags_f0 & RXPKTDONE) {
         handled_f0 |= RXPKTDONE;
-        /* CRC check */
-        uint8_t pkt_len = rfcore_peek_rx_fifo(0);
-        if (rfcore_peek_rx_fifo(pkt_len) & CC2538_CRC_BIT_MASK) {
+        /* CRC_OK bit is in the last byte in the RX FIFO */
+        uint8_t crc_loc = RFCORE_XREG_RXFIFOCNT - 1;
+        if (rfcore_peek_rx_fifo(crc_loc) & CC2538_CRC_BIT_MASK) {
             /* Disable RX while the frame has not been processed */
             _disable_rx();
             /* If AUTOACK is disabled or the ACK request bit is not set */


### PR DESCRIPTION
### Contribution description

Instead of using the length byte from a received packet (that might be corrupted), use the number of bytes in the RX FIFO to determine the location of the CRC OK bit.

### Testing procedure

Flashed this change on two CC2538s, started ping while under heavy Wi-Fi interference. In the case where the old `pkt_len` was not equal to the new `crc_loc`, the error from #20955 did not appear. Also, the reported `pkt_len` in this case is always `crc_loc + 128`, indicating that the receiver actually only uses the 7 LSBs from the length byte.

### Issues/PRs references

Fixes #20955.
