### PR TITLE
sys/net/nanocoap: Fix sending bogus separate responses

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -229,9 +229,7 @@ typedef struct {
  */
 typedef struct {
     sock_udp_ep_t remote;           /**< remote to send response to         */
-#if defined(MODULE_SOCK_AUX_LOCAL) || DOXYGEN
     sock_udp_ep_t local;            /**< local from which to send response  */
-#endif
     uint8_t token[COAP_TOKEN_LENGTH_MAX];   /**< request token              */
     uint8_t tkl;                    /**< request token length               */
     uint8_t no_response;            /**< no-response bitmap                 */
@@ -245,6 +243,9 @@ typedef struct {
  *
  * The CoAP handler should then respond with an empty ACK by calling
  * @ref coap_build_empty_ack
+ *
+ * @warning This function is only available when using the module
+ *          `nanocoap_server_separate`
  *
  * @param[out]  ctx     Context information for separate response
  * @param[in]   pkt     CoAP packet to which the response will be generated
@@ -266,6 +267,11 @@ int nanocoap_server_prepare_separate(nanocoap_server_response_ctx_t *ctx,
  *
  * @pre     @ref nanocoap_server_prepare_separate has been called on @p ctx
  *          inside the CoAP handler
+ * @pre     Synchronization between calls of this function and calls of
+ *          @ref nanocoap_server_prepare_separate is ensured
+ *
+ * @warning This function is only available when using the module
+ *          `nanocoap_server_separate`
  *
  * @param[in]   ctx     Context information for the CoAP response
  * @param[in]   code    CoAP response code

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -1075,6 +1075,7 @@ void auto_init_nanocoap_server(void)
     nanocoap_server_start(&local);
 }
 
+#if MODULE_NANOCOAP_SERVER_SEPARATE
 int nanocoap_server_prepare_separate(nanocoap_server_response_ctx_t *ctx,
                                      coap_pkt_t *pkt, const coap_request_ctx_t *req)
 {
@@ -1092,10 +1093,8 @@ int nanocoap_server_prepare_separate(nanocoap_server_response_ctx_t *ctx,
     ctx->tkl = tkl;
     memcpy(ctx->token, coap_get_token(pkt), tkl);
     memcpy(&ctx->remote, req->remote, sizeof(ctx->remote));
-#ifdef MODULE_SOCK_AUX_LOCAL
     assert(req->local);
     memcpy(&ctx->local, req->local, sizeof(ctx->local));
-#endif
     uint32_t no_response = 0;
     coap_opt_get_uint(pkt, COAP_OPT_NO_RESPONSE, &no_response);
     ctx->no_response = no_response;
@@ -1137,7 +1136,6 @@ int nanocoap_server_send_separate(const nanocoap_server_response_ctx_t *ctx,
     }
 
     sock_udp_aux_tx_t *aux_out_ptr = NULL;
-#ifdef MODULE_SOCK_AUX_LOCAL
     /* make sure we reply with the same address that the request was
      * destined for -- except in the multicast case */
     sock_udp_aux_tx_t aux_out = {
@@ -1147,6 +1145,6 @@ int nanocoap_server_send_separate(const nanocoap_server_response_ctx_t *ctx,
     if (!sock_udp_ep_is_multicast(&ctx->local)) {
         aux_out_ptr = &aux_out;
     }
-#endif
     return sock_udp_sendv_aux(NULL, &head, &ctx->remote, aux_out_ptr);
 }
+#endif


### PR DESCRIPTION
### Contribution description

When module `nanocoap_server_separate` is not used, the functions to send separate responses are still provided, just in a broken version: They will send the separate replies from a different endpoint than the request was received at (even on machines with only one IP address, as also the source port is randomized).

This changes the behavior to only provide the functions for separate response when the do work, so that others will detect an invalid configuration at compile time rather than at run time.

The documentation is duly updated.

### Testing procedure

```
$ make BOARD=same54-xpro flash term -C examples/nanocoap_server
[...]
2024-12-12 10:30:46,488 # {"IPv6 addresses": ["fe80::fec2:3dff:fe0b:cf49"]}
2024-12-12 10:30:49,421 # _separate_handler(): send ACK, schedule response
2024-12-12 10:30:50,425 # _separate_handler(): send delayed response
```

```
$ coap-client-notls -p 1234 -a 'fe80::183:ade0:3cd0:d5b%enp1s0f0' -m get 'coap://[fe80::fec2:3dff:fe0b:cf49]/separate'
This is a delayed response.
```

### Issues/PRs references

None
