### PR TITLE
dist/tools/bmp: additional improvements to auto-detection

### DIFF
--- a/dist/tools/bmp/README.md
+++ b/dist/tools/bmp/README.md
@@ -51,13 +51,17 @@ The probe is auto discovered based on the USB VID (0x1D50) and PID (0x6018,
 `--serial` is provided.
 
 If `--port` is provided, then that port will be used as the GDB port for all
-actions, except for the `term` action.
+actions, except for the `term` action. `--port` also accepts values such as
+network addresses.
 
 ## Supported firmwares
-This tool assumes firmware version 1.10 of the Black Magic debugger.
+There are minor differences in the available firmwares of the Black Magic
+debugger. Compatibility has been tested with version 1.8+.
 
-Compatibility for older versions is limited, but can be selected by providing
-`--bmp-version x.y.z`.
+This tool will try to determine which version of the firmware is installed,
+unless the probe is accessed remotely (e.g. `--port` is a network address). If
+the firmware version cannot be determined, it will assume version 1.10.2. This
+can be overridden using the `--bmp-version` flag.
 
 ## Examples (tested with BluePill STM32F103F8C6)
 * test connection:

--- a/dist/tools/bmp/README.md
+++ b/dist/tools/bmp/README.md
@@ -63,6 +63,10 @@ unless the probe is accessed remotely (e.g. `--port` is a network address). If
 the firmware version cannot be determined, it will assume version 1.10.2. This
 can be overridden using the `--bmp-version` flag.
 
+As of firmware version 2.0.0 of the Black Magic debugger, support for targets
+depend on the 'flavor' of firmware selected. This tool will indicate if that
+is the case.
+
 ## Examples (tested with BluePill STM32F103F8C6)
 * test connection:
 ```

--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -258,7 +258,7 @@ def parse_args():
     parser.add_argument('--tpwr', action='store_true', help='enable target power')
     parser.add_argument('--serial', help='choose specific probe by serial number')
     parser.add_argument('--port', help='choose specific probe by port (overrides auto selection)')
-    parser.add_argument('--attach', help='choose specific target by number', default='1')
+    parser.add_argument('--attach', help='choose specific target by number', type=int, default=1)
     parser.add_argument('--gdb-path', help='path to GDB', default='gdb-multiarch')
     parser.add_argument('--bmp-version', help='choose specific firmware version', default='1.10.0')
     parser.add_argument('--term-cmd', help='serial terminal command',


### PR DESCRIPTION
### Contribution description
This extends the auto-detection logic by parsing the firmware version number from the device descriptor as returned by PySerial. For stable releases, this should return a proper version number, and restores out-of-the-box compatibility with older firmware versions.

```
found following Black Magic GDB servers:
        [/dev/cu.usbmodem81C986981] Serial: 81C98698 Firmware: 2.0.0 <- default 
connecting to [/dev/cu.usbmodem81C986981]...
auto-detected firmware version 2.0.0
GDB EXECUTABLE NOT FOUND! FALLING BACK TO /opt/homebrew/bin/arm-none-eabi-gdb
connecting successful.
```

The second improvements is to detect unsupported targets. The former message was a bit misleading. At least in v1.10.2 and v2.0.0 of the BMP, unsupported targets are prefixed with ***:

```
(gdb) mon swd_scan
Target voltage: 3.3V
Please report unknown device with Designer 0x673 Part ID 0x801
Available Targets:
No. Att Driver
*** 1   Unknown ARM Cortex-M Designer 0x673 Part ID 0x801 M4
```

The improvement will detect this, and report back. If the user tries attach to the chosen target, a proper error will occur.

```
found following Black Magic GDB servers:
        [/dev/cu.usbmodem81C986981] Serial: 81C98698 Firmware: 2.0.0 <- default 
connecting to [/dev/cu.usbmodem81C986981]...
auto-detected firmware version 2.0.0
GDB EXECUTABLE NOT FOUND! FALLING BACK TO /opt/homebrew/bin/arm-none-eabi-gdb
connecting successful.
scanning using SWD...
found following targets:
        Unknown ARM Cortex-M Designer 0x673 Part ID 0x801 M4 (unsupported)

Traceback (most recent call last):
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_bmp/dist/tools/bmp/./bmp.py", line 376, in <module>
    main()
    ~~~~^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_bmp/dist/tools/bmp/./bmp.py", line 348, in main
    assert targets[args.attach - 1][0], "target unsupported by probe"
```

Lastly, some code improvements are added as well. Most of them were suggested by @maribu in a patch that laid the groundwork for auto-detection.

### Testing procedure
Use the tool with firmware versions 1.8.0 - 2.0.0-rc1.

### Issues/PRs references
Follow-up of #21107.