### PR TITLE
sys/ztimer: implement ztimer_mbox_get_timeout() and use it to fix race in gnrc_sock_recv()

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -264,10 +264,11 @@
 
 #include <stdint.h>
 
-#include "sched.h"
+#include "mbox.h"
 #include "msg.h"
 #include "mutex.h"
 #include "rmutex.h"
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -529,6 +530,22 @@ int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg,
 
 /* created with dist/tools/define2u16.py */
 #define MSG_ZTIMER 0xc83e   /**< msg type used by ztimer_msg_receive_timeout */
+
+/**
+ * @brief Get message from mailbox, blocking with a timeout
+ *
+ * If the mailbox is empty, this function will block until a message becomes
+ * available or the timeout triggers
+ *
+ * @param[in]   clock           ztimer clock to operate on
+ * @param[in]   mbox            ptr to mailbox to operate on
+ * @param[in]   msg             ptr to storage for retrieved message
+ * @param[in]   timeout         relative timeout, in @p clock time units
+ *
+ * @retval  0           Got a message
+ * @retval -ETIMEDOUT   Timeout triggered before a message was obtained
+ */
+int ztimer_mbox_get_timeout(ztimer_clock_t *clock, mbox_t *mbox, msg_t *msg, uint32_t timeout);
 
 /**
  * @brief ztimer_now() for extending timers

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -30,6 +30,9 @@
 #include "thread.h"
 #include "ztimer.h"
 
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
 static void _callback_unlock_mutex(void *arg)
 {
     mutex_t *mutex = (mutex_t *)arg;
@@ -127,6 +130,49 @@ int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg,
 }
 
 #endif /* MODULE_CORE_MSG */
+
+#ifdef MODULE_CORE_MBOX
+struct ztimer_mbox_thread_status {
+    ztimer_t timer;
+    mbox_t *mbox;
+    thread_t *thread;
+    int status;
+};
+
+static void _ztimer_mbox_get_timeout(void *arg)
+{
+    struct ztimer_mbox_thread_status *data = arg;
+    if (!list_remove(&data->mbox->readers, &data->thread->rq_entry)) {
+        /* timeout triggered just after the message was received but before the
+         * timer was canceled. --> ignore the timeout */
+        DEBUG_PUTS("ztimer_mbox_get_timeout: timeout triggered, but message already received");
+        return;
+    }
+
+    sched_set_status(data->thread, STATUS_PENDING);
+    data->status = -ETIMEDOUT;
+    thread_yield_higher();
+    DEBUG_PUTS("ztimer_mbox_get_timeout: timeout triggered");
+}
+
+int ztimer_mbox_get_timeout(ztimer_clock_t *clock, mbox_t *mbox, msg_t *msg, uint32_t timeout)
+{
+    struct ztimer_mbox_thread_status data = {
+        .timer = {
+            .arg = &data,
+            .callback = _ztimer_mbox_get_timeout,
+        },
+        .mbox = mbox,
+        .thread = thread_get_active(),
+        .status = 0,
+    };
+
+    ztimer_set(clock, &data.timer, timeout);
+    mbox_get(mbox, msg);
+    ztimer_remove(clock, &data.timer);
+    return data.status;
+}
+#endif
 
 #ifdef MODULE_CORE_THREAD_FLAGS
 static void _set_timeout_flag_callback(void *arg)

--- a/tests/sys/ztimer_mbox_get_timeout/Makefile
+++ b/tests/sys/ztimer_mbox_get_timeout/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.sys_common
+
+USEMODULE += ztimer_usec
+USEMODULE += core_thread_flags
+USEMODULE += core_mbox
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/ztimer_mbox_get_timeout/Makefile.ci
+++ b/tests/sys/ztimer_mbox_get_timeout/Makefile.ci
@@ -1,0 +1,4 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    atmega8 \
+    nucleo-l011k4 \
+    #

