### PR TITLE
tests/sys/shell: use default terminal instead of socat

### DIFF
--- a/tests/sys/shell/Makefile
+++ b/tests/sys/shell/Makefile
@@ -9,9 +9,6 @@ USEMODULE += ztimer_msec
 # JSON help is needed by test script
 USEMODULE += shell_builtin_cmd_help_json
 
-# Use a terminal that does not introduce extra characters into the stream.
-RIOT_TERMINAL ?= socat
-
 APP_SHELL_FMT ?= NONE
 
 # microbit qemu failing currently


### PR DESCRIPTION
### Contribution description

`tests/sys/shell` currently per default uses `socat` as terminal, according to the comment to avoid having extra characters put into the IO by the terminal program. But that's exactly what `make cleanterm` is for, which is already used per default by the python testrunner.

I encountered issues with `socat` for this test (newlines not properly matched against) on boards that use `usb_cdc_acm` as stdio, while the approach with `cleanterm` works as expected.


### Testing procedure

Run the test with some boards using `make -C tests/sys/shell BOARD=xxx flash test`. Successfully tested with `native`, `nrf52840dk` and `feather-nrf52840-sense`.


### Issues/PRs references

The commit https://github.com/RIOT-OS/RIOT/pull/11004/commits/cdfece682f5c38d399ba44b8ee162b67f80bcdd8 that introduced the change was merged one and a half months before the introduction of the `cleanterm` target in https://github.com/RIOT-OS/RIOT/pull/12107/
