### PR TITLE
pkg/tinydtls: fix compilation with sock_async

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -1063,13 +1063,13 @@ void sock_dtls_set_cb(sock_dtls_t *sock, sock_dtls_cb_t cb, void *cb_arg)
 {
     sock->async_cb = cb;
     sock->async_cb_arg = cb_arg;
-    if (IS_USED(MODULE_SOCK_ASYNC_EVENT)) {
-        sock_async_ctx_t *ctx = sock_dtls_get_async_ctx(sock);
-        if (ctx->queue) {
-            sock_udp_event_init(sock->udp_sock, ctx->queue, _udp_cb, sock);
-            return;
-        }
+#if MODULE_SOCK_ASYNC_EVENT
+    sock_async_ctx_t *ctx = sock_dtls_get_async_ctx(sock);
+    if (ctx->queue) {
+        sock_udp_event_init(sock->udp_sock, ctx->queue, _udp_cb, sock);
+        return;
     }
+#endif
     sock_udp_set_cb(sock->udp_sock, _udp_cb, sock);
 }
 


### PR DESCRIPTION
### Contribution description

When module `sock_async` is used but `sock_async_event` is not, compilation previously failed. This fixes the issue.

### Testing procedure

#### In `master`

```
USEMODULE=sock_async make -C tests/net/nanocoap_cli BOARD=native64 -j
[...]
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/tinydtls/contrib/sock_dtls.c: In function ‘sock_dtls_set_cb’:
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/tinydtls/contrib/sock_dtls.c:1067:9: error: unknown type name ‘sock_async_ctx_t’; did you mean ‘sock_async_flags_t’?
 1067 |         sock_async_ctx_t *ctx = sock_dtls_get_async_ctx(sock);
      |         ^~~~~~~~~~~~~~~~
      |         sock_async_flags_t
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/tinydtls/contrib/sock_dtls.c:1067:33: error: implicit declaration of function ‘sock_dtls_get_async_ctx’ [-Werror=implicit-function-declaration]
 1067 |         sock_async_ctx_t *ctx = sock_dtls_get_async_ctx(sock);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/tinydtls/contrib/sock_dtls.c:1067:33: error: initialization of ‘int *’ from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion]
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/tinydtls/contrib/sock_dtls.c:1068:16: error: request for member ‘queue’ in something not a structure or union
 1068 |         if (ctx->queue) {
      |                ^~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/tinydtls/contrib/sock_dtls.c:1069:52: error: request for member ‘queue’ in something not a structure or union
 1069 |             sock_udp_event_init(sock->udp_sock, ctx->queue, _udp_cb, sock);
      |                                                    ^~
cc1: all warnings being treated as errors
```

#### This PR

```
USEMODULE=sock_async make -C tests/net/nanocoap_cli BOARD=native64 -j
[...]
   text	  data	   bss	   dec	   hex	filename
 265870	  4328	154128	424326	 67986	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/nanocoap_cli/bin/native64/tests_nanocoap_cli.elf
make: Leaving directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/nanocoap_cli'
```

### Issues/PRs references

None