### PR TITLE
gnrc/ipv6/nib: make ABR run-time configurable

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -334,6 +334,20 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif);
 void gnrc_ipv6_nib_iface_down(gnrc_netif_t *netif, bool send_final_ra);
 
 /**
+ * @brief   Start sending periodic router solicitations on an interface
+ *
+ * @param[in] netif     The interface to send the solicitations on
+ */
+void gnrc_ipv6_nib_start_search_rtr(gnrc_netif_t *netif);
+
+/**
+ * @brief   Stop sending periodic router solicitations on an interface
+ *
+ * @param[in] netif     The interface to cease sending solicitations
+ */
+void gnrc_ipv6_nib_stop_search_rtr(gnrc_netif_t *netif);
+
+/**
  * @brief   Gets link-layer address of next hop to a destination address
  *
  * @pre `(dst != NULL) && (nce != NULL)`

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -124,7 +124,7 @@ extern "C" {
 #endif
 
 /**
- * @brief    activate router advertising at interface start-up
+ * @brief   activate router advertising at interface start-up
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_ADV_ROUTER
 #  define CONFIG_GNRC_IPV6_NIB_ADV_ROUTER             0
@@ -135,6 +135,13 @@ extern "C" {
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_SOL_ROUTER
 #  define CONFIG_GNRC_IPV6_NIB_SOL_ROUTER             1
+#endif
+
+/**
+ * @brief   activate authoritative border router functionality at interface start-up
+ */
+#ifndef CONFIG_GNRC_IPV6_NIB_ABR
+#define CONFIG_GNRC_IPV6_NIB_ABR                    CONFIG_GNRC_IPV6_NIB_6LBR
 #endif
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -141,7 +141,7 @@ extern "C" {
  * @brief   activate authoritative border router functionality at interface start-up
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_ABR
-#define CONFIG_GNRC_IPV6_NIB_ABR                    CONFIG_GNRC_IPV6_NIB_6LBR
+#  define CONFIG_GNRC_IPV6_NIB_ABR                  CONFIG_GNRC_IPV6_NIB_6LBR
 #endif
 
 /**
@@ -237,6 +237,13 @@ extern "C" {
 #  else
 #    define CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C         0
 #  endif
+#endif
+
+/**
+ * @brief   Start sending RAs when a RA has been received
+ */
+#ifndef CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C_AUTO_ADV
+#  define CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C_AUTO_ADV CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C
 #endif
 
 /**

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -563,6 +563,13 @@ typedef enum {
     NETOPT_6LO_IPHC,
 
     /**
+     * @brief   (@ref netopt_enable_t) authoritative border router
+     *
+     * @see [RFC 6775](https://datatracker.ietf.org/doc/html/rfc6775#section-4.3)
+     */
+    NETOPT_6LO_ABR,
+
+    /**
      * @brief   (uint8_t) retry amount from missing ACKs of the last transmission
      *
      * This retrieves the number of retries needed for the last transmission.

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -91,6 +91,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_TX_RETRIES_NEEDED]     = "NETOPT_TX_RETRIES_NEEDED",
     [NETOPT_6LO]                   = "NETOPT_6LO",
     [NETOPT_6LO_IPHC]              = "NETOPT_6LO_IPHC",
+    [NETOPT_6LO_ABR]               = "NETOPT_6LO_ABR",
     [NETOPT_BLE_CTX]               = "NETOPT_BLE_CTX",
     [NETOPT_CHECKSUM]              = "NETOPT_CHECKSUM",
     [NETOPT_PHY_BUSY]              = "NETOPT_PHY_BUSY",

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -304,6 +304,15 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
             res = sizeof(netopt_enable_t);
             break;
 #endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)
+        case NETOPT_6LO_ABR:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+            *((netopt_enable_t *)opt->data) = (netif->flags & GNRC_NETIF_FLAGS_6LO_ABR)
+                                            ? NETOPT_ENABLE
+                                            : NETOPT_DISABLE;
+            res = sizeof(netopt_enable_t);
+            break;
+#endif
         default:
             break;
     }
@@ -409,6 +418,30 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
             res = sizeof(netopt_enable_t);
             break;
 #endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)
+        case NETOPT_6LO_ABR:
+            assert(opt->data_len == sizeof(netopt_enable_t));
+
+            extern void _start_search_rtr(gnrc_netif_t *netif);
+            extern void _stop_search_rtr(gnrc_netif_t *netif);
+
+            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
+                if (!(netif->flags & GNRC_NETIF_FLAGS_6LO_ABR)) {
+                    /* we were no ABR before */
+                    _stop_search_rtr(netif);
+                }
+                netif->flags |= GNRC_NETIF_FLAGS_6LO_ABR;
+            }
+            else {
+                if (netif->flags & GNRC_NETIF_FLAGS_6LO_ABR) {
+                    /* we were a ABR before */
+                    _start_search_rtr(netif);
+                }
+                netif->flags &= ~GNRC_NETIF_FLAGS_6LO_ABR;
+            }
+            res = sizeof(netopt_enable_t);
+            break;
+#endif
         case NETOPT_RAWMODE:
             if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
                 netif->flags |= GNRC_NETIF_FLAGS_RAWMODE;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -421,21 +421,18 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)
         case NETOPT_6LO_ABR:
             assert(opt->data_len == sizeof(netopt_enable_t));
