### PR TITLE
makefiles: add `FAST_FLASH` option to speed up flashing

### DIFF
--- a/dist/tools/edbg/edbg.sh
+++ b/dist/tools/edbg/edbg.sh
@@ -18,6 +18,17 @@ do_flash() {
     test_imagefile
 
     # Configure edbg flash flags
+    local _fflags="${EDBG_ARGS} --verbose --file ${IMAGE_FILE}"
+
+    # flash device
+    sh -c "${EDBG} ${_fflags} --program" && echo 'Done flashing'
+}
+
+do_flash_verify() {
+    IMAGE_FILE=$1
+    test_imagefile
+
+    # Configure edbg flash flags
     local _fflags="${EDBG_ARGS} --verbose --file ${IMAGE_FILE} --verify"
 
     # flash device
@@ -36,8 +47,12 @@ shift # pop $1 from $@
 
 case "${ACTION}" in
   flash)
-    echo "### Flashing Target ###"
+    echo "### Flashing Target (quick) ###"
     do_flash "$@"
+    ;;
+  flash_verify)
+    echo "### Flashing Target ###"
+    do_flash_verify "$@"
     ;;
   reset)
     echo "### Resetting Target ###"

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -173,7 +173,11 @@ ifneq (,$(filter uf2conv,$(PROGRAMMER)))
 	sleep $(PREFLASH_DELAY)
   flash: riotboot/flash-slot0-remount
 else
-  FLASHFILE = $(RIOTBOOT_EXTENDED_BIN)
+  ifeq (1, $(FAST_FLASH))
+    FLASHFILE = $(RIOTBOOT_COMBINED_BIN)
+  else
+    FLASHFILE = $(RIOTBOOT_EXTENDED_BIN)
+  endif
 endif
 
 else

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -28,7 +28,11 @@ $(call target-export-variables,$(EDBG_TARGETS),EDBG_ARGS)
 
 # Set flasher and reset for the RIOT build system
 FLASHER ?= $(RIOTTOOLS)/edbg/edbg.sh
-FFLAGS ?= flash $(FLASHFILE)
+ifeq (1, $(FAST_FLASH))
+  FFLAGS ?= flash $(FLASHFILE)
+else
+  FFLAGS ?= flash_verify $(FLASHFILE)
+endif
 
 RESET ?= $(RIOTTOOLS)/edbg/edbg.sh
 RESET_FLAGS ?= reset

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -18,6 +18,10 @@ ifneq (,$(OPENOCD_DEBUG_ADAPTER))
   endif
 endif
 
+ifeq (1, $(FAST_FLASH))
+  OPENOCD_SKIP_VERIFY = 1
+endif
+
 OPENOCD_CONFIG ?= $(BOARDDIR)/dist/openocd.cfg
 
 OPENOCD_TARGETS = debug% flash% reset


### PR DESCRIPTION
 - flash slot0-combined.bin instead of slot0-extended.bin
 - don't read back image after flashing

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When iterating on a firmware long programming times can be quite distracting. Major slowdown come from

 - flashing `slot0-extended.bin` which will overwrite the entire first slot + first few bytes of the 2nd slot. The idea is to clear out the 2nd slot header, so we don't boot that by accident if the version number is higher. But if we flash the firmware onto the same device during development, there is no reason to do this.
 - We read back the firmware from the device twice: Once before flashing to check if we need to flash at all and a 2nd time after flashing to ensure all bytes have been written correctly. But we can just skip that - I've never seen the verify step fail.

We don't want to skip those steps during production though, so keep the default behavior.
But during development, setting `FAST_FLASH=1` will yield a nice speedup.

### Testing procedure

Try it out with `make flash FAST_FLASH=1`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
