### PR TITLE
dist/tools/bmp: in-line dependencies using PEP 723

### DIFF
--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S pipx run
 
 # Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
 #
@@ -8,6 +8,19 @@
 #
 # @author   Maximilian Deubel <maximilian.deubel@ovgu.de>
 # @author   Bas Stottelaar <basstottelaar@gmail.com>
+
+# Dependencies are also listed in `requirements.txt` for compatibility reasons.
+#
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "humanize",
+#   "packaging",
+#   "progressbar",
+#   "pygdbmi",
+#   "pyserial"
+# ]
+# ///
 
 # Black Magic Probe helper script
 # This script can detect connected Black Magic Probes and can be used as a flashloader and much more

--- a/dist/tools/bmp/requirements.txt
+++ b/dist/tools/bmp/requirements.txt
@@ -1,5 +1,7 @@
+# Dependencies are listed as PEP 723 metadata in `bmp.py`. This file exists
+# for compatibility reasons.
 humanize
 packaging
+progressbar
 pygdbmi
 pyserial
-progressbar


### PR DESCRIPTION
### Contribution description
[PEP 723](https://peps.python.org/pep-0723/) is an accepted proposal to in-line script metadata. One such use cases is to list script dependencies inside the script, which makes the `requirements.txt` redundant.

With the correct shebang, it becomes even possible to run the script directly, without creating a virtual environment and installing dependencies in advance. Combining both makes the execution of single-file scripts within RIOT much easier and friendlier.

PEP 723 metadata can be used by [`pipx`](https://github.com/pypa/pipx) and can be easily installed when `pip` is available. It is maintained by the PyPA, just like `pip`. 

I chose this file to start with, but there are at least five more scripts with `requirements.txt` that could benefit from the same change. Because `pip install` still requires a `requirements.txt` file, which is generally accepted during development, I kept both for now. An open issue [exists](https://github.com/pypa/pip/issues/12891) to add support for reading dependencies from PEP 723, which might make it superfluous in the future.

### Testing procedure
Ensure that `pipx` is installed.

This script is part of the Black Magic Debugger. Execute it from the `dist/tools/bmp` folder, or compile any application and use `PROGRAMMER=bmp` to execute it from the build process.

### Issues/PRs references
None