### PR TITLE
sys/shell: reduce overhead of XFA shell commands

### DIFF
--- a/examples/rust-async/Cargo.lock
+++ b/examples/rust-async/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#cdf3fc2825591d897ffd2f5a43e10ff9dc179b0c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#cdf3fc2825591d897ffd2f5a43e10ff9dc179b0c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#cdf3fc2825591d897ffd2f5a43e10ff9dc179b0c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -302,15 +302,14 @@ int shell_parse_file(const shell_command_t *commands,
  * ```
  */
 #define SHELL_COMMAND(cmd, help, func) \
-    XFA_USE_CONST(shell_command_xfa_t*, shell_commands_xfa); \
+    XFA_USE_CONST(shell_command_xfa_t, shell_commands_xfa_v2); \
     static FLASH_ATTR const char _xfa_ ## cmd ## _cmd_name[] = #cmd; \
     static FLASH_ATTR const char _xfa_ ## cmd ## _cmd_desc[] = help; \
-    static const shell_command_xfa_t _xfa_ ## cmd ## _cmd = { \
+    XFA_CONST(shell_command_xfa_t, shell_commands_xfa_v2, 0) _xfa_ ## cmd ## _cmd = { \
         .name = _xfa_ ## cmd ## _cmd_name, \
         .desc = _xfa_ ## cmd ## _cmd_desc, \
         .handler = &func \
-    }; \
-    XFA_ADD_PTR(shell_commands_xfa, cmd, cmd, &_xfa_ ## cmd ## _cmd)
+    };
 #endif /* __cplusplus */
 
 #ifdef __cplusplus

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#cdf3fc2825591d897ffd2f5a43e10ff9dc179b0c"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -36,7 +36,6 @@
 #include <assert.h>
 #include <errno.h>
 
-#include "kernel_defines.h"
 #include "xfa.h"
 #include "shell.h"
 #include "shell_lock.h"
@@ -47,7 +46,7 @@
 #endif
 
 /* define shell command cross file array */
-XFA_INIT_CONST(shell_command_xfa_t*, shell_commands_xfa);
+XFA_INIT_CONST(shell_command_xfa_t, shell_commands_xfa_v2);
 
 #define ETX '\x03'  /** ASCII "End-of-Text", or Ctrl-C */
 #define EOT '\x04'  /** ASCII "End-of-Transmission", or Ctrl-D */
@@ -102,10 +101,10 @@ static shell_command_handler_t search_commands(const shell_command_t *entry,
 
 static shell_command_handler_t search_commands_xfa(char *command)
 {
-    unsigned n = XFA_LEN(shell_command_t*, shell_commands_xfa);
+    unsigned n = XFA_LEN(shell_command_t, shell_commands_xfa_v2);
 
     for (unsigned i = 0; i < n; i++) {
-        const volatile shell_command_xfa_t *entry = shell_commands_xfa[i];
+        const volatile shell_command_xfa_t *entry = &shell_commands_xfa_v2[i];
         if (flash_strcmp(command, entry->name) == 0) {
             return entry->handler;
         }
@@ -147,7 +146,7 @@ static void print_commands_json(const shell_command_t *cmd_list)
         }
     }
 
-    unsigned n = XFA_LEN(shell_command_xfa_t*, shell_commands_xfa);
+    unsigned n = XFA_LEN(shell_command_xfa_t, shell_commands_xfa_v2);
     for (unsigned i = 0; i < n; i++) {
         if (first) {
             first = false;
@@ -155,7 +154,7 @@ static void print_commands_json(const shell_command_t *cmd_list)
         else {
             printf(", ");
         }
-        const volatile shell_command_xfa_t *entry = shell_commands_xfa[i];
+        const volatile shell_command_xfa_t *entry = &shell_commands_xfa_v2[i];
         printf("{\"cmd\": \"%s\", \"desc\": \"%s\"}", entry->name, entry->desc);
     }
     puts("]}");
@@ -170,9 +169,9 @@ static void print_commands(const shell_command_t *entry)
 
 static void print_commands_xfa(void)
 {
-    unsigned n = XFA_LEN(shell_command_xfa_t*, shell_commands_xfa);
+    unsigned n = XFA_LEN(shell_command_xfa_t, shell_commands_xfa_v2);
     for (unsigned i = 0; i < n; i++) {
-        const volatile shell_command_xfa_t *entry = shell_commands_xfa[i];
+        const volatile shell_command_xfa_t *entry = &shell_commands_xfa_v2[i];
         printf("%-20" PRIsflash " %" PRIsflash "\n",
                      entry->name, entry->desc);
     }

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#b531cc9ccb9c3cebc99d626b74b0b84a453fe58c"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#cdf3fc2825591d897ffd2f5a43e10ff9dc179b0c"
 dependencies = [
  "bare-metal",
  "coap-handler",


### PR DESCRIPTION
### Contribution description

We do not need to add an array of pointers to the shell commands, just an array of shell commands is sufficient. This reduced the overhead of XFA by `sizeof(void *)` per command.

### Testing procedure

```
$ make BOARD=arduino-uno flash term -C examples/default
[...]