-
-            extern void _start_search_rtr(gnrc_netif_t *netif);
-            extern void _stop_search_rtr(gnrc_netif_t *netif);
-
             if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
                 if (!(netif->flags & GNRC_NETIF_FLAGS_6LO_ABR)) {
-                    /* we were no ABR before */
-                    _stop_search_rtr(netif);
+                    /* we were no ABR before,
+                     * as ABR we must not search for routers */
+                    gnrc_ipv6_nib_stop_search_rtr(netif);
                 }
                 netif->flags |= GNRC_NETIF_FLAGS_6LO_ABR;
             }
             else {
                 if (netif->flags & GNRC_NETIF_FLAGS_6LO_ABR) {
-                    /* we were a ABR before */
-                    _start_search_rtr(netif);
+                    /* we were a ABR before, better search for (upstream) routers */
+                    gnrc_ipv6_nib_start_search_rtr(netif);
                 }
                 netif->flags &= ~GNRC_NETIF_FLAGS_6LO_ABR;
             }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -253,8 +253,8 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_DNS */
     if (gnrc_netif_is_6lr(netif)) {
-        assert(abr != NULL);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
+        assert(abr != NULL);
         uint16_t ltime_min;
         gnrc_pktsnip_t *abro;
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
@@ -50,7 +50,7 @@ static inline void _init_iface_router(gnrc_netif_t *netif)
         netif->flags |= GNRC_NETIF_FLAGS_IPV6_RTR_ADV;
     }
 
-    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)) {
+    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ABR)) {
         netif->flags |= GNRC_NETIF_FLAGS_6LO_ABR;
     }
 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -189,7 +189,7 @@ static void _add_dynamic_lladdr(gnrc_netif_t *netif)
                                       GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
 }
 
-void _start_search_rtr(gnrc_netif_t *netif)
+void gnrc_ipv6_nib_start_search_rtr(gnrc_netif_t *netif)
 {
     uint32_t next_rs_time = random_uint32_range(0, NDP_MAX_RS_MS_DELAY);
 
@@ -197,7 +197,7 @@ void _start_search_rtr(gnrc_netif_t *netif)
                  next_rs_time);
 }
 
-void _stop_search_rtr(gnrc_netif_t *netif)
+void gnrc_ipv6_nib_stop_search_rtr(gnrc_netif_t *netif)
 {
     _evtimer_del(&netif->ipv6.search_rtr);
 }
