### PR TITLE
cpu/stm32: Make ADC Resolution Definition uniform

### DIFF
--- a/cpu/stm32/include/periph/c0/periph_cpu.h
+++ b/cpu/stm32/include/periph/c0/periph_cpu.h
@@ -32,6 +32,21 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
 /**
+ * @brief   Override ADC resolution values
+ * @{
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = (ADC_CFGR1_RES),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR1_RES_1),  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR1_RES_0),  /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported) */
+} adc_res_t;
+/** @} */
+
+/**
  * @name   Constants for internal VBAT ADC line
  * @{
  */

--- a/cpu/stm32/include/periph/f0/periph_cpu.h
+++ b/cpu/stm32/include/periph/f0/periph_cpu.h
@@ -53,12 +53,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (0x3 << 3),     /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (0x2 << 3),     /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (0x1 << 3),     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0 << 3),     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),         /**< not applicable */
-    ADC_RES_16BIT = (0xff)          /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CFGR1_RES),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR1_RES_1),  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR1_RES_0),  /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/f2/periph_cpu.h
+++ b/cpu/stm32/include/periph/f2/periph_cpu.h
@@ -54,12 +54,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = 0x03000000,  /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = 0x02000000,  /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = 0x01000000,  /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = 0x00000000,  /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 1,           /**< ADC resolution: 14 bit (not supported) */
-    ADC_RES_16BIT = 2            /**< ADC resolution: 16 bit (not supported)*/
+    ADC_RES_6BIT  = (ADC_CR1_RES),      /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CR1_RES_1),    /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CR1_RES_0),    /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported)*/
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/f3/periph_cpu.h
+++ b/cpu/stm32/include/periph/f3/periph_cpu.h
@@ -61,12 +61,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (ADC_CFGR_RES),   /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (ADC_CFGR_RES_1), /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (ADC_CFGR_RES_0), /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0),            /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0x1),            /**< not applicable */
-    ADC_RES_16BIT = (0x2)             /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CFGR_RES),     /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR_RES_1),   /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR_RES_0),   /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/f4/periph_cpu.h
+++ b/cpu/stm32/include/periph/f4/periph_cpu.h
@@ -56,17 +56,17 @@ extern "C" {
 #define GET_RDP(x) ((x & 0xFF00) >> 8)
 
 /**
- * @brief   Override the ADC resolution configuration
+ * @brief   Override ADC resolution values
  * @{
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = 0x03000000,     /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = 0x02000000,     /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = 0x01000000,     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = 0x00000000,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 1,              /**< ADC resolution: 14 bit (not supported) */
-    ADC_RES_16BIT = 2               /**< ADC resolution: 16 bit (not supported)*/
+    ADC_RES_6BIT  = (ADC_CR1_RES),      /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CR1_RES_1),    /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CR1_RES_0),    /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/f7/periph_cpu.h
+++ b/cpu/stm32/include/periph/f7/periph_cpu.h
@@ -44,17 +44,17 @@ extern "C" {
 #define ADC_DEVS            (3U)
 
 /**
- * @brief   Override the ADC resolution configuration
+ * @brief   Override ADC resolution values
  * @{
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = 0x03000000,     /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = 0x02000000,     /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = 0x01000000,     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = 0x00000000,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 1,              /**< ADC resolution: 14 bit (not supported) */
-    ADC_RES_16BIT = 2               /**< ADC resolution: 16 bit (not supported)*/
+    ADC_RES_6BIT  = (ADC_CR1_RES),      /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CR1_RES_1),    /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CR1_RES_0),    /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/g0/periph_cpu.h
+++ b/cpu/stm32/include/periph/g0/periph_cpu.h
@@ -33,6 +33,21 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
 /**
+ * @brief   Override ADC resolution values
+ * @{
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = (ADC_CFGR1_RES),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR1_RES_1),  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR1_RES_0),  /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported) */
+} adc_res_t;
+/** @} */
+
+/**
  * @name   Constants for internal VBAT ADC line
  * @{
  */

