### PR TITLE
gnrc/ipv6/nib: make `CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED` the default & deprecate it

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -178,7 +178,7 @@ extern "C" {
  * set static address but use the same static link local address for all interfaces.
  */
 #ifndef CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED
-#define CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED 0
+#define CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED 1
 #endif
 
 /**

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -174,6 +174,10 @@ extern "C" {
 /**
  * @brief   Use the same static IPv6 link local address on every network interface
  *
+ * @deprecated  Will be removed after release 2025.07 - after this the static link-local
+ *              address will always be fixed unless a use-case for the auto-increment
+ *              can be found.
+ *
  * When CONFIG_GNRC_IPV6_STATIC_LLADDR is used, to not add the interface pid to the
  * set static address but use the same static link local address for all interfaces.
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Adding the pseudo-random PID to a static link-local prefix is not very useful when we want predictable addresses.

Previously there was an attempt to remove the entire `CONFIG_GNRC_IPV6_STATIC_LLADDR` feature (https://github.com/RIOT-OS/RIOT/pull/13075), but with `CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED` set it's actually useful.

So make `CONFIG_GNRC_IPV6_STATIC_LLADDR_IS_FIXED` the default as that's what people would expect from that feature and deprecate it's alternative (original) behavior.

If no use-case can be found for adding the PID to the link-local address, we should just drop it and always consider a static address static. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
