### PR TITLE
README.md: add Section Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ RIOT provides features including, but not limited to:
 * UWB
 * Bluetooth (BLE) via [NimBLE](https://github.com/apache/mynewt-nimble)
 
-### Related Projects
-
-- [Ariel OS](https://github.com/ariel-os/ariel-os) is an offspring of RIOT written
-in Rust following RIOT's goals and [vision](https://doc.riot-os.org/vision.html).
-- [Contiki(-NG)](https://github.com/contiki-ng/contiki-ng) was an inspiration for starting RIOT, an operating system for constrained devices with a focus on networking.
-- [NuttX](https://github.com/apache/nuttx) is another general purpose microcontroller OS with a focus on bringing POSIX to MCUs
-- [RT-Thread](https://github.com/RT-Thread/rt-thread) is a microcontroller operating system with strong roots in China and a large community there, it has extensive support for MCUs from Chinese vendors, but also for western ones.
-- [Zephyr](https://github.com/zephyrproject-rtos/zephyr) is a general-purpose operating system for microcontrollers, shepherded by the Linux foundation.
-
 ## Getting RIOT
 
 The most convenient way to get RIOT is to clone it via Git
@@ -153,6 +144,10 @@ only "this isn't working". These details include:
 1. What you want to achieve.
 2. What have you tried so far (for example the commands you typed).
 3. What happened so far.
+
+### Collaboration
+
+RIOT closely collaborates with and inspires other open source projects, e.g., [Ariel OS](https://ariel-os.org/), an IoT OS written in Rust. We are more than happy to collaborate with those who share our [vision](https://doc.riot-os.org/vision.html).
 
 ## Contribute
 


### PR DESCRIPTION
This PR removes the Subsection Related Projects in favor of adding the Subsection Collaboration in the Section Community.  The content of the new subsection conveys a more generic message. It gives an example by referring to Ariel.

This PR is the outcome of discussions in PR #21063.