### PR TITLE
sys/net/nanocoap: Implement Observe (Server-Side)

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -20,7 +20,7 @@ USEMODULE += gnrc_icmpv6_echo
 USEMODULE += nanocoap_sock
 USEMODULE += nanocoap_resources
 
-USEMODULE += xtimer
+USEMODULE += ztimer_msec
 
 # include this for nicely formatting the returned internal value
 USEMODULE += fmt
@@ -48,10 +48,12 @@ HIGH_MEMORY_BOARDS := native native64 same54-xpro mcb2388
 
 ifneq (,$(filter $(BOARD),$(HIGH_MEMORY_BOARDS)))
   # enable separate response
-  USEMODULE += nanocoap_server_separate
   USEMODULE += event_callback
+  USEMODULE += event_periodic
   USEMODULE += event_thread
   USEMODULE += event_timeout_ztimer
+  USEMODULE += nanocoap_server_observe
+  USEMODULE += nanocoap_server_separate
 
   # enable fileserver
   USEMODULE += nanocoap_fileserver

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -11,13 +11,13 @@
 #include <string.h>
 
 #include "event/callback.h"
-#include "event/timeout.h"
+#include "event/periodic.h"
 #include "event/thread.h"
+#include "event/timeout.h"
 #include "fmt.h"
 #include "net/nanocoap.h"
 #include "net/nanocoap_sock.h"
 #include "hashes/sha256.h"
-#include "kernel_defines.h"
 
 /* internal value that can be read/written via CoAP */
 static uint8_t internal_value = 0;
@@ -59,7 +59,7 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, c
 
     bufpos += coap_put_option_ct(bufpos, 0, COAP_FORMAT_TEXT);
     bufpos += coap_opt_put_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &slicer, 1);
-    *bufpos++ = 0xff;
+    *bufpos++ = COAP_PAYLOAD_MARKER;
 
     /* Add actual content */
     bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_intro, sizeof(block2_intro)-1);
@@ -196,7 +196,7 @@ static void _send_response(void *ctx)
 
     puts("_separate_handler(): send delayed response");
     nanocoap_server_send_separate(ctx, COAP_CODE_CONTENT, COAP_TYPE_NON,
-                                response, sizeof(response));
+                                  response, sizeof(response));
 }
 
 static ssize_t _separate_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
@@ -233,6 +233,107 @@ NANOCOAP_RESOURCE(separate) {
     .path = "/separate", .methods = COAP_GET, .handler = _separate_handler,
 };
 #endif /* MODULE_EVENT_THREAD */
+
+#ifdef MODULE_NANOCOAP_SERVER_OBSERVE
+static ssize_t _time_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
+{
+    uint32_t obs;
+    bool registered = false;
+    if (coap_opt_get_uint(pkt, COAP_OPT_OBSERVE, &obs)) {
+        /* No (valid) observe option present */
+        obs = UINT32_MAX;
+    }
+
+    uint32_t now = ztimer_now(ZTIMER_MSEC);
+
+    switch (obs) {
+    case 0:
+        /* register */
+        if (nanocoap_register_observer(context, pkt) == 0) {
+            registered = true;
+        }
+        break;
+    case 1:
+        /* unregister */
+        nanocoap_unregister_observer(context, pkt);
+        break;
+    default:
+        /* No (valid) observe option present --> ignore observe and handle
+         * as regular GET */
+        break;
+    }
+
+    const size_t estimated_data_len =
+        4       /* Max Observe Option size */
+        + 1     /* payload marker */
+        + 10    /* strlen("4294967295"), 4294967295 == UINT32_MAX */
+        + 1;    /* '\n' */
+    ssize_t hdr_len = coap_build_reply(pkt, COAP_CODE_CONTENT, buf, len, estimated_data_len);
+
+    if (hdr_len < 0) {
+        /* we undo any potential registration if we cannot reply */
+        nanocoap_unregister_observer(context, pkt);
+        return len;
+    }
+
+    if (hdr_len == 0) {
+        /* no response required, probably because of no-response option matching
+         * the response class */
+        return 0;
+    }
+
+    /* coap_build_reply() is a bit goofy: It returns the size of the written
+     * header + `estiamted_data_len`, so we have to subtract it again to obtain
+     * the size of data written. */
+    uint8_t *pos = buf + hdr_len - estimated_data_len;
+
+    if (registered) {
+        uint16_t last_opt = 0;
+        pos += coap_opt_put_observe(pos, last_opt, now);
+    }
+    *pos++ = COAP_PAYLOAD_MARKER;
+    pos += fmt_u32_dec((void *)pos, now);
+    *pos++ = '\n';
+
+    return (uintptr_t)pos - (uintptr_t)buf;
+}
+
+NANOCOAP_RESOURCE(time) {
+    .path = "/time", .methods = COAP_GET, .handler = _time_handler,
+};
+
+static void _notify_observer_handler(event_t *ev)
+{
+    (void)ev;
+    uint32_t now = ztimer_now(ZTIMER_MSEC);
+    uint8_t buf[32];
+    uint8_t *pos = buf;
+    uint16_t last_opt = 0;
+    pos += coap_opt_put_observe(pos, last_opt, now);
+    *pos++ = COAP_PAYLOAD_MARKER;
+    pos += fmt_u32_dec((void *)pos, now);
+    *pos++ = '\n';
+    iolist_t data = {
+        .iol_base = buf,
+        .iol_len = (uintptr_t)pos - (uintptr_t)buf,
+    };
+
+    /* `NANOCOAP_RESOURCE(time)` expends to XFA magic adding an entry named
+     * `coap_resource_time`. */
+    nanocoap_notify_observers(&coap_resource_time, &data);
+}
+
+void setup_observe_event(void)
+{
+    static event_t ev = {
+        .handler = _notify_observer_handler
+    };
+    static event_periodic_t pev;
+
+    event_periodic_init(&pev, ZTIMER_MSEC, EVENT_PRIO_MEDIUM, &ev);
+    event_periodic_start(&pev, MS_PER_SEC);
+}
+#endif /* MODULE_NANOCOAP_SERVER_OBSERVE */
 
 /* we can also include the fileserver module */
 #ifdef MODULE_NANOCOAP_FILESERVER

