### PR TITLE
{drivers/sx126x, ieee802154/submac, sys/net/ieee802154} run LoRa for sx126x over IEEE802.15.4 using submac

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -345,7 +345,7 @@ static int _set_cca_threshold(ieee802154_dev_t *dev, int8_t threshold)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     (void) dev;
     int8_t pow = conf->pow;

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -419,7 +419,7 @@ static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *b
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     socket_zep_t *zepdev = dev->priv;
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -580,7 +580,7 @@ static int _request_on(ieee802154_dev_t *dev)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     (void)dev;
     int8_t pow = conf->pow;

--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -54,17 +54,26 @@ typedef struct {
     int8_t retrans;                     /**< number of frame retransmissions of the last TX */
     bool dispatch;                      /**< whether an event should be dispatched or not */
     netdev_event_t ev;                  /**< event to be dispatched */
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy;                   /**< For drivers that also implement the old netdev API,
+                                             this pointer shall be set to the netdev_t inside the driver struct,
+                                             to have the old netdev driver's get and set functions,
+                                             supporting device specific netopts. */
+#endif
 } netdev_ieee802154_submac_t;
 
 /**
  * @brief Init the IEEE 802.15.4 SubMAC netdev adoption.
  *
  * @param[in] netdev_submac pointer to the netdev submac descriptor.
+ * @param[in] legacy pointer to an old netdev, set up with the old netdev driver.
+ *
+ * @note @p legacy can be NULL. If not, it should have been set up in *_hal_setup().
  *
  * @return 0 on success.
  * @return negative errno on failure.
  */
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac);
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac, netdev_t *legacy);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -260,6 +260,7 @@ struct sx126x {
     bool ack_filter     : 1;                /**< whether the ACK filter is activated or not */
     bool promisc        : 1;                /**< whether the device is in promiscuous mode or not */
     bool pending        : 1;                /**< whether there pending bit should be set in the ACK frame or not */
+    bool incoming       : 1;                /**< whether currently a frame is demodulated */
     uint8_t short_addr[IEEE802154_SHORT_ADDRESS_LEN];   /**< Short (2 bytes) device address */
     uint8_t long_addr[IEEE802154_LONG_ADDRESS_LEN];     /**< Long (8 bytes) device address */
     uint16_t pan_id;                                    /**< PAN ID */

--- a/drivers/kw2xrf/kw2xrf_radio_hal.c
+++ b/drivers/kw2xrf/kw2xrf_radio_hal.c
@@ -545,7 +545,7 @@ static const uint16_t pll_frac_lt[16] = {
     2048, 12288, 22528, 32768
 };
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     kw2xrf_t *kw_dev = dev->priv;
     kw2xrf_set_tx_power(kw_dev, conf->pow);

--- a/drivers/mrf24j40/mrf24j40_radio_hal.c
+++ b/drivers/mrf24j40/mrf24j40_radio_hal.c
@@ -249,7 +249,7 @@ static int _set_cca_mode(ieee802154_dev_t *dev, ieee802154_cca_mode_t mode)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *hal, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *hal, ieee802154_phy_conf_t *conf)
 {
     mrf24j40_t *dev = hal->priv;
     int8_t pow = conf->pow;

--- a/drivers/netdev_ieee802154_submac/Makefile.include
+++ b/drivers/netdev_ieee802154_submac/Makefile.include
@@ -1,1 +1,2 @@
 PSEUDOMODULES += netdev_ieee802154_submac_soft_ack
+PSEUDOMODULES += netdev_ieee802154_submac_legacy

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -64,7 +64,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
     netdev_ieee802154_submac_t *netdev_submac = container_of(netdev_ieee802154, netdev_ieee802154_submac_t, dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
-
+    DEBUG("IEEE802154 submac: _get(): opt %d\n", opt);
     switch (opt) {
         case NETOPT_STATE:
             *((netopt_state_t*) value) = _get_submac_state(submac);
@@ -85,8 +85,21 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             break;
     }
 
-    return netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev), opt,
-                                 value, max_len);
+    int get =  netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev), opt,
+                                     value, max_len);
+    if (get > 0) {
+        return get;
+    }
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy = netdev_submac->legacy;
+    if (legacy && legacy->driver && legacy->driver->get) {
+        if ((get = legacy->driver->get(legacy, opt, value, max_len))) {
+            return get;
+        }
+    }
+#endif
+
+    return -ENOTSUP;
 }
 
 static int _set_submac_state(ieee802154_submac_t *submac, netopt_state_t state)
@@ -114,7 +127,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
 
     int res;
     int16_t tx_power;
-
+    DEBUG("IEEE802154 submac: _set(): opt %d\n", opt);
     switch (opt) {
     case NETOPT_ADDRESS:
         ieee802154_set_short_addr(submac, value);
@@ -145,8 +158,21 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
         break;
     }
 
-    return netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev),
-                                 opt, value, value_len);
+    int set =  netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev), opt,
+                                     value, value_len);
+    if (set > 0) {
+        return set;
+    }
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy = netdev_submac->legacy;
+    if (legacy && legacy->driver && legacy->driver->set) {
+        if ((set = legacy->driver->set(legacy, opt, value, value_len))) {
+            return set;
+        }
+    }
+#endif
+
+    return -ENOTSUP;
 }
 
 void ieee802154_submac_bh_request(ieee802154_submac_t *submac)
@@ -454,7 +480,7 @@ static int _confirm_send(netdev_t *netdev, void *info)
     return netdev_submac->bytes_tx;
 }
 
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac, netdev_t *legacy)
 {
     netdev_t *netdev = &netdev_submac->dev.netdev;
 
@@ -468,6 +494,10 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;
+    (void)legacy;
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_submac->legacy = legacy;
+#endif
 
     return 0;
 }

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -172,7 +172,7 @@ void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac)
                                                              netdev_ieee802154_submac_t,
                                                              submac);
     ieee802154_submac_ack_timer_cancel(submac);
-    DEBUG("IEEE802154 submac: Setting ACK timeout %"PRIu16" us\n", submac->ack_timeout_us);
+    DEBUG("IEEE802154 submac: Setting ACK timeout %"PRIu32" us\n", submac->ack_timeout_us);
     ztimer_set(ZTIMER_USEC, &netdev_submac->ack_timer, submac->ack_timeout_us);
 }
 

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -69,7 +69,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
     netdev_ieee802154_submac_t *netdev_submac = container_of(netdev_ieee802154, netdev_ieee802154_submac_t, dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
-
+    DEBUG("IEEE802154 submac: _get(): opt %d\n", opt);
     switch (opt) {
         case NETOPT_STATE:
             *((netopt_state_t*) value) = _get_submac_state(submac);
@@ -90,8 +90,21 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             break;
     }
 
-    return netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev), opt,
-                                 value, max_len);
+    int get =  netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev), opt,
+                                     value, max_len);
+    if (get > 0) {
+        return get;
+    }
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy = netdev_submac->legacy;
+    if (legacy && legacy->driver && legacy->driver->get) {
+        if ((get = legacy->driver->get(legacy, opt, value, max_len))) {
+            return get;
+        }
+    }
+#endif
+
+    return -ENOTSUP;
 }
 
 static int _set_submac_state(ieee802154_submac_t *submac, netopt_state_t state)
@@ -119,7 +132,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
 
     int res;
     int16_t tx_power;
-
+    DEBUG("IEEE802154 submac: _set(): opt %d\n", opt);
     switch (opt) {
     case NETOPT_ADDRESS:
         ieee802154_set_short_addr(submac, value);
@@ -150,8 +163,21 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
         break;
     }
 
-    return netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev),
-                                 opt, value, value_len);
+    int set =  netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev), opt,
+                                     value, value_len);
+    if (set > 0) {
+        return set;
+    }
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy = netdev_submac->legacy;
+    if (legacy && legacy->driver && legacy->driver->set) {
+        if ((set = legacy->driver->set(legacy, opt, value, value_len))) {
+            return set;
+        }
+    }
+#endif
+
+    return -ENOTSUP;
 }
 
 void ieee802154_submac_bh_request(ieee802154_submac_t *submac)
@@ -455,7 +481,7 @@ static int _confirm_send(netdev_t *netdev, void *info)
     return netdev_submac->bytes_tx;
 }
 
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac, netdev_t *legacy)
 {
     netdev_t *netdev = &netdev_submac->dev.netdev;
 
@@ -469,6 +495,10 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;
+    (void)legacy;
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_submac->legacy = legacy;
+#endif
 
     return 0;
 }

--- a/drivers/sx126x/Makefile.dep
+++ b/drivers/sx126x/Makefile.dep
@@ -1,6 +1,12 @@
 USEMODULE += iolist
+USEMODULE += od
 USEMODULE += netdev_legacy_api
 USEPKG += driver_sx126x
 FEATURES_REQUIRED += periph_gpio_irq
 
 USEMODULE += lora
+
+ifneq (,$(filter sx126x_ieee802154,$(USEMODULE)))
+  USEMODULE += netdev_ieee802154_submac
+  USEMODULE += bhp_event
+endif

--- a/drivers/sx126x/Makefile.dep
+++ b/drivers/sx126x/Makefile.dep
@@ -8,5 +8,6 @@ USEMODULE += lora
 
 ifneq (,$(filter sx126x_ieee802154,$(USEMODULE)))
   USEMODULE += netdev_ieee802154_submac
+  USEMODULE += netdev_ieee802154_submac_soft_ack
   USEMODULE += bhp_event
 endif

--- a/drivers/sx126x/Makefile.include
+++ b/drivers/sx126x/Makefile.include
@@ -7,6 +7,7 @@ PSEUDOMODULES += sx126x_stm32wl
 
 # include RF switch implemented in the board for use with sx126x
 PSEUDOMODULES += sx126x_rf_switch
+PSEUDOMODULES += sx126x_ieee802154
 PSEUDOMODULES += sx126x_dio2
 PSEUDOMODULES += sx126x_dio3
 

--- a/drivers/sx126x/include/sx126x_internal.h
+++ b/drivers/sx126x/include/sx126x_internal.h
@@ -19,8 +19,10 @@
 
 #include <assert.h>
 
+#include "log.h"
 #include "net/lora.h"
 #include "sx126x.h"
+#include "thread.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -257,6 +259,33 @@ static inline int _sx126x_lora_cr_to(sx126x_lora_cr_t cr)
             return -1;
     }
 }
+
+/**
+ * @name    Internal debug macros for sx126x identification
+ * @{
+ */
+/**
+ * @brief   Get sx126x device ID to distinguish between multiple devices when printing
+ *          debug messages.
+ */
+#define SX126X_ID(d)                    thread_getpid()
+/**
+ * @brief   Internal device driver DEBUG() macro
+ */
+#define SX126X_DEBUG(d, msg, ...)       DEBUG("[sx126x %i] " msg, SX126X_ID(d), ##__VA_ARGS__)
+/**
+ * @brief   Internal device driver LOG_INFO() macro
+ */
+#define SX126X_LOG_INFO(d, msg, ...)    LOG_INFO("[sx126x %i] " msg, SX126X_ID(d), ##__VA_ARGS__)
+/**
+ * @brief   Internal device driver LOG_WARNING() macro
+ */
+#define SX126X_LOG_WARNING(d, msg, ...) LOG_WARNING("[sx126x %i] " msg, SX126X_ID(d), ##__VA_ARGS__)
+/**
+ * @brief   Internal device driver LOG_ERROR() macro
+ */
+#define SX126X_LOG_ERROR(d, msg, ...)   LOG_ERROR("[sx126x %i] " msg, SX126X_ID(d), ##__VA_ARGS__)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/drivers/sx126x/include/sx126x_internal.h
+++ b/drivers/sx126x/include/sx126x_internal.h
@@ -287,6 +287,23 @@ static inline int _sx126x_lora_cr_to(sx126x_lora_cr_t cr)
 #define SX126X_LOG_ERROR(d, msg, ...)   LOG_ERROR("[sx126x %i] " msg, SX126X_ID(d), ##__VA_ARGS__)
 /** @} */
 
+/**
+ * @brief   Check sx126x API return values.
+ *
+ * API return value is of type sx126x_status_t.
+ * The RIOT HAL always returns 0 as SPI transfer currently is not expected to fail.
+ * However checking return values will not hide potential errors in the future.
+ *
+ * @param[in]   func_call      Function call with arguments to check
+ * @param[in]   return_val     Returned value if the function call does not return SX126X_STATUS_OK
+ *
+ */
+#define SX126X_CHECK_API(func_call, return_val) \
+if (func_call != SX126X_STATUS_OK) { \
+    SX126X_DEBUG(dev, "[%s] API call failed: %s\n", __func__, #func_call); \
+    return_val; \
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/sx126x/include/sx126x_internal.h
+++ b/drivers/sx126x/include/sx126x_internal.h
@@ -18,11 +18,30 @@
  */
 
 #include <assert.h>
+
+#include "net/lora.h"
 #include "sx126x.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief   Get the current chip state
+ *
+ * @param[in]   dev                     Device descriptor of the driver
+ *
+ * @return  Chip state
+ */
+sx126x_chip_modes_t sx126x_get_state(const sx126x_t *dev);
+
+/**
+ * @brief   Set the internal chip state
+ *
+ * @param[in]   dev                     Device descriptor of the driver
+ * @param[in]   state                   State to set
+ */
+void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state);
 
 /**
  * @brief   Check whether the device model is sx1261
@@ -120,21 +139,124 @@ static inline bool sx126x_is_stm32wl(sx126x_t *dev)
 }
 
 /**
- * @brief   Get the current chip state
+ * @brief   Mapping of general LoRA bandwidth in lora.h to sx126x_lora_bw_t
  *
- * @param[in]   dev                     Device descriptor of the driver
+ * @param[in]   lora_bw     LoRa bandwidth LORA_BW_
  *
- * @return  Chip state
+ * @return  Corresponding sx126x_lora_bw_t value or default value
  */
-sx126x_chip_modes_t sx126x_get_state(const sx126x_t *dev);
+static inline sx126x_lora_bw_t _sx126x_lora_bw_from(int lora_bw)
+{
+    switch (lora_bw) {
+        case LORA_BW_125_KHZ: return SX126X_LORA_BW_125;
+        case LORA_BW_250_KHZ: return SX126X_LORA_BW_250;
+        case LORA_BW_500_KHZ: return SX126X_LORA_BW_500;
+        default:
+            return SX126X_LORA_BW_125;
+    }
+}
 
 /**
- * @brief   Set the internal chip state
+ * @brief   Mapping of sx126x_lora_bw_t to general LoRA bandwidth in lora.h
  *
- * @param[in]   dev                     Device descriptor of the driver
- * @param[in]   state                   State to set
+ * @param[in]   bw      sx126x_lora_bw_t
+ *
+ * @return  Corresponding LoRa bandwidth
  */
-void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state);
+static inline int _sx126x_lora_bw_to(sx126x_lora_bw_t bw)
+{
+    switch (bw) {
+        case SX126X_LORA_BW_125: return LORA_BW_125_KHZ;
+        case SX126X_LORA_BW_250: return LORA_BW_250_KHZ;
+        case SX126X_LORA_BW_500: return LORA_BW_500_KHZ;
+        default:
+            return -1;
+    }
+}
+
+/**
+ * @brief   Mapping of general LoRA spreading factor in lora.h to sx126x_lora_sf_t
+ *
+ * @param[in]   lora_sf     LoRa spreading factor LORA_SF
+ *
+ * @return  Corresponding sx126x_lora_sf_t value or default value
+ */
+static inline sx126x_lora_sf_t _sx126x_lora_sf_from(int lora_sf)
+{
+    switch (lora_sf) {
+        case LORA_SF5: return SX126X_LORA_SF5;
+        case LORA_SF6: return SX126X_LORA_SF6;
+        case LORA_SF7: return SX126X_LORA_SF7;
+        case LORA_SF8: return SX126X_LORA_SF8;
+        case LORA_SF9: return SX126X_LORA_SF9;
+        case LORA_SF10: return SX126X_LORA_SF10;
+        case LORA_SF11: return SX126X_LORA_SF11;
+        case LORA_SF12: return SX126X_LORA_SF12;
+        default:
+            return SX126X_LORA_SF7;
+    }
+}
+
+/**
+ * @brief   Mapping of sx126x_lora_sf_t to general LoRA spreading factor in lora.h
+ *
+ * @param[in]   sf      sx126x_lora_sf_t
+ *
+ * @return  Corresponding LoRa spreading factor
+ */
+static inline int _sx126x_lora_sf_to(sx126x_lora_sf_t sf)
+{
+    switch (sf) {
+        case SX126X_LORA_SF5: return LORA_SF5;
+        case SX126X_LORA_SF6: return LORA_SF6;
+        case SX126X_LORA_SF7: return LORA_SF7;
+        case SX126X_LORA_SF8: return LORA_SF8;
+        case SX126X_LORA_SF9: return LORA_SF9;
+        case SX126X_LORA_SF10: return LORA_SF10;
+        case SX126X_LORA_SF11: return LORA_SF11;
+        case SX126X_LORA_SF12: return LORA_SF12;
+        default:
+            return -1;
+    }
+}
+
+/**
+ * @brief   Mapping of general LoRA coding rate in lora.h to sx126x_lora_cr_t
+ *
+ * @param[in]   lora_cr     LoRa coding rate LORA_CR_
+ *
+ * @return  Corresponding sx126x_lora_cr_t value or default value
+ */
+static inline sx126x_lora_cr_t _sx126x_lora_cr_from(int lora_cr)
+{
+    switch (lora_cr) {
+        case LORA_CR_4_5: return SX126X_LORA_CR_4_5;
+        case LORA_CR_4_6: return SX126X_LORA_CR_4_6;
+        case LORA_CR_4_7: return SX126X_LORA_CR_4_7;
+        case LORA_CR_4_8: return SX126X_LORA_CR_4_8;
+        default:
+            return SX126X_LORA_CR_4_5;
+    }
+}
+
+/**
+ * @brief   Mapping of sx126x_lora_cr_t to general LoRA coding rate in lora.h
+ *
+ * @param[in]   cr      sx126x_lora_cr_t
+ *
+ * @return  Corresponding LoRa coding rate
+ */
+static inline int _sx126x_lora_cr_to(sx126x_lora_cr_t cr)
+{
+    switch (cr) {
+        case SX126X_LORA_CR_4_5: return LORA_CR_4_5;
+        case SX126X_LORA_CR_4_6: return LORA_CR_4_6;
+        case SX126X_LORA_CR_4_7: return LORA_CR_4_7;
+        case SX126X_LORA_CR_4_8: return LORA_CR_4_8;
+        default:
+            return -1;
+    }
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/sx126x/include/sx126x_internal.h
+++ b/drivers/sx126x/include/sx126x_internal.h
@@ -42,8 +42,10 @@ sx126x_chip_modes_t sx126x_get_state(const sx126x_t *dev);
  *
  * @param[in]   dev                     Device descriptor of the driver
  * @param[in]   state                   State to set
+ * @retval      0                       Success
+ * @retval      -EIO                    Chip reported back an error
  */
-void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state);
+int sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state);
 
 /**
  * @brief   Check whether the device model is sx1261

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -40,23 +40,38 @@ extern "C" {
  * Default values are adapted for mbed shield used with to nucleo64 boards
  * @{
  */
-#ifndef SX126X_PARAM_SPI
+#if !defined(SX126X_PARAM_SPI) || defined(DOXYGEN)
+/**
+ * @brief   SPI bus
+ */
 #  define SX126X_PARAM_SPI                  SPI_DEV(0)
 #endif
 
-#ifndef SX126X_PARAM_SPI_NSS
+#if !defined(SX126X_PARAM_SPI_NSS) || defined(DOXYGEN)
+/**
+ * @brief   SPI chip select pin
+ */
 #  define SX126X_PARAM_SPI_NSS              GPIO_PIN(0, 8)  /* D7 */
 #endif
 
-#ifndef SX126X_PARAM_RESET
+#if !defined(SX126X_PARAM_RESET) || defined(DOXYGEN)
+/**
+ * @brief   Reset pin
+ */
 #  define SX126X_PARAM_RESET                GPIO_PIN(0, 0)  /* A0 */
 #endif
 
-#ifndef SX126X_PARAM_BUSY
+#if !defined(SX126X_PARAM_BUSY) || defined(DOXYGEN)
+/**
+ * @brief   Busy pin
+ */
 #  define SX126X_PARAM_BUSY                 GPIO_PIN(1, 3)  /* D3 */
 #endif
 
-#ifndef SX126X_PARAM_DIO1
+#if !defined(SX126X_PARAM_DIO1) || defined(DOXYGEN)
+/**
+ * @brief   DIO1 interrupt pin
+ */
 #  define SX126X_PARAM_DIO1                 GPIO_PIN(1, 4)  /* D5 */
 #endif
 
