### PR TITLE
netdev_new_api: allow `.send()` to return > 0 to signal synchronos send

### DIFF
--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -217,45 +217,42 @@ void sam0_eth_get_mac(eui48_t *out)
 
 int sam0_eth_send(const struct iolist *iolist)
 {
-    unsigned len = iolist_size(iolist);
     unsigned tx_len = 0;
     tx_curr = &tx_desc[tx_idx];
 
     if (_is_sleeping) {
-        return -ENOTSUP;
+        return -ENETDOWN;
     }
 
     /* load packet data into TX buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         if (tx_len + iol->iol_len > ETHERNET_MAX_LEN) {
-            return -EBUSY;
+            return -EOVERFLOW;
         }
         if (iol->iol_len) {
             memcpy ((uint32_t*)(tx_curr->address + tx_len), iol->iol_base, iol->iol_len);
             tx_len += iol->iol_len;
         }
     }
-    if (len == tx_len) {
-        /* Clear and set the frame size */
-        tx_curr->status = (len & DESC_TX_STATUS_LEN_MASK)
-        /* Indicate this is the last buffer and the frame is ready */
-                        | DESC_TX_STATUS_LAST_BUF;
-        /* Prepare next buffer index */
-        if (++tx_idx == ETH_TX_BUFFER_COUNT) {
-            /* Set WRAP flag to indicate last buffer */
-            tx_curr->status |= DESC_TX_STATUS_WRAP;
-            tx_idx = 0;
-        }
-        __DMB();
-        /* Start transmission */
-        GMAC->NCR.reg |= GMAC_NCR_TSTART;
-        /* Set the next buffer */
-        tx_curr = &tx_desc[tx_idx];
+
+    /* Clear and set the frame size */
+    tx_curr->status = (tx_len & DESC_TX_STATUS_LEN_MASK)
+    /* Indicate this is the last buffer and the frame is ready */
+                    | DESC_TX_STATUS_LAST_BUF;
+    /* Prepare next buffer index */
+    if (++tx_idx == ETH_TX_BUFFER_COUNT) {
+        /* Set WRAP flag to indicate last buffer */
+        tx_curr->status |= DESC_TX_STATUS_WRAP;
+        tx_idx = 0;
     }
-    else {
-        DEBUG("Mismatch TX len, abort send\n");
-    }
-    return len;
+    __DMB();
+
+    /* Start transmission */
+    GMAC->NCR.reg |= GMAC_NCR_TSTART;
+    /* Set the next buffer */
+    tx_curr = &tx_desc[tx_idx];
+
+    return 0;
 }
 
 unsigned _sam0_eth_get_last_len(void)

--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -197,15 +197,8 @@ static int _sam0_eth_recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _sam0_eth_send(netdev_t *netdev, const iolist_t *iolist)
 {
-    int ret;
-
     netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
-    ret = sam0_eth_send(iolist);
-    if (ret == -EOVERFLOW) {
-        /* TODO: use a specific netdev callback here ? */
-        return -EOVERFLOW;
-    }
-    return ret;
+    return sam0_eth_send(iolist);
 }
 
 static int _sam0_eth_confirm_send(netdev_t *netdev, void *info)

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -440,13 +440,19 @@ typedef struct netdev_driver {
      * @retval  -ENETDOWN   Device is powered down
      * @retval  <0          Other error
      * @retval  0           Transmission successfully started
-     * @retval  >0          Number of bytes transmitted (deprecated!)
+     * @retval  >0          Number of bytes transmitted (transmission already complete)
      *
      * This function will cause the driver to start the transmission in an
      * async fashion. The driver will "own" the `iolist` until a subsequent
      * call to @ref netdev_driver_t::confirm_send returns something different
      * than `-EAGAIN`. The driver must signal completion using the
      * NETDEV_EVENT_TX_COMPLETE event, regardless of success or failure.
+     *
+     * If the driver implements blocking send (e.g. because it writes out the
+     * frame byte-by-byte over a serial line) it can also return the number of bytes
+     * transmitted here directly. In this case it MUST NOT emit a NETDEV_EVENT_TX_COMPLETE
+     * event, netdev_driver_t::confirm_send will never be called but should still be
+     * implemented to signal conformance to the new API.
      *
      * Old drivers might not be ported to the new API and have
      * netdev_driver_t::confirm_send set to `NULL`. In that case the driver

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1915,7 +1915,7 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
      * completed. For new netdevs (with confirm_send), TX is async. It is only
      * done if TX failed right away (res < 0).
      */
-    if (gnrc_netif_netdev_legacy_api(netif) || (res < 0)) {
+    if (gnrc_netif_netdev_legacy_api(netif) || (res != 0)) {
         _tx_done(netif, pkt, tx_sync, res, push_back);
     }
 #if IS_USED(MODULE_NETDEV_NEW_API)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The new netdev API makes implementing drivers where `.send` is inherently synchronous (slip, dose, ethos) kind of awkward. They need to memorize the frame size, generate an event, and return the frame size in `.confirm_send` to signal completion.

However, the new netdev API does not use `.send` return values that are > 0. We can use those to signal that send is complete already and no further action is needed.

This makes writing and understanding synchronos drivers much easier, the code changes to support this in GNRC and LWIP are minimal. 


### Testing procedure

You can test with SLIP with is now trivial to convert:

<details><summary>slip.patch</summary>

```patch
--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -1,6 +1,6 @@
 USEMODULE += chunked_ringbuffer
 USEMODULE += eui_provider
-USEMODULE += netdev_legacy_api
+USEMODULE += netdev_new_api
 USEMODULE += netdev_register
 FEATURES_REQUIRED += periph_uart
 
diff --git a/drivers/slipdev/slipdev.c b/drivers/slipdev/slipdev.c
index ff6880a5b6..b0c0c827ff 100644
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -234,10 +234,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     slipdev_write_byte(dev->config.uart, SLIPDEV_END);
     slipdev_unlock();
 
-    if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-    }
-
     return bytes;
 }
 
@@ -327,9 +323,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_SLIP;
             return sizeof(uint16_t);
-        case NETOPT_TX_END_IRQ:
-            *((netopt_enable_t *)value) = NETOPT_ENABLE;
-            return sizeof(netopt_enable_t);
 #if IS_USED(MODULE_SLIPDEV_L2ADDR)
         case NETOPT_ADDRESS_LONG:
             assert(max_len == sizeof(eui64_t));
@@ -341,12 +334,20 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     }
 }
 
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev;
+    (void)info;
+    return 0;
+}
+
 static const netdev_driver_t slip_driver = {
     .send = _send,
     .recv = _recv,
     .init = _init,
     .isr = _isr,
     .get = _get,
+    .confirm_send = _confirm_send,
 #if IS_USED(MODULE_SLIPDEV_STDIO)
     .set = netdev_set_notsup,
 #else
```
</details>


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
