### PR TITLE
drivers/can: add board_candev_set_power() hook

### DIFF
--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -19,7 +19,6 @@
  */
 
 #include "board.h"
-#include "can/device.h"
 #include "container.h"
 #include "periph/can.h"
 #include "periph/gpio.h"

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -22,7 +22,6 @@
 #include "container.h"
 #include "periph/can.h"
 #include "periph/gpio.h"
-#include "periph_conf.h"
 #include "time_units.h"
 
 #ifdef MODULE_VFS_DEFAULT

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -19,6 +19,7 @@
  */
 
 #include "board.h"
+#include "can/device.h"
 #include "container.h"
 #include "periph/can.h"
 #include "periph/gpio.h"

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -102,7 +102,6 @@ VFS_AUTO_MOUNT(lwext4, VFS_MTD(sdhc_dev), VFS_DEFAULT_SD(0), 1);
 #endif /* MODULE_VFS_DEFAULT */
 #endif /* MODULE_SAM0_SDHC */
 
-
 void board_candev_set_power(candev_t *dev, bool active)
 {
     can_t *periph_can = candev2periph(dev);

--- a/cpu/esp32/periph/can.c
+++ b/cpu/esp32/periph/can.c
@@ -614,6 +614,9 @@ static void _esp_can_power_up(can_t *dev)
     /* initialize used GPIOs */
     _esp_can_init_pins();
 
+    /* request board to power on CAN transceiver */
+    board_candev_set_power(&dev->candev, true);
+
     dev->powered_up = true;
 
     critical_exit();
@@ -628,6 +631,9 @@ static void _esp_can_power_down(can_t *dev)
     if (!dev->powered_up) {
         return;
     }
+
+    /* request board to power off CAN transceiver */
+    board_candev_set_power(&dev->candev, false);
 
     /* deinitialize used GPIOs */
     _esp_can_deinit_pins();
@@ -937,6 +943,17 @@ void can_init(can_t *dev, const can_conf_t *conf)
 void can_print_config(void)
 {
     printf("\tCAN_DEV(0)\ttxd=%d rxd=%d\n", CAN_TX, CAN_RX);
+}
+
+can_t *candev2periph(candev_t *candev)
+{
+    if (candev && (candev->driver == &_esp_can_driver)) {
+        /* this is an ESP peripheral CAN, as opposed to e.g. an external SPI
+         * attached one */
+        return container_of(candev, can_t, candev);
+    }
+
+    return NULL;
 }
 
 /**@}*/

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -106,6 +106,17 @@ static const struct can_bittiming_const bittiming_const = {
     .brp_inc = 1,
 };
 
+can_t *candev2periph(candev_t *candev)
+{
+    if (candev && (candev->driver == &candev_samd5x_driver)) {
+        /* this is an SAMD5x peripheral CAN, as opposed to e.g. an external SPI
+         * attached one */
+        return container_of(candev, can_t, candev);
+    }
+
+    return NULL;
+}
+
 static int _power_on(can_t *dev)
 {
     /* CAN required CLK_CANx_APB and GCLK_CANx to be running and will not
@@ -145,6 +156,8 @@ static int _power_on(can_t *dev)
         assert(0);
     }
 
+    board_candev_set_power(&dev->candev, true);
+
     return 0;
 }
 
@@ -153,6 +166,8 @@ static int _power_off(can_t *dev)
     if (IS_USED(MODULE_PM_LAYERED)) {
         pm_unblock(SAM0_PM_IDLE);
     }
+
+    board_candev_set_power(&dev->candev, false);
 
     if (dev->conf->can == CAN0) {
         DEBUG_PUTS("CAN0 controller is used");

--- a/drivers/include/candev_mcp2515.h
+++ b/drivers/include/candev_mcp2515.h
@@ -128,6 +128,20 @@ struct candev_mcp2515 {
 void candev_mcp2515_init(candev_mcp2515_t *dev,
                          const candev_mcp2515_conf_t *conf);
 
+/**
+ * @brief   Get the @ref candev_mcp2515_t for the given @p candev
+ *
+ * @param[in]   candev      CAN device to get the @ref candev_mcp2515_t from
+ *
+ * @return  The corresponding `candev_mcp2515_t` pointer to @p candev
+ * @retval  NULL        This is not an MCP2515 CAN device
+ *
+ * @note    It is safe to call this on any initialized @p candev regardless of
+ *          driver, as the implementation will check that the driver actually
+ *          is an MCP2515 before doing the cast.
+ */
+candev_mcp2515_t *candev2mcp2515(candev_t *candev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/can.h
+++ b/drivers/include/periph/can.h
@@ -58,6 +58,17 @@ typedef int can_conf_t;
  */
 void can_init(can_t *dev, const can_conf_t *conf);
 
+/**
+ * @brief   Convert a `candev_t *` to `can_t`
+ * @param[in]   candev      `candev_t` pointer to convert
+ * @return  The matching equivalent `can_t` pointer
+ * @retval  NULL    Argument @p candev is not a `can_t` pointers
+ *
+ * @note    Implementations **MUST** check that @ref candev_t::driver indeed
+ *          points to the peripheral CAN driver, before casting to `can_t *`.
+ */
+can_t *candev2periph(candev_t *candev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -59,6 +59,13 @@ static void pm_reset(candev_dev_t *candev_dev, uint32_t value);
 static int power_up(candev_dev_t *candev_dev);
 static int power_down(candev_dev_t *candev_dev);
 
+__attribute__((weak))
+void board_candev_set_power(candev_t *dev, bool active)
+{
+    (void)dev;
+    (void)active;
+}
+
 static void _can_event(candev_t *dev, candev_event_t event, void *arg)
 {
     msg_t msg;

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -129,7 +129,7 @@ int can_device_calc_bittiming(uint32_t clock, const struct can_bittiming_const *
  *          boards that actually can enable/disable the transceiver need to
  *          provide this.
  */
-void board_candev_set_power(candev_t *dev, bool active)
+void board_candev_set_power(candev_t *dev, bool active);
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -118,6 +118,18 @@ kernel_pid_t can_device_init(char *stack, int stacksize, char priority,
 int can_device_calc_bittiming(uint32_t clock, const struct can_bittiming_const *timing_const,
                               struct can_bittiming *bittiming);
 
+/**
+ * @brief   Function to provide by the board specification to enable the CAN
+ *          transceiver for the given CAN device to the given power state
+ *
+ * @param[in]   dev     CAN device to enable/disable the transceiver of
+ * @param[in]   active  `true` means set to active state, `false` means power
+ *                      off
+ * @note    A default no-op implementation is provided as `weak` symbol. On
+ *          boards that actually can enable/disable the transceiver need to
+ *          provide this.
+ */
+void board_candev_set_power(candev_t *dev, bool active)
 #ifdef __cplusplus
 }
 #endif

--- a/tests/drivers/candev/main.c
+++ b/tests/drivers/candev/main.c
@@ -283,10 +283,6 @@ int main(void)
     puts("Initializing CAN periph device");
     can_init(&periph_dev, &(candev_conf[0]));
     candev = &(periph_dev.candev);
-#if defined(BOARD_SAME54_XPRO)
-    gpio_init(AT6561_STBY_PIN, GPIO_OUT);
-    gpio_clear(AT6561_STBY_PIN);
-#endif
 #elif defined(MODULE_MCP2515)
     puts("Initializing MCP2515");
     candev_mcp2515_init(&mcp2515_dev, &candev_mcp2515_conf[0]);


### PR DESCRIPTION
### Contribution description

This provides a default (weak) implementation of

    void board_candev_set_power(candev_t *dev, bool active);

that is a no-op, and adds calls to this function to each and every CAN controller driver. The idea is that a board can provide this, if it can power up and down the CAN transceivers, freeing applications from having to add board specific hacks to enable CAN transceivers.

In addition, the following two helpers are added:

    can_t *candev2periph(candev_t *candev);
    candev_mcp2515_t *candev2mcp2515(candev_t *candev);

These safely convert a `candev_t` pointer back to the underlying type, return `NULL` if the given `candev_t *` is not of the requested type. This aids in implementing `board_candev_set_power()`, as it provides a board with the means to figure out for which CAN controller the CAN transceiver needs to be enabled/disabled for.

Finally, the new board hook is added for the `same54-xpro` and the board specific hacks from `tests/drivers/candev` are dropped.

### Testing procedure

```
$ make BOARD=same54-xpro flash term -C tests/drivers/candev 
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/drivers/candev'
Building application "tests_candev" for "same54-xpro" with CPU "samd5x".

"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/pkg/cmsis/ 
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/boards/common/init
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/boards/same54-xpro
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/core
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/core/lib
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/samd5x
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/cortexm_common
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/cortexm_common/periph
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/sam0_common/periph
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/cpu/samd5x/periph
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/drivers
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/can
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/div
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/libc
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/memarray
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/newlib_syscalls_default
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/shell
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/stdio
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/tsrb
   text	  data	   bss	   dec	   hex	filename
  20368	   128	 13432	 33928	  8488	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/drivers/candev/bin/same54-xpro/tests_candev.elf
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/edbg/edbg.sh flash /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/drivers/candev/bin/same54-xpro/tests_candev.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2748051800006032 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM E54P20A (Rev A)
Verification.......................................
at address 0x4853 expected 0x35, read 0x33
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2748051800006032 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM E54P20A (Rev A)
Programming...... done.
Verification............................................ done.
Done flashing
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM1" -b "115200" -ln "/tmp/pyterm-marian.buschsieweke@ml-pa.loc" -rn "2025-02-10_21.15.00-tests_candev-same54-xpro"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2025-02-10 21:15:00,457 # Connect to serial port /dev/ttyACM1
Welcome to pyterm!
Type '/exit' to exit.
send
2025-02-10 21:15:02,933 # send
> receive
2025-02-10 21:15:05,356 # receive
2025-02-10 21:15:05,358 # Reading from Rxbuf...
2025-02-10 21:15:08,966 # id: 1 dlc: hx data: 0xCA 0xFE 
```

```
$ candump any            
  can0  001   [3]  AB CD EF
  can0  001   [2]  CA FE
```

```
$ cansend can0 '001#cafe'
```

### Issues/PRs references

None