### PR TITLE
boards/adafruit-grand-central-m4-express: improve TTY detection

### DIFF
--- a/boards/adafruit-grand-central-m4-express/Makefile.include
+++ b/boards/adafruit-grand-central-m4-express/Makefile.include
@@ -1,5 +1,7 @@
 CFLAGS += -DBOOTLOADER_UF2
 
+PROG_TTY_BOARD_FILTER := --vendor 'Adafruit Industries' --model 'Grand Central M4 Express'
+
 # Include all definitions for flashing with bossa other USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 # Include handling of serial and non-bossa programmers (if selected by user)


### PR DESCRIPTION
### Contribution description

With `MOST_RECENT_PORT=1`, detect the board correctly also when running the default bootloader and not a RIOT app flashed on it.

### Testing procedure

Double-tap the reset button to enter bootloader mode. Then run

```
make BOARD=adafruit-grand-central-m4-express -C examples/default flash term
```

It would fail in `master` due to no TTY being detected, but succeed with this PR.

### Issues/PRs references

None