### PR TITLE
build_system/xfa: change API to fix alignment [backport 2024.10]

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -43,18 +43,18 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  * @internal
  */
-#define _XFA(name, prio) \
+#define _XFA(type, name, prio) \
     NO_SANITIZE_ARRAY \
-    __attribute__((used, section(".xfa." #name "." #prio)))
+    __attribute__((used, section(".xfa." #name "." #prio))) _Alignas(type) type
 
 /**
  * @brief helper macro for other XFA_* macros
  *
  * @internal
  */
-#define _XFA_CONST(name, prio) \
+#define _XFA_CONST(type, name, prio) \
     NO_SANITIZE_ARRAY \
-    __attribute__((used, section(".roxfa." #name "." #prio)))
+    __attribute__((used, section(".roxfa." #name "." #prio))) _Alignas(type) type
 
 /**
  * @brief Define a read-only cross-file array
@@ -73,8 +73,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
 #define XFA_INIT_CONST(type, name) \
     _Pragma("GCC diagnostic push") \
     _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
-    _XFA_CONST(name, 0_) type name [0] = {}; \
-    _XFA_CONST(name, 9_) type name ## _end [0] = {}; \
+    _XFA_CONST(type, name, 0_) name [0] = {}; \
+    _XFA_CONST(type, name, 9_) name ## _end [0] = {}; \
     _Pragma("GCC diagnostic pop") \
     extern const unsigned __xfa_dummy
 
@@ -95,8 +95,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
 #define XFA_INIT(type, name) \
     _Pragma("GCC diagnostic push") \
     _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
-    _XFA(name, 0_) type name [0] = {}; \
-    _XFA(name, 9_) type name ## _end [0] = {}; \
+    _XFA(type, name, 0_) name [0] = {}; \
+    _XFA(type, name, 9_) name ## _end [0] = {}; \
     _Pragma("GCC diagnostic pop") \
     extern const unsigned __xfa_dummy
 
@@ -136,12 +136,13 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  * Add this to the type in a variable definition, e.g.:
  *
- *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
+ *     XFA(driver_params_t, driver_params, 0) _onboard = { .pin=42 };
  *
+ * @param[in]   type        type of the xfa elements
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa
  */
-#define XFA(xfa_name, prio) _XFA(xfa_name, 5_ ## prio)
+#define XFA(type, xfa_name, prio) _XFA(type, xfa_name, 5_ ## prio)
 
 /**
  * @brief Define variable in read-only cross-file array
@@ -150,12 +151,13 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  * Add this to the type in a variable definition, e.g.:
  *
- *     XFA(driver_params, 0) driver_params_t _onboard = { .pin=42 };
+ *     XFA(driver_params_t, driver_params, 0) _onboard = { .pin=42 };
  *
+ * @param[in]   type        type of the xfa elements
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa
  */
-#define XFA_CONST(xfa_name, prio) _XFA_CONST(xfa_name, 5_ ## prio)
+#define XFA_CONST(type, xfa_name, prio) _XFA_CONST(type, xfa_name, 5_ ## prio)
 
 /**
  * @brief Add a pointer to cross-file array
@@ -174,8 +176,8 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * @param[in]   entry       pointer variable to add to xfa
  */
 #define XFA_ADD_PTR(xfa_name, prio, name, entry) \
-    _XFA_CONST(xfa_name, 5_ ## prio) \
-    __typeof__(entry) xfa_name ## _ ## prio ## _ ## name = entry
+    _XFA_CONST(__typeof__(entry), xfa_name, 5_ ## prio) \
+    xfa_name ## _ ## prio ## _ ## name = entry
 
 /**
  * @brief Calculate number of entries in cross-file array

--- a/cpu/esp32/periph/sdmmc.c
+++ b/cpu/esp32/periph/sdmmc.c
@@ -111,9 +111,9 @@ static_assert(SDMMC_CONFIG_NUMOF == ARRAY_SIZE(_sdmmc_devs),
 static_assert(SDMMC_CONFIG_NUMOF <= SOC_SDMMC_NUM_SLOTS,
               "SDMMC_CONFIG_NUMOF is greater than the supported number of slots");
 
-XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_0 = (sdmmc_dev_t * const)&_sdmmc_devs[0];
+XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_0 = (sdmmc_dev_t * const)&_sdmmc_devs[0];
 #if SDMMC_CONFIG_NUMOF > 1
-XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_1 = (sdmmc_dev_t * const)&_sdmmc_devs[1];
+XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_1 = (sdmmc_dev_t * const)&_sdmmc_devs[1];
 #endif
 
 /* forward declaration of internal functions */

--- a/cpu/stm32/periph/sdmmc.c
+++ b/cpu/stm32/periph/sdmmc.c
@@ -239,9 +239,9 @@ static_assert(SDMMC_CONFIG_NUMOF < 3, "MCU supports only 2 SDIO/SD/MMC interface
 static_assert(SDMMC_CONFIG_NUMOF < 2, "MCU supports only 1 SDIO/SD/MMC interface");
 #endif
 
-XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_1 = (sdmmc_dev_t * const)&_sdmmc_devs[0];
+XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_1 = (sdmmc_dev_t * const)&_sdmmc_devs[0];
 #if SDMMC_CONFIG_NUMOF > 1
-XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_2 = (sdmmc_dev_t * const)&_sdmmc_devs[1];
+XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_2 = (sdmmc_dev_t * const)&_sdmmc_devs[1];
 #endif
 
 static inline bool _use_dma(const sdmmc_conf_t *conf)

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -164,7 +164,7 @@ mtd_dev_t * const mtd_dev_xfa[];
  * @param   idx     Priority of the MTD device pointer within the XFA
  */
 #define MTD_XFA_ADD(dev, idx) \
-    XFA_CONST(mtd_dev_xfa, idx) mtd_dev_t *mtd ## idx = (mtd_dev_t *)&(dev)
+    XFA_CONST(mtd_dev_t, mtd_dev_xfa, idx) *mtd ## idx = (mtd_dev_t *)&(dev)
 
 /**
  * @brief   Number of MTDs defined in the MTD device array in XFA

--- a/drivers/include/mtd_emulated.h
+++ b/drivers/include/mtd_emulated.h
@@ -63,7 +63,7 @@ extern "C" {
         .init_done = false,                             \
     };                                                  \
                                                         \
-    XFA_CONST(mtd_dev_xfa, 99) mtd_dev_t CONCAT(*mtd_emulated, n) = (mtd_dev_t *)&mtd_emulated_dev ## n
+    XFA_CONST(mtd_dev_t, mtd_dev_xfa, 99) CONCAT(*mtd_emulated, n) = (mtd_dev_t *)&mtd_emulated_dev ## n
 
 #if MODULE_VFS_AUTO_MOUNT || DOXYGEN
 /**

--- a/drivers/include/sdmmc/sdmmc.h
+++ b/drivers/include/sdmmc/sdmmc.h
@@ -1397,9 +1397,10 @@ typedef struct sdmmc_dev {
  *
  * @warning To ensure to have the references to all SDIO/SD/MMC device
  *          descriptors in this array, the low-level SDIO/SD/MMC peripheral
- *          drivers must define the references to their SDIO/SD/MMC
- *          device descriptors as XFA members by using the macro
- *          `XFA_CONST(sdmmc_devs, 0)` as shown in the example below.
+ *          drivers must define the references to their SDIO/SD/MMC device
+ *          descriptors as XFA members by using the macro
+ *          `XFA_CONST(sdmmc_dev_t *, sdmmc_devs, 0)` as shown in the example
+ *          below.
  *
  * For example, if the low-level
  * SDIO/SD/MMC peripheral driver defines an MCU-specific SDIO/SD/MMC
@@ -1422,8 +1423,8 @@ typedef struct sdmmc_dev {
  *     },
  * };
  *
- * XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_1 = (sdmmc_dev_t * const)&_mcu_sdmmc_devs[0];
- * XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_2 = (sdmmc_dev_t * const)&_mcu_sdmmc_devs[1];
+ * XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_1 = (sdmmc_dev_t * const)&_mcu_sdmmc_devs[0];
+ * XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_2 = (sdmmc_dev_t * const)&_mcu_sdmmc_devs[1];
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  */

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -226,7 +226,7 @@ const mtd_desc_t mtd_sdcard_driver = {
         .params = &sdcard_spi_params[n]     \
     };                                      \
                                             \
-    XFA_CONST(mtd_dev_xfa, m) mtd_dev_t CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdcard_dev ## n
+    XFA_CONST(mtd_dev_t, mtd_dev_xfa, m) CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdcard_dev ## n
 
 #define MTD_SDCARD_DEV_FS(n, m, filesystem) \
     VFS_AUTO_MOUNT(filesystem, VFS_MTD(mtd_sdcard_dev ## n), VFS_DEFAULT_SD(n), m)

--- a/drivers/mtd_sdmmc/mtd_sdmmc.c
+++ b/drivers/mtd_sdmmc/mtd_sdmmc.c
@@ -194,7 +194,7 @@ const mtd_desc_t mtd_sdmmc_driver = {
         .sdmmc_idx = n,                     \
     };                                      \
                                             \
-    XFA_CONST(mtd_dev_xfa, m) mtd_dev_t CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdmmc_dev ## n
+    XFA_CONST(mtd_dev_t, mtd_dev_xfa, m) CONCAT(*mtd, m) = (mtd_dev_t *)&mtd_sdmmc_dev ## n
 
 #if IS_USED(MODULE_MTD_SDCARD_DEFAULT)
 /* we use /sd1 as default mount point for coexistence with mtd_sdcard */

--- a/drivers/sdmmc/sdmmc_sdhc.c
+++ b/drivers/sdmmc/sdmmc_sdhc.c
@@ -144,9 +144,9 @@ static_assert(SDHC_CONFIG_NUMOF < 3, "MCU supports only 2 SDHC peripherals");
 static_assert(SDHC_CONFIG_NUMOF < 2, "MCU supports only 1 SDHC peripheral");
 #endif
 
-XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_0 = (sdmmc_dev_t * const)&_sdhc_devs[0];
+XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_0 = (sdmmc_dev_t * const)&_sdhc_devs[0];
 #if SDHC_CONFIG_NUMOF > 1
-XFA_CONST(sdmmc_devs, 0) sdmmc_dev_t * const _sdmmc_1 = (sdmmc_dev_t * const)&_sdhc_devs[1];
+XFA_CONST(sdmmc_dev_t * const, sdmmc_devs, 0) _sdmmc_1 = (sdmmc_dev_t * const)&_sdhc_devs[1];
 #endif
 
 static int _set_clock_rate(sdmmc_dev_t *dev, sdmmc_clock_rate_t rate);

--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -51,8 +51,8 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 #if IS_USED(MODULE_SUIT_STORAGE_VFS)
 XFA_USE(char*, suit_storage_files_reg);
 #ifdef CPU_NATIVE
-XFA(suit_storage_files_reg, 0) char* _slot0 = VFS_DEFAULT_DATA "/SLOT0.txt";
-XFA(suit_storage_files_reg, 1) char* _slot1 = VFS_DEFAULT_DATA "/SLOT1.txt";
+XFA(char*, suit_storage_files_reg, 0) _slot0 = VFS_DEFAULT_DATA "/SLOT0.txt";
+XFA(char*, suit_storage_files_reg, 1) _slot1 = VFS_DEFAULT_DATA "/SLOT1.txt";
 #endif
 #endif
 

--- a/sys/include/auto_init_utils.h
+++ b/sys/include/auto_init_utils.h
@@ -75,15 +75,15 @@ typedef struct {
  * @param   priority    Priority level @ref auto_init_prio_t
  */
 #define AUTO_INIT(function, priority)                                                   \
-    XFA_CONST(auto_init_xfa, priority)                                                  \
-    auto_init_module_t auto_init_xfa_ ## function                                       \
+    XFA_CONST(auto_init_module_t, auto_init_xfa, priority)                              \
+    auto_init_xfa_ ## function                                                          \
         = { .init = (auto_init_fn_t)function,                                           \
             .prio = priority,                                                           \
             .name = XTSTR(function) }
 #else
 #define AUTO_INIT(function, priority)                                                   \
-    XFA_CONST(auto_init_xfa, priority)                                                  \
-    auto_init_module_t auto_init_xfa_ ## function                                       \
+    XFA_CONST(auto_init_module_t, auto_init_xfa, priority)                              \
+    auto_init_xfa_ ## function                                                          \
         = { .init = (auto_init_fn_t)function }
 #endif
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -428,7 +428,7 @@ typedef struct {
  * @param name  internal name of the resource entry, must be unique
  */
 #define NANOCOAP_RESOURCE(name) \
-    XFA_CONST(coap_resources_xfa, 0) coap_resource_t CONCAT(coap_resource_, name) =
+    XFA_CONST(coap_resource_t, coap_resources_xfa, 0) CONCAT(coap_resource_, name) =
 #else
 /**
  * @brief   Global CoAP resource list

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -143,7 +143,7 @@ void stdio_close(void);
  * @param _write    write function
  */
 #define STDIO_PROVIDER(_type, _open, _close, _write)        \
-    XFA_CONST(stdio_provider_xfa, 0) stdio_provider_t stdio_ ##_type = { \
+    XFA_CONST(stdio_provider_t, stdio_provider_xfa, 0) stdio_ ##_type = { \
         .open = _open,                                      \
         .close = _close,                                    \
         .write = _write,                                    \

--- a/sys/include/suit/storage/vfs.h
+++ b/sys/include/suit/storage/vfs.h
@@ -18,7 +18,7 @@
  * #include "xfa.h"
  *
  * XFA_USE(char*, suit_storage_files_reg);
- * XFA(suit_storage_files_reg, 0) char* _firmware_0 = VFS_DEFAULT_DATA "/FW0.TXT";
+ * XFA(char*, suit_storage_files_reg, 0) _firmware_0 = VFS_DEFAULT_DATA "/FW0.TXT";
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * Once registered its content may be securely updated via SUIT by specifying the

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -330,8 +330,8 @@ extern "C" {
 #define VFS_AUTO_MOUNT(type, mtd, path, idx)        \
     static type ## _desc_t fs_desc_ ## idx = mtd;   \
                                                     \
-    XFA(vfs_mountpoints_xfa, 0)                     \
-    vfs_mount_t _mount_mtd_ ## idx = {              \
+    XFA(vfs_mount_t, vfs_mountpoints_xfa, 0)        \
+    _mount_mtd_ ## idx = {                          \
         .fs = &type ## _file_system,                \
         .mount_point = path,                        \
         .private_data = &fs_desc_ ## idx,           \

--- a/sys/suit/storage/flashwrite.c
+++ b/sys/suit/storage/flashwrite.c
@@ -244,4 +244,4 @@ static suit_storage_flashwrite_t suit_storage_flashwrite = {
     },
 };
 
-XFA(suit_storage_reg, 0) suit_storage_t* suit_storage_flashwrite_ptr = &suit_storage_flashwrite.storage;
+XFA(suit_storage_t *, suit_storage_reg, 0) suit_storage_flashwrite_ptr = &suit_storage_flashwrite.storage;

--- a/sys/suit/storage/ram.c
+++ b/sys/suit/storage/ram.c
@@ -231,4 +231,4 @@ suit_storage_ram_t suit_storage_ram = {
     },
 };
 
-XFA(suit_storage_reg, 0) suit_storage_t* suit_storage_ram_ptr = &suit_storage_ram.storage;
+XFA(suit_storage_t *, suit_storage_reg, 0) suit_storage_ram_ptr = &suit_storage_ram.storage;

--- a/sys/suit/storage/vfs.c
+++ b/sys/suit/storage/vfs.c
@@ -272,4 +272,4 @@ suit_storage_vfs_t suit_storage_vfs = {
     },
 };
 
-XFA(suit_storage_reg, 0) suit_storage_t *suit_storage_vfs_ptr = &suit_storage_vfs.storage;
+XFA(suit_storage_t *, suit_storage_reg, 0) suit_storage_vfs_ptr = &suit_storage_vfs.storage;

--- a/tests/build_system/xfa/main.c
+++ b/tests/build_system/xfa/main.c
@@ -19,7 +19,6 @@
  */
 
 #include <stdio.h>
-#include <stdint.h>
 
 #include "xfa.h"
 
@@ -35,12 +34,14 @@ int main(void)
     unsigned n = XFA_LEN(xfatest_t, xfatest);
     printf("xfatest[%u]:\n", n);
     for (unsigned i = 0; i < n; i++) {
-        printf("[%u] = %u, \"%s\"\n", i, xfatest[i].val, xfatest[i].text);
+        printf("[%u] = %u, \"%s\", '%c'\n",
+                i, xfatest[i].val, xfatest[i].text, xfatest[i].letter);
     }
     n = XFA_LEN(xfatest_t, xfatest_const);
     printf("xfatest_const[%u]:\n", n);
     for (unsigned i = 0; i < n; i++) {
-        printf("[%u] = %u, \"%s\"\n", i, xfatest_const[i].val, xfatest_const[i].text);
+        printf("[%u] = %u, \"%s\", '%c'\n",
+                i, xfatest_const[i].val, xfatest_const[i].text, xfatest_const[i].letter);
     }
 
     return 0;

--- a/tests/build_system/xfa/tests/01-run.py
+++ b/tests/build_system/xfa/tests/01-run.py
@@ -14,12 +14,16 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact('Cross file array test')
-    child.expect_exact('xfatest[2]:')
-    child.expect_exact('[0] = 1, "xfatest1"')
-    child.expect_exact('[1] = 2, "xfatest2"')
-    child.expect_exact('xfatest_const[2]:')
-    child.expect_exact('[0] = 123, "xfatest_const1"')
-    child.expect_exact('[1] = 45, "xfatest_const2"')
+    child.expect_exact('xfatest[4]:')
+    child.expect_exact("[0] = 1, \"xfatest1\", 'a'")
+    child.expect_exact("[1] = 2, \"xfatest2\", 'b'")
+    child.expect_exact("[2] = 3, \"xfatest3\", 'c'")
+    child.expect_exact("[3] = 4, \"xfatest4\", 'd'")
+    child.expect_exact('xfatest_const[4]:')
+    child.expect_exact("[0] = 123, \"xfatest_const1\", 'a'")
+    child.expect_exact("[1] = 45, \"xfatest_const2\", 'b'")
+    child.expect_exact("[2] = 42, \"xfatest_const3\", 'c'")
+    child.expect_exact("[3] = 44, \"xfatest_const4\", 'd'")
 
 
 if __name__ == "__main__":

--- a/tests/build_system/xfa/xfatest.h
+++ b/tests/build_system/xfa/xfatest.h
@@ -18,6 +18,7 @@ extern "C" {
 typedef struct {
     unsigned val;
     const char *text;
+    char letter;
 } xfatest_t;
 
 #endif /* DOXYGEN */

--- a/tests/build_system/xfa/xfatest1.c
+++ b/tests/build_system/xfa/xfatest1.c
@@ -1,5 +1,5 @@
 #include "xfa.h"
 #include "xfatest.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest1 = { .val = 1, .text = "xfatest1" };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const1 = { .val = 123, .text = "xfatest_const1" };
+XFA(xfatest, 0) xfatest_t _xfatest1 = { .val = 1, .text = "xfatest1", .letter = 'a' };
+XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const1 = { .val = 123, .text = "xfatest_const1", .letter = 'a' };

--- a/tests/build_system/xfa/xfatest1.c
+++ b/tests/build_system/xfa/xfatest1.c
@@ -1,5 +1,5 @@
 #include "xfa.h"
 #include "xfatest.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest1 = { .val = 1, .text = "xfatest1", .letter = 'a' };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const1 = { .val = 123, .text = "xfatest_const1", .letter = 'a' };
+XFA(xfatest_t, xfatest, 0) _xfatest1 = { .val = 1, .text = "xfatest1", .letter = 'a' };
+XFA_CONST(xfatest_t, xfatest_const, 0) _xfatest_const1 = { .val = 123, .text = "xfatest_const1", .letter = 'a' };

--- a/tests/build_system/xfa/xfatest2.c
+++ b/tests/build_system/xfa/xfatest2.c
@@ -1,5 +1,10 @@
 #include "xfa.h"
 #include "xfatest.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest2 = { .val = 2, .text = "xfatest2" };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const2 = { .val = 45, .text = "xfatest_const2" };
+XFA(xfatest, 1) xfatest_t _xfatest2 = { .val = 2, .text = "xfatest2", .letter = 'b' };
+XFA(xfatest, 3) xfatest_t _xfatest4 = { .val = 4, .text = "xfatest4", .letter = 'd' };
+XFA(xfatest, 2) xfatest_t _xfatest3 = { .val = 3, .text = "xfatest3", .letter = 'c' };
+
+XFA_CONST(xfatest_const, 1) xfatest_t _xfatest_const2 = { .val = 45, .text = "xfatest_const2", .letter = 'b' };
+XFA_CONST(xfatest_const, 3) xfatest_t _xfatest_const4 = { .val = 44, .text = "xfatest_const4", .letter = 'd' };
+XFA_CONST(xfatest_const, 2) xfatest_t _xfatest_const3 = { .val = 42, .text = "xfatest_const3", .letter = 'c' };

--- a/tests/build_system/xfa/xfatest2.c
+++ b/tests/build_system/xfa/xfatest2.c
@@ -1,10 +1,10 @@
 #include "xfa.h"
 #include "xfatest.h"
 
-XFA(xfatest, 1) xfatest_t _xfatest2 = { .val = 2, .text = "xfatest2", .letter = 'b' };
-XFA(xfatest, 3) xfatest_t _xfatest4 = { .val = 4, .text = "xfatest4", .letter = 'd' };
-XFA(xfatest, 2) xfatest_t _xfatest3 = { .val = 3, .text = "xfatest3", .letter = 'c' };
+XFA(xfatest_t, xfatest, 1) _xfatest2 = { .val = 2, .text = "xfatest2", .letter = 'b' };
+XFA(xfatest_t, xfatest, 3) _xfatest4 = { .val = 4, .text = "xfatest4", .letter = 'd' };
+XFA(xfatest_t, xfatest, 2) _xfatest3 = { .val = 3, .text = "xfatest3", .letter = 'c' };
 
-XFA_CONST(xfatest_const, 1) xfatest_t _xfatest_const2 = { .val = 45, .text = "xfatest_const2", .letter = 'b' };
-XFA_CONST(xfatest_const, 3) xfatest_t _xfatest_const4 = { .val = 44, .text = "xfatest_const4", .letter = 'd' };
-XFA_CONST(xfatest_const, 2) xfatest_t _xfatest_const3 = { .val = 42, .text = "xfatest_const3", .letter = 'c' };
+XFA_CONST(xfatest_t, xfatest_const, 1) _xfatest_const2 = { .val = 45, .text = "xfatest_const2", .letter = 'b' };
+XFA_CONST(xfatest_t, xfatest_const, 3) _xfatest_const4 = { .val = 44, .text = "xfatest_const4", .letter = 'd' };
+XFA_CONST(xfatest_t, xfatest_const, 2) _xfatest_const3 = { .val = 42, .text = "xfatest_const3", .letter = 'c' };

--- a/tests/unittests/tests-core/tests-core-xfa-data1.c
+++ b/tests/unittests/tests-core/tests-core-xfa-data1.c
@@ -18,15 +18,15 @@
 #include "xfa.h"
 #include "tests-core-xfa.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest1 = { .val = 12345, .text = "xfatest1" };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const1 = { .val = 0xcafe, .text = "xfatest_const1" };
+XFA(xfatest_t, xfatest, 0) _xfatest1 = { .val = 12345, .text = "xfatest1" };
+XFA_CONST(xfatest_t, xfatest_const, 0) _xfatest_const1 = { .val = 0xcafe, .text = "xfatest_const1" };
 
 XFA_INIT(xfatest_t, xfatest_use);
 XFA_INIT_CONST(xfatest_t, xfatest_use_const);
 
-XFA(xfatest_use, 0) xfatest_t _xfatest_use1 = { .val = 3333, .text = "xfatest_use1" };
-XFA(xfatest_use, 0) xfatest_t _xfatest_use_again = { .val = 555, .text = "xfatest use again" };
-XFA_CONST(xfatest_use_const, 0) xfatest_t _xfatest_use_const1 =
+XFA(xfatest_t, xfatest_use, 0) _xfatest_use1 = { .val = 3333, .text = "xfatest_use1" };
+XFA(xfatest_t, xfatest_use, 0) _xfatest_use_again = { .val = 555, .text = "xfatest use again" };
+XFA_CONST(xfatest_t, xfatest_use_const, 0) _xfatest_use_const1 =
     { .val = 4444, .text = "xfatest_use_const1" };
 
 int hack1;

--- a/tests/unittests/tests-core/tests-core-xfa-data2.c
+++ b/tests/unittests/tests-core/tests-core-xfa-data2.c
@@ -18,11 +18,11 @@
 #include "xfa.h"
 #include "tests-core-xfa.h"
 
-XFA(xfatest, 0) xfatest_t _xfatest2 = { .val = 0xbeef, .text = "another test string" };
-XFA_CONST(xfatest_const, 0) xfatest_t _xfatest_const2 =
+XFA(xfatest_t, xfatest, 0) _xfatest2 = { .val = 0xbeef, .text = "another test string" };
+XFA_CONST(xfatest_t, xfatest_const, 0) _xfatest_const2 =
     { .val = 32444, .text = "const string xfa 2" };
-XFA(xfatest_use, 0) xfatest_t _xfatest_use2 = { .val = 11111, .text = "xfatest_use2" };
-XFA_CONST(xfatest_use_const, 0) xfatest_t _xfatest_use_const2 =
+XFA(xfatest_t, xfatest_use, 0) _xfatest_use2 = { .val = 11111, .text = "xfatest_use2" };
+XFA_CONST(xfatest_t, xfatest_use_const, 0) _xfatest_use_const2 =
     { .val = 22222, .text = "xfatest_use_const2" };
 
 /** @} */


### PR DESCRIPTION
# Backport of #20960

### Contribution description

This changes the API of xfa from

    XFA(array_name, prio) type element_name = INITIALIZER;

to

    XFA(type, array_name, prio) element_name = INITIALIZER;

this allows forcing natural alignment of the type, fixing failing tests
on `native64`.

### Testing procedure

The tests from https://github.com/RIOT-OS/RIOT/pull/20959 is included here. It should now pass.

### Issues/PRs references

Includes https://github.com/RIOT-OS/RIOT/pull/20959