### PR TITLE
gnrc/ipv6_auto_subnets: add option to derive subnet prefix from EUI

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -107,6 +107,7 @@ PSEUDOMODULES += gnrc_dhcpv6_client_simple_pd
 ## @}
 ## @}
 PSEUDOMODULES += gnrc_ipv6_auto_subnets_auto_init
+PSEUDOMODULES += gnrc_ipv6_auto_subnets_eui
 PSEUDOMODULES += gnrc_ipv6_auto_subnets_simple
 PSEUDOMODULES += gnrc_ipv6_classic
 PSEUDOMODULES += gnrc_ipv6_default

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -126,6 +126,10 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += evtimer
 endif
 
+ifneq (,$(filter gnrc_ipv6_auto_subnets_eui,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6_auto_subnets_simple
+endif
+
 ifneq (,$(filter gnrc_ipv6_auto_subnets_simple,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_auto_subnets
 endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -849,8 +849,9 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                 /* notify optional PIO consumer */
                 if (IS_USED(MODULE_GNRC_IPV6_NIB_RTR_ADV_PIO_CB)) {
                     extern void gnrc_ipv6_nib_rtr_adv_pio_cb(gnrc_netif_t *netif,
-                                                             const ndp_opt_pi_t *pio);
-                    gnrc_ipv6_nib_rtr_adv_pio_cb(netif, (ndp_opt_pi_t *)opt);
+                                                             const ndp_opt_pi_t *pio,
+                                                             const ipv6_addr_t *src);
+                    gnrc_ipv6_nib_rtr_adv_pio_cb(netif, (ndp_opt_pi_t *)opt, &ipv6->src);
                 }
                 break;
             }

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -404,7 +404,7 @@ static bool _remove_old_prefix(gnrc_netif_t *netif,
 }
 
 static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t *upstream,
-                               const ndp_opt_pi_t *pio)
+                               const ndp_opt_pi_t *pio, const ipv6_addr_t *src)
 {
     gnrc_netif_t *downstream = NULL;
     gnrc_pktsnip_t *ext_opts = NULL;
@@ -490,13 +490,14 @@ static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t 
 
     /* immediately send an RA with RIO */
     if (ext_opts) {
-        gnrc_ndp_rtr_adv_send(upstream, NULL, NULL, true, ext_opts);
+        gnrc_ndp_rtr_adv_send(upstream, NULL, src, true, ext_opts);
     } else {
         DEBUG("auto_subnets: Options empty, not sending RA\n");
     }
 }
 
