### PR TITLE
sys/tiny_strerror: fix compilation with picolibc on Ubuntu

### DIFF
--- a/sys/tiny_strerror/tiny_strerror.c
+++ b/sys/tiny_strerror/tiny_strerror.c
@@ -48,7 +48,9 @@ static FLASH_ATTR const char _edquot[] = "-EDQUOT";
 static FLASH_ATTR const char _eexist[] = "-EEXIST";
 static FLASH_ATTR const char _efault[] = "-EFAULT";
 static FLASH_ATTR const char _efbig[] = "-EFBIG";
+#ifdef EHOSTDOWN /* not part of POSIX and not universally available */
 static FLASH_ATTR const char _ehostdown[] = "-EHOSTDOWN";
+#endif
 static FLASH_ATTR const char _ehostunreach[] = "-EHOSTUNREACH";
 static FLASH_ATTR const char _eidrm[] = "-EIDRM";
 static FLASH_ATTR const char _eilseq[] = "-EILSEQ";
@@ -93,7 +95,9 @@ static FLASH_ATTR const char _enxio[] = "-ENXIO";
 static FLASH_ATTR const char _eoverflow[] = "-EOVERFLOW";
 static FLASH_ATTR const char _eownerdead[] = "-EOWNERDEAD";
 static FLASH_ATTR const char _eperm[] = "-EPERM";
+#ifdef EPFNOSUPPORT /* not part of POSIX and not universally available */
 static FLASH_ATTR const char _epfnosupport[] = "-EPFNOSUPPORT";
+#endif
 static FLASH_ATTR const char _epipe[] = "-EPIPE";
 static FLASH_ATTR const char _eprotonosupport[] = "-EPROTONOSUPPORT";
 static FLASH_ATTR const char _eprototype[] = "-EPROTOTYPE";
@@ -105,7 +109,9 @@ static FLASH_ATTR const char _esrch[] = "-ESRCH";
 static FLASH_ATTR const char _estale[] = "-ESTALE";
 static FLASH_ATTR const char _etimedout[] = "-ETIMEDOUT";
 static FLASH_ATTR const char _etime[] = "-ETIME";
+#ifdef ETOOMANYREFS /* not part of POSIX and not universally available */
 static FLASH_ATTR const char _etoomanyrefs[] = "-ETOOMANYREFS";
+#endif
 static FLASH_ATTR const char _etxtbsy[] = "-ETXTBSY";
 static FLASH_ATTR const char _exdev[] = "-EXDEV";
 /* EAGAIN and EWOULDBLOCK have the exact same meaning and consequently may
@@ -143,7 +149,9 @@ static FLASH_ATTR const char * FLASH_ATTR const lookup[] = {
     [EEXIST]            = _eexist,
     [EFAULT]            = _efault,
     [EFBIG]             = _efbig,
+#ifdef EHOSTDOWN /* not part of POSIX and not universally available */
     [EHOSTDOWN]         = _ehostdown,
+#endif
     [EHOSTUNREACH]      = _ehostunreach,
     [EIDRM]             = _eidrm,
     [EILSEQ]            = _eilseq,
@@ -188,7 +196,9 @@ static FLASH_ATTR const char * FLASH_ATTR const lookup[] = {
     [EOVERFLOW]         = _eoverflow,
     [EOWNERDEAD ]       = _eownerdead,
     [EPERM]             = _eperm,
+#ifdef EPFNOSUPPORT /* not part of POSIX and not universally available */
     [EPFNOSUPPORT]      = _epfnosupport,
+#endif
     [EPIPE]             = _epipe,
     [EPROTONOSUPPORT]   = _eprotonosupport,
     [EPROTOTYPE]        = _eprototype,
@@ -200,7 +210,9 @@ static FLASH_ATTR const char * FLASH_ATTR const lookup[] = {
     [ESTALE]            = _estale,
     [ETIMEDOUT]         = _etimedout,
     [ETIME]             = _etime,
+#ifdef ETOOMANYREFS /* not part of POSIX and not universally available */
     [ETOOMANYREFS]      = _etoomanyrefs,
+#endif
     [ETXTBSY]           = _etxtbsy,
     [EXDEV]             = _exdev,
 #if EAGAIN != EWOULDBLOCK


### PR DESCRIPTION
### Contribution description

The picolibc shipped in Ubuntu does not provided non-POSIX errnos by default. If the errno codes are not provided, we can also not provide corresponding strings.

This guards the effected strings corresponding to non-POSIX errnos behind `#ifdef`, so that they are only provided when the corresponding errno is.

### Testing procedure

```
$ FEATURES_REQUIRED=picolibc make BOARD=nucleo-f767zi -C tests/periph/selftest_shield
```

<details><summary>on Ubuntu with <code>master</code> gives:</summary>

```
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:146:6: error: 'EHOSTDOWN' undeclared here (not in a function); did you mean 'ENETDOWN'?
  146 |     [EHOSTDOWN]         = _ehostdown,
      |      ^~~~~~~~~
      |      ENETDOWN
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:146:6: error: array index in initializer not of integer type
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:146:6: note: (near initialization for 'lookup')
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:176:27: error: initialized field overwritten [-Werror=override-init]
  176 |     [ENOSPC]            = _enospc,
      |                           ^~~~~~~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:176:27: note: (near initialization for 'lookup[28]')
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:191:6: error: 'EPFNOSUPPORT' undeclared here (not in a function); did you mean 'EAFNOSUPPORT'?
  191 |     [EPFNOSUPPORT]      = _epfnosupport,
      |      ^~~~~~~~~~~~
      |      EAFNOSUPPORT
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:191:6: error: array index in initializer not of integer type
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:191:6: note: (near initialization for 'lookup')
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:191:27: error: initialized field overwritten [-Werror=override-init]
  191 |     [EPFNOSUPPORT]      = _epfnosupport,
      |                           ^~~~~~~~~~~~~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:191:27: note: (near initialization for 'lookup[2]')
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:203:6: error: 'ETOOMANYREFS' undeclared here (not in a function)
  203 |     [ETOOMANYREFS]      = _etoomanyrefs,
      |      ^~~~~~~~~~~~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:203:6: error: array index in initializer not of integer type
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:203:6: note: (near initialization for 'lookup')
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:203:27: error: initialized field overwritten [-Werror=override-init]
  203 |     [ETOOMANYREFS]      = _etoomanyrefs,
      |                           ^~~~~~~~~~~~~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror/tiny_strerror.c:203:27: note: (near initialization for 'lookup[63]')
```

</details>

with this PR:

```
...
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tiny_strerror
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  13396	    44	  2400	 15840	  3de0	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/selftest_shield/bin/nucleo-f767zi/tests_selftest_shield.elf
make: Leaving directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/selftest_shield'
```

### Issues/PRs references

None
