### PR TITLE
sys/net/nanocoap: align request handling with spec

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -500,16 +500,40 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
                                                   coap_get_id(pkt));
     }
 
-    if (coap_get_code_class(pkt) != COAP_REQ) {
-        DEBUG("coap_handle_req(): not a request.\n");
+    switch (coap_get_type(pkt)) {
+    case COAP_TYPE_CON:
+    case COAP_TYPE_NON:
+        /* could be a request ==> proceed */
+        break;
+    default:
+        DEBUG_PUTS("coap_handle_req(): ignoring RST/ACK");
         return -EBADMSG;
     }
 
-    if (pkt->hdr->code == 0) {
-        return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
+    if (coap_get_code_class(pkt) != COAP_REQ) {
+        DEBUG_PUTS("coap_handle_req(): not a request --> ignore");
+        return -EBADMSG;
     }
-    return coap_tree_handler(pkt, resp_buf, resp_buf_len, ctx,
-                             coap_resources, coap_resources_numof);
+
+    if (coap_get_code_raw(pkt) == COAP_CODE_EMPTY) {
+        /* we are not able to process a CON/NON message with an empty code,
+         * so we reply with a RST, unless we got a multicast message */
+        if (!sock_udp_ep_is_multicast(coap_request_ctx_get_local_udp(ctx))) {
+            return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
+        }
+    }
+
+    ssize_t retval = coap_tree_handler(pkt, resp_buf, resp_buf_len, ctx,
+                                       coap_resources, coap_resources_numof);
+    if (retval < 0) {
+        /* handlers were not able to process this, so we reply with a RST,
+         * unless we got a multicast message */
+        if (!sock_udp_ep_is_multicast(coap_request_ctx_get_local_udp(ctx))) {
+            return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
+        }
+    }
+
+    return retval;
 }
 
 ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,


### PR DESCRIPTION
### Contribution description

- Do not reply with a reset message to a reset or an ACK message
- Reply with a reset message when not able to process a CON/NON message (not even a suitable error reply)

### Testing procedure

```
$ sudo ip tuntap add tap0 mode tap user $(whoami)
$ sudo ip link set tap0 up
$ make BOARD=native64 -C examples/nanocoap_server -j flash term
```

```
$ cat test.py                     
import socket, aiocoap
m = aiocoap.Message()
m.code = 0
m.mid = 0
m.mtype = aiocoap.RST
s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
s.connect(('fe80::9826:30ff:feb8:31f4', 5683, 0, socket.if_nametoindex('tap0')))
s.send(m.encode())
s.recv(1024)
$ python3 test.py
```

#### With `master`:

```
$ tshark -i tap0 -Y "coap"
Capturing on 'tap0'
    3 0.000397706 fe80::9826:30ff:feb8:31f3 56273 5683 fe80::9826:30ff:feb8:31f4 CoAP 66 RST, MID:0, Empty Message
    4 0.000675868 fe80::9826:30ff:feb8:31f4 5683 56273 fe80::9826:30ff:feb8:31f3 CoAP 66 RST, MID:0, Empty Message
```

Note the RST "reply" to the RST

#### With this PR:

```
$ tshark -i tap0 -Y "coap"
Capturing on 'tap0'
    7 3.994693734 fe80::9826:30ff:feb8:31f3 54684 5683 fe80::9826:30ff:feb8:31f4 CoAP 66 RST, MID:0, Empty Message
```

Note that no RST "reply" is send to the RST

### Issues/PRs references

None