### PR TITLE
dist/tools/esptools: add support for installing esp8266 toolchain

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -486,7 +486,7 @@ toolchain (Debian/Ubuntu package names):
 The shell script `$RIOTBASE/dist/tools/esptools/install.sh` is used to
 install Espressif's precompiled versions of the following tools:
 
-- ESP32 vendor toolchain (for ESP32, ESP32-S2, ESP32-S3 and ESP32-C3)
+- ESP32 vendor toolchain (for ESP8266, ESP32, ESP32-S2, ESP32-S3 and ESP32-C3)
 - GDB for ESP32x SoCs based on Xtensa or RISC-V
 - OpenOCD for ESP32 (for ESP32, ESP32-S2, ESP32-S3 and ESP32-C3)
 - QEMU for ESP32 (only for ESP32)
@@ -499,7 +499,7 @@ $ dist/tools/esptools/install.sh
 
 Usage: install.sh <tool>
        install.sh gdb <platform>
-<tool> = all | esp32 | esp32c3 | esp32s2 | esp32s3 | gdb | openocd | qemu
+<tool> = all | esp8266 | esp32 | esp32c3 | esp32s2 | esp32s3 | gdb | openocd | qemu
 <platform> = xtensa | riscv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -308,7 +308,7 @@ system using the `BUILD_IN_DOCKER` variable:
 
 ## Manual Toolchain Installation {#esp8266_manual_toolchain_installation}
 
-A more difficult way to install the toolchain is the manual installation of
+A more simple way to install the toolchain is the manual installation of
 all required components as described below.
 
 @note To install the toolchain manually, a 64-bit Linux system is required.
@@ -325,17 +325,18 @@ The Xtensa GCC compiler for ESP8266 configured for use with RIOT-OS can
 be downloaded and installed as precompiled binary archive from
 [GitHub](https://github.com/gschorcht/xtensa-esp8266-elf):
 
+The shell script `$RIOTBASE/dist/tools/esptools/install.sh` is used to
+install the custom ESP8266 toolchain:
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-mkdir -p $HOME/esp
-cd $HOME/esp
-git clone https://github.com/gschorcht/xtensa-esp8266-elf
+$ dist/tools/esptools/install.sh esp8266
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once the compiler is installed, you have to expand your `PATH` variable by
 the directory with Xtensa GCC binaries:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export PATH=$HOME/esp/xtensa-esp8266-elf/bin:$PATH
+$ . dist/tools/esptools/export.sh esp8266
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp8266_toc)

--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -38,10 +38,19 @@ export_arch()
     TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP32_GCC_RELEASE}/${TARGET_ARCH}"
     TOOLS_DIR_IN_PATH="$(echo $PATH | grep "${TOOLS_DIR}")"
 
-    if [ -e "${TOOLS_DIR}" ] && [ -z "${TOOLS_DIR_IN_PATH}" ]; then
+    if [ ! -e "${TOOLS_DIR}" ]; then
+        echo "${TOOLS_DIR} does not exist - please run"
+        echo $(echo $0 | sed 's/export/install/') $1
+        exit 1
+    fi
+
+    if [ -z "${TOOLS_DIR_IN_PATH}" ]; then
         echo "Extending PATH by ${TOOLS_DIR}/bin"
         export PATH="${TOOLS_DIR}/bin:${PATH}"
     fi
+
+    echo "To make this permanent, add this line to your ~/.bashrc or ~/.profile:"
+    echo PATH="\$PATH:${TOOLS_DIR}/bin"
 
     unset TOOLS_DIR
 }

--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ESP32_GCC_RELEASE="esp-12.2.0_20230208"
+ESP8266_GCC_RELEASE="esp-5.2.0_20191018"
 
 ESP32_OPENOCD_VERSION="v0.12.0-esp32-20230313"
 
@@ -13,6 +14,10 @@ TOOLS_PATH="${IDF_TOOLS_PATH}/tools"
 export_arch()
 {
     case $1 in
+        esp8266)
+            TARGET_ARCH="xtensa-esp8266-elf"
+            ESP32_GCC_RELEASE=${ESP8266_GCC_RELEASE}
+            ;;
         esp32)
             TARGET_ARCH="xtensa-esp32-elf"
             ;;
@@ -130,7 +135,7 @@ if [ -z "$1" ]; then
     echo "<tool> = all | esp32 | esp32c3 | esp32s2 | esp32s3 | gdb | openocd | qemu"
     echo "<platform> = xtensa | riscv"
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp32 esp32c3 esp32s2 esp32s3"
+    ARCH_ALL="esp8266 esp32 esp32c3 esp32s2 esp32s3"
     for arch in ${ARCH_ALL}; do
         export_arch "$arch"
     done

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -4,6 +4,8 @@ ESP32_GCC_RELEASE="esp-12.2.0_20230208"
 ESP32_GCC_VERSION_DIR="12.2.0"
 ESP32_GCC_VERSION_DOWNLOAD="12.2.0_20230208"
 
