### PR TITLE
nanocoap_sock: implement observe (Client-Side)

### DIFF
--- a/examples/networking/coap/nanocoap_server/coap_handler.c
+++ b/examples/networking/coap/nanocoap_server/coap_handler.c
@@ -252,6 +252,9 @@ static ssize_t _time_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_req
         if (nanocoap_register_observer(context, pkt) == 0) {
             registered = true;
         }
+        else {
+            puts("_time_handler: can't register observer");
+        }
         break;
     case 1:
         /* unregister */

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -564,6 +564,12 @@ ifneq (,$(filter nanocoap_link_format,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter nanocoap_sock_observe,$(USEMODULE)))
+  USEMODULE += event_thread
+  USEMODULE += sock_async_event
+  USEMODULE += nanocoap_sock
+endif
+
 ifneq (,$(filter nanocoap_vfs,$(USEMODULE)))
   USEMODULE += nanocoap_sock
   USEMODULE += vfs

--- a/tests/net/nanocoap_cli/Makefile
+++ b/tests/net/nanocoap_cli/Makefile
@@ -48,6 +48,8 @@ LOW_MEMORY_BOARDS := \
   bluepill-stm32f103c8 \
   derfmega128 \
   im880b \
+  nucleo-f070rb \
+  nucleo-f072rb \
   nucleo-f302r8 \
   saml10-xpro \
   saml11-xpro \
@@ -63,6 +65,7 @@ ifeq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   USEMODULE += nanocoap_dtls
   USEMODULE += prng_sha256prng
 
+  USEMODULE += nanocoap_sock_observe
   USEMODULE += nanocoap_vfs
   USEMODULE += vfs_default
   # USEMODULE += vfs_auto_format


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A new `observe` command was added to `tests/net/nanocoap_cli`:

```
> observe coap://[fe80::d07c:7cff:fe6d:9441]/time
2025-01-23 16:25:24,793 # 00000000  32  37  36  32  30  0A
2025-01-23 16:25:25,175 # 00000000  32  38  30  30  32  0A
2025-01-23 16:25:26,174 # 00000000  32  39  30  30  31  0A
2025-01-23 16:25:27,175 # 00000000  33  30  30  30  31  0A
2025-01-23 16:25:28,175 # 00000000  33  31  30  30  32  0A
2025-01-23 16:25:29,173 # 00000000  33  32  30  30  31  0A
2025-01-23 16:25:30,173 # 00000000  33  33  30  30  31  0A
2025-01-23 16:25:31,175 # 00000000  33  34  30  30  31  0A
2025-01-23 16:25:32,175 # 00000000  33  35  30  30  32  0A
2025-01-23 16:25:33,175 # 00000000  33  36  30  30  32  0A
2025-01-23 16:25:34,173 # 00000000  33  37  30  30  31  0A
2025-01-23 16:25:35,173 # 00000000  33  38  30  30  31  0A

> observe coap://[fe80::d07c:7cff:fe6d:9441]/time off
2025-01-23 16:25:36,148 # gnrc_sock: timeout != 0 within the asynchronous callback lead to unexpected delays within the asynchronous handler.
2025-01-23 16:25:36,148 # 00000000  33  38  39  37  36  0A
> 

```


### Issues/PRs references

based on #21147
