### PR TITLE
tests/periph/pm: print some output on alarm

### DIFF
--- a/tests/periph/pm/main.c
+++ b/tests/periph/pm/main.c
@@ -82,6 +82,7 @@ static void cb_rtc(void *arg)
     int level = (int)arg;
 
     pm_block(level);
+    puts("RTC alarm");
 }
 
 static void cb_rtc_puts(void *arg)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

That the PM mode just gets unblocked without any output is rather confusing. Add a small printout to the alarm to make it clear that we just woke up.


### Testing procedure

```
2024-11-21 14:55:08,216 # > unblock_rtc 2 5
2024-11-21 14:55:08,219 # Unblocking power mode 2 for 5 seconds.
2024-11-21 14:55:13,567 # RTC alarm
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