--- a/cpu/stm32/include/periph/l0/periph_cpu.h
+++ b/cpu/stm32/include/periph/l0/periph_cpu.h
@@ -40,12 +40,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (0x3 << 3),     /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (0x2 << 3),     /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (0x1 << 3),     /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0 << 3),     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),         /**< not applicable */
-    ADC_RES_16BIT = (0xff)          /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CFGR1_RES),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR1_RES_1),  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR1_RES_0),  /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported)*/
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported)*/
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/stm32/include/periph/l1/periph_cpu.h
+++ b/cpu/stm32/include/periph/l1/periph_cpu.h
@@ -45,12 +45,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (ADC_CR1_RES_0 | ADC_CR1_RES_1),    /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (ADC_CR1_RES_1),                    /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (ADC_CR1_RES_0),                    /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x00),                             /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),                             /**< not applicable */
-    ADC_RES_16BIT = (0xff)                              /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CR1_RES),      /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CR1_RES_1),    /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CR1_RES_0),    /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),     /**< ADC resolution: 14 bit (not supported)*/
+    ADC_RES_16BIT = (0xff)      /**< ADC resolution: 16 bit (not supported)*/
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -61,12 +61,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (ADC_CFGR_RES),   /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (ADC_CFGR_RES_1), /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (ADC_CFGR_RES_0), /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0),            /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0x1),            /**< not applicable */
-    ADC_RES_16BIT = (0x2)             /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CFGR_RES),     /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR_RES_1),   /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR_RES_0),   /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe), /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)  /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/wb/periph_cpu.h
+++ b/cpu/stm32/include/periph/wb/periph_cpu.h
@@ -58,12 +58,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (ADC_CFGR_RES),   /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (ADC_CFGR_RES_1), /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (ADC_CFGR_RES_0), /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0),            /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0x1),            /**< not applicable */
-    ADC_RES_16BIT = (0x2)             /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CFGR_RES),     /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR_RES_1),   /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR_RES_0),   /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe), /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)  /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/include/periph/wl/periph_cpu.h
+++ b/cpu/stm32/include/periph/wl/periph_cpu.h
@@ -42,12 +42,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (ADC_CFGR1_RES),   /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (ADC_CFGR1_RES_1), /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (ADC_CFGR1_RES_0), /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0),            /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0x1),            /**< not applicable */
-    ADC_RES_16BIT = (0x2)             /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CFGR1_RES),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR1_RES_1),  /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR1_RES_0),  /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe), /**< ADC resolution: 14 bit (not supported) */
+    ADC_RES_16BIT = (0xff)  /**< ADC resolution: 16 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32/periph/adc_f0_g0_c0.c
+++ b/cpu/stm32/periph/adc_f0_g0_c0.c
@@ -201,7 +201,7 @@ int32_t adc_sample(adc_t line,  adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if (res > 0xf0) {
+    if ((res & ADC_CFGR1_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -109,7 +109,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if (res < 0xff) {
+    if ((res & ADC_CR1_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_f3.c
+++ b/cpu/stm32/periph/adc_f3.c
@@ -207,7 +207,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* Check if resolution is applicable */
-    if (res & 0x3) {
+    if ((res & ADC_CFGR_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_f4_f7.c
+++ b/cpu/stm32/periph/adc_f4_f7.c
@@ -129,7 +129,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if (res & 0xff) {
+    if ((res & ADC_CR1_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_l0.c
+++ b/cpu/stm32/periph/adc_l0.c
@@ -118,10 +118,7 @@ int32_t adc_sample(adc_t line,  adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if ( (res != ADC_RES_6BIT) &&
-         (res != ADC_RES_8BIT) &&
-         (res != ADC_RES_10BIT) &&
-         (res != ADC_RES_12BIT)) {
+    if ((res & ADC_CFGR1_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_l1.c
+++ b/cpu/stm32/periph/adc_l1.c
@@ -145,10 +145,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if ( (res != ADC_RES_6BIT) &&
-         (res != ADC_RES_8BIT) &&
-         (res != ADC_RES_10BIT) &&
-         (res != ADC_RES_12BIT)) {
+    if ((res & ADC_CR1_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_l4_wb.c
+++ b/cpu/stm32/periph/adc_l4_wb.c
@@ -221,7 +221,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if (res & 0x3) {
+    if ((res & ADC_CFGR_RES) != res) {
         return -1;
     }
 

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -168,7 +168,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if (res & 0x3) {
+    if ((res & ADC_CFGR1_RES) != res) {
         return -1;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR is based on #20780.

The different implementations for the STM32 ADCs had wildly different styles of defining (in `cpu/stm32/include/periph/xx/periph_cpu.h`) and checking the resolution flags (in `cpu/stm32/periph/adc_xxx.c` ).

The c0 and g0 did not define the `adc_res_t` structure at all, so the generic fallback from `drivers/include/periph/adc.h` was used. However it appears that this did not set the right flags, because for example the value for 6-bit resolution from the generic structure is `00` whereas it should be `(0x3 << 3)`. Even worse, for higher resolutions, the DMA bits would be set instead of the resolution bits.

I did not check it yet, but it seems like the c0 and g0 STM32s were always stuck in 12-bit mode with the current code.

This PR makes all `adc_res_t` structure definitions uniformly, using the official register macros instead of magic numbers. Furthermore, the resolution check uses the official register mask for evaluating the resolution.

(Note: The F1 series only supports 12-bit mode, so nothing was changed here. There are no registers to be set, so the generic structure works for it.)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I did not test this PR yet, because I don't have any Nucleos on hand until next week, but the `tests/periph/adc` test should be working on all affected Nucleos now.
@krzysztof-cabaj if you have time, you could look into testing this PR with some Nucleos that I don't have?

- [x] C0 Series tested
- [x] F0 Series tested
- [x] F2 Series tested
- [x] F3 Series tested
- [x] F4 Series tested
- [x] F7 Series tested
- [x] G0 Series tested
- [x] L0 Series tested
- [x] L1 Series tested
- [x] L4 Series tested
- [x] WB Series tested
- [x] WL Series tested


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This closes #20780.

Depends on #21011 - merged.
Depends on #21230 - merged.
Depends on #21238 - merged.
Depends on #21346.

STM32C0x1 Reference Manual: https://www.st.com/resource/en/reference_manual/rm0490-stm32c0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p.215

STM32F205, 207, 215, 217 Reference Manual: https://www.st.com/resource/en/reference_manual/rm0033-stm32f205xx-stm32f207xx-stm32f215xx-and-stm32f217xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p.240

STM32G0x0 Reference Manual: https://www.st.com/resource/en/reference_manual/rm0454-stm32g0x0-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p.320

STM32G0x1 Reference Manual: https://www.st.com/resource/en/reference_manual/dm00371828-stm32g0x1-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf The resolution bits are defined on p.389


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
