### PR TITLE
sys/ztimer: mention ztimer_auto_adjust in relevant places

### DIFF
--- a/doc/doxygen/src/porting-boards.md
+++ b/doc/doxygen/src/porting-boards.md
@@ -178,13 +178,13 @@ PROGRAMMER ?= openocd
 
 ## Timer Configurations                            {#board-timer-configurations}
 
-When using high level timers, i.e. `ztimer` there is an overhead in calling
-for @ref ztimer_sleep and @ref ztimer_set functions. This offset can be
+When using the high level timer `ztimer` there is an overhead in calling
+the @ref ztimer_sleep and @ref ztimer_set functions. This offset can be
 compensated for. It can be measured by running `tests/sys/ztimer_overhead`
 on your board, i.e:
 
 ```shell
-$ BOARD=my-new-board make -C tests/sys/ztimer_overhead
+$ BOARD=my-new-board make -C tests/sys/ztimer_overhead flash term
 main(): This is RIOT!
 ZTIMER_USEC auto_adjust params:
     ZTIMER_USEC->adjust_set = xx
@@ -210,6 +210,10 @@ The last two lines can be added as defines to the new board `board.h`:
 #define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   21
 /** @} */
 ```
+
+Alternatively, the pseudomodule @ref pseudomodule_ztimer_auto_adjust can be used
+in an application to enable automatic timer offset compensation at board startup.
+This however incurs overhead both in the text segment and at bootup time.
 
 ## doc.txt                                                          {#board-doc}
 

--- a/tests/sys/ztimer_overhead/README.md
+++ b/tests/sys/ztimer_overhead/README.md
@@ -22,3 +22,7 @@ ZTIMER_USEC adjust params for dwm1001:
     CONFIG_ZTIMER_USEC_ADJUST_SET    6
     CONFIG_ZTIMER_USEC_ADJUST_SLEEP  21
 ```
+
+This test application also makes use of the `ztimer_auto_adjust` pseudomodule
+and thereby allows for comparison of the offset values calculated during
+auto-initialization and later during this test.

--- a/tests/sys/ztimer_overhead/main.c
+++ b/tests/sys/ztimer_overhead/main.c
@@ -67,9 +67,9 @@ int main(void)
     ZTIMER_USEC->adjust_sleep = 0;
     printf("ZTIMER_USEC auto_adjust params cleared\n");
 
-    printf("zitmer_overhead_set...\n");
+    printf("ztimer_overhead_set...\n");
     ZTIMER_USEC->adjust_set = _ztimer_usec_overhead(SAMPLES, BASE, ztimer_overhead_set);
-    printf("zitmer_overhead_sleep...\n");
+    printf("ztimer_overhead_sleep...\n");
     ZTIMER_USEC->adjust_sleep = _ztimer_usec_overhead(SAMPLES, BASE, ztimer_overhead_sleep);
     printf("ZTIMER_USEC adjust params for %s:\n", RIOT_BOARD);
     printf("    CONFIG_ZTIMER_USEC_ADJUST_SET    %" PRIi16 "\n", ZTIMER_USEC->adjust_set);


### PR DESCRIPTION
### Contribution description

Since #17633, there is an alternative to configuring the ztimer overhead compensation in the board.h file. Mention this in the relevant places in the documentation and the test application.

While we are at it, also fixing a typo in the test application.


### Testing procedure

Check generated doc and changes to README.


### Issues/PRs references

Stumbled upon this while going through https://doc.riot-os.org/porting-boards.html#board-timer-configurations for #20980. Interesting enough that this configuration values are currently only set for a handful of boards :eyes:
