### PR TITLE
examples/default: fix dependency modeling

### DIFF
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -27,14 +27,12 @@
 
 #include "shell.h"
 
-#ifdef MODULE_NETIF
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc.h"
-#endif
 
 int main(void)
 {
-#ifdef MODULE_NETIF
+#ifdef MODULE_GNRC_PKTDUMP
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                           gnrc_pktdump_pid);
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fixes an issue reported to the RIOT matrix chat, where the user wanted to have a network interface but not the packet dump for the `default` example.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Comment out the `gnrc_pktdump` module in `examples/default/Makefile.board.dep`

```diff
diff --git a/examples/default/Makefile.board.dep b/examples/default/Makefile.board.dep
index ca5f03cba7..ee0f1c5e1f 100644
--- a/examples/default/Makefile.board.dep
+++ b/examples/default/Makefile.board.dep
@@ -9,7 +9,7 @@ ifneq (,$(filter netif,$(FEATURES_USED)))
   # shell command to send L2 packets with a simple string
   USEMODULE += gnrc_txtsnd
   # the application dumps received packets to stdout
-  USEMODULE += gnrc_pktdump
+  # USEMODULE += gnrc_pktdump
 
   # We use only the lower layers of the GNRC network stack, hence, we can
   # reduce the size of the packet buffer a bit
```

The example should still compile, sending packets should also still be possible, but the example will not provide any output when it receives a packet.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
