### PR TITLE
sys/stdio_nimble: add version note to README

### DIFF
--- a/sys/stdio_nimble/README.md
+++ b/sys/stdio_nimble/README.md
@@ -86,7 +86,8 @@ SERVICE e6d54866-0292-4779-b8f8-c52bbec91e71 (Handle: 10): Unknown
 Completed deep scan of 6BE8174C-A0F8-4479-AFA6-9828372CAFE9
 ```
 
-- Create a virtual port and mount it on /tmp/dev_riot_ble
+- Create a virtual port and mount it on /tmp/dev_riot_ble\
+**NOTE:** with `ble-serial` version `>=3.0.0`, the command line option `--write-with-response` has to be added!
 ```
 $ ble-serial -d 6BE8174C-A0F8-4479-AFA6-9828372CAFE9 -p /tmp/dev_riot_ble --write-uuid ccdd113f-40d5-4d68-86ac-a728dd82f4aa --read-uuid 35f28386-3070-4f3b-ba38-27507e991762
 17:44:18.765 | INFO | linux_pty.py: Slave created on /tmp/dev_riot_ble -> /dev/ttys006


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In the latest release of `ble-serial`, a new command line option `--write-with-response` was added and the default value is `False`. 
(See https://github.com/Jakeler/ble-serial/issues/109 and https://github.com/Jakeler/ble-serial/releases/tag/v3.0.0 ).
This will lead to the following error when trying to connect to the `test/sys/shell_ble` example or any application that uses the `stdio_nimble` module.

```
~/RIOTdev/RIOT/tests/sys/shell_ble$ ble-serial -d DA:ED:02:2A:35:CE -p /tmp/dev_riot_ble --write-uuid ccdd113f-40d5-4d68-86ac-a728dd82f4aa --read-uuid 35f28386-3070-4f3b-ba38-27507e991762
16:46:15.471 | INFO | linux_pty.py: Port endpoint created on /tmp/dev_riot_ble -> /dev/pts/1
16:46:15.471 | INFO | ble_client.py: Receiver set up
16:46:17.565 | INFO | ble_client.py: Trying to connect with DA:ED:02:2A:35:CE: tests/sys/shell/_ble
16:46:17.973 | WARNING | ble_client.py: Device DA:ED:02:2A:35:CE disconnected
16:46:17.974 | INFO | ble_client.py: Stopping Bluetooth event loop
16:46:19.446 | INFO | ble_client.py: Device DA:ED:02:2A:35:CE connected
16:46:19.446 | ERROR | main.py: No characteristic with ['write-without-response'] property found!
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ble_serial/main.py", line 53, in _run
    await self.bt.setup_chars(args.write_uuid, args.read_uuid, args.mode, args.write_with_response)
  File "/usr/local/lib/python3.10/dist-packages/ble_serial/bluetooth/ble_client.py", line 44, in setup_chars
    self.write_char = self.find_char(write_uuid, write_cap)
  File "/usr/local/lib/python3.10/dist-packages/ble_serial/bluetooth/ble_client.py", line 84, in find_char
    assert len(results) > 0, \
AssertionError: No characteristic with ['write-without-response'] property found!
16:46:19.447 | WARNING | main.py: Shutdown initiated
16:46:19.447 | INFO | linux_pty.py: Serial reader and symlink removed
16:46:21.677 | WARNING | ble_client.py: Device DA:ED:02:2A:35:CE disconnected
16:46:21.677 | INFO | ble_client.py: Stopping Bluetooth event loop
16:46:21.678 | INFO | ble_client.py: Bluetooth disconnected
16:46:21.678 | INFO | main.py: Shutdown complete.
```

Using the new command line option makes the command work as expected:
```
~/RIOTdev/RIOT/tests/sys/shell_ble$ ble-serial -d DA:ED:02:2A:35:CE -p /tmp/dev_riot_ble --write-uuid ccdd113f-40d5-4d68-86ac-a728dd82f4aa --read-uuid 35f28386-3070-4f3b-ba38-27507e991762 --write-with-response
16:47:52.167 | INFO | linux_pty.py: Port endpoint created on /tmp/dev_riot_ble -> /dev/pts/1
16:47:52.167 | INFO | ble_client.py: Receiver set up
16:47:52.803 | INFO | ble_client.py: Trying to connect with DA:ED:02:2A:35:CE: tests/sys/shell/_ble
16:47:54.068 | INFO | ble_client.py: Device DA:ED:02:2A:35:CE connected
16:47:54.068 | INFO | ble_client.py: Found write characteristic ccdd113f-40d5-4d68-86ac-a728dd82f4aa (H. 14)
16:47:54.068 | INFO | ble_client.py: Found notify characteristic 35f28386-3070-4f3b-ba38-27507e991762 (H. 11)
16:47:54.409 | INFO | main.py: Running main loop!
```

### Testing procedure

This is only a documentation change, but the test procedure would be as following:

Make sure you have the latest version of `ble-serial` installed. Otherwise you can upgrade it with `pip install ble-serial --upgrade`.
The latest version at the time of writing is 3.0.0.

```
$ pip show ble-serial
Name: ble-serial
Version: 3.0.0
Summary: Connects BLE adapters with virtual serial ports
Home-page: 
Author: 
Author-email: Jake <ble-serial-pypi@ja-ke.tech>
License: MIT License
Location: /usr/local/lib/python3.10/dist-packages
Requires: bleak, coloredlogs
Required-by:
```

The test in `tests/sys/shell_ble` runs on all nRF52 devices (and probably others as well with NimBLE support). I used an nRF52840DK and our own hardware.
You can follow the procedure described in the text and should observe the aforementioned error when trying to connect to the device.