@@ -68,11 +83,18 @@ extern "C" {
 #  define SX126X_PARAM_REGULATOR            SX126X_REG_MODE_DCDC
 #endif
 
-#ifndef SX126X_PARAM_SET_RF_MODE_CB
+#if !defined(SX126X_PARAM_SET_RF_MODE_CB) || defined(DOXYGEN)
+/**
+ * @brief   Callback function to call when switching between RX and TX states
+ */
 #  define SX126X_PARAM_SET_RF_MODE_CB       NULL
 #endif
 
-#ifndef SX126X_PARAM_TX_PA_MODE
+#if !defined(SX126X_PARAM_TX_PA_MODE) || defined(DOXYGEN)
+/**
+ * @brief   Transmit power amplifier mode which can be
+ *          SX126X_RF_MODE_TX_HPA or SX126X_RF_MODE_TX_LPA
+ */
 #  define SX126X_PARAM_TX_PA_MODE           SX126X_RF_MODE_TX_LPA
 #endif
 

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -384,12 +384,12 @@ int sx126x_init(sx126x_t *dev)
     int res = spi_init_cs(dev->params->spi, dev->params->nss_pin);
 
     if (res != SPI_OK) {
-        DEBUG("[sx126x] error: failed to initialize SPI_%i device (code %i)\n",
-              dev->params->spi, res);
+        SX126X_DEBUG(dev, "error: failed to initialize SPI_%i device (code %i)\n",
+                     dev->params->spi, res);
         return -1;
     }
 
-    DEBUG("[sx126x] init: SPI_%i initialized with success\n", dev->params->spi);
+    SX126X_DEBUG(dev, "init: SPI_%i initialized with success\n", dev->params->spi);
 
 #if IS_ACTIVE(SX126X_SPI)
     gpio_init(dev->params->reset_pin, GPIO_OUT);
@@ -400,12 +400,12 @@ int sx126x_init(sx126x_t *dev)
         res = gpio_init_int(dev->params->dio1_pin, GPIO_IN, GPIO_RISING,
                             dev->event_cb, dev->event_arg);
         if (res < 0) {
-            DEBUG("[sx126x] error: failed to initialize DIO1 pin\n");
+            SX126X_DEBUG(dev, "error: failed to initialize DIO1 pin\n");
             return res;
         }
     }
     else {
-        DEBUG("[sx126x] error: no DIO1 pin defined\n");
+        SX126X_DEBUG(dev, "error: no DIO1 pin defined\n");
         return -EIO;
     }
 #endif
@@ -449,13 +449,13 @@ int sx126x_init(sx126x_t *dev)
                              sizeof(trimming_capacitor_values));
         /* 11.3 pF + x * 0.47pF  = 33.4pF | x = 0x2f*/
         if (trimming_capacitor_values[0] != 0x2f) {
-            DEBUG("[sx126x] warning: failed to set TCXO control: SX126X_REG_XTATRIM=%02x\n",
-                  trimming_capacitor_values[0]);
+            SX126X_DEBUG(dev, "warning: failed to set TCXO control: SX126X_REG_XTATRIM=%02x\n",
+                    trimming_capacitor_values[0]);
         }
-        DEBUG("[sx126x] XTA capacitor ~ %upF\n",
-              (unsigned)(0.5f + (11.3f + trimming_capacitor_values[0] * 0.47f)));
-        DEBUG("[sx126x] XTB capacitor ~ %upF\n",
-              (unsigned)(0.5f + (11.3f + trimming_capacitor_values[1] * 0.47f)));
+        SX126X_DEBUG(dev, "XTA capacitor ~ %upF\n",
+                     (unsigned)(0.5f + (11.3f + trimming_capacitor_values[0] * 0.47f)));
+        SX126X_DEBUG(dev, "XTB capacitor ~ %upF\n",
+                     (unsigned)(0.5f + (11.3f + trimming_capacitor_values[1] * 0.47f)));
 
         /* When the 32 MHz clock is coming from a TCXO, the calibration will fail
            and the user should request a complete calibration after calling the function
@@ -477,12 +477,12 @@ int sx126x_init(sx126x_t *dev)
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         sx126x_pkt_type_t pkt_type;
         sx126x_get_pkt_type(dev, &pkt_type);
-        DEBUG("[sx126x] init radio: pkt type: %d\n", pkt_type);
+        SX126X_DEBUG(dev, "init radio: pkt type: %d\n", pkt_type);
 
         sx126x_chip_status_t radio_status;
         sx126x_get_status(dev, &radio_status);
-        DEBUG("[sx126x] init: chip mode %d\n", radio_status.chip_mode);
-        DEBUG("[sx126x] init: cmd status %d\n", radio_status.cmd_status);
+        SX126X_DEBUG(dev, "init: chip mode %d\n", radio_status.chip_mode);
+        SX126X_DEBUG(dev, "init: cmd status %d\n", radio_status.cmd_status);
     }
 
     /* Radio Rx timeout timer stopped on preamble detection */
@@ -536,7 +536,7 @@ void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
 
 uint32_t sx126x_get_channel(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_radio_status \n");
+    SX126X_DEBUG(dev, "sx126x_get_radio_status \n");
     return dev->channel;
 }
 
@@ -576,7 +576,7 @@ static void _cal_img(sx126x_t *dev, uint32_t freq)
 
 void sx126x_set_channel(sx126x_t *dev, uint32_t freq)
 {
-    DEBUG("[sx126x]: sx126x_set_channel %" PRIu32 "Hz \n", freq);
+    SX126X_DEBUG(dev, "sx126x_set_channel %" PRIu32 "Hz \n", freq);
     dev->channel = freq;
     sx126x_set_rf_freq(dev, dev->channel);
     _cal_img(dev, freq);
@@ -584,13 +584,13 @@ void sx126x_set_channel(sx126x_t *dev, uint32_t freq)
 
 uint8_t sx126x_get_bandwidth(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_bandwidth \n");
+    SX126X_DEBUG(dev, "sx126x_get_bandwidth \n");
     return _sx126x_lora_bw_to(dev->mod_params.bw);
 }
 
 void sx126x_set_bandwidth(sx126x_t *dev, uint8_t bandwidth)
 {
-    DEBUG("[sx126x]: sx126x_set_bandwidth %02x\n", bandwidth);
+    SX126X_DEBUG(dev, "sx126x_set_bandwidth %02x\n", bandwidth);
     dev->mod_params.bw = _sx126x_lora_bw_from(bandwidth);
     dev->mod_params.ldro = _ldro(dev);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
@@ -598,13 +598,13 @@ void sx126x_set_bandwidth(sx126x_t *dev, uint8_t bandwidth)
 
 uint8_t sx126x_get_spreading_factor(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_spreading_factor \n");
+    SX126X_DEBUG(dev, "sx126x_get_spreading_factor \n");
     return _sx126x_lora_sf_to(dev->mod_params.sf);
 }
 
 void sx126x_set_spreading_factor(sx126x_t *dev, uint8_t sf)
 {
-    DEBUG("[sx126x]: sx126x_set_spreading_factor : %02x\n", sf);
+    SX126X_DEBUG(dev, "sx126x_set_spreading_factor : %02x\n", sf);
     dev->mod_params.sf = _sx126x_lora_sf_from(sf);
     dev->mod_params.ldro = _ldro(dev);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
@@ -612,20 +612,20 @@ void sx126x_set_spreading_factor(sx126x_t *dev, uint8_t sf)
 
 uint8_t sx126x_get_coding_rate(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_coding_rate \n");
+    SX126X_DEBUG(dev, "sx126x_get_coding_rate \n");
     return _sx126x_lora_cr_to(dev->mod_params.cr);
 }
 
 void sx126x_set_coding_rate(sx126x_t *dev, uint8_t cr)
 {
-    DEBUG("[sx126x]: sx126x_set_coding_rate %01x\n", cr);
+    SX126X_DEBUG(dev, "sx126x_set_coding_rate %01x\n", cr);
     dev->mod_params.cr = _sx126x_lora_cr_from(cr);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
 }
 
 void sx126x_set_tx_power(sx126x_t *dev, int8_t power_dbm, sx126x_ramp_time_t ramp_time)
 {
-    DEBUG("[sx126x]: sx126x_set_tx_power %ddBm\n", power_dbm);
+    SX126X_DEBUG(dev, "sx126x_set_tx_power %ddBm\n", power_dbm);
     const sx126x_pa_cfg_params_t *pa_cfg;
     int8_t pow = _select_pa_cfg(dev, power_dbm, &pa_cfg);
     if (pow > 0) {
@@ -636,7 +636,7 @@ void sx126x_set_tx_power(sx126x_t *dev, int8_t power_dbm, sx126x_ramp_time_t ram
 
 uint8_t sx126x_get_lora_payload_length(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_lora_payload_length \n");
+    SX126X_DEBUG(dev, "sx126x_get_lora_payload_length \n");
     sx126x_rx_buffer_status_t rx_buffer_status;
 
     sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
@@ -645,59 +645,59 @@ uint8_t sx126x_get_lora_payload_length(const sx126x_t *dev)
 
 void sx126x_set_lora_payload_length(sx126x_t *dev, uint8_t len)
 {
-    DEBUG("[sx126x]: sx126x_set_lora_payload_length %d\n", len);
+    SX126X_DEBUG(dev, "sx126x_set_lora_payload_length %d\n", len);
     dev->pkt_params.pld_len_in_bytes = len;
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
 }
 
 bool sx126x_get_lora_crc(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_lora_crc \n");
+    SX126X_DEBUG(dev, "sx126x_get_lora_crc \n");
     return dev->pkt_params.crc_is_on;
 }
 
 void sx126x_set_lora_crc(sx126x_t *dev, bool crc)
 {
-    DEBUG("[sx126x]: sx126x_set_lora_crc %d\n", crc);
+    SX126X_DEBUG(dev, "sx126x_set_lora_crc %d\n", crc);
     dev->pkt_params.crc_is_on = crc;
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
 }
 
 bool sx126x_get_lora_implicit_header(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_lora_implicit_header \n");
+    SX126X_DEBUG(dev, "sx126x_get_lora_implicit_header \n");
     return dev->pkt_params.header_type == SX126X_LORA_PKT_IMPLICIT;
 }
 
 void sx126x_set_lora_implicit_header(sx126x_t *dev, bool mode)
 {
-    DEBUG("[sx126x]: sx126x_set_lora_implicit_header %d\n", mode);
+    SX126X_DEBUG(dev, "sx126x_set_lora_implicit_header %d\n", mode);
     dev->pkt_params.header_type = (mode ? SX126X_LORA_PKT_IMPLICIT : SX126X_LORA_PKT_EXPLICIT);
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
 }
 
 uint16_t sx126x_get_lora_preamble_length(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_lora_preamble_length \n");
+    SX126X_DEBUG(dev, "sx126x_get_lora_preamble_length \n");
     return dev->pkt_params.preamble_len_in_symb;
 }
 
 void sx126x_set_lora_preamble_length(sx126x_t *dev, uint16_t preamble)
 {
-    DEBUG("[sx126x]: sx126x_set_lora_preamble_length %" PRIu16 "\n", preamble);
+    SX126X_DEBUG(dev, "sx126x_set_lora_preamble_length %" PRIu16 "\n", preamble);
     dev->pkt_params.preamble_len_in_symb = preamble;
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
 }
 
 bool sx126x_get_lora_iq_invert(const sx126x_t *dev)
 {
-    DEBUG("[sx126x]: sx126x_get_lora_iq_invert \n");
+    SX126X_DEBUG(dev, "sx126x_get_lora_iq_invert \n");
     return dev->pkt_params.invert_iq_is_on;
 }
 
 void sx126x_set_lora_iq_invert(sx126x_t *dev, bool iq_invert)
 {
-    DEBUG("[sx126x]: sx126x_set_lora_iq_invert %d\n", iq_invert);
+    SX126X_DEBUG(dev, "sx126x_set_lora_iq_invert %d\n", iq_invert);
     dev->pkt_params.invert_iq_is_on = iq_invert;
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
 }

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -342,13 +342,6 @@ static void sx126x_init_default_config(sx126x_t *dev)
     sx126x_cfg_rx_boosted(dev, false);
 }
 
-#if IS_ACTIVE(SX126X_SPI)
-static void _dio1_isr(void *arg)
-{
-    netdev_trigger_event_isr(arg);
-}
-#endif
-
 /**
  * @brief   Detect whether an SX126x device is actually connected
  * @param   dev     Initialized device descriptor to use

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -319,18 +319,19 @@ static uint32_t _symbols_numof(const sx126x_t *dev, uint16_t payload_len)
 static void sx126x_init_default_config(sx126x_t *dev)
 {
     /* packet type must be set first */
-    sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA);
+    SX126X_CHECK_API(sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA), /* no return */);
     sx126x_set_channel(dev, CONFIG_SX126X_CHANNEL_DEFAULT);
     sx126x_set_tx_power(dev,  CONFIG_SX126X_TX_POWER_DEFAULT, CONFIG_SX126X_RAMP_TIME_DEFAULT);
 #ifdef CONFIG_SX126X_DEFAULT_SYNC_WORD
-    sx126x_set_lora_sync_word(dev, CONFIG_SX126X_DEFAULT_SYNC_WORD);
+    SX126X_CHECK_API(sx126x_set_lora_sync_word(dev, CONFIG_SX126X_DEFAULT_SYNC_WORD),
+                     /* no return */);
 #endif
 
     dev->mod_params.bw = _sx126x_lora_bw_from(CONFIG_SX126X_LORA_BW_DEFAULT);
     dev->mod_params.sf = _sx126x_lora_sf_from(CONFIG_SX126X_LORA_SF_DEFAULT);
     dev->mod_params.cr = _sx126x_lora_cr_from(CONFIG_SX126X_LORA_CR_DEFAULT);
     dev->mod_params.ldro = _ldro(dev);
-    sx126x_set_lora_mod_params(dev, &dev->mod_params);
+    SX126X_CHECK_API(sx126x_set_lora_mod_params(dev, &dev->mod_params), /* no return */);
 
     dev->pkt_params.pld_len_in_bytes = CONFIG_SX126X_LORA_FIXED_PAYLOAD_LENGTH_DEFAULT;
     dev->pkt_params.crc_is_on = !IS_ACTIVE(CONFIG_SX126X_LORA_PAYLOAD_CRC_OFF_DEFAULT);
@@ -338,8 +339,8 @@ static void sx126x_init_default_config(sx126x_t *dev)
                                     ? SX126X_LORA_PKT_IMPLICIT : SX126X_LORA_PKT_EXPLICIT;
     dev->pkt_params.preamble_len_in_symb = CONFIG_SX126X_LORA_PREAMBLE_LENGTH_DEFAULT;
     dev->pkt_params.invert_iq_is_on = IS_ACTIVE(CONFIG_SX126X_LORA_IQ_INVERTED_DEFAULT);
-    sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
-    sx126x_cfg_rx_boosted(dev, false);
+    SX126X_CHECK_API(sx126x_set_lora_pkt_params(dev, &dev->pkt_params), /* no return */);
+    SX126X_CHECK_API(sx126x_cfg_rx_boosted(dev, false), /* no return */);
 }
 
 /**
@@ -358,9 +359,9 @@ static bool _sx126x_detect(sx126x_t *dev)
 {
     sx126x_pkt_type_t pkt_type = UINT8_MAX;
     sx126x_chip_status_t radio_status = { 0 };
-    sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA);
-    sx126x_get_status(dev, &radio_status);
-    sx126x_get_pkt_type(dev, &pkt_type);
+    SX126X_CHECK_API(sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA), /* no return */);
+    SX126X_CHECK_API(sx126x_get_status(dev, &radio_status), /* no return */);
+    SX126X_CHECK_API(sx126x_get_pkt_type(dev, &pkt_type), /* no return */);
 
     if ((pkt_type == SX126X_PKT_TYPE_LORA) && (radio_status.chip_mode)) {
         return true;
@@ -404,7 +405,7 @@ int sx126x_init(sx126x_t *dev)
 #endif
 
     /* Reset the device */
-    sx126x_reset(dev);
+    SX126X_CHECK_API(sx126x_reset(dev), return -EIO);
 
     if (!_sx126x_detect(dev)) {
         return -ENODEV;
@@ -414,34 +415,35 @@ int sx126x_init(sx126x_t *dev)
         /*  Workaround for SX1262, during the chip initialization.
             Calling this function optimizes the PA clamping threshold.
             The call must be done after a Power On Reset or a wake-up from cold start */
-        sx126x_cfg_tx_clamp(dev);
+        SX126X_CHECK_API(sx126x_cfg_tx_clamp(dev), /* no return */);
     }
 
     /* check for errors */
     sx126x_errors_mask_t error = 0;
-    sx126x_get_device_errors(dev, &error);
+    SX126X_CHECK_API(sx126x_get_device_errors(dev, &error), /* no return */);
     if (error) {
         SX126X_LOG_ERROR(dev, "startup: device errors 0x%04x\n", error);
     }
-    sx126x_clear_device_errors(dev);
+    SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
 
 #if IS_USED(MODULE_SX126X_DIO2)
     if (dev->params->dio2_mode == SX126X_DIO2_RF_SWITCH) {
-        sx126x_set_dio2_as_rf_sw_ctrl(dev, true);
+        SX126X_CHECK_API(sx126x_set_dio2_as_rf_sw_ctrl(dev, true), return -EIO);
     }
 #endif
 #if IS_USED(MODULE_SX126X_DIO3)
      if (dev->params->dio3_mode == SX126X_DIO3_TCXO) {
-        sx126x_set_dio3_as_tcxo_ctrl(dev, dev->params->dio3_arg.tcxo_volt,
-                                     dev->params->dio3_arg.tcxo_timeout);
+        SX126X_CHECK_API(sx126x_set_dio3_as_tcxo_ctrl(dev, dev->params->dio3_arg.tcxo_volt,
+                                                      dev->params->dio3_arg.tcxo_timeout),
+                                                      return -EIO);
         /* Once the command SetDIO3AsTCXOCtrl(...) is sent to the device,
            the register controlling the internal cap on XTA will be automatically
            changed to 0x2F (33.4 pF) to filter any spurious injection which could occur
            and be propagated to the PLL.- Verify that. */
         uint8_t trimming_capacitor_values[2] = { 0 };
-        sx126x_read_register(dev, SX126X_REG_XTATRIM,
-                             trimming_capacitor_values,
-                             sizeof(trimming_capacitor_values));
+        SX126X_CHECK_API(sx126x_read_register(dev, SX126X_REG_XTATRIM,
+                         trimming_capacitor_values,
+                         sizeof(trimming_capacitor_values)), /* no return */);
         /* 11.3 pF + x * 0.47pF  = 33.4pF | x = 0x2f*/
         if (trimming_capacitor_values[0] != 0x2f) {
             SX126X_DEBUG(dev, "warning: failed to set TCXO control: SX126X_REG_XTATRIM=%02x\n",
@@ -455,43 +457,44 @@ int sx126x_init(sx126x_t *dev)
         /* When the 32 MHz clock is coming from a TCXO, the calibration will fail
            and the user should request a complete calibration after calling the function
            SetDIO3AsTcxoCtrl(...). */
-        sx126x_cal(dev, SX126X_CAL_ALL);
+        SX126X_CHECK_API(sx126x_cal(dev, SX126X_CAL_ALL), /* no return */);
     }
 #endif
     error = 0;
-    sx126x_get_device_errors(dev, &error);
+    SX126X_CHECK_API(sx126x_get_device_errors(dev, &error), /* no return */);
     if (error) {
         SX126X_LOG_ERROR(dev, "error: device error 0x%04x\n", error);
     }
     else {
         SX126X_LOG_INFO(dev, "startup successful\n");
     }
-    sx126x_clear_device_errors(dev);
+    SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
 
     /* The user can specify the use of DC-DC by using the command SetRegulatorMode(...).
        This operation must be carried out in STDBY_RC mode only.*/
-    sx126x_set_reg_mode(dev, dev->params->regulator);
+    SX126X_CHECK_API(sx126x_set_reg_mode(dev, dev->params->regulator), /* no return */);
 
     /* Initialize radio with the default parameters */
     sx126x_init_default_config(dev);
 
-    sx126x_set_standby(dev, SX126X_STANDBY_CFG_XOSC);
+    SX126X_CHECK_API(sx126x_set_standby(dev, SX126X_STANDBY_CFG_XOSC), /* no return */);
 
-    sx126x_set_dio_irq_params(dev, SX126X_IRQ_MASK_ALL, SX126X_IRQ_MASK_ALL, 0, 0);
+    SX126X_CHECK_API(sx126x_set_dio_irq_params(dev, SX126X_IRQ_MASK_ALL, SX126X_IRQ_MASK_ALL, 0, 0),
+                     /* no return */);
 
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         sx126x_pkt_type_t pkt_type;
-        sx126x_get_pkt_type(dev, &pkt_type);
+        SX126X_CHECK_API(sx126x_get_pkt_type(dev, &pkt_type), /* no return */);
         SX126X_DEBUG(dev, "init radio: pkt type: %d\n", pkt_type);
 
         sx126x_chip_status_t radio_status;
-        sx126x_get_status(dev, &radio_status);
+        SX126X_CHECK_API(sx126x_get_status(dev, &radio_status), /* no return */);
         SX126X_DEBUG(dev, "init: chip mode %d\n", radio_status.chip_mode);
         SX126X_DEBUG(dev, "init: cmd status %d\n", radio_status.cmd_status);
     }
 
     /* Radio Rx timeout timer stopped on preamble detection */
-    sx126x_stop_timer_on_preamble(dev, true);
+    SX126X_CHECK_API(sx126x_stop_timer_on_preamble(dev, true), /* no return */);
 
     return res;
 }
@@ -499,7 +502,7 @@ int sx126x_init(sx126x_t *dev)
 sx126x_chip_modes_t sx126x_get_state(const sx126x_t *dev)
 {
     sx126x_chip_status_t radio_status;
-    sx126x_get_status(dev, &radio_status);
+    SX126X_CHECK_API(sx126x_get_status(dev, &radio_status), /* no return */);
     return radio_status.chip_mode;
 }
 
@@ -507,26 +510,27 @@ void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
 {
     /* check for errors */
     sx126x_errors_mask_t error = 0;
-    sx126x_get_device_errors(dev, &error);
+    SX126X_CHECK_API(sx126x_get_device_errors(dev, &error), /* no return */);
     if (error) {
         SX126X_DEBUG(dev, "before set state: device error 0x%04x before setting state\n", error);
     }
-    sx126x_clear_device_errors(dev);
+    SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
 
     switch (state) {
     case SX126X_CHIP_MODE_TX:
-        sx126x_set_tx(dev, 0); /* no TX frame timeout */
+        SX126X_CHECK_API(sx126x_set_tx(dev, 0), /* no return */); /* no TX frame timeout */
         break;
     case SX126X_CHIP_MODE_RX: {
-        sx126x_cfg_rx_boosted(dev, true);
+        SX126X_CHECK_API(sx126x_cfg_rx_boosted(dev, true), /* no return */);
         if (dev->rx_timeout >= 0) {
             int timeout = (sx126x_symbol_to_msec(dev, dev->rx_timeout));
-            sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_STDBY_XOSC);
+            SX126X_CHECK_API(sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_STDBY_XOSC),
+                             /* no return */);
             if (timeout > 0) {
-                sx126x_set_rx(dev, timeout);
+                SX126X_CHECK_API(sx126x_set_rx(dev, timeout), /* no return */);
             }
             else {
-                sx126x_set_rx(dev, SX126X_RX_SINGLE_MODE);
+                SX126X_CHECK_API(sx126x_set_rx(dev, SX126X_RX_SINGLE_MODE), /* no return */);
             }
         }
         else {
@@ -534,24 +538,24 @@ void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
                unless the configuration is changed by using this command.
                Changing the default mode from STDBY_RC to STDBY_XOSC or FS
                will only have an impact on the switching time of the radio */
-            sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_FS);
-            sx126x_set_rx_with_timeout_in_rtc_step(dev, SX126X_RX_CONTINUOUS);
+            SX126X_CHECK_API(sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_FS), /* no return */);
+            SX126X_CHECK_API(sx126x_set_rx_with_timeout_in_rtc_step(dev, SX126X_RX_CONTINUOUS), /* no return */);
         }
     } break;
     case SX126X_CHIP_MODE_STBY_RC:
     case SX126X_CHIP_MODE_STBY_XOSC:
-        sx126x_set_standby(dev, state);
+        SX126X_CHECK_API(sx126x_set_standby(dev, state), /* no return */);
         break;
     default:
         break;
     }
 
     error = 0;
