### PR TITLE
cpu/cc2538: mask length byte before checking CRC [backport 2024.10]

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -41,6 +41,7 @@ extern "C" {
 #define CC2538_AUTOCRC_LEN          (2)
 #define CC2538_RF_FIFO_SIZE         (128)
 #define CC2538_PACKET_LENGTH_SIZE   (1)
+#define CC2538_LENGTH_BYTE_MASK     (0x7F) /**< Mask for the length byte in the packet */
 
 #define CC2538_RF_MAX_DATA_LEN (CC2538_RF_FIFO_SIZE - CC2538_PACKET_LENGTH_SIZE)
 

--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -412,8 +412,10 @@ void cc2538_irq_handler(void)
 
     if (flags_f0 & RXPKTDONE) {
         handled_f0 |= RXPKTDONE;
-        /* CRC check */
-        uint8_t pkt_len = rfcore_peek_rx_fifo(0);
+        /* CRC_OK bit is located in the last byte of the packet.
+         * The radio masks the length byte before filling the FIFO with the
+         * corresponding number of bytes. */
+        uint8_t pkt_len = (rfcore_peek_rx_fifo(0) & CC2538_LENGTH_BYTE_MASK);
         if (rfcore_peek_rx_fifo(pkt_len) & CC2538_CRC_BIT_MASK) {
             /* Disable RX while the frame has not been processed */
             _disable_rx();


### PR DESCRIPTION
# Backport of #20998

### Contribution description
This is a follow-up for #20956.

I found that the solution applied there wasn’t robust, because when receiving short packets quickly after each other the RX FIFO might be filling up with a new packet while handling the IRQ. Then, the number of bytes in the FIFO will be bigger than the packet length of the first packet. Even though the second packet will be dropped anyway, the length of the first packet can still be correctly obtained from the length byte in the packet.

Namely, from section 23.9.5.1 of the CC2538 User’s Guide it follows that indeed the radio will mask out bit 7 of the length byte:
![image](https://github.com/user-attachments/assets/7d67e9c0-ab68-4703-8087-fee3a6da428c)

Then, it continues to fill the RX FIFO with this number of bytes as follows from section 23.9.3:
![image](https://github.com/user-attachments/assets/21eac5ff-4353-4de1-8855-794651a26a01)


This means that with this approach, always the correct byte is used for checking the CRC result.

### Testing procedure

Flashed this PR on two devices, and tested with long packets that the error from #20955 didn't appear. When testing short packets quickly after each other, in case the old `crc_loc` was not equal to the corrected `pkt_len`, the `pkt_len` had the expected number of bytes, while `crc_loc` was usually a couple bytes more than that.

### Issues/PRs references

This is a more proper fix for #20955.
