### PR TITLE
bootloaders/riotboot: don't change CPU/pin state

### DIFF
--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -4,4 +4,8 @@ APPLICATION = riotboot
 # Include riotboot flash partition functionality
 USEMODULE += riotboot_slot
 
+# We don't want to re-configure any hardware
+CFLAGS += -DDISABLE_BOARD_INIT=1
+CFLAGS += -DDISABLE_CPU_INIT=1
+
 include ../riotboot_common.mk

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -197,12 +197,15 @@ void reset_handler_default(void)
     dbgpin_init();
 #endif
 
+#if !DISABLE_CPU_INIT
     /* initialize the CPU */
     extern void cpu_init(void);
     cpu_init();
-
-    /* initialize the board (which also initiates CPU initialization) */
+#endif
+#if !DISABLE_BOARD_INIT
+    /* initialize the board */
     board_init();
+#endif
 
 #if MODULE_NEWLIB || MODULE_PICOLIBC
     /* initialize std-c library (this must be done after board_init) */

--- a/cpu/doc.txt
+++ b/cpu/doc.txt
@@ -20,3 +20,27 @@
  * @ingroup     config
  * @brief       Compile time configurations for different kinds of CPU.
  */
+
+/**
+ * @brief   Skip calling `board_init()`
+ *
+ * Don't call `board_init()`, leave all pins in their default state.
+ *
+ * This is intended to be used with basic riotboot_slot which does not interact
+ * with any external hardware.
+ *
+ * @experimental    Only use this if you know what you are doing
+ */
+#define DISABLE_BOARD_INIT  0
+
+/**
+ * @brief   Skip calling `cpu_init()`
+ *
+ * Don't call `cpu_init()`, leave all CPU configuration in boot-up state.
+ *
+ * This is intended to be used with basic riotboot_slot which does not interact
+ * with any CPU peripherals.
+ *
+ * @experimental    Only use this if you know what you are doing
+ */
+#define DISABLE_CPU_INIT    0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A reoccurring issue is that some board sets way too much pin state in `board_init()` and this carries over to `riotboot` where it is then frozen forever.

But riotboot has no business to set any hw state, it just needs to compare two values in flash and jump to an address - we don't need to touch any hardware registers for that.


### Testing procedure

An app that makes use of riotboot, e.g. `examples/suit_update` still boots as before.

This was verified on `same54-xpro`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
