### PR TITLE
drivers/periph_init: initialize watchdog first

### DIFF
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -64,6 +64,17 @@
 
 void periph_init(void)
 {
+#if defined(MODULE_PERIPH_INIT_WDT)
+    if (WDT_HAS_INIT) {
+        wdt_init();
+    }
+
+    if (IS_ACTIVE(MODULE_PERIPH_WDT_AUTO_START)) {
+        wdt_setup_reboot(CONFIG_PERIPH_WDT_WIN_MIN_MS, CONFIG_PERIPH_WDT_WIN_MAX_MS);
+        wdt_start();
+    }
+#endif
+
 #ifdef MODULE_PERIPH_INIT
     /* initialize buttonss */
     if (IS_USED(MODULE_PERIPH_INIT_BUTTONS)) {
@@ -105,17 +116,6 @@ void periph_init(void)
 
 #ifdef MODULE_PERIPH_INIT_USBDEV
     usbdev_init_lowlevel();
-#endif
-
-#if defined(MODULE_PERIPH_INIT_WDT)
-    if (WDT_HAS_INIT) {
-        wdt_init();
-    }
-
-    if (IS_ACTIVE(MODULE_PERIPH_WDT_AUTO_START)) {
-        wdt_setup_reboot(CONFIG_PERIPH_WDT_WIN_MIN_MS, CONFIG_PERIPH_WDT_WIN_MAX_MS);
-        wdt_start();
-    }
 #endif
 
 #if defined(MODULE_PERIPH_INIT_PTP)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We want to initialize the watchdog early so it can detect a hang in later init functions.



### Testing procedure

I flashed `examples/gnrc_networking` with `periph_wdt_auto_start` on `same54-xpro`.
We still reach `main()` (and reset a bit after that because I didn't service the watchdog)

```
2024-11-21 16:34:40,149 # main(): This is RIOT! (Version: 2025.01-devel-150-g220d10-drivers/wdt-early_init)
2024-11-21 16:34:40,152 # RIOT network stack example application
2024-11-21 16:34:40,155 # All up, running the shell now
> 
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
