### PR TITLE
pkg/relic: let user or build system select random implementation

### DIFF
--- a/pkg/relic/Makefile.dep
+++ b/pkg/relic/Makefile.dep
@@ -1,2 +1,1 @@
 USEMODULE += random
-USEMODULE += prng_xorshift


### PR DESCRIPTION
### Contribution description

The Relic `Makefile.dep` currently hard-codes `prng_xorshift` as random implementation, although there is another general default for RIOT (`prng_musl_lcg`) and users might want to select it manually. So let's use the RIOT default or the user-provided one instead.


### Testing procedure

on `master`:
```
$ make -C tests/pkg/relic info-modules | grep prng
prng
prng_xorshift
$ USEMODULE='prng_sha256prng' make -C tests/pkg/relic info-modules 
make: Entering directory '/home/mikolai/TUD/Code/RIOT/tests/pkg/relic'
Currently the following prng modules are used: prng_sha256prng prng_shaxprng prng_xorshift
/home/mikolai/TUD/Code/RIOT/sys/random/Makefile.include:14: *** Only one implementation of PRNG should be used..  Stop.
make: Leaving directory '/home/mikolai/TUD/Code/RIOT/tests/pkg/relic'
```

with this patch:
```
$ make -C tests/pkg/relic info-modules | grep prng            
prng
prng_musl_lcg
$ USEMODULE='prng_sha256prng' make -C tests/pkg/relic info-modules | grep prng
prng
prng_sha256prng
prng_shaxprng
```


### Issues/PRs references

Introduced in #13254