### PR TITLE
cpu/sam3: optimize gpio ISR processing

### DIFF
--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include "bitarithm.h"
 #include "cpu.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
@@ -313,11 +314,11 @@ static inline void isr_handler(Pio *port, int port_num)
     /* take interrupt flags only from pins which interrupt is enabled */
     uint32_t status = (port->PIO_ISR & port->PIO_IMR);
 
-    for (int i = 0; i < 32; i++) {
-        if (status & ((uint32_t)1 << i)) {
-            int ctx = _ctx(port_num, i);
-            exti_ctx[ctx].cb(exti_ctx[ctx].arg);
-        }
+    while (status) {
+        uint8_t pin_number;
+        status = bitarithm_test_and_clear(status, &pin_number);
+        int ctx = _ctx(port_num, pin_number);
+        exti_ctx[ctx].cb(exti_ctx[ctx].arg);
     }
     cortexm_isr_end();
 }


### PR DESCRIPTION
### Contribution description

This PR makes use of `bitarithm_test_and_clear` to process gpio ISR instead of looping through every bits inside the register.
It will use `CLZ` ARM instruction to catch the position of all bits set and clear them one by one which is faster than checking every bits every time.


### Testing procedure
Tested on `arduino-due` with `tests/buttons` (I've wired up 4 external buttons with a breadboard for this).

### Issues/PRs references
None
