### PR TITLE
.clang-format: Set ColumnLimit to 0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -57,7 +57,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit: 100
+ColumnLimit: 0
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false


### PR DESCRIPTION
### Contribution description

This disables adding/removing line breaks by `clang-format`, as this could very well introduce regressions in code formatting in terms of our coding convention: If a long array was matching the soft limit of 80 chars per line, `clang-format` would reflow it to match the hard limit of 100 chars.

One can selectively disable `clang-format` with magic comments. But at this point, I'd say we should rather disable this feature until we can configure it in a way to match our coding convention better (without having to add magic comments).

### Testing procedure

With this PR, `clang-format` should not increase the column with above 80 chars anymore.

### Issues/PRs references

None