### PR TITLE
tests/sys/shell_lock: increase robustness of the test

### DIFF
--- a/tests/sys/shell_lock/main.c
+++ b/tests/sys/shell_lock/main.c
@@ -20,6 +20,21 @@
 
 #include "test_utils/interactive_sync.h"
 
+/* this command is used by the test automation to check whether commands are
+ * executed or not (due to the shell being locked). */
+static int _cmd_ping(int argc, char **argv)
+{
+    if (argc != 1) {
+        printf("Usage: %s\n", argv[0]);
+        return 1;
+    }
+
+    puts("PONG!");
+    return 0;
+}
+
+SHELL_COMMAND(ping, "Echo \"PONG!\"", _cmd_ping);
+
 int main(void)
 {
     test_utils_interactive_sync();

--- a/tests/sys/shell_lock/tests/01-run.py
+++ b/tests/sys/shell_lock/tests/01-run.py
@@ -22,15 +22,6 @@ PASSWORDS_INCORRECT = [
     "_password"
 ]
 
-EXPECTED_HELP = (
-    'Command              Description',
-    '---------------------------------------',
-    'lock                 Lock the shell',
-    'pm                   interact with layered PM subsystem',
-    'reboot               Reboot the node',
-    'version              Prints current RIOT_VERSION',
-)
-
 AUTO_LOCK_TIMEOUT_MS = 7000
 SHELL_PROMPT = '> '
 PASSWORD_PROMPT = 'Password: '
@@ -49,16 +40,15 @@ def testfunc(child):
     child.expect_exact(SHELL_PROMPT)
 
     # check we have access
-    child.sendline('help')
-    for line in EXPECTED_HELP:
-        child.expect_exact(line)
+    child.sendline('ping')
+    child.expect_exact("PONG!")
 
     # lock
     child.sendline('lock')
     child.expect(SHELL_PROMPT)
 
     # trigger password prompt
-    child.sendline('help')
+    child.sendline('ping')
     child.expect('The shell is locked. Enter a valid password to unlock.')
 
     # test different incorrect passwords
@@ -82,16 +72,15 @@ def testfunc(child):
     child.expect_exact(SHELL_PROMPT)
 
     # check we have access
-    child.sendline('help')
-    for line in EXPECTED_HELP:
-        child.expect_exact(line)
+    child.sendline('ping')
+    child.expect_exact("PONG!")
 
     # wait until auto_lock locks the shell after
     # CONFIG_SHELL_LOCK_AUTO_LOCK_TIMEOUT_MS (+ 1 second buffer time)
     time.sleep((AUTO_LOCK_TIMEOUT_MS / 1000.0) + 1)
 
     # trigger password prompt
-    child.sendline('help')
+    child.sendline('ping')
     child.expect('The shell is locked. Enter a valid password to unlock.')
 
 


### PR DESCRIPTION
### Contribution description

Before the test used the `help` command to verify that access to the shell is present. While this does have the benefit of not requiring a custom command, it does have some robustness issues:

- When new default commands get added, this test will fail
- When the help message of a command gets reworded, the test will fail
- When the order of commands in the test will change, the test will fail
    - Note that with the XFA based `SHELL_COMMAND()` macro, we do not guarantee any particular order. Specifically, the order can change with implementation details.

### Testing procedure

The test should pass.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/20958 has shown that changing implementation details of `SHELL_COMMAND()` does affect the order of commands in the `help` list.