### PR TITLE
examples: migrate to XFA SHELL_COMMAND

### DIFF
--- a/examples/asymcute_mqttsn/main.c
+++ b/examples/asymcute_mqttsn/main.c
@@ -269,6 +269,8 @@ static int _cmd_connect(int argc, char **argv)
     return _ok(req);
 }
 
+SHELL_COMMAND(connect, "connect to MQTT-SN gateway", _cmd_connect);
+
 static int _cmd_disconnect(int argc, char **argv)
 {
     (void)argc;
@@ -287,6 +289,8 @@ static int _cmd_disconnect(int argc, char **argv)
     }
     return _ok(req);
 }
+
+SHELL_COMMAND(disconnect, "disconnect from MQTT-SN gateway", _cmd_disconnect);
 
 static int _cmd_reg(int argc, char **argv)
 {
@@ -330,6 +334,8 @@ static int _cmd_reg(int argc, char **argv)
     return _ok(req);
 }
 
+SHELL_COMMAND(reg, "register a given topic", _cmd_reg);
+
 static int _cmd_unreg(int argc, char **argv)
 {
     if (argc < 2) {
@@ -354,6 +360,8 @@ static int _cmd_unreg(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(unreg, "remove a topic registration [locally]", _cmd_unreg);
 
 static int _cmd_pub(int argc, char **argv)
 {
@@ -398,6 +406,8 @@ static int _cmd_pub(int argc, char **argv)
     }
     return _ok(req);
 }
+
+SHELL_COMMAND(pub, "publish data", _cmd_pub);
 
 static int _cmd_sub(int argc, char **argv)
 {
@@ -469,6 +479,8 @@ static int _cmd_sub(int argc, char **argv)
     return _ok(req);
 }
 
+SHELL_COMMAND(sub, "subscribe to topic", _cmd_sub);
+
 static int _cmd_unsub(int argc, char **argv)
 {
     if (argc < 2) {
@@ -498,6 +510,8 @@ static int _cmd_unsub(int argc, char **argv)
 
     return _ok(req);
 }
+
+SHELL_COMMAND(unsub, "unsubscribe from topic", _cmd_unsub);
 
 static int _cmd_info(int argc, char **argv)
 {
@@ -536,17 +550,7 @@ static int _cmd_info(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "connect", "connect to MQTT-SN gateway", _cmd_connect },
-    { "disconnect", "disconnect from MQTT-SN gateway", _cmd_disconnect },
-    { "reg", "register a given topic", _cmd_reg },
-    { "unreg", "remove a topic registration [locally]", _cmd_unreg },
-    { "pub", "publish data", _cmd_pub },
-    { "sub", "subscribe to topic", _cmd_sub },
-    { "unsub", "unsubscribe from topic", _cmd_unsub },
-    { "info", "print state information", _cmd_info },
-    { NULL, NULL, NULL },
-};
+SHELL_COMMAND(info, "print state information", _cmd_info);
 
 int main(void)
 {
@@ -559,7 +563,7 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     /* start shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/cord_lc/cord_lc_cli.c
+++ b/examples/cord_lc/cord_lc_cli.c
@@ -26,6 +26,7 @@
 #include "net/gnrc/netif.h"
 #include "net/gcoap.h"
 #include "net/sock/util.h"
+#include "shell.h"
 
 static cord_lc_rd_t rd;
 static sock_udp_ep_t remote;
@@ -91,7 +92,7 @@ static void _print_usage(void) {
          "example: cord_lc [2001:db8:3::dead:beef]:5683 endpoint");
 }
 
-int cord_lc_cli_cmd(int argc, char **argv) {
+static int _cli_cmd(int argc, char **argv) {
     char bufpool[1024] = {0};
     int raw_mode = 0;
 
@@ -175,3 +176,5 @@ int cord_lc_cli_cmd(int argc, char **argv) {
     }
     return 0;
 }
+
+SHELL_COMMAND(cord_lc, "Cord LC example", _cli_cmd);

--- a/examples/cord_lc/main.c
+++ b/examples/cord_lc/main.c
@@ -26,13 +26,6 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern int cord_lc_cli_cmd(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "cord_lc", "Cord LC example", cord_lc_cli_cmd },
-    { NULL, NULL, NULL },
-};
-
 int main(void)
 {
     /* we need a message queue for the thread running the shell in order to
@@ -41,7 +34,7 @@ int main(void)
 
     puts("CoRE RD lookup client example!\n");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -28,6 +28,7 @@
 #include "timex.h"
 #include "net/gnrc/netif.h"
 #include "net/sock/udp.h"
+#include "shell.h"
 #include "tinydtls_keys.h"
 
 /* TinyDTLS */
@@ -485,7 +486,7 @@ static void client_send(char *addr_str, char *data)
     return;
 }
 
-int udp_client_cmd(int argc, char **argv)
+static int _client_cmd(int argc, char **argv)
 {
     if (argc != 3) {
         printf("usage: %s <addr> <data> \n", argv[0]);
@@ -495,3 +496,5 @@ int udp_client_cmd(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(dtlsc, "Start a DTLS client", _client_cmd);

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -28,6 +28,7 @@
 
 #include "net/sock/udp.h"
 #include "msg.h"
+#include "shell.h"
 #include "timex.h"
 #include "tinydtls_keys.h"
 
@@ -419,7 +420,7 @@ static void stop_server(void)
     puts("Success: DTLS server stopped");
 }
 
-int udp_server_cmd(int argc, char **argv)
+static int _server_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         printf("usage: %s start|stop\n", argv[0]);
@@ -436,3 +437,5 @@ int udp_server_cmd(int argc, char **argv)
     }
     return 0;
 }
+
+SHELL_COMMAND(dtlss, "Start and stop a DTLS server", _server_cmd);

--- a/examples/dtls-echo/main.c
+++ b/examples/dtls-echo/main.c
@@ -34,15 +34,6 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern int udp_client_cmd(int argc, char **argv);
-extern int udp_server_cmd(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "dtlsc", "Start a DTLS client", udp_client_cmd },
-    { "dtlss", "Start and stop a DTLS server", udp_server_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* we need a message queue for the thread running the shell in order to
@@ -56,7 +47,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -28,6 +28,7 @@
 #include "net/credman.h"
 #include "net/sock/util.h"
 #include "net/utils.h"
+#include "shell.h"
 
 #include "dtls_client_credentials.h"
 
@@ -235,7 +236,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     return 0;
 }
 
-int dtls_client_cmd(int argc, char **argv)
+static int _client_cmd(int argc, char **argv)
 {
     if (argc != 3) {
         printf("usage %s <addr> <data>\n", argv[0]);
@@ -252,3 +253,5 @@ int dtls_client_cmd(int argc, char **argv)
 
     return client_send(argv[1], argv[2], strlen(argv[2]));
 }
+
+SHELL_COMMAND(dtlsc, "Start a DTLS client", _client_cmd);

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -25,6 +25,7 @@
 #include "net/sock/util.h"
 #include "net/credman.h"
 #include "msg.h"
+#include "shell.h"
 #include "thread.h"
 #include "timex.h"
 
@@ -283,7 +284,7 @@ void _print_usage(const char *cmd)
     }
 }
 
-int dtls_server_cmd(int argc, char **argv)
+static int _server_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         _print_usage(argv[0]);
@@ -326,3 +327,5 @@ int dtls_server_cmd(int argc, char **argv)
     }
     return 0;
 }
