### PR TITLE
drivers/at24cxxx: fix uninitialized return value in `_set()`

### DIFF
--- a/drivers/at24cxxx/at24cxxx.c
+++ b/drivers/at24cxxx/at24cxxx.c
@@ -188,7 +188,7 @@ int _write(const at24cxxx_t *dev, uint32_t pos, const void *data, size_t len)
 static
 int _set(const at24cxxx_t *dev, uint32_t pos, uint8_t val, size_t len)
 {
-    int check;
+    int check = 0;
     uint8_t set_buffer[AT24CXXX_SET_BUF_SIZE];
 
     memset(set_buffer, val, sizeof(set_buffer));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If `len` is 0, `check` will be uniinitialized.
`_write()` already handles this correctly. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
