### PR TITLE
tests/periph/selftest_shield: fix invalid calls to timer_init() + GPIO IRQ tests

### DIFF
--- a/tests/periph/selftest_shield/Makefile
+++ b/tests/periph/selftest_shield/Makefile
@@ -18,6 +18,7 @@ FEATURES_OPTIONAL += periph_i2c
 FEATURES_OPTIONAL += periph_pwm
 FEATURES_OPTIONAL += periph_spi
 FEATURES_OPTIONAL += periph_timer
+FEATURES_OPTIONAL += periph_timer_query_freqs
 FEATURES_OPTIONAL += periph_uart
 
 USEMODULE += tiny_strerror

--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -554,6 +554,9 @@ static bool periph_gpio_irq_test_falling(void)
     brief_delay();
     failed |= TEST(atomic_load(&cnt) == 3);
 
+    /* disable IRQ again to not have side effects */
+    gpio_irq_disable(ARDUINO_PIN_3);
+
     print_result(failed);
     return failed;
 }
@@ -616,6 +619,9 @@ static bool periph_gpio_irq_test_rising(void)
     gpio_set(ARDUINO_PIN_4);
     brief_delay();
     failed |= TEST(atomic_load(&cnt) == 3);
+
+    /* disable IRQ again to not have side effects */
+    gpio_irq_disable(ARDUINO_PIN_3);
 
     print_result(failed);
     return failed;

--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -731,7 +731,7 @@ static void uart_rx_cb(void *arg, uint8_t data)
     serial_buf.pos++;
 }
 
-static bool periph_uart_rxtx_test(uint32_t symbolrate)
+static bool periph_uart_rxtx_test(uint32_t symbolrate, uint32_t timer_freq)
 {
     bool failed = 0;
     uint16_t duration_ticks = 0;
@@ -742,7 +742,7 @@ static bool periph_uart_rxtx_test(uint32_t symbolrate)
     ASSERT_NO_ERROR(uart_init(UART_TEST_DEV, symbolrate, uart_rx_cb, NULL));
 
     if (IS_USED(MODULE_PERIPH_TIMER)) {
-        bit_ticks = TIMER_FREQ_UART_TEST / symbolrate;
+        bit_ticks = timer_freq / symbolrate;
         duration_ticks = 9ULL * sizeof(testdata) * bit_ticks;
     }
 
@@ -787,20 +787,20 @@ static bool periph_uart_rxtx_test(uint32_t symbolrate)
     return failed;
 }
 
-static bool periph_uart_test_slow(void)
+static bool periph_uart_test_slow(uint32_t timer_freq)
 {
     bool failed = false;
     print_start("UART", "slow");
-    failed |= periph_uart_rxtx_test(9600);
+    failed |= periph_uart_rxtx_test(9600, timer_freq);
     print_result(failed);
     return failed;
 }
 
-static bool periph_uart_test_fast(void)
+static bool periph_uart_test_fast(uint32_t timer_freq)
 {
     bool failed = false;
     print_start("UART", "fast");
-    failed |= periph_uart_rxtx_test(115200);
+    failed |= periph_uart_rxtx_test(115200, timer_freq);
     print_result(failed);
     return failed;
 }
