### PR TITLE
tests/sys/events: test if event_timeout_is_pending returns false

### DIFF
--- a/tests/sys/events/main.c
+++ b/tests/sys/events/main.c
@@ -196,6 +196,16 @@ int main(void)
 
     event_timeout_t event_timeout;
 
+    /* uninitialied event_timeout_t should return false */
+    event_timeout_ztimer_init(&event_timeout, NULL, &queue, (event_t *)&event_callback);
+    expect(!event_timeout_is_pending(&event_timeout));
+
+    event_timeout_ztimer_init(&event_timeout, ZTIMER_USEC, NULL, (event_t *)&event_callback);
+    expect(!event_timeout_is_pending(&event_timeout));
+
+    event_timeout_ztimer_init(&event_timeout, ZTIMER_USEC, &queue, NULL);
+    expect(!event_timeout_is_pending(&event_timeout));
+
     puts("posting timed callback with timeout 1sec");
     event_timeout_init(&event_timeout, &queue, (event_t *)&event_callback);
 #if IS_USED(MODULE_ZTIMER_USEC)


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This change edits the /sys/events/ test to test if `event_timeout_is_pending` returns false when `event_timeout_t ` is not completely  initialized. Meaning when `event_timeout_t ->queue`, `event_timeout_t ->clock` or `event_timeout_t ->event`  is NULL `event_timeout_is_pending` should return false.
This was previously not tested.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=native make -C tests/sys/events flash test`