-    sx126x_get_device_errors(dev, &error);
+    SX126X_CHECK_API(sx126x_get_device_errors(dev, &error), /* no return */);
     if (error) {
         SX126X_DEBUG(dev, "after set state: device error 0x%04x before setting state\n", error);
     }
-    sx126x_clear_device_errors(dev);
+    SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
 }
 
 uint32_t sx126x_get_channel(const sx126x_t *dev)
@@ -567,23 +571,23 @@ static void _cal_img(sx126x_t *dev, uint32_t freq)
     /* don't know what to do with frequencies that don't fit in the intervals from the datasheet */
     if (freq >= MHZ(902) && freq <= MHZ(928)) {
         /* 902 - 928 MHz band and anything upper */
-        sx126x_cal_img_in_mhz(dev, 902, 928);
+        SX126X_CHECK_API(sx126x_cal_img_in_mhz(dev, 902, 928), /* no return */);
     }
     else if (freq >= MHZ(863) && freq <= MHZ(870)) {
         /* 863 - 870 MHz band */
-        sx126x_cal_img_in_mhz(dev, 863, 870);
+        SX126X_CHECK_API(sx126x_cal_img_in_mhz(dev, 863, 870), /* no return */);
     }
     else if (freq >= MHZ(779) && freq <= MHZ(787)) {
         /* 779 - 787 MHz band */
-        sx126x_cal_img_in_mhz(dev, 779, 787);
+        SX126X_CHECK_API(sx126x_cal_img_in_mhz(dev, 779, 787), /* no return */);
     }
     else if (freq >= MHZ(470) && freq <= MHZ(510)) {
         /* 470 - 510 MHz band */
-        sx126x_cal_img_in_mhz(dev, 470, 510);
+        SX126X_CHECK_API(sx126x_cal_img_in_mhz(dev, 470, 510), /* no return */);
     }
     else if (freq >= MHZ(430) && freq <= MHZ(440)) {
         /* 430 - 440 MHz band and anything lower */
-        sx126x_cal_img_in_mhz(dev, 430, 440);
+        SX126X_CHECK_API(sx126x_cal_img_in_mhz(dev, 430, 440), /* no return */);
     }
     else {
         /* Contact your Semtech representative for the other optimal calibration settings
@@ -596,17 +600,17 @@ static void _cal_img(sx126x_t *dev, uint32_t freq)
 
 void sx126x_set_channel(sx126x_t *dev, uint32_t freq)
 {
-    sx126x_clear_device_errors(dev);
+    SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
     SX126X_DEBUG(dev, "sx126x_set_channel %" PRIu32 "Hz \n", freq);
     dev->channel = freq;
     sx126x_set_rf_freq(dev, dev->channel);
     _cal_img(dev, freq);
     sx126x_errors_mask_t error = 0;
-    sx126x_get_device_errors(dev, &error);
+    SX126X_CHECK_API(sx126x_get_device_errors(dev, &error), /* no return */);
     if (error) {
         SX126X_DEBUG(dev, "sx126x_set_channel: device errors 0x%04x\n", error);
     }
-    sx126x_clear_device_errors(dev);
+    SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
 }
 
 uint8_t sx126x_get_bandwidth(const sx126x_t *dev)
@@ -620,7 +624,7 @@ void sx126x_set_bandwidth(sx126x_t *dev, uint8_t bandwidth)
     SX126X_DEBUG(dev, "sx126x_set_bandwidth %02x\n", bandwidth);
     dev->mod_params.bw = _sx126x_lora_bw_from(bandwidth);
     dev->mod_params.ldro = _ldro(dev);
-    sx126x_set_lora_mod_params(dev, &dev->mod_params);
+    SX126X_CHECK_API(sx126x_set_lora_mod_params(dev, &dev->mod_params), /* no return */);
 }
 
 uint8_t sx126x_get_spreading_factor(const sx126x_t *dev)
@@ -634,7 +638,7 @@ void sx126x_set_spreading_factor(sx126x_t *dev, uint8_t sf)
     SX126X_DEBUG(dev, "sx126x_set_spreading_factor : %02x\n", sf);
     dev->mod_params.sf = _sx126x_lora_sf_from(sf);
     dev->mod_params.ldro = _ldro(dev);
-    sx126x_set_lora_mod_params(dev, &dev->mod_params);
+    SX126X_CHECK_API(sx126x_set_lora_mod_params(dev, &dev->mod_params), /* no return */);
 }
 
 uint8_t sx126x_get_coding_rate(const sx126x_t *dev)
@@ -647,7 +651,7 @@ void sx126x_set_coding_rate(sx126x_t *dev, uint8_t cr)
 {
     SX126X_DEBUG(dev, "sx126x_set_coding_rate %01x\n", cr);
     dev->mod_params.cr = _sx126x_lora_cr_from(cr);
-    sx126x_set_lora_mod_params(dev, &dev->mod_params);
+    SX126X_CHECK_API(sx126x_set_lora_mod_params(dev, &dev->mod_params), /* no return */);
 }
 
 void sx126x_set_tx_power(sx126x_t *dev, int8_t power_dbm, sx126x_ramp_time_t ramp_time)
@@ -656,8 +660,8 @@ void sx126x_set_tx_power(sx126x_t *dev, int8_t power_dbm, sx126x_ramp_time_t ram
     const sx126x_pa_cfg_params_t *pa_cfg;
     int8_t pow = _select_pa_cfg(dev, power_dbm, &pa_cfg);
     if (pow > 0) {
-        sx126x_set_pa_cfg(dev, pa_cfg);
-        sx126x_set_tx_params(dev, pow, ramp_time);
+        SX126X_CHECK_API(sx126x_set_pa_cfg(dev, pa_cfg), /* no return */);
+        SX126X_CHECK_API(sx126x_set_tx_params(dev, pow, ramp_time), /* no return */);
     }
 }
 
@@ -666,7 +670,7 @@ uint8_t sx126x_get_lora_payload_length(const sx126x_t *dev)
     SX126X_DEBUG(dev, "sx126x_get_lora_payload_length \n");
     sx126x_rx_buffer_status_t rx_buffer_status;
 
-    sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+    SX126X_CHECK_API(sx126x_get_rx_buffer_status(dev, &rx_buffer_status), /* no return */);
     return rx_buffer_status.pld_len_in_bytes;
 }
 
@@ -674,7 +678,7 @@ void sx126x_set_lora_payload_length(sx126x_t *dev, uint8_t len)
 {
     SX126X_DEBUG(dev, "sx126x_set_lora_payload_length %d\n", len);
     dev->pkt_params.pld_len_in_bytes = len;
-    sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
+    SX126X_CHECK_API(sx126x_set_lora_pkt_params(dev, &dev->pkt_params), /* no return */);
 }
 
 bool sx126x_get_lora_crc(const sx126x_t *dev)
@@ -687,7 +691,7 @@ void sx126x_set_lora_crc(sx126x_t *dev, bool crc)
 {
     SX126X_DEBUG(dev, "sx126x_set_lora_crc %d\n", crc);
     dev->pkt_params.crc_is_on = crc;
-    sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
+    SX126X_CHECK_API(sx126x_set_lora_pkt_params(dev, &dev->pkt_params), /* no return */);
 }
 
 bool sx126x_get_lora_implicit_header(const sx126x_t *dev)
@@ -700,7 +704,7 @@ void sx126x_set_lora_implicit_header(sx126x_t *dev, bool mode)
 {
     SX126X_DEBUG(dev, "sx126x_set_lora_implicit_header %d\n", mode);
     dev->pkt_params.header_type = (mode ? SX126X_LORA_PKT_IMPLICIT : SX126X_LORA_PKT_EXPLICIT);
-    sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
+    SX126X_CHECK_API(sx126x_set_lora_pkt_params(dev, &dev->pkt_params), /* no return */);
 }
 
 uint16_t sx126x_get_lora_preamble_length(const sx126x_t *dev)
@@ -713,7 +717,7 @@ void sx126x_set_lora_preamble_length(sx126x_t *dev, uint16_t preamble)
 {
     SX126X_DEBUG(dev, "sx126x_set_lora_preamble_length %" PRIu16 "\n", preamble);
     dev->pkt_params.preamble_len_in_symb = preamble;
-    sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
+    SX126X_CHECK_API(sx126x_set_lora_pkt_params(dev, &dev->pkt_params), /* no return */);
 }
 
 bool sx126x_get_lora_iq_invert(const sx126x_t *dev)
@@ -726,7 +730,7 @@ void sx126x_set_lora_iq_invert(sx126x_t *dev, bool iq_invert)
 {
     SX126X_DEBUG(dev, "sx126x_set_lora_iq_invert %d\n", iq_invert);
     dev->pkt_params.invert_iq_is_on = iq_invert;
-    sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
+    SX126X_CHECK_API(sx126x_set_lora_pkt_params(dev, &dev->pkt_params), /* no return */);
 }
 
 uint32_t sx126x_symbol_time_on_air_us(const sx126x_t *dev)

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -424,11 +424,13 @@ int sx126x_init(sx126x_t *dev)
         sx126x_cfg_tx_clamp(dev);
     }
 
-    /* Configure the power regulator mode */
-    sx126x_set_reg_mode(dev, dev->params->regulator);
-
-    /* Initialize radio with the default parameters */
-    sx126x_init_default_config(dev);
+    /* check for errors */
+    sx126x_errors_mask_t error = 0;
+    sx126x_get_device_errors(dev, &error);
+    if (error) {
+        SX126X_LOG_ERROR(dev, "startup: device errors 0x%04x\n", error);
+    }
+    sx126x_clear_device_errors(dev);
 
 #if IS_USED(MODULE_SX126X_DIO2)
     if (dev->params->dio2_mode == SX126X_DIO2_RF_SWITCH) {
@@ -463,6 +465,16 @@ int sx126x_init(sx126x_t *dev)
         sx126x_cal(dev, SX126X_CAL_ALL);
     }
 #endif
+    error = 0;
+    sx126x_get_device_errors(dev, &error);
+    if (error) {
+        SX126X_LOG_ERROR(dev, "error: device error 0x%04x\n", error);
+    }
+    else {
+        SX126X_LOG_INFO(dev, "startup successful\n");
+    }
+    sx126x_clear_device_errors(dev);
+
     /* The user can specify the use of DC-DC by using the command SetRegulatorMode(...).
        This operation must be carried out in STDBY_RC mode only.*/
     sx126x_set_reg_mode(dev, dev->params->regulator);
@@ -500,6 +512,14 @@ sx126x_chip_modes_t sx126x_get_state(const sx126x_t *dev)
 
 void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
 {
+    /* check for errors */
+    sx126x_errors_mask_t error = 0;
+    sx126x_get_device_errors(dev, &error);
+    if (error) {
+        SX126X_DEBUG(dev, "before set state: device error 0x%04x before setting state\n", error);
+    }
+    sx126x_clear_device_errors(dev);
+
     switch (state) {
     case SX126X_CHIP_MODE_TX:
         sx126x_set_tx(dev, 0); /* no TX frame timeout */
@@ -532,6 +552,13 @@ void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
     default:
         break;
     }
+
+    error = 0;
+    sx126x_get_device_errors(dev, &error);
+    if (error) {
+        SX126X_DEBUG(dev, "after set state: device error 0x%04x before setting state\n", error);
+    }
+    sx126x_clear_device_errors(dev);
 }
 
 uint32_t sx126x_get_channel(const sx126x_t *dev)
@@ -576,10 +603,17 @@ static void _cal_img(sx126x_t *dev, uint32_t freq)
 
 void sx126x_set_channel(sx126x_t *dev, uint32_t freq)
 {
+    sx126x_clear_device_errors(dev);
     SX126X_DEBUG(dev, "sx126x_set_channel %" PRIu32 "Hz \n", freq);
     dev->channel = freq;
     sx126x_set_rf_freq(dev, dev->channel);
     _cal_img(dev, freq);
+    sx126x_errors_mask_t error = 0;
+    sx126x_get_device_errors(dev, &error);
+    if (error) {
+        SX126X_DEBUG(dev, "sx126x_set_channel: device errors 0x%04x\n", error);
+    }
+    sx126x_clear_device_errors(dev);
 }
 
 uint8_t sx126x_get_bandwidth(const sx126x_t *dev)

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -16,13 +16,17 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 
 #include "sx126x_netdev.h"
 
 #include "log.h"
+#include "macros/math.h"
 #include "macros/units.h"
+#include "macros/utils.h"
 #include "net/lora.h"
 #include "periph/spi.h"
+#include "time_units.h"
 
 #include "sx126x.h"
 #include "sx126x_regs.h"
@@ -31,22 +35,6 @@
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
-
-#ifndef CONFIG_SX126X_PKT_TYPE_DEFAULT
-#define CONFIG_SX126X_PKT_TYPE_DEFAULT          (SX126X_PKT_TYPE_LORA)
-#endif
-
-#ifndef CONFIG_SX126X_CHANNEL_DEFAULT
-#define CONFIG_SX126X_CHANNEL_DEFAULT           (868300000UL)   /* in Hz */
-#endif
-
-#ifndef CONFIG_SX126X_TX_POWER_DEFAULT
-#define CONFIG_SX126X_TX_POWER_DEFAULT          (14U)           /* in dBm */
-#endif
-
-#ifndef CONFIG_SX126X_RAMP_TIME_DEFAULT
-#define CONFIG_SX126X_RAMP_TIME_DEFAULT         (SX126X_RAMP_10_US)
-#endif
 
 #if IS_USED(MODULE_SX1268)
 /* sx1268 */
@@ -257,31 +245,75 @@ static int8_t _select_pa_cfg(sx126x_t *dev, int8_t tx_power_dbm,
     return -1; /* should not be return if any available driver is used */
 }
 
