### PR TITLE
tree-wide: use alignas() for alignment

### DIFF
--- a/boards/cc2650stk/doc.md
+++ b/boards/cc2650stk/doc.md
@@ -128,7 +128,9 @@ advertising channels, as well as the corresponding variables in the RIOT
 command.
 
 ```c
-typedef struct __attribute__ ((aligned(4))) {
+#include <stdalign.h>
+
+typedef struct alignas(4) {
     radio_op_command_t ropCmd;
     uint8_t channel;
     struct {

--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -22,6 +22,8 @@
  */
 
 #include <inttypes.h>
+#include <stdalign.h>
+
 #include "compiler_hints.h"
 
 /*
@@ -41,7 +43,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  */
 #define _XFA(type, name, prio) \
     NO_SANITIZE_ARRAY \
-    __attribute__((used, section(".xfa." #name "." #prio))) _Alignas(type) type
+    __attribute__((used, section(".xfa." #name "." #prio))) alignas(type) type
 
 /**
  * @brief helper macro for other XFA_* macros
@@ -50,7 +52,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  */
 #define _XFA_CONST(type, name, prio) \
     NO_SANITIZE_ARRAY \
-    __attribute__((used, section(".roxfa." #name "." #prio))) _Alignas(type) type
+    __attribute__((used, section(".roxfa." #name "." #prio))) alignas(type) type
 
 /**
  * @brief Define a read-only cross-file array

--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -13,8 +13,10 @@
  * @}
  */
 
+#include <stdalign.h>
 #include <stdint.h>
 #include <stdio.h>
+
 #include "arm_cpu.h"
 #include "irq.h"
 #include "sched.h"
@@ -23,12 +25,12 @@
 #define STACK_MARKER    (0x77777777)
 #define REGISTER_CNT    (12)
 
-__attribute__((used, section(".usr_stack"), aligned(4))) uint8_t usr_stack[USR_STACKSIZE];
-__attribute__((used, section(".und_stack"), aligned(4))) uint8_t und_stack[UND_STACKSIZE];
-__attribute__((used, section(".fiq_stack"), aligned(4))) uint8_t fiq_stack[FIQ_STACKSIZE];
-__attribute__((used, section(".irq_stack"), aligned(4))) uint8_t irq_stack[ISR_STACKSIZE];
-__attribute__((used, section(".abt_stack"), aligned(4))) uint8_t abt_stack[ABT_STACKSIZE];
-__attribute__((used, section(".svc_stack"), aligned(4))) uint8_t svc_stack[ISR_STACKSIZE];
+__attribute__((used, section(".usr_stack"))) alignas(4) uint8_t usr_stack[USR_STACKSIZE];
+__attribute__((used, section(".und_stack"))) alignas(4) uint8_t und_stack[UND_STACKSIZE];
+__attribute__((used, section(".fiq_stack"))) alignas(4) uint8_t fiq_stack[FIQ_STACKSIZE];
+__attribute__((used, section(".irq_stack"))) alignas(4) uint8_t irq_stack[ISR_STACKSIZE];
+__attribute__((used, section(".abt_stack"))) alignas(4) uint8_t abt_stack[ABT_STACKSIZE];
+__attribute__((used, section(".svc_stack"))) alignas(4) uint8_t svc_stack[ISR_STACKSIZE];
 
 #if (ISR_STACKSIZE % 4)
 #error "ISR_STACKSIZE must be a multiple of 4"

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -15,6 +15,8 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
+
+#include <stdalign.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "sdkconfig.h"
@@ -723,7 +725,7 @@ typedef struct {
 /**
  * @brief  SDIO/SDMMC buffer instantiation requirement for SDHC
  */
-#define SDMMC_CPU_DMA_REQUIREMENTS  __attribute__((aligned(SDMMC_CPU_DMA_ALIGNMENT)))
+#define SDMMC_CPU_DMA_REQUIREMENTS  alignas(SDMMC_CPU_DMA_ALIGNMENT)
 
 /**
  * @brief  SDIO/SDMMC buffer alignment for SDHC because of DMA/FIFO buffer restrictions

--- a/cpu/native/periph/flashpage.c
+++ b/cpu/native/periph/flashpage.c
@@ -12,6 +12,7 @@
  */
 
 #include <assert.h>
+#include <stdalign.h>
 #include <string.h>
 
 #include "cpu.h"
@@ -20,7 +21,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-__attribute__((aligned(FLASHPAGE_SIZE * FLASHPAGE_NUMOF)))
+alignas(FLASHPAGE_SIZE * FLASHPAGE_NUMOF)
 char _native_flash[FLASHPAGE_SIZE * FLASHPAGE_NUMOF];
 
 void flashpage_erase(unsigned page)

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -15,6 +15,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
+#include <stdalign.h>
+
 #include "cpu.h"
 
 #ifdef __cplusplus
@@ -413,7 +415,7 @@ typedef struct {
 /**
  * @brief USBDEV buffer instantiation requirement
  */
-#define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
+#define USBDEV_CPU_DMA_REQUIREMENTS    alignas(USBDEV_CPU_DMA_ALIGNMENT)
 
 #if !defined(CPU_FAM_NRF51) && !defined(DOXYGEN)
 /**

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -17,6 +17,8 @@
  * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
 
+#include <stdalign.h>
+
 #include "cpu.h"
 #include "exti_config.h"
 #include "timer_config.h"
@@ -1005,7 +1007,7 @@ typedef struct {
 /**
  * @brief USBDEV buffer instantiation requirement
  */
-#define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
+#define USBDEV_CPU_DMA_REQUIREMENTS    alignas(USBDEV_CPU_DMA_ALIGNMENT)
 
 /**
  * @brief USB peripheral parameters
@@ -1028,7 +1030,7 @@ typedef struct {
 /**
  * @brief SDIO/SDMMC buffer instantiation requirement for SDHC
  */
-#define SDMMC_CPU_DMA_REQUIREMENTS  __attribute__((aligned(SDMMC_CPU_DMA_ALIGNMENT)))
+#define SDMMC_CPU_DMA_REQUIREMENTS  alignas(SDMMC_CPU_DMA_ALIGNMENT)
 
 /**
  * @brief SDHC peripheral configuration

--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -15,21 +15,19 @@
  * @}
  */
 
+#include <stdalign.h>
+#include <string.h>
+
 #include "iolist.h"
 #include "mii.h"
-#include "net/eui48.h"
 #include "net/ethernet.h"
-#include "net/netdev/eth.h"
-
+#include "net/eui48.h"
 #include "periph/gpio.h"
-
 #include "sam0_eth_netdev.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
-#include "log.h"
 
-#include <string.h>
 
 /* Internal helpers */
 #define PHY_READ_OP 0x02
@@ -75,8 +73,8 @@ struct eth_buf_desc {
 /* GMAC buffer descriptors */
 #define GMAC_DESC_ALIGNMENT 8
 #define GMAC_BUF_ALIGNMENT  32
-static struct eth_buf_desc rx_desc[ETH_RX_BUFFER_COUNT] __attribute__((aligned(GMAC_DESC_ALIGNMENT)));
-static struct eth_buf_desc tx_desc[ETH_TX_BUFFER_COUNT] __attribute__((aligned(GMAC_DESC_ALIGNMENT)));
+static alignas(GMAC_DESC_ALIGNMENT) struct eth_buf_desc rx_desc[ETH_RX_BUFFER_COUNT];
+static alignas(GMAC_DESC_ALIGNMENT) struct eth_buf_desc tx_desc[ETH_TX_BUFFER_COUNT];
 
 static struct eth_buf_desc *rx_curr;
 static struct eth_buf_desc *tx_curr;
@@ -86,8 +84,8 @@ static struct eth_buf_desc *tx_curr;
 static uint8_t  tx_idx;
 static uint8_t  rx_idx;
 
-static uint8_t  rx_buf[ETH_RX_BUFFER_COUNT][ETH_RX_BUFFER_SIZE] __attribute__((aligned(GMAC_BUF_ALIGNMENT)));
-static uint8_t  tx_buf[ETH_TX_BUFFER_COUNT][ETH_TX_BUFFER_SIZE] __attribute__((aligned(GMAC_BUF_ALIGNMENT)));
+static alignas(GMAC_BUF_ALIGNMENT) uint8_t  rx_buf[ETH_RX_BUFFER_COUNT][ETH_RX_BUFFER_SIZE];
+static alignas(GMAC_BUF_ALIGNMENT) uint8_t  tx_buf[ETH_TX_BUFFER_COUNT][ETH_TX_BUFFER_SIZE];
 extern sam0_eth_netdev_t _sam0_eth_dev;
 
 static bool _is_sleeping;

--- a/cpu/stm32/include/periph/cpu_sdmmc.h
+++ b/cpu/stm32/include/periph/cpu_sdmmc.h
@@ -15,6 +15,8 @@
  * @author          Gunar Schorcht <gunar@schorcht.net>
  */
 
+
+#include <stdalign.h>
 #include <stdint.h>
 
 #include "periph/cpu_dma.h"
@@ -41,7 +43,7 @@ extern "C" {
 /**
  * @brief SDIO/SDMMC buffer instantiation requirement for STM32
  */
-#define SDMMC_CPU_DMA_REQUIREMENTS  __attribute__((aligned(SDMMC_CPU_DMA_ALIGNMENT)))
+#define SDMMC_CPU_DMA_REQUIREMENTS  alignas(SDMMC_CPU_DMA_ALIGNMENT)
 
 /**
  * @brief SDIO/SDMMC pin structure for STM32

--- a/cpu/stm32/include/periph/cpu_usbdev.h
+++ b/cpu/stm32/include/periph/cpu_usbdev.h
@@ -17,6 +17,7 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
+#include <stdalign.h>
 #include <stdint.h>
 
 #include "periph/cpu_gpio.h"
@@ -33,7 +34,7 @@ extern "C" {
 /**
  * @brief USBDEV buffer instantiation requirement
  */
-#define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
+#define USBDEV_CPU_DMA_REQUIREMENTS    alignas(USBDEV_CPU_DMA_ALIGNMENT)
 
 /**
  * @name Flags used in stm32_usbdev_fs_config_t

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -44,6 +44,7 @@
  *
  */
 
+#include <stdalign.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -167,7 +168,7 @@ enum {
  * @param[in] size size of the array in unit of @ref FLASHPAGE_SIZE
  */
 #define FLASH_WRITABLE_INIT(name, size) \
-    __attribute__((aligned(FLASHPAGE_SIZE))) \
+    alignas(FLASHPAGE_SIZE) \
     __attribute__((section(".flash_writable." #name))) \
     static const uint8_t name [size * FLASHPAGE_SIZE]
 #endif

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -18,9 +18,10 @@
  * @}
  */
 
-#include <string.h>
-#include <errno.h>
 #include <assert.h>
+#include <errno.h>
+#include <stdalign.h>
+#include <string.h>
 
 #include "architecture.h"
 #include "cpu.h"
@@ -111,8 +112,7 @@ static int _write_page(mtd_dev_t *dev, const void *buf, uint32_t page, uint32_t 
 
     if ((addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) || (size < FLASHPAGE_WRITE_BLOCK_SIZE) ||
         ((uintptr_t)buf % FLASHPAGE_WRITE_BLOCK_ALIGNMENT)) {
-        uint8_t tmp[FLASHPAGE_WRITE_BLOCK_SIZE]
-                __attribute__ ((aligned (FLASHPAGE_WRITE_BLOCK_ALIGNMENT)));
+        uint8_t alignas(FLASHPAGE_WRITE_BLOCK_ALIGNMENT) tmp[FLASHPAGE_WRITE_BLOCK_SIZE];
 
         offset = addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT;
         size = MIN(size, FLASHPAGE_WRITE_BLOCK_SIZE - offset);

--- a/examples/lang_support/community/lua_REPL/main.c
+++ b/examples/lang_support/community/lua_REPL/main.c
@@ -15,6 +15,7 @@
  * @}
  */
 
+#include <stdalign.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -28,7 +29,7 @@
  */
 #define MAIN_LUA_MEM_SIZE (40000)
 
-static char lua_memory[MAIN_LUA_MEM_SIZE] __attribute__ ((aligned(__BIGGEST_ALIGNMENT__)));
+static alignas(__BIGGEST_ALIGNMENT__) char lua_memory[MAIN_LUA_MEM_SIZE];
 
 #define BARE_MINIMUM_MODS (LUAR_LOAD_BASE | LUAR_LOAD_IO | LUAR_LOAD_CORO | LUAR_LOAD_PACKAGE)
 

--- a/examples/lang_support/community/lua_basic/main.c
+++ b/examples/lang_support/community/lua_basic/main.c
@@ -15,6 +15,7 @@
  * @}
  */
 
+#include <stdalign.h>
 #include <stdio.h>
 #include <errno.h>
 
@@ -29,7 +30,7 @@
 #else
 #define LUA_MEM_SIZE (11000)
 #endif
-static char lua_mem[LUA_MEM_SIZE] __attribute__ ((aligned(__BIGGEST_ALIGNMENT__)));
+static alignas(__BIGGEST_ALIGNMENT__) char lua_mem[LUA_MEM_SIZE];
 
 int lua_run_script(const uint8_t *buffer, size_t buffer_len)
 {

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -17,12 +17,13 @@
  * @file
  * @brief       Platform-independent access to architecture details
  *
- * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
  */
 
-#include <stdint.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <stdalign.h>
+#include <stdint.h>
 
 #include "architecture_arch.h" /* IWYU pragma: export */
 
@@ -219,7 +220,7 @@ typedef uintptr_t   uinttxtptr_t;
  * char WORD_ALIGNED thread_stack[THREAD_STACKSIZE_DEFAULT];
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-#define WORD_ALIGNED __attribute__((aligned(ARCHITECTURE_WORD_BYTES)))
+#define WORD_ALIGNED alignas(ARCHITECTURE_WORD_BYTES)
 
 /**
  * @brief       Check if @p addr is alignment to @p alignment

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -22,11 +22,12 @@
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
 
+#include <stdalign.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 #if defined(__linux__)
 
@@ -104,7 +105,7 @@ struct can_frame {
     uint8_t __res0;     /**< reserved / padding */
     uint8_t __res1;     /**< reserved / padding */
     /** Frame data */
-    uint8_t data[CAN_MAX_DLEN] __attribute__((aligned(8)));
+    uint8_t alignas(8) data[CAN_MAX_DLEN];
 };
 
 #ifdef MODULE_FDCAN

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -147,7 +147,8 @@ struct event {
 /**
  * @brief   event queue structure
  */
-typedef struct PTRTAG {
+typedef struct {
+    PTRTAG
     clist_node_t event_list;    /**< list of queued events              */
     thread_t *waiter;           /**< thread owning event queue          */
 } event_queue_t;

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -51,8 +51,9 @@ extern "C" {
  * @brief Power Management mode blocker typedef
  */
 typedef struct {
+    WORD_ALIGNED
     uint8_t blockers[PM_NUM_MODES];     /**< number of blockers for the mode */
-} WORD_ALIGNED pm_blocker_t;
+} pm_blocker_t;
 
 /**
  * @brief   Block a power mode

--- a/sys/include/ptrtag.h
+++ b/sys/include/ptrtag.h
@@ -59,6 +59,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <stdalign.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -68,7 +69,11 @@ extern "C" {
 /**
  * @brief   Pointers to data marked with this attribute will be tag-able.
  *
- * @details This will ensure a minimum alignment of 4 bytes
+ * @details We cannot use `alignas()` here, as we need to define a minimum
+ *          alignment. We cannot lower the alignment of something that must be
+ *          aligned to e.g. 8 or 16 bytes, but this is what `alignas()` would
+ *          (try to) do, which in turn results in a compilation error.
+ * @note    This will ensure a minimum alignment of 4 bytes
  */
 #define PTRTAG  __attribute__((aligned(4)))
 

--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -55,12 +55,14 @@
  * @}
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <stdalign.h>
 
 #include "riotboot/slot.h"
 #include "periph/flashpage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Enable/disable raw writes to flash
@@ -90,7 +92,7 @@ extern "C" {
  * @brief Extra attributes required for the firmware intermediate buffer
  */
 #define RIOTBOOT_FLASHPAGE_BUFFER_ATTRS \
-    __attribute__((aligned(FLASHPAGE_WRITE_BLOCK_ALIGNMENT)))
+    alignas(FLASHPAGE_WRITE_BLOCK_ALIGNMENT)
 
 /**
  * @brief   firmware update state structure

--- a/sys/riotboot/serial.c
+++ b/sys/riotboot/serial.c
@@ -19,6 +19,7 @@
  */
 
 #include <assert.h>
+#include <stdalign.h>
 #include <string.h>
 
 #include "stdio_uart.h"
@@ -109,8 +110,7 @@ static bool _bootdelay(unsigned tries, volatile bool *boot_default)
     return *boot_default;
 }
 
-__attribute__ ((aligned(4)))
-static struct {
+static alignas(4) struct {
     uint8_t pos;                /* current pos in rx buffer */
     uint8_t remaining;          /* remaining bytes to read  */
     union {

--- a/tests/drivers/mtd_flashpage/main.c
+++ b/tests/drivers/mtd_flashpage/main.c
@@ -8,6 +8,7 @@
  *
  * @file
  */
+#include <stdalign.h>
 #include <stdbool.h>
 #include <string.h>
 #include <errno.h>
@@ -115,8 +116,7 @@ static void test_mtd_write_erase(void)
 
 static void test_mtd_write_read(void)
 {
-    const char buf[] __attribute__ ((aligned (FLASHPAGE_WRITE_BLOCK_ALIGNMENT)))
-            = "ABCDEFGHIJKLMNO";
+    const alignas(FLASHPAGE_WRITE_BLOCK_ALIGNMENT) char buf[] = "ABCDEFGHIJKLMNO";
 
     uint8_t buf_empty[3];
     memset(buf_empty, FLASHPAGE_ERASE_STATE, sizeof(buf_empty));

--- a/tests/periph/flashpage/main.c
+++ b/tests/periph/flashpage/main.c
@@ -15,44 +15,45 @@
  * @}
  */
 
-#include <inttypes.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 #include <ctype.h>
+#include <inttypes.h>
+#include <stdalign.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "architecture.h"
-#include "od.h"
-#include "shell.h"
-#include "periph/flashpage.h"
-#include "unaligned.h"
 #include "fmt.h"
+#include "od.h"
+#include "periph/flashpage.h"
+#include "shell.h"
 #include "test_utils/expect.h"
+#include "unaligned.h"
 
-#define LINE_LEN            (16)
+#define LINE_LEN (16)
 
 /* For MSP430 cpu's the last page holds the interrupt vector, although the api
    should not limit erasing that page, we don't want to break when testing */
 #if defined(CPU_CC430) || defined(CPU_MSP430FXYZ)
-#define TEST_LAST_AVAILABLE_PAGE    (FLASHPAGE_NUMOF - 2)
+#  define TEST_LAST_AVAILABLE_PAGE (FLASHPAGE_NUMOF - 2)
 #else
-#define TEST_LAST_AVAILABLE_PAGE    (FLASHPAGE_NUMOF - 1)
+#  define TEST_LAST_AVAILABLE_PAGE (FLASHPAGE_NUMOF - 1)
 #endif
 
 /* When writing raw bytes on flash, data must be correctly aligned. */
-#define ALIGNMENT_ATTR __attribute__((aligned(FLASHPAGE_WRITE_BLOCK_ALIGNMENT)))
+#define ALIGNMENT_ATTR alignas(FLASHPAGE_WRITE_BLOCK_ALIGNMENT)
 
 /* We must not write chunks smaller than FLASHPAGE_WRITE_BLOCK_SIZE */
 #if FLASHPAGE_WRITE_BLOCK_SIZE > 64
-#define RAW_BUF_SIZE FLASHPAGE_WRITE_BLOCK_SIZE
+#  define RAW_BUF_SIZE FLASHPAGE_WRITE_BLOCK_SIZE
 #else
-#define RAW_BUF_SIZE 64
+#  define RAW_BUF_SIZE 64
 #endif
 
 /*
  * @brief   Allocate an aligned buffer for raw writings
  */
-static uint8_t raw_buf[RAW_BUF_SIZE] ALIGNMENT_ATTR;
+static ALIGNMENT_ATTR uint8_t raw_buf[RAW_BUF_SIZE];
 
 #ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 /**
@@ -63,9 +64,9 @@ static uint8_t raw_buf[RAW_BUF_SIZE] ALIGNMENT_ATTR;
  *          32 bit alignment implicitly and there are cases (stm32l4) that
  *          requires 64 bit alignment.
  */
-static uint8_t page_mem[FLASHPAGE_SIZE] ALIGNMENT_ATTR;
+static ALIGNMENT_ATTR uint8_t page_mem[FLASHPAGE_SIZE];
 
-#ifdef MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
+#  ifdef MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
 /**
  * @brief Reserve 1 page of flash memory
  */
@@ -75,8 +76,8 @@ FLASH_WRITABLE_INIT(_backing_memory, 0x1);
 * @brief Created to test the sorting of symbols in .flash_writable section
 */
 FLASH_WRITABLE_INIT(_abacking_memory, 0x1);
-#endif /* MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE */
-#endif /* MODULE_PERIPH_FLASHPAGE_PAGEWISE */
+#  endif /* MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE */
+#endif   /* MODULE_PERIPH_FLASHPAGE_PAGEWISE */
 
 static int getpage(const char *str)
 {
@@ -91,7 +92,7 @@ static int getpage(const char *str)
 #ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 static void memdump(void *addr, size_t len)
 {
-    od_hex_dump	(addr, len, LINE_LEN);
+    od_hex_dump(addr, len, LINE_LEN);
 }
 
 static void dump_local(void)
@@ -228,7 +229,7 @@ static int cmd_write_raw(int argc, char **argv)
     /* try to align */
     int len;
     if ((len = strlen(argv[2])) % 2 || (unsigned)len > sizeof(raw_buf) * 2) {
-        printf("error: data must have an even length and must be <= %"PRIuSIZE"\n",
+        printf("error: data must have an even length and must be <= %" PRIuSIZE "\n",
                sizeof(raw_buf) * 2);
         return 1;
     }
@@ -240,7 +241,7 @@ static int cmd_write_raw(int argc, char **argv)
     }
     len = fmt_hex_bytes(raw_buf, argv[2]);
 
-    flashpage_write((void*)(uintptr_t)addr, raw_buf, len);
+    flashpage_write((void *)(uintptr_t)addr, raw_buf, len);
     printf("wrote local data to flash address %#" PRIxPTR " of len %d\n",
            addr, len);
     return 0;
@@ -334,8 +335,8 @@ static int cmd_test(int argc, char **argv)
  */
 static int cmd_test_last(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     char fill = 'a';
 
     for (unsigned i = 0; i < sizeof(page_mem); i++) {
@@ -344,9 +345,9 @@ static int cmd_test_last(int argc, char **argv)
             fill = 'a';
         }
     }
-#if defined(CPU_CC430) || defined(CPU_MSP430FXYZ)
+#  if defined(CPU_CC430) || defined(CPU_MSP430FXYZ)
     printf("The last page holds the ISR vector, so test page %d\n", TEST_LAST_AVAILABLE_PAGE);
-#endif
+#  endif
     if (flashpage_write_and_verify(TEST_LAST_AVAILABLE_PAGE, page_mem) != FLASHPAGE_OK) {
         puts("error verifying the content of last page");
         return 1;
@@ -356,14 +357,14 @@ static int cmd_test_last(int argc, char **argv)
     return 0;
 }
 
-#ifdef MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
+#  ifdef MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
 /**
  * @brief   Does a write and verify test on reserved page
  */
 static int cmd_test_reserved(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
 
     /**
      * Arrays created by the FLASH_WRITABLE_INIT macro should be sorted in
@@ -372,7 +373,7 @@ static int cmd_test_reserved(int argc, char **argv)
     expect(&_abacking_memory < &_backing_memory);
 
     char fill = 'a';
-    const char sig[] = {"RIOT"};
+    const char sig[] = { "RIOT" };
     unsigned page = flashpage_page((void *)_backing_memory);
 
     printf("Reserved page num: %u \n", page);
@@ -389,7 +390,8 @@ static int cmd_test_reserved(int argc, char **argv)
     }
 
     printf("Since the last firmware update this test has been run "
-           "%u times \n", page_mem[0]);
+           "%u times \n",
+           page_mem[0]);
 
     /* fill memory after counter and signature */
     for (unsigned i = 0x1 + sizeof(sig); i < sizeof(page_mem); i++) {
@@ -410,8 +412,8 @@ static int cmd_test_reserved(int argc, char **argv)
 
     return 0;
 }
-#endif /* MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE */
-#endif /* MODULE_PERIPH_FLASHPAGE_PAGEWISE */
+#  endif /* MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE */
+#endif   /* MODULE_PERIPH_FLASHPAGE_PAGEWISE */
 
 /**
  * @brief   Does a short raw write on last page available
@@ -422,8 +424,8 @@ static int cmd_test_reserved(int argc, char **argv)
  */
 static int cmd_test_last_raw(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
 
     memset(raw_buf, 0xff, sizeof(raw_buf));
 
@@ -548,8 +550,8 @@ static int cmd_test_rwwee(int argc, char **argv)
  */
 static int cmd_test_last_rwwee(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     char fill = 'a';
 
     for (unsigned i = 0; i < sizeof(page_mem); i++) {
@@ -577,8 +579,8 @@ static int cmd_test_last_rwwee(int argc, char **argv)
  */
 static int cmd_test_last_rwwee_raw(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
 
     /* try to align */
     memcpy(raw_buf, "test12344321tset", 16);
@@ -603,14 +605,14 @@ static int cmd_test_last_rwwee_raw(int argc, char **argv)
 #ifdef NVMCTRL_USER
 static int cmd_dump_config(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
 
-#ifdef FLASH_USER_PAGE_SIZE
-    od_hex_dump_ext((void*)NVMCTRL_USER, FLASH_USER_PAGE_SIZE, 0, NVMCTRL_USER);
-#else
-    od_hex_dump_ext((void*)NVMCTRL_USER, AUX_PAGE_SIZE * AUX_NB_OF_PAGES, 0, NVMCTRL_USER);
-#endif
+#  ifdef FLASH_USER_PAGE_SIZE
+    od_hex_dump_ext((void *)NVMCTRL_USER, FLASH_USER_PAGE_SIZE, 0, NVMCTRL_USER);
+#  else
+    od_hex_dump_ext((void *)NVMCTRL_USER, AUX_PAGE_SIZE * AUX_NB_OF_PAGES, 0, NVMCTRL_USER);
+#  endif
 
     return 0;
 }
@@ -622,8 +624,8 @@ static int cmd_test_config(int argc, char **argv)
      * driver implementation
      */
 
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
 
     const uint16_t single_data = 0x1234;
     const uint8_t test_data[] = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE };
@@ -634,8 +636,7 @@ static int cmd_test_config(int argc, char **argv)
 
     for (uint32_t dst_offset = 0; dst_offset < 4; dst_offset++) {
         /* destination base at 4 byte aligned address */
-        uint32_t dst = (uint32_t)(FLASH_USER_PAGE_AUX_SIZE
-                - (sizeof(test_data) + 2 + 3)) & ~((uint32_t)0x3);
+        uint32_t dst = (uint32_t)(FLASH_USER_PAGE_AUX_SIZE - (sizeof(test_data) + 2 + 3)) & ~((uint32_t)0x3);
         /* add data destination offset */
         dst += dst_offset;
 
@@ -644,8 +645,8 @@ static int cmd_test_config(int argc, char **argv)
 
         /* check if the AUX page has been cleared */
         for (uint32_t i = 0; i < FLASH_USER_PAGE_AUX_SIZE; ++i) {
-            if (*(uint8_t*)sam0_flashpage_aux_get(i) != 0xFF) {
-                printf("dst_offset=%"PRIu32": user page not cleared at offset 0x%"PRIx32"\n", dst_offset, i);
+            if (*(uint8_t *)sam0_flashpage_aux_get(i) != 0xFF) {
+                printf("dst_offset=%" PRIu32 ": user page not cleared at offset 0x%" PRIx32 "\n", dst_offset, i);
                 return -1;
             }
         }
@@ -659,13 +660,13 @@ static int cmd_test_config(int argc, char **argv)
         /* check if half-word was written correctly */
         uint16_t data_in = unaligned_get_u16(sam0_flashpage_aux_get(dst + sizeof(test_data)));
         if (data_in != single_data) {
-            printf("dst_offset=%"PRIu32": %x != %x, offset = 0x%"PRIx32"\n", dst_offset, single_data, data_in, dst + sizeof(test_data));
+            printf("dst_offset=%" PRIu32 ": %x != %x, offset = 0x%" PRIx32 "\n", dst_offset, single_data, data_in, dst + sizeof(test_data));
             return -1;
         }
 
         /* check if test data was written correctly */
         if (memcmp(sam0_flashpage_aux_get(dst), test_data, sizeof(test_data))) {
-            printf("dst_offset=%"PRIu32": write test_data failed, offset = 0x%"PRIx32"\n", dst_offset, dst);
+            printf("dst_offset=%" PRIu32 ": write test_data failed, offset = 0x%" PRIx32 "\n", dst_offset, dst);
             return -1;
         }
     }
@@ -692,7 +693,7 @@ static const shell_command_t shell_commands[] = {
     { "test_last_pagewise", "Write and verify test pattern on last page available", cmd_test_last },
 #endif
 #ifdef MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
-    { "test_reserved_pagewise", "Write and verify short write on reserved page", cmd_test_reserved},
+    { "test_reserved_pagewise", "Write and verify short write on reserved page", cmd_test_reserved },
 #endif
     { "test_last_raw", "Write and verify raw short write on last page available", cmd_test_last_raw },
 #ifdef FLASHPAGE_RWWEE_NUMOF

--- a/tests/pkg/lua_loader/main.c
+++ b/tests/pkg/lua_loader/main.c
@@ -22,6 +22,7 @@
  */
 
 #include <stdio.h>
+#include <stdalign.h>
 #include <string.h>
 
 #include "lua_run.h"
@@ -71,7 +72,7 @@ const size_t lua_riot_builtin_c_table_len =
 #else
 #define LUA_MEM_SIZE (11000)
 #endif
-static char lua_mem[LUA_MEM_SIZE] __attribute__ ((aligned(__BIGGEST_ALIGNMENT__)));
+static alignas(__BIGGEST_ALIGNMENT__) char lua_mem[LUA_MEM_SIZE];
 
 #define LINEBUF_SZ (32)
 static char linebuf[LINEBUF_SZ];

--- a/tests/sys/ptrtag/main.c
+++ b/tests/sys/ptrtag/main.c
@@ -22,7 +22,8 @@
 #include "ptrtag.h"
 #include "test_utils/expect.h"
 
-typedef struct PTRTAG {
+typedef struct {
+    PTRTAG
     uint8_t a;
 } custom_type_t;
 


### PR DESCRIPTION
### Contribution description

- Use of `__attribute__((aligned(<NUM>)))` is a compiler extension. We
  can just use `alignas()`, which is part of the C standard since C11
- Use of `_Alignas()` is a keyword since C11 and `alignas()` the alias
  provided by `<stdalign.h>`. But `_Alignas()` is deprecated since C23.
  Let's just go for `alignas()` instead.
- In some cases, we stick with the `__attribute((aligned()))`
    - `alignas(<num>)` only applies to variables, aligning functions in
      code requires `__attribute__((aligned(<num>)))`
    - `alignas(<num>)` specifies the *exact* alignment, whereas
      `__attribute__((aligned(<num>)))` specifies the minimum alignment.
      E.g. for `PTR_TAG`, we only want to specify a minimum alignment

### Testing procedure

`alignas()` and `__attribute__((aligned()))` have almost the same semantics, but `alignas` is a bit more specific. The good thing is that the mismatches will all cause compilation errors. Hence:

- Any `__attribute__((aligned()))` should have been replaced by a (almost) identical `alignas()`
- Green CI

### Issues/PRs references

None