### PR TITLE
sys/rtc_utils: make parameter to `rtc_mktime()` const

### DIFF
--- a/sys/include/rtc_utils.h
+++ b/sys/include/rtc_utils.h
@@ -69,7 +69,7 @@ int rtc_tm_compare(const struct tm *a, const struct tm *b);
  *
  * @return            elapsed seconds since `RIOT_EPOCH`
  */
-uint32_t rtc_mktime(struct tm *t);
+uint32_t rtc_mktime(const struct tm *t);
 
 /**
  * @brief Converts an RTC timestamp into a  time struct.

--- a/sys/rtc_utils/rtc_utils.c
+++ b/sys/rtc_utils/rtc_utils.c
@@ -177,7 +177,7 @@ void rtc_tm_normalize(struct tm *t)
 #endif
 }
 
-uint32_t rtc_mktime(struct tm *t)
+uint32_t rtc_mktime(const struct tm *t)
 {
     unsigned year = t->tm_year + 1900;
     uint32_t time = t->tm_sec


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The function does not modify it, so make the time struct `const`

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
