### PR TITLE
gnrc_netif: netdev_new_api implies TX end irq, no need to check it

### DIFF
--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -323,7 +323,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
         case NETOPT_RX_START_IRQ:
         case NETOPT_TX_START_IRQ:
-        case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) = NETOPT_ENABLE;
             return sizeof(netopt_enable_t);
 

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -238,6 +238,7 @@ typedef enum {
     NETDEV_EVENT_RX_COMPLETE,               /**< finished receiving a frame */
     NETDEV_EVENT_TX_STARTED,                /**< started to transfer a frame */
     NETDEV_EVENT_TX_COMPLETE,               /**< transfer frame complete */
+#if IS_USED(MODULE_NETDEV_LEGACY_API) || DOXYGEN
     /**
      * @brief   transfer frame complete and data pending flag
      *
@@ -261,6 +262,7 @@ typedef enum {
      *              `-EBUSY` in netdev_driver_t::confirm_send.
      */
     NETDEV_EVENT_TX_MEDIUM_BUSY,
+#endif
     NETDEV_EVENT_LINK_UP,                   /**< link established */
     NETDEV_EVENT_LINK_DOWN,                 /**< link gone */
     NETDEV_EVENT_TX_TIMEOUT,                /**< timeout when sending */

--- a/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal.c
+++ b/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal.c
@@ -177,6 +177,7 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
         puts("Tx complete");
         break;
 
+#if IS_USED(MODULE_NETDEV_LEGACY_API)
     case NETDEV_EVENT_TX_COMPLETE_DATA_PENDING:
         puts("Tx complete (with pending data)");
         break;
@@ -188,7 +189,7 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
     case NETDEV_EVENT_TX_NOACK:
         puts("No ACK");
         break;
-
+#endif
     default:
         printf("Event: %d\n", event);
         break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - `netdev_new_api` implies a TX_COMPLETE event, so no need to check for it
 - hide the legacy `TX_COMPLETE` events behind a `MODULE_NETDEV_LEGACY_API` check so they are not used by accident when porting a driver to the new API.


### Testing procedure

`NETOPT_TX_END_IRQ not implemented by driver` should go away with `netdev_new_api` once and for all - the TX_COMPLETE event is now mandated.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
