### PR TITLE
sys/net/nanocoap: drop typedef hack [v2] [backport 2025.01]

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -85,24 +85,14 @@
 #include <string.h>
 #include <unistd.h>
 
-#ifdef RIOT_VERSION
 #include "bitarithm.h"
 #include "bitfield.h"
 #include "byteorder.h"
 #include "iolist.h"
 #include "macros/utils.h"
-#include "net/coap.h"
 #include "modules.h"
-#else
-#include "coap.h"
-#include <arpa/inet.h>
-#endif
-
-#if defined(MODULE_SOCK_UDP) || defined(DOXYGEN)
+#include "net/coap.h"
 #include "net/sock/udp.h"
-#else
-typedef void sock_udp_ep_t;
-#endif
 
 #if defined(MODULE_NANOCOAP_RESOURCES)
 #include "xfa.h"

--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -25,7 +25,9 @@
 #ifndef SUIT_TRANSPORT_WORKER_H
 #define SUIT_TRANSPORT_WORKER_H
 
-#include "net/nanocoap.h"
+#if MODULE_NANOCOAP
+#  include "net/nanocoap.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -61,3 +61,9 @@ ifeq (, $(UNIT_TESTS))
 else
   CFLAGS += -DTEST_SUITES='$(subst $() $(),$(comma),$(UNIT_TESTS:tests-%=%))'
 endif
+
+# Hack: If GNRC is not used, still provide access to sock_types.h to allow
+# building nanocoap
+ifeq (,$(filter gnrc_sock,$(USEMODULE)))
+  CFLAGS +=-I$(RIOTBASE)/sys/net/gnrc/sock/include
+endif


### PR DESCRIPTION
# Backport of #21193

### Contribution description

There is an `typdef void sock_udp_ep_t` hack in `nanocoap.h` that tries allow using parts of nanocoap without a RIOT network stack.

There is a similar hack to allow it to be used without RIOT at all. This has been used in the early days during development on Linux directly. This however has not been tested and left bit rotting.

Both hacks are remove and nanocoap now just depends on sock/udp.h.

In a future cleanup, the CoAP packet parsing and building code of nanocoap can be separated from the part that does the transmission and reception of UDP packets. That way, using nanocoap's packet parsing and building will again be available without using a network stack.

Until then, let's drop the hacks and just depend on a network stack.

### Testing procedure

```
$ make BOARD=native64 -C tests/unittests/ tests-nanocoap test
$ make BOARD=native64 -C tests/unittests/ tests-nanocoap_cache test
$ TZ=UTC make BOARD=native64 -C tests/unittests/ test
```

should now all three pass, instead of just the last.

### Issues/PRs references

Fixes regression introduced in https://github.com/RIOT-OS/RIOT/pull/21163 and https://github.com/RIOT-OS/RIOT/pull/21163

See also https://github.com/RIOT-OS/RIOT/pull/21190 for a different approach