### PR TITLE
tests/build_system/xfa: improve test coverage

### DIFF
--- a/tests/build_system/xfa/main.c
+++ b/tests/build_system/xfa/main.c
@@ -19,7 +19,6 @@
  */
 
 #include <stdio.h>
-#include <stdint.h>
 
 #include "xfa.h"
 
@@ -35,12 +34,14 @@ int main(void)
     unsigned n = XFA_LEN(xfatest_t, xfatest);
     printf("xfatest[%u]:\n", n);
     for (unsigned i = 0; i < n; i++) {
-        printf("[%u] = %u, \"%s\"\n", i, xfatest[i].val, xfatest[i].text);
+        printf("[%u] = %u, \"%s\", '%c'\n",
+                i, xfatest[i].val, xfatest[i].text, xfatest[i].letter);
     }
     n = XFA_LEN(xfatest_t, xfatest_const);
     printf("xfatest_const[%u]:\n", n);
     for (unsigned i = 0; i < n; i++) {
-        printf("[%u] = %u, \"%s\"\n", i, xfatest_const[i].val, xfatest_const[i].text);
+        printf("[%u] = %u, \"%s\", '%c'\n",
+                i, xfatest_const[i].val, xfatest_const[i].text, xfatest_const[i].letter);
     }
 
     return 0;

--- a/tests/build_system/xfa/tests/01-run.py
+++ b/tests/build_system/xfa/tests/01-run.py
@@ -14,12 +14,16 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact('Cross file array test')
-    child.expect_exact('xfatest[2]:')
-    child.expect_exact('[0] = 1, "xfatest1"')
-    child.expect_exact('[1] = 2, "xfatest2"')
-    child.expect_exact('xfatest_const[2]:')
-    child.expect_exact('[0] = 123, "xfatest_const1"')
-    child.expect_exact('[1] = 45, "xfatest_const2"')
+    child.expect_exact('xfatest[4]:')
+    child.expect_exact("[0] = 1, \"xfatest1\", 'a'")
+    child.expect_exact("[1] = 2, \"xfatest2\", 'b'")
+    child.expect_exact("[2] = 3, \"xfatest3\", 'c'")
+    child.expect_exact("[3] = 4, \"xfatest4\", 'd'")
+    child.expect_exact('xfatest_const[4]:')
+    child.expect_exact("[0] = 123, \"xfatest_const1\", 'a'")
+    child.expect_exact("[1] = 45, \"xfatest_const2\", 'b'")
+    child.expect_exact("[2] = 42, \"xfatest_const3\", 'c'")
+    child.expect_exact("[3] = 44, \"xfatest_const4\", 'd'")
 
 
 if __name__ == "__main__":

--- a/tests/build_system/xfa/xfatest.h
+++ b/tests/build_system/xfa/xfatest.h
@@ -18,6 +18,7 @@ extern "C" {
 typedef struct {
     unsigned val;
     const char *text;
+    char letter;
 } xfatest_t;
 
 #endif /* DOXYGEN */

--- a/tests/build_system/xfa/xfatest1.c
+++ b/tests/build_system/xfa/xfatest1.c
@@ -1,5 +1,5 @@
 #include "xfa.h"
 #include "xfatest.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest1 = { .val = 1, .text = "xfatest1" };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const1 = { .val = 123, .text = "xfatest_const1" };
+XFA(xfatest, 0) xfatest_t _xfatest1 = { .val = 1, .text = "xfatest1", .letter = 'a' };
+XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const1 = { .val = 123, .text = "xfatest_const1", .letter = 'a' };

--- a/tests/build_system/xfa/xfatest2.c
+++ b/tests/build_system/xfa/xfatest2.c
@@ -1,5 +1,10 @@
 #include "xfa.h"
 #include "xfatest.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest2 = { .val = 2, .text = "xfatest2" };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const2 = { .val = 45, .text = "xfatest_const2" };
+XFA(xfatest, 1) xfatest_t _xfatest2 = { .val = 2, .text = "xfatest2", .letter = 'b' };
+XFA(xfatest, 3) xfatest_t _xfatest4 = { .val = 4, .text = "xfatest4", .letter = 'd' };
+XFA(xfatest, 2) xfatest_t _xfatest3 = { .val = 3, .text = "xfatest3", .letter = 'c' };
+
+XFA_CONST(xfatest_const, 1) xfatest_t _xfatest_const2 = { .val = 45, .text = "xfatest_const2", .letter = 'b' };
+XFA_CONST(xfatest_const, 3) xfatest_t _xfatest_const4 = { .val = 44, .text = "xfatest_const4", .letter = 'd' };
+XFA_CONST(xfatest_const, 2) xfatest_t _xfatest_const3 = { .val = 42, .text = "xfatest_const3", .letter = 'c' };


### PR DESCRIPTION
### Contribution description

This increases the test coverage for XFA:

- Multiple entries are added from a single file
- Priorities are assigned to enforce a given order
- The size of the `struct` to add is changed to no longer be a power of 2

### Testing procedure

The test is automated and should pass in the CI. It will fail on `native64`, though.

### Issues/PRs references

None