+ESP8266_GCC_RELEASE="esp-5.2.0_20191018"
+
 ESP32_OPENOCD_VERSION="v0.12.0-esp32-20230313"
 ESP32_OPENOCD_VERSION_TGZ="0.12.0-esp32-20230313"
 
@@ -84,6 +86,10 @@ download()
 install_arch()
 {
     case "$1" in
+        esp8266)
+            TARGET_ARCH="xtensa-esp8266-elf"
+            ESP32_GCC_RELEASE=${ESP8266_GCC_RELEASE}
+            ;;
         esp32)
             TARGET_ARCH="xtensa-esp32-elf"
             ;;
@@ -103,19 +109,23 @@ install_arch()
 
     TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP32_GCC_RELEASE}"
 
-    URL_PATH="https://github.com/espressif/crosstool-NG/releases/download"
-    URL_TGZ="${TARGET_ARCH}-${ESP32_GCC_VERSION_DOWNLOAD}-${OS}.tar.xz"
-    URL="${URL_PATH}/${ESP32_GCC_RELEASE}/${URL_TGZ}"
+    if [ "$1" = "esp8266" ]; then
+        git clone https://github.com/gschorcht/xtensa-esp8266-elf ${TOOLS_DIR}/${TARGET_ARCH}
+    else
+        URL_PATH="https://github.com/espressif/crosstool-NG/releases/download"
+        URL_TGZ="${TARGET_ARCH}-${ESP32_GCC_VERSION_DOWNLOAD}-${OS}.tar.xz"
+        URL="${URL_PATH}/${ESP32_GCC_RELEASE}/${URL_TGZ}"
 
-    echo "Creating directory ${TOOLS_DIR} ..." && \
-    mkdir -p "${TOOLS_DIR}" && \
-    cd "${TOOLS_DIR}" && \
-    echo "Downloading ${URL_TGZ} ..." && \
-    download "${URL}" "${URL_TGZ}" && \
-    echo "Extracting ${URL_TGZ} in ${TOOLS_DIR} ..." && \
-    tar xfJ "${URL_TGZ}" && \
-    echo "Removing ${URL_TGZ} ..." && \
-    rm -f "${URL_TGZ}" && \
+        echo "Creating directory ${TOOLS_DIR} ..." && \
+        mkdir -p "${TOOLS_DIR}" && \
+        cd "${TOOLS_DIR}" && \
+        echo "Downloading ${URL_TGZ} ..." && \
+        download "${URL}" "${URL_TGZ}" && \
+        echo "Extracting ${URL_TGZ} in ${TOOLS_DIR} ..." && \
+        tar xfJ "${URL_TGZ}" && \
+        echo "Removing ${URL_TGZ} ..." && \
+        rm -f "${URL_TGZ}"
+    fi
     echo "$1 toolchain installed in ${TOOLS_DIR}/$TARGET_ARCH"
 }
 
@@ -214,11 +224,11 @@ echo $URL_GET $URL
 if [ -z "$1" ]; then
     echo "Usage: install.sh <tool>"
     echo "       install.sh gdb <platform>"
-    echo "<tool> = all | esp32 | esp32c3 | esp32s2 | esp32s3 | gdb | openocd | qemu"
+    echo "<tool> = all | esp8266 | esp32 | esp32c3 | esp32s2 | esp32s3 | gdb | openocd | qemu"
     echo "<platform> = xtensa | riscv"
     exit 1
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp32 esp32c3 esp32s2 esp32s3"
+    ARCH_ALL="esp8266 esp32 esp32c3 esp32s2 esp32s3"
     for arch in ${ARCH_ALL}; do
         install_arch "$arch"
     done
@@ -241,4 +251,4 @@ else
 fi
 
 echo "Use following command to extend the PATH variable:"
-echo ". $(dirname "$0")/export.sh"
+echo ". $(dirname "$0")/export.sh $1"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`esptools` provide a handy way to quickly install the toolchain needed for the various ESP32 family members.

Installing the toolchain for the venerable esp8266 always requires looking up the right wiki page since it uses a custom toolchain that does not follow the same format.

To streamline this, add a special case for esp8266 to the `install.sh` script so the same script can be used to get all the Espressif toolchains.


### Testing procedure

Simply run 

    ./dist/tools/esptools/install.sh esp8266

and 

    ./dist/tools/esptools/export.sh esp8266


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
