### PR TITLE
cpu/esp_common: create partitions.csv more robustly

### DIFF
--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -157,14 +157,16 @@ $(BINDIR)/partitions.csv: $(FLASHFILE)
 	$(Q)printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $@
 	$(Q)printf "flashpage, data, phy, $(FLASHPAGE_ADDR_START), $(FLASHPAGE_CAP)\n" >> $@
 	$(Q)printf "factory, app, factory, $(FLASHFILE_POS), " >> $@
-	$(Q)ls -l $< | awk '{ print $$5 }' >> $@
+	# append size of $(FLASHFILE)
+	$(Q)wc -c < $< >> $@
 else
 $(BINDIR)/partitions.csv: $(FLASHFILE)
 	$(Q)printf "\n" > $(BINDIR)/partitions.csv
 	$(Q)printf "nvs, data, nvs, 0x9000, 0x6000\n" >> $@
 	$(Q)printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $@
 	$(Q)printf "factory, app, factory, $(FLASHFILE_POS), " >> $@
-	$(Q)ls -l $< | awk '{ print $$5 }' >> $@
+	# append size of $(FLASHFILE)
+	$(Q)wc -c < $< >> $@
 endif
 
 $(BINDIR)/partitions.bin: $(PARTITION_TABLE_CSV)


### PR DESCRIPTION
### Contribution description

The generated `partitions.csv` needs to state the size of the flash file. This so far used `ls -l | awk '{print $5}'` to achieve that, but that is not robust, as the columns of `ls -l` depend on the tool and system configuration used.

This commit replaces the call with `wc -c | cut -f 1 -d " "`, which should be more robust.

### Testing procedure

Building any app for any ESP8266/ESP32 should still work without regressions. In addition, it should now work on Ubuntu 24.04.1 LTS machines that are connected into some cooperate identity management stuff (I believe the last part adding a column to `ls -l` on my system).

### Issues/PRs references

None