### PR TITLE
tests/periph/selftest_shield: Fix UART test

### DIFF
--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -55,10 +55,14 @@
 /* In order to run the periph_uart test all of the following needs to be true:
  * - periph_uart needs to be used
  * - an I/O mapping for the UART at D0/D1 needs to be provided
- * - this UART dev is not busy with stdio
+ * - this UART dev is not busy with stdio (either not using `stdio_uart` or a different UART is used for stdio)
  */
 #if defined(ARDUINO_UART_D0D1) && defined(MODULE_PERIPH_UART)
-#  define ENABLE_UART_TEST (STDIO_UART_DEV != ARDUINO_UART_D0D1)
+#  if MODULE_STDIO_UART
+#    define ENABLE_UART_TEST (STDIO_UART_DEV != ARDUINO_UART_D0D1)
+#  else
+#    define ENABLE_UART_TEST 1
+#  endif
 #  define UART_TEST_DEV ARDUINO_UART_D0D1
 #else
 #  define ENABLE_UART_TEST 0

--- a/tests/periph/selftest_shield/main.c
+++ b/tests/periph/selftest_shield/main.c
@@ -790,6 +790,9 @@ static bool periph_uart_rxtx_test(uint32_t symbolrate, uint32_t timer_freq)
     failed |= TEST(memcmp(testdata, serial_buf.data, sizeof(serial_buf.data)) == 0);
     failed |= TEST(serial_buf.pos == sizeof(testdata));
 
+    /* disable UART again, in case it is a shared peripheral */
+    uart_poweroff(UART_TEST_DEV);
+
     return failed;
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes two issues in the UART test:

1. Some boards (e.g. the Adafruit Metro M4 Express) have hardware conflicts between UART and other serial buses (e.g. I2C and UART for the M4 Express): The same hardware is used to provide both interface. However, we can implement time-sharing of common peripherals to provide multiple serial interfaces with the same hardware (as we already do for I2C and SPI on nRF5x, or SPI and UART on MSP430, or as https://github.com/RIOT-OS/RIOT/pull/21029 will provide for I2C, SPI and UART on SAM0). But to actually allow time-sharing, the UART needs to be powered off again after the UART test to release the shared hardware peripheral. The first commit adds this.
2. The UART test is not enabled, when the D0/D1 UART is also the stdio UART no matter what. But if `stdio_uart` is not used but e.g. `stdio_cdc_acm` instead, we can still use it. The second commit addresses this.

### Testing procedure

Done in https://github.com/RIOT-OS/RIOT/pull/21029

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/21029