### PR TITLE
sys/net/gnrc_pktbuf_static: add double free detection

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -240,12 +240,13 @@ gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt)
 }
 
 #ifdef DEVELHELP
-#ifdef MODULE_OD
 static inline void _print_chunk(void *chunk, size_t size, int num)
 {
     printf("=========== chunk %3i (%-10p size: %4" PRIuSIZE ") ===========\n", num, chunk,
            size);
+#ifdef MODULE_OD
     od_hex_dump(chunk, size, OD_WIDTH_DEFAULT);
+#endif
 }
 
 static inline void _print_ptr(_unused_t *ptr)
@@ -266,11 +267,9 @@ static inline void _print_unused(_unused_t *ptr)
     _print_ptr(ptr->next);
     printf(", size: %4u) ~\n", ptr->size);
 }
-#endif
 
 void gnrc_pktbuf_stats(void)
 {
-#ifdef MODULE_OD
     _unused_t *ptr = _first_unused;
     uint8_t *chunk = &_static_buf[0];
     int count = 0;
@@ -306,9 +305,6 @@ void gnrc_pktbuf_stats(void)
     if (chunk <= &_static_buf[CONFIG_GNRC_PKTBUF_SIZE - 1]) {
         _print_chunk(chunk, &_static_buf[CONFIG_GNRC_PKTBUF_SIZE] - chunk, count);
     }
-#else
-    DEBUG("pktbuf: needs od module\n");
-#endif
 }
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The basic idea is: all free data is filled with `CANARY` bytes, once data is allocated this is overwritten with `~CANARY`.
When data is freed we now check if the chunk is only set to `CANARY` - if this happens, it was already freed.


### Testing procedure

Set `CONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE` to `1`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
