### PR TITLE
.gitignore: add .gdb_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ cachegrind.out*
 tags
 # GDB initialization scripts
 .gdbinit
+# GDB history (when using gdb-dashboard)
+.gdb_history
 
 # Eclipse symbol file (output from make eclipsesym)
 eclipsesym.xml


### PR DESCRIPTION
### Contribution description

When using gdb-dashboard, GDB by default writes the history in the folder where `make debug` was executed (e.g. the application folder).

The GDB history will never be useful to upstream, so let's ignore it.

### Testing procedure

#### In `master`:

```
$ touch examples/default/.gdb_history
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	examples/default/.gdb_history

nothing added to commit but untracked files present (use "git add" to track)
```

#### This PR

```
$ touch examples/default/.gdb_history
$ git status
On branch gitignore/gdb_history
Your branch is up to date with 'origin/gitignore/gdb_history'.

nothing to commit, working tree clean
```

### Issues/PRs references

None