### PR TITLE
sys/stdio: stdio_available is always false with missing stdin module

### DIFF
--- a/sys/stdio/stdio.c
+++ b/sys/stdio/stdio.c
@@ -75,6 +75,9 @@ ssize_t stdio_read(void* buffer, size_t len)
 MAYBE_WEAK
 int stdio_available(void)
 {
+    if (!IS_USED(MODULE_STDIN)) {
+        return 0;
+    }
     return tsrb_avail(&stdin_isrpipe.tsrb);
 }
 #endif


### PR DESCRIPTION
### Contribution description

If I understand the purpose of the pseudomodule `stdin` correctly, it should describe the fact that the user wants to read from the stdio. If not selected, `stdio_available` (which returns the number of bytes available to be read) should thus always return zero.


### Testing procedure

Wait for @benpicco's take on this. Check for regressions via CI.

### Issues/PRs references

Encountered while working on #21039.
