### PR TITLE
tests/drivers/candev: prefer periph_can when available

### DIFF
--- a/tests/drivers/candev/Makefile
+++ b/tests/drivers/candev/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.drivers_common
 
+FEATURES_OPTIONAL += periph_can
+
 USEMODULE += shell
 USEMODULE += can
 USEMODULE += isrpipe

--- a/tests/drivers/candev/Makefile.board.dep
+++ b/tests/drivers/candev/Makefile.board.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter native native64,$(BOARD)))
+ifneq (,$(filter periph_can,$(FEATURES_USED)))
   CAN_DRIVER ?= PERIPH_CAN
 endif
 


### PR DESCRIPTION
### Contribution description

This changes the app config to prefer periph_can whenever that feature is provided, and fall back to mcp2515 as default if not.

### Testing procedure

```
$ for board in same54-xpro native native64 samr21-xpro hifive1b; do printf "%s: " "$board"; make -C tests/drivers/candev BOARD=$board info-modules | grep 'periph_can\|mcp2515'; done
same54-xpro: periph_can
native: periph_can
native64: periph_can
samr21-xpro: mcp2515
hifive1b: mcp2515
```

### Issues/PRs references

None