### PR TITLE
drivers/atwinc15x0: port to `netdev_new_api`

### DIFF
--- a/drivers/atwinc15x0/Makefile.dep
+++ b/drivers/atwinc15x0/Makefile.dep
@@ -1,6 +1,6 @@
 USEMODULE += netdev_eth
 USEMODULE += ztimer_msec
-USEMODULE += netdev_legacy_api
+USEMODULE += netdev_new_api
 
 ifeq (,$(filter atwinc15x0_dynamic_%,$(USEMODULE)))
   # use static connect by default when no dynamic module is loaded

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -539,11 +539,11 @@ static int _atwinc15x0_send(netdev_t *netdev, const iolist_t *iolist)
     /* send wakes from standby but not from sleep */
     if (_atwinc15x0_is_sleeping(dev)) {
         DEBUG("%s WiFi is in SLEEP state, cannot send\n", __func__);
-        return -ENODEV;
+        return -ENETDOWN;
     }
     if (!_atwinc15x0_is_connected(dev)) {
         DEBUG("%s WiFi is still not connected to AP, cannot send\n", __func__);
-        return -ENODEV;
+        return -ENETDOWN;
     }
     /* atwinc15x0_eth_buf should not be used for incoming packets here */
     assert(dev->rx_buf == NULL);
@@ -570,13 +570,20 @@ static int _atwinc15x0_send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the the packet */
     if (m2m_wifi_send_ethernet_pkt(atwinc15x0_eth_buf, tx_len) == M2M_SUCCESS) {
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
         return tx_len;
     }
     else {
         DEBUG("%s sending WiFi packet failed", __func__);
         return -EIO;
     }
+}
+
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev;
+    (void)info;
+
+    return -EOPNOTSUPP;
 }
 
 static int _atwinc15x0_recv(netdev_t *netdev, void *buf, size_t len, void *info)
@@ -1077,6 +1084,7 @@ const netdev_driver_t atwinc15x0_netdev_driver = {
     .isr = _atwinc15x0_isr,
     .get = _atwinc15x0_get,
     .set = _atwinc15x0_set,
+    .confirm_send = _confirm_send,
 };
 
 void atwinc15x0_setup(atwinc15x0_t *dev, const atwinc15x0_params_t *params, uint8_t idx)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

While `atwinc15x0` is a real radio that would benefit from async send, the driver wraps a package that exposes a very high level synchronous send API.

This however makes porting the device to the `netdev_new_api` trivial.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
