### PR TITLE
sys: make auto init default with DHCPv6 client

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -98,6 +98,7 @@ ifneq (,$(filter dhcpv6_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter dhcpv6_client,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_dhcpv6_client
   USEMODULE += event
   USEMODULE += event_timeout
   ifneq (,$(filter ztimer,$(USEMODULE)))

--- a/sys/auto_init/include/auto_init_priorities.h
+++ b/sys/auto_init/include/auto_init_priorities.h
@@ -335,19 +335,19 @@ extern "C" {
 /**
  * @brief   DHCPv6 client priority
  */
-#define AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT                1470
+#define AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT                1480
 #endif
 #ifndef AUTO_INIT_PRIO_MOD_DHCPV6_RELAY
 /**
  * @brief   DHCPv6 relay priority
  */
-#define AUTO_INIT_PRIO_MOD_DHCPV6_RELAY                 1480
+#define AUTO_INIT_PRIO_MOD_DHCPV6_RELAY                 1490
 #endif
 #ifndef AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT_SIMPLE_PD
 /**
  * @brief   DHCPv6 client simple PD priority
  */
-#define AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT_SIMPLE_PD      1490
+#define AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT_SIMPLE_PD      1470
 #endif
 #ifndef AUTO_INIT_PRIO_MOD_GNRC_IPV6_AUTO_SUBNETS
 /**

--- a/sys/include/net/dhcpv6/client.h
+++ b/sys/include/net/dhcpv6/client.h
@@ -108,6 +108,16 @@ typedef struct __attribute__((packed)) {
 
 #if defined(MODULE_AUTO_INIT_DHCPV6_CLIENT) || defined(DOXYGEN)
 /**
+ * @brief   Configure a hook function to be executed during dhcpv6 client's
+ *          auto init.
+ *
+ * @param[in] _hook     The hook function to be called during auto init.
+ * @param[in] netif         The network interface the client should listen on.
+ *                          SOCK_ADDR_ANY_NETIF for any interface
+ */
+void dhcpv6_client_set_init_hook(void (*_hook)(void), uint16_t netif);
+
+/**
  * @brief   Auto-initializes the client in its own thread
  *
  * @note    Only available with (and called by) the `dhcpv6_client_auto_init`


### PR DESCRIPTION
### Contribution description

The DHCPv6 client uses an event queue that needs to get initialized. The auto_init code does that and, hence, should be used by default.

### Testing procedure

Build the `gnrc_networking` example with DHCPv6 client support:
```
USEMODULE=gnrc_dhcpv6_client make -C examples/gnrc_networking all term
```

**Result**

```
2025-01-30 23:50:21,735 # All up, running the shell now
> 2025-01-30 23:50:22,631 # sys/event/event.c:39 => *** RIOT kernel panic:
2025-01-30 23:50:22,632 # FAILED ASSERTION.
2025-01-30 23:50:22,632 # 
2025-01-30 23:50:22,633 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2025-01-30 23:50:22,634 # 	 - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) |  0x80898e0 |  0x80898e0
2025-01-30 23:50:22,634 # 	 1 | idle                 | pending  Q |  15 |   8192 (  436) ( 7756) |  0x80842e0 |  0x808613c 
2025-01-30 23:50:22,635 # 	 2 | main                 | running  Q |   7 |  12288 ( 1664) (10624) |  0x80862e0 |  0x808913c 
2025-01-30 23:50:22,635 # 	 3 | pktdump              | bl rx    _ |   6 |  12224 (  896) (11328) |  0x8091f80 |  0x8094d9c 
2025-01-30 23:50:22,636 # 	 4 | ipv6                 | bl rx    _ |   4 |   8128 ( 1776) ( 6352) |  0x808c1c0 |  0x808dfdc 
2025-01-30 23:50:22,636 # 	 5 | udp                  | bl rx    _ |   5 |   4032 (  960) ( 3072) |  0x8097220 |  0x809803c 
2025-01-30 23:50:22,637 # 	 6 | gnrc_netdev_tap      | bl anyfl _ |   2 |   8064 ( 2264) ( 5800) |  0x808e760 |  0x809053c 
2025-01-30 23:50:22,637 # 	 7 | RPL                  | bl rx    _ |   5 |   8192 (  896) ( 7296) |  0x80951c0 |  0x809701c 
2025-01-30 23:50:22,637 # 	   | SUM                  |            |     |  69312 ( 8892) (60420)
2025-01-30 23:50:22,638 # 
2025-01-30 23:50:22,638 # *** halted.
```

**Expected result**
DHCP client works, RIOT doesn't crash.