### PR TITLE
sys/ztimer: fix small typo in doc

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -404,7 +404,7 @@ void ztimer_handler(ztimer_clock_t *clock);
 /**
  * @brief   Acquire a clock
  *
- * This will indicate the the underlying clock is required to be running.
+ * This will indicate the underlying clock is required to be running.
  * If time differences are measured using @ref ztimer_now this will make
  * sure ztimer won't turn of the clock source.
  *
@@ -425,7 +425,7 @@ static inline bool ztimer_acquire(ztimer_clock_t *clock)
 /**
  * @brief   Release a clock
  *
- * This will indicate the the underlying clock isn't required to be running
+ * This will indicate the underlying clock isn't required to be running
  * anymore and may be turned off.
  *
  * @param[in]   clock       ztimer clock to operate on


### PR DESCRIPTION
### Contribution description

This PR fix small typo in doxygen documentation for `ztimer_acquire` and `ztimer_release` functions - in description appears 'the the' phrase.

### Testing procedure

Generate doc and see if everything is ok.

```
make doc
xdg-open doc/doxygen/html/group__sys__ztimer.html
```

### Issues/PRs references

None