-void sx126x_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index)
-{
-    netdev_t *netdev = &dev->netdev;
-
-    netdev->driver = &sx126x_driver;
-    dev->params = (sx126x_params_t *)params;
-    netdev_register(&dev->netdev, NETDEV_SX126X, index);
-}
-
-static const uint16_t _bw_khz[3] = {
-    [LORA_BW_125_KHZ] = 125,
-    [LORA_BW_250_KHZ] = 250,
-    [LORA_BW_500_KHZ] = 500,
+static const uint16_t _bw_khz[11] = {
+    [SX126X_LORA_BW_007] = 7,
+    [SX126X_LORA_BW_010] = 10,
+    [SX126X_LORA_BW_015] = 15,
+    [SX126X_LORA_BW_020] = 20,
+    [SX126X_LORA_BW_031] = 31,
+    [SX126X_LORA_BW_041] = 41,
+    [SX126X_LORA_BW_062] = 62,
+    [SX126X_LORA_BW_125] = 125,
+    [SX126X_LORA_BW_250] = 250,
+    [SX126X_LORA_BW_500] = 500,
 };
 
-static uint8_t _compute_ldro(sx126x_t *dev)
+/* 6.1.4 LoRa® Time-on-Air */
+static uint16_t _symbol_time_on_air_us(const sx126x_t *dev)
 {
-    uint32_t symbol_len =
-        (uint32_t)(1 << dev->mod_params.sf) / _bw_khz[dev->mod_params.bw - SX126X_LORA_BW_125];
+    /* 1/KHz -> ms */
+    /* US_PER_MS to compensate for truncate of integer division */
+    uint32_t toa_us = ((uint32_t)(1 << dev->mod_params.sf) * US_PER_MS)
+                      / _bw_khz[dev->mod_params.bw];
+    return toa_us;
 
-    if (symbol_len >= 16) {
+}
+
+/* 13.4.5 SetModulationParams */
+static uint8_t _ldro(const sx126x_t *dev)
+{
+    /* This parameter is usually set when the LoRa symbol time is equal or above 16.38 ms,
+       but can be used if necessary in other situations.*/
+    if (_symbol_time_on_air_us(dev) >= 16380) {
         return 0x01;
     }
-
     return 0x00;
+}
+
+/* 6.1.4 LoRa® Time-on-Air */
+static uint32_t _symbols_numof(const sx126x_t *dev, uint16_t payload_len)
+{
+    uint8_t bit_crc = dev->pkt_params.crc_is_on ? 16 : 0;
+    /* header is transmitted with 4/8 CR */
+    uint8_t sym_header = dev->pkt_params.header_type == SX126X_LORA_PKT_IMPLICIT ? 0 : 20;
+    uint8_t sf = dev->mod_params.sf;
+    uint8_t cr = dev->mod_params.cr;
+    if (sf == SX126X_LORA_SF5 || sf == SX126X_LORA_SF6) {
+        /* SF5 and SF6:
+           NSYM_preamble + 6.25 + 8 + ceil(max(8 * NBYTE_payload + NBIT_crc - 4 * SF + NSYM_header, 0) / 4 * SF) * (CR * 4)
+        */
+        int32_t max = MAX(8 * payload_len + bit_crc - 4 * sf + sym_header, 0);
+        uint32_t ceil = DIV_ROUND_UP(max, 4 * sf);
+        return dev->pkt_params.preamble_len_in_symb + 7 /* 6.25 */ + 8 + ceil * (cr * 4);
+    }
+    else {
+        if (_ldro(dev)) {
+            /* all other SF with LDRO:
+               NSYM_preamble + 4.25 + 8 + ceil(max(8 * NBYTE_payload + NBIT_crc - 4 * SF + 8 + NSYM_header, 0) / 4 * SF) * (CR * 4)
+            */
+            int32_t max = MAX(8 * payload_len + bit_crc - 4 * sf + 8 + sym_header, 0);
+            uint32_t ceil = DIV_ROUND_UP(max, 4 * sf);
+            return dev->pkt_params.preamble_len_in_symb + 5 /* 4.25 */ + 8 + ceil * (cr * 4);
+        }
+        else {
+            /* all other SF without LDRO:
+               NSYM_preamble + 4.25 + 8 + ceil(max(8 * NBYTE_payload + NBIT_crc - 4 * SF + 8 + NSYM_header, 0) / 4 * (SF - 2)) * (CR * 4)
+            */
+            int32_t max = MAX(8 * payload_len + bit_crc - 4 * sf + 8 + sym_header, 0);
+            uint32_t ceil = DIV_ROUND_UP(max, 4 * (sf - 2));
+            return dev->pkt_params.preamble_len_in_symb + 5 /* 4.25 */ + 8 + ceil * (cr * 4);
+        }
+    }
 }
 
 static void sx126x_init_default_config(sx126x_t *dev)
@@ -294,22 +326,20 @@ static void sx126x_init_default_config(sx126x_t *dev)
     sx126x_set_lora_sync_word(dev, CONFIG_SX126X_DEFAULT_SYNC_WORD);
 #endif
 
-    dev->mod_params.bw = (sx126x_lora_bw_t)(CONFIG_LORA_BW_DEFAULT + SX126X_LORA_BW_125);
-    dev->mod_params.sf = (sx126x_lora_sf_t)CONFIG_LORA_SF_DEFAULT;
-    dev->mod_params.cr = (sx126x_lora_cr_t)CONFIG_LORA_CR_DEFAULT;
-    dev->mod_params.ldro = _compute_ldro(dev);
+    dev->mod_params.bw = _sx126x_lora_bw_from(CONFIG_SX126X_LORA_BW_DEFAULT);
+    dev->mod_params.sf = _sx126x_lora_sf_from(CONFIG_SX126X_LORA_SF_DEFAULT);
+    dev->mod_params.cr = _sx126x_lora_cr_from(CONFIG_SX126X_LORA_CR_DEFAULT);
+    dev->mod_params.ldro = _ldro(dev);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
 
-    dev->pkt_params.pld_len_in_bytes = 0;
-    dev->pkt_params.crc_is_on = !IS_ACTIVE(CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT);
-    dev->pkt_params.header_type = (
-        IS_ACTIVE(CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT) ? true : false
-        );
-    dev->pkt_params.preamble_len_in_symb = CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT;
-    dev->pkt_params.invert_iq_is_on = (
-        IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false
-        );
+    dev->pkt_params.pld_len_in_bytes = CONFIG_SX126X_LORA_FIXED_PAYLOAD_LENGTH_DEFAULT;
+    dev->pkt_params.crc_is_on = !IS_ACTIVE(CONFIG_SX126X_LORA_PAYLOAD_CRC_OFF_DEFAULT);
+    dev->pkt_params.header_type = IS_ACTIVE(CONFIG_SX126X_LORA_FIXED_HEADER_LEN_MODE_DEFAULT)
+                                    ? SX126X_LORA_PKT_IMPLICIT : SX126X_LORA_PKT_EXPLICIT;
+    dev->pkt_params.preamble_len_in_symb = CONFIG_SX126X_LORA_PREAMBLE_LENGTH_DEFAULT;
+    dev->pkt_params.invert_iq_is_on = IS_ACTIVE(CONFIG_SX126X_LORA_IQ_INVERTED_DEFAULT);
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
+    sx126x_cfg_rx_boosted(dev, false);
 }
 
 #if IS_ACTIVE(SX126X_SPI)
@@ -363,11 +393,12 @@ int sx126x_init(sx126x_t *dev)
 
 #if IS_ACTIVE(SX126X_SPI)
     gpio_init(dev->params->reset_pin, GPIO_OUT);
+    gpio_set(dev->params->reset_pin); /* must be held low for 100us to reset */
     gpio_init(dev->params->busy_pin, GPIO_IN_PD);
-
     /* Initialize DIOs */
-    if (gpio_is_valid(dev->params->dio1_pin)) {
-        res = gpio_init_int(dev->params->dio1_pin, GPIO_IN, GPIO_RISING, _dio1_isr, dev);
+    if (gpio_is_valid(dev->params->dio1_pin) && dev->event_cb) {
+        res = gpio_init_int(dev->params->dio1_pin, GPIO_IN, GPIO_RISING,
+                            dev->event_cb, dev->event_arg);
         if (res < 0) {
             DEBUG("[sx126x] error: failed to initialize DIO1 pin\n");
             return res;
@@ -474,13 +505,24 @@ void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
         sx126x_set_tx(dev, 0); /* no TX frame timeout */
         break;
     case SX126X_CHIP_MODE_RX: {
-        int timeout = (sx126x_symbol_to_msec(dev, dev->rx_timeout));
-        sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_STDBY_XOSC);
-        if (timeout > 0) {
-            sx126x_set_rx(dev, timeout);
+        sx126x_cfg_rx_boosted(dev, true);
+        if (dev->rx_timeout >= 0) {
+            int timeout = (sx126x_symbol_to_msec(dev, dev->rx_timeout));
+            sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_STDBY_XOSC);
+            if (timeout > 0) {
+                sx126x_set_rx(dev, timeout);
+            }
+            else {
+                sx126x_set_rx(dev, SX126X_RX_SINGLE_MODE);
+            }
         }
         else {
-            sx126x_set_rx(dev, SX126X_RX_SINGLE_MODE);
+            /* By default, the radio will always return in STDBY_RC
+               unless the configuration is changed by using this command.
+               Changing the default mode from STDBY_RC to STDBY_XOSC or FS
+               will only have an impact on the switching time of the radio */
+            sx126x_set_rx_tx_fallback_mode(dev, SX126X_FALLBACK_FS);
+            sx126x_set_rx_with_timeout_in_rtc_step(dev, SX126X_RX_CONTINUOUS);
         }
     } break;
     case SX126X_CHIP_MODE_STBY_RC:
@@ -543,41 +585,41 @@ void sx126x_set_channel(sx126x_t *dev, uint32_t freq)
 uint8_t sx126x_get_bandwidth(const sx126x_t *dev)
 {
     DEBUG("[sx126x]: sx126x_get_bandwidth \n");
-    return dev->mod_params.bw - SX126X_LORA_BW_125;
+    return _sx126x_lora_bw_to(dev->mod_params.bw);
 }
 
 void sx126x_set_bandwidth(sx126x_t *dev, uint8_t bandwidth)
 {
     DEBUG("[sx126x]: sx126x_set_bandwidth %02x\n", bandwidth);
-    dev->mod_params.bw = bandwidth + SX126X_LORA_BW_125;
-    dev->mod_params.ldro = _compute_ldro(dev);
+    dev->mod_params.bw = _sx126x_lora_bw_from(bandwidth);
+    dev->mod_params.ldro = _ldro(dev);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
 }
 
 uint8_t sx126x_get_spreading_factor(const sx126x_t *dev)
 {
     DEBUG("[sx126x]: sx126x_get_spreading_factor \n");
-    return dev->mod_params.sf;
+    return _sx126x_lora_sf_to(dev->mod_params.sf);
 }
 
 void sx126x_set_spreading_factor(sx126x_t *dev, uint8_t sf)
 {
     DEBUG("[sx126x]: sx126x_set_spreading_factor : %02x\n", sf);
-    dev->mod_params.sf = (sx126x_lora_sf_t)sf;
-    dev->mod_params.ldro = _compute_ldro(dev);
+    dev->mod_params.sf = _sx126x_lora_sf_from(sf);
+    dev->mod_params.ldro = _ldro(dev);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
 }
 
 uint8_t sx126x_get_coding_rate(const sx126x_t *dev)
 {
     DEBUG("[sx126x]: sx126x_get_coding_rate \n");
-    return dev->mod_params.cr;
+    return _sx126x_lora_cr_to(dev->mod_params.cr);
 }
 
 void sx126x_set_coding_rate(sx126x_t *dev, uint8_t cr)
 {
     DEBUG("[sx126x]: sx126x_set_coding_rate %01x\n", cr);
-    dev->mod_params.cr = (sx126x_lora_cr_t)cr;
+    dev->mod_params.cr = _sx126x_lora_cr_from(cr);
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
 }
 
@@ -659,3 +701,27 @@ void sx126x_set_lora_iq_invert(sx126x_t *dev, bool iq_invert)
     dev->pkt_params.invert_iq_is_on = iq_invert;
     sx126x_set_lora_pkt_params(dev, &dev->pkt_params);
 }
+
+uint32_t sx126x_symbol_time_on_air_us(const sx126x_t *dev)
+{
+    return _symbol_time_on_air_us(dev);
+}
+
+uint32_t sx126x_time_on_air_us(const sx126x_t *dev, uint16_t payload_len)
+{
+    return _symbols_numof(dev, payload_len) * _symbol_time_on_air_us(dev);
+}
+
+#if IS_USED(MODULE_SX126X_STM32WL)
+sx126x_t *sx126x_stm32wl = NULL;
+void isr_subghz_radio(void)
+{
+    /* Disable NVIC to avoid ISR conflict in CPU. */
+    NVIC_DisableIRQ(SUBGHZ_Radio_IRQn);
+    NVIC_ClearPendingIRQ(SUBGHZ_Radio_IRQn);
+    if (sx126x_stm32wl && sx126x_stm32wl->event_cb) {
+        sx126x_stm32wl->event_cb(sx126x_stm32wl->event_arg);
+    }
+    cortexm_isr_end();
+}
+#endif

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -422,7 +422,7 @@ int sx126x_init(sx126x_t *dev)
     sx126x_errors_mask_t error = 0;
     SX126X_CHECK_API(sx126x_get_device_errors(dev, &error), /* no return */);
     if (error) {
-        SX126X_LOG_ERROR(dev, "startup: device errors 0x%04x\n", error);
+        SX126X_DEBUG(dev, "startup: device errors 0x%04x\n", error);
     }
     SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
 

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -506,7 +506,7 @@ sx126x_chip_modes_t sx126x_get_state(const sx126x_t *dev)
     return radio_status.chip_mode;
 }
 
-void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
+int sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
 {
     /* check for errors */
     sx126x_errors_mask_t error = 0;
@@ -556,6 +556,7 @@ void sx126x_set_state(sx126x_t *dev, sx126x_chip_modes_t state)
         SX126X_DEBUG(dev, "after set state: device error 0x%04x before setting state\n", error);
     }
     SX126X_CHECK_API(sx126x_clear_device_errors(dev), /* no return */);
+    return (error) ? -EIO : 0;
 }
 
 uint32_t sx126x_get_channel(const sx126x_t *dev)

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -53,7 +53,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     /* Write payload buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         if (iol->iol_len > 0) {
-            sx126x_write_buffer(dev, pos, iol->iol_base, iol->iol_len);
+            SX126X_CHECK_API(sx126x_write_buffer(dev, pos, iol->iol_base, iol->iol_len),
+                             return -EIO);
             SX126X_DEBUG(dev, "netdev: send: wrote data to payload buffer.\n");
             pos += iol->iol_len;
         }
@@ -83,14 +84,14 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     if (packet_info) {
         sx126x_pkt_status_lora_t pkt_status;
-        sx126x_get_lora_pkt_status(dev, &pkt_status);
+        SX126X_CHECK_API(sx126x_get_lora_pkt_status(dev, &pkt_status), return -EIO);
         packet_info->snr = pkt_status.snr_pkt_in_db;
         packet_info->rssi = pkt_status.rssi_pkt_in_dbm;
     }
 
     sx126x_rx_buffer_status_t rx_buffer_status;
 
-    sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+    SX126X_CHECK_API(sx126x_get_rx_buffer_status(dev, &rx_buffer_status), return -EIO);
 
     size = rx_buffer_status.pld_len_in_bytes;
 
@@ -102,7 +103,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         return -ENOBUFS;
     }
 
-    sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer, buf, size);
+    SX126X_CHECK_API(sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer, buf, size),
+                                        return -EIO);
 
     return size;
 }
@@ -132,7 +134,7 @@ static void _isr(netdev_t *netdev)
 
     sx126x_irq_mask_t irq_mask;
 
-    sx126x_get_and_clear_irq_status(dev, &irq_mask);
+    SX126X_CHECK_API(sx126x_get_and_clear_irq_status(dev, &irq_mask), /* no return */);
 
     if (sx126x_is_stm32wl(dev)) {
 #if IS_USED(MODULE_SX126X_STM32WL)
@@ -258,7 +260,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     case NETOPT_RANDOM:
         assert(max_len >= sizeof(uint32_t));
-        sx126x_get_random_numbers(dev, val, 1);
+        SX126X_CHECK_API(sx126x_get_random_numbers(dev, val, 1), return -EIO);
         return sizeof(uint32_t);
 
     case NETOPT_IQ_INVERT:
@@ -268,7 +270,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     case NETOPT_RSSI:
         assert(max_len >= sizeof(int16_t));
-        sx126x_get_rssi_inst(dev, ((int16_t *)val));
+        SX126X_CHECK_API(sx126x_get_rssi_inst(dev, ((int16_t *)val)), return -EIO);
         return sizeof(int16_t);
 
     default:
@@ -310,7 +312,7 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
 
     case NETOPT_STATE_RESET:
         SX126X_DEBUG(dev, "netdev: set NETOPT_STATE_RESET state\n");
-        sx126x_reset(dev);
+        SX126X_CHECK_API(sx126x_reset(dev), return -EIO);
         break;
 
     default:
@@ -338,7 +340,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         assert(len <= sizeof(uint16_t));
         /* Only LoRa modem is supported for the moment */
         if (*(const uint16_t *)val == NETDEV_TYPE_LORA) {
-            sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA);
+            SX126X_CHECK_API(sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA), return -EIO);
             return sizeof(uint16_t);
         }
         else {
@@ -438,7 +440,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
     case NETOPT_SYNCWORD:
         assert(len <= sizeof(uint8_t));
-        sx126x_set_lora_sync_word(dev, *((uint8_t *)val));
+        SX126X_CHECK_API(sx126x_set_lora_sync_word(dev, *((uint8_t *)val)), return -EIO);
         return sizeof(uint8_t);
 
     case NETOPT_IQ_INVERT:

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -44,7 +44,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
     netdev->driver->get(netdev, NETOPT_STATE, &state, sizeof(uint8_t));
     if (state == NETOPT_STATE_TX) {
-        DEBUG("[sx126x] netdev: cannot send packet, radio is already transmitting.\n");
+        SX126X_DEBUG(dev, "netdev: cannot send packet, radio is already transmitting.\n");
         return -ENOTSUP;
     }
 
@@ -54,7 +54,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         if (iol->iol_len > 0) {
             sx126x_write_buffer(dev, pos, iol->iol_base, iol->iol_len);
-            DEBUG("[sx126x] netdev: send: wrote data to payload buffer.\n");
+            SX126X_DEBUG(dev, "netdev: send: wrote data to payload buffer.\n");
             pos += iol->iol_len;
         }
     }
@@ -64,23 +64,21 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         return 0;
     }
 
-    DEBUG("[sx126x] netdev: sending packet now (size: %" PRIuSIZE ").\n", pos);
+    SX126X_DEBUG(dev, "netdev: sending packet now (size: %" PRIuSIZE ").\n", pos);
     sx126x_set_lora_payload_length(dev, pos);
 
     state = NETOPT_STATE_TX;
     netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(uint8_t));
-    DEBUG("[sx126x] netdev: send: transmission in progress.\n");
+    SX126X_DEBUG(dev, "netdev: send: transmission in progress.\n");
 
     return 0;
 }
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    DEBUG("[sx126x] netdev: read received data.\n");
-
     sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
+    SX126X_DEBUG(dev, "netdev: read received data.\n");
     uint8_t size = 0;
-
     netdev_lora_rx_info_t *packet_info = info;
 
     if (packet_info) {
@@ -114,13 +112,13 @@ static int _init(netdev_t *netdev)
     sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
 
     /* Launch initialization of driver and device */
-    DEBUG("[sx126x] netdev: initializing driver...\n");
+    SX126X_DEBUG(dev, "netdev: initializing driver...\n");
     if (sx126x_init(dev) != 0) {
-        DEBUG("[sx126x] netdev: initialization failed\n");
+        SX126X_DEBUG(dev, "netdev: initialization failed\n");
         return -1;
     }
 
-    DEBUG("[sx126x] netdev: initialization successful\n");
+    SX126X_DEBUG(dev, "netdev: initialization successful\n");
 
     /* signal link UP */
     netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
@@ -143,43 +141,43 @@ static void _isr(netdev_t *netdev)
     }
 
     if (irq_mask & SX126X_IRQ_TX_DONE) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_TX_DONE\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_TX_DONE\n");
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
     }
     else if (irq_mask & SX126X_IRQ_RX_DONE) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_RX_DONE\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_RX_DONE\n");
         netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
     }
     else if (irq_mask & SX126X_IRQ_PREAMBLE_DETECTED) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_PREAMBLE_DETECTED\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_PREAMBLE_DETECTED\n");
     }
     else if (irq_mask & SX126X_IRQ_SYNC_WORD_VALID) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_SYNC_WORD_VALID\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_SYNC_WORD_VALID\n");
     }
     else if (irq_mask & SX126X_IRQ_HEADER_VALID) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_HEADER_VALID\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_HEADER_VALID\n");
         netdev->event_callback(netdev, NETDEV_EVENT_RX_STARTED);
     }
     else if (irq_mask & SX126X_IRQ_HEADER_ERROR) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_HEADER_ERROR\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_HEADER_ERROR\n");
     }
     else if (irq_mask & SX126X_IRQ_CRC_ERROR) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_CRC_ERROR\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_CRC_ERROR\n");
         netdev->event_callback(netdev, NETDEV_EVENT_CRC_ERROR);
     }
     else if (irq_mask & SX126X_IRQ_CAD_DONE) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_CAD_DONE\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_CAD_DONE\n");
         netdev->event_callback(netdev, NETDEV_EVENT_CAD_DONE);
     }
     else if (irq_mask & SX126X_IRQ_CAD_DETECTED) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_CAD_DETECTED\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_CAD_DETECTED\n");
     }
     else if (irq_mask & SX126X_IRQ_TIMEOUT) {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_TIMEOUT\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_TIMEOUT\n");
         netdev->event_callback(netdev, NETDEV_EVENT_RX_TIMEOUT);
     }
     else {
-        DEBUG("[sx126x] netdev: SX126X_IRQ_NONE\n");
+        SX126X_DEBUG(dev, "netdev: SX126X_IRQ_NONE\n");
     }
 }
 
