### PR TITLE
pkg/nimble: Fix compilation with `USEMODULE += nimble_svc_bas`

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -62,6 +62,9 @@ nimble_host_store_ram:
 	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/store/ram/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 # service implementations
+nimble_svc_bas:
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/services/bas/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+
 nimble_svc_gap:
 	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 

--- a/pkg/nimble/patches/0001-port-npl-riot-add-svc_bas-config.patch
+++ b/pkg/nimble/patches/0001-port-npl-riot-add-svc_bas-config.patch
@@ -1,0 +1,35 @@
+From 3cd2f7dc9f2c17ffb83499ab569a291988cbbc08 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ml-pa.com>
+Date: Sat, 8 Feb 2025 13:54:20 +0100
+Subject: [PATCH] port/npl/riot: add svc_bas config
+
+---
+ porting/npl/riot/include/syscfg/syscfg.h | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/porting/npl/riot/include/syscfg/syscfg.h b/porting/npl/riot/include/syscfg/syscfg.h
+index 84bdea5..a0b49c8 100644
+--- a/porting/npl/riot/include/syscfg/syscfg.h
++++ b/porting/npl/riot/include/syscfg/syscfg.h
+@@ -670,6 +670,19 @@
+ #define MYNEWT_VAL_BASELIBC_PRESENT (1)
+ #endif
+ 
++/*** @apache-mynewt-nimble/nimble/host/services/bas */
++#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE
++#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE (1)
++#endif
++
++#ifndef MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM
++#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM (0)
++#endif
++
++#ifndef MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE
++#define MYNEWT_VAL_BLE_SVC_BAS_SYSINIT_STAGE (303)
++#endif
++
+ /*** @apache-mynewt-core/sys/console/stub */
+ #ifndef MYNEWT_VAL_CONSOLE_UART_BAUD
+ #define MYNEWT_VAL_CONSOLE_UART_BAUD (115200)
+-- 
+2.43.0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

`pkg/nimble/Makefile.include` includes logic for the module, however the corresponding Make target is missing.

This produces the following error:
```
make[3]: *** No rule to make target 'nimble_svc_bas', needed by 'all'.  Stop.
```
