### PR TITLE
cpu/nRF52: Always recover Device before Flashing

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -18,8 +18,12 @@ else
   PROGRAMMER ?= openocd
 endif
 
-# setup OpenOCD for flashing. Version 0.10 of OpenOCD doesn't contain support
-# for nrf52dk and nrf52840dk boards. To use OpenOCD with these a version
-# build from source (master > 2018, August the 13rd) is required.
+# Setup OpenOCD for flashing. The nRF52 series is supported from OpenOCD v0.11
+# onwards.
 OPENOCD_DEBUG_ADAPTER ?= jlink
 OPENOCD_CONFIG = $(RIOTBOARD)/common/nrf52/dist/openocd.cfg
+
+# From Build Code Fxx and later, the nRF52 device is automatically locked after
+# a power cycle and has to be recovered with a separate command after the
+# initialization. Otherwise the Flash can not be accessed.
+OPENOCD_POST_INIT_CMDS = -c 'nrf52_recover'

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -346,6 +346,7 @@ do_flash() {
             -c 'telnet_port 0' \
             -c 'gdb_port 0' \
             -c 'init' \
+            ${OPENOCD_POST_INIT_CMDS} \
             -c 'targets' \
             ${OPENOCD_CMD_RESET_HALT} \
             ${OPENOCD_PRE_FLASH_CMDS} \

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -34,6 +34,12 @@ $(call target-export-variables,$(OPENOCD_TARGETS),OPENOCD_CORE)
 # Export OPENOCD_ADAPTER_INIT to required targets
 $(call target-export-variables,$(OPENOCD_TARGETS),OPENOCD_ADAPTER_INIT)
 
+# Export OPENOCD_EXTRA_INIT to required targets
+$(call target-export-variables,$(OPENOCD_TARGETS),OPENOCD_EXTRA_INIT)
+
+# Export OPENOCD_EXTRA_RESET_INIT to required targets
+$(call target-export-variables,$(OPENOCD_TARGETS),OPENOCD_EXTRA_RESET_INIT)
+
 # Export OPENOCD_RESET_USE_CONNECT_ASSERT_SRST to required targets
 $(call target-export-variables,$(OPENOCD_TARGETS),OPENOCD_RESET_USE_CONNECT_ASSERT_SRST)
 
@@ -65,6 +71,11 @@ OPENOCD_FLASH_TARGETS = flash flash-only flashr
 ifneq (,$(IMAGE_OFFSET))
   # Export IMAGE_OFFSET only to the flash/flash-only target
   $(call target-export-variables,$(OPENOCD_FLASH_TARGETS),IMAGE_OFFSET)
+endif
+
+ifneq (,$(OPENOCD_POST_INIT_CMDS))
+  # Export OPENOCD_POST_INIT_CMDS only to the flash/flash-only target
+  $(call target-export-variables,$(OPENOCD_FLASH_TARGETS),OPENOCD_POST_INIT_CMDS)
 endif
 
 ifneq (,$(OPENOCD_PRE_VERIFY_CMDS))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With nRF52 silicon revision Fxx and newer, the behavior of the APPROTECT flash protection was changed. Previously it had to be activated manually and as long as it was not activated, the flash could be read from and written to without issues.
After the revision, the device is in a protected state after the first power cycle, making it impossible to read/write/modify the flash memory with an external debugger.

Furthermore, the device has to be unlocked (or in Nordic terms "recovered") explicitly. Unlike the term "recover" might suggest, the flash is erased during that "recovery".
The Segger J-Link does that recovery process implicitly, while OpenOCD has a dedicated `nrf52_recover` command for it which has to be called after the `init` command and before any other command.

This necessitated the introduction of another OpenOCD variable, which is between the `init` and the following `target` command in the flash procedure, called `OPENOCD_POST_INIT_CMDS`.

This variable is defined in the shared `boards/common/nrf52/Makefile.include` and is therefore set for all nRF52 devices. When not using OpenOCD, it does not have any effect and there should not be any adverse effects on other programmers.

A side effect is that earlier silicon revisions might get their flash memory erased by the `nrf52_recover` command even though it is not necessary for them, but adding a distinction for the old chips is beyond the scope of the RIOT flashing scripts I think.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Programming any nRF52 board using an external programmer (J-Link or ST-LINK) in conjunction with OpenOCD with the newer silicon revisions should throw an OpenOCD error about the missing recovery command with the current master.

```
chris@ThinkPias:~/flashdev-riot/RIOT$ PROGRAMMER=openocd BOARD=nrf52840dk make -C examples/hello-world flash -j12
make: Verzeichnis „/home/chris/flashdev-riot/RIOT/examples/hello-world“ wird betreten
Building application "hello-world" for "nrf52840dk" with CPU "nrf52".

"make" -C /home/chris/flashdev-riot/RIOT/pkg/cmsis/ 
...
"make" -C /home/chris/flashdev-riot/RIOT/cpu/cortexm_common/periph
   text    data     bss     dec     hex filename
  11456     108    2328   13892    3644 /home/chris/flashdev-riot/RIOT/examples/hello-world/bin/nrf52840dk/hello-world.elf
/home/chris/flashdev-riot/RIOT/dist/tools/openocd/openocd.sh flash /home/chris/flashdev-riot/RIOT/examples/hello-world/bin/nrf52840dk/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Info : J-Link EDU Mini V1 compiled Apr 15 2024 17:39:18
Info : Hardware version: 1.00
Info : VTarget = 2.992 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Error: Could not find MEM-AP to control the core
****** WARNING ******
nRF52 device has AP lock engaged (see UICR APPROTECT register).
Debug access is denied.
Use 'nrf52_recover' to erase and unlock the device.

Warn : target nrf52.cpu examination failed
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 39965 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          unknown

Error: Could not find MEM-AP to control the core
****** WARNING ******
nRF52 device has AP lock engaged (see UICR APPROTECT register).
Debug access is denied.
Use 'nrf52_recover' to erase and unlock the device.

Error: Target not examined, reset NOT asserted!
```

With this PR, it should just work. I tested it with a J-Link EDU (an unrelated issue prevents using the builtin J-Link with the latest firmware) and a Nordic Semiconductor nRF52840 DK (PCA10056 Revision 3.0.1 from 2023.6).

```
chris@ThinkPias:~/flashdev-riot/RIOT$ PROGRAMMER=openocd BOARD=nrf52840dk make -C examples/hello-world flash -j12
make: Verzeichnis „/home/chris/flashdev-riot/RIOT/examples/hello-world“ wird betreten
Building application "hello-world" for "nrf52840dk" with CPU "nrf52".
...
   text    data     bss     dec     hex filename
  11472     108    2328   13908    3654 /home/chris/flashdev-riot/RIOT/examples/hello-world/bin/nrf52840dk/hello-world.elf
/home/chris/flashdev-riot/RIOT/dist/tools/openocd/openocd.sh flash /home/chris/flashdev-riot/RIOT/examples/hello-world/bin/nrf52840dk/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Info : J-Link EDU Mini V1 compiled Apr 15 2024 17:39:18
Info : Hardware version: 1.00
Info : VTarget = 2.990 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Error: Could not find MEM-AP to control the core
****** WARNING ******
nRF52 device has AP lock engaged (see UICR APPROTECT register).
Debug access is denied.
Use 'nrf52_recover' to erase and unlock the device.

Warn : target nrf52.cpu examination failed
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 35695 for gdb connections
Waiting for chip erase...
nrf52.cpu device has been successfully erased and unlocked.
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
Error: nrf52.cpu -- clearing lockup after double fault
Polling target nrf52.cpu failed, trying to reexamine
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0xfffffffe msp: 0xfffffffc
Info : nRF52840-xxAA(build code: F0) 1024kB Flash, 256kB RAM
Warn : Adding extra erase range, 0x00002d3c .. 0x00002fff
auto erase enabled
wrote 11580 bytes from file /home/chris/flashdev-riot/RIOT/examples/hello-world/bin/nrf52840dk/hello-world.elf in 0.511253s (22.119 KiB/s)

verified 11580 bytes in 0.079247s (142.701 KiB/s)

shutdown command invoked
Done flashing
make: Verzeichnis „/home/chris/flashdev-riot/RIOT/examples/hello-world“ wird verlassen
```


### Issues/PRs references

This solves #20968 (at least the issues we can fix from RIOTs side).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
