### PR TITLE
boards/seeedstudio-xiao-nrf52840: initial board support

### DIFF
--- a/boards/seeedstudio-xiao-nrf52840/Kconfig
+++ b/boards/seeedstudio-xiao-nrf52840/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 TU Dresden
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "seeedstudio-xiao-nrf52840" if BOARD_XIAO_NRF52840
+
+config BOARD_XIAO_NRF52840
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/seeedstudio-xiao-nrf52840/Makefile
+++ b/boards/seeedstudio-xiao-nrf52840/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/seeedstudio-xiao-nrf52840/Makefile.dep
+++ b/boards/seeedstudio-xiao-nrf52840/Makefile.dep
@@ -1,0 +1,17 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_spi_nor
+endif
+
+# default to using littlefs2 on the external flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/seeedstudio-xiao-nrf52840/Makefile.features
+++ b/boards/seeedstudio-xiao-nrf52840/Makefile.features
@@ -1,0 +1,12 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/seeedstudio-xiao-nrf52840/Makefile.features
+++ b/boards/seeedstudio-xiao-nrf52840/Makefile.features
@@ -7,6 +7,12 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart
 FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += xiao_shield
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/seeedstudio-xiao-nrf52840/Makefile.include
+++ b/boards/seeedstudio-xiao-nrf52840/Makefile.include
@@ -1,0 +1,1 @@
+../feather-nrf52840/Makefile.include

