### PR TITLE
doc: fix image references for ESP32x boards

### DIFF
--- a/boards/esp32-ethernet-kit-v1_0/doc.txt
+++ b/boards/esp32-ethernet-kit-v1_0/doc.txt
@@ -26,7 +26,7 @@
 
 ## Overview {#esp32_ethernet_kit_v1_0_overview}
 
-The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.0.html) is a development board that uses the ESP32-WROVER-B module. Most important features of the board are
+The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32/esp32-ethernet-kit/user_guide.html) is a development board that uses the ESP32-WROVER-B module. Most important features of the board are
 
 - 100 Mbps Ethernet via IP101G PHY
 - USB bridge with JTAG interface
@@ -34,7 +34,7 @@ The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/e
 Furthermore, some GPIOs are broken out for extension. The USB bridge based on FDI FT2232HL provides a JTAG interface for OCD debugging through the USB interface.
 For flashing and debugging the board, see \ref boards_esp32_esp-ethernet-kit common board documentation.
 
-@image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-ethernet-kit-v1.0.png" "ESP32-Ethernet-Kit V1.0" width=500
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32/_images/esp32-ethernet-kit-v1.0.png" "ESP32-Ethernet-Kit V1.0" width=500
 
 [Back to table of contents](#esp32_ethernet_kit_v1_0_toc)
 

--- a/boards/esp32-ethernet-kit-v1_1/doc.txt
+++ b/boards/esp32-ethernet-kit-v1_1/doc.txt
@@ -34,7 +34,7 @@ The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/e
 Furthermore, some GPIOs are broken out for extension. The USB bridge based on FDI FT2232HL provides a JTAG interface for OCD debugging through the USB interface.
 For flashing and debugging the board, see \ref boards_esp32_esp-ethernet-kit common board documentation.
 
-@image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-ethernet-kit-v1.1.png" "ESP32-Ethernet-Kit V1.1" width=500
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32/_images/esp32-ethernet-kit-v1.1.png" "ESP32-Ethernet-Kit V1.1" width=500
 
 [Back to table of contents](#esp32_ethernet_kit_v1_1_toc)
 

--- a/boards/esp32-ethernet-kit-v1_2/doc.txt
+++ b/boards/esp32-ethernet-kit-v1_2/doc.txt
@@ -34,7 +34,7 @@ The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/e
 Furthermore, some GPIOs are broken out for extension. The USB bridge based on FDI FT2232HL provides a JTAG interface for OCD debugging through the USB interface.
 For flashing and debugging the board, see \ref boards_esp32_esp-ethernet-kit common board documentation.
 
-@image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-ethernet-kit-v1.2.jpg" "ESP32-Ethernet-Kit V1.2" width=500
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32/_images/esp32-ethernet-kit-v1.2.jpg" "ESP32-Ethernet-Kit V1.2" width=500
 
 [Back to table of contents](#esp32_ethernet_kit_v1_2_toc)
 

--- a/boards/esp32-heltec-lora32-v2/doc.txt
+++ b/boards/esp32-heltec-lora32-v2/doc.txt
@@ -37,7 +37,7 @@ Since the board is
 [open source hardware](https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series),
 a number of clones are available.
 
-@image html "https://heltec.org/wp-content/uploads/2020/04/SAM_0748_800X800.png" "Heltec WiFi Lora 32 V2" width=400px
+@image html "https://heltec.org/wp-content/uploads/2024/07/wifi-lora-32-v2-1.png" "Heltec WiFi Lora 32 V2" width=400px
 
 [Back to table of contents](#esp32_heltec_lora32_v2_toc)
 

--- a/boards/esp32c3-devkit/doc.txt
+++ b/boards/esp32c3-devkit/doc.txt
@@ -36,7 +36,7 @@ limited, the ESP32-C3-DevKit should also work for most other ESP32-C3 boards.
 Any modifications required for specific applications could be overridden by
 \ref esp32_application_specific_configurations "application-specific board configuration".
 
-\image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/_images/esp32-c3-devkitm-1-v1-annotated-photo.png" "Espressif ESP32-C3-DevKitM-1" width=800px
+\image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c3/_images/esp32-c3-devkitm-1-v1-annotated-photo.png" "Espressif ESP32-C3-DevKitM-1" width=800px
 
 [Back to table of contents](#esp32c3_devkit_toc)
 

--- a/boards/esp32s2-devkit/doc.txt
+++ b/boards/esp32s2-devkit/doc.txt
@@ -35,7 +35,7 @@ the following modules:
 - ESP32-S2-WROOM module (ESP32-S2-Saola-1 board)
 - ESP32-S2-WROVER-N4R2 module (ESP32-S2-Saola-1R board)
 
-\image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2-devkitm-1-v1-annotated-photo.png" "Espressif ESP32-S2-DevKitM-1" width=600px
+\image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s2/_images/esp32-s2-devkitm-1-v1-annotated-photo.png" "Espressif ESP32-S2-DevKitM-1" width=600px
 
 <br>
 Due to the different modules used, the available versions of the
@@ -174,9 +174,9 @@ boards, see section \ref esp32_peripherals "Common Peripherals".
 The following figures show the pinouts as configured by default board
 definition.
 
-@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2-devkitm-1-v1-pin-layout.png "ESP32-S2-DevKitM-1x Pinout" width=900px
-@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2-devkitc-1-v1-pinout.png "ESP32-S2-DevKitC-1x Pinout" width=900px
-@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2_saola1-pinout.jpg "ESP32-S2-Saola-1x Pinout" width=900px
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s2/_images/esp32-s2-devkitm-1-v1-pin-layout.png" "ESP32-S2-DevKitM-1x Pinout" width=900px
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s2/_images/esp32-s2-devkitm-1-v1-pin-layout.png" "ESP32-S2-DevKitC-1x Pinout" width=900px
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s2/_images/esp32-s2_saola1-pinout.jpg" "ESP32-S2-Saola-1x Pinout" width=900px
 
 The corresponding board schematics can be found:
 

--- a/boards/esp32s3-devkit/doc.txt
+++ b/boards/esp32s3-devkit/doc.txt
@@ -32,7 +32,7 @@ the following modules:
 - ESP32-S3-WROOM-1x module (ESP32-S3-DevKitC-1 board)
 - ESP32-S3-WROOM-2 module (ESP32-S3-DevKitC-1 board)
 
-\image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/_images/ESP32-S3-DevKitC-1_v2-annotated-photo.png" "Espressif ESP32-S3-DevKitM-1" width=600px
+\image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/_images/ESP32-S3-DevKitC-1_v2-annotated-photo.png" "Espressif ESP32-S3-DevKitM-1" width=600px
 
 <br>
 Due to the different modules used, the available versions of the
@@ -179,8 +179,8 @@ boards, see section \ref esp32_peripherals "Common Peripherals".
 The following figures show the pinouts as configured by default board
 definition.
 
-@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/_images/ESP32-S3_DevKitC-1_pinlayout.jpg "ESP32-S3-DevKitC-1 Pinout" width=900px
-@image html https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/_images/ESP32-S3_DevKitM-1_pinlayout.jpg "ESP32-S3-DevKitM-1 Pinout" width=900px
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/_images/ESP32-S3_DevKitC-1_pinlayout_v1.1.jpg" "ESP32-S3-DevKitC-1 Pinout" width=900px
+@image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/_images/ESP32-S3_DevKitM-1_pinlayout.jpg" "ESP32-S3-DevKitM-1 Pinout" width=900px
 
 The corresponding board schematics can be found:
 

--- a/boards/esp32s3-usb-otg/doc.txt
+++ b/boards/esp32s3-usb-otg/doc.txt
@@ -32,7 +32,7 @@ it is equipped with two USB type A ports:
 - `USB_DEV` male port that is used to connect the board as a USB device to a host.
 - `USB_HOST` female port that is used to connect other USB devices to the board.
 
-\image html "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/_images/pic_board_top_lable.png" "Espressif ESP32-S3-USB-OTG" width=600px
+\image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/_images/pic_board_top_lable.png" "Espressif ESP32-S3-USB-OTG" width=600px
 
 @note RIOT-OS does only support the `USB_DEV` port, that is the board can only
       be used as USB device.


### PR DESCRIPTION
### Contribution description

This PR fixes some links to board images an pinouts in the documentation of some ESP32x boards.

### Testing procedure

Without this PR, the following board documentation has some broken links to board images and pinouts:

https://doc.riot-os.org/group__boards__esp32__esp-ethernet-kit-v1__0.html
https://doc.riot-os.org/group__boards__esp32__esp-ethernet-kit-v1__1.html
https://doc.riot-os.org/group__boards__esp32__esp-ethernet-kit-v1__2.html
https://doc.riot-os.org/group__boards__esp32__heltec-lora32-v2.html
https://doc.riot-os.org/group__boards__esp32c3__devkit.html
https://doc.riot-os.org/group__boards__esp32s2__devkit.html
https://doc.riot-os.org/group__boards__esp32s3__devkit.html
https://doc.riot-os.org/group__boards__esp32s3__usb__otg.html

With the PR, the images and pinouts are shown correctly.

### Issues/PRs references
