### PR TITLE
sys: net: dns: use Quad9 resolver

### DIFF
--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -55,11 +55,11 @@ extern "C" {
  * @brief Address of the DNS server
  */
 #ifndef CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR
-    /* Default to Google Public DNS */
+    /* Default to Quad9 Public DNS */
     #if CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION == 6
-        #define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR "2001:4860:4860::8888"
+        #define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR "2620:fe::fe"
     #elif CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION == 4
-        #define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR "8.8.8.8"
+        #define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR "9.9.9.9"
     #endif
 #endif
 


### PR DESCRIPTION
### Contribution description

Replaces Google's name servers with the ~[OpenNIC](https://opennic.org/)~ [Quad9](https://quad9.net/) ones. This is better aligned with RIOT's spirit I belive.

### Testing procedure

Build, for instance, `gnrc_networking` with `auto_init_sock_dns` and `sock_dns` enabled and try to ping riot-os.org.