### PR TITLE
tests: no default interactive sync for native

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,17 +1,20 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
-
-ifneq (,$(wildcard $(CURDIR)/tests*/.))
-  # add interactive test configuration when testing Kconfig
-  DEFAULT_MODULE += test_utils_interactive_sync
-  # add stack metric printing configuration when testing Kconfig
-  DEFAULT_MODULE += test_utils_print_stack_usage
-endif
-
-# terminate native when the test is complete
-CFLAGS += -DNATIVE_AUTO_EXIT=1
-
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 QUIET ?= 1
 # DEVELHELP enabled by default for all tests, set 0 to disable
 DEVELHELP ?= 1
+
+ifneq (,$(wildcard $(CURDIR)/tests*/.))
+  # add interactive test configuration when automated testing is available,
+  # except for `native` and `native64` where we control when the RIOT app is
+  # started
+  ifeq (,$(filter native native64,$(BOARD)))
+    DEFAULT_MODULE += test_utils_interactive_sync
+  endif
+  # print stack usage by default when automated testing is available
+  DEFAULT_MODULE += test_utils_print_stack_usage
+endif
+
+# terminate native when the test is complete
+CFLAGS += -DNATIVE_AUTO_EXIT=1

--- a/tests/README.md
+++ b/tests/README.md
@@ -127,7 +127,8 @@ As some board can't be reset without a manual trigger tests should be implemente
 with some kind of `synchronization`. This can be done in two ways:
 
 - use `test_utils_interactive_sync` when uart input/output does not need to be
-  disabled for the test. This is enabled by default.
+  disabled for the test. This is enabled by default, except for `native` and
+  `native64`.
 - set up the test in a loop so the test script will be able so sync with some kind
   of start condition in the test.
 

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure/main.c
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure/main.c
@@ -802,6 +802,10 @@ int main(void)
 {
     _tests_init();
 
+    /* work around issue in _check_congure_snd_msg(): the assert for
+     * time > o will not work when the time is 0 */
+    while (xtimer_now_usec() / US_PER_MS == 0) { }
+
     TESTS_START();
     TESTS_RUN(tests_gnrc_sixlowpan_frag_sfr_congure_integration());
     TESTS_END();

--- a/tests/periph/timer_periodic/Makefile
+++ b/tests/periph/timer_periodic/Makefile
@@ -4,4 +4,9 @@ FEATURES_REQUIRED = periph_timer_periodic
 
 USEMODULE += fmt
 
+# Interactive sync improves accuracy of timestamping the output
+# and is also needed on native for the automatic test to
+# pass. Hence, we just depend on it here.
+USEMODULE += test_utils_interactive_sync
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/posix_sleep/Makefile
+++ b/tests/sys/posix_sleep/Makefile
@@ -2,6 +2,11 @@ include ../Makefile.sys_common
 
 USEMODULE += posix_sleep
 
+# Interactive sync improves accuracy of timestamping the output
+# and is also needed on native for the automatic test to
+# pass. Hence, we just depend on it here.
+USEMODULE += test_utils_interactive_sync
+
 # microbit qemu failing currently
 TEST_ON_CI_BLACKLIST += microbit
 


### PR DESCRIPTION
### Contribution description

The aim is to allow faster test cycles on native for unit test style apps (that don't need interaction) by bypassing the python test framework using e.g.:

    make RIOT_TERMINAL=native all term

This would work already before, but now is more convenient as no manual press of the `s` key is needed to start the test.

For non-native boards we need the sync, as otherwise the board may finish booting before the python test automation framework can capture output. For `native` and `native64`, we actually control when the RIOT app is started and do not need to sync.

On a typical machine this can reduce the test cycle by more than 4 seconds.

### Testing procedure


With this change:

    $ time sh -c 'make BOARD=native -C tests/unittests tests-nanocoap -j && make BOARD=native RIOT_TERMINAL=native -C tests/unittests term'
    [...]
    main(): This is RIOT! (Version: 2024.10-devel-394-gd65dec-tests/no-sync-control)
    ...................................
    OK (35 tests)
    [...]
    make: Leaving directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests'
    sh -c   0.30s user 0.24s system 113% cpu 0.476 total

Before t his change:

    $ time sh -c 'make BOARD=native -C tests/unittests tests-nanocoap -j && make BOARD=native -C tests/unittests test'
    [...]
    main(): This is RIOT! (Version: 2024.10-devel-394-gd65dec-tests/no-sync-control)
    Help: Press s to start test, r to print it is ready
    READY
    s
    START
    ...................................
    OK (35 tests)
    [...]
    make: Leaving directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests'
    sh -c   0.50s user 0.37s system 17% cpu 4.863 total

### Issues/PRs references

None