### PR TITLE
drivers/at: at_readline_stop_at_str fix remaining buffer length

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -513,7 +513,6 @@ static ssize_t at_readline_stop_at_str(at_dev_t *dev, char *resp_buf, size_t len
         }
 
         resp_pos++;
-        len--;
 
         if ((size_t)(resp_pos - resp_buf) >= strlen(AT_RECV_EOL)) {
             char *const eol_begin = resp_pos - strlen(AT_RECV_EOL);
@@ -534,8 +533,10 @@ static ssize_t at_readline_stop_at_str(at_dev_t *dev, char *resp_buf, size_t len
                 substr_p++;
             }
         }
+
+        len--;
     }
-    if (len <= 1) {
+    if (len == 1) {
         return -ENOBUFS;
     }
     if (res < 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fixes a tiny bug in the `at` driver that causes a return of `-ENOBUFS` although the received response fits in the buffer.
It happens when the end-of-line sequence is at the last position before `\0`.

https://github.com/RIOT-OS/RIOT/blob/c20ce6996739f33243847f0d85bc19036091a547/drivers/at/at.c#L518-L528

When the `while` loop is exited because '\n' was received at the last position before the last `\0`, the `len` variable was already decremented. So the  `-ENOBUFS` condition triggers.

https://github.com/RIOT-OS/RIOT/blob/c20ce6996739f33243847f0d85bc19036091a547/drivers/at/at.c#L538-L540



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Configure a URC and send a sequence over the UART via `pyterm` to the microcontroller.
For example "012345678901234567890123456789\n\0" for  `rp_buf_size` = 32.
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
