### PR TITLE
drivers/dose: fix poweroff

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -679,7 +679,10 @@ static void _poweroff(dose_t *ctx, dose_state_t sleep_state)
         return;
     }
 
-    wait_for_state(ctx, DOSE_STATE_IDLE);
+    /* allow powering off without a state transition */
+    if (ctx->state != DOSE_STATE_IDLE) {
+        wait_for_state(ctx, DOSE_STATE_IDLE);
+    }
 
     if (gpio_is_valid(ctx->standby_pin)) {
         gpio_set(ctx->standby_pin);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

If there's no state transition within the driver, powering off (STANDBY, SLEEP) a DOSE interface might result in a deadlock. Specifically, `wait_for_state()` will block forever.

Note, there is (and always was) a race condition here, i.e. even if we observed the state IDLE, this might transition to RECEIVE at any time. However, this case is covered by improvements in the chunked buffer implementation (see depencencies below).

### Testing procedure

Tested this on a SAME54 board.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
 - [ ] Depends on PR #21073 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
