### PR TITLE
makefiles: select default prng _after_ recursive dependency resolution

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -46,13 +46,6 @@ ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
   USEMODULE += libfixmath
 endif
 
-ifneq (,$(filter random,$(USEMODULE)))
-  # select default prng if no prng is selected
-  ifeq (,$(filter prng_%,$(USEMODULE)))
-    USEMODULE += prng_musl_lcg
-  endif
-endif
-
 ifneq (,$(filter spiffs,$(USEMODULE)))
   USEPKG += spiffs
   USEMODULE += vfs

--- a/makefiles/defaultmodules_deps.inc.mk
+++ b/makefiles/defaultmodules_deps.inc.mk
@@ -22,6 +22,13 @@ ifneq (,$(filter auto_init_libcose_crypt,$(USEMODULE)))
   USEMODULE += libcose_crypt_init
 endif
 
+ifneq (,$(filter random,$(USEMODULE)))
+  # select default prng if no prng is selected
+  ifeq (,$(filter prng_%,$(USEMODULE)))
+    USEMODULE += prng_musl_lcg
+  endif
+endif
+
 ifneq (,$(filter xtimer,$(USEMODULE)))
   ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
     USEMODULE += div

--- a/tests/build_system/external_module_dirs/README.md
+++ b/tests/build_system/external_module_dirs/README.md
@@ -7,5 +7,5 @@ It demonstrates:
 
  * Adding a module with source code
  * Setting a header include directory
- * Adding dependencies, which are evaluated before other modules dependencies
+ * Adding (transitive) dependencies, which are evaluated before other modules dependencies
  * Registering a module for auto-initialization

--- a/tests/build_system/external_module_dirs/external_modules/external_module/Makefile.dep
+++ b/tests/build_system/external_module_dirs/external_modules/external_module/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += random
-# Set a different prng than the default
-USEMODULE += prng_xorshift
+USEMODULE += transitive

--- a/tests/build_system/external_module_dirs/external_modules/transitive/Makefile
+++ b/tests/build_system/external_module_dirs/external_modules/transitive/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/build_system/external_module_dirs/external_modules/transitive/Makefile.dep
+++ b/tests/build_system/external_module_dirs/external_modules/transitive/Makefile.dep
@@ -1,0 +1,2 @@
+# Set a different prng than the default
+USEMODULE += prng_xorshift


### PR DESCRIPTION
### Contribution description

The PRNG is supposed to be set only if there is none selected at the end of the recursive dependency resolution. However, this is currently not the case: a transitive dependency setting the PRNG (encountered with `psa_crypto` which selects `prng_sha256prng`) will lead to a user-facing dependency clash.

The first commit extends `tests/build_system/external_module` to showcase the issue and the second one fixes it by moving the automatic prng selection to `defaultmodules_deps.inc.mk`.

Disclaimer: I'm not sure if this is the right approach to follow, but it seems to work. Any suggestions from people with more insights on the build system are welcome.


### Testing procedure

with only the first commit:
```
$ make -C tests/build_system/external_module_dirs info-modules
make: Entering directory '/home/mikolai/TUD/Code/RIOT-build/tests/build_system/external_module_dirs'
Currently the following prng modules are used: prng_musl_lcg prng_xorshift
/home/mikolai/TUD/Code/RIOT-build/sys/random/Makefile.include:14: *** Only one implementation of PRNG should be used..  Stop.
make: Leaving directory '/home/mikolai/TUD/Code/RIOT-build/tests/build_system/external_module_dirs'
```

with both commits:
```
$ make -C tests/build_system/external_module_dirs info-modules
make: Entering directory '/home/mikolai/TUD/Code/RIOT-build/tests/build_system/external_module_dirs'
auto_init
auto_init_random
board
board_common_init
core
core_idle_thread
core_init
core_lib
core_msg
core_panic
core_thread
cpu
external_module
libc
luid
native_drivers
periph
periph_common
periph_cpuid
periph_gpio
periph_gpio_linux
periph_hwrng
periph_init
periph_init_cpuid
periph_init_gpio
periph_init_gpio_linux
periph_init_hwrng
periph_init_led0
periph_init_led1
periph_init_led2
periph_init_led3
periph_init_led4
periph_init_led5
periph_init_led6
periph_init_led7
periph_init_leds
periph_init_pm
periph_init_uart
periph_pm
periph_uart
preprocessor
preprocessor_successor
prng
prng_xorshift
random
stdio_native
sys
transitive
make: Leaving directory '/home/mikolai/TUD/Code/RIOT-build/tests/build_system/external_module_dirs'
```
