### PR TITLE
README.md: Fix inconsistent formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ RIOT provides features including, but not limited to:
 
 ### Related Projects
 
-- [**Ariel OS**](https://github.com/ariel-os/ariel-os) is an offspring of RIOT written
+- [Ariel OS](https://github.com/ariel-os/ariel-os) is an offspring of RIOT written
 in Rust following RIOT's goals and [vision](https://doc.riot-os.org/vision.html).
 - [Contiki(-NG)](https://github.com/contiki-ng/contiki-ng) was an inspiration for starting RIOT, an operating system for constrained devices with a focus on networking.
 - [NuttX](https://github.com/apache/nuttx) is another general purpose microcontroller OS with a focus on bringing POSIX to MCUs


### PR DESCRIPTION
### Contribution description

In the related projects, one project name was formatted as bold, while the others were not. This removes the bold formatting from "Ariel OS", so that it matches the formatting of the other project names.

### Testing procedure

The README.md should now be consistent.

### Issues/PRs references

Inconsistent formatting introduced in: https://github.com/RIOT-OS/RIOT/pull/21052