### PR TITLE
sys/usb_cdc_acm_stdio: only submit and flush for non-empty buffer

### DIFF
--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -37,13 +37,13 @@ static uint8_t _cdc_tx_buf_mem[CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE];
 static ssize_t _write(const void* buffer, size_t len)
 {
     const char *start = buffer;
-    do {
+    while (len) {
         size_t n = usbus_cdc_acm_submit(&cdcacm, buffer, len);
         usbus_cdc_acm_flush(&cdcacm);
         /* Use tsrb and flush */
         buffer = (char *)buffer + n;
         len -= n;
-    } while (len);
+    }
     return (char *)buffer - start;
 }
 


### PR DESCRIPTION

### Contribution description

There seems to be some problem the implementation of stdio over usbus_cdc_acm where printing an empty string _sometimes_ leads to the next character being missed in the printout. I've managed to pin the problem down to the call to `usbus_cdc_acm_flush(&cdcacm);` in `sys/usb/usbus/cdc/acm/cdc_acm_stdio.c` and, more specifically, to `_ep_xmit` in `cpu/nrf5x_common/periph/usbdev.c`, but since I have no non-nRF hardware at hand, I cannot tell whether it is a nRF specific issue.

In any case, skipping the flushing (and submitting) in the first place seems to fix the issue for now. If anyone has an idea how to investigate this further and maybe fix the root cause somewhere deeper in the usb driver, please tell me, I'm happy to test more.


### Testing procedure

1. apply the following diff:

```diff
diff --git a/tests/sys/usbus_cdc_acm_stdio/main.c b/tests/sys/usbus_cdc_acm_stdio/main.c
index c603882121..50c0b9a9d8 100644
--- a/tests/sys/usbus_cdc_acm_stdio/main.c
+++ b/tests/sys/usbus_cdc_acm_stdio/main.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 
 #include "shell.h"
+#include "fmt.h"
 
 static int cmd_text(int argc, char **argv)
 {
@@ -30,7 +31,7 @@ static int cmd_text(int argc, char **argv)
         return -1;
     }
     int n = atoi(argv[1]);
-    if (n <= 0) {
+    if (n < 0) {
         puts(usage);
         return -1;
     }
@@ -40,7 +41,9 @@ static int cmd_text(int argc, char **argv)
         }
         putc('0' + (i % 10), stdout);
     }
-    puts("");
+    print_str("");
+    print_str("x");
+    print_str("\n");
     return 0;
 }
```

2. pick any (nrf-based?) board  using `stdio_cdc_acm` such as `feather-nrf52840-sense`
3. `make -C tests/sys/usbus_cdc_acm_stdio BOARD=feather-nrf52840-sense flash term`
4. repeatedly enter `text 0`

On `master`, this _sometimes_ skips over the `x` in the printout. With this PR, I never managed to reproduce the issue.


### Issues/PRs references

Found while investigating failing tests for #20980 
