### PR TITLE
{cpu/sam0_common/sam0_sdhc,drivers/mtd}: do not allocate `work_area` twice

### DIFF
--- a/cpu/sam0_common/sam0_sdhc/mtd_sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/mtd_sdhc.c
@@ -46,9 +46,11 @@ static int _init(mtd_dev_t *dev)
 
 #if IS_USED(MODULE_MTD_WRITE_PAGE)
     /* TODO: move to MTD layer */
-    dev->work_area = malloc(SD_MMC_BLOCK_SIZE);
-    if (dev->work_area == NULL) {
-        return -ENOMEM;
+    if (!dev->work_area) {
+        dev->work_area = malloc(SD_MMC_BLOCK_SIZE);
+        if (dev->work_area == NULL) {
+            return -ENOMEM;
+        }
     }
     dev->write_size = 1;
 #endif

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -76,9 +76,11 @@ int mtd_init(mtd_dev_t *mtd)
 
 #ifdef MODULE_MTD_WRITE_PAGE
     if ((mtd->driver->flags & MTD_DRIVER_FLAG_DIRECT_WRITE) == 0) {
-        mtd->work_area = malloc(mtd->pages_per_sector * mtd->page_size);
-        if (mtd->work_area == NULL) {
-            res = -ENOMEM;
+        if (!mtd->work_area) {
+            mtd->work_area = malloc(mtd->pages_per_sector * mtd->page_size);
+            if (mtd->work_area == NULL) {
+                res = -ENOMEM;
+            }
         }
     }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The MTD `work_area` could be allocated multiple times when MTD is reinitialized.
A check for not `NULL` is added.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Custom board with an eMMC. I can craete a fatfs filesystem on it with:
```Makefile
ifneq (,$(filter mtd,$(USEMODULE)))
  USEMODULE += mtd_write_page
  USEMODULE += mtd_sdmmc_default
  USEMODULE += sdmmc_mmc
endif

ifneq (,$(filter vfs_default,$(USEMODULE)))
  USEMODULE += fatfs_vfs
  USEMODULE += mtd
endif
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
