### PR TITLE
cpu/sam0_common: Claim support for BlackMagic Probe

### DIFF
--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -26,3 +26,6 @@ CFLAGS += -DCPU_COMMON_SAMD21
 
 include $(RIOTCPU)/sam0_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk
+
+# The Black Magic Probe has tested to work fine on SAMD21
+PROGRAMMERS_SUPPORTED += bmp

--- a/cpu/samd5x/Makefile.include
+++ b/cpu/samd5x/Makefile.include
@@ -17,3 +17,6 @@ BACKUP_RAM_LEN  = 0x2000
 
 include $(RIOTCPU)/sam0_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk
+
+# The Black Magic Probe has tested to work fine on SAMD5x
+PROGRAMMERS_SUPPORTED += bmp

--- a/cpu/saml21/Makefile.include
+++ b/cpu/saml21/Makefile.include
@@ -28,3 +28,6 @@ endif
 
 include $(RIOTCPU)/sam0_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk
+
+# The Black Magic Probe has tested to work fine on SAML21
+PROGRAMMERS_SUPPORTED += bmp


### PR DESCRIPTION
### Contribution description

Using `PROGRAMMER=bmp` has been proven to work reliably at least on SAMD21, SAMD5x and SAML21. According to [1] the BlackMagic Probe does support all SAMD, SAM3 and SAM4L MCUs, so we can just claim support for all.

Since using unsupported programmers is treated as a warning, this change only reduces the noise in the shell a bit and is not a functional change.

[1]: https://black-magic.org/supported-targets.html

### Testing procedure

```
 make BOARD=adafruit-grand-central-m4-express PROGRAMMER=bmp debug
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/bmp/bmp.py  debug /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/selftest_shield/bin/adafruit-grand-central-m4-express/tests_selftest_shield.elf
found following Black Magic GDB servers:
	[/dev/ttyACM0] Serial: F02C616B <- default 
connecting to [/dev/ttyACM0]...
GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/selftest_shield/bin/adafruit-grand-central-m4-express/tests_selftest_shield.elf...
Remote debugging using /dev/ttyACM0
Target voltage: 3.3V
Available Targets:
No. Att Driver
 1      Microchip SAMD51P20A (rev D) M4
Attaching to program: /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/selftest_shield/bin/adafruit-grand-central-m4-express/tests_selftest_shield.elf, Remote target
__set_PRIMASK (priMask=1) at /home/marian.buschsieweke@ml-pa.loc/.cache/RIOT/pkg/cmsis/CMSIS/Core/Include/cmsis_gcc.h:1236
1236	 __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
(gdb)
```

In `master` the output would be the same, except for an additional warning about the unsupported programmer.

### Issues/PRs references

None