### PR TITLE
tests/net/nanocoap_cli: make use of XFA for shell commands

### DIFF
--- a/tests/net/nanocoap_cli/main.c
+++ b/tests/net/nanocoap_cli/main.c
@@ -22,8 +22,6 @@
 #include "msg.h"
 
 #include "net/nanocoap_sock.h"
-#include "net/gnrc/netif.h"
-#include "net/ipv6/addr.h"
 #include "shell.h"
 
 #define MAIN_QUEUE_SIZE (4)
@@ -31,7 +29,6 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 #if IS_USED(MODULE_NANOCOAP_DTLS)
 #include "net/credman.h"
-#include "net/dsm.h"
 #include "tinydtls_keys.h"
 
 static const uint8_t psk_id_0[] = PSK_DEFAULT_IDENTITY;
@@ -47,25 +44,6 @@ static const credman_credential_t credential = {
     },
 };
 #endif
-
-extern int nanotest_client_cmd(int argc, char **argv);
-extern int nanotest_client_url_cmd(int argc, char **argv);
-extern int nanotest_server_cmd(int argc, char **argv);
-extern int nanotest_client_put_cmd(int argc, char **argv);
-extern int nanotest_client_put_non_cmd(int argc, char **argv);
-extern int nanotest_client_get_non_cmd(int argc, char **argv);
-static int _list_all_inet6(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "client", "CoAP client", nanotest_client_cmd },
-    { "url", "CoAP client URL request", nanotest_client_url_cmd },
-    { "put", "experimental put", nanotest_client_put_cmd },
-    { "put_non", "non-confirmable put", nanotest_client_put_non_cmd },
-    { "get_non", "non-confirmable get", nanotest_client_get_non_cmd },
-    { "server", "CoAP server", nanotest_server_cmd },
-    { "inet6", "IPv6 addresses", _list_all_inet6 },
-    { NULL, NULL, NULL }
-};
 
 /* _list_all_inet6() and _print_addr() derived from sc_gnrc_netif.c */
 
@@ -105,7 +83,7 @@ static void _print_addr(ipv6_addr_t *addr, uint8_t flags)
     printf("\n");
 }
 
-static int _list_all_inet6(int argc, char **argv)
+static int _cmd_inet6(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -137,6 +115,8 @@ static int _list_all_inet6(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(inet6, "IPv6 addresses", _cmd_inet6);
+
 int main(void)
 {
     /* for the thread running the shell */
@@ -154,7 +134,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should never be reached */
     return 0;

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -25,15 +25,14 @@
 
 #include "net/coap.h"
 #include "net/gnrc/netif.h"
-#include "net/ipv6.h"
 #include "net/nanocoap.h"
 #include "net/nanocoap_sock.h"
-#include "net/sock/udp.h"
 #include "net/sock/util.h"
-
 #include "od.h"
+#include "shell.h"
 
-static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str)
+static ssize_t _send(coap_pkt_t *pkt, size_t len,
+                          char *addr_str, const char *port_str)
 {
     ipv6_addr_t addr;
     sock_udp_ep_t remote;
@@ -81,7 +80,7 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
     return nanocoap_request(pkt, NULL, &remote, len);
 }
 
-int nanotest_client_cmd(int argc, char **argv)
+static int _cmd_client(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
     const char *method_codes[] = {"get", "post", "put"};
@@ -166,7 +165,10 @@ int nanotest_client_cmd(int argc, char **argv)
     return 1;
 }
 
-static int _blockwise_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
+SHELL_COMMAND(client, "CoAP client", _cmd_client);
+
+static int _blockwise_cb(void *arg, size_t offset, uint8_t *buf,
+                         size_t len, int more)
 {
     (void)arg;
     (void)more;
@@ -180,7 +182,7 @@ static int _blockwise_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int
     return 0;
 }
 
-int nanotest_client_url_cmd(int argc, char **argv)
+static int _cmd_url(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
     const char *method_codes[] = { "get", "post", "put", "delete" };
@@ -248,6 +250,8 @@ error:
     return -1;
 }
 
+SHELL_COMMAND(url, "CoAP client URL request", _cmd_url);
+
 static const char song[] =
     "Join us now and share the software;\n"
     "You'll be free, hackers, you'll be free.\n"
@@ -269,7 +273,7 @@ static const char song[] =
     "Join us now and share the software;\n"
     "You'll be free, hackers, you'll be free.\n";
 
-int nanotest_client_put_cmd(int argc, char **argv)
+static int _cmd_put(int argc, char **argv)
 {
     int res;
     nanocoap_sock_t sock;
@@ -304,7 +308,9 @@ int nanotest_client_put_cmd(int argc, char **argv)
     return res;
 }
 
-int nanotest_client_put_non_cmd(int argc, char **argv)
+SHELL_COMMAND(put, "experimental put", _cmd_put);
+
+static int _cmd_put_non(int argc, char **argv)
 {
     int res;
 
@@ -323,7 +329,9 @@ int nanotest_client_put_non_cmd(int argc, char **argv)
     return res;
 }
 
-int nanotest_client_get_non_cmd(int argc, char **argv)
+SHELL_COMMAND(put_non, "non-confirmable put", _cmd_put_non);
+
+static int _cmd_get_non(int argc, char **argv)
 {
     int res;
 
@@ -348,3 +356,5 @@ int nanotest_client_get_non_cmd(int argc, char **argv)
     }
     return res;
 }
+
+SHELL_COMMAND(get_non, "non-confirmable get", _cmd_get_non);

--- a/tests/net/nanocoap_cli/nanocli_server.c
+++ b/tests/net/nanocoap_cli/nanocli_server.c
@@ -21,8 +21,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "net/nanocoap_sock.h"
+#include "net/coap.h"
+#include "net/nanocoap.h"
 #include "net/sock/udp.h"
+#include "shell.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -69,6 +71,9 @@ static int _nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize,
             }
             if ((res = coap_handle_req(&pkt, buf, bufsize, &ctx)) > 0) {
                 res = sock_udp_send(&sock, buf, res, &remote);
+                if (res < 0) {
+                    DEBUG("nanocoap: failed to send: %" PRIdSIZE "\n", res);
+                }
             }
         }
     }
@@ -83,7 +88,7 @@ static void _start_server(uint16_t port, int ignore_count)
     _nanocoap_server(&local, buf, sizeof(buf), ignore_count);
 }
 
-int nanotest_server_cmd(int argc, char **argv)
+static int _cmd_server(int argc, char **argv)
 {
     if (argc < 2) {
         goto error;
@@ -132,3 +137,5 @@ int nanotest_server_cmd(int argc, char **argv)
     printf("  port  defaults to %u\n", COAP_PORT);
     return 1;
 }
+
+SHELL_COMMAND(server, "CoAP server", _cmd_server);


### PR DESCRIPTION
### Contribution description

As the title says: This changes the test to make use of the `SHELL_COMMAND()` macro.

### Testing procedure

Everything should work as before, except for the order of the commands in `help`.

This sadly increases the size of `.text` a bit. Something that https://github.com/RIOT-OS/RIOT/pull/20958 would fix.

### Issues/PRs references

None