### PR TITLE
cpu/sam0_common/periph_gpio_ll: fix gpio_get_port() and gpio_ll_query_conf() [backport 2024.10]

### DIFF
--- a/cpu/sam0_common/include/gpio_ll_arch.h
+++ b/cpu/sam0_common/include/gpio_ll_arch.h
@@ -159,7 +159,15 @@ static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
 
 static inline gpio_port_t gpio_get_port(gpio_t pin)
 {
-    return (gpio_port_t)(pin & ~(0x1f));
+    /* GPIO LL and legacy GPIO API may disagree on what is the GPIO base
+     * address if one is using the IOBUS and the other is using the APB for
+     * access. In this case, we need to do impedance matching by adding the
+     * offset. */
+    const uintptr_t gpio_ll_base = GPIO_PORT_0;
+    const uintptr_t gpio_legacy_base = GPIO_PIN(0, 0) & ~(0x1f);
+    uintptr_t addr = (pin & ~(0x1f));
+
+    return addr + (gpio_ll_base - gpio_legacy_base);
 }
 
 static inline uint8_t gpio_get_pin_num(gpio_t pin)

--- a/cpu/sam0_common/periph/gpio_ll.c
+++ b/cpu/sam0_common/periph/gpio_ll.c
@@ -204,7 +204,12 @@ gpio_conf_t gpio_ll_query_conf(gpio_port_t port, uint8_t pin)
         }
     }
 
-    result.initial_value = iobus->OUT.reg & pin_mask;
+    if (result.state == GPIO_INPUT) {
+        result.initial_value = (gpio_ll_read(port) >> pin) & 1UL;
+    }
+    else {
+        result.initial_value = (gpio_ll_read_output(port) >> pin) & 1UL;
+    }
 
     return result;
 }


### PR DESCRIPTION
# Backport of #20999

### Contribution description

#### `gpio_get_port()`

It turns out that the legacy GPIO API and GPIO LL may disagree on what the GPIO base address is: GPIO LL will use the IOBUS as base address no matter what, the legacy GPIO API will use the APB as base address unless `periph_gpio_fast_read` is used.

If the APIs disagree, we need to do impedance matching.

#### `gpio_ll_query_conf()`

For the other MCUs, we take the input register state instead of the output register state when the pin is configured as input. Let's do the same here, as this is a lot more useful and intuitive.

### Testing procedure

`gpio_query_conf(gpio_get_port(GPIO_PIN(PA, 1)), gpio_get_pin_num(GPIO_PIN(PA, 1));` should no longer run into a blown assertion.

### Issues/PRs references

None