### PR TITLE
dist/tools/bmp: improve compatibility

### DIFF
--- a/dist/tools/bmp/README.md
+++ b/dist/tools/bmp/README.md
@@ -32,6 +32,8 @@ options:
                         selection)
   --attach ATTACH       choose specific target by number
   --gdb-path GDB_PATH   path to GDB
+  --bmp-version BMP_VERSION
+                        choose specific firmware version
   --term-cmd TERM_CMD   serial terminal command
 ```
 
@@ -50,6 +52,12 @@ The probe is auto discovered based on the USB VID (0x1D50) and PID (0x6018,
 
 If `--port` is provided, then that port will be used as the GDB port for all
 actions, except for the `term` action.
+
+## Supported firmwares
+This tool assumes firmware version 1.10 of the Black Magic debugger.
+
+Compatibility for older versions is limited, but can be selected by providing
+`--bmp-version x.y.z`.
 
 ## Examples (tested with BluePill STM32F103F8C6)
 * test connection:

--- a/dist/tools/bmp/README.md
+++ b/dist/tools/bmp/README.md
@@ -21,26 +21,35 @@ positional arguments:
                         choose a task to perform
   file                  file to load to target (hex or elf)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --jtag                use JTAG transport
   --swd                 use SWD transport (default)
   --connect-srst        reset target while connecting
   --tpwr                enable target power
   --serial SERIAL       choose specific probe by serial number
-  --port PORT           choose specific probe by port
+  --port PORT           choose specific probe by port (overrides auto
+                        selection)
   --attach ATTACH       choose specific target by number
   --gdb-path GDB_PATH   path to GDB
   --term-cmd TERM_CMD   serial terminal command
 ```
 
-## Available Actions
+## Available actions
 * `list` lists connected targets (default action)
 * `flash` load file to target
 * `erase` erase target flash
 * `debug` start GDB shell that is attached to target
 * `term` start TTY emulator program to look into connected UART
 * `reset` reset target (using RST line)
+
+## Probe selection
+The probe is auto discovered based on the USB VID (0x1D50) and PID (0x6018,
+0x6017). The first discovered probe will be selected, unless `--port` or
+`--serial` is provided.
+
+If `--port` is provided, then that port will be used as the GDB port for all
+actions, except for the `term` action.
 
 ## Examples (tested with BluePill STM32F103F8C6)
 * test connection:

--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -7,6 +7,7 @@
 # directory for more details.
 #
 # @author   Maximilian Deubel <maximilian.deubel@ovgu.de>
+# @author   Bas Stottelaar <basstottelaar@gmail.com>
 
 # Black Magic Probe helper script
 # This script can detect connected Black Magic Probes and can be used as a flashloader and much more

--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -14,13 +14,13 @@
 import argparse
 import os
 import re
+import shutil
 import sys
 
 import humanize
 import serial.tools.list_ports
 from progressbar import Bar, Percentage, ProgressBar
 from pygdbmi.gdbcontroller import GdbController
-import distutils.spawn
 
 parser = argparse.ArgumentParser(description='Black Magic Tool helper script.')
 parser.add_argument('--jtag', action='store_true', help='use JTAG transport')
@@ -43,11 +43,11 @@ TIMEOUT = 100  # seconds
 
 # find a suitable gdb executable, falling back to defaults if needed
 def find_suitable_gdb(gdb_path):
-    if distutils.spawn.find_executable(gdb_path):
+    if shutil.which(gdb_path):
         return gdb_path
     else:
         for p in ['arm-none-eabi-gdb', 'gdb-multiarch']:
-            p = distutils.spawn.find_executable(p)
+            p = shutil.which(p)
             if p:
                 print("GDB EXECUTABLE NOT FOUND! FALLING BACK TO %s" % p, file=sys.stderr)
                 return p

--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -282,6 +282,7 @@ def main():
 
         # reset mode: reset device using reset pin
         if args.action == 'reset':
+            print('resetting...')
             assert gdb_write_and_wait_for_result(gdbmi, 'monitor hard_srst', 'resetting target')
             sys.exit(0)
         # erase mode
@@ -291,6 +292,7 @@ def main():
             sys.exit(0)
         # flashloader mode: flash, check and restart
         elif args.action == 'flash':
+            print('flashing...')
             download_to_flash(gdbmi)
             check_flash(gdbmi)
 

--- a/dist/tools/bmp/requirements.txt
+++ b/dist/tools/bmp/requirements.txt
@@ -1,4 +1,5 @@
 humanize
+packaging
 pygdbmi
 pyserial
 progressbar


### PR DESCRIPTION
### Contribution description
The Black Magic Probe is a great debugger. Current implementation does not work with more modern firmware versions, because some commands have been renamed. Further more, Python 3.12 deprecated the `distutils` package (removed in 3.13), so this tool did not work on my machine.

Compatibility with older firmware versions has been maintained (or at least, I tried). I first wanted to implement auto--detection of the firmware version, but that does not work with debug mode in the current state.

I also cleaned up the code a tiny bit, and made things a bit more logical (IMHO).

Before, port detection would always throw an exception if no debugger was found, even if `--port` was provided. I relaxed this check, which gives me the possibility to provide any port. In my particular use-case, I run the debugger via `ser2net`, so local detection would not work.

Created separate commits with all changes. Will squash once approved.

### Testing procedure
I tested this as follows: 

* Locally: `BOARD=some-board PROGRAMMER=bmp make flash|reset|debug|erase`
* Remotely: `BOARD=some-board PROGRAMMER=bmp BMP_OPTIONS="--port 10.0.0.192:2000" make flash|reset|debug|erase`.

### Issues/PRs references
None