### PR TITLE
drivers/netdev: revise return values of `.confirm_send()`

### DIFF
--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -221,13 +221,13 @@ static int _sam0_eth_confirm_send(netdev_t *netdev, void *info)
         return -EAGAIN;
     }
 
-    /* Retry Limit Exceeded */
-    if (tsr & GMAC_TSR_RLE) {
+    /* Retry Limit Exceeded, Collision Occurred */
+    if (tsr & (GMAC_TSR_RLE | GMAC_TSR_COL)) {
         return -EBUSY;
     }
 
-    /* Transmit Frame Corruption, Collision Occurred */
-    if (tsr & (GMAC_TSR_TFC | GMAC_TSR_COL)) {
+    /* Transmit Frame Corruption */
+    if (tsr & GMAC_TSR_TFC) {
         return -EIO;
     }
 

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -468,10 +468,12 @@ typedef struct netdev_driver {
      *          frame delimiters, etc. May be an estimate for performance
      *          reasons.)
      * @retval  -EAGAIN     Transmission still ongoing. (Call later again!)
-     * @retval  -ECOMM      Any kind of transmission error, such as collision
-     *                      detected, layer 2 ACK timeout, etc.
+     * @retval  -EHOSTUNREACH  Layer 2 ACK timeout
+     * @retval  -EBUSY      Medium is busy. (E.g. Auto-CCA failed / timed out,
+     *                      collision detected)
+     * @retval  -ENETDOWN   Interface is not connected / powered down
+     * @retval  -EIO        Any kind of transmission error
      *                      Use @p info for more details
-     * @retval  -EBUSY      Medium is busy. (E.g. Auto-CCA failed / timed out)
      * @retval  <0          Other error. (Please use a negative errno code.)
      *
      * @warning After netdev_driver_t::send was called and returned zero, this


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - Missing l2 ACK should be `EHOSTUNREACH`
 - Collision should be `EBUSY`
 - stm32 eth already uses `ENETDOWN` for no link / sleep, document that


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
