### PR TITLE
cpu/stm32l0,l1: Fix ADC initialization order

### DIFF
--- a/cpu/stm32/periph/adc_l0.c
+++ b/cpu/stm32/periph/adc_l0.c
@@ -128,9 +128,6 @@ int32_t adc_sample(adc_t line,  adc_res_t res)
     /* lock and power on the ADC device  */
     prep();
 
-    /* Enable ADC */
-    _enable_adc();
-
     /* Reactivate VREFINT and temperature sensor if necessary */
     if (adc_config[line].chan == 17) {
         ADC->CCR |= ADC_CCR_VREFEN;
@@ -144,6 +141,9 @@ int32_t adc_sample(adc_t line,  adc_res_t res)
     ADC1->CFGR1 &= ~ADC_CFGR1_RES;
     ADC1->CFGR1 |= res & ADC_CFGR1_RES;
     ADC1->CHSELR = (1 << adc_config[line].chan);
+
+    /* Enable ADC */
+    _enable_adc();
 
     /* clear flag */
     ADC1->ISR |= ADC_ISR_EOC;

--- a/cpu/stm32/periph/adc_l1.c
+++ b/cpu/stm32/periph/adc_l1.c
@@ -131,8 +131,6 @@ int adc_init(adc_t line)
         ADC->CCR |= ADC_CCR_TSVREFE;
     }
 
-    /* enable the ADC module */
-    ADC1->CR2 = ADC_CR2_ADON;
     /* turn off during idle phase*/
     ADC1->CR1 = ADC_CR1_PDI;
 
@@ -157,12 +155,17 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     /* lock and power on the ADC device  */
     prep();
 
-    /* set resolution, conversion channel and single read */
-    ADC1->CR1 |= res & ADC_CR1_RES;
+    /* mask and set resolution, conversion channel and single read */
+    ADC1->CR1 = (ADC1->CR1 & ~ADC_CR1_RES) | (res & ADC_CR1_RES);
     ADC1->SQR1 &= ~ADC_SQR1_L;
     ADC1->SQR5 = adc_config[line].chan;
 
-    /* wait for regulat channel to be ready*/
+    /* only set ADON when ADONS bit is cleared (ADC not ready) */
+    if (!(ADC1->SR & ADC_SR_ADONS)) {
+        ADC1->CR2 |= ADC_CR2_ADON;
+    }
+
+    /* wait for regular channel to be ready*/
     while (!(ADC1->SR & ADC_SR_RCNR)) {}
     /* start conversion and wait for results */
     ADC1->CR2 |= ADC_CR2_SWSTART;
@@ -170,6 +173,10 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     /* finally read sample and reset the STRT bit in the status register */
     sample = (int)ADC1->DR;
     ADC1 -> SR &= ~ADC_SR_STRT;
+
+    /* wait for ADC to become ready before disabling it */
+    while (!(ADC1->SR & ADC_SR_ADONS)) {}
+    ADC1->CR2 &= ~ADC_CR2_ADON;
 
     /* power off and unlock device again */
     done();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Most of this PR is already described in #20780.

The STM32L0 was enabled before the resolution bits were set, but any access to configuration registers is prohibited (and seemingly ignored by the microcontroller). Therefore, the resolution set in `adc_sample` was not actually applied and the resolution was always 12-bit.

The same issue was present in the STM32L1, however this ADC hardware implementation does not seem to ignore configuration register calls (even though they are prohibited when the ADC is on). However, the resolution bits were not masked in the configuration register before setting the new resolution, leading to the resolution being stuck at 6-bit (0b11). The resolution was only OR-ed to the register.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

For convenience you can change the test application (`tests/periph/adc`) to print all resolution values at once, as described in https://github.com/RIOT-OS/RIOT/issues/20780#issuecomment-2482672894.

Due to the issue described in #21010, I recommend flashing the NUCLEO-L152RE board with the Mass Storage Driver of the ST-Link or doing a powercycle (unplug and plug the USB cable back in) after flashing. This issue is not related to these changes.

You can connect one of the A0 to A5 pins of the Nucleo to +3.3V and observe the output.
tl;dr: The output should look something like this, when the channel is maxed out on all implemented bit sizes. The two `-1` at the end show that the 14-bit and 16-bit resolution is not implemented.
```
expected:
ADC_LINE(5): 63 255 1023 4095 -1 -1

actual:
ADC_LINE(5): 4095 4095 4095 4095 -1 -1 (NUCLEO-L073RZ)
ADC_LINE(5): 63 63 63 63 -1 -1 (NUCLEO-L152RE)
```

<hr>

Nucleo-L073RZ Master:
```
main(): This is RIOT! (Version: 2025.01-devel-29-g76b9b)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
a 10-bit resolution and print the sampled results to STDIO


Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
ADC_LINE(0): 73 32 14 6 -1 -1
ADC_LINE(1): 515 526 530 530 -1 -1
ADC_LINE(2): 325 152 74 39 -1 -1
ADC_LINE(3): 476 518 524 531 -1 -1
ADC_LINE(4): 482 514 537 536 -1 -1
ADC_LINE(5): 4095 4095 4095 4095 -1 -1
```

Nucleo-L073RZ this PR:
```
main(): This is RIOT! (Version: 2025.01-devel-31-g5de25c-pr/stm32l0_adc_fix)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
a 10-bit resolution and print the sampled results to STDIO


Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
ADC_LINE(0): 1 2 4 8 -1 -1
ADC_LINE(1): 7 32 133 522 -1 -1
ADC_LINE(2): 5 10 19 52 -1 -1
ADC_LINE(3): 7 32 129 528 -1 -1
ADC_LINE(4): 7 32 132 537 -1 -1
ADC_LINE(5): 63 255 1023 4095 -1 -1
```


Nucleo-L152RE Master:
```
main(): This is RIOT! (Version: 2025.01-devel-29-g76b9b)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
a 10-bit resolution and print the sampled results to STDIO


Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
ADC_LINE(0): 24 27 29 30 -1 -1
ADC_LINE(1): 25 29 30 31 -1 -1
ADC_LINE(2): 21 24 26 28 -1 -1
ADC_LINE(3): 23 26 28 29 -1 -1
ADC_LINE(4): 24 28 30 31 -1 -1
ADC_LINE(5): 63 63 63 63 -1 -1
```

Nucleo-L152RE with the fixes applied:
```
main(): This is RIOT! (Version: 2025.01-devel-31-g5de25c-pr/stm32l0_adc_fix)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
a 10-bit resolution and print the sampled results to STDIO


Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
ADC_LINE(0): 23 110 473 1967 -1 -1
ADC_LINE(1): 28 123 503 2039 -1 -1
ADC_LINE(2): 21 98 423 1813 -1 -1
ADC_LINE(3): 22 103 447 1879 -1 -1
ADC_LINE(4): 22 111 481 1999 -1 -1
ADC_LINE(5): 63 255 1023 4095 -1 -1
```



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This PR is a requirement for #20971, otherwise the changes in that PR can't be tested.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
