### PR TITLE
cpu/sam0_eth: fix hang with broken PHY

### DIFF
--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -134,7 +134,7 @@ unsigned sam0_read_phy(uint8_t phy, uint8_t addr)
     /* Wait for operation completion */
     while (!(GMAC->NSR.reg & GMAC_NSR_IDLE)) {}
     /* return content of shift register */
-    return (GMAC->MAN.reg & GMAC_MAN_DATA_Msk);
+    return GMAC->MAN.reg & GMAC_MAN_DATA_Msk;
 }
 
 void sam0_write_phy(uint8_t phy, uint8_t addr, uint16_t data)
@@ -158,8 +158,14 @@ void sam0_eth_poweron(void)
 
     /* enable PHY */
     gpio_set(sam_gmac_config[0].rst_pin);
-    _is_sleeping = false;
 
+    /* if the PHY is not idle, it's likely broken */
+    if (!(GMAC->NSR.reg & GMAC_NSR_IDLE)) {
+        DEBUG_PUTS("sam0_eth: PHY not IDLE, likely broken.");
+        return;
+    }
+
+    _is_sleeping = false;
     while (MII_BMCR_RESET & sam0_read_phy(0, MII_BMCR)) {}
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

On boards with a broken PHY the init will hang indefinitely.
This is not very nice and makes it hard to tell what's wrong - instead, bail out early if the PHY does not become IDLE at all.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
