### PR TITLE
lwip: bump to v2.2.1

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=lwip
 PKG_URL=https://github.com/lwip-tcpip/lwip.git
-# lwIP v2.2.0
-PKG_VERSION=07a0dec3d4fa08ec332e5c297c40899ae6c727c6
+# lwIP v2.2.1
+PKG_VERSION=77dcd25a72509eb83f72b033d219b1d40cd8eb95
 PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
lwIP v2.2.1 [came out this morning](https://savannah.nongnu.org/news/?id=10724), so let's bump our package for it.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I ran the same old loops for lwIP testing:

```bash
for ipv4 in 0 1; do
    for ipv6 in 0 1; do
        for board in native samr21-xpro; do
            for app in lwip_sock_ip lwip_sock_tcp lwip_sock_udp; do
                if [ $ipv4 == 0 ] && [ $ipv6 == 0 ]; then
                    continue;
                fi;
                BOARD=$board LWIP_IPV4=$ipv4 LWIP_IPV6=$ipv6 make -C tests/pkg/${app} -j flash test
            done;
        done;
    done;
done
```

I also ran the `tests/pkg/lwip` test for native and tested the IP/UDP/TCP functionality on a 6LoWPAN-capable board (`samr21-xpro`), so after this (and scrolling through the changes since v2.2.0 a little bit) I am confident, that this does not break things.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
