### PR TITLE
LOSTANDFOUND.md: add missing URL, fix Markdown typo [backport 2025.01]

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -287,7 +287,7 @@ Author(s):
 Reason for removal:
 - Hardware not available so can't be tested
 
-### boards/waspmote-pro [2b8a0d48940517f7df4e78c7a0b16024f46a8694]:
+### boards/waspmote-pro [2b8a0d48940517f7df4e78c7a0b16024f46a8694]
 Author(s):
 - Hinnerk van Bruinehsen
 - Kaspar Schleiser <kaspar@schleiser.de>
@@ -302,6 +302,7 @@ therefore, have no interest in supporting this board. As result, none of the
 RIOT core contributors has access to the hardware, preventing us from doing the
 necessary testing for maintaining this board.
 
+[6cad5d24771ba6199228351a11b5062cd2e9b36d]: https://github.com/RIOT-OS/RIOT/commit/6cad5d24771ba6199228351a11b5062cd2e9b36d
 [d83d08f0995a88f399e70a7d07b44dd780082436]: https://github.com/RIOT-OS/RIOT/commit/d83d08f0995a88f399e70a7d07b44dd780082436
 [cdc252ab7bd4161cc046bf93a3e55995704b24d4]: https://github.com/RIOT-OS/RIOT/commit/cdc252ab7bd4161cc046bf93a3e55995704b24d4
 [ed3887ac5c1e95308c2827bce3cdca8b0f146c22]: https://github.com/RIOT-OS/RIOT/commit/ed3887ac5c1e95308c2827bce3cdca8b0f146c22


### PR DESCRIPTION
# Backport of #21154

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In Pull Request #18562, the removal of MIPS support was documented and the headline had the right Commit ID, however the URL was not added to the link section below.

In Pull Request #21146, a `:` was added after the headline, leading to Doxygen not recognizing the link and therefore not applying it.
Unfortunately while this PR was open, I didn't see it in time, so now it has to be fixed afterwards.

I think both PRs are from @MrKevinWeiss, but I don't want to blame him. I fought for hours with the `LOSTANDFOUND.md` to find the bug described in #21106, so I know how easy it is to get Markdown angry :D


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

The documentation should still build and now show the links (they are still broken because of #21106, BUT there should now be `<a href=...` in the headlines.

### Issues/PRs references

Corrects the regressions introduced in #18562 and #21146.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
