### PR TITLE
Request temporary address (IA_NA) for the 6lbr example

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -57,6 +57,9 @@ endif
 ifeq (dhcpv6,$(PREFIX_CONF))
   # include DHCPv6 client for 6LoWPAN border router
   USEMODULE += gnrc_dhcpv6_client_6lbr
+  # optionally also request an address via IA_NA in addition to the prefix.
+  # this is not needed when using SLAAC
+  USEMODULE += dhcpv6_client_ia_na
 else ifeq (uhcp,$(PREFIX_CONF))
   # include UHCP client
   USEMODULE += gnrc_uhcpc


### PR DESCRIPTION
### Contribution description

Additionally to requesting a delegated prefix via DHCPv6 this also enables to ask for a temporary (non-permanent) address on the 6lbr. If the upstream DHCP server provides one, this can be used to establish end-to-end connectivity from the 6lbr towards an Internet host directly.

### Testing procedure

1. Bridge the upstream interface of the border router to your upstream router (assuming that it does DHCPv6) or configure a local DHCPv6 server, for instance [KEA](https://www.isc.org/kea/) with a configuration like [this](https://github.com/user-attachments/files/18290754/kea-dhcp6.txt)
2. Run the border router and check if you can ping Internet hosts directly.