2024-11-06 18:27:11,666 # main(): This is RIOT! (Version: 2024.10-devel-388-gf4b2ef-sys/shell/xfa-reduce-overhead)
2024-11-06 18:27:11,686 # Welcome to RIOT!
help
2024-11-06 18:27:25,324 # help
2024-11-06 18:27:25,361 # Command              Description
2024-11-06 18:27:25,402 # ---------------------------------------
2024-11-06 18:27:25,459 # pm                   interact with layered PM subsystem
2024-11-06 18:27:25,525 # ps                   Prints information about running threads.
2024-11-06 18:27:25,594 # saul                 interact with sensors and actuators using SAUL
2024-11-06 18:27:25,648 # version              Prints current RIOT_VERSION
2024-11-06 18:27:25,684 # reboot               Reboot the node
> ps
2024-11-06 18:27:27,196 # ps
2024-11-06 18:27:27,302 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2024-11-06 18:27:27,405 # 	 1 | idle                 | pending  Q |  15 |    128 (   90) (   38) |      0x3f2 |      0x41a 
2024-11-06 18:27:27,507 # 	 2 | main                 | running  Q |   7 |    644 (  296) (  348) |      0x472 |      0x5fc 
2024-11-06 18:27:27,581 # 	   | SUM                  |            |     |    772 (  386) (  386)
> 2024-11-06 18:27:28,874 # Exiting Pyterm
```

```
$ make BOARD=same54-xpro flash term -C examples/default
[...]
> help
2024-11-06 18:29:29,540 # help
2024-11-06 18:29:29,543 # Command              Description
2024-11-06 18:29:29,546 # ---------------------------------------
2024-11-06 18:29:29,551 # ifconfig             Configure network interfaces
2024-11-06 18:29:29,557 # txtsnd               Sends a custom string as is over the link layer
2024-11-06 18:29:29,562 # pm                   interact with layered PM subsystem
2024-11-06 18:29:29,567 # ps                   Prints information about running threads.
2024-11-06 18:29:29,572 # rtc                  control RTC peripheral interface
2024-11-06 18:29:29,578 # saul                 interact with sensors and actuators using SAUL
2024-11-06 18:29:29,582 # version              Prints current RIOT_VERSION
2024-11-06 18:29:29,585 # reboot               Reboot the node
> ps
2024-11-06 18:29:31,316 # ps
2024-11-06 18:29:31,324 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2024-11-06 18:29:31,333 # 	 - | isr_stack            | -        - |   - |    512 (  172) (  340) | 0x20000000 | 0x200001c8
2024-11-06 18:29:31,342 # 	 1 | main                 | running  Q |   7 |   1536 (  700) (  836) | 0x200002c0 | 0x20000724 
2024-11-06 18:29:31,350 # 	 2 | pktdump              | bl rx    _ |   6 |   1472 (  468) ( 1004) | 0x20001048 | 0x2000155c 
2024-11-06 18:29:31,359 # 	 3 | sam0_eth             | bl anyfl _ |   2 |    896 (  276) (  620) | 0x20000a5c | 0x20000d1c 
```

And `native` will be tested by the CI.

### Issues/PRs references

- [x] Depends on and includes https://github.com/RIOT-OS/RIOT/pull/20960