@@ -187,6 +185,7 @@ static int _get_state(sx126x_t *dev, void *val)
 {
     netopt_state_t state;
     sx126x_chip_modes_t mode = sx126x_get_state(dev);
+    SX126X_DEBUG(dev, "netdev: state: %d\n", mode);
     switch (mode) {
     case SX126X_CHIP_MODE_FS:
         state = NETOPT_STATE_IDLE;
@@ -283,13 +282,13 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
 {
     switch (state) {
     case NETOPT_STATE_STANDBY:
-        DEBUG("[sx126x] netdev: set NETOPT_STATE_STANDBY state\n");
+        SX126X_DEBUG(dev, "netdev: set NETOPT_STATE_STANDBY state\n");
         sx126x_set_state(dev, SX126X_CHIP_MODE_STBY_XOSC);
         break;
 
     case NETOPT_STATE_IDLE:
     case NETOPT_STATE_RX:
-        DEBUG("[sx126x] netdev: set NETOPT_STATE_RX state\n");
+        SX126X_DEBUG(dev, "netdev: set NETOPT_STATE_RX state\n");
 #if IS_USED(MODULE_SX126X_RF_SWITCH)
         /* Refer Section 4.2 RF Switch in Application Note (AN5406) */
         if (dev->params->set_rf_mode) {
@@ -300,7 +299,7 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
         break;
 
     case NETOPT_STATE_TX:
-        DEBUG("[sx126x] netdev: set NETOPT_STATE_TX state\n");
+        SX126X_DEBUG(dev, "netdev: set NETOPT_STATE_TX state\n");
 #if IS_USED(MODULE_SX126X_RF_SWITCH)
         if (dev->params->set_rf_mode) {
             dev->params->set_rf_mode(dev, dev->params->tx_pa_mode);
@@ -310,7 +309,7 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
         break;
 
     case NETOPT_STATE_RESET:
-        DEBUG("[sx126x] netdev: set NETOPT_STATE_RESET state\n");
+        SX126X_DEBUG(dev, "netdev: set NETOPT_STATE_RESET state\n");
         sx126x_reset(dev);
         break;
 

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include <errno.h>
 
@@ -34,19 +35,6 @@
 
 const uint8_t llcc68_max_sf = LORA_SF11;
 const uint8_t sx126x_max_sf = LORA_SF12;
-
-#if IS_USED(MODULE_SX126X_STM32WL)
-static netdev_t *_dev;
-
-void isr_subghz_radio(void)
-{
-    /* Disable NVIC to avoid ISR conflict in CPU. */
-    NVIC_DisableIRQ(SUBGHZ_Radio_IRQn);
-    NVIC_ClearPendingIRQ(SUBGHZ_Radio_IRQn);
-    netdev_trigger_event_isr(_dev);
-    cortexm_isr_end();
-}
-#endif
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
@@ -124,12 +112,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 static int _init(netdev_t *netdev)
 {
     sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
-
-    if (sx126x_is_stm32wl(dev)) {
-#if IS_USED(MODULE_SX126X_STM32WL)
-        _dev = netdev;
-#endif
-    }
 
     /* Launch initialization of driver and device */
     DEBUG("[sx126x] netdev: initializing driver...\n");
@@ -369,6 +351,17 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         sx126x_set_channel(dev, *((const uint32_t *)val));
         return sizeof(uint32_t);
 
+    case NETOPT_SINGLE_RECEIVE:
+        assert(len <= sizeof(netopt_enable_t));
+        netopt_enable_t single_rx = *((const netopt_enable_t *)val);
+        if (single_rx) {
+            dev->rx_timeout = 0;
+        }
+        else {
+            dev->rx_timeout = -1;
+        }
+        return sizeof(netopt_enable_t);
+
     case NETOPT_BANDWIDTH:
         assert(len <= sizeof(uint8_t));
         uint8_t bw = *((const uint8_t *)val);
@@ -413,18 +406,25 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         return sizeof(netopt_enable_t);
 
     case NETOPT_RX_SYMBOL_TIMEOUT:
-        assert(len <= sizeof(uint16_t));
-        dev->rx_timeout = *(const uint16_t *)val;
-        return sizeof(uint16_t);
+        assert(len <= sizeof(int32_t));
+        int32_t timeout = *((const int32_t *)val);
+        if (timeout >= 0) {
+            dev->rx_timeout = *(const int32_t *)val;
+            return sizeof(int32_t);
+        }
+        else {
+            res = -EINVAL;
+            break;
+        }
 
     case NETOPT_TX_POWER:
         assert(len <= sizeof(int16_t));
         int16_t power = *((const int16_t *)val);
-        if ((power < INT8_MIN) || (power > INT8_MAX)) {
+        if ((power < SX126X_POWER_MIN) || (power > SX126X_POWER_MAX)) {
             res = -EINVAL;
             break;
         }
-        sx126x_set_tx_power(dev, power, SX126X_RAMP_10_US);
+        sx126x_set_tx_power(dev, power, CONFIG_SX126X_RAMP_TIME_DEFAULT);
         return sizeof(int16_t);
 
     case NETOPT_FIXED_HEADER:
@@ -462,3 +462,24 @@ const netdev_driver_t sx126x_driver = {
     .get = _get,
     .set = _set,
 };
+
+static void _event_cb(void *arg)
+{
+    netdev_trigger_event_isr(arg);
+}
+
+void sx126x_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index)
+{
+    memset((uint8_t *)dev + sizeof(dev->netdev), 0, sizeof(*dev) - sizeof(dev->netdev));
+    netdev_t *netdev = &dev->netdev;
+    netdev->driver = &sx126x_driver;
+    dev->params = (sx126x_params_t *)params;
+    dev->event_cb = _event_cb;
+    dev->event_arg = netdev;
+    netdev_register(&dev->netdev, NETDEV_SX126X, index);
+#if IS_USED(MODULE_SX126X_STM32WL)
+#if SX126X_NUMOF == 1
+    extern sx126x_t *sx126x_stm32wl = dev;
+#endif
+#endif
+}

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -1,0 +1,589 @@
+/*
+ * Copyright (C) 2023-2025
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_sx126x
+ * @{
+ * @file
+ * @brief       Radio HAL implementation for the Semtech SX126x
+ *
+ * @author      Klim Evdokimov <klimevdokimov@mail.ru>
+ * @author      Fabian Hüßler <fabian.huessler@ml-pa.com
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "macros/utils.h"
+#include "modules.h"
+#if IS_USED(MODULE_SX126X_IEEE802154)
+#include "net/ieee802154/radio.h"
+#include "net/ieee802154/submac.h"
+#endif
+#include "od.h"
+
+#include "sx126x.h"
+#include "sx126x_params.h"
+#include "sx126x_internal.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#define SX126X_BUFFER_SIZE              (256)
+#define SX126X_RX_BUFFER_OFFSET         (0)
+#define SX126X_TX_BUFFER_OFFSET         ((SX126X_BUFFER_SIZE) / 2)
+
+#if IS_USED(MODULE_SX126X_IEEE802154)
+
+/**
+ * @brief   Internal sx126x device states
+ */
+typedef enum {
+    SX126X_STATE_STANDBY,
+    SX126X_STATE_TX,
+    SX126X_STATE_RX,
+    SX126X_STATE_CAD,
+} sx126x_state_t;
+
+static int _set_state(sx126x_t *dev, sx126x_state_t state);
+static int _get_state(sx126x_t *dev, void  *val);
+
+static bool _l2filter(ieee802154_dev_t *hal, uint8_t *mhr)
+{
+    sx126x_t *dev = hal->priv;
+    uint8_t dst_addr[IEEE802154_LONG_ADDRESS_LEN];
+    le_uint16_t dst_pan;
+    le_uint16_t pan_bcast = { .u8 = IEEE802154_PANID_BCAST };
+
+    int addr_len = ieee802154_get_dst(mhr, dst_addr, &dst_pan);
+
+    if ((mhr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_BEACON) {
+        if (dev->pan_id ==  pan_bcast.u16) {
+            DEBUG("[sx126x] hal: beacon\n");
+            return true;
+        }
+    }
+
+    /* filter PAN ID */
+    /* Will only work on little endian platform (all?) */
+
+    if (pan_bcast.u16 != byteorder_ltohs(dst_pan) &&
+        dev->pan_id != byteorder_ltohs(dst_pan)) {
+        DEBUG("[sx126x] hal: PAN ID mismatch\n");
+        return false;
+    }
+
+    /* check destination address */
+    if (addr_len == IEEE802154_SHORT_ADDRESS_LEN) {
+        if (memcmp(dev->short_addr, dst_addr, addr_len) == 0 ||
+            memcmp(ieee802154_addr_bcast, dst_addr, addr_len) == 0) {
+            return true;
+        }
+        else {
+            DEBUG("[sx126x] hal: short address mismatch 0x%02x:0x%02x\n",
+                  dst_addr[0], dst_addr[1]);
+            return false;
+        }
+    }
+    else if (addr_len == IEEE802154_LONG_ADDRESS_LEN) {
+        if (memcmp(dev->long_addr, dst_addr, addr_len) == 0) {
+            return true;
+        }
+        else {
+            DEBUG("[sx126x] hal: long address mismatch 0x%02x:0x%02x:0x%02x:0x%02x:0x%02x:0x%02x:0x%02x:0x%02x\n",
+                  dst_addr[0], dst_addr[1], dst_addr[2], dst_addr[3], dst_addr[4], dst_addr[5], dst_addr[6], dst_addr[7]);
+            return false;
+        }
+    }
+
+    return false;
+}
+
+static int _set_state(sx126x_t *dev, sx126x_state_t state)
+{
+    switch (state) {
+    case SX126X_STATE_STANDBY:
+        DEBUG("[sx126x] hal: set STATE_STANDBY\n");
+        sx126x_set_state(dev, SX126X_CHIP_MODE_STBY_XOSC);
+        break;
+
+    case SX126X_STATE_RX:
+        DEBUG("[sx126x] hal: set STATE_RX\n");
+#if IS_USED(MODULE_SX126X_RF_SWITCH)
+        /* Refer Section 4.2 RF Switch in Application Note (AN5406) */
+        if (dev->params->set_rf_mode) {
+            dev->params->set_rf_mode(dev, SX126X_RF_MODE_RX);
+        }
+#endif
+        sx126x_set_state(dev, SX126X_CHIP_MODE_RX);
+        break;
+
+    case SX126X_STATE_TX:
+        DEBUG("[sx126x] hal: set STATE_TX\n");
+#if IS_USED(MODULE_SX126X_RF_SWITCH)
+        if (dev->params->set_rf_mode) {
+            dev->params->set_rf_mode(dev, dev->params->tx_pa_mode);
+        }
+#endif
+        sx126x_set_state(dev, SX126X_CHIP_MODE_TX);
+        break;
+
+    case SX126X_STATE_CAD:
+        DEBUG("[sx126x] hal: set STATE_CCA\n");
+        dev->cad_done = false;
+        sx126x_set_cad(dev);
+        break;
+
+    default:
+        return -ENOTSUP;
+    }
+    return sizeof(sx126x_state_t);
+}
+
+static int _get_state(sx126x_t *dev, void *val)
+{
+    sx126x_state_t state;
+    sx126x_chip_modes_t mode = sx126x_get_state(dev);
+    DEBUG("[sx126x] hal: state %d\n", mode);
+    switch (mode) {
+    case SX126X_CHIP_MODE_TX:
+        state = SX126X_STATE_TX;
+        break;
+
+    case SX126X_CHIP_MODE_RX:
+        state = SX126X_STATE_RX;
+        break;
+
+    default:
+        state = SX126X_STATE_STANDBY;
+        break;
+    }
+    memcpy(val, &state, sizeof(sx126x_state_t));
+    return sizeof(sx126x_state_t);
+}
+
+void sx126x_hal_event_handler(ieee802154_dev_t *hal)
+{
+    sx126x_t *dev = hal->priv;
+    sx126x_irq_mask_t irq_mask;
+
+    sx126x_get_and_clear_irq_status(dev, &irq_mask);
+    DEBUG("sx126x_hal_event_handler(): 0x%"PRIx16"\n", irq_mask);
+    if (sx126x_is_stm32wl(dev)) {
+#if IS_USED(MODULE_SX126X_STM32WL)
+        NVIC_EnableIRQ(SUBGHZ_Radio_IRQn);
+#endif
+    }
+    if (irq_mask & SX126X_IRQ_TX_DONE) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_TX_DONE\n");
+        hal->cb(hal, IEEE802154_RADIO_CONFIRM_TX_DONE);
+    }
+    else if (irq_mask & SX126X_IRQ_RX_DONE) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_RX_DONE\n");
+        uint8_t mhdr[IEEE802154_MAX_HDR_LEN];
+        sx126x_rx_buffer_status_t rx_buffer_status;
+        sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+        size_t rx_size = MIN(sizeof(mhdr), rx_buffer_status.pld_len_in_bytes);
+        sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer, mhdr, rx_size);
+        bool is_ack = (mhdr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_ACK;
+        bool is_data = (mhdr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA;
+        bool ackf = dev->ack_filter;
+        bool match = false;
+
+        /* If the L2 filter passes, device if the frame is indicated
+         * directly or if the driver should send an ACK frame before the indication */
+        if (is_ack || (!ackf && (match = _l2filter(hal, mhdr)))) {
+            if (is_data && (mhdr[0] & IEEE802154_FCF_ACK_REQ)) {
+                DEBUG("Received valid frame, need to send ack\n");
+            }
+            DEBUG("[sx126x] RX (%s) frame\n", is_ack ? "ACK" : (is_data ? "DATA" : "UNKNOWN"));
+            hal->cb(hal, IEEE802154_RADIO_INDICATION_RX_DONE);
+        }
+        /* If radio is in promiscuos mode, indicate packet and
+         * don't event think of sending an ACK frame :) */
+        else if (dev->promisc) {
+            DEBUG("[sx126x] Promiscuous mode is enabled.\n");
+            hal->cb(hal, IEEE802154_RADIO_INDICATION_RX_DONE);
+        }
+        /* If all failed, simply drop the frame and continue listening
+         * to incoming frames */
+        else {
+            DEBUG("[sx126x] ACK filter %s.\n", ackf ? "enabled" : "disabled");
+            DEBUG("[sx126x] L2 filter %s.\n", match ? "passed" : "failed");
+            _set_state(dev, SX126X_STATE_RX);
+        }
+    }
+    else if (irq_mask & SX126X_IRQ_PREAMBLE_DETECTED) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_PREAMBLE_DETECTED\n");
+    }
+    else if (irq_mask & SX126X_IRQ_SYNC_WORD_VALID) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_SYNC_WORD_VALID\n");
+    }
+    else if (irq_mask & SX126X_IRQ_HEADER_VALID) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_HEADER_VALID\n");
+        hal->cb(hal, IEEE802154_RADIO_INDICATION_RX_START);
+    }
+    else if (irq_mask & SX126X_IRQ_HEADER_ERROR) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_HEADER_ERROR\n");
+    }
+    else if (irq_mask & SX126X_IRQ_CRC_ERROR) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_CRC_ERROR\n");
+        hal->cb(hal, IEEE802154_RADIO_INDICATION_CRC_ERROR);
+    }
+    else if (irq_mask & SX126X_IRQ_CAD_DONE) {
+        if (irq_mask & SX126X_IRQ_CAD_DETECTED){
+            DEBUG("[sx126x] hal: SX126X_IRQ_CAD_DETECTED \n");
+            dev->cad_detected = true;
+        }
+        DEBUG("[sx126x] hal: SX126X_IRQ_CAD_DONE\n");
+        dev->cad_done = true;
+        hal->cb(hal, IEEE802154_RADIO_CONFIRM_CCA);
+        _set_state(dev, SX126X_STATE_RX);
+    }
+    else if (irq_mask & SX126X_IRQ_TIMEOUT) {
+        DEBUG("[sx126x] hal: SX126X_IRQ_TIMEOUT\n");
+    }
+    else {
+        DEBUG("[sx126x] hal: SX126X_IRQ_NONE\n");
+    }
+}
+
+static int _write(ieee802154_dev_t *hal, const iolist_t *iolist)
+{
+    sx126x_t *dev = hal->priv;
+    size_t pos = 0;
+    /* Full buffer used for Tx */
+    sx126x_set_buffer_base_address(dev, SX126X_TX_BUFFER_OFFSET, SX126X_RX_BUFFER_OFFSET);
+    /* Write payload buffer */
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        if (pos + iol->iol_len > SX126X_BUFFER_SIZE - SX126X_TX_BUFFER_OFFSET - IEEE802154_FCS_LEN) {
+            DEBUG("[sx126] hal: no buffer space to write payload\n");
+            return -E2BIG;
+        }
+        if (iol->iol_len > 0) {
+            sx126x_write_buffer(dev, SX126X_TX_BUFFER_OFFSET + pos, iol->iol_base, iol->iol_len);
+            DEBUG("[sx126x] hal: wrote data to payload buffer\n");
+            pos += iol->iol_len;
+#if IS_ACTIVE(ENABLE_DEBUG)
+            od_hex_dump(iol->iol_base, iol->iol_len, OD_WIDTH_DEFAULT);
+#endif
+        }
+    }
+    /* Do not compute IEEE 802.15.4 CRC because LoRa frame also provides CRC */
+    uint16_t chksum = 0;
+    sx126x_write_buffer(dev, SX126X_TX_BUFFER_OFFSET + pos, (uint8_t *)&chksum, sizeof(chksum));
+    pos += sizeof(chksum);
+    sx126x_set_lora_payload_length(dev, pos);
+    DEBUG("[sx126x] writing (size: %d)\n", (pos));
+    return 0;
+}
+
+static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
+{
+    sx126x_t *dev = hal->priv;
+    (void)ctx;
+    switch (op) {
+    case IEEE802154_HAL_OP_TRANSMIT:
+        dev->pending = false;
+        ieee802154_radio_cca(hal);
+        _set_state(dev, SX126X_STATE_TX);
+        break;
+
+    case IEEE802154_HAL_OP_SET_RX:
+        _set_state(dev, SX126X_STATE_RX);
+        break;
+
+    case IEEE802154_HAL_OP_SET_IDLE:
+        _set_state(dev, SX126X_STATE_STANDBY);
+        break;
+
+    case IEEE802154_HAL_OP_CCA:
+        DEBUG("[sx126x] hal: HAL_OP_CCA (CAD Detection state)\n");
+        dev->cad_detected = false;
+        _set_state(dev, SX126X_STATE_STANDBY);
+        sx126x_set_cad(dev);
+        break;
+    }
+    return 0;
+}
+
+static int _confirm_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
+{
+    sx126x_t *dev = hal->priv;
+    ieee802154_tx_info_t *info = ctx;
+    bool eagain = false;
+    sx126x_state_t state;
+    _get_state(dev, &state);
+
+    switch (op){
+    case IEEE802154_HAL_OP_TRANSMIT:
+        if (state == SX126X_STATE_TX) {
+            eagain = true;
+        }
+        else if (info) {
+            info->status = (dev->cad_detected) ? TX_STATUS_MEDIUM_BUSY : TX_STATUS_SUCCESS;
+        }
+        break;
+
+    case IEEE802154_HAL_OP_SET_RX:
+        eagain = (state != SX126X_STATE_RX);
+        break;
+
+    case IEEE802154_HAL_OP_SET_IDLE:
+        eagain = (state != SX126X_STATE_STANDBY);
+        break;
+
+    case IEEE802154_HAL_OP_CCA:
+        *((bool *)ctx) = !dev->cad_detected;
+        break;
+    }
+    return eagain ? -EAGAIN : 0;
+}
+
+static int _len(ieee802154_dev_t *hal)
+{
+    sx126x_t *dev = hal->priv;
+    sx126x_rx_buffer_status_t rx_buffer_status;
+    sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+    return rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN;
+}
+
+static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_rx_info_t *info)
+{
+    sx126x_t* dev = hal->priv;
+    /* Getting information about last received packet */
+    sx126x_rx_buffer_status_t rx_buffer_status;
+    sx126x_pkt_status_lora_t pkt_status;
+    sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+    sx126x_get_lora_pkt_status(dev, &pkt_status);
+
+    if (info) {
+        /* scale int8_t LoRa SNR into uint8_t IEEE 802.15.4 LQI */
+        DEBUG("[sx126x] hal: SNR %"PRId8"db\n", pkt_status.snr_pkt_in_db);
+        info->lqi = (-INT8_MIN) + pkt_status.snr_pkt_in_db;
+        /* scale into IEEE 802.15.4 RSSI [-174,80] dbm */
+        DEBUG("[sx126x] hal: RSSI %"PRId8"dbm\n", pkt_status.rssi_pkt_in_dbm);
+        info->rssi = ieee802154_dbm_to_rssi(pkt_status.rssi_pkt_in_dbm);
+    }
+    /* Put PSDU to the output buffer */
+    if (buf == NULL) {
+        return rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN;
+    }
+    if (rx_buffer_status.pld_len_in_bytes > max_size + IEEE802154_FCS_LEN) {
+        return -ENOBUFS;
+    }
+    if (rx_buffer_status.pld_len_in_bytes < IEEE802154_ACK_FRAME_LEN) {
+        return -EBADMSG;
+    }
+    sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer,
+                       buf, rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN);
+    /* Do not compute IEEE 802.15.4 CRC because LoRa frame also provides CRC */
+    return rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN;
+}
+
+static int _set_cca_threshold(ieee802154_dev_t *hal, int8_t threshold)
+{
+    (void)hal;
+    (void)threshold;
+    return 0;
+}
+
+static int _config_phy(ieee802154_dev_t *hal, ieee802154_phy_conf_t *conf)
+{
+    sx126x_t *dev = hal->priv;
+    /* Ignore channel number and page because it does not apply for LoRa */
+    sx126x_set_tx_power(dev, conf->pow, CONFIG_SX126X_RAMP_TIME_DEFAULT);
+    conf->res.ack_timeout_us =
+        sx126x_symbol_time_on_air_us(dev) * (IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+                                             IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS) +
+        sx126x_time_on_air_us(dev, IEEE802154_ACK_FRAME_LEN);
+    assert(conf->res.ack_timeout_us);
+    return 0;
+}
+
+static int _off(ieee802154_dev_t *hal)
+{
+    (void)hal;
+    sx126x_t *dev = hal->priv;
+    sx126x_set_sleep(dev, SX126X_SLEEP_CFG_WARM_START);
+    return 0;
+}
+
+static int _config_addr_filter(ieee802154_dev_t *hal, ieee802154_af_cmd_t cmd, const void *value)
+{
+    (void)cmd;
+    (void)value;
+    sx126x_t *dev = hal->priv;
+    switch(cmd) {
+        case IEEE802154_AF_SHORT_ADDR:
+            memcpy(dev->short_addr, value, IEEE802154_SHORT_ADDRESS_LEN);
+            break;
+        case IEEE802154_AF_EXT_ADDR:
+            memcpy(dev->long_addr, value, IEEE802154_LONG_ADDRESS_LEN);
+            break;
+        case IEEE802154_AF_PANID:
+            dev->pan_id = *(uint16_t *)value;
+            break;
+        case IEEE802154_AF_PAN_COORD:
+            return -ENOTSUP;
+    }
+    return 0;
+}
+
+static int _request_on(ieee802154_dev_t *hal)
+{
+    (void)hal;
+    sx126x_t *dev = hal->priv;
+    _set_state(dev, SX126X_STATE_STANDBY);
+    return 0;
+}
+
+static int _confirm_on(ieee802154_dev_t *hal)
+{
+    (void)hal;
+    return -ENOTSUP;
+}
+
+static int _set_cca_mode(ieee802154_dev_t *hal, ieee802154_cca_mode_t mode)
+{
+    (void)mode;
+    sx126x_t* dev = hal->priv;
+    DEBUG("[sx126x] hal: set_cca_mode \n");
+    sx126x_cad_params_t cad_params = {
+        .cad_exit_mode = SX126X_CAD_ONLY,
+        .cad_detect_min = 10,
+        .cad_detect_peak = 22,
+        .cad_symb_nb = SX126X_CAD_02_SYMB,
+        /* Rx timeout = cad_timeout * 15.625us */
+        /* Rx timeout = 60ms */
+        .cad_timeout = 0x000F00,
+    };
+    sx126x_set_cad_params(dev, &cad_params);
+    return 0;
+}
+
+static int _config_src_addr_match(ieee802154_dev_t *hal, ieee802154_src_match_t cmd, const void *value)
+{
+    (void)hal;
+    (void)cmd;
+    (void)value;
+    return -ENOTSUP;
+}
+
+static int _set_frame_filter_mode(ieee802154_dev_t *hal, ieee802154_filter_mode_t mode)
+{
+    sx126x_t* dev = hal->priv;
+
+    bool ackf = false;
+    bool promisc = false;
+
+    switch (mode) {
+    case IEEE802154_FILTER_ACCEPT:
+        DEBUG("[sx126x] hal: Filter accept all\n");
+        break;
+    case IEEE802154_FILTER_PROMISC:
+        promisc = true;
+        break;
+    case IEEE802154_FILTER_ACK_ONLY:
+        ackf = true;
+        DEBUG("[sx126x] hal: Filter ACK only\n");
+        break;
+    default:
+        return -ENOTSUP;
+    }
+
+    dev->ack_filter = ackf;
+    dev->promisc = promisc;
+
+    return 0;
+}
+
+static int _get_frame_filter_mode(ieee802154_dev_t *hal, ieee802154_filter_mode_t *mode)
+{
+    sx126x_t* dev = hal->priv;
+
+    if (dev->ack_filter) {
+        *mode = IEEE802154_FILTER_ACK_ONLY;
+    }
+    else if (dev->promisc) {
+        *mode = IEEE802154_FILTER_PROMISC;
+    }
+    else {
+        *mode = IEEE802154_FILTER_ACCEPT;
+    }
+    DEBUG("[sx126x] hal: get_frame_filter_mode %d\n", *mode);
+    return 0;
+}
+
+static int _set_csma_params(ieee802154_dev_t *hal, const ieee802154_csma_be_t *bd, int8_t retries)
+{
+    (void)hal;
+    (void)bd;
+    (void)retries;
+
+    return -ENOTSUP;
+}
+
+static const ieee802154_radio_ops_t _sx126x_ops = {
+    .caps =  IEEE802154_CAP_SUB_GHZ
+          | IEEE802154_CAP_IRQ_CRC_ERROR
+          | IEEE802154_CAP_IRQ_RX_START
+          | IEEE802154_CAP_IRQ_TX_DONE
+          | IEEE802154_CAP_IRQ_CCA_DONE,
+    .write = _write,
+    .read = _read,
+    .request_on = _request_on,
+    .confirm_on = _confirm_on,
+    .len = _len,
+    .off = _off,
+    .request_op = _request_op,
+    .confirm_op = _confirm_op,
+    .set_cca_threshold = _set_cca_threshold,
+    .set_cca_mode = _set_cca_mode,
+    .config_phy = _config_phy,
+    .set_csma_params = _set_csma_params,
+    .config_addr_filter = _config_addr_filter,
+    .config_src_addr_match = _config_src_addr_match,
+    .set_frame_filter_mode = _set_frame_filter_mode,
+    .get_frame_filter_mode = _get_frame_filter_mode,
+};
+
+#endif /* IS_USED(MODULE_SX126X_IEEE802154) */
+
+extern const netdev_driver_t sx126x_driver;
+
+void sx126x_hal_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index,
+                      void *hal, void (*event_cb)(void *arg), void *arg)
+{
+    (void)dev;
+    (void)params;
+    (void)hal;
+    (void)index;
+    (void)event_cb;
+    (void)arg;
+    /* legacy */
+    memset((uint8_t *)dev + sizeof(dev->netdev), 0, sizeof(*dev) - sizeof(dev->netdev));
+    netdev_t *netdev = &dev->netdev;
+    netdev->driver = &sx126x_driver;
+#if IS_USED(MODULE_SX126X_IEEE802154)
+    dev->params = (sx126x_params_t *)params;
+    dev->ack_filter = false;
+    dev->pending = false;
+    dev->event_cb = event_cb;
+    dev->event_arg = arg;
+    ((ieee802154_dev_t *)hal)->driver = &_sx126x_ops;
+    ((ieee802154_dev_t *)hal)->priv = dev;
+#if IS_USED(MODULE_SX126X_STM32WL)
+#if SX126X_NUMOF == 1
+    extern sx126x_t *sx126x_stm32wl = dev;
+#endif
+#endif
+#endif
+}

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -404,7 +404,9 @@ static int _config_phy(ieee802154_dev_t *hal, ieee802154_phy_conf_t *conf)
         sx126x_symbol_time_on_air_us(dev) * (IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
                                              IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS) +
         sx126x_time_on_air_us(dev, IEEE802154_ACK_FRAME_LEN);
