### PR TITLE
sys/chunked_ringbuffer: discard stale chunk when starting a new one

### DIFF
--- a/sys/include/chunked_ringbuffer.h
+++ b/sys/include/chunked_ringbuffer.h
@@ -73,7 +73,24 @@ typedef void (*crb_foreach_callback_t)(void *ctx, uint8_t *bytes, size_t len);
 void crb_init(chunk_ringbuf_t *rb, void *buffer, size_t len);
 
 /**
+ * @brief Close the current chunk
+ *
+ * @note  This function is expected to be called in ISR context / with
+ *        interrupts disabled.
+ *
+ * @param[in] rb        The Ringbuffer to work on
+ * @param[in] valid     True if the chunk is valid and should be stored
+ *                      False if the current chunk should be discarded
+ *
+ * @return true         If the chunk could be stored in the valid chunk array
+ * @return false        If there is no more space in the valid chunk array
+ */
+bool crb_end_chunk(chunk_ringbuf_t *rb, bool valid);
+
+/**
  * @brief Start a new chunk on the ringbuffer
+ *
+ * If an unfinished chunk already exists, it will be discarded.
  *
  * @note  This function is expected to be called in ISR context / with
  *        interrupts disabled.
@@ -85,6 +102,11 @@ void crb_init(chunk_ringbuf_t *rb, void *buffer, size_t len);
  */
 static inline bool crb_start_chunk(chunk_ringbuf_t *rb)
 {
+    /* discard stale chunk */
+    if (rb->cur_start) {
+        crb_end_chunk(rb, false);
+    }
+
     /* pointing to the start of the first chunk */
     if (rb->cur == rb->protect) {
         return false;
@@ -149,21 +171,6 @@ static inline bool crb_add_byte(chunk_ringbuf_t *rb, uint8_t b)
  * @return false        If the ringbuffer is full
  */
 bool crb_add_bytes(chunk_ringbuf_t *rb, const void *data, size_t len);
-
-/**
- * @brief Close the current chunk
- *
- * @note  This function is expected to be called in ISR context / with
- *        interrupts disabled.
- *
- * @param[in] rb        The Ringbuffer to work on
- * @param[in] valid     True if the chunk is valid and should be stored
- *                      False if the current chunk should be discarded
- *
- * @return true         If the chunk could be stored in the valid chunk array
- * @return false        If there is no more space in the valid chunk array
- */
-bool crb_end_chunk(chunk_ringbuf_t *rb, bool valid);
 
 /**
  * @brief Add a complete chunk to the Ringbuffer

--- a/tests/unittests/tests-chunked_ringbuffer/tests-chunked_ringbuffer.c
+++ b/tests/unittests/tests-chunked_ringbuffer/tests-chunked_ringbuffer.c
@@ -25,6 +25,13 @@ static void test_crb_add_and_consume(void)
 
     crb_init(&cb, buffer, sizeof(buffer));
 
+    /* add a chunk but don't finish it */
+    crb_start_chunk(&cb);
+    crb_add_byte(&cb, 1);
+    crb_add_byte(&cb, 2);
+    crb_add_byte(&cb, 3);
+
+    /* unfinished chunk should be silently discarded */
     TEST_ASSERT(crb_add_chunk(&cb, "one", 4));
     TEST_ASSERT(crb_add_chunk(&cb, "two", 4));
     TEST_ASSERT(crb_add_chunk(&cb, "three", 6));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If there is a non-finished chunk in the ringbuffer when a new one is started, discard the stale chunk first. 

### Testing procedure

The unit test is expanded to cover this case.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
