### PR TITLE
pkg/relic: bump version to 0.7.0

### DIFF
--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=relic
 PKG_URL=https://github.com/relic-toolkit/relic.git
-PKG_VERSION=e3f82e36250b228f3b4646781f6e06a8be497d18
+# version 0.7.0
+PKG_VERSION=e8b13783dbbe120cff5a68ff460f3bb9bec69666
 PKG_LICENSE=LGPL-2.1
 
 PKG_CUSTOM_PREPARED = $(BINDIR)/pkg-build/$(PKG_NAME)/include
@@ -13,7 +14,8 @@ CMAKE_MINIMAL_VERSION = 3.6.0
 
 CFLAGS += -Wno-unused-function -Wno-old-style-definition -Wno-unused-parameter \
           -Wno-pedantic -Wno-array-parameter -Wno-unused-but-set-variable \
-          -Wno-stringop-overflow
+          -Wno-stringop-overflow -Wno-sign-compare -Wno-type-limits \
+          -Wno-shift-count-overflow -Wno-format
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += $(GCC_C_INCLUDES)

--- a/pkg/relic/patches/0001-use-modul-random-for-seeding.patch
+++ b/pkg/relic/patches/0001-use-modul-random-for-seeding.patch
@@ -1,14 +1,14 @@
-From 14b985c86fd0f97b186adc445c224794c3c1b97b Mon Sep 17 00:00:00 2001
+From 736bfaae854159d944772f24b2ab9b2622808470 Mon Sep 17 00:00:00 2001
 From: maksim-ka <42pema1bif@hft-stuttgart.de>
 Date: Fri, 31 Jan 2020 15:15:46 +0100
-Subject: [PATCH 1/2] use modul random for seeding
+Subject: [PATCH 1/3] use modul random for seeding
 
 ---
  src/rand/relic_rand_core.c | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/rand/relic_rand_core.c b/src/rand/relic_rand_core.c
