### PR TITLE
cpu/stm32/eth: fix and improve ETH defines

### DIFF
--- a/cpu/stm32/include/periph/cpu_eth.h
+++ b/cpu/stm32/include/periph/cpu_eth.h
@@ -96,7 +96,7 @@ typedef struct eth_dma_desc {
  */
 #define RX_DESC_STAT_FL         (0x3FFF0000) /* bits 16-29 */
 #define RX_DESC_STAT_DE         (BIT14) /**< If set, a frame too large to fit buffers given by descriptors was received */
-#define RX_DESC_STAT_ES         (BIT14) /**< If set, an error occurred during RX */
+#define RX_DESC_STAT_ES         (BIT15) /**< If set, an error occurred during RX */
 #define RX_DESC_STAT_OWN        (BIT31) /**< If set, descriptor is owned by DMA, otherwise by CPU */
 /** @} */
 /**

--- a/cpu/stm32/include/periph/cpu_eth.h
+++ b/cpu/stm32/include/periph/cpu_eth.h
@@ -140,7 +140,11 @@ typedef struct eth_dma_desc {
  * | `0b10` | Calculate and insert IPv4 checksum, insert pre-calculated payload checksum    |
  * | `0b11  | Calculated and insert both IPv4 and payload checksum                          |
  */
-#define TX_DESC_STAT_CIC        (BIT22 | BIT23)
+#define TX_DESC_STAT_CIC                    (BIT22 | BIT23)
+#define TX_DESC_STAT_CIC_NO_HW_CHECKSUM     (0)             /**< Do not compute checksums in hardware */
+#define TX_DESC_STAT_CIC_HW_CHECKSUM_IPV4   (BIT22)         /**< Compute the IPv4 header checksum in hardware */
+#define TX_DESC_STAT_CIC_HW_CHECKSUM_BOTH   (BIT22 | BIT32) /**< Compute the IPv4 header and payload checksum in hardware */
+
 #define TX_DESC_STAT_TTSE       (BIT25) /**< If set, an PTP timestamp is added to the descriptor after TX completed */
 #define TX_DESC_STAT_FS         (BIT28) /**< If set, buffer contains first segment of frame to transmit */
 #define TX_DESC_STAT_LS         (BIT29) /**< If set, buffer contains last segment of frame to transmit */


### PR DESCRIPTION
### Contribution description

This PR fixes and improves some ETH defines from [cpu_eth.h](https://github.com/RIOT-OS/RIOT/blob/master/cpu/stm32/include/periph/cpu_eth.h):
- RX_DESC_STAT_ES  (line 99) - wrong bit number - see reference manual, page 1812,
- TX_DESC_STAT_CIC... (line 143) - some improvements from @maribu, [see PR #19952](https://github.com/RIOT-OS/RIOT/pull/19952#issuecomment-1738733909).

### Testing procedure

I tested this change in `nucleo-f439zi` and `nucleo-f207zg` - and after change they works.
Check once again reference manual and used bits.

### Issues/PRs references

PR #19952