### PR TITLE
drivers/sx126x: add #ifndef for SX126X_PARAMS

### DIFF
--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -101,7 +101,8 @@ extern "C" {
 #  define SX126X_TX_PA_MODE
 #endif
 
-#define SX126X_PARAMS             { .spi = SX126X_PARAM_SPI,            \
+#ifndef SX126X_PARAMS
+#  define SX126X_PARAMS           { .spi = SX126X_PARAM_SPI,            \
                                     .nss_pin = SX126X_PARAM_SPI_NSS,    \
                                     .reset_pin = SX126X_PARAM_RESET,    \
                                     .busy_pin = SX126X_PARAM_BUSY,      \
@@ -110,6 +111,7 @@ extern "C" {
                                     .regulator = SX126X_PARAM_REGULATOR, \
                                     SX126X_SET_RF_MODE \
                                     SX126X_TX_PA_MODE}
+#endif
 
 /**@}*/
 


### PR DESCRIPTION
### Contribution description

To be able to use multiple sx126x connected to one mcu.
