### PR TITLE
sys/net/nanocoap: fix buffer overflow in separate response handling [backport 2024.10]

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -209,9 +209,13 @@ static ssize_t _separate_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap
         return coap_build_reply(pkt, COAP_CODE_SERVICE_UNAVAILABLE, buf, len, 0);
     }
 
-    puts("_separate_handler(): send ACK, schedule response");
+    if (nanocoap_server_prepare_separate(&_separate_ctx, pkt, context)) {
+        puts("_separate_handler(): failed to prepare context for separate response");
+        /* send a reset message, as we don't support large tokens here */
+        return coap_build_reply(pkt, 0, buf, len, 0);
+    }
 
-    nanocoap_server_prepare_separate(&_separate_ctx, pkt, context);
+    puts("_separate_handler(): send ACK, schedule response");
 
     event_timeout_ztimer_init(&event_timeout, ZTIMER_MSEC, EVENT_PRIO_MEDIUM,
                               &event_timed.super);

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -246,9 +246,15 @@ typedef struct {
  * @param[out]  ctx     Context information for separate response
  * @param[in]   pkt     CoAP packet to which the response will be generated
  * @param[in]   req     Context of the CoAP request
+ *
+ * @retval  0           Success
+ * @retval  -EOVERFLOW  Storing context would have overflown buffers in @p ctx
+ *                      (e.g. RFC 8974 (module `nanocoap_token_ext`) is in
+ *                      use and token too long)
+ * @retval  <0          Other error
  */
-void nanocoap_server_prepare_separate(nanocoap_server_response_ctx_t *ctx,
-                                      coap_pkt_t *pkt, const coap_request_ctx_t *req);
+int nanocoap_server_prepare_separate(nanocoap_server_response_ctx_t *ctx,
+                                     coap_pkt_t *pkt, const coap_request_ctx_t *req);
 
 /**
  * @brief   Send a separate response to a CoAP request

--- a/tests/net/nanocoap_cli/Makefile
+++ b/tests/net/nanocoap_cli/Makefile
@@ -15,6 +15,7 @@ USEMODULE += gnrc_ipv6_default
 
 USEMODULE += nanocoap_sock
 USEMODULE += nanocoap_resources
+USEMODULE += fmt # scn_buf_hex() for shell cmd client_token
 
 # boards where basic nanocoap functionality fits, but no VFS
 LOW_MEMORY_BOARDS := \

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "fmt.h"
 #include "net/coap.h"
 #include "net/gnrc/netif.h"
 #include "net/ipv6.h"


### PR DESCRIPTION
# (Partial) Backport of https://github.com/RIOT-OS/RIOT/pull/21075

### Contribution description

When RFC 8974 support (module `nanocoap_token_ext`) is in use, the request token may be longer than the buffer in the separate response context is large. This adds a check to not overflow the buffer.

Sadly, this is an API change: Preparing the separate response context can actually fail, so we need to report this with a return value.

The example application has been adapted to only proceed if the separate reply context could have been prepared, and rather directly emit a reset message if the token exceeds the static buffer.

### Testing procedure

This requires a client from `master`, as extending the test to allow specifying the token is not backported.

#### Preparation

```
$  sudo ./dist/tools/tapsetup/tapsetup 
```

#### Running the Server

This should be done with `2024.10-branch` and this PR

```
$ USEMODULE=nanocoap_token_ext make BOARD=native64 -C examples/nanocoap_server && examples/nanocoap_server/bin/native64/nanocoap_server.elf -w tap1
[...]
main(): This is RIOT! (Version: 2025.01-devel-261-g75828)
RIOT nanocoap example application
Waiting for address autoconfiguration...
{"IPv6 addresses": ["<IPV6_ADDR>"]}
```

copy the `<IPV6_ADDR>` part of the output

#### Running the Client

This should be done with `master`.

```
$ USEMODULE=nanocoap_token_ext make BOARD=native64 -C tests/net/nanocoap_cli flash term
[...]
2024-12-11 18:10:58,750 # RIOT native interrupts/signals initialized.
2024-12-11 18:10:58,751 # RIOT native board initialized.
2024-12-11 18:10:58,751 # RIOT native hardware initialization complete.
2024-12-11 18:10:58,751 # 
2024-12-11 18:10:58,752 # main(): This is RIOT! (Version: 2025.01-devel-262-g562036-sys/net/nanocoap/buffer-overflow-separate-response)
2024-12-11 18:10:58,752 # nanocoap test app
2024-12-11 18:10:58,752 # All up, running the shell now
> client_token deadbeefdeadbeefdeadbeef
2024-12-11 18:12:11,060 # client_token deadbeefdeadbeefdeadbeef
> client get fe80::24de:d0ff:fe85:bdb2 5683 /separate
2024-12-11 18:12:27,736 # client get fe80::24de:d0ff:fe85:bdb2 5683 /separate
2024-12-11 18:12:27,736 # nanocli: sending msg ID 1, 25 bytes
2024-12-11 18:13:45,417 # nanocli: msg send failed: -110
```

####

Expected result: No segfault in the server

### Issues/PRs references

Partial backport of https://github.com/RIOT-OS/RIOT/pull/21075