### PR TITLE
doxygen/Makefile: fix `make latex` and `make clean`

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -43,8 +43,8 @@ src/coc.md: ../../CODE_OF_CONDUCT.md
 	awk 'NR == 1 {print $$0,"{#coc}"} NR > 1 {print $$0}' $< > $@
 
 .PHONY:
-latex: src/changelog.md
+latex: src/changelog.md src/coc.md
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
 
 clean:
-	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md
+	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md src/coc.md


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
While rebasing #21067 I noticed that I forgot to add the `coc.md` dependency to the `latex` and `clean` targets in #21071.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make latex` should work again and `make clean` should now remove the generated `src/coc.md` as well. 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up fix for #21071.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
