### PR TITLE
README.md: add reference to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ in Rust following RIOT's goals and [vision](https://doc.riot-os.org/vision.html)
 - [RT-Thread](https://github.com/RT-Thread/rt-thread) is a microcontroller operating system with strong roots in China and a large community there, it has extensive support for MCUs from Chinese vendors, but also for western ones.
 - [Zephyr](https://github.com/zephyrproject-rtos/zephyr) is a general-purpose operating system for microcontrollers, shepherded by the Linux foundation.
 
+For more details on how RIOT compares to other projects, refer to the
+[comparison][faq-riot-vs-others] of RIOT with other operating systems for
+embedded and IoT devices [in our FAQ][faq-riot-vs-others].
+
+[faq-riot-vs-others]: https://www.riot-os.org/#faq-12
+
 ## Getting RIOT
 
 The most convenient way to get RIOT is to clone it via Git


### PR DESCRIPTION
### Contribution description

At the bottom the related projects section in the README.me, this adds a reference to the in-detail comparison between RIOT and related OSes in our FAQ.

### Testing procedure

Proofreading and possible checking the output of the rendered version (easiest [in the branch](https://github.com/maribu/RIOT/tree/README.md/add-ref-to-detailed-comparison) corresponding to this PR).

### Issues/PRs references

Follow up to https://github.com/RIOT-OS/RIOT/pull/21052