### PR TITLE
sys/cord/doc.txt: Update additional references to RFC 9176

### DIFF
--- a/sys/net/application_layer/cord/doc.txt
+++ b/sys/net/application_layer/cord/doc.txt
@@ -52,9 +52,9 @@
  * different roles described in `RFC 9176`:
  *
  * - `cord_ep`:     standard endpoint implementation following the rules as
- *                  defined i.a. in sections 5.2, 5.3, A.1, and A.2
+ *                  defined i.a. in sections 4.3 and 5
  * - `cord_epsim`:  endpoint implementation following the simple registration
- *                  procedure as defined in section 5.3.1
+ *                  procedure as defined in section 5.1
  * - `cord_lc`:     lookup client implementation for querying information from
  *                  an RD using the lookup interfaces
  * - `cord_config`: header file collection (default) configuration values used


### PR DESCRIPTION
### Contribution description:

This PR updates the **doc** file of the `CORD` module in RIOT. Updates:

- Update of additional references to **RFC 9176**.

### Testing procedure:

- The **draft-ietf-core-resource-directory-27** was compared in the previous update with the **RFC 9176** and no extensions in the implementation were found. However, the Section References in the description of the `cord_ep` and `cord_epsim` submodules seemed not to be correct, not only for the **RFC 9176**, but also for the **draft-ietf-core-resource-directory-27**. Consequently, since the **draft-ietf-core-resource-directory-15** was the original version used before the reference update to the **draft-ietf-core-resource-directory-27**, it was compared with it and was found out that the references are valid for **draft-ietf-core-resource-directory-15** . During the reference update from **draft-ietf-core-resource-directory-15** to **draft-ietf-core-resource-directory-27** they were seemingly not included in the updating process.

### Issues/PRs references:

- [CORD](https://doc.riot-os.org/group__net__cord.html)
- [draft-ietf-core-resource-directory-15 vs draft-ietf-core-resource-directory-27](https://author-tools.ietf.org/iddiff?url1=draft-ietf-core-resource-directory-15&url2=draft-ietf-core-resource-directory-27&difftype=--html)
- [draft-ietf-core-resource-directory-27 vs RFC 9176](https://author-tools.ietf.org/iddiff?url1=draft-ietf-core-resource-directory-27&url2=rfc9176&difftype=--html)