+    conf->res.sifs_period_us = 12 * sx126x_symbol_time_on_air_us(dev);
     assert(conf->res.ack_timeout_us);
+    assert(conf->res.sifs_period_us);
     return 0;
 }
 
@@ -536,7 +538,8 @@ static const ieee802154_radio_ops_t _sx126x_ops = {
           | IEEE802154_CAP_IRQ_CRC_ERROR
           | IEEE802154_CAP_IRQ_RX_START
           | IEEE802154_CAP_IRQ_TX_DONE
-          | IEEE802154_CAP_IRQ_CCA_DONE,
+          | IEEE802154_CAP_IRQ_CCA_DONE
+          | IEEE802154_CAP_PHY_LORA,
     .write = _write,
     .read = _read,
     .request_on = _request_on,

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -263,7 +263,7 @@ static int _write(ieee802154_dev_t *hal, const iolist_t *iolist)
     sx126x_set_buffer_base_address(dev, SX126X_TX_BUFFER_OFFSET, SX126X_RX_BUFFER_OFFSET);
     /* Write payload buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-        if (pos + iol->iol_len > SX126X_BUFFER_SIZE - SX126X_TX_BUFFER_OFFSET - IEEE802154_FCS_LEN) {
+        if (pos + iol->iol_len > SX126X_BUFFER_SIZE - SX126X_TX_BUFFER_OFFSET) {
             SX126X_DEBUG(dev, "hal: no buffer space to write payload\n");
             return -E2BIG;
         }
@@ -349,7 +349,7 @@ static int _len(ieee802154_dev_t *hal)
     sx126x_t *dev = hal->priv;
     sx126x_rx_buffer_status_t rx_buffer_status;
     sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
-    return rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN;
+    return rx_buffer_status.pld_len_in_bytes;
 }
 
 static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_rx_info_t *info)
@@ -371,16 +371,16 @@ static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_r
     }
     /* Put PSDU to the output buffer */
     if (buf == NULL) {
-        return rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN;
+        return rx_buffer_status.pld_len_in_bytes;
     }
-    if (rx_buffer_status.pld_len_in_bytes > max_size + IEEE802154_FCS_LEN) {
+    if (rx_buffer_status.pld_len_in_bytes > max_size) {
         return -ENOBUFS;
     }
     if (rx_buffer_status.pld_len_in_bytes < IEEE802154_ACK_FRAME_LEN) {
         return -EBADMSG;
     }
     sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer,
-                       buf, rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN);
+                       buf, rx_buffer_status.pld_len_in_bytes);
     /* Do not expect IEEE 802.15.4 CRC because LoRa frame also provides CRC */
     return rx_buffer_status.pld_len_in_bytes;
 }

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -138,7 +138,7 @@ static int _set_state(sx126x_t *dev, sx126x_state_t state)
     case SX126X_STATE_CAD:
         SX126X_DEBUG(dev, "hal: set STATE_CCA\n");
         dev->cad_done = false;
-        sx126x_set_cad(dev);
+        SX126X_CHECK_API(sx126x_set_cad(dev), return -EIO);
         break;
 
     default:
@@ -174,7 +174,7 @@ void sx126x_hal_event_handler(ieee802154_dev_t *hal)
     sx126x_t *dev = hal->priv;
     sx126x_irq_mask_t irq_mask;
 
-    sx126x_get_and_clear_irq_status(dev, &irq_mask);
+    SX126X_CHECK_API(sx126x_get_and_clear_irq_status(dev, &irq_mask), /* no return */);
     SX126X_DEBUG(dev, "sx126x_hal_event_handler(): 0x%"PRIx16"\n", irq_mask);
     if (sx126x_is_stm32wl(dev)) {
 #if IS_USED(MODULE_SX126X_STM32WL)
@@ -189,9 +189,10 @@ void sx126x_hal_event_handler(ieee802154_dev_t *hal)
         SX126X_DEBUG(dev, "hal: SX126X_IRQ_RX_DONE\n");
         uint8_t mhdr[IEEE802154_MAX_HDR_LEN];
         sx126x_rx_buffer_status_t rx_buffer_status;
-        sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+        SX126X_CHECK_API(sx126x_get_rx_buffer_status(dev, &rx_buffer_status), /* no return */);
         size_t rx_size = MIN(sizeof(mhdr), rx_buffer_status.pld_len_in_bytes);
-        sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer, mhdr, rx_size);
+        SX126X_CHECK_API(sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer, mhdr, rx_size),
+                         /* no return */);
         bool is_ack = (mhdr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_ACK;
         bool is_data = (mhdr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA;
         bool ackf = dev->ack_filter;
@@ -260,7 +261,8 @@ static int _write(ieee802154_dev_t *hal, const iolist_t *iolist)
     sx126x_t *dev = hal->priv;
     size_t pos = 0;
     /* Full buffer used for Tx */
-    sx126x_set_buffer_base_address(dev, SX126X_TX_BUFFER_OFFSET, SX126X_RX_BUFFER_OFFSET);
+    SX126X_CHECK_API(sx126x_set_buffer_base_address(dev, SX126X_TX_BUFFER_OFFSET, SX126X_RX_BUFFER_OFFSET),
+                     return -EIO);
     /* Write payload buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         if (pos + iol->iol_len > SX126X_BUFFER_SIZE - SX126X_TX_BUFFER_OFFSET) {
@@ -268,7 +270,8 @@ static int _write(ieee802154_dev_t *hal, const iolist_t *iolist)
             return -E2BIG;
         }
         if (iol->iol_len > 0) {
-            sx126x_write_buffer(dev, SX126X_TX_BUFFER_OFFSET + pos, iol->iol_base, iol->iol_len);
+            SX126X_CHECK_API(sx126x_write_buffer(dev, SX126X_TX_BUFFER_OFFSET + pos, iol->iol_base, iol->iol_len),
+                             return -EIO);
             SX126X_DEBUG(dev, "hal: wrote data to payload buffer\n");
             pos += iol->iol_len;
 #if IS_ACTIVE(ENABLE_DEBUG)
@@ -305,7 +308,7 @@ static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
         SX126X_DEBUG(dev, "hal: HAL_OP_CCA (CAD Detection state)\n");
         dev->cad_detected = false;
         _set_state(dev, SX126X_STATE_STANDBY);
-        sx126x_set_cad(dev);
+        SX126X_CHECK_API(sx126x_set_cad(dev), return -EIO);
         break;
     }
     return 0;
@@ -348,7 +351,7 @@ static int _len(ieee802154_dev_t *hal)
 {
     sx126x_t *dev = hal->priv;
     sx126x_rx_buffer_status_t rx_buffer_status;
-    sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
+    SX126X_CHECK_API(sx126x_get_rx_buffer_status(dev, &rx_buffer_status), return -EIO);
     return rx_buffer_status.pld_len_in_bytes;
 }
 
@@ -358,8 +361,8 @@ static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_r
     /* Getting information about last received packet */
     sx126x_rx_buffer_status_t rx_buffer_status;
     sx126x_pkt_status_lora_t pkt_status;
-    sx126x_get_rx_buffer_status(dev, &rx_buffer_status);
-    sx126x_get_lora_pkt_status(dev, &pkt_status);
+    SX126X_CHECK_API(sx126x_get_rx_buffer_status(dev, &rx_buffer_status), return -EIO);
+    SX126X_CHECK_API(sx126x_get_lora_pkt_status(dev, &pkt_status), return -EIO);
 
     if (info) {
         /* scale int8_t LoRa SNR into uint8_t IEEE 802.15.4 LQI */
@@ -379,8 +382,9 @@ static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_r
     if (rx_buffer_status.pld_len_in_bytes < IEEE802154_ACK_FRAME_LEN) {
         return -EBADMSG;
     }
-    sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer,
-                       buf, rx_buffer_status.pld_len_in_bytes);
+    SX126X_CHECK_API(sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer,
+                                        buf, rx_buffer_status.pld_len_in_bytes),
+                                        return -EIO);
     /* Do not expect IEEE 802.15.4 CRC because LoRa frame also provides CRC */
     return rx_buffer_status.pld_len_in_bytes;
 }
@@ -411,7 +415,7 @@ static int _off(ieee802154_dev_t *hal)
 {
     (void)hal;
     sx126x_t *dev = hal->priv;
-    sx126x_set_sleep(dev, SX126X_SLEEP_CFG_WARM_START);
+    SX126X_CHECK_API(sx126x_set_sleep(dev, SX126X_SLEEP_CFG_WARM_START), return -EIO);
     return 0;
 }
 
@@ -464,7 +468,7 @@ static int _set_cca_mode(ieee802154_dev_t *hal, ieee802154_cca_mode_t mode)
         /* Rx timeout = 60ms */
         .cad_timeout = 0x000F00,
     };
-    sx126x_set_cad_params(dev, &cad_params);
+    SX126X_CHECK_API(sx126x_set_cad_params(dev, &cad_params), return -EIO);
     return 0;
 }
 

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -276,10 +276,7 @@ static int _write(ieee802154_dev_t *hal, const iolist_t *iolist)
 #endif
         }
     }
-    /* Do not compute IEEE 802.15.4 CRC because LoRa frame also provides CRC */
-    uint16_t chksum = 0;
-    sx126x_write_buffer(dev, SX126X_TX_BUFFER_OFFSET + pos, (uint8_t *)&chksum, sizeof(chksum));
-    pos += sizeof(chksum);
+    /* Do not add IEEE 802.15.4 CRC because LoRa frame also provides CRC */
     sx126x_set_lora_payload_length(dev, pos);
     SX126X_DEBUG(dev, "hal: writing (size: %d)\n", (pos));
     return 0;
@@ -384,8 +381,8 @@ static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_r
     }
     sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer,
                        buf, rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN);
-    /* Do not compute IEEE 802.15.4 CRC because LoRa frame also provides CRC */
-    return rx_buffer_status.pld_len_in_bytes - IEEE802154_FCS_LEN;
+    /* Do not expect IEEE 802.15.4 CRC because LoRa frame also provides CRC */
+    return rx_buffer_status.pld_len_in_bytes;
 }
 
 static int _set_cca_threshold(ieee802154_dev_t *hal, int8_t threshold)

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -161,8 +161,19 @@ static int _get_state(sx126x_t *dev, void *val)
         state = SX126X_STATE_RX;
         break;
 
-    default:
+    case SX126X_CHIP_MODE_STBY_XOSC:
+    case SX126X_CHIP_MODE_STBY_RC:
         state = SX126X_STATE_STANDBY;
+        break;
+
+    default:
+        if (!dev->cad_done) {
+            state = SX126X_STATE_CAD;
+        }
+        else {
+            SX126X_DEBUG(dev, "hal: unknown mode %d\n", mode);
+            state = SX126X_STATE_STANDBY;
+        }
         break;
     }
     memcpy(val, &state, sizeof(sx126x_state_t));
@@ -292,8 +303,22 @@ static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
     switch (op) {
     case IEEE802154_HAL_OP_TRANSMIT:
         dev->pending = false;
-        ieee802154_radio_cca(hal);
-        _set_state(dev, SX126X_STATE_TX);
+        int cca = ieee802154_radio_cca(hal);
+        if (cca > 0) {
+            _set_state(dev, SX126X_STATE_TX);
+        }
+        else {
+            sx126x_state_t state;
+            _get_state(dev, &state);
+            if (cca < 0) { /* error */
+                SX126X_DEBUG(dev, "hal: CCA error, state: %d\n", state);
+                return -EIO;
+            }
+            else { /* busy */
+                SX126X_DEBUG(dev, "hal: CCA busy, state: %d\n", state);
+                return -EBUSY;
+            }
+        }
         break;
 
     case IEEE802154_HAL_OP_SET_RX:
@@ -341,7 +366,10 @@ static int _confirm_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
         break;
 
     case IEEE802154_HAL_OP_CCA:
-        *((bool *)ctx) = !dev->cad_detected;
+        eagain = (state == SX126X_STATE_CAD);
+        if (!eagain) {
+             *((bool *)ctx) = !dev->cad_detected;
+        }
         break;
     }
     return eagain ? -EAGAIN : 0;
@@ -457,13 +485,68 @@ static int _confirm_on(ieee802154_dev_t *hal)
 static int _set_cca_mode(ieee802154_dev_t *hal, ieee802154_cca_mode_t mode)
 {
     (void)mode;
-    sx126x_t* dev = hal->priv;
+    sx126x_t *dev = hal->priv;
     SX126X_DEBUG(dev, "hal: set_cca_mode \n");
+    /* The settings are based on best practice CAD performance evaluation AN1200.48.
+       Results are only available for 125 kHz and 250 kHz bandwidths.
+       https://semtech.my.salesforce.com/sfc/p/E0000000JelG/a/3n000000qSr3/s723KzQi7zXFhBPKqesoF11.MtwYu6B8pdEQcmInlkE */
+    uint8_t cad_det_peak;
+    uint8_t cad_symbol_num;
+    uint8_t bw = sx126x_get_bandwidth(dev);
+    uint8_t sf = sx126x_get_spreading_factor(dev);
+    if (bw < LORA_BW_500_KHZ) {
+        if (sf <= LORA_SF8) {
+            cad_det_peak = 22;
+            cad_symbol_num = SX126X_CAD_02_SYMB;
+        }
+        else {
+            cad_symbol_num = SX126X_CAD_04_SYMB;
+            if (sf == LORA_SF9) {
+                cad_det_peak = 23;
+            }
+            else if (sf == LORA_SF10) {
+                cad_det_peak = 24;
+            }
+             else if (sf == LORA_SF11) {
+                cad_det_peak = 25;
+            }
+             else {
+                cad_det_peak = 28;
+            }
+        }
+    }
+    else {
+        if (sf <= LORA_SF11) {
+            cad_symbol_num = SX126X_CAD_04_SYMB;
+        }
+        else {
+            cad_symbol_num = SX126X_CAD_08_SYMB;
+        }
+        if (sf == LORA_SF7) {
+            cad_det_peak = 21;
+        }
+        else if (sf == LORA_SF8) {
+            cad_det_peak = 22;
+        }
+        else if (sf == LORA_SF9) {
+            cad_det_peak = 22;
+        }
+        else if (sf == LORA_SF10) {
+            cad_det_peak = 23;
+        }
+        else if (sf == LORA_SF11) {
+            cad_det_peak = 25;
+        }
+        else {
+            cad_det_peak = 29;
+        }
+    }
+
     sx126x_cad_params_t cad_params = {
-        .cad_exit_mode = SX126X_CAD_ONLY,
-        .cad_detect_min = 10,
-        .cad_detect_peak = 22,
-        .cad_symb_nb = SX126X_CAD_02_SYMB,
+        .cad_exit_mode = SX126X_CAD_RX, /* go to Rx when CAD positive */
+        .cad_detect_min = 10, /* no need to change this value */
+        .cad_detect_peak = cad_det_peak,
+        .cad_symb_nb = cad_symbol_num,
         /* Rx timeout = cad_timeout * 15.625us */
         /* Rx timeout = 60ms */
         .cad_timeout = 0x000F00,

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -111,8 +111,7 @@ static int _set_state(sx126x_t *dev, sx126x_state_t state)
     switch (state) {
     case SX126X_STATE_STANDBY:
         SX126X_DEBUG(dev, "hal: set STATE_STANDBY\n");
-        sx126x_set_state(dev, SX126X_CHIP_MODE_STBY_XOSC);
-        break;
+        return sx126x_set_state(dev, SX126X_CHIP_MODE_STBY_XOSC);
 
     case SX126X_STATE_RX:
         SX126X_DEBUG(dev, "hal: set STATE_RX\n");
@@ -122,8 +121,7 @@ static int _set_state(sx126x_t *dev, sx126x_state_t state)
             dev->params->set_rf_mode(dev, SX126X_RF_MODE_RX);
         }
 #endif
-        sx126x_set_state(dev, SX126X_CHIP_MODE_RX);
-        break;
+        return sx126x_set_state(dev, SX126X_CHIP_MODE_RX);
 
     case SX126X_STATE_TX:
         SX126X_DEBUG(dev, "hal: set STATE_TX\n");
@@ -132,8 +130,7 @@ static int _set_state(sx126x_t *dev, sx126x_state_t state)
             dev->params->set_rf_mode(dev, dev->params->tx_pa_mode);
         }
 #endif
-        sx126x_set_state(dev, SX126X_CHIP_MODE_TX);
-        break;
+        return sx126x_set_state(dev, SX126X_CHIP_MODE_TX);
 
     case SX126X_STATE_CAD:
         SX126X_DEBUG(dev, "hal: set STATE_CCA\n");
@@ -144,7 +141,7 @@ static int _set_state(sx126x_t *dev, sx126x_state_t state)
     default:
         return -ENOTSUP;
     }
-    return sizeof(sx126x_state_t);
+    return 0;
 }
 
 static int _get_state(sx126x_t *dev, void *val)
@@ -314,11 +311,13 @@ static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
     sx126x_t *dev = hal->priv;
     (void)ctx;
     switch (op) {
+    default:
+        return -ENOTSUP;
     case IEEE802154_HAL_OP_TRANSMIT:
         dev->pending = false;
         int cca = ieee802154_radio_cca(hal);
         if (cca > 0) {
-            _set_state(dev, SX126X_STATE_TX);
+            return _set_state(dev, SX126X_STATE_TX);
         }
         else {
             sx126x_state_t state;
@@ -332,15 +331,12 @@ static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
                 return -EBUSY;
             }
         }
-        break;
 
     case IEEE802154_HAL_OP_SET_RX:
-        _set_state(dev, SX126X_STATE_RX);
-        break;
+        return _set_state(dev, SX126X_STATE_RX);
 
     case IEEE802154_HAL_OP_SET_IDLE:
