### PR TITLE
pkg/wakaama: Fix usages of `lwm2m_uri_t` and ISPO sensor

### DIFF
--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -117,9 +117,9 @@ static credman_tag_t _get_credential(const sock_udp_ep_t *ep, uint8_t security_m
     }
 
     /* prepare query */
-    lwm2m_uri_t query_uri = {
-        .objectId = LWM2M_SECURITY_OBJECT_ID,
-    };
+    lwm2m_uri_t query_uri;
+    LWM2M_URI_RESET(&query_uri);
+    query_uri.objectId = LWM2M_SECURITY_OBJECT_ID;
 
     lwm2m_list_t *instance = sec->instanceList;
 
@@ -409,9 +409,9 @@ void lwm2m_client_refresh_dtls_credentials(void)
     }
 
     /* prepare query */
-    lwm2m_uri_t query_uri = {
-        .objectId = LWM2M_SECURITY_OBJECT_ID,
-    };
+    lwm2m_uri_t query_uri;
+    LWM2M_URI_RESET(&query_uri);
+    query_uri.objectId = LWM2M_SECURITY_OBJECT_ID;
 
     lwm2m_list_t *instance = sec->instanceList;
     int64_t val;

--- a/pkg/wakaama/contrib/lwm2m_client_connection.c
+++ b/pkg/wakaama/contrib/lwm2m_client_connection.c
@@ -280,11 +280,11 @@ static lwm2m_client_connection_t *_connection_create(uint16_t sec_obj_inst_id,
     DEBUG("Creating connection\n");
 
     /* prepare Server URI query */
-    lwm2m_uri_t resource_uri = {
-        .objectId = LWM2M_SECURITY_URI_ID,
-        .instanceId = sec_obj_inst_id,
-        .resourceId = LWM2M_SECURITY_URI_ID,
-    };
+    lwm2m_uri_t resource_uri;
+    LWM2M_URI_RESET(&resource_uri);
+    resource_uri.objectId = LWM2M_SECURITY_URI_ID;
+    resource_uri.instanceId = sec_obj_inst_id;
+    resource_uri.resourceId = LWM2M_SECURITY_URI_ID;
 
     int res = lwm2m_get_string(client_data, &resource_uri, uri, &uri_len);
     if (res < 0) {

--- a/pkg/wakaama/contrib/objects/ipso_sensor_base.c
+++ b/pkg/wakaama/contrib/objects/ipso_sensor_base.c
@@ -257,7 +257,7 @@ out:
 }
 
 static uint8_t _exec_cb(lwm2m_context_t * context, uint16_t instance_id, uint16_t resource_id,
-                        uint8_t * buffer, int length, lwm2m_object_t * object);
+                        uint8_t * buffer, int length, lwm2m_object_t * object)
 {
     (void)context;
     (void)buffer;

--- a/pkg/wakaama/contrib/objects/ipso_sensor_base.c
+++ b/pkg/wakaama/contrib/objects/ipso_sensor_base.c
@@ -380,12 +380,11 @@ static void _mark_resource_as_changed(const lwm2m_object_t *object, uint16_t ins
                                       uint16_t resource_id)
 {
     lwm2m_uri_t uri;
+    LWM2M_URI_RESET(&uri);
 
     uri.objectId = object->objID;
     uri.instanceId = instance_id;
     uri.resourceId = resource_id;
-
-    uri.flag = LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID | LWM2M_URI_FLAG_RESOURCE_ID;
 
     lwm2m_resource_value_changed(lwm2m_client_get_ctx(object->userData), &uri);
 }

--- a/pkg/wakaama/contrib/objects/light_control.c
+++ b/pkg/wakaama/contrib/objects/light_control.c
@@ -343,6 +343,7 @@ free_out:
 static void _mark_resource_changed(uint16_t instance_id, uint16_t resource_id)
 {
     lwm2m_uri_t uri;
+    LWM2M_URI_RESET(&uri);
     uri.objectId = LWM2M_LIGHT_CONTROL_OBJECT_ID;
     uri.instanceId = instance_id;
     uri.resourceId = resource_id;

--- a/pkg/wakaama/include/objects/common.h
+++ b/pkg/wakaama/include/objects/common.h
@@ -507,41 +507,6 @@ int lwm2m_set_objlink(lwm2m_client_data_t *client_data, const lwm2m_uri_t *uri,
 int lwm2m_set_objlink_by_path(lwm2m_client_data_t *client_data, const char *path, size_t path_len,
                               uint16_t object_id_in, uint16_t instance_id_in);
 
-#ifdef DOXYGEN
-/**
- * @name    URI representation
- * @brief   Note that these are defined in `liblwm2m.h`.
- * @{
- */
-
-/**
- * @brief Flag to indicate in @ref lwm2m_uri_t::flag that the object ID is present.
- */
-#define LWM2M_URI_FLAG_OBJECT_ID    (uint8_t)0x04
-
-/**
- * @brief Flag to indicate in @ref lwm2m_uri_t::flag that the instance ID is present.
- */
-#define LWM2M_URI_FLAG_INSTANCE_ID  (uint8_t)0x02
-
-/**
- * @brief Flag to indicate in @ref lwm2m_uri_t::flag that the resource ID is present.
- */
-#define LWM2M_URI_FLAG_RESOURCE_ID  (uint8_t)0x01
-
-/**
- * @brief Representation of an URI in a LwM2M client (defined in `liblwm2m.h`).
- */
-typedef struct {
-    uint8_t     flag;       /**< indicates which segments are present */
-    uint16_t    objectId;   /**< object ID */
-    uint16_t    instanceId; /**< instance ID */
-    uint16_t    resourceId; /**< resource ID */
-} lwm2m_uri_t;
-
-/** @} */
-#endif /* DOXYGEN */
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

#20930 updated the Wakaama package version. This version had some breaking changes. It seems that a change in `lwm2m_uri_t` slipped through. This fixes its usages throughout the contrib code.

EDIT:
I added a fix for a typo introduced in ISPO sensor base.

### Testing procedure

The best test would be an example that uses some of the IPSO objects, because there the URIs are manipulated. But there's currently no example with them. You can check the upstream type definitions:
https://github.com/eclipse-wakaama/wakaama/blob/d28bd1411413e7978269dcdb538f0cee3d3c82ec/include/liblwm2m.h#L329-L348


### Issues/PRs references
#20930
