### PR TITLE
sys: shell: posix_inet as dependency for LWIP

### DIFF
--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -204,6 +204,7 @@ ifneq (,$(filter shell_cmd_iw,$(USEMODULE)))
 endif
 ifneq (,$(filter shell_cmd_lwip_netif,$(USEMODULE)))
   USEMODULE += lwip_netif
+  USEMODULE += posix_inet
 endif
 ifneq (,$(filter shell_cmd_mci,$(USEMODULE)))
   USEMODULE += mci


### PR DESCRIPTION
### Contribution description

The LWIP netif shell commands make use of POSIX functions like inet_pton(). Hence, the module needs to be a dependency.

Without this dependency the build will fail on certain machines (e.g., Arch Linux) when building for certain platforms (e.g., esp32).

### Testing procedure

Build the paho-mqtt example for LWIP with IPv4 for an esp32 board on Arch Linux.