### PR TITLE
dist/tools/esptool: fix the all target

### DIFF
--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -16,32 +16,36 @@ export_arch()
     case $1 in
         esp8266)
             TARGET_ARCH="xtensa-esp8266-elf"
-            ESP32_GCC_RELEASE=${ESP8266_GCC_RELEASE}
+            ESP_GCC_RELEASE="${ESP8266_GCC_RELEASE}"
             ;;
         esp32)
             TARGET_ARCH="xtensa-esp32-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         esp32c3)
             TARGET_ARCH="riscv32-esp-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         esp32s2)
             TARGET_ARCH="xtensa-esp32s2-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         esp32s3)
             TARGET_ARCH="xtensa-esp32s3-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         *)
             echo "Unknown architecture $1"
             return
     esac
 
-    TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP32_GCC_RELEASE}/${TARGET_ARCH}"
+    TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP_GCC_RELEASE}/${TARGET_ARCH}"
     TOOLS_DIR_IN_PATH="$(echo $PATH | grep "${TOOLS_DIR}")"
 
     if [ ! -e "${TOOLS_DIR}" ]; then
         echo "${TOOLS_DIR} does not exist - please run"
         echo $(echo $0 | sed 's/export/install/') $1
-        exit 1
+        return
     fi
 
     if [ -z "${TOOLS_DIR_IN_PATH}" ]; then

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -88,33 +88,37 @@ install_arch()
     case "$1" in
         esp8266)
             TARGET_ARCH="xtensa-esp8266-elf"
-            ESP32_GCC_RELEASE=${ESP8266_GCC_RELEASE}
+            ESP_GCC_RELEASE="${ESP8266_GCC_RELEASE}"
             ;;
         esp32)
             TARGET_ARCH="xtensa-esp32-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         esp32c3)
             TARGET_ARCH="riscv32-esp-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         esp32s2)
             TARGET_ARCH="xtensa-esp32s2-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         esp32s3)
             TARGET_ARCH="xtensa-esp32s3-elf"
+            ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
         *)
             echo "error: Unknown architecture $1"
             exit 1
     esac
 
-    TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP32_GCC_RELEASE}"
+    TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP_GCC_RELEASE}"
 
     if [ "$1" = "esp8266" ]; then
         git clone https://github.com/gschorcht/xtensa-esp8266-elf ${TOOLS_DIR}/${TARGET_ARCH}
     else
         URL_PATH="https://github.com/espressif/crosstool-NG/releases/download"
         URL_TGZ="${TARGET_ARCH}-${ESP32_GCC_VERSION_DOWNLOAD}-${OS}.tar.xz"
-        URL="${URL_PATH}/${ESP32_GCC_RELEASE}/${URL_TGZ}"
+        URL="${URL_PATH}/${ESP_GCC_RELEASE}/${URL_TGZ}"
 
         echo "Creating directory ${TOOLS_DIR} ..." && \
         mkdir -p "${TOOLS_DIR}" && \


### PR DESCRIPTION
### Contribution description

This PR fixes the `all` parameter in `dist/tools/esptool/intall.sh` and `dist/tools/esptool/export.sh`.

With PR #21094, the installation of the ESP8266 toolchain was added to the tools by overriding the `ESP32_GCC_RELEASE` variable with the `ESP8266_GCC_RELEASE` variable. This leads to wrong settings when iterating over all architectures if the tools are called with parameter `all`.

### Testing procedure

`dist/tools/esptool/install.sh all`
`. dist/tools/esptool/export.sh all`

Without the patch, the installation only works for the ESP8266 toolchain.

### Issues/PRs references

Fixes PR #21094 