-void gnrc_ipv6_nib_rtr_adv_pio_cb(gnrc_netif_t *upstream, const ndp_opt_pi_t *pio)
+void gnrc_ipv6_nib_rtr_adv_pio_cb(gnrc_netif_t *upstream, const ndp_opt_pi_t *pio,
+                                  const ipv6_addr_t *src)
 {
     /* create a subnet for each downstream interface */
     unsigned subnets = gnrc_netif_numof() - 1;
@@ -515,8 +516,12 @@ void gnrc_ipv6_nib_rtr_adv_pio_cb(gnrc_netif_t *upstream, const ndp_opt_pi_t *pi
     }
 
 #if IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_SIMPLE)
+    /* 'don't broadcast RA if we are a 6lo node - unicast allows l2 retransmissions */
+    if (!gnrc_netif_is_6ln(upstream)) {
+        src = NULL;
+    }
     /* if we are the only router on this bus, we can directly choose a prefix */
-    _configure_subnets(subnets, 0, upstream, pio);
+    _configure_subnets(subnets, 0, upstream, pio, src);
 #else
 
     /* store PIO information for later use */
@@ -689,7 +694,7 @@ static void _process_pio_cache(uint8_t subnets, uint8_t idx_start, gnrc_netif_t 
         }
 
         /* use PIO for prefix configuration */
-        _configure_subnets(subnets, idx_start, upstream, &_pio_cache[i]);
+        _configure_subnets(subnets, idx_start, upstream, &_pio_cache[i], NULL);
 
         /* invalidate entry */
         _pio_cache[i].len = 0;

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -83,6 +83,16 @@
  * The upstream network will be automatically chosen as the one that first
  * receives a router advertisement.
  *
+ * If only a single level of downstream routers exists and a sufficiently small
+ * upstream prefix is provided, we can skip the synchronisation and instead derive
+ * the *prefix* from the EUI of the downstream interface.
+ *
+ * e.g. given a prefix `fd12::/16` a router with a downstream interface with the
+ * layer 2 address `12:84:0C:87:1F:B7` would create the prefix `fd12:1284:c87:1fb7::/64`
+ * for the downstream network.
+ *
+ * To enable this behavior, chose the `gnrc_ipv6_auto_subnets_eui` module.
+ *
  * @{
  *
  * @file
@@ -99,6 +109,12 @@
 #include "net/gnrc/rpl.h"
 #include "random.h"
 #include "xtimer.h"
+
+/* If we derive the subnet from the interface's EUI, we have to use all
+   available prefix bits to ensure uniqueness */
+#if IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_EUI)
+#define CONFIG_GNRC_IPV6_AUTO_SUBNETS_PREFIX_MIN_LEN (64)
+#endif
 
 /**
  * @brief Port for the custom UDP sync protocol
@@ -305,6 +321,40 @@ static void _init_sub_prefix(ipv6_addr_t *out,
     out->u8[bytes] |= idx << shift;
 }
 
+static void _init_sub_prefix_uid(ipv6_addr_t *out,
+                                 const ipv6_addr_t *prefix, uint8_t bits,
+                                 const uint8_t *uid, uint8_t uid_len)
+{
+    uint8_t out_bytes = 64 / 8;
+    uint8_t bytes = (bits + 7) / 8;
+    uint8_t rem   = bits % 8;
+
+    /* first copy old prefix */
+    memset(out, 0, sizeof(*out));
+    ipv6_addr_init_prefix(out, prefix, bits);
+
+    /* If the UID does not fit, truncate it */
+    if (uid_len > out_bytes - bytes) {
+        /* we can use some bits of the first byte */
+        if (rem) {
+            --bytes;
+        }
+
+        /* calculate by how many bytes the UID is too large */
+        uint8_t uid_overhang = uid_len - (out_bytes - bytes);
+        uid += uid_overhang;
+        uid_len -= uid_overhang;
+
+        if (rem) {
+            uint8_t mask = 0xff >> rem;
+            out->u8[bytes++] |= *uid++ & mask;
+            --uid_len;
+        }
+    }
+
+    memcpy(&out->u8[bytes], uid, uid_len);
+}
+
 /* returns true if a new prefix was added, false if nothing changed */
 static bool _remove_old_prefix(gnrc_netif_t *netif,
                                const ipv6_addr_t *pfx, uint8_t pfx_len,
@@ -393,7 +443,18 @@ static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t 
         }
 
         /* create subnet from upstream prefix */
-        _init_sub_prefix(&new_prefix, prefix, prefix_len, ++start_idx, subnet_len);
+        if (IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_EUI)) {
+            uint8_t hwaddr[GNRC_NETIF_L2ADDR_MAXLEN];
+            int res = netif_get_opt(&downstream->netif, NETOPT_ADDRESS, 0,
+                                    hwaddr, sizeof(hwaddr));
+            if (res <= 0) {
+                DEBUG("auto_subnets: can't get l2 address from netif %u\n", downstream->pid);
+                continue;
+            }
+            _init_sub_prefix_uid(&new_prefix, prefix, prefix_len, hwaddr, res);
+        } else {
+            _init_sub_prefix(&new_prefix, prefix, prefix_len, ++start_idx, subnet_len);
+        }
 
         DEBUG("auto_subnets: configure prefix %s/%u on %u\n",
               ipv6_addr_to_str(addr_str, &new_prefix, sizeof(addr_str)),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the `gnrc_ipv6_auto_subnets_eui` pseudo-module. 

We have a number of wireless 802.15.4 nodes that each have a set of wired nodes connected locally.

```
[6LBR] - - - - [6LR]----[Node A]
   ¦             |
   ¦             \------[Node B]
   ¦
    \ - - - - - [6LR]---[Node C]
                  |
                  \-----[Node D]
```

To limit communication over the wireless link (The `gnrc_ipv6_auto_subnets` sync algorithm creates O(n) messages and does not deal well with lost messages) an alternative scheme of assigning subnet prefixes is needed.

Since this is a local sensor network, we can just choose a sufficiently small upstream prefix (e.g. `fd12::/16`) and create the downstream network by filling in the remaining bits with the EUI of the downstream wired interface. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
