### PR TITLE
drivers/dose: port to netdev_new_api

### DIFF
--- a/drivers/dose/Makefile.dep
+++ b/drivers/dose/Makefile.dep
@@ -12,6 +12,6 @@ USEMODULE += chunked_ringbuffer
 USEMODULE += eui_provider
 USEMODULE += iolist
 USEMODULE += netdev_eth
-USEMODULE += netdev_legacy_api
+USEMODULE += netdev_new_api
 USEMODULE += random
 USEMODULE += ztimer_usec

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -530,6 +530,13 @@ static inline void _send_done(dose_t *ctx, bool collision)
 #endif
 }
 
+static int _confirm_send(netdev_t *dev, void *info)
+{
+    (void)dev;
+    (void)info;
+    return -EOPNOTSUPP;
+}
+
 static int _send(netdev_t *dev, const iolist_t *iolist)
 {
     dose_t *ctx = container_of(dev, dose_t, netdev);
@@ -593,9 +600,6 @@ send:
 
     _send_done(ctx, false);
 
-    /* We probably sent the whole packet?! */
-    dev->event_callback(dev, NETDEV_EVENT_TX_COMPLETE);
-
     /* Get out of the SEND state */
     state(ctx, DOSE_SIGNAL_END);
 
@@ -605,7 +609,6 @@ collision:
     _send_done(ctx, true);
     DEBUG("dose _send(): collision!\n");
     if (--retries < 0) {
-        dev->event_callback(dev, NETDEV_EVENT_TX_MEDIUM_BUSY);
         return -EBUSY;
     }
 
@@ -765,7 +768,8 @@ static const netdev_driver_t netdev_driver_dose = {
     .init = _init,
     .isr = _isr,
     .get = _get,
-    .set = _set
+    .set = _set,
+    .confirm_send = _confirm_send,
 };
 
 void dose_setup(dose_t *ctx, const dose_params_t *params, uint8_t index)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As we already implement `NETDEV_EVENT_TX_COMPLETE` we only need to provide `.confirm_send` 


### Testing procedure

*This is still untested* 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