-index 10f8929f..804b4455 100644
+index c21c5a9..09cd948 100644
 --- a/src/rand/relic_rand_core.c
 +++ b/src/rand/relic_rand_core.c
 @@ -171,6 +171,11 @@ void rand_init(void) {
@@ -24,5 +24,5 @@ index 10f8929f..804b4455 100644
  
  #endif /* RAND == UDEV */
 -- 
-2.33.1
+2.39.5
 

--- a/pkg/relic/patches/0002-add-RIOT-random-support-to-cmake-and-relic_conf.h.patch
+++ b/pkg/relic/patches/0002-add-RIOT-random-support-to-cmake-and-relic_conf.h.patch
@@ -1,7 +1,7 @@
-From ce1cd836aafefa92c3138f3e923147a42e95c886 Mon Sep 17 00:00:00 2001
+From e2f067469fb02535f8cf773a3b9de1c2cd8543af Mon Sep 17 00:00:00 2001
 From: Kaspar Schleiser <kaspar@schleiser.de>
 Date: Mon, 8 Nov 2021 22:37:38 +0100
-Subject: [PATCH 2/2] add RIOT random support to cmake and relic_conf.h
+Subject: [PATCH 2/3] add RIOT random support to cmake and relic_conf.h
 
 ---
  cmake/rand.cmake        | 1 +
@@ -9,7 +9,7 @@ Subject: [PATCH 2/2] add RIOT random support to cmake and relic_conf.h
  2 files changed, 3 insertions(+)
 
 diff --git a/cmake/rand.cmake b/cmake/rand.cmake
-index ed90c769..9f79fd6d 100644
+index ed90c76..9f79fd6 100644
 --- a/cmake/rand.cmake
 +++ b/cmake/rand.cmake
 @@ -12,6 +12,7 @@ message("   SEED=LIBC      Use rand()/random() functions. (insecure!)")
@@ -21,10 +21,10 @@ index ed90c769..9f79fd6d 100644
  # Choose the pseudo-random number generator.
  set(RAND "HASHD" CACHE STRING "Pseudo-random number generator")
 diff --git a/include/relic_conf.h.in b/include/relic_conf.h.in
-index 1245edc0..4e807621 100644
+index f9bb79a..33db9d7 100644
 --- a/include/relic_conf.h.in
 +++ b/include/relic_conf.h.in
-@@ -656,6 +656,8 @@
+@@ -669,6 +669,8 @@
  #define UDEV     3
  /** Use Windows' CryptGenRandom. */
  #define WCGR     4
@@ -34,5 +34,5 @@ index 1245edc0..4e807621 100644
  #cmakedefine SEED     @SEED@
  
 -- 
-2.33.1
+2.39.5
 

--- a/pkg/relic/patches/0003-fix-Wformat-nonliteral-by-using-printf-directly.patch
+++ b/pkg/relic/patches/0003-fix-Wformat-nonliteral-by-using-printf-directly.patch
@@ -1,7 +1,7 @@
-From be6a8c76f021a2cba3d371c16bfb84a8264f51fe Mon Sep 17 00:00:00 2001
+From 49e5e3576572ebcaefab7fe996c89789c5476073 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
-Date: Sat, 20 May 2023 21:41:32 +0200
-Subject: [PATCH] fix -Wformat-nonliteral by using printf() directly
+Date: Mon, 13 Jan 2025 14:13:25 +0100
+Subject: [PATCH 3/3] fix -Wformat-nonliteral by using printf() directly
 
 ---
  include/relic_util.h |  2 +-
@@ -9,10 +9,10 @@ Subject: [PATCH] fix -Wformat-nonliteral by using printf() directly
  2 files changed, 1 insertion(+), 37 deletions(-)
 
 diff --git a/include/relic_util.h b/include/relic_util.h
-index 0dd1744..74e3216 100644
+index cdca0dc..379aa25 100644
 --- a/include/relic_util.h
 +++ b/include/relic_util.h
-@@ -296,7 +296,7 @@ int util_cmp_const(const void *a, const void *b, int n);
+@@ -316,7 +316,7 @@ void util_perm(uint_t p[], size_t n);
   * @param[in] format		- the format.
   * @param[in] ...			- the list of arguments matching the format.
   */
@@ -22,11 +22,11 @@ index 0dd1744..74e3216 100644
  /**
   * Prints a digit.
 diff --git a/src/relic_util.c b/src/relic_util.c
-index 3bb369d..133153d 100644
+index c69fb5c..8207a41 100644
 --- a/src/relic_util.c
 +++ b/src/relic_util.c
-@@ -151,42 +151,6 @@ int util_cmp_const(const void *a, const void *b, int size) {
- 	return (result == 0 ? RLC_EQ : RLC_NE);
+@@ -162,42 +162,6 @@ void util_perm(uint_t p[], size_t n) {
+ 	}
  }
  
 -#ifndef QUIET
@@ -69,5 +69,5 @@ index 3bb369d..133153d 100644
  #if RLC_DIG == 64
  	if (pad) {
 -- 
-2.40.1
+2.39.5
 

--- a/tests/pkg/relic/Makefile.ci
+++ b/tests/pkg/relic/Makefile.ci
@@ -1,11 +1,20 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    airfy-beacon \
+    atmega1284p \
     atmega8 \
     bluepill-stm32f030c8 \
+    calliope-mini \
     i-nucleo-lrwan1 \
+    im880b \
+    microbit \
+    nrf51dongle \
+    nrf6310 \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f070rb \
+    nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
@@ -14,10 +23,14 @@ BOARD_INSUFFICIENT_MEMORY := \
     olimex-msp430-h1611 \
     olimex-msp430-h2618 \
     samd10-xmini \
+    saml10-xpro \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
     stm32g0316-disco \
     stm32l0538-disco \
     weact-g030f6 \
+    yunjia-nrf51822 \
+    zigduino \
     #

--- a/tests/pkg/relic/main.c
+++ b/tests/pkg/relic/main.c
@@ -114,7 +114,7 @@ static void tests_relic_ecdh(void)
 #endif
 
         /* The secrets should be the same now */
-        TEST_ASSERT_EQUAL_INT(RLC_EQ, util_cmp_const(sharedKeyA, sharedKeyB, RLC_MD_LEN));
+        TEST_ASSERT_EQUAL_INT(RLC_EQ, util_cmp_sec(sharedKeyA, sharedKeyB, RLC_MD_LEN));
 
         bn_free(privateA);
         ec_free(publicA);


### PR DESCRIPTION
### Contribution description

Update `pkg/relic` to [version 0.7.0](https://github.com/relic-toolkit/relic/releases/tag/0.7.0). I had to rewrite the patches since the last one could not apply anymore, but the actual changes stayed the same. Also needed one adaption in the respective test due to a function being gone.


### Testing procedure

`make -C tests/pkg/relic all tests`
