### PR TITLE
drivers/slipdev: port to netdev_new_api

### DIFF
--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -1,6 +1,6 @@
 USEMODULE += chunked_ringbuffer
 USEMODULE += eui_provider
-USEMODULE += netdev_legacy_api
+USEMODULE += netdev_new_api
 USEMODULE += netdev_register
 FEATURES_REQUIRED += periph_uart
 

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -234,10 +234,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     slipdev_write_byte(dev->config.uart, SLIPDEV_END);
     slipdev_unlock();
 
-    if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-    }
-
     return bytes;
 }
 
@@ -327,9 +323,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_SLIP;
             return sizeof(uint16_t);
-        case NETOPT_TX_END_IRQ:
-            *((netopt_enable_t *)value) = NETOPT_ENABLE;
-            return sizeof(netopt_enable_t);
 #if IS_USED(MODULE_SLIPDEV_L2ADDR)
         case NETOPT_ADDRESS_LONG:
             assert(max_len == sizeof(eui64_t));
@@ -341,12 +334,20 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     }
 }
 
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev;
+    (void)info;
+    return -EOPNOTSUPP;
+}
+
 static const netdev_driver_t slip_driver = {
     .send = _send,
     .recv = _recv,
     .init = _init,
     .isr = _isr,
     .get = _get,
+    .confirm_send = _confirm_send,
 #if IS_USED(MODULE_SLIPDEV_STDIO)
     .set = netdev_set_notsup,
 #else


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Not sure how much sense this makes, since send is still blocking.
I mainly did this to reduce the number of code paths with `at86rf215` in the border router use case.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
