### PR TITLE
tests/cpu/mpu*: exclude boards using highlevel_stdio

### DIFF
--- a/tests/cpu/mpu_noexec_ram/Makefile
+++ b/tests/cpu/mpu_noexec_ram/Makefile
@@ -4,4 +4,7 @@ include ../Makefile.cpu_common
 
 USEMODULE += mpu_noexec_ram
 
+# boards using highlevel_stdio will crash without printing
+FEATURES_BLACKLIST += highlevel_stdio
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpu/mpu_stack_guard/Makefile
+++ b/tests/cpu/mpu_stack_guard/Makefile
@@ -4,6 +4,9 @@ include ../Makefile.cpu_common
 
 USEMODULE += mpu_stack_guard
 
+# boards using highlevel_stdio will crash without printing
+FEATURES_BLACKLIST += highlevel_stdio
+
 include $(RIOTBASE)/Makefile.include
 
 ifeq (llvm,$(TOOLCHAIN))


### PR DESCRIPTION
### Contribution description

Boards using highlevel_stdio do no print on crash, but the two mpu tests check for this printout. This PR blacklists the feature for those tests.


### Testing procedure

`make -C tests/cpu/mpu_noexec_ram BOARD=feather-nrf52840-sense flash test`

and

`make -C tests/cpu/mpu_stack_guard BOARD=feather-nrf52840-sense flash test`

are now refused to be run


### Issues/PRs references

Encountered while working on #20980 