### PR TITLE
cpu/cortexm_common: Make cpu.h IWYU clean

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -30,12 +30,10 @@
 #ifndef CPU_H
 #define CPU_H
 
-#include <stdio.h>
-
 #include "irq.h"
 #include "sched.h"
 #include "thread.h"
-#include "cpu_conf.h"
+#include "cpu_conf.h" /* IWYU pragma: export */
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/esp32/periph/gpio_ll.c
+++ b/cpu/esp32/periph/gpio_ll.c
@@ -24,9 +24,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
-#include <string.h>
 
-#include "log.h"
 #include "irq.h"
 #include "periph/gpio_ll.h"
 
@@ -39,8 +37,9 @@
 #include "esp_idf_api/gpio.h"
 
 #ifdef MODULE_FMT
-#include "fmt.h"
+#  include "fmt.h"
 #else
+#  include <stdio.h>
 static inline void print_str(const char *str)
 {
     fputs(str, stdout);

--- a/cpu/gd32v/periph/gpio_ll.c
+++ b/cpu/gd32v/periph/gpio_ll.c
@@ -28,8 +28,9 @@
 #include "debug.h"
 
 #ifdef MODULE_FMT
-#include "fmt.h"
+#  include "fmt.h"
 #else
+#  include <stdio.h>
 static inline void print_str(const char *str)
 {
     fputs(str, stdout);

--- a/cpu/nrf5x_common/periph/gpio_ll.c
+++ b/cpu/nrf5x_common/periph/gpio_ll.c
@@ -37,8 +37,9 @@
 #include "periph_conf.h"
 
 #ifdef MODULE_FMT
-#include "fmt.h"
+#  include "fmt.h"
 #else
+#  include <stdio.h>
 static inline void print_str(const char *str)
 {
     fputs(str, stdout);

--- a/cpu/sam0_common/periph/gpio_ll.c
+++ b/cpu/sam0_common/periph/gpio_ll.c
@@ -45,8 +45,9 @@
 #include "periph/gpio_ll.h"
 
 #ifdef MODULE_FMT
-#include "fmt.h"
+#  include "fmt.h"
 #else
+#  include <stdio.h>
 static inline void print_str(const char *str)
 {
     fputs(str, stdout);

--- a/cpu/stm32/periph/gpio_ll.c
+++ b/cpu/stm32/periph/gpio_ll.c
@@ -34,8 +34,9 @@
 #include "periph/gpio_ll.h"
 
 #ifdef MODULE_FMT
-#include "fmt.h"
+#  include "fmt.h"
 #else
+#  include <stdio.h>
 static inline void print_str(const char *str)
 {
     fputs(str, stdout);

--- a/drivers/periph_common/gpio_ll.c
+++ b/drivers/periph_common/gpio_ll.c
@@ -6,8 +6,6 @@
  * directory for more details.
  */
 
-#include <stdio.h>
-
 #include "periph/gpio_ll.h"
 
 /* Optimizing for low stack usage by not using printf(), which on newlib is
@@ -19,8 +17,9 @@
  * printf().
  */
 #ifdef MODULE_FMT
-#include "fmt.h"
+#  include "fmt.h"
 #else
+#  include <stdio.h>
 static inline void print_str(const char *str)
 {
     fputs(str, stdout);

--- a/examples/pio_blink/main.c
+++ b/examples/pio_blink/main.c
@@ -9,6 +9,8 @@
 #include "board.h"
 #include "periph/pio.h"
 
+#include <stdio.h>
+
 /* see blink.c */
 pio_program_t pio_blink_export_program(void);
 

--- a/pkg/openwsn/include/openwsn_log.h
+++ b/pkg/openwsn/include/openwsn_log.h
@@ -22,6 +22,8 @@
 #ifndef OPENWSN_LOG_H
 #define OPENWSN_LOG_H
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description

1. drop `#include <stdio.h>` from `cpu.h`. This clearly should not belong here
    - This causes some fallout, as some code relied on `cpu.h` including `<stdio.h>`. Those missing includes are added first to ease bisecting
2. Add IWYU pragma export to `cpu_conf.h`, as portable code is expected to not include `cpu_conf.h` directly (which does not exist across MCU families), but indirectly via `cpu.h`

### Testing procedure

Green CI

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/21029