### PR TITLE
usbus/cdc_ecm: port to netdev_new_api

### DIFF
--- a/sys/usb/usbus/Makefile.dep
+++ b/sys/usb/usbus/Makefile.dep
@@ -16,6 +16,7 @@ ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
   USEMODULE += iolist
   USEMODULE += fmt
   USEMODULE += usbus_urb
+  USEMODULE += netdev_new_api
   USEMODULE += netdev_eth
   USEMODULE += luid
 endif

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -62,6 +62,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     uint8_t *buf = cdcecm->data_in;
     const iolist_t *iolist_start = iolist;
     size_t len = iolist_size(iolist);
+    size_t res = len;
     /* interface with alternative function ID 1 is the interface containing the
      * data endpoints, no sense trying to transmit data if it is not active */
     if (cdcecm->active_iface != 1) {
@@ -124,7 +125,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         cdcecm->tx_len = 0;
         _signal_tx_xmit(cdcecm);
     }
-    return len;
+    return res;
 }
 
 static int _recv(netdev_t *netdev, void *buf, size_t max_len, void *info)
@@ -204,6 +205,14 @@ static void _isr(netdev_t *dev)
     }
 }
 
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev;
+    (void)info;
+
+    return -EOPNOTSUPP;
+}
+
 static const netdev_driver_t netdev_driver_cdcecm = {
     .send = _send,
     .recv = _recv,
@@ -211,4 +220,5 @@ static const netdev_driver_t netdev_driver_cdcecm = {
     .isr = _isr,
     .get = _get,
     .set = _set,
+    .confirm_send = _confirm_send,
 };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The driver implements a blocking send interface, so the port is trivial. 


### Testing procedure

Ping still works

```
2024-11-21 19:13:46,298 # ping ff02::1
2024-11-21 19:13:46,305 # 12 bytes from fe80::eb2f:25e2:a25c:77d2%4: icmp_seq=0 ttl=64 time=0.522 ms
2024-11-21 19:13:47,305 # 12 bytes from fe80::eb2f:25e2:a25c:77d2%4: icmp_seq=1 ttl=64 time=0.615 ms
2024-11-21 19:13:48,305 # 12 bytes from fe80::eb2f:25e2:a25c:77d2%4: icmp_seq=2 ttl=64 time=0.737 ms
2024-11-21 19:13:48,306 # 
2024-11-21 19:13:48,308 # --- ff02::1 PING statistics ---
2024-11-21 19:13:48,313 # 3 packets transmitted, 3 packets received, 0% packet loss
2024-11-21 19:13:48,317 # round-trip min/avg/max = 0.522/0.624/0.737 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