@@ -809,19 +809,35 @@ static bool periph_uart_test(void)
 {
     bool failed = false;
 
+    uint32_t timer_freq = TIMER_FREQ_UART_TEST;
+
+    /* Select a frequency >= TIMER_FREQ_UART_TEST that is closest to it. If no
+     * such exists, select the highest supported frequency instead. */
+    if (IS_USED(MODULE_PERIPH_TIMER_QUERY_FREQS)) {
+        timer_freq = timer_query_freqs(TIMER, 0);
+        for (uword_t i = 0; i < timer_query_freqs_numof(TIMER); i++) {
+            uint32_t tmp = timer_query_freqs(TIMER, i);
+            if (tmp < TIMER_FREQ_UART_TEST) {
+                break;
+            }
+            timer_freq = tmp;
+        }
+    }
+
     if (IS_USED(MODULE_PERIPH_TIMER)) {
-        ASSERT_NO_ERROR(timer_init(TIMER, TIMER_FREQ_UART_TEST, NULL, NULL));
+        ASSERT_NO_ERROR(timer_init(TIMER, timer_freq, NULL, NULL));
         timer_start(TIMER);
     }
 
-    failed |= periph_uart_test_slow();
-    failed |= periph_uart_test_fast();
+    failed |= periph_uart_test_slow(timer_freq);
+    failed |= periph_uart_test_fast(timer_freq);
     return failed;
 }
 
 static bool periph_spi_rxtx_test(spi_t bus, spi_mode_t mode, spi_clk_t clk,
                                  uint32_t clk_hz, gpio_t clk_check, bool idle_level,
-                                 const char *test_in_detail)
+                                 const char *test_in_detail,
+                                 uint32_t timer_freq)
 {
     (void)test_in_detail;
     bool failed = false;
@@ -831,7 +847,7 @@ static bool periph_spi_rxtx_test(spi_t bus, spi_mode_t mode, spi_clk_t clk,
     memset(&serial_buf, 0, sizeof(serial_buf));
 
     if (IS_USED(MODULE_PERIPH_TIMER)) {
-        byte_transfer_ticks = 8ULL * TIMER_FREQ_SPI_TEST / clk_hz;
+        byte_transfer_ticks = 8ULL * timer_freq / clk_hz;
     }
 
     /* D10 is C̅S̅, D7 is connected to C̅S̅ */
@@ -917,8 +933,24 @@ static bool periph_spi_rxtx_test(spi_t bus, spi_mode_t mode, spi_clk_t clk,
 
 static bool periph_spi_test(void)
 {
+
+    uint32_t timer_freq = TIMER_FREQ_SPI_TEST;
+
+    /* Select a frequency >= TIMER_FREQ_SPI_TEST that is closest to it. If no
+     * such exists, select the highest supported frequency instead. */
+    if (IS_USED(MODULE_PERIPH_TIMER_QUERY_FREQS)) {
+        timer_freq = timer_query_freqs(TIMER, 0);
+        for (uword_t i = 0; i < timer_query_freqs_numof(TIMER); i++) {
+            uint32_t tmp = timer_query_freqs(TIMER, i);
+            if (tmp < TIMER_FREQ_SPI_TEST) {
+                break;
+            }
+            timer_freq = tmp;
+        }
+    }
+
     if (IS_USED(MODULE_PERIPH_TIMER)) {
-        ASSERT_NO_ERROR(timer_init(TIMER, TIMER_FREQ_SPI_TEST, NULL, NULL));
+        ASSERT_NO_ERROR(timer_init(TIMER, timer_freq, NULL, NULL));
         timer_start(TIMER);
     }
 
@@ -943,10 +975,10 @@ static bool periph_spi_test(void)
             if (DETAILED_OUTPUT) {
                 printf("SPI CLK %" PRIu32 " Hz\n", clk_hz);
             }
-            failed |= periph_spi_rxtx_test(bus, SPI_MODE_0, clk, clk_hz, clk_check, false, "mode 0");
-            failed |= periph_spi_rxtx_test(bus, SPI_MODE_1, clk, clk_hz, clk_check, false, "mode 1");
-            failed |= periph_spi_rxtx_test(bus, SPI_MODE_2, clk, clk_hz, clk_check, true, "mode 2");
-            failed |= periph_spi_rxtx_test(bus, SPI_MODE_3, clk, clk_hz, clk_check, true, "mode 3");
+            failed |= periph_spi_rxtx_test(bus, SPI_MODE_0, clk, clk_hz, clk_check, false, "mode 0", timer_freq);
+            failed |= periph_spi_rxtx_test(bus, SPI_MODE_1, clk, clk_hz, clk_check, false, "mode 1", timer_freq);
+            failed |= periph_spi_rxtx_test(bus, SPI_MODE_2, clk, clk_hz, clk_check, true, "mode 2", timer_freq);
+            failed |= periph_spi_rxtx_test(bus, SPI_MODE_3, clk, clk_hz, clk_check, true, "mode 3", timer_freq);
         }
     }
     return failed;


### PR DESCRIPTION
### Contribution description

#### Regarding Invalid Calls to `timer_init()`

Calling `timer_init()` with unsupported frequencies on some MCUs just selects the closest possible frequency. But e.g. on SAM0, using an unsupported frequency will cause `timer_init()` to fail; which probably is the better option.

However, a failing calling to `timer_init()` results in a test failure. This is now worked around by using timer_query_freq() to select a suitable timer frequency that is supported.

#### Regarding GPIO IRQ Tests

The GPIO IRQ tests had a side-effect that IRQs remained configured after the test case was complete. This caused stray IRQs to trigger on SAM0 MCUs and they consequently (and incorrectly) failed the test.

### Testing procedure

On e.g. `wemos-zero` or `arduino-zero` the test should now run to completion and - with the exception of the ADC tests - pass.

In `master` GPIO IRQ tests will fail and the test will abort after a failing call to `timer_init()`.

### Issues/PRs references

None