### PR TITLE
buildsystem: keep subfolders of sources unique

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -112,7 +112,7 @@ ifneq (,$(SUBDIRS_IN_DIRS))
     $(patsubst $(CURDIR)/%,./%, $(SUBDIRS_IN_DIRS)). \
     Please select a single approach for each subfolder to prevent linking errors.)
 endif
-SUBDIRS := $(filter-out $(BINDIR)/$(MODULE)/, $(dir $(OBJ)))
+SUBDIRS := $(sort $(filter-out $(BINDIR)/$(MODULE)/, $(dir $(OBJ))))
 
 include $(RIOTMAKE)/blob.inc.mk
 include $(RIOTMAKE)/tools/fixdep.inc.mk

--- a/examples/subfolders/Makefile
+++ b/examples/subfolders/Makefile
@@ -13,7 +13,7 @@ USEMODULE += my_module # name as defined in module/Makefile
 
 # Add source files in subfolders manually
 SRC += main.c
-SRC += folder/a.c folder/subfolder/b.c
+SRC += folder/a.c folder/subfolder/b.c folder/subfolder/c.c
 
 # Alternative method to add files in subfolders using wildcards
 # SRC += $(wildcard *.c folder/*.c folder/**/*.c)

--- a/examples/subfolders/folder/subfolder/c.c
+++ b/examples/subfolders/folder/subfolder/c.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+
+void folder_c(void)
+{
+    puts("./folder/subfolder/c.c");
+}

--- a/examples/subfolders/main.c
+++ b/examples/subfolders/main.c
@@ -24,6 +24,7 @@ void module_a(void);
 void module_b(void);
 void folder_a(void);
 void folder_b(void);
+void folder_c(void);
 
 int main(void)
 {
@@ -34,6 +35,7 @@ int main(void)
     // call functions from subfolder
     folder_a();
     folder_b();
+    folder_c();
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fixes a tiny `make` warning when a subfolder has multiple source files.
> RIOT/Makefile.base:120: target 'RIOT/examples/subfolders/bin/native/application_subfolders/folder/subfolder/' given more than once in the same rule

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Compile `examples/subfolders` without the fix now and you will get the warning.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