+
+SHELL_COMMAND(dtlss, "Start and stop a DTLS server", _server_cmd);

--- a/examples/dtls-sock/main.c
+++ b/examples/dtls-sock/main.c
@@ -20,15 +20,6 @@
 
 #include "shell.h"
 
-extern int dtls_client_cmd(int argc, char **argv);
-extern int dtls_server_cmd(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "dtlsc", "Start a DTLS client", dtls_client_cmd },
-    { "dtlss", "Start and stop a DTLS server", dtls_server_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     puts("DTLS sock example application");
@@ -36,7 +27,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should never be reached */
     return 0;

--- a/examples/dtls-wolfssl/dtls-client.c
+++ b/examples/dtls-wolfssl/dtls-client.c
@@ -28,6 +28,7 @@
 
 #include "net/gnrc/netif.h"
 #include "log.h"
+#include "shell.h"
 
 #define SERVER_PORT 11111
 #define APP_DTLS_BUF_SIZE 64
@@ -83,7 +84,7 @@ static inline unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
 }
 #endif
 
-int dtls_client(int argc, char **argv)
+static int _client_cmd(int argc, char **argv)
 {
     int ret = 0;
     char buf[APP_DTLS_BUF_SIZE] = "Hello from DTLS client!";
@@ -191,3 +192,5 @@ int dtls_client(int argc, char **argv)
     sock_dtls_close(sk);
     return 0;
 }
