### PR TITLE
tests/drivers/candev: minor cleanup

### DIFF
--- a/tests/drivers/candev/Makefile
+++ b/tests/drivers/candev/Makefile
@@ -6,6 +6,11 @@ USEMODULE += shell
 USEMODULE += can
 USEMODULE += isrpipe
 
+# The number of the CAN bus to use can be controlled via environment
+# variable CAN_DEV:
+CAN_DEV ?= 0
+CFLAGS += -DCONFIG_CAN_DEV=$(CAN_DEV)
+
 include $(RIOTBASE)/Makefile.include
 
 # Loop delay


### PR DESCRIPTION
### Contribution description

- Do not hard code the number of the CAN interface to use. (This also allows specifying it via make command line / environment variable.)
- Make less use of preprocessor and rely on compiler to eliminate dead branches and unused variables.

### Testing procedure

The test should behave as before. (Unless one would pass e.g. `CAN_DEV=1`, in which case the 2nd CAN interface would be used instead of the first.)

### Issues/PRs references

None