### PR TITLE
drivers/netdev_ieee802154_submac: port to netdev_new_api

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -251,7 +251,7 @@ typedef enum {
      * @brief   ACK requested but not received
      *
      * @deprecated  Issue an NETDEV_EVENT_TX_COMPLETE event instead and return
-     *              `-ECOMM` in netdev_driver_t::confirm_send. Via the `info`
+     *              `-EHOSTUNREACH` in netdev_driver_t::confirm_send. Via the `info`
      *              parameter additional details about the error can be passed
      */
     NETDEV_EVENT_TX_NOACK,

--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -50,6 +50,7 @@ typedef struct {
     ieee802154_submac_t submac;         /**< IEEE 802.15.4 SubMAC descriptor */
     ztimer_t ack_timer;                 /**< ztimer descriptor for the ACK timeout timer */
     int isr_flags;                      /**< netdev submac @ref NETDEV_EVENT_ISR flags */
+    int bytes_tx;                       /**< size of the sent frame or tx error */
     int8_t retrans;                     /**< number of frame retransmissions of the last TX */
     bool dispatch;                      /**< whether an event should be dispatched or not */
     netdev_event_t ev;                  /**< event to be dispatched */

--- a/drivers/netdev_ieee802154_submac/Makefile.dep
+++ b/drivers/netdev_ieee802154_submac/Makefile.dep
@@ -1,0 +1,5 @@
+USEMODULE += netdev_ieee802154
+USEMODULE += netdev_new_api
+USEMODULE += ieee802154
+USEMODULE += ieee802154_submac
+USEMODULE += ztimer_usec

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -67,8 +67,10 @@ static void _event_cb(netdev_t *dev, netdev_event_t event) {
             recv_pkt(sInstance, dev);
             break;
         case NETDEV_EVENT_TX_COMPLETE:
+#ifndef MODULE_NETDEV_NEW_API
         case NETDEV_EVENT_TX_NOACK:
         case NETDEV_EVENT_TX_MEDIUM_BUSY:
+#endif
             DEBUG("openthread_netdev: Transmission of a packet\n");
             send_pkt(sInstance, dev, event);
             break;

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -172,6 +172,27 @@ void recv_pkt(otInstance *aInstance, netdev_t *dev)
 }
 
 /* Called upon TX event */
+#ifdef MODULE_NETDEV_NEW_API
+void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event)
+{
+    (void)event;
+
+    assert(dev->driver->confirm_send);
+
+    int res = dev->driver->confirm_send(dev, NULL);
+    DEBUG("openthread: confirm_send returned %d\n", res);
+
+    if (res > 0) {
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
+    } else if (res == -EBUSY) {
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_CHANNEL_ACCESS_FAILURE);
+    } else if (res == -EHOSTUNREACH) {
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NO_ACK);
+    } else {
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_FAILED);
+    }
+}
+#else
 void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event)
 {
     (void)dev;
@@ -198,6 +219,7 @@ void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event)
             break;
     }
 }
+#endif
 
 /* OpenThread will call this for setting PAN ID */
 void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -150,14 +150,6 @@ ifneq (,$(filter netdev_ieee802154,$(USEMODULE)))
   USEMODULE += random
 endif
 
-ifneq (,$(filter netdev_ieee802154_submac,$(USEMODULE)))
-  USEMODULE += netdev_ieee802154
-  USEMODULE += netdev_legacy_api
-  USEMODULE += ieee802154
-  USEMODULE += ieee802154_submac
-  USEMODULE += ztimer_usec
-endif
-
 ifneq (,$(filter uhcpc,$(USEMODULE)))
   USEMODULE += posix_inet
   USEMODULE += ztimer_msec


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We only have `NETDEV_EVENT_TX_COMPLETE` now, store error codes in device struct.

### Testing procedure

*only lightly tested*


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
