### PR TITLE
boards/stm32f429i-disc1: fix touch screen axis [backport 2024.10]

### DIFF
--- a/boards/stm32f429i-disc1/include/board.h
+++ b/boards/stm32f429i-disc1/include/board.h
@@ -57,6 +57,13 @@ extern "C" {
 #define L3GXXXX_INT2_PIN    GPIO_PIN(PORT_A, 2) /**< INT2/DRDY pin used for L3Gxxxx */
 /** @} */
 
+/**
+ * @brief stmpe811 driver parameters
+ * @{
+ */
+#define STMPE811_PARAM_XYCONV (STMPE811_MIRROR_Y | STMPE811_SWAP_XY)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Backport of #21007

### Contribution description

This patch fixes a missmatch between the LCD and touch drivers' coordinate systems.


### Testing procedure

Build and flash with `make -C tests/pkg/lvgl_touch/ flash`, and observe the test works as intended with this patch, but not without it.


### Issues/PRs references

none known