-        _set_state(dev, SX126X_STATE_STANDBY);
-        break;
+        return _set_state(dev, SX126X_STATE_STANDBY);
 
     case IEEE802154_HAL_OP_CCA:
         SX126X_DEBUG(dev, "hal: HAL_OP_CCA (CAD Detection state)\n");
@@ -348,9 +344,9 @@ static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
             return -EBUSY;
         }
         dev->cad_detected = false;
-        _set_state(dev, SX126X_STATE_STANDBY);
+        int err = _set_state(dev, SX126X_STATE_STANDBY);
         SX126X_CHECK_API(sx126x_set_cad(dev), return -EIO);
-        break;
+        return err;
     }
     return 0;
 }
@@ -488,8 +484,7 @@ static int _request_on(ieee802154_dev_t *hal)
 {
     (void)hal;
     sx126x_t *dev = hal->priv;
-    _set_state(dev, SX126X_STATE_STANDBY);
-    return 0;
+    return _set_state(dev, SX126X_STATE_STANDBY);
 }
 
 static int _confirm_on(ieee802154_dev_t *hal)

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -423,7 +423,7 @@ static int _read(ieee802154_dev_t *hal, void *buf, size_t max_size, ieee802154_r
     if (rx_buffer_status.pld_len_in_bytes > max_size) {
         return -ENOBUFS;
     }
-    if (rx_buffer_status.pld_len_in_bytes < IEEE802154_ACK_FRAME_LEN) {
+    if (rx_buffer_status.pld_len_in_bytes < IEEE802154_MIN_FRAME_LEN) {
         return -EBADMSG;
     }
     SX126X_CHECK_API(sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer,

--- a/drivers/sx126x/sx126x_radio_hal.c
+++ b/drivers/sx126x/sx126x_radio_hal.c
@@ -184,6 +184,10 @@ void sx126x_hal_event_handler(ieee802154_dev_t *hal)
 {
     sx126x_t *dev = hal->priv;
     sx126x_irq_mask_t irq_mask;
+    const sx126x_irq_mask_t rx_mask = SX126X_IRQ_SYNC_WORD_VALID
+                                     | SX126X_IRQ_HEADER_VALID
+                                     | SX126X_IRQ_HEADER_ERROR
+                                     | SX126X_IRQ_CRC_ERROR;
 
     SX126X_CHECK_API(sx126x_get_and_clear_irq_status(dev, &irq_mask), /* no return */);
     SX126X_DEBUG(dev, "sx126x_hal_event_handler(): 0x%"PRIx16"\n", irq_mask);
@@ -192,11 +196,15 @@ void sx126x_hal_event_handler(ieee802154_dev_t *hal)
         NVIC_EnableIRQ(SUBGHZ_Radio_IRQn);
 #endif
     }
+
+    dev->incoming = rx_mask & irq_mask;
+
     if (irq_mask & SX126X_IRQ_TX_DONE) {
         SX126X_DEBUG(dev, "hal: SX126X_IRQ_TX_DONE\n");
         hal->cb(hal, IEEE802154_RADIO_CONFIRM_TX_DONE);
     }
     else if (irq_mask & SX126X_IRQ_RX_DONE) {
+        dev->incoming = 0;
         SX126X_DEBUG(dev, "hal: SX126X_IRQ_RX_DONE\n");
         uint8_t mhdr[IEEE802154_MAX_HDR_LEN];
         sx126x_rx_buffer_status_t rx_buffer_status;
@@ -218,7 +226,7 @@ void sx126x_hal_event_handler(ieee802154_dev_t *hal)
             SX126X_DEBUG(dev, "hal: RX (%s) frame\n", is_ack ? "ACK" : (is_data ? "DATA" : "UNKNOWN"));
             hal->cb(hal, IEEE802154_RADIO_INDICATION_RX_DONE);
         }
-        /* If radio is in promiscuos mode, indicate packet and
+        /* If radio is in promiscuous mode, indicate packet and
          * don't event think of sending an ACK frame :) */
         else if (dev->promisc) {
             SX126X_DEBUG(dev, "hal: Promiscuous mode is enabled.\n");
@@ -271,6 +279,11 @@ static int _write(ieee802154_dev_t *hal, const iolist_t *iolist)
 {
     sx126x_t *dev = hal->priv;
     size_t pos = 0;
+
+    if (dev->incoming) {
+        return -EBUSY;
+    }
+
     /* Full buffer used for Tx */
     SX126X_CHECK_API(sx126x_set_buffer_base_address(dev, SX126X_TX_BUFFER_OFFSET, SX126X_RX_BUFFER_OFFSET),
                      return -EIO);
@@ -331,6 +344,9 @@ static int _request_op(ieee802154_dev_t *hal, ieee802154_hal_op_t op, void *ctx)
 
     case IEEE802154_HAL_OP_CCA:
         SX126X_DEBUG(dev, "hal: HAL_OP_CCA (CAD Detection state)\n");
+        if (dev->incoming) {
+            return -EBUSY;
+        }
         dev->cad_detected = false;
         _set_state(dev, SX126X_STATE_STANDBY);
         SX126X_CHECK_API(sx126x_set_cad(dev), return -EIO);

--- a/pkg/lwip/init_devs/auto_init_cc2538_rf.c
+++ b/pkg/lwip/init_devs/auto_init_cc2538_rf.c
@@ -31,7 +31,7 @@ static netdev_ieee802154_submac_t cc2538_rf_netdev;
 static void auto_init_cc2538_rf(void)
 {
     netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev, NULL);
     cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
 
     cc2538_init();

--- a/pkg/lwip/init_devs/auto_init_kw2xrf.c
+++ b/pkg/lwip/init_devs/auto_init_kw2xrf.c
@@ -44,7 +44,7 @@ static void auto_init_kw2xrf(void)
                     bhp_event_isr_cb, &netif[i].bhp);
 
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
-        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i], NULL);
 
         if (lwip_add_6lowpan(&netif[i], &kw2xrf_netdev[i].dev.netdev) == NULL) {
             DEBUG("Could not add kw2xrf device\n");

--- a/pkg/lwip/init_devs/auto_init_mrf24j40.c
+++ b/pkg/lwip/init_devs/auto_init_mrf24j40.c
@@ -45,7 +45,7 @@ static void auto_init_mrf24j40(void)
 
 
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, i);
-        netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);
+        netdev_ieee802154_submac_init(&mrf24j40_netdev[i], NULL);
 
         if (lwip_add_6lowpan(&netif[i], &mrf24j40_netdev[i].dev.netdev) == NULL) {
             DEBUG("Could not add mrf24j40 device\n");

--- a/pkg/lwip/init_devs/auto_init_nrf802154.c
+++ b/pkg/lwip/init_devs/auto_init_nrf802154.c
@@ -31,7 +31,7 @@ static netdev_ieee802154_submac_t nrf802154_netdev;
 static void auto_init_nrf802154(void)
 {
     netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
-    netdev_ieee802154_submac_init(&nrf802154_netdev);
+    netdev_ieee802154_submac_init(&nrf802154_netdev, NULL);
 
     nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
     nrf802154_init();

--- a/pkg/lwip/init_devs/auto_init_socket_zep.c
+++ b/pkg/lwip/init_devs/auto_init_socket_zep.c
@@ -36,7 +36,7 @@ static void auto_init_socket_zep(void)
 {
     for (unsigned i = 0; i < NETIF_SOCKET_ZEP_NUMOF; i++) {
         netdev_register(&socket_zep_netdev[i].dev.netdev, NETDEV_SOCKET_ZEP, i);
-        netdev_ieee802154_submac_init(&socket_zep_netdev[i]);
+        netdev_ieee802154_submac_init(&socket_zep_netdev[i], NULL);
         socket_zep_hal_setup(&socket_zep_devs[i], &socket_zep_netdev[i].submac.dev);
 
         socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i]);

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -87,14 +87,14 @@ void openthread_bootstrap(void)
 #endif
 #ifdef MODULE_CC2538_RF
     netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev, NULL);
     cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
     cc2538_init();
     netdev_t *netdev = &cc2538_rf_netdev.dev.netdev;
 #endif
 #ifdef MODULE_NRF802154
     netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
-    netdev_ieee802154_submac_init(&nrf802154_netdev);
+    netdev_ieee802154_submac_init(&nrf802154_netdev, NULL);
     nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
     nrf802154_init();
     netdev_t *netdev = &nrf802154_netdev.dev.netdev;

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -120,6 +120,77 @@ extern "C" {
 #define IEEE802154_ACK_TIMEOUT_SYMS     (54)
 
 /**
+ * @name    Time in µs per symbol for different OQPSK PHYs depending on frequency band
+ *
+ * @see IEEE 802.15.4-2020, Section 12. O-QPSK PHY
+ *
+ * 8 symbols == 4 octets => 1 symbol == 4 bits
+ * 2450MHz, 915MHz, 780MHz, 2380MHz: 250 kb/s ==> 62.5 ksymbol/s ==> 16 us/symbol
+ * 868MHz: 100 kb/s ==> 25 ksymbol/s ==> 40 us/symbol
+ * @{
+ */
+/**
+ * @brief Symbol time for IEEE 802.15.4 868MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_868_SYMBOL_TIME_US     (40)
+/**
+ * @brief Symbol time for IEEE 802.15.4 2450MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_2450_SYMBOL_TIME_US    (16)
+/**
+ * @brief Symbol time for IEEE 802.15.4 2380MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_2380_SYMBOL_TIME_US    (16)
+/**
+ * @brief Symbol time for IEEE 802.15.4 915MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_915_SYMBOL_TIME_US     (16)
+/**
+ * @brief Symbol time for IEEE 802.15.4 780MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_780_SYMBOL_TIME_US     (16)
+/** @} */
+
+/**
+ * @name    Time in µs per symbol for different BPSK PHYs depending on frequency band
+ *
+ * @see IEEE 802.15.4-2020, Section 13. Binary phase-shift keying (BPSK) PHY
+ *
+ * 32 symbols == 4 octets => 1 symbol = 1 bit
+ * 868 MHz: 20kb/s ==> 50us/symbol
+ * 915 MHz: 40kb/s ==> 25us/symbol
+ * @{
+ */
+/**
+ * @brief Symbol time for IEEE 802.15.4 BPSK PHY in µs
+ */
+#define IEEE802154_BPSK_868_SYMBOL_TIME_US       (50)
+/**
+ * @brief Symbol time for IEEE 802.15.4 BPSK PHY in µs
+ */
+#define IEEE802154_BPSK_915_SYMBOL_TIME_US       (25)
+/** @} */
+
+/**
+ * @name    Time in µs per symbol for different ASK PHYs depending on frequency band
+ *
+ * @see IEEE 802.15.4-2015, Section 14. Amplitude shift keying (ASK) PHY
+ *
+ * 868 MHz: 250 kb/s ==> 12.5 ksymbol/s ==> 80 us/symbol
+ * 915 MHz: 250 kb/s ==> 50 ksymbols/s ==> 20 us/symbol
+ * @{
+ */
+/**
+ * @brief Symbol time for IEEE 802.15.4 ASK 868MHz PHY in µs
+ */
+#define IEEE802154_ASK_868_SYMBOL_TIME_US        (80)
+/**
+ * @brief Symbol time for IEEE 802.15.4 ASK 915MHz PHY in µs
+ */
+#define IEEE802154_ASK_915_SYMBOL_TIME_US        (20)
+/** @} */
+
+/**
  * @brief Symbol time for IEEE 802.15.4 MR-OFDM in µs
  */
 #define IEEE802154_MR_OFDM_SYMBOL_TIME_US   (120)
@@ -188,6 +259,15 @@ extern "C" {
  * [1] all but MR-O-QPSK
  */
 #define IEEE802154_CCA_DURATION_IN_SYMBOLS      (8)
+
+/**
+ * IEEE Std 802.15.4-2020
+ * Table 8-93—MAC sublayer constants: For all PHYs except SUN PHYs
+ * operating in the 920 MHz band, aTurnaroundTime + aCcaTime.
+ * For SUN PHYs operating in the 920 MHz band, aTurnaround-Time + phyCcaDuration.
+ */
+#define IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS   (IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS + \
+                                                     IEEE802154_CCA_DURATION_IN_SYMBOLS)
 
 /**
  * @brief   802.15.4 PHY modes

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -280,6 +280,7 @@ typedef enum {
     IEEE802154_PHY_MR_OQPSK,        /**< Multi-Rate Offset Quadrature Phase-Shift Keying */
     IEEE802154_PHY_MR_OFDM,         /**< Multi-Rate Orthogonal Frequency-Division Multiplexing */
     IEEE802154_PHY_MR_FSK,          /**< Multi-Rate Frequency Shift Keying */
+    IEEE802154_PHY_LORA,            /**< LoRa modulation (no standard for IEEE 802.15.4) */
 
     IEEE802154_PHY_NO_OP,           /**< don't change PHY configuration */
 } ieee802154_phy_mode_t;

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -456,13 +456,23 @@ typedef enum {
 } ieee802154_cca_mode_t;
 
 /**
+ * @brief   Derived submac parameters from PHY configuration
+ */
+typedef struct {
+    uint32_t ack_timeout_us;            /**< Ack timeout in µs */
+    uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
+    uint16_t sifs_period_us;            /**< SIFS period in µs */
+} ieee802154_phy_conf_result_t;
+
+/**
  * @brief Holder of the PHY configuration
  */
 typedef struct {
-    ieee802154_phy_mode_t phy_mode; /**< IEEE802.15.4 PHY mode */
-    uint16_t channel;               /**< IEEE802.15.4 channel number */
-    uint8_t page;                   /**< IEEE802.15.4 channel page */
-    int8_t pow;                     /**< TX power in dBm */
+    ieee802154_phy_mode_t phy_mode;     /**< IEEE802.15.4 PHY mode */
+    uint16_t channel;                   /**< IEEE802.15.4 channel number */
+    uint8_t page;                       /**< IEEE802.15.4 channel page */
+    int8_t pow;                         /**< TX power in dBm */
+    ieee802154_phy_conf_result_t res;   /**< PHY configuration deduced parameters */
 } ieee802154_phy_conf_t;
 
 /**
@@ -736,13 +746,13 @@ struct ieee802154_radio_ops {
      * @pre the transceiver state is IDLE.
      *
      * @param[in] dev IEEE802.15.4 device descriptor
-     * @param[in] conf the PHY configuration
+     * @param[in,out] conf the PHY configuration
      *
      * @retval 0        on success
      * @retval -EINVAL  if the configuration is not valid for the device.
      * @retval <0       error, return value is negative errno indicating the cause.
      */
-    int (*config_phy)(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf);
+    int (*config_phy)(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf);
 
     /**
      * @brief Set number of frame retransmissions
@@ -998,7 +1008,7 @@ static inline int ieee802154_radio_set_cca_mode(ieee802154_dev_t *dev,
  * @return result of @ref ieee802154_radio_ops::config_phy
  */
 static inline int ieee802154_radio_config_phy(ieee802154_dev_t *dev,
-                                              const ieee802154_phy_conf_t *conf)
+                                              ieee802154_phy_conf_t *conf)
 {
     return dev->driver->config_phy(dev, conf);
 }

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -466,6 +466,27 @@ typedef struct {
 } ieee802154_phy_conf_t;
 
 /**
+ * @brief extension for IEEE 802.15.4 OQPSK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+} ieee802154_oqpsk_conf_t;
+
+/**
+ * @brief extension for IEEE 802.15.4 BPSK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+} ieee802154_bpsk_conf_t;
+
+/**
+ * @brief extension for IEEE 802.15.4 ASK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+} ieee802154_ask_conf_t;
+
+/**
  * @brief extension for IEEE 802.15.4g MR-OQPSK PHY
  */
 typedef struct {

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -156,6 +156,10 @@ typedef enum {
      */
     IEEE802154_CAP_PHY_MR_FSK           = BIT18,
     /**
+     * @brief LoRa capability mode (not standardized in IEEE 802.15.4)
+     */
+    IEEE802154_CAP_PHY_LORA             = BIT19,
+    /**
      * @brief the device supports source address match table.
      *
      * A Source Address Match table contains source addresses with pending
@@ -163,7 +167,7 @@ typedef enum {
      * Request command from a child node, the Frame Pending bit of the ACK is
      * set if the source address matches one from the table.
      */
-    IEEE802154_CAP_SRC_ADDR_MATCH       = BIT19,
+    IEEE802154_CAP_SRC_ADDR_MATCH       = BIT20,
 } ieee802154_rf_caps_t;
 
 /**
@@ -175,7 +179,8 @@ typedef enum {
     | IEEE802154_CAP_PHY_OQPSK      \
     | IEEE802154_CAP_PHY_MR_OQPSK   \
     | IEEE802154_CAP_PHY_MR_OFDM    \
-    | IEEE802154_CAP_PHY_MR_FSK)    \
+    | IEEE802154_CAP_PHY_MR_FSK     \
+    | IEEE802154_CAP_PHY_LORA)      \
 
 /**
  * @brief Transmission status
@@ -1683,6 +1688,8 @@ static inline uint32_t ieee802154_phy_mode_to_cap(
             return IEEE802154_CAP_PHY_MR_OFDM;
         case IEEE802154_PHY_MR_FSK:
             return IEEE802154_CAP_PHY_MR_FSK;
+        case IEEE802154_PHY_LORA:
+            return IEEE802154_CAP_PHY_LORA;
 
         case IEEE802154_PHY_DISABLED:
         default:
@@ -1718,6 +1725,8 @@ static inline ieee802154_phy_mode_t ieee802154_cap_to_phy_mode(uint32_t cap)
             return IEEE802154_PHY_MR_OFDM;
         case IEEE802154_CAP_PHY_MR_FSK:
             return IEEE802154_PHY_MR_FSK;
+        case IEEE802154_CAP_PHY_LORA:
+            return IEEE802154_PHY_LORA;
 
         default:
             break;

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -197,6 +197,7 @@ struct ieee802154_submac {
     bool wait_for_ack;                  /**< SubMAC is waiting for an ACK frame */
     uint16_t ack_timeout_us;            /**< ACK timeout in µs */
     uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
+    uint16_t sifs_period_us;            /**< SIFS period in µs */
     uint16_t panid;                     /**< IEEE 802.15.4 PAN ID */
     uint16_t channel_num;               /**< IEEE 802.15.4 channel number */
     uint8_t channel_page;               /**< IEEE 802.15.4 channel page */

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -195,7 +195,7 @@ struct ieee802154_submac {
     const ieee802154_submac_cb_t *cb;   /**< pointer to the SubMAC callbacks */
     ieee802154_csma_be_t be;            /**< CSMA-CA backoff exponent params */
     bool wait_for_ack;                  /**< SubMAC is waiting for an ACK frame */
-    uint16_t ack_timeout_us;            /**< ACK timeout in µs */
+    uint32_t ack_timeout_us;            /**< ACK timeout in µs */
     uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
     uint16_t sifs_period_us;            /**< SIFS period in µs */
     uint16_t panid;                     /**< IEEE 802.15.4 PAN ID */
@@ -313,7 +313,7 @@ static inline ieee802154_phy_mode_t ieee802154_get_phy_mode(
  * @brief Set IEEE 802.15.4 PHY configuration (channel, TX power)
  *
  * @param[in] submac pointer to the SubMAC descriptor
- * @param[in] conf   pointer to the PHY configuration
+ * @param[in,out] conf   pointer to the PHY configuration
  *
  * @return 0 on success
  * @return -ENOTSUP if the PHY settings are not supported
@@ -322,7 +322,7 @@ static inline ieee802154_phy_mode_t ieee802154_get_phy_mode(
  *         @ref ieee802154_submac_cb_t::tx_done
  * @return negative errno on error
  */
-int ieee802154_set_phy_conf(ieee802154_submac_t *submac, const ieee802154_phy_conf_t *conf);
+int ieee802154_set_phy_conf(ieee802154_submac_t *submac, ieee802154_phy_conf_t *conf);
 
 /**
  * @brief Set IEEE 802.15.4 channel number
@@ -342,7 +342,7 @@ int ieee802154_set_phy_conf(ieee802154_submac_t *submac, const ieee802154_phy_co
 static inline int ieee802154_set_channel_number(ieee802154_submac_t *submac,
                                                 uint16_t channel_num)
 {
-    const ieee802154_phy_conf_t conf = {
+    ieee802154_phy_conf_t conf = {
         .phy_mode = IEEE802154_PHY_NO_OP,
         .channel = channel_num,
         .page = submac->channel_page,
@@ -370,7 +370,7 @@ static inline int ieee802154_set_channel_number(ieee802154_submac_t *submac,
 static inline int ieee802154_set_channel_page(ieee802154_submac_t *submac,
                                               uint16_t channel_page)
 {
-    const ieee802154_phy_conf_t conf = {
+    ieee802154_phy_conf_t conf = {
         .phy_mode = IEEE802154_PHY_NO_OP,
         .channel = submac->channel_num,
         .page = channel_page,
@@ -398,7 +398,7 @@ static inline int ieee802154_set_channel_page(ieee802154_submac_t *submac,
 static inline int ieee802154_set_tx_power(ieee802154_submac_t *submac,
                                           int8_t tx_pow)
 {
-    const ieee802154_phy_conf_t conf = {
+    ieee802154_phy_conf_t conf = {
         .phy_mode = IEEE802154_PHY_NO_OP,
         .channel = submac->channel_num,
         .page = submac->channel_page,

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
@@ -42,7 +42,7 @@ void auto_init_cc2538_rf(void)
     LOG_DEBUG("[auto_init_netif] initializing cc2538 radio\n");
 
     netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev, NULL);
     cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
 
     cc2538_init();

--- a/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
@@ -50,7 +50,7 @@ void auto_init_esp_ieee802154(void)
     esp_ieee802154_init();
 
     netdev_register(&esp_ieee802154_netdev.dev.netdev, NETDEV_ESP_IEEE802154, 0);
-    netdev_ieee802154_submac_init(&esp_ieee802154_netdev);
+    netdev_ieee802154_submac_init(&esp_ieee802154_netdev, NULL);
 
     esp_ieee802154_setup(&esp_ieee802154_netdev.submac.dev);
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
@@ -62,7 +62,7 @@ void auto_init_kw2xrf(void)
                         bhp_event_isr_cb, &kw2xrf_bhp[i]);
 
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
-        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i], NULL);
 
         gnrc_netif_ieee802154_create(&_netif[i], _kw2xrf_stacks[i], KW2XRF_MAC_STACKSIZE,
                                      KW2XRF_MAC_PRIO, "kw2xrf",

--- a/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
@@ -58,7 +58,7 @@ void auto_init_mrf24j40(void)
                         bhp_event_isr_cb, &mrf24j40_bhp[i]);
 
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, i);
-        netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);
+        netdev_ieee802154_submac_init(&mrf24j40_netdev[i], NULL);
 
         gnrc_netif_ieee802154_create(&_netif[i], _mrf24j40_stacks[i],
                                      MRF24J40_MAC_STACKSIZE, MRF24J40_MAC_PRIO,

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
@@ -63,7 +63,7 @@ void auto_init_nrf802154(void)
                                  NRF802154_MAC_PRIO, "nrf802154",
                                  (netdev_t*) &nrf802154_netdev.submac.dev);
 #else
-        netdev_ieee802154_submac_init(&nrf802154_netdev);
+        netdev_ieee802154_submac_init(&nrf802154_netdev, NULL);
         nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
         gnrc_netif_ieee802154_create(&_netif, _stack,
                                  NRF802154_MAC_STACKSIZE,

--- a/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
@@ -49,7 +49,7 @@ void auto_init_socket_zep(void)
         LOG_DEBUG("[auto_init_netif: initializing socket ZEP device #%u\n", i);
         /* setup netdev device */
         netdev_register(&_socket_zep_netdev[i].dev.netdev, NETDEV_SOCKET_ZEP, i);
-        netdev_ieee802154_submac_init(&_socket_zep_netdev[i]);
+        netdev_ieee802154_submac_init(&_socket_zep_netdev[i], NULL);
         socket_zep_hal_setup(&_socket_zeps[i], &_socket_zep_netdev[i].submac.dev);
 
         socket_zep_setup(&_socket_zeps[i], &socket_zep_params[i]);

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
@@ -21,8 +21,11 @@
 
 #include "log.h"
 #include "board.h"
+#include "bhp/event.h"
 #include "net/gnrc/netif/lorawan_base.h"
 #include "net/gnrc/netif/raw.h"
+#include "net/gnrc/netif/ieee802154.h"
+#include "net/netdev/ieee802154_submac.h"
 #include "net/gnrc.h"
 #include "include/init_devs.h"
 
@@ -37,9 +40,15 @@
 /**
  * @brief   Define stack parameters for the MAC layer thread
  */
-#define SX126X_STACKSIZE            (GNRC_NETIF_STACKSIZE_DEFAULT)
+#ifndef SX126X_STACKSIZE
+#if IS_USED(MODULE_SX126X_IEEE802154)
+#  define SX126X_STACKSIZE            (IEEE802154_STACKSIZE_DEFAULT)
+#else
+#  define SX126X_STACKSIZE            (GNRC_NETIF_STACKSIZE_DEFAULT)
+#endif
+#endif
 #ifndef SX126X_PRIO
-#define SX126X_PRIO                 (GNRC_NETIF_PRIO)
+#  define SX126X_PRIO                 (GNRC_NETIF_PRIO)
 #endif
 
 /**
@@ -47,22 +56,42 @@
  */
 static sx126x_t sx126x_devs[SX126X_NUMOF];
 static char sx126x_stacks[SX126X_NUMOF][SX126X_STACKSIZE];
+static netdev_ieee802154_submac_t sx126x_netdev[SX126X_NUMOF];
+static bhp_event_t sx126x_bhp[SX126X_NUMOF];
 static gnrc_netif_t _netif[SX126X_NUMOF];
+
+static void _bhp_cb(void *hal)
+{
+    void sx126x_hal_event_handler(ieee802154_dev_t *hal);
+    sx126x_hal_event_handler(hal);
+}
 
 void auto_init_sx126x(void)
 {
     for (unsigned i = 0; i < SX126X_NUMOF; ++i) {
         LOG_DEBUG("[auto_init_netif] initializing sx126x #%u\n", i);
-        sx126x_setup(&sx126x_devs[i], &sx126x_params[i], i);
         if (IS_USED(MODULE_GNRC_NETIF_LORAWAN)) {
             /* Currently only one lora device is supported */
             assert(SX126X_NUMOF == 1);
-
+            sx126x_setup(&sx126x_devs[i], &sx126x_params[i], i);
             gnrc_netif_lorawan_create(&_netif[i], sx126x_stacks[i],
                                       SX126X_STACKSIZE, SX126X_PRIO,
                                       "sx126x", &sx126x_devs[i].netdev);
         }
+        else if(IS_USED(MODULE_SX126X_IEEE802154)) {
+            netdev_register(&sx126x_netdev[i].dev.netdev, NETDEV_SX126X, i);
+            netdev_ieee802154_submac_init(&sx126x_netdev[i]);
+            bhp_event_init(&sx126x_bhp[i], &_netif[i].evq[GNRC_NETIF_EVQ_INDEX_PRIO_HIGH], _bhp_cb, &sx126x_netdev[i].submac.dev);
+            sx126x_hal_setup(&sx126x_devs[i], &sx126x_params[i], i,
+                             &sx126x_netdev[i].submac.dev, bhp_event_isr_cb, &sx126x_bhp[i]);
+            if (!sx126x_init(&sx126x_devs[i])) {
+                gnrc_netif_ieee802154_create(&_netif[i], sx126x_stacks[i],
+                                             SX126X_STACKSIZE, SX126X_PRIO,
+                                             "sx126x", &sx126x_netdev[i].dev.netdev);
+            }
+        }
         else {
+            sx126x_setup(&sx126x_devs[i], &sx126x_params[i], i);
             gnrc_netif_raw_create(&_netif[i], sx126x_stacks[i],
                                   SX126X_STACKSIZE, SX126X_PRIO,
                                   "sx126x", &sx126x_devs[i].netdev);

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
@@ -80,7 +80,7 @@ void auto_init_sx126x(void)
         }
         else if(IS_USED(MODULE_SX126X_IEEE802154)) {
             netdev_register(&sx126x_netdev[i].dev.netdev, NETDEV_SX126X, i);
-            netdev_ieee802154_submac_init(&sx126x_netdev[i]);
+            netdev_ieee802154_submac_init(&sx126x_netdev[i], &sx126x_devs[i].netdev);
             bhp_event_init(&sx126x_bhp[i], &_netif[i].evq[GNRC_NETIF_EVQ_INDEX_PRIO_HIGH], _bhp_cb, &sx126x_netdev[i].submac.dev);
             sx126x_hal_setup(&sx126x_devs[i], &sx126x_params[i], i,
                              &sx126x_netdev[i].submac.dev, bhp_event_isr_cb, &sx126x_bhp[i]);

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include "compiler_hints.h"
 #include "net/ieee802154/submac.h"
 #include "net/ieee802154.h"
 #include "ztimer.h"
@@ -502,6 +503,214 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
 }
 
 /*
+ * macAckWaitDuration [symbol periods] =
+ * aUnitBackoffPeriod + aTurnaroundTime + phySHRDuration + 6 x phySymbolsPerOctet
+ *
+ *  54 symbols
+ */
+static inline uint16_t _oqpsk_ack_timeout_symbols(const ieee802154_oqpsk_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS +
+           IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+           10 + /* SHR: 32bit preamble + 8 bit SFD => 40 bit => 10 symbols */
+           6 * 2; /* 2 symbols per octet and 4 bit per symbol */
+}
+
+/*
+ * macAckWaitDuration [us] = macAckWaitDuration [symbol periods] * symbol duration [us]
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ */
+static inline uint16_t _oqpsk_ack_timeout_us(const ieee802154_oqpsk_conf_t *conf)
+{
+    if (conf->super.page == 2 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return _oqpsk_ack_timeout_symbols(conf) * IEEE802154_OQPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 2 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return _oqpsk_ack_timeout_symbols(conf) * IEEE802154_OQPSK_915_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 11 && conf->super.channel <= 26) {
+        /* 2.4 GHz */
+        return _oqpsk_ack_timeout_symbols(conf) * IEEE802154_OQPSK_2450_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _oqpsk_csma_backoff_period_us(const ieee802154_oqpsk_conf_t *conf)
+{
+    if (conf->super.page == 2 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_OQPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 2 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_OQPSK_915_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 11 && conf->super.channel <= 26) {
+        /* 2.4 GHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_OQPSK_2450_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _oqpsk_sifs_period_us(const ieee802154_oqpsk_conf_t *conf)
+{
+    if (conf->super.page == 2 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_OQPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 2 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_OQPSK_915_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 11 && conf->super.channel <= 26) {
+        /* 2.4 GHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_OQPSK_2450_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+/*
+ * macAckWaitDuration [symbol periods] =
+ * aUnitBackoffPeriod + aTurnaroundTime + phySHRDuration + 6 x phySymbolsPerOctet
+ *
+ * 120 symbols
+ */
+static inline uint16_t _bpsk_ack_timeout_symbols(const ieee802154_bpsk_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS +
+           IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+           40 + /* SHR: 32bit preamble + 8 bit SFD => 40 bit => 40 symbols */
+           6 * 8; /* 8 symbols per octet and 1 bit per symbol */
+}
+
+/*
+ * macAckWaitDuration [us] = macAckWaitDuration [symbol periods] * symbol duration [us]
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ */
+static inline uint16_t _bpsk_ack_timeout_us(const ieee802154_bpsk_conf_t *conf)
+{
+    if (conf->super.page == 0 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return _bpsk_ack_timeout_symbols(conf) * IEEE802154_BPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return _bpsk_ack_timeout_symbols(conf) * IEEE802154_BPSK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _bpsk_csma_backoff_period_us(const ieee802154_bpsk_conf_t *conf)
+{
+    if (conf->super.page == 0 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_BPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_BPSK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _bpsk_sifs_period_us(const ieee802154_bpsk_conf_t *conf)
+{
+    if (conf->super.page == 0 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_BPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_BPSK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+/*
+ * macAckWaitDuration [symbol periods] =
+ * aUnitBackoffPeriod + aTurnaroundTime + phySHRDuration + 6 x phySymbolsPerOctet
+ *
+ * IEEE 802.15.4-2006, Section 6.3 PPDU format
+ * SHR duration is different for 868 MHz and 915 MHz
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ * Page 1, Channel 0: 868 MHz
+ * Page 1, Channel 1-10: 915 MHz
+ */
+static inline uint16_t _ask_ack_timeout_symbols(const ieee802154_ask_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS +
+           IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+           conf->super.page == 1 && conf->super.channel == 0
+            /* 868 MHz */
+            ? (3 + /* SHR: 2 symbols preamble + 1 symbol SFD */
+               (uint16_t)(6 * 0.4f + 0.5f)) /* 0.4 symbols per octet (+0.5 to round up) */
+            /* 915 MHz */
+            : (7 + /* SHR: 6 symbols preamble + 1 symbol SFD */
+               (uint16_t)(6 * 1.6f + 0.5f)); /* 1.6 symbols per octet (+0.5 to round up) */
+}
+
+/*
+ * macAckWaitDuration [us] = macAckWaitDuration [symbol periods] * symbol duration [us]
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ */
+static inline uint16_t _ask_ack_timeout_us(const ieee802154_ask_conf_t *conf)
+{
+    if (conf->super.page == 1 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return _ask_ack_timeout_symbols(conf) * IEEE802154_ASK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 1 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return _ask_ack_timeout_symbols(conf) * IEEE802154_ASK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _ask_csma_backoff_period_us(const ieee802154_ask_conf_t *conf)
+{
+    if (conf->super.page == 1 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_ASK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 1 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_ASK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _ask_sifs_period_us(const ieee802154_ask_conf_t *conf)
+{
+    if (conf->super.page == 1 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_ASK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 1 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_ASK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+/*
  * MR-OQPSK timing calculations
  *
  * The standard unfortunately does not list the formula, instead it has to be pieced together
@@ -588,6 +797,12 @@ static inline uint16_t _mr_oqpsk_csma_backoff_period_us(const ieee802154_mr_oqps
          + IEEE802154G_ATURNAROUNDTIME_US;
 }
 
+MAYBE_UNUSED
+static inline uint16_t _mr_oqpsk_sifs_period_us(const ieee802154_mr_oqpsk_conf_t *conf)
+{
+    return IEEE802154_SIFS_SYMS * _mr_oqpsk_symbol_duration_us(conf->chips);
+}
+
 /*
  * MR-OFDM timing calculations
  *
@@ -620,6 +835,13 @@ static inline uint16_t _mr_ofdm_csma_backoff_period_us(const ieee802154_mr_ofdm_
 }
 
 MAYBE_UNUSED
+static inline uint16_t _mr_ofdm_sifs_period_us(const ieee802154_mr_ofdm_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_SIFS_SYMS * IEEE802154_MR_OFDM_SYMBOL_TIME_US;
+}
+
+MAYBE_UNUSED
 static inline uint16_t _mr_ofdm_ack_timeout_us(const ieee802154_mr_ofdm_conf_t *conf)
 {
     return _mr_ofdm_csma_backoff_period_us(conf)
@@ -641,6 +863,13 @@ static inline uint16_t _mr_fsk_csma_backoff_period_us(const ieee802154_mr_fsk_co
 
     return IEEE802154_CCA_DURATION_IN_SYMBOLS * IEEE802154_MR_FSK_SYMBOL_TIME_US
          + IEEE802154G_ATURNAROUNDTIME_US;
+}
+
+MAYBE_UNUSED
+static inline uint16_t _mr_fsk_sifs_period_us(const ieee802154_mr_fsk_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_SIFS_SYMS * IEEE802154_MR_FSK_SYMBOL_TIME_US;
 }
 
 MAYBE_UNUSED
@@ -672,26 +901,40 @@ static int ieee802154_submac_config_phy(ieee802154_submac_t *submac,
                                         const ieee802154_phy_conf_t *conf)
 {
     switch (conf->phy_mode) {
+    case IEEE802154_PHY_BPSK:
+        submac->ack_timeout_us = _bpsk_ack_timeout_us((void *)conf);
+        submac->csma_backoff_us = _bpsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _bpsk_sifs_period_us((void *)conf);
+        break;
+    case IEEE802154_PHY_ASK:
+        submac->ack_timeout_us = _ask_ack_timeout_us((void *)conf);
+        submac->csma_backoff_us = _ask_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _ask_sifs_period_us((void *)conf);
+        break;
     case IEEE802154_PHY_OQPSK:
-        submac->ack_timeout_us = ACK_TIMEOUT_US;
-        submac->csma_backoff_us = CSMA_SENDER_BACKOFF_PERIOD_UNIT_US;
+        submac->ack_timeout_us = _oqpsk_ack_timeout_us((void *)conf);
+        submac->csma_backoff_us = _oqpsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _oqpsk_sifs_period_us((void *)conf);
         break;
 #ifdef MODULE_NETDEV_IEEE802154_MR_OQPSK
     case IEEE802154_PHY_MR_OQPSK:
         submac->ack_timeout_us = _mr_oqpsk_ack_timeout_us((void *)conf);
         submac->csma_backoff_us = _mr_oqpsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _mr_oqpsk_sifs_period_us((void *)conf);
         break;
 #endif
 #ifdef MODULE_NETDEV_IEEE802154_MR_OFDM
     case IEEE802154_PHY_MR_OFDM:
         submac->ack_timeout_us = _mr_ofdm_ack_timeout_us((void *)conf);
         submac->csma_backoff_us = _mr_ofdm_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _mr_ofdm_sifs_period_us((void *)conf);
         break;
 #endif
 #ifdef MODULE_NETDEV_IEEE802154_MR_FSK
     case IEEE802154_PHY_MR_FSK:
         submac->ack_timeout_us = _mr_fsk_ack_timeout_us((void *)conf);
         submac->csma_backoff_us = _mr_fsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _mr_fsk_sifs_period_us((void *)conf);
         break;
 #endif
     case IEEE802154_PHY_NO_OP:
@@ -784,6 +1027,7 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
         ieee802154_mr_fsk_conf_t mr_fsk;
 #endif
     } conf;
+    memset(&conf, 0, sizeof(conf));
 
 #ifdef MODULE_NETDEV_IEEE802154_MR_OQPSK
     if (submac->phy_mode == IEEE802154_PHY_MR_OQPSK) {

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -289,7 +289,7 @@ static ieee802154_fsm_state_t _fsm_state_prepare(ieee802154_submac_t *submac,
         }
         else if (ftype == IEEE802154_FCF_TYPE_ACK) {
             /* no backoff for ACK frames but wait for SIFSPeriod */
-            ztimer_sleep(ZTIMER_USEC, SIFS_PERIOD_US);
+            ztimer_sleep(ZTIMER_USEC, submac->sifs_period_us);
         }
 
         while (ieee802154_radio_request_transmit(dev) == -EBUSY) {}

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -532,7 +532,8 @@ static const char *_netopt_ieee802154_phy_str[] = {
     [IEEE802154_PHY_OQPSK] = "O-QPSK",
     [IEEE802154_PHY_MR_OQPSK] = "MR-O-QPSK",
     [IEEE802154_PHY_MR_OFDM] = "MR-OFDM",
-    [IEEE802154_PHY_MR_FSK] = "MR-FSK"
+    [IEEE802154_PHY_MR_FSK] = "MR-FSK",
+    [IEEE802154_PHY_LORA] = "LORA",
 };
 #endif
 

--- a/tests/drivers/cc2538_rf/main.c
+++ b/tests/drivers/cc2538_rf/main.c
@@ -31,7 +31,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     puts("Initializing CC2538_RF device");
 
     netdev_register(netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf);
+    netdev_ieee802154_submac_init(&cc2538_rf, NULL);
 
     /* set the application-provided callback */
     netdev->event_callback = cb;

--- a/tests/drivers/kw2xrf/main.c
+++ b/tests/drivers/kw2xrf/main.c
@@ -132,7 +132,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     for (unsigned i = 0; i < KW2XRF_NUM; i++) {
         printf("%d out of %d\n", i + 1, KW2XRF_NUM);
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, 0);
-        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i], NULL);
 
         /* set the application-provided callback */
         kw2xrf_netdev[i].dev.netdev.event_callback = cb;

--- a/tests/drivers/mrf24j40/main.c
+++ b/tests/drivers/mrf24j40/main.c
@@ -46,7 +46,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     for (unsigned i = 0; i < MRF24J40_NUM; i++) {
         printf("%d out of %u\n", i + 1, (unsigned)MRF24J40_NUM);
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, 0);
-        netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);
+        netdev_ieee802154_submac_init(&mrf24j40_netdev[i], NULL);
 
         /* set the application-provided callback */
         mrf24j40_netdev[i].dev.netdev.event_callback = cb;

--- a/tests/drivers/nrf802154/main.c
+++ b/tests/drivers/nrf802154/main.c
@@ -31,7 +31,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     puts("Initializing NRF802154 device");
 
     netdev_register(netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&nrf802154);
+    netdev_ieee802154_submac_init(&nrf802154, NULL);
 
     /* set the application-provided callback */
     netdev->event_callback = cb;

--- a/tests/net/socket_zep/main.c
+++ b/tests/net/socket_zep/main.c
@@ -53,7 +53,7 @@ static void test_init(void)
            p->local_addr, p->local_port, p->remote_addr, p->remote_port);
     netdev_register(&_socket_zep_netdev.dev.netdev, NETDEV_SOCKET_ZEP, 0);
     netdev->event_callback = _event_cb;
-    netdev_ieee802154_submac_init(&_socket_zep_netdev);
+    netdev_ieee802154_submac_init(&_socket_zep_netdev, NULL);
     socket_zep_hal_setup(&_dev, &_socket_zep_netdev.submac.dev);
     socket_zep_setup(&_dev, p);
     expect(netdev->driver->init(netdev) >= 0);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Picked up #19172 to run IEEE802.15.4 over LoRa using the submac layer.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Used to test with two `adafruit-metro-m4-express` having attached a `shield_llcc68`.
Fragmented pings over 6lowpan was only working with increased timeouts.
Output of `gnrc_networking` will be added. 

`DEVELHELP=1 VERBOSE_ASSERT=1 USEMODULE+="shell_cmd_ps shield_llcc68 sx126x_ieee802154 bhp gnrc_txtsnd gnrc_pktdump" BOARD=adafruit-metro-m4-express make -C examples/gnrc_networking flash term PORT=/dev/ttyACM0`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#19172 continued
#19668 is necessarily included


# Integration PR