### PR TITLE
drivers/slipdev: implement NETDEV_EVENT_TX_COMPLETE event

### DIFF
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -233,6 +233,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     }
     slipdev_write_byte(dev->config.uart, SLIPDEV_END);
     slipdev_unlock();
+
+    if (netdev->event_callback) {
+        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
+    }
+
     return bytes;
 }
 
@@ -322,6 +327,9 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_SLIP;
             return sizeof(uint16_t);
+        case NETOPT_TX_END_IRQ:
+            *((netopt_enable_t *)value) = NETOPT_ENABLE;
+            return sizeof(netopt_enable_t);
 #if IS_USED(MODULE_SLIPDEV_L2ADDR)
         case NETOPT_ADDRESS_LONG:
             assert(max_len == sizeof(eui64_t));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This appears to be required with `gnrc_netif_pktq` - it does not fix the memory leak though :confused: 


### Testing procedure

The `NETOPT_TX_END_IRQ not implemented by driver` warning is no longer being printed.  


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