--- a/examples/nanocoap_server/main.c
+++ b/examples/nanocoap_server/main.c
@@ -20,12 +20,14 @@
 #include <stdio.h>
 
 #include "net/nanocoap_sock.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define COAP_INBUF_SIZE (256U)
 
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+extern void setup_observe_event(void);
 
 int main(void)
 {
@@ -35,7 +37,11 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     puts("Waiting for address autoconfiguration...");
-    xtimer_sleep(3);
+    ztimer_sleep(ZTIMER_MSEC, 3 * MS_PER_SEC);
+
+    if (IS_USED(MODULE_NANOCOAP_SERVER_OBSERVE)) {
+        setup_observe_event();
+    }
 
     /* print network addresses */
     printf("{\"IPv6 addresses\": [\"");

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -529,6 +529,10 @@ ifneq (,$(filter nanocoap_server_auto_init,$(USEMODULE)))
   USEMODULE += nanocoap_server
 endif
 
+ifneq (,$(filter nanocoap_server_observe,$(USEMODULE)))
+  USEMODULE += nanocoap_server_separate
+endif
+
 ifneq (,$(filter nanocoap_server_separate,$(USEMODULE)))
   USEMODULE += nanocoap_server
   USEMODULE += sock_aux_local

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -519,6 +519,7 @@ typedef enum {
  */
 #define COAP_OBS_REGISTER        (0)
 #define COAP_OBS_DEREGISTER      (1)
+#define COAP_OBS_MAX_VALUE_MASK  (0xffffff) /**< observe value is 24 bits */
 /** @} */
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1791,6 +1791,22 @@ static inline size_t coap_opt_put_block2_control(uint8_t *buf, uint16_t lastonum
 }
 
 /**
+ * @brief   Insert an CoAP Observe Option into the buffer
+ *
+ * @param[out]  buf         Buffer to write to
+ * @param[in]   lastonum    last option number (must be < 6)
+ * @param[in]   obs         observe number to write
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_observe(uint8_t *buf, uint16_t lastonum,
+                                          uint32_t obs)
+{
+    obs &= COAP_OBS_MAX_VALUE_MASK; /* trim obs down to 24 bit */
+    return coap_opt_put_uint(buf, lastonum, COAP_OPT_OBSERVE, obs);
+}
+
+/**
  * @brief   Encode the given string as multi-part option into buffer
  *
  * @param[out]  buf         buffer to write to

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -28,6 +28,7 @@
 
 #include "bitarithm.h"
 #include "net/nanocoap.h"
+#include "net/nanocoap_sock.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -493,6 +494,11 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
                         coap_request_ctx_t *ctx)
 {
     assert(ctx);
+
+    if (IS_USED(MODULE_NANOCOAP_SERVER_OBSERVE) && (coap_get_type(pkt) == COAP_TYPE_RST)) {
+        nanocoap_unregister_observer_due_to_reset(coap_request_ctx_get_remote_udp(ctx),
+                                                  coap_get_id(pkt));
+    }
 
     if (coap_get_code_class(pkt) != COAP_REQ) {
         DEBUG("coap_handle_req(): not a request.\n");


### PR DESCRIPTION
### Contribution description

- Clean up and extend the separate response feature of nanocoap
- Add a bit of glue to use the separate response feature to implement observe

### Testing procedure

#### Starting the Server

```
$ sudo ip tuntap add tap0 mode tap user $(whoami)
$ sudo ip link set tap0 up
$ make BOARD=native64 -C examples/nanocoap_server -j flash term
```

#### Running a Client

```
$ coap-client-notls -s 60 -m get 'coap://[fe80::9826:30ff:feb8:31f4%tap0]/time'
8326
9000
10001
11000
12001
13000
14000
15001
16000
17001
18000
19000
20001
21000
22000
[...]
```

### Issues/PRs references

None