### PR TITLE
feather-nrf52840: add config for NeoPixel LED

### DIFF
--- a/boards/feather-nrf52840/Makefile.dep
+++ b/boards/feather-nrf52840/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += ws281x
 endif
 
 # include common nrf52 dependencies

--- a/boards/feather-nrf52840/include/board.h
+++ b/boards/feather-nrf52840/include/board.h
@@ -57,6 +57,21 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
+/**
+ * @name    WS281x RGB LEDs configuration
+ * @{
+ */
+#ifndef WS281X_PARAM_PIN
+/**
+ * @brief GPIO pin connected to the data pin of the first LED
+ */
+#define WS281X_PARAM_PIN    GPIO_PIN(0, 16)
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#define WS281X_PARAM_NUMOF  (1U)      /**< Number of LEDs chained */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Adds the NeoPixel LED config for the Adafruit nRF52840 Express (its the same as for the Sense).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash, e.g., the `examples/saul` app to a `feather-nrf52840`. The on-board RGB-LED should be controllable by the app.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Exposed while testing #20996.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