@@ -223,7 +223,7 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
     _auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
 
     if (_should_search_rtr(netif)) {
-        _start_search_rtr(netif);
+        gnrc_ipv6_nib_start_search_rtr(netif);
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
     else {
@@ -242,7 +242,7 @@ void gnrc_ipv6_nib_iface_down(gnrc_netif_t *netif, bool send_final_ra)
 
     _deinit_iface_arsm(netif);
     if (_should_search_rtr(netif)) {
-        _stop_search_rtr(netif);
+        gnrc_ipv6_nib_stop_search_rtr(netif);
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
     else {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -189,6 +189,19 @@ static void _add_dynamic_lladdr(gnrc_netif_t *netif)
                                       GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
 }
 
+void _start_search_rtr(gnrc_netif_t *netif)
+{
+    uint32_t next_rs_time = random_uint32_range(0, NDP_MAX_RS_MS_DELAY);
+
+    _evtimer_add(netif, GNRC_IPV6_NIB_SEARCH_RTR, &netif->ipv6.search_rtr,
+                 next_rs_time);
+}
+
+void _stop_search_rtr(gnrc_netif_t *netif)
+{
+    _evtimer_del(&netif->ipv6.search_rtr);
+}
+
 void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
 {
     assert(netif != NULL);
@@ -208,11 +221,9 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
     _add_static_lladdr(netif);
     _add_dynamic_lladdr(netif);
     _auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
-    if (_should_search_rtr(netif)) {
-        uint32_t next_rs_time = random_uint32_range(0, NDP_MAX_RS_MS_DELAY);
 
-        _evtimer_add(netif, GNRC_IPV6_NIB_SEARCH_RTR, &netif->ipv6.search_rtr,
-                     next_rs_time);
+    if (_should_search_rtr(netif)) {
+        _start_search_rtr(netif);
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
     else {
@@ -231,7 +242,7 @@ void gnrc_ipv6_nib_iface_down(gnrc_netif_t *netif, bool send_final_ra)
 
     _deinit_iface_arsm(netif);
     if (_should_search_rtr(netif)) {
-        _evtimer_del(&netif->ipv6.search_rtr);
+        _stop_search_rtr(netif);
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ROUTER)
     else {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -933,7 +933,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     if (gnrc_netif_is_6ln(netif) && !gnrc_netif_is_6lbr(netif)) {
-        if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)) {
+        if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C_AUTO_ADV)) {
             _set_rtr_adv(netif);
         }
         /* but re-fetch information from router in time */

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -62,6 +62,7 @@ static const struct {
     netopt_t opt;
 } flag_cmds[] = {
     { "6lo", NETOPT_6LO },
+    { "abr", NETOPT_6LO_ABR },
     { "ack_req", NETOPT_ACK_REQ },
     { "gts", NETOPT_GTS_TX },
     { "pan_coord", NETOPT_PAN_COORD },
@@ -888,6 +889,9 @@ static void _netif_list(netif_t *iface)
                                    line_thresh);
 #ifdef MODULE_GNRC_SIXLOWPAN
     line_thresh = _netif_list_flag(iface, NETOPT_6LO, "6LO  ", line_thresh);
+#endif
+#if CONFIG_GNRC_IPV6_NIB_6LBR
+    line_thresh = _netif_list_flag(iface, NETOPT_6LO_ABR, "ABR  ", line_thresh);
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
     line_thresh += _LINE_THRESHOLD + 1; /* enforce linebreak after this option */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently all nodes compiled with `gnrc_sixlowpan_border_router_default` will act as an authoritative border router by default.

We have a setup with many wireless nodes that are all potential (authoritative) border routers (see #21080), but only one of them will be selected (at run-time) to do so.

This adds a `NETOPT_6LO_ABR` that can be used to enable / disable the authoritative border router functionality on an interface as well as a `CONFIG_GNRC_IPV6_NIB_ABR` to control the start-up default.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
