### PR TITLE
pkg/lwip: fix unused parameter error, when DEVELHELP = 0

### DIFF
--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -94,6 +94,7 @@ int netif_set_opt(const netif_t *iface, netopt_t opt, uint16_t context,
     switch (opt) {
     case NETOPT_ACTIVE: {
             assert(value_len >= sizeof(netopt_enable_t));
+            (void)value_len; /* Eliminates compilation unused parameter error, when DEVELHELP = 0*/
             netopt_enable_t *state = value;
             if (*state == NETOPT_ENABLE) {
                 netifapi_netif_set_up(netif);


### PR DESCRIPTION
### Contribution description

This PR fixes compilation error for applications which utilize LWIP, when `DEVELHELP` is set to 0.

### Testing procedure

Enable LWIP for IPv4 or IPv6 on `examples/gcoap` (in `Makefile` set 1 to `LWIP_IPV4` or `LWIP_IPV6` lines 17 or 18) and disable DEVELHELP (in `Makefile` set 0 or comment line 63). 

Without this PR compilation ends with error:

```
"make" -C /data/RIOT/RIOT/pkg/lwip/contrib
/data/RIOT/RIOT/pkg/lwip/contrib/_netif.c: In function 'netif_set_opt':
/data/RIOT/RIOT/pkg/lwip/contrib/_netif.c:87:39: error: unused parameter 'value_len' [-Werror=unused-parameter]
   87 |                   void *value, size_t value_len)
      |                                ~~~~~~~^~~~~~~~~
cc1: all warnings being treated as errors
```

With this PR everything works fine.

### Issues/PRs references

None