### PR TITLE
cpu/sam0_common: flashpage: disable cache while writing

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -64,7 +64,7 @@ static inline void wait_nvm_is_ready(void)
 #endif
 }
 
-static unsigned _unlock(void)
+static void _unlock(void)
 {
     /* remove peripheral access lock for the NVMCTRL peripheral */
 #ifdef REG_PAC_WRCTRL
@@ -74,14 +74,13 @@ static unsigned _unlock(void)
 #endif
 
     /* NVM reads could be corrupted when mixing NVM reads with Page Buffer writes. */
-    return irq_disable();
 #ifdef NVMCTRL_CTRLA_CACHEDIS1
     _NVMCTRL->CTRLA.reg |= NVMCTRL_CTRLA_CACHEDIS0
                         |  NVMCTRL_CTRLA_CACHEDIS1;
 #endif
 }
 
-static void _lock(unsigned state)
+static void _lock(void)
 {
     wait_nvm_is_ready();
 
@@ -101,8 +100,6 @@ static void _lock(unsigned state)
 #ifdef CMCC
     CMCC->MAINT0.reg |= CMCC_MAINT0_INVALL;
 #endif
-
-    irq_restore(state);
 }
 
 static void _cmd_clear_page_buffer(void)
@@ -239,7 +236,7 @@ static void _write_page(void* dst, const void *data, size_t len, void (*cmd_writ
     /* word align destination address */
     uint32_t *dst32 = (void*)((uintptr_t)dst & ~0x3);
 
-    unsigned state = _unlock();
+    _unlock();
     _cmd_clear_page_buffer();
 
     /* write the first, unaligned bytes */
@@ -266,7 +263,7 @@ static void _write_page(void* dst, const void *data, size_t len, void (*cmd_writ
     }
 
     cmd_write();
-    _lock(state);
+    _lock();
 }
 
 static void _erase_page(void* page, void (*cmd_erase)(void))
@@ -274,7 +271,7 @@ static void _erase_page(void* page, void (*cmd_erase)(void))
     uintptr_t page_addr = (uintptr_t)page;
 
     /* erase given page (the ADDR register uses 16-bit addresses) */
-    unsigned state = _unlock();
+    _unlock();
 
     /* ADDR drives the hardware (16-bit) address to the NVM when a command is executed using CMDEX.
      * 8-bit addresses must be shifted one bit to the right before writing to this register.
@@ -287,7 +284,7 @@ static void _erase_page(void* page, void (*cmd_erase)(void))
     _NVMCTRL->ADDR.reg = page_addr;
 
     cmd_erase();
-    _lock(state);
+    _lock();
 }
 
 static void _write_row(uint8_t *dst, const void *_data, size_t len, size_t chunk_size,

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -73,7 +73,12 @@ static unsigned _unlock(void)
     PAC1->WPCLR.reg = PAC1_WPROT_DEFAULT_VAL;
 #endif
 
+    /* NVM reads could be corrupted when mixing NVM reads with Page Buffer writes. */
     return irq_disable();
+#ifdef NVMCTRL_CTRLA_CACHEDIS1
+    _NVMCTRL->CTRLA.reg |= NVMCTRL_CTRLA_CACHEDIS0
+                        |  NVMCTRL_CTRLA_CACHEDIS1;
+#endif
 }
 
 static void _lock(unsigned state)
@@ -85,6 +90,11 @@ static void _lock(unsigned state)
     PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_SET | ID_NVMCTRL);
 #else
     PAC1->WPSET.reg = PAC1_WPROT_DEFAULT_VAL;
+#endif
+
+#ifdef NVMCTRL_CTRLA_CACHEDIS1
+    _NVMCTRL->CTRLA.reg &= ~NVMCTRL_CTRLA_CACHEDIS0
+                        &  ~NVMCTRL_CTRLA_CACHEDIS1;
 #endif
 
     /* cached flash contents may have changed - invalidate cache */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

From errata 2.14.1:
> NVM reads could be corrupted when mixing NVM reads with Page Buffer writes.
> #### Workaround
> Disable cache lines before writing to the Page Buffer when executing from NVM or reading
data from NVM while writing to the Page Buffer. Cache lines are disabled by writing a one to
`CTRLA.CACHEDIS0` and `CTRLA.CACHEDIS1`.


### Testing procedure

I ran `examples/suit_update` on `same54-xpro`.
This would previously crash when *not* disabling the interrupts.

I also tested this on `samr34-xpro` to ensure no regressions on `saml21`.

`samd21` never needed the disabled interrupts in the first place.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
