### PR TITLE
cpu/samd5x: disable ONDEMAND on clock with periph_can

### DIFF
--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -379,7 +379,9 @@ void cpu_init(void)
 
     /* select the source of the main clock */
     if (USE_DPLL) {
-        fdpll_init_nolock(0, CLOCK_CORECLOCK * DPLL_DIV, OSCCTRL_DPLLCTRLA_ONDEMAND);
+        /* CAN does not work with ondemand */
+        const uint8_t flags = IS_USED(MODULE_PERIPH_CAN) ? 0 : OSCCTRL_DPLLCTRLA_ONDEMAND;
+        fdpll_init_nolock(0, CLOCK_CORECLOCK * DPLL_DIV, flags);
         gclk_connect(SAM0_GCLK_MAIN, GCLK_SOURCE_DPLL0,
                      GCLK_GENCTRL_DIV(DPLL_DIV));
         fdpll_lock(0);
@@ -416,5 +418,7 @@ void cpu_init(void)
 
     /* set ONDEMAND bit after all clocks have been configured */
     /* This is to avoid setting the source for the main clock to ONDEMAND before using it. */
-    OSCCTRL->Dpll[0].DPLLCTRLA.reg |= OSCCTRL_DPLLCTRLA_ONDEMAND;
+    if (!IS_USED(MODULE_PERIPH_CAN)) {
+        OSCCTRL->Dpll[0].DPLLCTRLA.reg |= OSCCTRL_DPLLCTRLA_ONDEMAND;
+    }
 }


### PR DESCRIPTION
### Contribution description

From [SAME54 errata][1] 2.4.9:

> ## On Demand
> The CAN is not compatible with on-demand clock requests.
>
> ## Workaround
> Clear the ONDEMAND bit to zero for the oscillator source that
> provides the GCLK to the CAN.

Since the same CAN peripheral is used across all supported SAMD5x MCUs, the same should be true for the other MCUs.

[1]: https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/Errata/SAM-D5x-E5x-Family-Silicon-Errata-and-Data-Sheet-Clarification-DS80000748.pdf

### Testing procedure

This should actually cause issue with the CAN driver, but it works fine for most boards.

For the board where CAN does not behave correctly, it does not fix the issue.

### Issues/PRs references

None