### PR TITLE
cpu/sam3: fix hwrng peripheral register access

### DIFF
--- a/cpu/sam3/periph/hwrng.c
+++ b/cpu/sam3/periph/hwrng.c
@@ -39,9 +39,9 @@ void hwrng_read(void *buf, unsigned int num)
     uint8_t *b = (uint8_t *)buf;
 
     /* enable clock signal for TRNG module */
-    PMC->PMC_PCER1 |= PMC_PCER1_PID41;
+    PMC->PMC_PCER1 = PMC_PCER1_PID41;
     /* enable the generation of random numbers */
-    TRNG->TRNG_CR |= (KEY | TRNG_CR_ENABLE);
+    TRNG->TRNG_CR = (KEY | TRNG_CR_ENABLE);
 
     while (count < num) {
         /* wait until new value is generated -> takes up to 84 cycles */
@@ -56,7 +56,7 @@ void hwrng_read(void *buf, unsigned int num)
     }
 
     /* disable the generation of random numbers */
-    TRNG->TRNG_CR &= ~(KEY | TRNG_CR_ENABLE);
+    TRNG->TRNG_CR = KEY;
     /* disable clock signal for TRNG module */
-    PMC->PMC_PCER1 &= ~(PMC_PCER1_PID41);
+    PMC->PMC_PCDR1 = PMC_PCER1_PID41;
 }


### PR DESCRIPTION
### Contribution description

This PR fixes the access of PMC enable/disable clock for `hwrng` peripheral.
It looks like I missed this one while doing #21168 

While at it, I also fixes the accesses of `CR` register.
Read-modify-write is useless for this register as there is no other bits available for this register.
In addition, the previous way to disable the hwrng through `CR` register was also broken.
Only the ENABLE bit must be set to 0, not the KEY mask. If the KEY mask written is incorrect, the write access will be ignored by the MCU.

![Copie d'écran_20250130_211254](https://github.com/user-attachments/assets/1c1026c1-6ee0-4ce8-b0c6-c359c0fe9cff)


For the record here is the log of `tests/periph/hwrng` on `arduino-due` board with this PR:

```
2025-01-30 20:54:14,475 # Help: Press s to start test, r to print it is ready
s
2025-01-30 20:54:21,283 # START
2025-01-30 20:54:21,287 # main(): This is RIOT! (Version: 2025.04-devel-52-g529a1)
2025-01-30 20:54:21,287 # 
2025-01-30 20:54:21,290 # HWRNG peripheral driver test
2025-01-30 20:54:21,291 # 
2025-01-30 20:54:21,295 # This test will print from 1 to 20 random bytes about every second
2025-01-30 20:54:21,295 # 
2025-01-30 20:54:21,299 # generating 1 random byte(s)
2025-01-30 20:54:21,300 # Got: 0xa9
2025-01-30 20:54:21,301 # generating 2 random byte(s)
2025-01-30 20:54:21,303 # Got: 0xa5 0x0f
2025-01-30 20:54:21,304 # generating 3 random byte(s)
2025-01-30 20:54:21,307 # Got: 0x3a 0xf5 0xc7
2025-01-30 20:54:21,308 # generating 4 random byte(s)
2025-01-30 20:54:21,311 # Got: 0xa0 0x48 0x05 0x1f
2025-01-30 20:54:21,312 # generating 5 random byte(s)
2025-01-30 20:54:21,316 # Got: 0xfa 0xf2 0xa3 0x7e 0x23
2025-01-30 20:54:21,319 # generating 6 random byte(s)
2025-01-30 20:54:21,321 # Got: 0x60 0xbd 0x5d 0x19 0x28 0xb6
2025-01-30 20:54:21,323 # generating 7 random byte(s)
2025-01-30 20:54:21,327 # Got: 0x9c 0xe0 0xd0 0x6f 0xb7 0x98 0x0e
2025-01-30 20:54:21,328 # generating 8 random byte(s)
2025-01-30 20:54:21,332 # Got: 0x0f 0xbf 0xf3 0x6d 0x6f 0x60 0x57 0x89
2025-01-30 20:54:21,336 # generating 9 random byte(s)
2025-01-30 20:54:21,340 # Got: 0xd3 0xa8 0x6c 0x32 0x09 0x30 0x26 0xfe 0x2a
2025-01-30 20:54:21,344 # generating 10 random byte(s)
2025-01-30 20:54:21,348 # Got: 0xc7 0x60 0x8f 0xd9 0x9b 0x43 0xde 0x94 0x60 0x4c
2025-01-30 20:54:21,349 # generating 11 random byte(s)
2025-01-30 20:54:21,356 # Got: 0x42 0xfd 0x8b 0x95 0xa4 0x8f 0xb3 0xa0 0xd1 0xfe 0xfc
2025-01-30 20:54:21,357 # generating 12 random byte(s)
2025-01-30 20:54:21,364 # Got: 0x2c 0xe7 0xe6 0x0b 0x32 0xef 0x1f 0x2a 0xdd 0x5a 0x8f 0xaa
2025-01-30 20:54:21,364 # generating 13 random byte(s)
2025-01-30 20:54:21,372 # Got: 0x2e 0x06 0x5a 0x8d 0xfa 0x3b 0x3e 0x2f 0x6f 0x58 0x25 0xf7 0x6b
2025-01-30 20:54:21,373 # generating 14 random byte(s)
2025-01-30 20:54:21,380 # Got: 0xb8 0x89 0x4a 0x2d 0xda 0xed 0x90 0x65 0xed 0xbd 0x32 0xec 0x79 0x1f
2025-01-30 20:54:21,381 # generating 15 random byte(s)
2025-01-30 20:54:21,389 # Got: 0xad 0x28 0xfb 0xe1 0x44 0x3c 0xb0 0x7c 0x80 0x27 0xbd 0xfb 0x92 0x83 0xbf
2025-01-30 20:54:21,393 # generating 16 random byte(s)
2025-01-30 20:54:21,401 # Got: 0x53 0x57 0x66 0xfa 0xa5 0x96 0x30 0x75 0xc9 0xed 0x4e 0xf5 0x12 0xdf 0xae 0xf3
2025-01-30 20:54:21,402 # generating 17 random byte(s)
2025-01-30 20:54:21,410 # Got: 0x60 0x12 0xb8 0x71 0xf4 0x86 0xfe 0xb6 0x46 0x07 0x4e 0xfc 0x61 0x70 0x3f 0x5c 0x61
2025-01-30 20:54:21,413 # generating 18 random byte(s)
2025-01-30 20:54:21,422 # Got: 0xec 0x65 0xeb 0x17 0x3d 0x13 0x4a 0x9f 0x0d 0x68 0xfd 0x6e 0x05 0xa1 0x54 0xfe 0x63 0xde
2025-01-30 20:54:21,424 # generating 19 random byte(s)
2025-01-30 20:54:21,434 # Got: 0x53 0xe1 0xa2 0xb8 0x63 0x44 0xac 0xc9 0x2b 0x4e 0xa8 0xa4 0x36 0xb5 0x70 0xd0 0xf2 0x88 0x1e
2025-01-30 20:54:21,436 # generating 20 random byte(s)
2025-01-30 20:54:21,442 # Got: 0xee 0x05 0xf3 0x32 0xa6 0xf9 0x7b 0x4b 0xb3 0x0c 0xdf 0x0d 0x81 0xce 0xf2 0x6f 0xc9 0x5d 0x08 0xf0
```



### Testing procedure

run `tests/periph/hwrng` on `arduino-due`

### Issues/PRs references

followup of #21168
