### PR TITLE
sys/net/nanocoap: improve `coap_build_reply()`

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -540,6 +540,7 @@ typedef enum {
  * @brief   Marks the boundary between header and payload
  */
 #define COAP_PAYLOAD_MARKER      (0xFF)
+#define COAP_PAYLOAD_MARKER_SIZE (1U)   /**< Size of the payload marker */
 
 /**
  * @defgroup net_coap_conf    CoAP compile configurations


### PR DESCRIPTION
### Contribution description
    
- The responsibility for handling matching CoAP No-Response Options has been split:
   - `coap_build_reply()` only needs to report this and return `-ECANCLED`
   - `coap_handle_req()` does generate the empty ACK is needed.
  ==> As a result, writing CoAP request handlers correctly becomes a lost easier. Correct error handling to be present is now sufficient for correct handling of No-Response options.
  ==> This change is backward compatible with existing code.
- The API doc has been cleaned up and straightened

### Testing procedure

- CoAP reply handlers that behaved correctly before should still behave correctly now
- CoAP reply handlers that did not behave correctly before in presence of No-Response options should now behave correctly, if they had correct error handling

(CoAP reply handlers that did not get error handling correctly will stay broken.)

### Issues/PRs references

None