### PR TITLE
boards/wemos-zero: fix Arduio I/O Map

### DIFF
--- a/boards/common/arduino-zero/include/arduino_iomap.h
+++ b/boards/common/arduino-zero/include/arduino_iomap.h
@@ -64,11 +64,22 @@ extern "C" {
  * @name    Mapping of MCU pins to Arduino pins
  * @{
  */
+
+/* The WeMos Zero / HW-819 has D2 and D4 swapped compared to official Arduino
+ * Zero, so we have to handle D2 and D4 differently depending on board */
+#ifdef BOARD_WEMOS_ZERO
+#  define ARDUINO_PIN_2         GPIO_PIN(PA, 8)
+#  define ARDUINO_PIN_4         GPIO_PIN(PA, 14)
+#else /* Official Arduino Zero or fully compatible: */
+#  define ARDUINO_PIN_2         GPIO_PIN(PA, 14)
+#  define ARDUINO_PIN_4         GPIO_PIN(PA, 8)
+#endif
+
+/* all other pins are identical for all currently supported Arduino Zero
+ * compatible boards */
 #define ARDUINO_PIN_0           GPIO_PIN(PA, 11)
 #define ARDUINO_PIN_1           GPIO_PIN(PA, 10)
-#define ARDUINO_PIN_2           GPIO_PIN(PA, 14)
 #define ARDUINO_PIN_3           GPIO_PIN(PA, 9)
-#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)
 #define ARDUINO_PIN_5           GPIO_PIN(PA, 15)
 #define ARDUINO_PIN_6           GPIO_PIN(PA, 20)
 #define ARDUINO_PIN_7           GPIO_PIN(PA, 21)

--- a/boards/wemos-zero/doc.txt
+++ b/boards/wemos-zero/doc.txt
@@ -6,13 +6,14 @@
 ## Overview
 
 The WeMos Zero is a cheap clone of Arduino Zero featuring a ATSAMD21G18A.
+These boards either have a silkscreen "WeMos" or "HW-910" label on their back.
 Unlike the original Zero, it does not include an embedded debugger/programmer.
 Instead, the [UF2 Bootloader](https://github.com/microsoft/uf2-samdx1) is
 used to program this board. The SAMD21 is a ARM Cortex-M0+ micro-controller.
 It has 256KiB of flash memory and 32KiB of RAM.
 
-Note: The official Arduino Zero using the native USB port and the Adafruit
-Metro M0 Express should also work with board definition.
+@note The official Arduino Zero using the native USB port and the Adafruit
+      Metro M0 Express should also work with this board definition.
 
 ## Hardware
 


### PR DESCRIPTION
### Contribution description

Two pins were incorrectly mapped: D2 and D4 are swapped compared to the official Arduino Zero. In addition the is slightly extended.

### Testing procedure

#### Pinout for Arduino Zero

![Official Pinout](https://content.arduino.cc/assets/Pinout-ZERO_latest.png)

#### Pinout for Clones

![Clone Pinout](https://www.fantasystudios.es/arduino/images/arduinos/zero/zero_pinout.jpg)

### Issues/PRs references

None