### PR TITLE
cpu/sam3: fix PMC enable/disable peripheral clock access

### DIFF
--- a/cpu/sam3/periph/rtt.c
+++ b/cpu/sam3/periph/rtt.c
@@ -88,12 +88,12 @@ void rtt_clear_alarm(void)
 
 void rtt_poweron(void)
 {
-    PMC->PMC_PCER0 |= (1 << ID_RTT);
+    PMC->PMC_PCER0 = (1 << ID_RTT);
 }
 
 void rtt_poweroff(void)
 {
-    PMC->PMC_PCER0 &= ~(1 << ID_RTT);
+    PMC->PMC_PCDR0 = (1 << ID_RTT);
 }
 
 void isr_rtt(void)

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -71,7 +71,7 @@ void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     /* lock bus */
     mutex_lock(&locks[bus]);
     /* enable SPI device clock */
-    PMC->PMC_PCER0 |= (1 << spi_config[bus].id);
+    PMC->PMC_PCER0 = (1 << spi_config[bus].id);
     /* set mode and speed */
     dev(bus)->SPI_CSR[0] = (SPI_CSR_SCBR(CLOCK_CORECLOCK / clk) | mode);
     dev(bus)->SPI_MR = (SPI_MR_MSTR | SPI_MR_MODFDIS);
@@ -82,7 +82,7 @@ void spi_release(spi_t bus)
 {
     /* disable device and turn off clock signal */
     dev(bus)->SPI_CR = 0;
-    PMC->PMC_PCER0 &= ~(1 << spi_config[bus].id);
+    PMC->PMC_PCDR0 = (1 << spi_config[bus].id);
     /* release device lock */
     mutex_unlock(&locks[bus]);
 }

--- a/cpu/sam3/periph/uart.c
+++ b/cpu/sam3/periph/uart.c
@@ -89,12 +89,12 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
 void uart_poweron(uart_t uart)
 {
-    PMC->PMC_PCER0 |= (1 << uart_config[uart].pmc_id);
+    PMC->PMC_PCER0 = (1 << uart_config[uart].pmc_id);
 }
 
 void uart_poweroff(uart_t uart)
 {
-    PMC->PMC_PCER0 &= ~(1 << uart_config[uart].pmc_id);
+    PMC->PMC_PCDR0 = (1 << uart_config[uart].pmc_id);
 }
 
 static inline void isr_handler(int num)


### PR DESCRIPTION
### Contribution description

This PR fixes the access of PMC enable/disable peripheral clock.
`PMC_PCERx` registers are labelled write-only in SAM3/SAM4S datasheet. Thus writing 0 has no effect. This means we cannot use `PCERx` to disable a peripheral clock. Instead one must use `PCEDx` register to properly disable a peripheral clock.

As both registers (enable/disable) are write-only, this PR also drops the read-modify-write for a single write.


### Testing procedure
CI should be enough I guess.


### Issues/PRs references
None
