### PR TITLE
tests/core/thread_msg: lower thread priority for consistent output order

### DIFF
--- a/tests/core/thread_msg/main.c
+++ b/tests/core/thread_msg/main.c
@@ -86,14 +86,11 @@ void *thread3(void *arg)
 int main(void)
 {
     p_main = thread_getpid();
-    p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD,
+    p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN + 1, 0,
                        thread1, NULL, "nr1");
-    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD,
+    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1, 0,
                        thread2, NULL, "nr2");
-    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD,
+    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN + 1, 0,
                        thread3, NULL, "nr3");
     puts("THREADS CREATED\n");
 


### PR DESCRIPTION
### Contribution description

For some reason, the threads are (seemingly?) scheduled differently on `nrf52840dk` and `feather-nrf52840-sense`, at least the output order is not consistent. This PR changes the child threads to have a lower priority than the main thread so that "THREADS STARTED" is always printed first.


### Testing procedure

`make -C tests/core/thread_msg BOARD=feather-nrf52840-sense flash test`

fails on master, passes with this PR


### Issues/PRs references

Encountered while working on #20980 