### PR TITLE
cpu/esp32: Cleanup of used ESP32x ROM linker scripts

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -270,6 +270,7 @@ LINKFLAGS += -T$(BINDIR)/sections.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/ld/$(CPU_FAM).peripherals.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld
+LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld
 
 ifneq (,$(filter esp32 esp32s2,$(CPU_FAM)))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-data.ld

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -268,8 +268,8 @@ LINKFLAGS += -T$(BINDIR)/memory.ld
 LINKFLAGS += -T$(BINDIR)/sections.ld
 
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/ld/$(CPU_FAM).peripherals.ld
-LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.ld
+LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld
 
 ifneq (,$(filter esp32 esp32s2,$(CPU_FAM)))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-data.ld

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -272,22 +272,13 @@ LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld
 
-ifneq (,$(filter esp32 esp32s2,$(CPU_FAM)))
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-data.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-funcs.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-time.ld
+ifeq (esp32s2,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.spiflash.ld
 else ifeq (esp32c3,$(CPU_FAM))
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.version.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3.ld
 else ifeq (esp32s3,$(CPU_FAM))
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.version.ld
-else
-  $(error Unknown link flags for ESP32x SoC variant (family): $(CPU_FAM))
 endif
 
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections

--- a/cpu/esp32/include/sys/features.h
+++ b/cpu/esp32/include/sys/features.h
@@ -41,6 +41,13 @@ extern "C" {
  */
 #undef _POSIX_THREADS
 
+/*
+ * To avoid type conflicts between the `pthread_rwlockattr_t` definition
+ * in RIOT's `pthread` implementation and newlibc's `sys/_pthreadtypes.h`,
+ * the macro `_POSIX_READER_WRITER_LOCKS` must be undefined.
+ */
+#undef _POSIX_READER_WRITER_LOCKS
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -278,32 +278,6 @@ extern struct __lock __attribute__((alias("s_shared_mutex"))) __lock___arc4rando
 
 void IRAM syscalls_init_arch(void)
 {
-#if defined(_RETARGETABLE_LOCKING)
-    /* initialization of static locking variables in ROM, different ROM
-     * versions of newlib use different locking variables */
-#if defined(CPU_FAM_ESP32)
-    extern _lock_t __sfp_lock;
-    extern _lock_t __sinit_lock;
-    extern _lock_t __env_lock_object;
-    extern _lock_t __tz_lock_object;
-
-    __sfp_lock = (_lock_t)&s_shared_rmutex;
-    __sinit_lock = (_lock_t)&s_shared_rmutex;
-    __env_lock_object = (_lock_t)&s_shared_mutex;
-    __tz_lock_object = (_lock_t)&s_shared_rmutex;
-#elif defined(CPU_FAM_ESP32S2)
-    extern _lock_t __sinit_recursive_mutex;
-    extern _lock_t __sfp_recursive_mutex;
-
-    __sinit_recursive_mutex = (_lock_t)&s_shared_rmutex;
-    __sfp_recursive_mutex = (_lock_t)&s_shared_rmutex;
-#else
-    /* TODO: Other platforms don't provide access to these ROM variables.
-     * It could be necessary to call `esp_rom_newlib_init_common_mutexes`. For
-     * the moment it doesn't seems to be necessary to call this function. */
-#endif
-#endif /* _RETARGETABLE_LOCKING */
-
     /* initialize and enable the system timer in us (TMG0 is enabled by default) */
     timer_hal_init(&sys_timer, TIMER_SYSTEM_GROUP, TIMER_SYSTEM_INDEX);
     timer_hal_set_divider(&sys_timer, rtc_clk_apb_freq_get() / MHZ);


### PR DESCRIPTION
### Contribution description

This PR provides a cleanup to reduce the number of linker scripts used for the ESP32x ROMs and thus the symbols used from the ESP32x ROMs. It works with both gcc 12.2 and gcc 14.2. The latter gcc version is a prerequisite for ESP-IDF v5.2 and higher version and thus a prerequisite for starting the work on the RIOT-OS port for the latest version of ESP-IDF. Thin in turn is a prerequisite to use newer ESP32x SoCs like ESP32-H2, ESP32-C2 and ESP32-C6 as well as the future ESP32-P4.

### Testing procedure

Compilation has to succeed.

The PR was tested with gcc 12.2 as well as gcc 14.2 for WiFi and BLE (the most complex usage of ESP32 SoCs) for all supported ESP32x variants.

### Issues/PRs references
