### PR TITLE
drivers/ethos: port to netdev_new_api

### DIFF
--- a/drivers/ethos/Makefile.dep
+++ b/drivers/ethos/Makefile.dep
@@ -1,7 +1,7 @@
 FEATURES_REQUIRED += periph_uart
 USEMODULE += iolist
 USEMODULE += netdev_eth
-USEMODULE += netdev_legacy_api
+USEMODULE += netdev_new_api
 USEMODULE += random
 USEMODULE += tsrb
 

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -442,6 +442,13 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
     return res;
 }
 
+static int _confirm_send(netdev_t *dev, void *info)
+{
+    (void)dev;
+    (void)info;
+    return -EOPNOTSUPP;
+}
+
 /* netdev interface */
 static const netdev_driver_t netdev_driver_ethos = {
     .send = _send,
@@ -449,5 +456,6 @@ static const netdev_driver_t netdev_driver_ethos = {
     .init = _init,
     .isr = _isr,
     .get = _get,
-    .set = netdev_eth_set
+    .set = netdev_eth_set,
+    .confirm_send = _confirm_send,
 };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The driver already does everything required by `netdev_new_api`, we only need to provide a dummy `confirm_send` to signal that it's conformant. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
