### PR TITLE
drivers/at86rf215: return ENETDOWN when interface is down

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -247,7 +247,7 @@ static bool _tx_ongoing(at86rf215_t *dev)
 int at86rf215_tx_prepare(at86rf215_t *dev)
 {
     if (dev->state == AT86RF215_STATE_SLEEP) {
-        return -EAGAIN;
+        return -ENETDOWN;
     }
 
     if (_tx_ongoing(dev)) {

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -176,9 +176,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         at86rf215_tx_exec(dev);
     }
 
-    /* store successfully sent number of bytes */
-    dev->tx_frame_len = len;
-
     /* netdev_new just returns 0 on success */
     return 0;
 }

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -149,10 +149,10 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
     at86rf215_t *dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
-    size_t len = 0;
 
-    if (at86rf215_tx_prepare(dev)) {
-        return -EBUSY;
+    ssize_t len = at86rf215_tx_prepare(dev);
+    if (len) {
+        return len;
     }
 
     /* load packet data into FIFO */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1807,7 +1807,7 @@ static void _tx_done(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt,
             return; /* early return to not release */
         }
         else {
-            LOG_ERROR("gnrc_netif: can't queue packet for sending\n");
+            LOG_ERROR("gnrc_netif: can't queue packet for sending, drop it\n");
             /* If we got here, it means the device was busy and the pkt queue
              * was full. The packet should be dropped here anyway */
             gnrc_pktbuf_release_error(pkt, ENOMEM);
@@ -1880,7 +1880,7 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
             return;
         }
         else {
-            LOG_WARNING("gnrc_netif: can't queue packet for sending\n");
+            LOG_WARNING("gnrc_netif: can't queue packet for sending, try sending\n");
             /* try to send anyway */
         }
     }

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -327,7 +327,7 @@ int nanotest_client_get_non_cmd(int argc, char **argv)
 {
     int res;
 
-    uint8_t response[CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT];
+    uint8_t response[coap_szx2size(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT)];
 
     if (argc < 2) {
         printf("usage: %s <url>\n", argv[0]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We would return EBUSY when the interface was in sleep, this caused the gnrc_netif to retry sending forever. Return ENETDOWN instead.

I added three additional minor fixes to this to not bother CI with those trivial changes:

 - better error messages in `gnrc_netif` to tell apart the case where a pkt can't be queued and is dropped and where we try sending it instead
 - wrong rx buffer size in the nanocoap_cli test
 - overwriting `tx_frame_len` that has already been set in `at86rf215_tx_load()`


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
