### PR TITLE
sys/evtimer/evtimer.c: change comment from xtimer to ztimer

### DIFF
--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -171,7 +171,7 @@ static void _evtimer_handler(void *arg)
 
     evtimer_t *evtimer = (evtimer_t *)arg;
 
-    /* this function gets called directly by xtimer if the set xtimer expired.
+    /* this function gets called directly by ztimer if the set ztimer expired.
      * Thus the offset of the first event is down to zero. */
     evtimer_event_t *event = evtimer->events;
     event->offset = 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Evtimer function `_evtimer_handler`  comment updated to `ztimer` because `xtimer` is no longer used in evtimer.

