### PR TITLE
feather-m0: add support for saul_bat_voltage

### DIFF
--- a/boards/common/particle-mesh/Makefile.dep
+++ b/boards/common/particle-mesh/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_bat_voltage
   USEMODULE += saul_pwm
 endif
 

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += board_bat_voltage
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/common/particle-mesh/bat_voltage.c
+++ b/boards/common/particle-mesh/bat_voltage.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)  2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @ingroup     saul_bat_voltage
+ * @{
+ * @file
+ * @brief       Implementation of battery voltage convert function
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SAUL_BAT_VOLTAGE
+#include "saul/bat_voltage.h"
+
+int16_t saul_bat_voltage_convert(int32_t adc_sample)
+{
+    /* See https://community.particle.io/t/can-argon-or-xenon-read-the-battery-state/45554/6
+     * and https://docs.particle.io/assets/images/xenon/schematic-main.png */
+    return (int16_t)((adc_sample * 33L * 1403L) / 10000L);
+}
+
+#endif /* MODULE_SAUL_BAT_VOLTAGE */

--- a/boards/common/particle-mesh/include/bat_voltage_params.h
+++ b/boards/common/particle-mesh/include/bat_voltage_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_particle-mesh
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped battery voltage information
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ */
+
+#ifndef BAT_VOLTAGE_PARAMS_H
+#define BAT_VOLTAGE_PARAMS_H
+
+#include "saul/bat_voltage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Conversion function to convert ADC sample to battery voltage
+ *
+ * @param[in] adc_sample    The raw ADC sample.
+ *
+ * @return Voltage value for phydat.
+ */
+int16_t saul_bat_voltage_convert(int32_t adc_sample);
+
+/**
+ * @brief   Battery voltage configuration
+ */
+static const saul_bat_voltage_params_t saul_bat_voltage_params[] =
+{
+    {
+        .name = "BAT",
+        .phydat_scale = -3,
+        .line = ADC_LINE(3),
+        .res = ADC_RES_10BIT,
+        .convert = saul_bat_voltage_convert,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BAT_VOLTAGE_PARAMS_H */
+/** @} */

--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_bat_voltage
 endif
 
 # setup the samd21 arduino bootloader related dependencies

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -15,4 +15,5 @@ FEATURES_PROVIDED += periph_usbdev
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += arduino_analog
 FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += board_bat_voltage
 FEATURES_PROVIDED += highlevel_stdio

--- a/boards/feather-m0/bat_voltage.c
+++ b/boards/feather-m0/bat_voltage.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)  2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-m0
+ * @ingroup     saul_bat_voltage
+ * @{
+ * @file
+ * @brief       Implementation of battery voltage convert function
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SAUL_BAT_VOLTAGE
+#include "saul/bat_voltage.h"
+
+int16_t saul_bat_voltage_convert(int32_t adc_sample)
+{
+    /* See
+     * https://learn.adafruit.com/adafruit-feather-m0-basic-proto/power-management
+     *
+     * we return in millivolt so we set the reference voltage to 3300
+     * instead of 3.3
+     */
+    return (int16_t)((adc_sample * 2L * 3300L) / 1024L);
+}
+
+#endif /* MODULE_SAUL_BAT_VOLTAGE */

--- a/boards/feather-m0/include/bat_voltage_params.h
+++ b/boards/feather-m0/include/bat_voltage_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped battery voltage information
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ */
+
+#ifndef BAT_VOLTAGE_PARAMS_H
+#define BAT_VOLTAGE_PARAMS_H
+
+#include "saul/bat_voltage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Conversion function to convert ADC sample to battery voltage
+ *
+ * @param[in] adc_sample    The raw ADC sample.
+ *
+ * @return Voltage value for phydat.
+ */
+int16_t saul_bat_voltage_convert(int32_t adc_sample);
+
+/**
+ * @brief   Battery voltage configuration
+ */
+static const saul_bat_voltage_params_t saul_bat_voltage_params[] =
+{
+    {
+        .name = "BAT",
+        .phydat_scale = -3,
+        .line = ADC_LINE(7),
+        .res = ADC_RES_10BIT,
+        .convert = saul_bat_voltage_convert,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BAT_VOLTAGE_PARAMS_H */
+/** @} */

--- a/boards/feather-nrf52840-sense/Makefile.dep
+++ b/boards/feather-nrf52840-sense/Makefile.dep
@@ -4,6 +4,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis3mdl
   USEMODULE += lsm6dsxx
   USEMODULE += saul_gpio
+  USEMODULE += saul_bat_voltage
   USEMODULE += sht3x
   USEMODULE += ws281x
 endif

--- a/boards/feather-nrf52840-sense/Makefile.features
+++ b/boards/feather-nrf52840-sense/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += board_bat_voltage
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart

--- a/boards/feather-nrf52840-sense/bat_voltage.c
+++ b/boards/feather-nrf52840-sense/bat_voltage.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)  2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @ingroup     saul_bat_voltage
+ * @{
+ * @file
+ * @brief       Implementation of battery voltage convert function
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SAUL_BAT_VOLTAGE
+#include "saul/bat_voltage.h"
+
+int16_t saul_bat_voltage_convert(int32_t adc_sample)
+{
+    /* See
+     * https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/power-management-2
+     *
+     * but the reference voltage is actually 3.3V (determined empirically)...
+     * we return in millivolt so we set the reference voltage to 3300
+     * instead of 3.3 */
+    return (int16_t)((adc_sample * 2L * 3300L) / 1024L);
+}
+
+#endif /* MODULE_SAUL_BAT_VOLTAGE */

--- a/boards/feather-nrf52840-sense/include/bat_voltage_params.h
+++ b/boards/feather-nrf52840-sense/include/bat_voltage_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840-sense
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped battery voltage information
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ */
+
+#ifndef BAT_VOLTAGE_PARAMS_H
+#define BAT_VOLTAGE_PARAMS_H
+
+#include "saul/bat_voltage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Conversion function to convert ADC sample to battery voltage
+ *
+ * @param[in] adc_sample    The raw ADC sample.
+ *
+ * @return Voltage value for phydat.
+ */
+int16_t saul_bat_voltage_convert(int32_t adc_sample);
+
+/**
+ * @brief   Battery voltage configuration
+ */
+static const saul_bat_voltage_params_t saul_bat_voltage_params[] =
+{
+    {
+        .name = "BAT",
+        .phydat_scale = -3,
+        .line = ADC_LINE(5),
+        .res = ADC_RES_10BIT,
+        .convert = saul_bat_voltage_convert,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BAT_VOLTAGE_PARAMS_H */
+/** @} */

--- a/boards/feather-nrf52840/Makefile.dep
+++ b/boards/feather-nrf52840/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_bat_voltage
 endif
 
 # include common nrf52 dependencies

--- a/boards/feather-nrf52840/Makefile.features
+++ b/boards/feather-nrf52840/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += board_bat_voltage
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart

--- a/boards/feather-nrf52840/bat_voltage.c
+++ b/boards/feather-nrf52840/bat_voltage.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)  2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @ingroup     saul_bat_voltage
+ * @{
+ * @file
+ * @brief       Implementation of battery voltage convert function
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SAUL_BAT_VOLTAGE
+#include "saul/bat_voltage.h"
+
+int16_t saul_bat_voltage_convert(int32_t adc_sample)
+{
+    /* See
+     * https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/power-management-2
+     *
+     * but the reference voltage is actually 3.3V (determined empirically)...
+     * we return in millivolt so we set the reference voltage to 3300
+     * instead of 3.3 */
+    return (int16_t)((adc_sample * 2L * 3300L) / 1024L);
+}
+
+#endif /* MODULE_SAUL_BAT_VOLTAGE */

--- a/boards/feather-nrf52840/include/bat_voltage_params.h
+++ b/boards/feather-nrf52840/include/bat_voltage_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped battery voltage information
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ */
+
+#ifndef BAT_VOLTAGE_PARAMS_H
+#define BAT_VOLTAGE_PARAMS_H
+
+#include "saul/bat_voltage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Conversion function to convert ADC sample to battery voltage
+ *
+ * @param[in] adc_sample    The raw ADC sample.
+ *
+ * @return Voltage value for phydat.
+ */
+int16_t saul_bat_voltage_convert(int32_t adc_sample);
+
+/**
+ * @brief   Battery voltage configuration
+ */
+static const saul_bat_voltage_params_t saul_bat_voltage_params[] =
+{
+    {
+        .name = "BAT",
+        .phydat_scale = -3,
+        .line = ADC_LINE(5),
+        .res = ADC_RES_10BIT,
+        .convert = saul_bat_voltage_convert,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BAT_VOLTAGE_PARAMS_H */
+/** @} */

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -264,6 +264,11 @@ ifneq (,$(filter ws281x_%,$(USEMODULE)))
   USEMODULE += ws281x
 endif
 
+ifneq (,$(filter saul_bat_voltage,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_adc
+  FEATURES_REQUIRED += board_bat_voltage
+endif
+
 ifneq (,$(filter saul_adc,$(USEMODULE)))
   FEATURES_REQUIRED += periph_adc
 endif

--- a/drivers/include/saul/bat_voltage.h
+++ b/drivers/include/saul/bat_voltage.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_saul
+ * @{
+ *
+ * @file
+ * @brief       Parameter definitions for mapping battery voltage to SAUL
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ */
+
+#ifndef SAUL_BAT_VOLTAGE_H
+#define SAUL_BAT_VOLTAGE_H
+
+#include <stdint.h>
+
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief SAUL battery voltage configuration values
+ */
+typedef struct {
+    const char *name;       /**< name of the device connected to this pin */
+    int8_t phydat_scale;    /**< Phydat scale of the resulting voltage */
+    adc_t line;             /**< ADC line to initialize and expose */
+    adc_res_t res;          /**< ADC resolution */
+    /**
+     * @brief   Conversion function to convert raw ADC data to voltage
+     *
+     * @param[in] adc_sample    The raw ADC sample.
+     *
+     * @return Voltage value for phydat.
+     */
+    int16_t (*convert)(int32_t adc_sample);
+} saul_bat_voltage_params_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SAUL_BAT_VOLTAGE_H */
+/** @} */

--- a/drivers/saul/Makefile
+++ b/drivers/saul/Makefile
@@ -3,6 +3,9 @@ SRC = saul.c saul_str.c
 ifneq (,$(filter saul_gpio,$(USEMODULE)))
   SRC += gpio_saul.c
 endif
+ifneq (,$(filter saul_bat_voltage,$(USEMODULE)))
+  SRC += bat_voltage_saul.c
+endif
 ifneq (,$(filter saul_adc,$(USEMODULE)))
   SRC += adc_saul.c
 endif

--- a/drivers/saul/bat_voltage_saul.c
+++ b/drivers/saul/bat_voltage_saul.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_saul
+ * @{
+ *
+ * @file
+ * @brief       SAUL wrapper to gauge battery voltage.
+ *
+ * Adafruit Feather-type boards typically have an ADC pin exposed to read
+ * the battery voltage.
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "saul/bat_voltage.h"
+#include "phydat.h"
+#include "periph/adc.h"
+
+static int read_adc(const void *dev, phydat_t *res)
+{
+    const saul_bat_voltage_params_t *params = *((const saul_bat_voltage_params_t **)dev);
+    int32_t sample = adc_sample(params->line, params->res);
+    res->val[0] = params->convert(sample);
+    res->unit = UNIT_V;
+    res->scale = params->phydat_scale;
+    return 1;
+}
+
+const saul_driver_t bat_voltage_saul_driver = {
+    .read = read_adc,
+    .write = saul_write_notsup,
+    .type = SAUL_SENSE_VOLTAGE,
+};

--- a/drivers/saul/init_devs/auto_init_saul_bat_voltage.c
+++ b/drivers/saul/init_devs/auto_init_saul_bat_voltage.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 TU Dresden
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of mapping battery voltage to SAUL
+ *
+ * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
+ *
+ * @}
+ */
+
+#include "log.h"
+#include "saul_reg.h"
+#include "saul/bat_voltage.h"
+#include "bat_voltage_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define SAUL_BAT_VOLTAGE_NUMOF  ARRAY_SIZE(saul_bat_voltage_params)
+
+/**
+ * @brief   Allocate memory for pointers to the BAT voltage parameter structs
+ *
+ * We use this extra level of indirection to be able to keep the saul_bat_voltage_params
+ * array const and residing in ROM.
+ */
+static const saul_bat_voltage_params_t *saul_bat_voltages[SAUL_BAT_VOLTAGE_NUMOF];
+
+/**
+ * @brief   Memory for the registry entries
+ */
+static saul_reg_t saul_reg_entries[SAUL_BAT_VOLTAGE_NUMOF];
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern saul_driver_t bat_voltage_saul_driver;
+
+void auto_init_saul_bat_voltage(void)
+{
+    for (unsigned i = 0; i < SAUL_BAT_VOLTAGE_NUMOF; i++) {
+        const saul_bat_voltage_params_t *p = &saul_bat_voltage_params[i];
+        saul_bat_voltages[i] = p;
+
+        printf("[auto_init_saul] initializing BAT voltage #%u\n", i);
+
+        saul_reg_entries[i].dev = &saul_bat_voltages[i];
+        saul_reg_entries[i].name = p->name;
+        saul_reg_entries[i].driver = &bat_voltage_saul_driver;
+        /* initialize the ADC line */
+        adc_init(p->line);
+        /* add to registry */
+        saul_reg_add(&(saul_reg_entries[i]));
+    }
+}

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -31,6 +31,10 @@ void saul_init_devs(void)
         extern void auto_init_saul_adc(void);
         auto_init_saul_adc();
     }
+    if (IS_USED(MODULE_SAUL_BAT_VOLTAGE)) {
+        extern void auto_init_saul_bat_voltage(void);
+        auto_init_saul_bat_voltage();
+    }
     if (IS_USED(MODULE_SAUL_GPIO)) {
         extern void auto_init_gpio(void);
         auto_init_gpio();

--- a/features.yaml
+++ b/features.yaml
@@ -796,6 +796,8 @@ groups:
   - title: Platform Specific
     help: Things specific to a single MCU family / MCU vendor
     features:
+    - name: board_bat_voltage
+      help: Measures battery voltage based on ADC sampling.
     - name: periph_ics
       help: An NXP Kinetis Internal Clock Source Controller (ICS peripheral) is
             present.

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -42,6 +42,7 @@ FEATURES_EXISTING := \
     ble_nimble_netif \
     ble_phy_2mbit \
     ble_phy_coded \
+    board_bat_voltage \
     bootloader_stm32 \
     can_rx_mailbox \
     cortexm_fpu \

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -374,6 +374,7 @@ PSEUDOMODULES += fortuna_reseed
 PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += rtt_cmd
 PSEUDOMODULES += saul_adc
+PSEUDOMODULES += saul_bat_voltage
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio
 PSEUDOMODULES += saul_nrf_temperature


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
When trying to get #21018 to work for the `feather-m0`, the ADC line only returned `-1`, so I removed this from #21018.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash `example/saul` to one (or ideally all) of the supported boards and use the CLI to read from the `BAT` registry entry. 

- [ ] ~~**feather-m0**, **feather-m0-lora**, or **feather-m0-wifi**~~
- [ ] 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Based on #21018 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
