### PR TITLE
boards/openmote-b: set at86rf215 reset pulse width to 50ms

### DIFF
--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -122,6 +122,12 @@
 #define AT86RF215_PARAM_CS         GPIO_PIN(0, 3) /* A3 */
 #define AT86RF215_PARAM_INT        GPIO_PIN(3, 0) /* D0 */
 #define AT86RF215_PARAM_RESET      GPIO_PIN(3, 1) /* D1 */
+
+/**
+ * @brief board requires unusually long reset */
+#ifndef CONFIG_AT86RF215_RESET_PULSE_WIDTH_US
+#define CONFIG_AT86RF215_RESET_PULSE_WIDTH_US   (50000u)
+#endif
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The board had the problem that the AT86RF215 radio would not come up, especially from cold boot.

Increasing the reset delay to 50ms appears to fix this issue for good.


### Testing procedure

Unplug the device, after plugging it in verify that the interface has come up:

```
2024-11-08 16:11:57,032 # Iface  6  HWaddr: 19:C4  Channel: 0  NID: 0x23  PHY: MR-O-QPSK 
2024-11-08 16:11:57,034 #            chip rate: 1000  rate mode: 2 
2024-11-08 16:11:57,036 #           Long HWaddr: AE:8D:FE:E1:60:ED:99:C4 
2024-11-08 16:11:57,048 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2024-11-08 16:11:57,052 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:2022  MTU:1280  HL:64  6LO  
2024-11-08 16:11:57,054 #           Source address length: 8
2024-11-08 16:11:57,055 #           Link type: wireless
2024-11-08 16:11:57,064 #           inet6 addr: fe80::ac8d:fee1:60ed:99c4  scope: link  VAL
2024-11-08 16:11:57,065 #           inet6 group: ff02::1
2024-11-08 16:11:57,066 #           
2024-11-08 16:11:57,068 # Iface  7  HWaddr: 19:C5  Channel: 26  NID: 0x23  PHY: MR-O-QPSK 
2024-11-08 16:11:57,079 #            chip rate: 1000  rate mode: 2 
2024-11-08 16:11:57,081 #           Long HWaddr: AE:8D:FE:E1:60:ED:99:C5 
2024-11-08 16:11:57,084 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2024-11-08 16:11:57,096 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:2022  MTU:1280  HL:64  6LO  
2024-11-08 16:11:57,097 #           Source address length: 8
2024-11-08 16:11:57,098 #           Link type: wireless
2024-11-08 16:11:57,111 #           inet6 addr: fe80::ac8d:fee1:60ed:99c5  scope: link  VAL
2024-11-08 16:11:57,112 #           inet6 group: ff02::1

```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
