### PR TITLE
boards/adafruit-metro-m4-express: Minor improvements

### DIFF
--- a/boards/adafruit-metro-m4-express/Makefile.features
+++ b/boards/adafruit-metro-m4-express/Makefile.features
@@ -19,3 +19,5 @@ FEATURES_PROVIDED += arduino_pins
 FEATURES_PROVIDED += arduino_shield_isp
 FEATURES_PROVIDED += arduino_shield_uno
 FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_uart

--- a/boards/adafruit-metro-m4-express/Makefile.include
+++ b/boards/adafruit-metro-m4-express/Makefile.include
@@ -1,5 +1,7 @@
 CFLAGS += -DBOOTLOADER_UF2
 
+PROG_TTY_BOARD_FILTER := --vendor 'Adafruit Industries' --model 'Metro M4 Express'
+
 # Include all definitions for flashing with bossa other USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 # Include handling of serial and non-bossa programmers (if selected by user)

--- a/boards/adafruit-metro-m4-express/include/arduino_iomap.h
+++ b/boards/adafruit-metro-m4-express/include/arduino_iomap.h
@@ -106,8 +106,26 @@ extern "C" {
  * SPI bus.
  */
 #if !MODULE_PERIPH_UART
-#  define ARDUINO_SPI_D11D12D13   SPI_DEV(1)
+#  define ARDUINO_SPI_D11D12D13 SPI_DEV(1)
 #endif
+/** @} */
+
+/**
+ * @name    Arduino's UART devices
+ * @{
+ */
+#define ARDUINO_UART_D0D1       UART_DEV(0)
+/** @} */
+
+/**
+ * @name    Arduino's I2C buses
+ * @{
+ */
+/**
+ * @brief   The first I2C bus is where shields for the Arduino UNO/Mega expect
+ *          it
+ */
+#define ARDUINO_I2C_UNO         I2C_DEV(0)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

This PR contains two commits with one minor improvement each:

- The I2C and UART Arduino Mapping is provided
- The TTY detection now also can detect the board when the bootloader is running (which registers using the bootloader's USB vendor ID and model, rather than the RIOT variant)

### Testing procedure

Both already tested using https://github.com/RIOT-OS/RIOT/pull/21029

It would be possible to do so now by:

- Adding the peripheral self-test shield and run the corresponding test (but UART and SPI are mutually exclusive due to lack of time-sharing for SERCOMs)
- double pressing the reset button (to enter bootloader mode) and run `make BOARD=adafruit-metro-m4-express MOST_RECENT_PORT=1 -C examples/default flash`. This does now work, but fails in `master`

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/21029