--- a/tests/sys/ztimer_mbox_get_timeout/main.c
+++ b/tests/sys/ztimer_mbox_get_timeout/main.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       testing ztimer_mbox_get_timeout function
+ *
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+ *
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "mbox.h"
+#include "test_utils/expect.h"
+#include "time_units.h"
+#include "ztimer.h"
+
+#define MSG_TYPE    42
+#define MSG_VAL     1337
+
+static msg_t queue[4];
+static mbox_t mbox = MBOX_INIT(queue, ARRAY_SIZE(queue));
+
+static void cb_mbox_put(void *arg)
+{
+    mbox_try_put(&mbox, arg);
+}
+
+static void test_mbox_already_full(void)
+{
+    printf("testing mbox already full prior call: ");
+    msg_t msg = { .type = MSG_TYPE, .content.value = MSG_VAL };
+    mbox_put(&mbox, &msg);
+    uint32_t start = ztimer_now(ZTIMER_USEC);
+    expect(ztimer_mbox_get_timeout(ZTIMER_USEC, &mbox, &msg, US_PER_SEC) == 0);
+    uint32_t stop = ztimer_now(ZTIMER_USEC);
+    /* Returning immediately should with nothing else running in this test app
+     * should not take more than a millisecond */
+    expect(stop - start < US_PER_MS);
+    printf("OK\n");
+}
+
+static void test_timeout_reached(void)
+{
+    const uint32_t timeout_us = 10 * US_PER_MS;
+    printf("testing timeout is reached: ");
+    msg_t msg = { .type = MSG_TYPE - 1, .content.value = MSG_VAL - 1 };
+    uint32_t start = ztimer_now(ZTIMER_USEC);
+    expect(ztimer_mbox_get_timeout(ZTIMER_USEC, &mbox, &msg, timeout_us) == -ETIMEDOUT);
+    uint32_t stop = ztimer_now(ZTIMER_USEC);
+    /* This may take longer than the timeout due to overhead, background tasks,
+     * etc. But it MUST NOT return early. */
+    expect(stop - start >= timeout_us);
+    /* But it should also not take way too long */
+    expect(stop - start < 2 * timeout_us);
+    /* msg must not be changed */
+    expect((msg.type == MSG_TYPE - 1) && (msg.content.value == MSG_VAL - 1));
+    printf("OK\n");
+}
+
+static void test_msg_prior_timeout(void)
+{
+    const uint32_t msg_timeout_us = 1 * US_PER_MS;
+#if defined(BOARD_NATIVE64) || defined(BOARD_NATIVE)
+    /* relax timing on native, as background load can mess with timing */
+    const uint32_t wait_timeout_us = 1000 * US_PER_MS;
+#else
+    const uint32_t wait_timeout_us = 2 * US_PER_MS;
+#endif
+
+    msg_t msg = { .type = MSG_TYPE, .content.value = MSG_VAL };
+    msg_t got = { .type = 0 };
+    ztimer_t t = {
+        .callback = cb_mbox_put,
+        .arg = &msg,
+    };
+
+    ztimer_set(ZTIMER_USEC, &t, msg_timeout_us);
+    uint32_t start = ztimer_now(ZTIMER_USEC);
+    expect(ztimer_mbox_get_timeout(ZTIMER_USEC, &mbox, &got, wait_timeout_us) == 0);
+    uint32_t stop = ztimer_now(ZTIMER_USEC);
+
+    /* the function should return AFTER the message was send, but BEFORE the
+     * timeout was triggered */
+    expect(stop - start >= msg_timeout_us);
+    expect(stop - start < wait_timeout_us);
+
+    /* we should have gotten the correct message */
+    expect((got.type == msg.type) && (got.content.value == msg.content.value));
+}
+
+static WORD_ALIGNED char stack_high_prio_thread[THREAD_STACKSIZE_TINY];
+static void * high_prio_thread(void *arg)
+{
+    uint32_t timeout = (uintptr_t)arg;
+
+    {
+        msg_t msg = { .type = MSG_TYPE, .content.value = MSG_VAL };
+        mbox_put(&mbox, &msg);
+    }
+
+    ztimer_spin(ZTIMER_USEC, timeout);
+    return NULL;
+}
+
+static void test_msg_race(void)
+{
+    printf("testing timeout is reached despite message received (race): ");
+    const uint32_t wait_timeout_us = 2 * US_PER_MS;
+    const uintptr_t spin_timeout_us = 2 * wait_timeout_us;
+
+    msg_t msg = { .type = MSG_TYPE, .content.value = MSG_VAL };
+    msg_t got = { .type = 0 };
+
+    thread_create(stack_high_prio_thread, sizeof(stack_high_prio_thread),
+                  THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_WOUT_YIELD,
+                  high_prio_thread, (void *)spin_timeout_us, "high_prio");
+    uint32_t start = ztimer_now(ZTIMER_USEC);
+    expect(ztimer_mbox_get_timeout(ZTIMER_USEC, &mbox, &got, wait_timeout_us) == 0);
+    uint32_t stop = ztimer_now(ZTIMER_USEC);
+
+    /* the high prio thread should prevent us from running while it spins. It
+     * will even prevent us from cancelling the timeout. We should still receive
+     * the message (which was received prior to the timeout), even though
+     * we get CPU time only way after the timeout. */
+    expect(stop - start > wait_timeout_us);
+
+    /* we should have gotten the correct message */
+    expect((got.type == msg.type) && (got.content.value == msg.content.value));
+    printf("OK\n");
+}
+
+int main(void)
+{
+    const unsigned repetitions = 1000;
+    printf("Testing ztimer_mbox_get_timeout()\n"
+           "=================================\n");
+    test_mbox_already_full();
+    test_timeout_reached();
+    test_msg_race();
+
+    printf("Running test for reception prior timeout %u times: ", repetitions);
+    for (unsigned i = 0; i < repetitions; i++) {
+        test_msg_prior_timeout();
+    }
+
+    printf("OK\n");
+
+    printf("\nALL TESTS SUCCEEDED\n");
+    return 0;
+}

--- a/tests/sys/ztimer_mbox_get_timeout/tests/01-run.py
+++ b/tests/sys/ztimer_mbox_get_timeout/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("Testing ztimer_mbox_get_timeout()")
+    child.expect("ALL TESTS SUCCEEDED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This implements `ztimer_mbox_get_timeout()` and salvages the test app from https://github.com/RIOT-OS/RIOT/pull/18977 with minor tweaking.

On top of `ztimer_mbox_get_timeout()`, the timeout of `gnrc_sock_recv()` is now implemented race-free. 

### Testing procedure

Run the provided test app. (Maybe also set `ENABLE_DEBUG` to `1` in `sys/ztimer/utils.c` to ensure that the race when a message was received just in time but the timeout was not cancelled in time is indeed triggered by the test app.)

Also do some testing with GNRC's SOCK implementation and proper timeout handling.

### Issues/PRs references

Better alternative to https://github.com/RIOT-OS/RIOT/pull/18977