### PR TITLE
netdev_tap: port to `netdev_new_api`

### DIFF
--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -41,7 +41,7 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
 endif
 
 ifneq (,$(filter netdev_tap,$(USEMODULE)))
-  USEMODULE += netdev_legacy_api
+  USEMODULE += netdev_new_api
 endif
 
 ifneq (,$(filter libc_gettimeofday,$(USEMODULE)))

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -166,6 +166,17 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
     return res;
 }
 
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev;
+    (void)info;
+
+    /* confirm_send should not be called with synchronos send */
+    assert(0);
+
+    return -EOPNOTSUPP;
+}
+
 static const netdev_driver_t netdev_driver_tap = {
     .send = _send,
     .recv = _recv,
@@ -173,6 +184,7 @@ static const netdev_driver_t netdev_driver_tap = {
     .isr = _isr,
     .get = _get,
     .set = _set,
+    .confirm_send = _confirm_send,
 };
 
 /* driver implementation */
@@ -293,12 +305,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     unsigned n;
     iolist_to_iovec(iolist, iov, &n);
 
-    int res = _native_writev(dev->tap_fd, iov, n);
-
-    if (netdev->event_callback) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-    }
-    return res;
+    return _native_writev(dev->tap_fd, iov, n);
 }
 
 void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params, int index) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`netdev_tap` uses synchronous send, so we can trivially port it to the (relaxed) new netdev API.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

depends on #21012