--- a/boards/seeedstudio-xiao-nrf52840/doc.md
+++ b/boards/seeedstudio-xiao-nrf52840/doc.md
@@ -1,0 +1,27 @@
+@defgroup    boards_seeedstudio-xiao-nrf52840 Seeed Studio XIAO nRF52840
+@ingroup     boards
+@brief       Support for the Seeed Studio XIAO nRF52840
+
+### General information
+
+The [XIAO nRF52840][seeedstudio-xiao-nrf52840] (formally known as XIAO BLE)
+is a development board from Seeed Studio's XIAO board family.
+
+It provides native USB support, Bluetooth
+Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
+
+<img src="https://files.seeedstudio.com/wiki/XIAO-BLE/pinout2.png"
+     alt="top-down view on seeedstudio-xiao-nrf52840" width="50%"/>
+
+[seeedstudio-xiao-nrf52840]: https://wiki.seeedstudio.com/XIAO_BLE/
+
+### Flashing, Bootloader, and Terminal
+
+Refer to the [Feather nRF52840 Express
+documentation](https://doc.riot-os.org/group__boards__feather-nrf52840.html) for further details.
+Both use the same flasher, bootloader, and terminal settings.
+
+Example with `hello-world` application:
+```shell
+make BOARD=seeedstudio-xiao-nrf52840 -C examples/basic/hello-world flash term
+```

--- a/boards/seeedstudio-xiao-nrf52840/include/arduino_iomap.h
+++ b/boards/seeedstudio-xiao-nrf52840/include/arduino_iomap.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ */
+
+#ifndef ARDUINO_IOMAP_H
+#define ARDUINO_IOMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    XIAO's UART devices
+ * @{
+ * @brief   Arduino's Serial uses USB-CDC-ACM stdio by default
+ */
+#define ARDUINO_UART_DEV    UART_UNDEF
+/** @} */
+
+/**
+ * @name    XIAO's SPI buses
+ * @{
+ */
+#define ARDUINO_SPI_DEV     SPI_DEV(0)
+/** @} */
+
+/**
+ * @name    XIAO's I2C buses
+ * @{
+ */
+#define ARDUINO_I2C_DEV     I2C_DEV(0)
+/** @} */
+
+/**
+ * @name    XIAO's on-board LED (LED_BUILTIN)
+ * @{
+ */
+#define ARDUINO_LED     (11)
+/** @} */
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+/* Left pins */
+#define ARDUINO_PIN_0       GPIO_PIN(0,  2)
+#define ARDUINO_PIN_1       GPIO_PIN(0,  3)
+#define ARDUINO_PIN_2       GPIO_PIN(0, 28)
+#define ARDUINO_PIN_3       GPIO_PIN(0, 29)
+#define ARDUINO_PIN_4       GPIO_PIN(0,  4)
+#define ARDUINO_PIN_5       GPIO_PIN(0,  5)
+#define ARDUINO_PIN_6       GPIO_PIN(1, 11)
+
+/* Right side */
+#define ARDUINO_PIN_7       GPIO_PIN(1, 12)
+#define ARDUINO_PIN_8       GPIO_PIN(1, 13)
+#define ARDUINO_PIN_9       GPIO_PIN(1, 14)
+#define ARDUINO_PIN_10      GPIO_PIN(1, 15)
+
+/* Internal (LEDs) */
+#define ARDUINO_PIN_11      GPIO_PIN(0, 26)
+#define ARDUINO_PIN_12      GPIO_PIN(0,  6)
+#define ARDUINO_PIN_13      GPIO_PIN(0, 30)
+
+#define ARDUINO_PIN_LAST    13
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0      ARDUINO_PIN_0
+#define ARDUINO_PIN_A1      ARDUINO_PIN_1
+#define ARDUINO_PIN_A2      ARDUINO_PIN_2
+#define ARDUINO_PIN_A3      ARDUINO_PIN_3
+#define ARDUINO_PIN_A4      ARDUINO_PIN_4
+#define ARDUINO_PIN_A5      ARDUINO_PIN_5
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+/* The Seeed Studio XIAO nRF52840 has a fixed ADC to GPIO mapping:
+ *
+ * nRF  | MCU pin   | Exposed as Arduino pin
+ * -----|-----------|-----------------------
+ * AIN0 | P0.02     | A0 (D0)
+ * AIN1 | P0.03     | A1 (D1)
+ * AIN2 | P0.04     | A4 (D4)
+ * AIN3 | P0.05     | A5 (D5)
+ * AIN4 | P0.28     | A2 (D2)
+ * AIN5 | P0.29     | A3 (D3)
+ * AIN6 | P0.30     | - (D13)
+ * AIN7 | P0.31     | - (-)
+ */
+#define ARDUINO_A0          ADC_LINE(0)
+#define ARDUINO_A1          ADC_LINE(1)
+#define ARDUINO_A2          ADC_LINE(4)
+#define ARDUINO_A3          ADC_LINE(5)
+#define ARDUINO_A4          ADC_LINE(2)
+#define ARDUINO_A5          ADC_LINE(3)
+
+#define ARDUINO_ANALOG_PIN_LAST 5
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_IOMAP_H */
+/** @} */

--- a/boards/seeedstudio-xiao-nrf52840/include/board.h
+++ b/boards/seeedstudio-xiao-nrf52840/include/board.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Seeed Studio XIAO nRF52840
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 26)
+#define LED1_PIN            GPIO_PIN(0, 30)
+#define LED2_PIN            GPIO_PIN(0, 6)
+
+#define LED_PORT            (NRF_P0)
+#define LED0_MASK           (1 << 26)
+#define LED1_MASK           (1 << 30)
+#define LED2_MASK           (1 << 6)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK)
+/** @} */
+
+/**
+ * @name SPI NOR flash hardware configuration
+ *
+ * A 2MB P25Q16H flash is present on the board.
+ *
+ * @see https://files.seeedstudio.com/wiki/github_weiruanexample/Flash_P25Q16H-UXH-IR_Datasheet.pdf
+ *
+ * @{
+ */
+#define XIAO_NRF52840_NOR_PAGE_SIZE          (256)
+#define XIAO_NRF52840_NOR_PAGES_PER_SECTOR   (16)
+#define XIAO_NRF52840_NOR_SECTOR_COUNT       (512)
+#define XIAO_NRF52840_NOR_FLAGS \
+    (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K | SPI_NOR_F_SECT_64K)
+#define XIAO_NRF52840_NOR_SPI_DEV            SPI_DEV(1)
+#define XIAO_NRF52840_NOR_SPI_CLK            SPI_CLK_10MHZ
+#define XIAO_NRF52840_NOR_SPI_CS             GPIO_PIN(0, 25)
+#define XIAO_NRF52840_NOR_SPI_WP             GPIO_PIN(0, 22)
+#define XIAO_NRF52840_NOR_SPI_HOLD           GPIO_PIN(0, 23)
+#define XIAO_NRF52840_NOR_SPI_MODE           SPI_MODE_0
+/** @} */
+
+/** Default MTD device */
+#define MTD_0 mtd_dev_get(0)
+
+/**
+ * @name    ztimer configuration values
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET    7
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP  22
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/seeedstudio-xiao-nrf52840/include/gpio_params.h
+++ b/boards/seeedstudio-xiao-nrf52840/include/gpio_params.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED Red (USR/D11)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Green (USR/D13)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Blue (USR/D12)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/seeedstudio-xiao-nrf52840/include/periph_conf.h
+++ b/boards/seeedstudio-xiao-nrf52840/include/periph_conf.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Seeed Studio XIAO nRF52840
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(1, 12),
+        .tx_pin     = GPIO_PIN(1, 11),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = GPIO_PIN(1, 13),
+        .mosi = GPIO_PIN(1, 15),
+        .miso = GPIO_PIN(1, 14),
+    },
+    {
+        .dev  = NRF_SPIM1,
+        .sclk = GPIO_PIN(0, 21),
+        .mosi = GPIO_PIN(0, 20),
+        .miso = GPIO_PIN(0, 24),
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 5),
+        .sda = GPIO_PIN(0, 4),
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/seeedstudio-xiao-nrf52840/mtd.c
+++ b/boards/seeedstudio-xiao-nrf52840/mtd.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       MTD configuration for the XIAO nRF52840
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_MTD
+
+#include "board.h"
+#include "mtd.h"
+#include "mtd_spi_nor.h"
+#include "periph_conf.h"
+#include "timex.h"
+
+static const mtd_spi_nor_params_t _xiao_nrf52840_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    /* datasheet reports 20ms, but experiments showed ~135ms*/
+    .wait_chip_erase = 200LU * US_PER_MS,
+    .wait_32k_erase = 20LU * US_PER_MS,
+    .wait_sector_erase = 20LU * US_PER_MS,
+    .wait_chip_wake_up = 35LU * US_PER_MS,
+    .clk = XIAO_NRF52840_NOR_SPI_CLK,
+    .flag = XIAO_NRF52840_NOR_FLAGS,
+    .spi = XIAO_NRF52840_NOR_SPI_DEV,
+    .mode = XIAO_NRF52840_NOR_SPI_MODE,
+    .cs = XIAO_NRF52840_NOR_SPI_CS,
+    .wp = XIAO_NRF52840_NOR_SPI_WP,
+    .hold = XIAO_NRF52840_NOR_SPI_HOLD,
+};
+
+static mtd_spi_nor_t xiao_nrf52840_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = XIAO_NRF52840_NOR_PAGE_SIZE,
+        .pages_per_sector = XIAO_NRF52840_NOR_PAGES_PER_SECTOR,
+        .sector_count = XIAO_NRF52840_NOR_SECTOR_COUNT,
+    },
+    .params = &_xiao_nrf52840_nor_params,
+};
+
+MTD_XFA_ADD(xiao_nrf52840_nor_dev, 0);
+
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(xiao_nrf52840_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
+#endif

--- a/boards/seeedstudio-xiao-nrf52840/reset.c
+++ b/boards/seeedstudio-xiao-nrf52840/reset.c
@@ -1,0 +1,1 @@
+../feather-nrf52840/reset.c

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -17,3 +17,4 @@ boards/waveshare-nrf52840-eval-kit/include/board\.h:[0-9]+: warning: Member SDCA
 boards/waveshare-nrf52840-eval-kit/include/periph_conf\.h:[0-9]+: warning: Member UART_[A-Z0-9_]+ \(macro definition\) of file periph_conf\.h is not documented\.
 boards/waveshare-nrf52840-eval-kit/include/periph_conf\.h:[0-9]+: warning: Member [A-Z0-9_]+NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/waveshare-nrf52840-eval-kit/include/periph_conf\.h:[0-9]+: warning: Member [a-z0-9_]+config\[\] \(variable\) of file periph_conf\.h is not documented\.
+warning: Member XIAO_NRF52840_[A-Z0-9_]+ \(macro definition\) of file board\.h is not documented\.

--- a/doc/doxygen/src/io-mapping-and-shields.md
+++ b/doc/doxygen/src/io-mapping-and-shields.md
@@ -90,11 +90,12 @@ mapping. For the official Arduino boards and compatible boards, the
 Please extend the table below to keep naming among boards of the same form
 factor consistent:
 
-| Form Factor   | Macro Name            | Description                       |
-|:------------- |:--------------------- |:--------------------------------- |
-| Arduino Nano  | `ARDUINO_UART_D0D1`   | UART on D0 (RXD) and D1 (TXD)     |
-| Arduino Uno   | `ARDUINO_UART_D0D1`   | UART on D0 (RXD) and D1 (TXD)     |
-| Arduino Mega  | `ARDUINO_UART_D0D1`   | UART on D0 (RXD) and D1 (TXD)     |
+| Form Factor      | Macro Name            | Description                       |
+|:---------------- |:--------------------- |:--------------------------------- |
+| Arduino Nano     | `ARDUINO_UART_D0D1`   | UART on D0 (RXD) and D1 (TXD)     |
+| Arduino Uno      | `ARDUINO_UART_D0D1`   | UART on D0 (RXD) and D1 (TXD)     |
+| Arduino Mega     | `ARDUINO_UART_D0D1`   | UART on D0 (RXD) and D1 (TXD)     |
+| Seeedstudio XIAO | `ARDUINO_UART_DEV`    | UART on D7 (RXD) and D6 (TXD)     |
 
 I²C Buses                                                 {#iomaps-mapping-i2c}
 ---------
@@ -102,13 +103,14 @@ I²C Buses                                                 {#iomaps-mapping-i2c}
 The feature `arduino_i2c` is provided by boards that do provide an I²C bus
 mapping.
 
-| Form Factor   | Macro Name            | Description                       |
-|:------------- |:--------------------- |:--------------------------------- |
-| Arduino Nano  | `ARDUINO_I2C_NANO`    | D18 (SDA) / D19 (SCL)             |
-| Arduino Uno   | `ARDUINO_I2C_UNO`     | D18 (SDA) / D19 (SCL)             |
-| Arduino Mega  | `ARDUINO_I2C_UNO`     | D20 (SDA) / D21 (SCL)             |
-| Arduino Zero  | `ARDUINO_I2C_UNO`     | D20 (SDA) / D21 (SCL)             |
-| Arduino Due   | `ARDUINO_I2C_UNO`     | D70 (SDA) / D71 (SCL)             |
+| Form Factor      | Macro Name            | Description                       |
+|:---------------- |:--------------------- |:--------------------------------- |
+| Arduino Nano     | `ARDUINO_I2C_NANO`    | D18 (SDA) / D19 (SCL)             |
+| Arduino Uno      | `ARDUINO_I2C_UNO`     | D18 (SDA) / D19 (SCL)             |
+| Arduino Mega     | `ARDUINO_I2C_UNO`     | D20 (SDA) / D21 (SCL)             |
+| Arduino Zero     | `ARDUINO_I2C_UNO`     | D20 (SDA) / D21 (SCL)             |
+| Arduino Due      | `ARDUINO_I2C_UNO`     | D70 (SDA) / D71 (SCL)             |
+| Seeedstudio XIAO | `ARDUINO_I2C_DEV`     | D4 (SDA) / D5 (SCL)               |
 
 The `ARDUINO_I2C_UNO` refers to the I²C bus next to the AREF pin (the topmost
 pins on header on the top right) of an Arduino Uno compatible board, e.g.
@@ -123,14 +125,15 @@ SPI Buses                                                 {#iomaps-mapping-spi}
 The feature `arduino_spi` is provided by boards that do provide an SPI bus
 mapping.
 
-| Form Factor   | Macro Name                | Description                           |
-|:------------- |:------------------------- |:------------------------------------- |
-| Arduino Nano  | `ARDUINO_SPI_ISP`         | The SPI on the ISP header             |
-| Arduino Nano  | `ARDUINO_SPI_D11D12D13`   | D11 (MOSI) / D12 (MISO) / D13 (SCK)   |
-| Arduino Uno   | `ARDUINO_SPI_ISP`         | The SPI on the ISP header             |
-| Arduino Uno   | `ARDUINO_SPI_D11D12D13`   | D11 (MOSI) / D12 (MISO) / D13 (SCK)   |
-| Arduino Mega  | `ARDUINO_SPI_ISP`         | The SPI on the ISP header             |
-| Arduino Mega  | `ARDUINO_SPI_D11D12D13`   | D11 (MOSI) / D12 (MISO) / D13 (SCK)   |
+| Form Factor      | Macro Name                | Description                           |
+|:---------------- |:------------------------- |:------------------------------------- |
+| Arduino Nano     | `ARDUINO_SPI_ISP`         | The SPI on the ISP header             |
+| Arduino Nano     | `ARDUINO_SPI_D11D12D13`   | D11 (MOSI) / D12 (MISO) / D13 (SCK)   |
+| Arduino Uno      | `ARDUINO_SPI_ISP`         | The SPI on the ISP header             |
+| Arduino Uno      | `ARDUINO_SPI_D11D12D13`   | D11 (MOSI) / D12 (MISO) / D13 (SCK)   |
+| Arduino Mega     | `ARDUINO_SPI_ISP`         | The SPI on the ISP header             |
+| Arduino Mega     | `ARDUINO_SPI_D11D12D13`   | D11 (MOSI) / D12 (MISO) / D13 (SCK)   |
+| Seeedstudio XIAO | `ARDUINO_SPI_DEV`         | D10 (MOSI) / D9 (MISO) / D8 (SCK)     |
 
 @note   The original AVR based Arduinos only have a single hard SPI bus which
         is only provided via the ISP header. Many modern Arduino compatible
@@ -144,12 +147,12 @@ Modules implementing drivers for extension boards, a.k.a. shields, can express
 their mechanical and electrical requirements by depending on `arduino_shield_...`
 features. The following list of features currently exists:
 
-| Feature Name          | Compatibility Claim                                       |
-|
-| `arduino_shield_nano` | Board has side headers compatible with the Arduino Nano   |
-| `arduino_shield_uno`  | Board has side headers compatible with the Arduino UNO    |
-| `arduino_shield_mega` | Board has side headers compatible with the Arduino MEGA   |
-| `arduino_shield_isp`  | Board has an ISP header                                   |
+| Feature Name          | Compatibility Claim                                           |
+|:--------------------- |:------------------------------------------------------------- |
+| `arduino_shield_nano` | Board has side headers compatible with the Arduino Nano       |
+| `arduino_shield_uno`  | Board has side headers compatible with the Arduino UNO        |
+| `arduino_shield_mega` | Board has side headers compatible with the Arduino MEGA       |
+| `xiao_shield`         | Board has headers compatible with the Seeedstudio XIAO boards |
 
 @note   A board providing `arduino_shield_mega` **MUST** also provide
         `arduino_shield_uno`, as Arduino MEGA boards are backward compatible to

--- a/features.yaml
+++ b/features.yaml
@@ -409,6 +409,10 @@ groups:
             Indicates that the board is mechanically and electrically compatible
             with shields developed for the Arduino Nano. (Note: Except the
             ISP header, that requires `arduino_shield_isp` in addition.)
+    - name: xiao_shield
+      help: >
+            Indicates that the board is mechanically and electrically compatible
+            with shields developed for the Seeed Studio XIAO board family.
 
 - title: RAM Related Features
   help: These features indicate presence of special RAM regions or features

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -267,4 +267,5 @@ FEATURES_EXISTING := \
     tinyusb_device \
     vdd_lc_filter_reg0 \
     vdd_lc_filter_reg1 \
+    xiao_shield \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Initial board support for the tiny [Seed Studio XIAO nRF52840](https://wiki.seeedstudio.com/XIAO_BLE/). It uses the same bootloader as the Adafruit nrf52840 Feather (Sense) boards.


### Testing procedure

- I'm still in the process of running `BUILD_IN_DOCKER=1 dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . seeedstudio-xiao-nrf52840` locally and will report back with the result later.

- Look through the header and configuration files. I've mostly followed the example from `feather-nrf52840-sense` and `nrf52840dk` (for the external flash).

- Check generated documentation for the board.
