### PR TITLE
README.md: remove section Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ RIOT provides features including, but not limited to:
 * UWB
 * Bluetooth (BLE) via [NimBLE](https://github.com/apache/mynewt-nimble)
 
-### Related Projects
-
-- [**Ariel OS**](https://github.com/ariel-os/ariel-os) is an offspring of RIOT written
-in Rust following RIOT's goals and [vision](https://doc.riot-os.org/vision.html).
-- [Contiki(-NG)](https://github.com/contiki-ng/contiki-ng) was an inspiration for starting RIOT, an operating system for constrained devices with a focus on networking.
-- [NuttX](https://github.com/apache/nuttx) is another general purpose microcontroller OS with a focus on bringing POSIX to MCUs
-- [RT-Thread](https://github.com/RT-Thread/rt-thread) is a microcontroller operating system with strong roots in China and a large community there, it has extensive support for MCUs from Chinese vendors, but also for western ones.
-- [Zephyr](https://github.com/zephyrproject-rtos/zephyr) is a general-purpose operating system for microcontrollers, shepherded by the Linux foundation.
-
 ## Getting RIOT
 
 The most convenient way to get RIOT is to clone it via Git


### PR DESCRIPTION
Whether PR #21052 should have been merged is debatable. The discussion of other PRs that try to improve PR #21052 may take some time. Instead of including content in the README.md, one very important entry point for interested RIOT users, that might conflict with rough consensus, I suggest to remove until we converged on what should be placed in the README (and how).