### PR TITLE
Set downstream route to delegated prefix in 6lbr example

### DIFF
--- a/examples/gnrc_border_router/Makefile.cdc-ecm.conf
+++ b/examples/gnrc_border_router/Makefile.cdc-ecm.conf
@@ -4,6 +4,7 @@ USEMODULE += usbus_cdc_ecm
 
 ifeq (dhcpv6,$(PREFIX_CONF))
   FLAGS_EXTRAS += --use-dhcpv6
+  STATIC_ROUTES ?= 1
 else ifeq (auto_subnets,$(PREFIX_CONF))
   FLAGS_EXTRAS += --use-radvd
 endif


### PR DESCRIPTION
### Contribution description

The gnrc_border_router example uses by default the start_networking script when used via `make term`. This script in turn uses the KEA DHCPv6 server which does not automatically configures a downstream route toward the delegated prefix. Hence, it is the responsibility of the caller to setup the route themselves. This can be done with RIOT when `STATIC_ROUTES` is set to `1`. (This will add a static link-local address to the border router's upstream interface (`fe80::2`) and a route via this address to the delegated prefix will be configured by the start_networking script.)

### Testing procedure

1. Setup a border router (for instance on the nrf52840dongle) with dhcpv6 for the prefix configuration, for instance, via  `BOARD=nrf52840dongle make -C examples/gnrc_border_router clean all flash ULINK=cdc-ecm PREFIX_CONF=dhcpv6`.
2. Check if the upstream interface (usually interface `#6`) has the address `fe80::2` configured.
3. Setup a second 6lowpan capable device with, for instance, `gnrc_networking`.
4. Check if pinging a global IPv6 address (e.g.,  2a01:4f9:1a:9508::1`) from the second device works.