+
+SHELL_COMMAND(dtlsc, "Start a DTLS client", _client_cmd);

--- a/examples/dtls-wolfssl/dtls-server.c
+++ b/examples/dtls-wolfssl/dtls-server.c
@@ -29,6 +29,7 @@
 #include <string.h>
 
 #include "log.h"
+#include "shell.h"
 
 #define SERVER_PORT 11111
 #define DEBUG 1
@@ -83,7 +84,7 @@ static inline unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
 
 #define APP_DTLS_BUF_SIZE 64
 
-int dtls_server(int argc, char **argv)
+static int _server_cmd(int argc, char **argv)
 {
     char buf[APP_DTLS_BUF_SIZE];
     int ret;
@@ -160,3 +161,5 @@ int dtls_server(int argc, char **argv)
     }
     return 0;
 }
+
+SHELL_COMMAND(dtlss, "Start and stop a DTLS server", _server_cmd);

--- a/examples/dtls-wolfssl/main.c
+++ b/examples/dtls-wolfssl/main.c
@@ -44,16 +44,8 @@ static int wolftest(int argc, char **argv)
     wolfcrypt_test(NULL);
     return 0;
 }
+SHELL_COMMAND(wolftest, "Perform wolfcrypt porting test", wolftest);
 #endif
-
-static const shell_command_t shell_commands[] = {
-    { "dtlsc", "Start a DTLS client", dtls_client },
-    { "dtlss", "Start and stop a DTLS server", dtls_server },
-#ifdef MODULE_WOLFCRYPT_TEST
-    { "wolftest", "Perform wolfcrypt porting test", wolftest },
-#endif
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
@@ -67,7 +59,7 @@ int main(void)
     /* start shell */
     LOG(LOG_INFO, "All up, running the shell now\n");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/emcute_mqttsn/main.c
+++ b/examples/emcute_mqttsn/main.c
@@ -110,6 +110,8 @@ static int cmd_con(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(con, "connect to MQTT broker", cmd_con);
+
 static int cmd_discon(int argc, char **argv)
 {
     (void)argc;
@@ -127,6 +129,8 @@ static int cmd_discon(int argc, char **argv)
     puts("Disconnect successful");
     return 0;
 }
+
+SHELL_COMMAND(discon, "disconnect from the current broker", cmd_discon);
 
 static int cmd_pub(int argc, char **argv)
 {
@@ -165,6 +169,8 @@ static int cmd_pub(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(pub, "publish something", cmd_pub);
+
 static int cmd_sub(int argc, char **argv)
 {
     unsigned flags = EMCUTE_QOS_0;
@@ -202,6 +208,8 @@ static int cmd_sub(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(sub, "subscribe topic", cmd_sub);
+
 static int cmd_unsub(int argc, char **argv)
 {
     if (argc < 2) {
@@ -228,6 +236,8 @@ static int cmd_unsub(int argc, char **argv)
     return 1;
 }
 
+SHELL_COMMAND(unsub, "unsubscribe from topic", cmd_unsub);
+
 static int cmd_will(int argc, char **argv)
 {
     if (argc < 3) {
@@ -248,15 +258,7 @@ static int cmd_will(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "con", "connect to MQTT broker", cmd_con },
-    { "discon", "disconnect from the current broker", cmd_discon },
-    { "pub", "publish something", cmd_pub },
-    { "sub", "subscribe topic", cmd_sub },
-    { "unsub", "unsubscribe from topic", cmd_unsub },
-    { "will", "register a last will", cmd_will },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(will, "register a last will", cmd_will);
 
 int main(void)
 {
@@ -276,7 +278,7 @@ int main(void)
 
     /* start shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -91,11 +91,8 @@ static int _tee(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "cat", "print the content of a file", _cat },
-    { "tee", "write a string in a file", _tee },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(cat, "print the content of a file", _cat);
+SHELL_COMMAND(tee, "write a string in a file", _tee);
 
 /* constfs example */
 #include "fs/constfs.h"
@@ -142,7 +139,7 @@ int main(void)
     }
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/examples/gcoap/client.c
+++ b/examples/gcoap/client.c
@@ -31,6 +31,7 @@
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
 #include "od.h"
+#include "shell.h"
 #include "uri_parser.h"
 
 #include "gcoap_example.h"
@@ -229,7 +230,7 @@ static int _uristr2remote(const char *uri, sock_udp_ep_t *remote, const char **p
     return 0;
 }
 
-int gcoap_cli_cmd(int argc, char **argv)
+static int _cli_cmd(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
     char *method_codes[] = {"ping", "get", "post", "put"};
@@ -397,3 +398,5 @@ int gcoap_cli_cmd(int argc, char **argv)
 help:
     return _print_usage(argv);
 }
+
+SHELL_COMMAND(coap, "CoAP example", _cli_cmd);

--- a/examples/gcoap/gcoap_example.h
+++ b/examples/gcoap/gcoap_example.h
@@ -36,14 +36,6 @@ extern "C" {
 extern uint16_t req_count;  /**< Counts requests sent by CLI. */
 
 /**
- * @brief   Shell interface exposing the client side features of gcoap
- * @param   argc    Number of shell arguments (including shell command name)
- * @param   argv    Shell argument values (including shell command name)
- * @return  Exit status of the shell command
- */
-int gcoap_cli_cmd(int argc, char **argv);
-
-/**
  * @brief   Registers the CoAP resources exposed in the example app
  *
  * Run this exactly one during startup.

--- a/examples/gcoap/main.c
+++ b/examples/gcoap/main.c
@@ -29,11 +29,6 @@
 #define MAIN_QUEUE_SIZE (4)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-static const shell_command_t shell_commands[] = {
-    { "coap", "CoAP example", gcoap_cli_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* for the thread running the shell */
@@ -44,7 +39,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should never be reached */
     return 0;

--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -32,6 +32,7 @@
 #include "net/utils.h"
 #include "od.h"
 #include "periph/rtc.h"
+#include "shell.h"
 #include "time_units.h"
 
 #include "gcoap_example.h"

--- a/examples/gcoap_block_server/gcoap_block.c
+++ b/examples/gcoap_block_server/gcoap_block.c
@@ -24,6 +24,7 @@
 #include "fmt.h"
 #include "hashes/sha256.h"
 #include "net/gcoap.h"
+#include "shell.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -135,7 +136,7 @@ static ssize_t _sha256_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_r
     return pdu_len;
 }
 
-int gcoap_cli_cmd(int argc, char **argv)
+static int _cli_cmd(int argc, char **argv)
 {
     if (argc == 1) {
         /* show help for main commands */
@@ -154,6 +155,8 @@ int gcoap_cli_cmd(int argc, char **argv)
     printf("usage: %s <info>\n", argv[0]);
     return 1;
 }
+
+SHELL_COMMAND(coap, "CoAP example", _cli_cmd);
 
 void gcoap_cli_init(void)
 {

--- a/examples/gcoap_block_server/main.c
+++ b/examples/gcoap_block_server/main.c
@@ -27,13 +27,7 @@
 #define MAIN_QUEUE_SIZE (4)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern int gcoap_cli_cmd(int argc, char **argv);
 extern void gcoap_cli_init(void);
-
-static const shell_command_t shell_commands[] = {
-    { "coap", "CoAP example", gcoap_cli_cmd },
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
@@ -45,7 +39,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should never be reached */
     return 0;

--- a/examples/gnrc_networking_mac/mac.c
+++ b/examples/gnrc_networking_mac/mac.c
@@ -23,8 +23,9 @@
 
 #include "net/gnrc.h"
 #include "net/gnrc/mac/types.h"
+#include "shell.h"
 
-int mac_cmd(int argc, char **argv)
+static int _mac_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         printf("usage: %s duty\n", argv[0]);
@@ -50,3 +51,5 @@ int mac_cmd(int argc, char **argv)
     }
     return 0;
 }
+
+SHELL_COMMAND(mac, "get MAC protocol's internal information", _mac_cmd);

--- a/examples/gnrc_networking_mac/main.c
+++ b/examples/gnrc_networking_mac/main.c
@@ -28,15 +28,6 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern int udp_cmd(int argc, char **argv);
-extern int mac_cmd(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "udp", "send data over UDP and listen on UDP ports", udp_cmd },
-    { "mac", "get MAC protocol's internal information", mac_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* we need a message queue for the thread running the shell in order to
@@ -47,7 +38,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/gnrc_networking_mac/udp.c
+++ b/examples/gnrc_networking_mac/udp.c
@@ -28,6 +28,7 @@
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/udp.h"
 #include "net/gnrc/pktdump.h"
+#include "shell.h"
 #include "timex.h"
 #include "utlist.h"
 #include "xtimer.h"
@@ -149,7 +150,7 @@ static void stop_server(void)
     puts("Success: stopped UDP server");
 }
 
-int udp_cmd(int argc, char **argv)
+static int _udp_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         printf("usage: %s [send|server]\n", argv[0]);
@@ -196,3 +197,5 @@ int udp_cmd(int argc, char **argv)
     }
     return 0;
 }
+
+SHELL_COMMAND(udp, "send data over UDP and listen on UDP ports", _udp_cmd);

--- a/examples/leds_shell/main.c
+++ b/examples/leds_shell/main.c
@@ -25,7 +25,7 @@
 #include "led.h"
 #include <periph/gpio.h>
 
-static int gpio_command(int argc, char **argv)
+static int _gpio_cmd(int argc, char **argv)
 {
     if (argc < 4) {
         printf("usage: %s <init/set/clear> <port no.> <pin no.>\n", argv[0]);
@@ -64,7 +64,9 @@ static int gpio_command(int argc, char **argv)
     return 0;
 }
 
-static int led_command(int argc, char **argv)
+SHELL_COMMAND(gpio, "GPIO pin initialization and set port state HIGH/LOW", _gpio_cmd);
+
+static int _led_cmd(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <id> <on|off|toggle>\n", argv[0]);
@@ -94,18 +96,14 @@ static int led_command(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t commands[] = {
-    { "gpio", "GPIO pin initialization and set port state HIGH/LOW", gpio_command },
-    { "led", "Switch on/off or toggle on-board LEDs", led_command},
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(led, "Switch on/off or toggle on-board LEDs", _led_cmd);
 
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     printf("This board has %d LEDs\n", LED_NUMOF);
 
-    shell_run(commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/examples/lwm2m/lwm2m_cli.c
+++ b/examples/lwm2m/lwm2m_cli.c
@@ -22,6 +22,8 @@
 #include "lwm2m_client_objects.h"
 #include "lwm2m_platform.h"
 
+#include "shell.h"
+
 #include "objects/common.h"
 #include "objects/device.h"
 #include "objects/security.h"
@@ -159,7 +161,7 @@ static int _parse_lwm2m_light_cmd(int argc, char **argv)
     return 0;
 }
 
-int lwm2m_cli_cmd(int argc, char **argv)
+static int _cli_cmd(int argc, char **argv)
 {
     if (argc == 1) {
         goto help_error;
@@ -192,3 +194,5 @@ help_error:
 
     return 1;
 }
+
+SHELL_COMMAND(lwm2m, "Start LwM2M client", _cli_cmd);

--- a/examples/lwm2m/main.c
+++ b/examples/lwm2m/main.c
@@ -31,11 +31,6 @@
 static msg_t _shell_queue[SHELL_QUEUE_SIZE];
 
 extern void lwm2m_cli_init(void);
-extern int lwm2m_cli_cmd(int argc, char **argv);
-static const shell_command_t my_commands[] = {
-    { "lwm2m", "Start LwM2M client", lwm2m_cli_cmd },
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
@@ -44,7 +39,7 @@ int main(void)
 
     msg_init_queue(_shell_queue, SHELL_QUEUE_SIZE);
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(my_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/examples/nimble_scanner/main.c
+++ b/examples/nimble_scanner/main.c
@@ -60,10 +60,7 @@ int _cmd_scan(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t _commands[] = {
-    { "scan", "trigger a BLE scan", _cmd_scan },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(scan, "trigger a BLE scan", _cmd_scan);
 
 int main(void)
 {
@@ -88,7 +85,7 @@ int main(void)
 
     /* start shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/examples/paho-mqtt/main.c
+++ b/examples/paho-mqtt/main.c
@@ -112,6 +112,8 @@ static int _cmd_discon(int argc, char **argv)
     return res;
 }
 
+SHELL_COMMAND(discon, "disconnect from the current broker", _cmd_discon);
+
 static int _cmd_con(int argc, char **argv)
 {
     if (argc < 2) {
@@ -189,6 +191,8 @@ static int _cmd_con(int argc, char **argv)
     return (ret > 0) ? 0 : 1;
 }
 
+SHELL_COMMAND(con, "connect to MQTT broker", _cmd_con);
+
 static int _cmd_pub(int argc, char **argv)
 {
     enum QoS qos = QOS0;
@@ -219,6 +223,8 @@ static int _cmd_pub(int argc, char **argv)
 
     return rc;
 }
+
+SHELL_COMMAND(pub, "publish something", _cmd_pub);
 
 static int _cmd_sub(int argc, char **argv)
 {
@@ -261,6 +267,8 @@ static int _cmd_sub(int argc, char **argv)
     return ret;
 }
 
+SHELL_COMMAND(sub, "subscribe topic", _cmd_sub);
+
 static int _cmd_unsub(int argc, char **argv)
 {
     if (argc < 2) {
@@ -281,15 +289,7 @@ static int _cmd_unsub(int argc, char **argv)
     return ret;
 }
 
-static const shell_command_t shell_commands[] =
-{
-    { "con",    "connect to MQTT broker",             _cmd_con    },
-    { "discon", "disconnect from the current broker", _cmd_discon },
-    { "pub",    "publish something",                  _cmd_pub    },
-    { "sub",    "subscribe topic",                    _cmd_sub    },
-    { "unsub",  "unsubscribe from topic",             _cmd_unsub  },
-    { NULL,     NULL,                                 NULL        }
-};
+SHELL_COMMAND(unsub, "unsubscribe from topic", _cmd_unsub);
 
 static unsigned char buf[BUF_SIZE];
 static unsigned char readbuf[BUF_SIZE];
@@ -314,6 +314,6 @@ int main(void)
     MQTTStartTask(&client);
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }

--- a/examples/posix_sockets/main.c
+++ b/examples/posix_sockets/main.c
@@ -26,13 +26,6 @@
 #define MAIN_MSG_QUEUE_SIZE (4)
 static msg_t main_msg_queue[MAIN_MSG_QUEUE_SIZE];
 
-extern int udp_cmd(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "udp", "send data over UDP and listen on UDP ports", udp_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* a sendto() call performs an implicit bind(), hence, a message queue is
@@ -42,7 +35,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/examples/posix_sockets/udp.c
+++ b/examples/posix_sockets/udp.c
@@ -38,6 +38,7 @@
 #include "net/netif.h"         /* for resolving ipv6 scope */
 #endif /* SOCK_HAS_IPV6 */
 
+#include "shell.h"
 #include "thread.h"
 
 #define SERVER_MSG_QUEUE_SIZE   (8)
@@ -163,7 +164,7 @@ static int udp_start_server(char *port_str)
     return 0;
 }
 
-int udp_cmd(int argc, char **argv)
+static int _udp_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         printf("usage: %s [send|server]\n", argv[0]);
@@ -208,5 +209,7 @@ int udp_cmd(int argc, char **argv)
         return 1;
     }
 }
+
+SHELL_COMMAND(udp, "send data over UDP and listen on UDP ports", _udp_cmd);
 
 /** @} */

--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -88,6 +88,8 @@ static int cmd_print_riotboot_hdr(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(riotboot_hdr, "Print current slot header", cmd_print_riotboot_hdr);
+
 static int cmd_print_current_slot(int argc, char **argv)
 {
     (void)argc;
@@ -101,6 +103,9 @@ static int cmd_print_current_slot(int argc, char **argv)
     irq_restore(state);
     return 0;
 }
+
+SHELL_COMMAND(current_slot, "Print current slot number", cmd_print_current_slot);
+
 #endif
 
 static int cmd_print_slot_content(int argc, char **argv)
@@ -141,6 +146,8 @@ static int cmd_print_slot_content(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(storage_content, "Print the slot content", cmd_print_slot_content);
+
 static int cmd_lsstorage(int argc, char **argv)
 {
     (void)argc;
@@ -165,15 +172,7 @@ static int cmd_lsstorage(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
-    { "current-slot", "Print current slot number", cmd_print_current_slot },
-    { "riotboot-hdr", "Print current slot header", cmd_print_riotboot_hdr },
-#endif
-    { "storage_content", "Print the slot content", cmd_print_slot_content },
-    { "lsstorage", "Print the available storage paths", cmd_lsstorage },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(lsstorage, "Print the available storage paths", cmd_lsstorage);
 
 int main(void)
 {
@@ -197,7 +196,7 @@ int main(void)
 
     puts("Starting the shell");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/examples/suit_update/tests-with-config/01-run.py
+++ b/examples/suit_update/tests-with-config/01-run.py
@@ -172,7 +172,7 @@ def seq_no(child):
 def running_slot(child):
     utils.test_utils_interactive_sync_shell(child, 5, 1)
 
-    child.sendline("current-slot")
+    child.sendline("current_slot")
     child.expect(r"Running from slot (\d+)\r\n")
     slot = int(child.match.group(1))
     return slot

--- a/examples/twr_aloha/main.c
+++ b/examples/twr_aloha/main.c
@@ -23,21 +23,12 @@
 
 #include "control.h"
 
-extern int _twr_handler(int argc, char **argv);
-extern int _twr_ifconfig(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "twr", "Two-way-ranging (TWR) cli", _twr_handler },
-    { "ifconfig", "Network interface information", _twr_ifconfig},
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* this should start ranging... */
     uwb_core_rng_init();
     /* define buffer to be used by the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 1;
 }

--- a/examples/twr_aloha/twr_shell.c
+++ b/examples/twr_aloha/twr_shell.c
@@ -42,7 +42,7 @@
 #define DW1000_TX_POWER_COARSE_STEP         (30)        /* 3dbM * 10 */
 #define DW1000_TX_POWER_FINE_STEP           (5)         /* 0.5dbM * 10 */
 
-int _twr_ifconfig(int argc, char **argv)
+static int _twr_ifconfig(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -78,6 +78,8 @@ int _twr_ifconfig(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(ifconfig, "Network interface information", _twr_ifconfig);
+
 static void _print_usage(void)
 {
     puts("Usage:");
@@ -92,7 +94,7 @@ static void _print_usage(void)
     puts("\ttwr lst off: stop listening for ranging requests");
 }
 
-int _twr_handler(int argc, char **argv)
+static int _twr_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _print_usage();
@@ -218,3 +220,5 @@ int _twr_handler(int argc, char **argv)
     _print_usage();
     return -1;
 }
+
+SHELL_COMMAND(twr, "Two-way-ranging (TWR) cli", _twr_handler);


### PR DESCRIPTION
### Contribution description

Migrate all remaining examples to using the XFA SHELL_COMMAND instead of the statically allocated list (often with `extern` function declarations) in `main.c`.


### Testing procedure

CI should find bugs.
