### PR TITLE
tests/sys/shell: skip reboot for boards using highlevel_stdio

### DIFF
--- a/tests/sys/shell/Makefile
+++ b/tests/sys/shell/Makefile
@@ -23,3 +23,9 @@ CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_SMALL+THREAD_EXTRA_STACKSIZ
 
 # the test script skips tests if socat is not used
 $(call target-export-variables,$(RIOT_TERMINAL),RIOT_TERMINAL)
+
+# skip reboot for boards using highlevel_stdio that would disconnect during reboot
+ifneq (,$(filter highlevel_stdio,$(FEATURES_USED)))
+  TESTRUNNER_SHELL_SKIP_REBOOT := 1
+endif
+$(call target-export-variables,$(TESTRUNNER_SHELL_SKIP_REBOOT),TESTRUNNER_SHELL_SKIP_REBOOT)


### PR DESCRIPTION
### Contribution description

Boards using highlevel_stdio disconnect on reboot, thereby failing the automatic python tests. The functionality to disable reboot was already there. This PR just disables it automatically when the board has the `highlevel_stdio` FEATURE.


### Testing procedure

`make -C tests/sys/shell BOARD=feather-nrf52840-sense flash test`

fails on master, passes with this PR


### Issues/PRs references

Encountered while working on #20980 