### PR TITLE
tests/core/cond_order/: calling cond signal and broadcast without waiting threads

### DIFF
--- a/tests/core/cond_order/main.c
+++ b/tests/core/cond_order/main.c
@@ -63,6 +63,10 @@ int main(void)
     mutex_init(&testlock);
     cond_init(&testcond);
 
+    /* Test if condition signal and broadcast works when no thread is waiting */
+    cond_signal(&testcond);
+    cond_broadcast(&testcond);
+
     /* create threads */
     for (unsigned i = 0; i < THREAD_NUMOF; i++) {
         thread_create(stacks[i], sizeof(stacks[i]), prios[i], 0,


### PR DESCRIPTION
### Contribution description

Through test coverage, I noticed the test never tried the functions `cond_signal` and `cond_broadcast` without a thread waiting. This change helps to find problems with the functions when no thread is waiting.

### Testing procedure

`BOARD=native make -C tests/core/cond_order flash test`
check test coverage before and after (I used [simple coverage of thread communication](https://github.com/JulianHolzwarth/RIOT_coverage))


