### PR TITLE
tests/sys/shell: make test script more robust

### DIFF
--- a/tests/sys/shell/Makefile
+++ b/tests/sys/shell/Makefile
@@ -6,6 +6,9 @@ USEMODULE += shell_cmds_default
 USEMODULE += ps
 USEMODULE += ztimer_msec
 
+# JSON help is needed by test script
+USEMODULE += shell_builtin_cmd_help_json
+
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 

--- a/tests/sys/shell/tests/01-run.py
+++ b/tests/sys/shell/tests/01-run.py
@@ -83,7 +83,7 @@ CMDS = (
     ('echo escaped\\ space', '"echo""escaped space"'),
     ('echo escape within \'\\s\\i\\n\\g\\l\\e\\q\\u\\o\\t\\e\'', '"echo""escape""within""singlequote"'),
     ('echo escape within "\\d\\o\\u\\b\\l\\e\\q\\u\\o\\t\\e"', '"echo""escape""within""doublequote"'),
-    ("""echo "t\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),  # noqa: W605
+    ("""echo "t\\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),  # noqa: W605
 
     # test correct quoting
     ('echo "hello"world', '"echo""helloworld"'),

--- a/tests/sys/shell/tests/01-run.py
+++ b/tests/sys/shell/tests/01-run.py
@@ -6,28 +6,30 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import sys
+import json
 import os
+import sys
 from testrunner import run
 
 
-EXPECTED_HELP = (
-    'Command              Description',
-    '---------------------------------------',
-    'bufsize              Get the shell\'s buffer size',
-    'start_test           starts a test',
-    'end_test             ends a test',
-    'echo                 prints the input command',
-    'empty                print nothing on command',
-    'periodic             periodically print command',
-    'app_metadata         Returns application metadata',
-    'pm                   interact with layered PM subsystem',
-    'ps                   Prints information about running threads.',
-    'reboot               Reboot the node',
-    'version              Prints current RIOT_VERSION',
-    'xfa_test1            xfa test command 1',
-    'xfa_test2            xfa test command 2'
-)
+# This is the minimum subset of commands expected to be available on all
+# boards. The test will still pass if additional commands are present, as
+# `shell_cmds_default` may pull in board specific commands.
+EXPECTED_CMDS = {
+    'bufsize': 'Get the shell\'s buffer size',
+    'start_test': 'starts a test',
+    'end_test': 'ends a test',
+    'echo': 'prints the input command',
+    'empty': 'print nothing on command',
+    'periodic': 'periodically print command',
+    'app_metadata': 'Returns application metadata',
+    'pm': 'interact with layered PM subsystem',
+    'ps': 'Prints information about running threads.',
+    'reboot': 'Reboot the node',
+    'version': 'Prints current RIOT_VERSION',
+    'xfa_test1': 'xfa test command 1',
+    'xfa_test2': 'xfa test command 2',
+}
 
 EXPECTED_PS = (
     '\tpid | state    Q | pri',
@@ -103,7 +105,6 @@ CMDS = (
 
     # test default commands
     ('ps', EXPECTED_PS),
-    ('help', EXPECTED_HELP),
 
     # test commands added to shell_commands_xfa
     ('xfa_test1', '[XFA TEST 1 OK]'),
@@ -149,6 +150,68 @@ def check_cmd(child, cmd, expected):
             child.expect(line)
         else:
             child.expect_exact(line)
+
+
+def check_help(child):
+    """
+    Runs the `help_json` and `help` command to check if the list of commands
+    and descriptions match and contain a list of expected commands.
+    """
+
+    # Run help_json to get the list of commands present
+    child.expect(PROMPT)
+    child.sendline('help_json')
+    # expect JSON object as response the covers the whole line
+    child.expect(r"(\{[^\n\r]*\})\r\n")
+
+    # use a set to track which expected commands were already covered
+    cmds_expected = set(EXPECTED_CMDS)
+
+    # record actually present commands (which may be more than the expected
+    # ones) and their descriptions in here
+    cmds_actual = set()
+    desc_actual = {}
+
+    # parse the commands and iterate over the list
+    cmdlist = json.loads(child.match.group(1))["cmds"]
+    for item in cmdlist:
+        # for expected commands, validate the description and ensure they
+        # are listed exactly once
+        if item['cmd'] in EXPECTED_CMDS:
+            assert item['cmd'] in cmds_expected, f"command {item['cmd']} listed twice"
+            assert item['desc'] == EXPECTED_CMDS[item['cmd']], f"description of {item['cmd']} not expected"
+            cmds_expected.remove(item['cmd'])
+
+        # populate the list of actually present commands and their description
+        cmds_actual.add(item['cmd'])
+        desc_actual[item['cmd']] = item['desc']
+
+    assert len(cmds_expected) == 0, f"commands {cmds_expected} missing"
+
+    # Now: Run regular help and expect the same commands as help_json
+    child.expect(PROMPT)
+    child.sendline('help')
+
+    # expect the header first
+    child.expect_exact('Command              Description\r\n')
+    child.expect_exact('---------------------------------------\r\n')
+
+    # loop until the set of actually present commands assembled from the JSON
+    # is empty. We remove each command from the set when we process it, so that
+    # we can detect duplicates
+    while len(cmds_actual) > 0:
+        # parse line into command and description
+        child.expect(r"([a-z0-9_-]*)[ \t]*(.*)\r\n")
+        cmd = child.match.group(1)
+        desc = child.match.group(2)
+
+        # expect the command to be in the set got from the JSON. Then remove
+        # it, so that a duplicated line would trigger the assert
+        assert cmd in cmds_actual, f"Command \"{cmd}\" unexpected or listed twice in help"
+        cmds_actual.remove(cmd)
+
+        # description should match the one got from JSON
+        assert desc == desc_actual[cmd], f"Description for \"{cmd}\" not matching"
 
 
 def check_startup(child):
@@ -246,6 +309,8 @@ def testfunc(child):
             continue
 
         check_cmd(child, cmd, expected)
+
+    check_help(child)
 
     if RIOT_TERMINAL in CLEANTERMS:
         for cmd, expected in CMDS_CLEANTERM:


### PR DESCRIPTION
### Contribution description

This changes the behavior of the test script for verifying the `help` command: It no longer assumes a specific order for the list of commands.

Making the test robust is a bit tricky, as the module `shell_cmds_default` that is used here may add commands specific to a set of board. We use `help_json` to get the list of commands actually provided, so that we know how many rows the command table printed by `help` need to be parsed.

A minimum set of commands that *must* be present for all boards is hard-coded in the test script and the actually provided commands are tested against this. Otherwise e.g. an empty list of commands presented by `help` and `help_json` would also pass.

### Testing procedure

<details><summary><code>make BOARD=samr21-xpro -C tests/sys/shell flash test</code></summary>

```
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/sys/shell'
Building application "tests_shell" for "samr21-xpro" with CPU "samd21".

"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/boards/common/init
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/boards/samr21-xpro
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/core
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/core/lib
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/samd21
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/cortexm_common/periph
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common/periph
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/samd21/periph
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/samd21/vectors
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/drivers
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/app_metadata
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/div
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/frac
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/libc
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/ps
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/shell
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/shell/cmds
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/stdio
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tsrb
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/ztimer
   text	  data	   bss	   dec	   hex	filename
  18928	   168	  2832	 21928	  55a8	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/sys/shell/bin/samr21-xpro/tests_shell.elf
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/edbg/edbg.sh flash /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/sys/shell/bin/samr21-xpro/tests_shell.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009225 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification....
at address 0x168 expected 0xc4, read 0xc0
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009225 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming...... done.
Verification...... done.
Done flashing
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/sys/shell/tests/01-run.py:88: SyntaxWarning: invalid escape sequence '\ '
  ("""echo "t\\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),  # noqa: W605


socat - open:/dev/ttyACM0,b115200,echo=0,raw,cs8,parenb=0,cstopb=0 

> bufsize

> bufsize
60
____________________________________________________verylong
> ____________________________________________________verylong
shell: maximum line length exceeded
> garbage1234
garbage1234

> 
> shell exited

> 
> periodic 5
> 
> periodic 5
> test
test
test
test
test


> start_test
start_test
[TEST_START]
> 


> 
> echo a string
echo a string
"echo""a""string"
> echo   multiple   spaces   between   argv
echo   multiple   spaces   between   argv
"echo""multiple""spaces""between""argv"
> echo 	tabs		processed 		like			spaces
echo 	tabs		processed 		like			spaces
"echo""tabs""processed""like""spaces"
> unknown_command
unknown_command
shell: command not found: unknown_command
>      echo leading spaces
     echo leading spaces
"echo""leading""spaces"
> 					echo leading tabs
					echo leading tabs
"echo""leading""tabs"
> echo trailing spaces     
echo trailing spaces     
"echo""trailing""spaces"
> echo trailing tabs					
echo trailing tabs					
"echo""trailing""tabs"
> hello-world
hello-world
shell: command not found: hello-world                                                                                                                                   echo
echo
"echo"
> echo \'
echo \'
"echo""'"
> echo \"
echo \"
"echo""""
> echo escaped\ space
echo escaped\ space
"echo""escaped space"
> echo escape within '\s\i\n\g\l\e\q\u\o\t\e'
echo escape within '\s\i\n\g\l\e\q\u\o\t\e'
"echo""escape""within""singlequote"
> echo escape within "\d\o\u\b\l\e\q\u\o\t\e"
echo escape within "\d\o\u\b\l\e\q\u\o\t\e"
"echo""escape""within""doublequote"
> echo "t\e st" "\"" '\'' a\ b
echo "t\e st" "\"" '\'' a\ b
"echo""te st"""""'""a b"
> echo "hello"world
echo "hello"world
"echo""helloworld"
> echo hel"lowo"rld
echo hel"lowo"rld
"echo""helloworld"
> echo hello"world"
echo hello"world"
"echo""helloworld"
> echo quoted space " "
echo quoted space " "
"echo""quoted""space"" "
> echo abc"def'ghijk"lmn
echo abc"def'ghijk"lmn
"echo""abcdef'ghijklmn"
> echo abc'def"ghijk'lmn
echo abc'def"ghijk'lmn
"echo""abcdef"ghijklmn"
> echo "'" '"'
echo "'" '"'
"echo""'""""
> echo a\
echo a\
shell: incorrect quoting
> echo "
echo "
shell: incorrect quoting
> echo '
echo '
shell: incorrect quoting
> echo abcdef"ghijklmn
echo abcdef"ghijklmn
shell: incorrect quoting
> echo abcdef'ghijklmn
echo abcdef'ghijklmn
shell: incorrect quoting
> ps
ps
	pid | state    Q | pri 
	 1 | running  Q |   7
> xfa_test1
xfa_test1
[XFA TEST 1 OK]
> xfa_test2
xfa_test2
[XFA TEST 2 OK]
> reboot
reboot
main(): This is RIOT! (Version: 2025.01-devel-189-g3e08d6-tests/sys/shell/fix-test)
test_shell.
> end_test
end_test
[TEST_END]
> help_json
help_json
{"cmds": [{"cmd": "bufsize", "desc": "Get the shell's buffer size"}, {"cmd": "start_test", "desc": "starts a test"}, {"cmd": "end_test", "desc": "ends a test"}, {"cmd": "echo", "desc": "prints the input command"}, {"cmd": "empty", "desc": "print nothing on command"}, {"cmd": "periodic", "desc": "periodically print command"}, {"cmd": "xfa_test1", "desc": "xfa test command 1"}, {"cmd": "xfa_test2", "desc": "xfa test command 2"}, {"cmd": "app_metadata", "desc": "Returns application metadata"}, {"cmd": "pm", "desc": "interact with layered PM subsystem"}, {"cmd": "ps", "desc": "Prints information about running threads."}, {"cmd": "version", "desc": "Prints current RIOT_VERSION"}, {"cmd": "reboot", "desc": "Reboot the node"}]}
> help
help
Command              Description
---------------------------------------
bufsize              Get the shell's buffer size
start_test           starts a test
end_test             ends a test
echo                 prints the input command
empty                print nothing on command
periodic             periodically print command
xfa_test1            xfa test command 1
xfa_test2            xfa test command 2
app_metadata         Returns application metadata
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
version              Prints current RIOT_VERSION
reboot               Reboot the node
> 

> 
make: Leaving directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/sys/shell'
```

</details>

### Issues/PRs references

Fixes regression from https://github.com/RIOT-OS/RIOT/pull/20958 that caused failing nightlies
