### PR TITLE
treewide: fix example references in docs

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -3,7 +3,7 @@
 # uncomment and change this to limit builds, e.g.,
 #export BOARDS="samr21-xpro native"
 # and / or
-#export APPS="examples/hello-world tests/unittests"
+#export APPS="examples/essentials/hello-world tests/unittests"
 
 QUICKBUILD_BOARDS="
 adafruit-itsybitsy-m4
@@ -43,7 +43,7 @@ esac
 # on LLVM.
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native native64 nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
-: ${TEST_WITH_CONFIG_SUPPORTED:="examples/suit_update tests/drivers/at86rf2xx_aes"}
+: ${TEST_WITH_CONFIG_SUPPORTED:="examples/advanced_examples/suit_update tests/drivers/at86rf2xx_aes"}
 
 export RIOT_CI_BUILD=1
 export CC_NOCOLOR=1

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ define welcome_message
 	@echo " doc doc-{man,latex}"
 	@echo ""
 	@echo "==> tl;dr Try running:"
-	@echo "    cd examples/default"
+	@echo "    cd examples/essentials/default"
 	@echo "    make BOARD=<INSERT_BOARD_NAME>"
 endef
 

--- a/boards/adafruit-clue/doc.txt
+++ b/boards/adafruit-clue/doc.txt
@@ -26,7 +26,7 @@ The board is flashed using the `adafruit-nrfutil` Python package:
 
 Example with `hello-world` application:
 ```
-    make BOARD=adafruit-clue -C examples/hello-world flash
+    make BOARD=adafruit-clue -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART
@@ -36,7 +36,7 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=adafruit-clue -C examples/hello-world term
+    make BOARD=adafruit-clue -C examples/essentials/hello-world term
 ```
 
 The `TERM_DELAY` environment variable can be used to add a delay (in second)

--- a/boards/adafruit-pybadge/doc.txt
+++ b/boards/adafruit-pybadge/doc.txt
@@ -26,7 +26,7 @@ Connect the board via USB and use `BOARD=adafruit-pybadge` with the `make` comma
 this uses the Arduino style bootloader preprogrammed on the board.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=adafruit-pybadge -C examples/hello-world flash
+     make BOARD=adafruit-pybadge -C examples/essentials/hello-world flash
 ```
 
 In case of a crash of the firmware, one has to manually reset the board in

--- a/boards/alientek-pandora/doc.txt
+++ b/boards/alientek-pandora/doc.txt
@@ -18,7 +18,7 @@ Additional resources may be found on [RT-Thread bsp support page](https://gitee.
 To flash the board, use the on board ST-Link programmer/debugger.
 Input the following command:
 
-    make BOARD=alientek-pandora -C examples/hello-world flash
+    make BOARD=alientek-pandora -C examples/essentials/hello-world flash
 
 The NRST pin is connected to the on board debugger, so users do not need to reset manually
 every time it requires to flash.
@@ -33,7 +33,7 @@ Before you begin, check that the both the jumper caps marked as 'USART1' is conn
 
 Use the `term` target to open a terminal:
 
-    make BOARD=alientek-pandora -C examples/hello-world term
+    make BOARD=alientek-pandora -C examples/essentials/hello-world term
 
 An on-board ST-Link compatible debugger is used to transport serial STDIO message.
 

--- a/boards/arduino-mkrfox1200/doc.txt
+++ b/boards/arduino-mkrfox1200/doc.txt
@@ -19,7 +19,7 @@ powered by an Atmel SAMD21 microcontroller.
 Use `BOARD=arduino-mkrfox1200` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=arduino-mkrfox1200 -C examples/hello-world flash
+     make BOARD=arduino-mkrfox1200 -C examples/essentials/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/arduino-mkrwan1300/doc.txt
+++ b/boards/arduino-mkrwan1300/doc.txt
@@ -19,7 +19,7 @@ powered by an Atmel SAMD21 microcontroller.
 Use `BOARD=arduino-mkrwan1300` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=arduino-mkrwan1300 -C examples/hello-world flash
+     make BOARD=arduino-mkrwan1300 -C examples/essentials/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/arduino-nano-33-ble-sense/doc.txt
+++ b/boards/arduino-nano-33-ble-sense/doc.txt
@@ -19,7 +19,7 @@ This board provides 802.15.4 and BLE connectivity.
 Use `BOARD=arduino-nano-33-ble-sense` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-    make BOARD=arduino-nano-33-ble-sense -C examples/hello-world flash
+    make BOARD=arduino-nano-33-ble-sense -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART
@@ -29,7 +29,7 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=arduino-nano-33-ble-sense -C examples/hello-world term
+    make BOARD=arduino-nano-33-ble-sense -C examples/essentials/hello-world term
 ```
  */
 

--- a/boards/arduino-nano-33-ble/doc.txt
+++ b/boards/arduino-nano-33-ble/doc.txt
@@ -19,7 +19,7 @@ This board provides 802.15.4 and BLE connectivity.
 Use `BOARD=arduino-nano-33-ble` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-    make BOARD=arduino-nano-33-ble -C examples/hello-world flash
+    make BOARD=arduino-nano-33-ble -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART
@@ -29,6 +29,6 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=arduino-nano-33-ble -C examples/hello-world term
+    make BOARD=arduino-nano-33-ble -C examples/essentials/hello-world term
 ```
  */

--- a/boards/arduino-nano-33-iot/doc.txt
+++ b/boards/arduino-nano-33-iot/doc.txt
@@ -14,7 +14,7 @@ powered by an Atmel SAMD21 microcontroller.
 Use `BOARD=arduino-nano-33-iot` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=arduino-nano-33-iot -C examples/hello-world flash
+     make BOARD=arduino-nano-33-iot -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART

--- a/boards/atmega256rfr2-xpro/doc.txt
+++ b/boards/atmega256rfr2-xpro/doc.txt
@@ -27,7 +27,7 @@ To flash the board, just call `make` from an application directory with the
 `flash` target:
 
 ```
-make BOARD=atmega256rfr2-xpro -C examples/hello-world flash
+make BOARD=atmega256rfr2-xpro -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART
@@ -36,7 +36,7 @@ STDIO can be accessed through the USB connector. The on-board UART-USB
 adapter is not affected by flashing. It shows up as /dev/ttyACM0 on Linux.
 It will be used automatically with `make term`:
 ```
-make BOARD=atmega256rfr2-xpro -C examples/hello-world term
+make BOARD=atmega256rfr2-xpro -C examples/essentials/hello-world term
 ```
 
 */

--- a/boards/common/nrf52/doc.txt
+++ b/boards/common/nrf52/doc.txt
@@ -11,7 +11,7 @@ uses PyOCD by default.
 To flash the board, use `BOARD=<nrf52 board>` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-    make BOARD=<nrf52 board> -C examples/hello-world flash
+    make BOARD=<nrf52 board> -C examples/essentials/hello-world flash
 ```
 
 OpenOCD can also be used to flash nrf52 boards (except thingy52 and ruuvitag
@@ -22,13 +22,13 @@ can be used.
 
 To flash the board with OpenOCD, use the `PROGRAMMER` variable:
 ```
-    PROGRAMMER=openocd make BOARD=<nrf52 board> -C examples/hello-world flash
+    PROGRAMMER=openocd make BOARD=<nrf52 board> -C examples/essentials/hello-world flash
 ```
 
 It is also possible to use the SWD interface of a ST-LINK/V2 in-circuit
 debugger/programmer with OpenOCD to flash a nrf52 board:
 ```
-    PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=stlink make BOARD=<nrf52 board> -C examples/hello-world flash
+    PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=stlink make BOARD=<nrf52 board> -C examples/essentials/hello-world flash
 ```
 
 */

--- a/boards/common/particle-mesh/doc.txt
+++ b/boards/common/particle-mesh/doc.txt
@@ -23,7 +23,7 @@ To flash the board, use `BOARD=<board name>` (with board name in {particle-argon
 particle-boron, particle-xenon}) with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-    make BOARD=particle-xenon -C examples/hello-world flash
+    make BOARD=particle-xenon -C examples/essentials/hello-world flash
 ```
 
 In this case, OpenOCD can also be used. For the moment, the latest stable
@@ -32,7 +32,7 @@ built against the actual development version can be used.
 
 To flash the board with OpenOCD, use the `PROGRAMMER` variable:
 ```
-    PROGRAMMER=openocd make BOARD=<board name> -C examples/hello-world flash
+    PROGRAMMER=openocd make BOARD=<board name> -C examples/essentials/hello-world flash
 ```
 
 #### Alternative flashing procedure: Particle bootloader and DFU-Util
@@ -72,7 +72,7 @@ Then, the checksum is only calculated over the memory region that contains the i
 The on-board reset button doesn't work, so to trigger a reset of the board, use
 the `reset` target with `make`:
 ```
-    make BOARD=<board name> -C examples/hello-world reset
+    make BOARD=<board name> -C examples/essentials/hello-world reset
 ```
 
 ### STDIO configuration

--- a/boards/dwm1001/doc.txt
+++ b/boards/dwm1001/doc.txt
@@ -19,13 +19,13 @@ To program this board, plug it to your computer via USB and run the following
 command:
 
 ```
-make BOARD=dwm1001 -C examples/hello-world flash
+make BOARD=dwm1001 -C examples/essentials/hello-world flash
 ```
 
 To program the board with OpenOCD, use:
 
 ```
-PROGRAMMER=openocd make BOARD=dwm1001 -C examples/hello-world flash
+PROGRAMMER=openocd make BOARD=dwm1001 -C examples/essentials/hello-world flash
 ```
 
 ## Accessing STDIO via UART
@@ -35,6 +35,6 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-make BOARD=dwm1001 -C examples/hello-world term
+make BOARD=dwm1001 -C examples/essentials/hello-world term
 ```
  */

--- a/boards/e104-bt5010a-tb/doc.txt
+++ b/boards/e104-bt5010a-tb/doc.txt
@@ -25,7 +25,7 @@ generally mapped to `/dev/ttyUSB0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=e104-bt5010a-tb -C examples/hello-world term
+    make BOARD=e104-bt5010a-tb -C examples/essentials/hello-world term
 ```
 
  */

--- a/boards/e104-bt5011a-tb/doc.txt
+++ b/boards/e104-bt5011a-tb/doc.txt
@@ -25,7 +25,7 @@ generally mapped to `/dev/ttyUSB0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=e104-bt5011a-tb -C examples/hello-world term
+    make BOARD=e104-bt5011a-tb -C examples/essentials/hello-world term
 ```
 
  */

--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -44,7 +44,7 @@ printf("Bat: %dV\n", vbat);
 Use `BOARD=feather-m0` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=feather-m0 -C examples/hello-world flash
+     make BOARD=feather-m0 -C examples/essentials/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained
@@ -59,7 +59,7 @@ automatically for networking applications, use `feather-m0-wifi` as board
 and define the required WiFi parameters, for example:
 ```
      CFLAGS='-DWIFI_SSID=\"<ssid>\" -DWIFI_PASS=\"<pass>\"' \
-     make BOARD=feather-m0-wifi -C examples/gnrc_networking
+     make BOARD=feather-m0-wifi -C examples/networking/gnrc_networking/gnrc_networking
 ```
 
 For detailed information about the parameters, see section
@@ -73,7 +73,7 @@ variant of the board automatically for LoRa applications,
 use `feather-m0-lora` as board:
 
 ```
-make BOARD=feather-m0-lora -C examples/gnrc_lorawan
+make BOARD=feather-m0-lora -C examples/networking/gnrc_networking/gnrc_lorawan
 ```
 
 For detailed information about the parameters, see section

--- a/boards/feather-nrf52840-sense/doc.txt
+++ b/boards/feather-nrf52840-sense/doc.txt
@@ -26,7 +26,7 @@ Both use the same flasher, bootloader, and terminal settings.
 
 Example with `hello-world` application:
 ```
-     make BOARD=feather-nrf52840-sense -C examples/hello-world flash term
+     make BOARD=feather-nrf52840-sense -C examples/essentials/hello-world flash term
 ```
 
 On "fresh" boards the

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -24,7 +24,7 @@ The rest of the process is automated in the usual way with `BOARD=feather-nrf528
 
 Example with `hello-world` application:
 ```
-     make BOARD=feather-nrf52840 -C examples/hello-world flash term
+     make BOARD=feather-nrf52840 -C examples/essentials/hello-world flash term
 ```
 
 If RIOT is already running on the board, it will automatically reset the CPU and enter

--- a/boards/i-nucleo-lrwan1/doc.txt
+++ b/boards/i-nucleo-lrwan1/doc.txt
@@ -48,7 +48,7 @@ index c59a1939a2..0c359e438c 100755
 ```
 - Run make flash:
 ```sh
-make BOARD=i-nucleo-lrwan1 -C examples/hello-world flash
+make BOARD=i-nucleo-lrwan1 -C examples/essentials/hello-world flash
 ```
   The command will fail but after that the memory will be unlocked after a
   power cycle. The line added above in `openocd.sh` can also be removed.

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -102,13 +102,13 @@ debug` - assuming that the current directory is your application directory. It
 establishes an openocd connection to the device and starts gdb connected to the
 openocd instance. For example, it should look something like this
 ```
-[user@host RIOT]$ cd examples/default/
+[user@host RIOT]$ cd examples/essentials/default/
 [user@host default]$ BOARD=iotlab-m3 make
 Building application default for iotlab-m3 w/ MCU stm32f1.
 ...
 [user@hostdefault]$ BOARD=iotlab-m3 make debug
 RIOT/boards/hikob-common/dist/debug.sh RIOT/boards/iotlab-m3/dist/gdb.conf
-RIOT/examples/default/bin/iotlab-m3/default.elf
+RIOT/examples/essentials/default/bin/iotlab-m3/default.elf
 Open On-Chip Debugger 0.8.0 (2014-07-27-20:18)
 Licensed under GNU GPL v2
 For bug reports, read
@@ -123,7 +123,7 @@ This GDB was configured as "--host=x86_64-apple-darwin10 --target=arm-none-
 eabi".
 For bug reporting instructions, please see:
 <http://www.gnu.org/software/gdb/bugs/>...
-Reading symbols from RIOT/examples/default/bin/iotlab-m3/default.elf...done.
+Reading symbols from RIOT/examples/essentials/default/bin/iotlab-m3/default.elf...done.
 idle_thread (arg=<optimized out>) at RIOT/core/kernel_init.c:67
 67               lpm_set(LPM_IDLE);
 JTAG tap: stm32f1x.cpu tap/device found: 0x3ba00477 (mfg: 0x23b, part:

--- a/boards/lsn50/doc.txt
+++ b/boards/lsn50/doc.txt
@@ -30,7 +30,7 @@ exposed with v1.0).
 Ensure SW1 is on `flash` position.
 Then use the following command:
 
-    make BOARD=lsn50 -C examples/hello-world flash
+    make BOARD=lsn50 -C examples/essentials/hello-world flash
 
 On the v1.0 version of the board, no NRST pin is exposed so one has to press the
 reset button during flash and release it when OpenOCD prints `adapter speed: 240 kHz`
@@ -43,7 +43,7 @@ application.
 STDIO is connected to pins PA9 (TX) and PA10 (RX) so an USB to UART adapter is
 required. Use the `term` target to open a terminal:
 
-    make BOARD=lsn50 -C examples/hello-world term
+    make BOARD=lsn50 -C examples/essentials/hello-world term
 
 If an external ST-Link adapter is used, RX and TX pins can be directly connected
 to it. In this case, STDIO is available on /dev/ttyACMx (Linux case).

--- a/boards/mega-xplained/doc.txt
+++ b/boards/mega-xplained/doc.txt
@@ -39,12 +39,12 @@ square pin on the adapter connecting with the square pin on the board.
 
    If using the Buspirate:
 ```
-     BOARD=mega-xplained make -C examples/hello-world flash
+     BOARD=mega-xplained make -C examples/essentials/hello-world flash
 ```
 
    If using the Atmel-ICE:
 ```
-     BOARD=mega-xplained PROGRAMMER=atmelice make -C examples/hello-world flash
+     BOARD=mega-xplained PROGRAMMER=atmelice make -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART
@@ -53,7 +53,7 @@ STDIO can be accessed through the USB connector. The on-board UART-USB
 adapter is not affected by flashing. It shows up as /dev/ttyACM0 on Linux.
 It will be used automatically with `make term`:
 ```
-     BOARD=mega-xplained make -C examples/hello-world term
+     BOARD=mega-xplained make -C examples/essentials/hello-world term
 ```
 
 ### Pin Change Interrupts

--- a/boards/microbit/doc.txt
+++ b/boards/microbit/doc.txt
@@ -92,7 +92,7 @@ fail.
 
 Use it like this:
 
-    $ cd examples/hello-world
+    $ cd examples/essentials/hello-world
     $ BOARD=microbit make clean all -j4
     $ EMULATE=1 BOARD=microbit make term
 

--- a/boards/msbiot/doc.txt
+++ b/boards/msbiot/doc.txt
@@ -215,7 +215,7 @@ respective board name.
 ### Compiling
 
 ```
-fabian@fabian-ThinkPad-L412:~/myriot/RIOT/examples/hello-world$ BOARD=msbiot
+fabian@fabian-ThinkPad-L412:~/myriot/RIOT/examples/essentials/hello-world$ BOARD=msbiot
 make
 Building application "hello-world" for "msbiot" with MCU "stm32f4".
 
@@ -229,14 +229,14 @@ Building application "hello-world" for "msbiot" with MCU "stm32f4".
 "make" -C /home/fabian/myriot/RIOT/sys/auto_init
    text     data     bss     dec     hex filename
   11116      116    6444   17676    450c
-/home/fabian/myriot/RIOT/examples/hello-world/bin/msbiot/hello-world.elf
+/home/fabian/myriot/RIOT/examples/essentials/hello-world/bin/msbiot/hello-world.elf
 ```
 
 
 ### Flashing
 
 ```
-fabian@fabian-ThinkPad-L412:~/myriot/RIOT/examples/hello-world$ BOARD=msbiot
+fabian@fabian-ThinkPad-L412:~/myriot/RIOT/examples/essentials/hello-world$ BOARD=msbiot
 make flash
 Building application "hello-world" for "msbiot" with MCU "stm32f4".
 
@@ -250,7 +250,7 @@ Building application "hello-world" for "msbiot" with MCU "stm32f4".
 "make" -C /home/fabian/myriot/RIOT/sys/auto_init
    text     data     bss     dec     hex filename
   11116      116    6444   17676    450c
-/home/fabian/myriot/RIOT/examples/hello-world/bin/msbiot/hello-world.elf
+/home/fabian/myriot/RIOT/examples/essentials/hello-world/bin/msbiot/hello-world.elf
 /home/fabian/myriot/RIOT/dist/tools/openocd/openocd.sh flash
 ### Flashing Target ###
 Open On-Chip Debugger 0.8.0 (2015-03-01-08:19)
@@ -305,7 +305,7 @@ Done flashing
 ### Debugging
 
 ```
-fabian@fabian-ThinkPad-L412:~/myriot/RIOT/examples/hello-world$ BOARD=msbiot
+fabian@fabian-ThinkPad-L412:~/myriot/RIOT/examples/essentials/hello-world$ BOARD=msbiot
 make debug
 /home/fabian/myriot/RIOT/dist/tools/openocd/openocd.sh debug
 ### Starting Debugging ###

--- a/boards/nrf52832-mdk/doc.txt
+++ b/boards/nrf52832-mdk/doc.txt
@@ -42,6 +42,6 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=nrf52832-mdk -C examples/hello-world term
+    make BOARD=nrf52832-mdk -C examples/essentials/hello-world term
 ```
  */

--- a/boards/nrf52840-mdk/doc.txt
+++ b/boards/nrf52840-mdk/doc.txt
@@ -32,6 +32,6 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=nrf52840-mdk -C examples/hello-world term
+    make BOARD=nrf52840-mdk -C examples/essentials/hello-world term
 ```
  */

--- a/boards/nrf52840dk/doc.txt
+++ b/boards/nrf52840dk/doc.txt
@@ -24,7 +24,7 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=nrf52840dk -C examples/hello-world term
+    make BOARD=nrf52840dk -C examples/essentials/hello-world term
 ```
 
  */

--- a/boards/nrf52840dongle/doc.txt
+++ b/boards/nrf52840dongle/doc.txt
@@ -6,7 +6,7 @@
 ### Quick start
 
 - Plug into a USB port.
-- `$ make BOARD=nrf52840dongle -C examples/saul flash term`
+- `$ make BOARD=nrf52840dongle -C examples/essentials/saul flash term`
   - See [Flash the board](#nrf52840dongle_flash) if anything goes wrong.
 - `> saul write 2 10 40 10`
   - The LED glows in a soft turquise.

--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -62,6 +62,6 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=nrf52dk -C examples/hello-world term
+    make BOARD=nrf52dk -C examples/essentials/hello-world term
 ```
  */

--- a/boards/nrf5340dk-app/doc.txt
+++ b/boards/nrf5340dk-app/doc.txt
@@ -32,7 +32,7 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=nrf5340dk-app -C examples/hello-world term
+    make BOARD=nrf5340dk-app -C examples/essentials/hello-world term
 ```
 
  */

--- a/boards/nrf9160dk/doc.txt
+++ b/boards/nrf9160dk/doc.txt
@@ -29,7 +29,7 @@ generally mapped to `/dev/ttyACM0`.
 
 Use the `term` target to connect to the board serial port<br/>
 ```
-    make BOARD=nrf9160dk -C examples/hello-world term
+    make BOARD=nrf9160dk -C examples/essentials/hello-world term
 ```
 
  */

--- a/boards/nucleo-l4r5zi/doc.txt
+++ b/boards/nucleo-l4r5zi/doc.txt
@@ -51,7 +51,7 @@ must be built from source to be able to flash this board.
 To flash this board, just use the following command:
 
 ```
-make BOARD=nucleo-l4r5zi flash -C examples/hello-world
+make BOARD=nucleo-l4r5zi flash -C examples/essentials/hello-world
 ```
 
 ### Flashing the Board Using ST-LINK Removable Media
@@ -77,6 +77,6 @@ The default baud rate is 115 200.
 
 Use the `term` target to open a terminal:
 
-    make BOARD=nucleo-l4r5zi -C examples/hello-world term
+    make BOARD=nucleo-l4r5zi -C examples/essentials/hello-world term
 
  */

--- a/boards/openlabs-kw41z-mini/doc.txt
+++ b/boards/openlabs-kw41z-mini/doc.txt
@@ -58,7 +58,7 @@ running OpenOCD.
 
 # build and flash the gnrc_networking example
 
-    cd RIOT/examples/gnrc_networking
+    cd RIOT/examples/networking/gnrc_networking/gnrc_networking
     BOARD=openlabs-kw41z-mini CFLAGS+="-DKW41ZRF_ENABLE_LEDS=1" make -j4 flash
 
 ### Debug Uart Pinout

--- a/boards/p-l496g-cell02/doc.txt
+++ b/boards/p-l496g-cell02/doc.txt
@@ -17,7 +17,7 @@ flashed using OpenOCD.
 To flash this board, just use the following command:
 
 ```
-make BOARD=p-l496g-cell02 flash -C examples/hello-world
+make BOARD=p-l496g-cell02 flash -C examples/essentials/hello-world
 ```
 
 ### STDIO
@@ -26,6 +26,6 @@ STDIO is available via the ST-Link programmer.
 
 Use the `term` target to open a terminal:
 
-    make BOARD=p-l496g-cell02 -C examples/hello-world term
+    make BOARD=p-l496g-cell02 -C examples/essentials/hello-world term
 
  */

--- a/boards/p-nucleo-wb55/doc.txt
+++ b/boards/p-nucleo-wb55/doc.txt
@@ -56,7 +56,7 @@ flashed using OpenOCD (use version 0.11.0 at least).
 To flash this board, just use the following command:
 
 ```
-make BOARD=p-nucleo-wb55 flash -C examples/hello-world
+make BOARD=p-nucleo-wb55 flash -C examples/essentials/hello-world
 ```
 
 ### Flashing the Board Using ST-LINK Removable Media
@@ -85,7 +85,7 @@ The default baud rate is 115 200.
 
 Use the `term` target to open a terminal:
 ```
-make BOARD=p-nucleo-wb55 -C examples/hello-world term
+make BOARD=p-nucleo-wb55 -C examples/essentials/hello-world term
 ```
 
 ## User Interface

--- a/boards/phynode-kw41z/doc.txt
+++ b/boards/phynode-kw41z/doc.txt
@@ -31,7 +31,7 @@ To flash the board using OpenOCD:
 1. Use `BOARD=phynode-kw41z` with the `make` command.<br/>
    Example with `hello-world` application:
 ```
-     make BOARD=phynode-kw41z -C examples/hello-world flash term
+     make BOARD=phynode-kw41z -C examples/essentials/hello-world flash term
 ```
 
 ### Current support

--- a/boards/samr21-xpro/doc.txt
+++ b/boards/samr21-xpro/doc.txt
@@ -164,7 +164,7 @@ STDIO is available through the edbg debugger.
 
 Use the `term` target to open a terminal:
 
-    make BOARD=samr21-xpro -C examples/hello-world term
+    make BOARD=samr21-xpro -C examples/essentials/hello-world term
 
 RTS / CTS hardware flow control is available on `UART_DEV(0)` and
 `UART_DEV(1)`. This is unavailable when using STDIO directly through

--- a/boards/seeedstudio-gd32/doc.txt
+++ b/boards/seeedstudio-gd32/doc.txt
@@ -152,17 +152,17 @@ By default, an FTDI adapter according to the configuration defined in
 [`interface/openocd-usb.cfg`](https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
 is assumed.
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+BOARD=seeedstudio-gd32 make -C examples/essentials/hello-world flash
 ```
 To use an FTDI adapter with a different configuration, the configuration can be
 defined using the variable `OPENOCD_FTDI_ADAPTER`, for example:
 ```
-OPENOCD_FTDI_ADAPTER=tigar BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+OPENOCD_FTDI_ADAPTER=tigar BOARD=seeedstudio-gd32 make -C examples/essentials/hello-world flash
 ```
 If another adapter is used, it can be specified using variable
 `OPENOCD_DEBUG_ADAPTER`, for example for a Segger J-Link adapter:
 ```
-OPENOCD_DEBUG_ADAPTER=jlink BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+OPENOCD_DEBUG_ADAPTER=jlink BOARD=seeedstudio-gd32 make -C examples/essentials/hello-world flash
 ```
 
 ## Accessing STDIO
@@ -174,7 +174,7 @@ the index of the CDC ACM interface, which is 0 by default.
 To use the first UART interface for `stdio` instead, the `stdio_uart` module
 has to be enabled:
 ```
-USEMODULE=stdio_uart BOARD=seeedstudio-gd32 make -C examples/hello-world flash
+USEMODULE=stdio_uart BOARD=seeedstudio-gd32 make -C examples/essentials/hello-world flash
 ```
 
 The `stdio` is then directly accessible through the first UART interface. If an
@@ -184,11 +184,11 @@ interface, which is 0 by default.
 
 Use the `term` target to connect to the board using `/dev/ttyUSB0`:
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world term PORT=/dev/ttyUSB0
+BOARD=seeedstudio-gd32 make -C examples/essentials/hello-world term PORT=/dev/ttyUSB0
 ```
 If the UART interface index of the USB-to-UART interface is not 0, use
 the following command to connect:
 ```
-BOARD=seeedstudio-gd32 make -C examples/hello-world term PORT=/dev/ttyUSB<n>
+BOARD=seeedstudio-gd32 make -C examples/essentials/hello-world term PORT=/dev/ttyUSB<n>
 ```
  */

--- a/boards/seeeduino_xiao/doc.txt
+++ b/boards/seeeduino_xiao/doc.txt
@@ -21,7 +21,7 @@ Use `BOARD=seeeduino_xiao` with the `make` command.<br/>
 
 Example with `default` application:
 ```
-     make BOARD=seeeduino_xiao -C examples/default flash
+     make BOARD=seeeduino_xiao -C examples/essentials/default flash
 ```
 
 RIOT will automatically trigger a reset to the bootloader, but this only works if RIOT is still

--- a/boards/sensebox_samd21/doc.txt
+++ b/boards/sensebox_samd21/doc.txt
@@ -21,7 +21,7 @@ SenseBox board is based on the Atmel SAMD21G18A microcontroller. See
 2. Use `BOARD=sensebox_samd21` with the `make` command.<br/>
     Example with `hello-world` application:
 ```
-    make BOARD=sensebox_samd21 -C examples/hello-world flash
+    make BOARD=sensebox_samd21 -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART

--- a/boards/serpente/doc.txt
+++ b/boards/serpente/doc.txt
@@ -26,7 +26,7 @@ and dirty, yet flexible, prototyping tools.
 Use `BOARD=serpente` with the `make` command.<br/>
 Example with `micropython` application:
 ```
-     make BOARD=serpente -C examples/micropython flash
+     make BOARD=serpente -C examples/language_bindings/community_supported/micropython flash
 ```
 
 RIOT will automatically trigger a reset to the bootloader, but this only works if RIOT is still

--- a/boards/sipeed-longan-nano/doc.txt
+++ b/boards/sipeed-longan-nano/doc.txt
@@ -160,7 +160,7 @@ The board is flashed via the in-ROM DFU bootloader by default.
 To enter bootloader mode, hold the BOOT0 button while pressing the RESET button.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BOARD=sipeed-longan-nano make -C examples/hello-world flash
+BOARD=sipeed-longan-nano make -C examples/essentials/hello-world flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After flashing you need to leave bootloader mode again by pressing the RESET button.
@@ -168,7 +168,7 @@ After flashing you need to leave bootloader mode again by pressing the RESET but
 @note For the Sipeed Longan Nano board version with TFT display, the
       `sipeed-longan-nano-tft` board definition has to be used.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BOARD=sipeed-longan-nano-tft make -C examples/hello-world flash
+BOARD=sipeed-longan-nano-tft make -C examples/essentials/hello-world flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ### Using an external debug adapter
@@ -179,18 +179,18 @@ By default, an FTDI adapter according to the configuration defined in
 [`interface/openocd-usb.cfg`](https://github.com/openocd-org/openocd/blob/9ea7f3d647c8ecf6b0f1424002dfc3f4504a162c/tcl/interface/ftdi/openocd-usb.cfg)
 is assumed.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-PROGRAMMER=openocd BOARD=sipeed-longan-nano make -C examples/hello-world flash
+PROGRAMMER=openocd BOARD=sipeed-longan-nano make -C examples/essentials/hello-world flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To use an FTDI adapter with a different configuration, the configuration can be
 defined using the variable `OPENOCD_FTDI_ADAPTER`, for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-PROGRAMMER=openocd OPENOCD_FTDI_ADAPTER=tigard BOARD=sipeed-longan-nano make -C examples/hello-world flash
+PROGRAMMER=openocd OPENOCD_FTDI_ADAPTER=tigard BOARD=sipeed-longan-nano make -C examples/essentials/hello-world flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If another adapter is used, it can be specified using variable
 `OPENOCD_DEBUG_ADAPTER`, for example for a Segger J-Link adapter:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink BOARD=sipeed-longan-nano make -C examples/hello-world flash
+PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=jlink BOARD=sipeed-longan-nano make -C examples/essentials/hello-world flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Using the TFT Display
@@ -210,7 +210,7 @@ the index of the CDC ACM interface, which is 0 by default.
 To use the first UART interface for `stdio` instead, the `stdio_uart` module
 has to be enabled:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-USEMODULE=stdio_uart BOARD=sipeed-longan-nano make -C examples/hello-world flash
+USEMODULE=stdio_uart BOARD=sipeed-longan-nano make -C examples/essentials/hello-world flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `stdio` is then directly accessible through the first UART interface. If an
@@ -220,11 +220,11 @@ interface, which is 0 by default.
 
 Use the `term` target to connect to the board using `/dev/ttyUSB0`:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BOARD=sipeed-longan-nano make -C examples/hello-world term PORT=/dev/ttyUSB0
+BOARD=sipeed-longan-nano make -C examples/essentials/hello-world term PORT=/dev/ttyUSB0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If the UART interface index of the USB-to-UART interface is not 0, use
 the following command to connect:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BOARD=sipeed-longan-nano make -C examples/hello-world term PORT=/dev/ttyUSB<n>
+BOARD=sipeed-longan-nano make -C examples/essentials/hello-world term PORT=/dev/ttyUSB<n>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */

--- a/boards/sodaq-autonomo/doc.txt
+++ b/boards/sodaq-autonomo/doc.txt
@@ -96,7 +96,7 @@ Besides the SAMD21 the board has the following features:
 Use `BOARD=sodaq-autonomo` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=sodaq-autonomo -C examples/hello-world flash
+     make BOARD=sodaq-autonomo -C examples/essentials/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/sodaq-explorer/doc.txt
+++ b/boards/sodaq-explorer/doc.txt
@@ -13,7 +13,7 @@ General information about this board can be found on the
 Use `BOARD=sodaq-explorer` with the `make` command.<br/>
 Example with `hello-world` application:
 ```
-     make BOARD=sodaq-explorer -C examples/hello-world flash
+     make BOARD=sodaq-explorer -C examples/essentials/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/sodaq-one/doc.txt
+++ b/boards/sodaq-one/doc.txt
@@ -13,7 +13,7 @@
  * Use `BOARD=sodaq-one` with the `make` command.<br/>
  * Example with `hello-world` application:
  * ```
- *      make BOARD=sodaq-one -C examples/hello-world flash
+ *      make BOARD=sodaq-one -C examples/essentials/hello-world flash
  * ```
  *
  * @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/sodaq-sara-aff/doc.txt
+++ b/boards/sodaq-sara-aff/doc.txt
@@ -15,7 +15,7 @@
  * Use `BOARD=sodaq-sara-aff` with the `make` command.<br/>
  * Example with `hello-world` application:
  * ```
- *      make BOARD=sodaq-sara-aff -C examples/hello-world flash
+ *      make BOARD=sodaq-sara-aff -C examples/essentials/hello-world flash
  * ```
  *
  * @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/sodaq-sara-sff/doc.txt
+++ b/boards/sodaq-sara-sff/doc.txt
@@ -16,7 +16,7 @@
  * Use `BOARD=sodaq-one` with the `make` command.<br/>
  * Example with `hello-world` application:
  * ```
- *      make BOARD=sodaq-one -C examples/hello-world flash
+ *      make BOARD=sodaq-one -C examples/essentials/hello-world flash
  * ```
  *
  * @note     If the application crashes, automatic reflashing via USB, as explained

--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -97,7 +97,7 @@ Build and flash
 ===============
 
 1. clone RIOT-OS
-2. cd to e.g. `examples/hello_world`
+2. cd to e.g. `examples/essentials/hello-world`
 3. enter `BOARD=spark-core make clean all flash`
 
 Use the UART

--- a/boards/stm32f723e-disco/doc.txt
+++ b/boards/stm32f723e-disco/doc.txt
@@ -17,7 +17,7 @@ flashed using OpenOCD.
 To flash this board, just use the following command:
 
 ```
-make BOARD=stm32f723e-disco flash -C examples/hello-world
+make BOARD=stm32f723e-disco flash -C examples/essentials/hello-world
 ```
 
 ### STDIO
@@ -26,12 +26,12 @@ STDIO is available via the ST-Link programmer.
 
 Use the `term` target to open a terminal:
 
-    make BOARD=stm32f723e-disco -C examples/hello-world term
+    make BOARD=stm32f723e-disco -C examples/essentials/hello-world term
 
 ### USB OTG Peripheral Device Driver
 
 By default, the USB OTG FS port is used. To use the USB OTG HS port with the
 internal UTMI+ HS PHY, enable the module `periph_usbdev_hs_utmi`:
 
-    make BOARD=stm32f723e-disco USEMODULE=periph_usbdev_hs_utmi -C examples/usbus_minimal
+    make BOARD=stm32f723e-disco USEMODULE=periph_usbdev_hs_utmi -C examples/advanced_examples/usbus_minimal
  */

--- a/boards/stm32g0316-disco/doc.txt
+++ b/boards/stm32g0316-disco/doc.txt
@@ -24,7 +24,7 @@
  * To flash this board, just use the following command:
  *
  * ```
- * make BOARD=stm32g0316-disco flash -C examples/hello-world
+ * make BOARD=stm32g0316-disco flash -C examples/essentials/hello-world
  * ```
  *
  * ### UART Terminal Interaction

--- a/boards/stm32l0538-disco/doc.txt
+++ b/boards/stm32l0538-disco/doc.txt
@@ -52,7 +52,7 @@ The board also provides an on-board 2.04\" E-paper display (not supported yet).
 The board can be flashed using OpenOCD via the on-board ST-Link adapter.
 Then use the following command:
 
-    make BOARD=stm32l0538-disco -C examples/hello-world flash
+    make BOARD=stm32l0538-disco -C examples/essentials/hello-world flash
 
 ## Flashing the Board Using ST-LINK Removable Media
 
@@ -72,7 +72,7 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 STDIO is connected to pins PA9 (TX) and PA10 (RX) so an USB to UART adapter is
 required. Use the `term` target to open a terminal:
 
-    make BOARD=stm32l0538-disco -C examples/hello-world term
+    make BOARD=stm32l0538-disco -C examples/essentials/hello-world term
 
 If an external ST-Link adapter is used, RX and TX pins can be directly connected
 to it. In this case, STDIO is available on /dev/ttyACMx (Linux case).

--- a/boards/teensy31/doc.txt
+++ b/boards/teensy31/doc.txt
@@ -27,7 +27,7 @@ microcontroller. See [Datasheet](http://cache.freescale.com/files/32bit/doc/data
 2. Use `BOARD=teensy31` with the `make` command. This works for Teensy 3.1 & 3.2<br/>
    Example with `hello-world` application:
 ```
-     make BOARD=teensy31 -C examples/hello-world flash
+     make BOARD=teensy31 -C examples/essentials/hello-world flash
 ```
 
 ### Accessing STDIO via UART

--- a/boards/usb-kw41z/doc.txt
+++ b/boards/usb-kw41z/doc.txt
@@ -32,7 +32,7 @@ debugging.
 2. Use `BOARD=usb-kw41z` with the `make` command.<br/>
    Example with `hello-world` application:
 ```
-     make BOARD=usb-kw41z -C examples/hello-world flash term
+     make BOARD=usb-kw41z -C examples/essentials/hello-world flash term
 ```
 
 [quick-start-guide]: https://www.nxp.com/products/wireless/bluetooth-low-energy-ble/bluetooth-low-energy-ieee-802.15.4-packet-sniffer-usb-dongle:USB-KW41Z?&tab=In-Depth_Tab&tid=van/usb-kw41z/startnow

--- a/boards/waveshare-nrf52840-eval-kit/doc.txt
+++ b/boards/waveshare-nrf52840-eval-kit/doc.txt
@@ -138,12 +138,12 @@ the index of the UART interface which is 0 by default.
 
 Use the `term` target to connect to the board serial port using `/dev/ttyUSB0`:
 ```
-    make BOARD=waveshare-nrf52840-eval-kit -C examples/hello-world term
+    make BOARD=waveshare-nrf52840-eval-kit -C examples/essentials/hello-world term
 ```
 If the UART interface index of board's USB to UART bridge is not 0, use
 the following command to connect to the board serial port:
 ```
-    make BOARD=waveshare-nrf52840-eval-kit -C examples/hello-world PORT=/dev/ttyUSB<n> term
+    make BOARD=waveshare-nrf52840-eval-kit -C examples/essentials/hello-world PORT=/dev/ttyUSB<n> term
 ```
 
 ## RESET Pin Configuration

--- a/bootloaders/riotboot/doc.txt
+++ b/bootloaders/riotboot/doc.txt
@@ -78,7 +78,7 @@ be booted.
 The image can also be flashed using `riotboot/flash` which also flashes
 the bootloader. Below a concrete example:
 
-`BOARD=samr21-xpro FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/hello-world riotboot/flash-combined-slot0`
+`BOARD=samr21-xpro FEATURES_REQUIRED+=riotboot APP_VER=$(date +%s) make -C examples/essentials/hello-world riotboot/flash-combined-slot0`
 
 The above compiles a hello world binary and a bootloader, then flashes the
 combined binary comprising of: bootloader + slot 0 header + slot 0 image.

--- a/bootloaders/riotboot_dfu/doc.txt
+++ b/bootloaders/riotboot_dfu/doc.txt
@@ -18,7 +18,7 @@ At startup, the DFU mode is entered when either
 
 # Prerequisites
 
-- The board must have functional USB support, easily tested using the `examples/usbus_minimal/` example.
+- The board must have functional USB support, easily tested using the `examples/advanced_examples/usbus_minimal/` example.
 
 - The board must have functional riotboot support, see @ref bootloader_riotboot.
 
@@ -51,7 +51,7 @@ When the device is attached and in DFU mode (or the current firmware uses the `u
 new firmware can be flashed to slot 0 using:
 
 ```
-$ FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=particle-xenon \
+$ FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/essentials/saul BOARD=particle-xenon \
   PROGRAMMER=dfu-util all riotboot/flash-slot0
 ```
 
@@ -61,7 +61,7 @@ the variable `DFU_USB_ID`, e.g. if the RIOT DFU bootloader was compiled for
 a different VID/PID pair.
 
 ```
-$ FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=particle-xenon \
+$ FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/essentials/saul BOARD=particle-xenon \
   PROGRAMMER=dfu-util DFU_USB_ID=1209:7d02 all riotboot/flash-slot0
 ```
 

--- a/bootloaders/riotboot_tinyusb_dfu/doc.txt
+++ b/bootloaders/riotboot_tinyusb_dfu/doc.txt
@@ -58,7 +58,7 @@ When the device is attached and in DFU mode (or the current firmware uses the
 `tinyusb_dfu` module), new firmware can be flashed to slot 0 using:
 
 ```
-$ FEATURES_REQUIRED+=riotboot USEMODULE+=tinyusb_dfu make -C examples/saul BOARD=particle-xenon \
+$ FEATURES_REQUIRED+=riotboot USEMODULE+=tinyusb_dfu make -C examples/essentials/saul BOARD=particle-xenon \
   PROGRAMMER=dfu-util USB_VID=1209 USB_PID=7d02 all riotboot/flash-slot0
 ```
 
@@ -66,7 +66,7 @@ Instead of setting `USB_VID` and `USB_PID`, the variable `DFU_USB_ID` could also
 be used to specify the DFU device to be used.
 
 ```
-$ FEATURES_REQUIRED+=riotboot USEMODULE+=tinyusb_dfu make -C examples/saul BOARD=particle-xenon \
+$ FEATURES_REQUIRED+=riotboot USEMODULE+=tinyusb_dfu make -C examples/essentials/saul BOARD=particle-xenon \
   PROGRAMMER=dfu-util DFU_USB_ID=1209:7d02 all riotboot/flash-slot0
 ```
 

--- a/cpu/cc26xx_cc13xx/doc.txt
+++ b/cpu/cc26xx_cc13xx/doc.txt
@@ -41,7 +41,7 @@ CC26xx/CC13xx MCUs. It can be done through Kconfig using `make menuconfig`.
 For example:
 
 ```
-make -C examples/hello-world menuconfig BOARD=cc1350-launchpad
+make -C examples/essentials/hello-world menuconfig BOARD=cc1350-launchpad
 ```
 
 It will open the Kconfig terminal configuration utility, you may see the
@@ -55,7 +55,7 @@ device.
 For example:
 
 ```
-make -C examples/hello-world flash BOARD=cc1350-launchpad
+make -C examples/essentials/hello-world flash BOARD=cc1350-launchpad
 ```
 
 @note Once flashed, there's no need to flash it again, unless the configuration

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1637,7 +1637,7 @@ line, for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_PASS=\"MyPassphrase\"' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
@@ -1694,7 +1694,7 @@ line, for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_enterprise \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_EAP_ID=\"anonymous\" -DWIFI_EAP_USER=\"MyUserName\" -DWIFI_EAP_PASS=\"MyPassphrase\"' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
@@ -1746,7 +1746,7 @@ line, for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_ap \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -731,7 +731,7 @@ line, e.g.:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_PASS=\"MyPassphrase\"' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
@@ -782,7 +782,7 @@ line, for example:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_ap \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note

--- a/cpu/esp_common/esp-wifi/doc.txt
+++ b/cpu/esp_common/esp-wifi/doc.txt
@@ -51,7 +51,7 @@ line, for example:
 ```
 USEMODULE=esp_wifi \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_PASS=\"MyPassphrase\"' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ```
 
 @note
@@ -102,7 +102,7 @@ line, for example:
 ```
 USEMODULE=esp_wifi_enterprise \
 CFLAGS='-DWIFI_SSID=\"MySSID\" -DWIFI_EAP_ID=\"anonymous\" -DWIFI_EAP_USER=\"MyUserName\" -DWIFI_EAP_PASS=\"MyPassphrase\"' \
-make -C examples/gnrc_networking BOARD=...
+make -C examples/networking/gnrc_networking/gnrc_networking BOARD=...
 ```
 
 @note

--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -49,7 +49,7 @@ _RATIOS = [
 ]
 
 DEFAULT_APPS = [
-    "examples/hello-world",
+    "examples/essentials/hello-world",
     "tests/drivers/mtd_mapper",
     "tests/drivers/saul",
     "tests/pkg/tinyusb_cdc_msc",

--- a/dist/tools/desvirt/README.desvirt.md
+++ b/dist/tools/desvirt/README.desvirt.md
@@ -85,16 +85,16 @@ lossnet        : line4: New link from line4_2 to line4_3, rate=100mbit, loss=0.0
 lossnet        : line4: New link from line4_3 to line4_2, rate=100mbit, loss=0.0, delay=0.0
 vnet           : Network Name: line4
 vm             : Defining RIOT native process line4_1
-riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf line4_1',end-close,stderr,pty TCP-L:4711,reuseaddr,fork
+riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/networking/gnrc_networking/gnrc_networking/bin/native/gnrc_networking.elf line4_1',end-close,stderr,pty TCP-L:4711,reuseaddr,fork
 riotnative     : PID: 18235
 vm             : Defining RIOT native process line4_0
-riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf line4_0',end-close,stderr,pty TCP-L:4712,reuseaddr,fork
+riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/networking/gnrc_networking/gnrc_networking/bin/native/gnrc_networking.elf line4_0',end-close,stderr,pty TCP-L:4712,reuseaddr,fork
 riotnative     : PID: 18236
 vm             : Defining RIOT native process line4_3
-riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf line4_3',end-close,stderr,pty TCP-L:4713,reuseaddr,fork
+riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/networking/gnrc_networking/gnrc_networking/bin/native/gnrc_networking.elf line4_3',end-close,stderr,pty TCP-L:4713,reuseaddr,fork
 riotnative     : PID: 18237
 vm             : Defining RIOT native process line4_2
-riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf line4_2',end-close,stderr,pty TCP-L:4714,reuseaddr,fork
+riotnative     : Start the RIOT: socat EXEC:'/home/pschmerzl/RIOT/examples/networking/gnrc_networking/gnrc_networking/bin/native/gnrc_networking.elf line4_2',end-close,stderr,pty TCP-L:4714,reuseaddr,fork
 riotnative     : PID: 18238
 
 ```

--- a/dist/tools/dhcpv6-pd_ia/README.md
+++ b/dist/tools/dhcpv6-pd_ia/README.md
@@ -22,4 +22,4 @@ the script
 [DHCPv6]: https://tools.ietf.org/html/rfc8415
 [prefix delegation]: https://en.wikipedia.org/wiki/Prefix_delegation
 [Kea]: http://kea.isc.org
-[`gnrc_border_router` example]: ../../../examples/gnrc_border_router
+[`gnrc_border_router` example]: ../../../examples/networking/gnrc_networking/gnrc_borader_router

--- a/dist/tools/eclipsesym/README.md
+++ b/dist/tools/eclipsesym/README.md
@@ -12,7 +12,7 @@ otherwise change cmdline2xml.sh accordingly (ECLIPSE_PROJECT_NAME=RIOT).
 
 In the shell:
 
-    cd to application directory (e.g. examples/hello-world)
+    cd to application directory (e.g. examples/essentials/hello-world)
     make eclipsesym
 
 In Eclipse:

--- a/dist/tools/vagrant/freebsd/README.md
+++ b/dist/tools/vagrant/freebsd/README.md
@@ -39,8 +39,8 @@ Even applications requiring network interface access should be able to work:
 
 ```sh
 sudo dist/tools/tapsetup/tapsetup
-make -C examples/gnrc_networking all -j16
-make -C examples/gnrc_networking term
+make -C examples/networking/gnrc_networking/gnrc_networking all -j16
+make -C examples/networking/gnrc_networking/gnrc_networking term
 ```
 
 ```

--- a/dist/tools/zep_dispatch/README.md
+++ b/dist/tools/zep_dispatch/README.md
@@ -117,7 +117,7 @@ This can be changed with the `TOPOLOGY` environment variable.
 
 Next, start the border router example with RPL enabled:
 
-    USEMODULE=gnrc_rpl make -C examples/gnrc_border_router all term
+    USEMODULE=gnrc_rpl make -C examples/networking/gnrc_networking/gnrc_borader_router all term
 
 Verify that the border router got a prefix on it's downstream interface with `ifconfig`.
 
@@ -149,8 +149,8 @@ Iface  6  HWaddr: 7A:37:FC:7D:1A:AF
 
 Now start as many `gnrc_networking` nodes as you have mesh nodes defined in your topology file:
 
-    USE_ZEP=1 make -C examples/gnrc_networking all term
-    USE_ZEP=1 make -C examples/gnrc_networking all term
+    USE_ZEP=1 make -C examples/networking/gnrc_networking/gnrc_networking all term
+    USE_ZEP=1 make -C examples/networking/gnrc_networking/gnrc_networking all term
     …
 
 The node should be able to join the DODAG as you can verify with the `rpl` command:

--- a/doc/doxygen/src/advanced-build-system-tricks.md
+++ b/doc/doxygen/src/advanced-build-system-tricks.md
@@ -78,7 +78,7 @@ Building application "default" for "samr21-xpro" with MCU "samd21".
 [...]
 
    text    data     bss     dec     hex filename
-  37016     180    6008   43204    a8c4 /home/kaspar/src/riot/examples/default/bin/samr21-xpro/default.elf
+  37016     180    6008   43204    a8c4 /home/kaspar/src/riot/examples/essentials/default/bin/samr21-xpro/default.elf
 
 real    0m12.321s
 user    0m10.317s
@@ -95,7 +95,7 @@ Building application "default" for "samr21-xpro" with MCU "samd21".
 [...]
 
 text    data     bss     dec     hex filename
-37016     180    6008   43204    a8c4 /home/kaspar/src/riot/examples/default/bin/samr21-xpro/default.elf
+37016     180    6008   43204    a8c4 /home/kaspar/src/riot/examples/essentials/default/bin/samr21-xpro/default.elf
 
 real    0m15.462s
 user    0m12.410s
@@ -112,7 +112,7 @@ Building application "default" for "samr21-xpro" with MCU "samd21".
 [...]
 
    text    data     bss     dec     hex filename
-  37016     180    6008   43204    a8c4 /home/kaspar/src/riot/examples/default/bin/samr21-xpro/default.elf
+  37016     180    6008   43204    a8c4 /home/kaspar/src/riot/examples/essentials/default/bin/samr21-xpro/default.elf
 
 real    0m2.157s
 user    0m1.213s

--- a/doc/doxygen/src/build-in-docker.md
+++ b/doc/doxygen/src/build-in-docker.md
@@ -32,7 +32,7 @@ When building in docker one might want for the command ran in docker to inherit
 variables that might have been set in the command line. e.g.:
 
 ```shell
-BOARD=samr21-xpro USEMODULE=xtimer make -C examples/hello-world
+BOARD=samr21-xpro USEMODULE=xtimer make -C examples/essentials/hello-world
 ```
 
 In `docker.ink.mk` the origin of a variable listed in `DOCKER_ENV_VARS` is checked
@@ -43,11 +43,11 @@ You can also set in `DOCKER_ENV_VARS` in the environment to add variables to the
 list, e.g.:
 
 ```shell
-DOCKER_ENV_VARS=BEER_TYPE BEER_TYPE="imperial stout" BUILD_IN_DOCKER=1 make -C examples/hello-world/
+DOCKER_ENV_VARS=BEER_TYPE BEER_TYPE="imperial stout" BUILD_IN_DOCKER=1 make -C examples/essentials/hello-world/
 docker run --rm -t -u "$(id -u)" \
     ...
     -e 'BEER_TYPE=imperial stout' \
-    -w '/data/riotbuild/riotbase/examples/hello-world/' \
+    -w '/data/riotbuild/riotbase/examples/essentials/hello-world/' \
     'riot/riotbuild:latest' make
 ```
 
@@ -61,11 +61,11 @@ but will need to be prefixed with `-e` (see [option-summary]).
 e.g.:
 
 ```
-DOCKER_ENVIRONMENT_CMDLINE='-e BEER_TYPE="imperial stout"' BUILD_IN_DOCKER=1 make -C examples/hello-world/
+DOCKER_ENVIRONMENT_CMDLINE='-e BEER_TYPE="imperial stout"' BUILD_IN_DOCKER=1 make -C examples/essentials/hello-world/
 docker run --rm -t -u "$(id -u)" \
     ...
     -e 'BEER_TYPE=imperial stout' \
-    -w '/data/riotbuild/riotbase/examples/hello-world/' \
+    -w '/data/riotbuild/riotbase/examples/essentials/hello-world/' \
     'riot/riotbuild:latest' make
 ```
 
@@ -81,11 +81,11 @@ To pass variables overriding the command-line to docker `DOCKER_OVERRIDE_CMDLINE
 may be used:
 
 ```shell
-DOCKER_OVERRIDE_CMDLINE="BEER_TYPE='imperial stout'" BUILD_IN_DOCKER=1 make -C examples/hello-world/ RIOT_CI_BUILD=1
+DOCKER_OVERRIDE_CMDLINE="BEER_TYPE='imperial stout'" BUILD_IN_DOCKER=1 make -C examples/essentials/hello-world/ RIOT_CI_BUILD=1
 Launching build container using image "riot/riotbuild:latest".
 sudo docker run --rm -t -u "$(id -u)" \
     ...
-    -w '/data/riotbuild/riotbase/examples/hello-world/' \
+    -w '/data/riotbuild/riotbase/examples/essentials/hello-world/' \
     'riot/riotbuild:latest' make  BEER_TYPE='imperial stout' 'RIOT_CI_BUILD=1'
 ```
 

--- a/doc/doxygen/src/creating-an-application.md
+++ b/doc/doxygen/src/creating-an-application.md
@@ -104,7 +104,7 @@ module support](#external-modules).
 2. Add the source files within subdirectories to `SRC`, either explicitly or with
 Makefile wildcards.
 
-Both approaches are illustrated and explained in `examples/subfolders`.
+Both approaches are illustrated and explained in `examples/essentials/subfolders`.
 
 
 # Helper tools

--- a/doc/doxygen/src/flashing.md
+++ b/doc/doxygen/src/flashing.md
@@ -293,7 +293,7 @@ Procedure:
   variable or on each `make` call:
 
 ~~~~~~~~~~~~~~~~~~~
-    $ RIOT_MAKEFILES_GLOBAL_PRE=/path/to/makefile.pre make -C examples/hello-world flash term
+    $ RIOT_MAKEFILES_GLOBAL_PRE=/path/to/makefile.pre make -C examples/essentials/hello-world flash term
 ~~~~~~~~~~~~~~~~~~~
 
 @note if set as an environment variable it would be a good idea to add a

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -207,7 +207,7 @@ Building and executing an example           {#building-and-executing-an-example}
 ---------------------------------
 RIOT provides a number of examples in the `examples/` directory. Every example
 has a README that documents its usage and its purpose. You can build them by
-opening a shell, navigating to an example (e.g. `examples/default`), and
+opening a shell, navigating to an example (e.g. `examples/essentials/default`), and
 running:
 
 ~~~~~~~~ {.sh}
@@ -258,7 +258,7 @@ the `dist/tools/pyterm/` directory. If you choose to use another terminal
 program you can set `TERMPROG` (and if need be the `TERMFLAGS`) macros:
 
 ~~~~~~~~ {.sh}
-make -C examples/gnrc_networking/ term \
+make -C examples/networking/gnrc_networking/gnrc_networking/ term \
     BOARD=samr21-xpro \
     TERMPROG=gtkterm \
     TERMFLAGS="-s 115200 -p /dev/ttyACM0 -e"
@@ -335,7 +335,7 @@ Usage
 
 The RIOT build system provides support for using the Docker container to build RIOT projects, so you do not need to type the long docker command line every time:
 
-(**from the directory you would normally run make, e.g. examples/default**)
+(**from the directory you would normally run make, e.g. examples/essentials/default**)
 
 ```console
 $ make BUILD_IN_DOCKER=1
@@ -403,4 +403,4 @@ To create a bridge and two (or `count` at your option) tap interfaces:
     sudo ./dist/tools/tapsetup/tapsetup [-c [<count>]]
 ~~~~~~~
 
-A detailed example can be found in `examples/gnrc_networking`.
+A detailed example can be found in `examples/networking/gnrc_networking/gnrc_networking`.

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -61,14 +61,14 @@ git checkout <LATEST_RELEASE>
 sudo ./dist/tools/tapsetup/tapsetup         # create virtual Ethernet
                                             # interfaces to connect multiple
                                             # RIOT instances
-cd examples/default/
+cd examples/essentials/default/
 make all
 make term
 ~~~~~~~
 
 ... and you are in the RIOT shell!
 Type `help` to discover available commands. For further information see the
-[README of the `default` example](https://github.com/RIOT-OS/RIOT/tree/master/examples/default).
+[README of the `default` example](https://github.com/RIOT-OS/RIOT/tree/master/examples/essentials/default).
 
 To use RIOT directly on your embedded platform, and for more hands-on details
 with RIOT, see @ref getting-started.

--- a/doc/guides/setup-windows/README.md
+++ b/doc/guides/setup-windows/README.md
@@ -215,7 +215,7 @@ sudo apt install make gcc-multilib python3-serial wget unzip git openocd gdb-mul
   Just wait for this to complete.)
 - Type `git clone https://github.com/RIOT-OS/RIOT` and confirm with the return-key
 - This may take some time. Eventually, it will print `done.` when it completed
-- Type `cd RIOT/examples/hello-world` and confirm with the return-key to enter
+- Type `cd RIOT/examples/essentials/hello-world` and confirm with the return-key to enter
   the folder `hello-world` example app in the RIOT repo
 - Type `make` and confirm with the return key to build the app for the board
   `native`
@@ -239,12 +239,12 @@ sudo apt install make gcc-multilib python3-serial wget unzip git openocd gdb-mul
 ![Ubuntu terminal running `make compile-commands` in the `hello-world` app](img/06-Use_VS_Code-00.png)
 
 - If not already open, open the Ubuntu terminal
-- Confirm that the terminal is pointed to the folder `~/RIOT/examples/hello-world`
+- Confirm that the terminal is pointed to the folder `~/RIOT/examples/essentials/hello-world`
     - The blue part left of the prompt (the `$` sign in the terminal) shows
       the current working directory for the terminal
-    - If the blue string is not `~/RIOT/examples/hello-world`, type
-      `cd ~/RIOT/examples/hello-world` to enter that path
-- Inside `~/RIOT/examples/hello-world` run the command `make compile-commands`
+    - If the blue string is not `~/RIOT/examples/essentials/hello-world`, type
+      `cd ~/RIOT/examples/essentials/hello-world` to enter that path
+- Inside `~/RIOT/examples/essentials/hello-world` run the command `make compile-commands`
 - The output should look like above
 
 ![Launching VS Code from Ubuntu](img/06-Use_VS_Code-01.png)
@@ -307,7 +307,7 @@ sudo apt install make gcc-multilib python3-serial wget unzip git openocd gdb-mul
   in the source code
 - Save the modified source code (e.g. `Ctrl`+`S`)
 - Open the integrated terminal by clicking on the terminal tab at the bottom
-- Navigate to `~/RIOT/examples/hello-world` using `cd ~/RIOT/examples/hello-world`
+- Navigate to `~/RIOT/examples/essentials/hello-world` using `cd ~/RIOT/examples/essentials/hello-world`
 - Run the `make` command to build the code
 - Run make `make term` to launch the application
 - The result should look like:
@@ -415,7 +415,7 @@ been attached to WSL and VS Code has been launched from within WSL by running
 2. Open the `default` folder within `examples`
 3. Open the `main.c` file in the `default` folder
 4. Select the "Terminal" tab at the bottom
-5. Enter `cd ~/RIOT/examples/default` to enter the `default` folder also in the terminal
+5. Enter `cd ~/RIOT/examples/essentials/default` to enter the `default` folder also in the terminal
 6. Run `make BOARD=esp32-mh-et-live-minikit compile-commands`
     - You can replace `esp32-mh-et-live-minikit` with the name of any other supported board
 

--- a/drivers/atwinc15x0/doc.txt
+++ b/drivers/atwinc15x0/doc.txt
@@ -168,7 +168,7 @@ CFLAGS='-DWIFI_SSID=\"ssid\" -DWIFI_PASS=\"pass\" \
         -DATWINC15X0_PARAM_SSN_PIN=GPIO_PIN\(1,6\) \
         -DATWINC15X0_PARAM_RESET_PIN=GPIO_PIN\(1,4\) \
         -DATWINC15X0_PARAM_IRQ_PIN=GPIO_PIN\(0,8\)' \
-make BOARD=... -C examples/gnrc_networking flash term
+make BOARD=... -C examples/networking/gnrc_networking/gnrc_networking flash term
 ```
 
 */

--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -157,7 +157,7 @@
  * The driver is enabled by using the module `shield_w5100`, e.g. with:
  *
  * ```
- * USEMODULE=shield_w5100 make BOARD=arduino-due -C examples/gnrc_networking
+ * USEMODULE=shield_w5100 make BOARD=arduino-due -C examples/networking/gnrc_networking/gnrc_networking
  * ```
  *
  * It depends on @ref drivers_w5100 and provides nothing more than the providing
@@ -191,6 +191,6 @@
  * Use the `shield_llcc68` module, e.g. using
  *
  * ```
- * USEMODULE=shield_llcc68 make BOARD=arduino-zero -C examples/lorawan
+ * USEMODULE=shield_llcc68 make BOARD=arduino-zero -C examples/networking/misc/lorawan
  * ```
  */

--- a/examples/README.md
+++ b/examples/README.md
@@ -134,7 +134,7 @@ Here is a quick overview of the examples available in the RIOT:
 |---------|-------------|
 | [bindist](./advanced_examples/bindist/README.md) | RIOT allows for creating a "binary distribution", which can be used to ship proprietary, compiled objects in a way that makes it possible to re-link them against a freshly compiled RIOT. This application serves as a simple example. |
 | [usbus_minimal](./advanced_examples/usbus_minimal/README.md) | This is a minimalistic example for RIOT's USB stack. |
-| [suit_update](./advanced_examples/suit_update/README.md) | This example shows how to integrate SUIT-compliant firmware updates into a RIOT application. |
+| [suit_update](./advanced_examples/advanced_examples/suit_update/README.md) | This example shows how to integrate SUIT-compliant firmware updates into a RIOT application. |
 | [thread_duel](./advanced_examples/thread_duel/README.md) | This is a thread duel application to show RIOTs abilities to run multiple-threads concurrently, even if they are neither cooperative nor dividable into different scheduler priorities, by using the optional round-robin scheduler module. |
 | [posix_select](./advanced_examples/posix_select/README.md) | This example is a showcase for RIOT's POSIX select support |
 | [psa_crypto](./advanced_examples/psa_crypto/README.md) | Basic functions of the PSA Crypto API |

--- a/examples/advanced_examples/suit_update/README.hardware.md
+++ b/examples/advanced_examples/suit_update/README.hardware.md
@@ -45,7 +45,7 @@ properly.
 
 In order to get a SUIT capable firmware onto the node, run
 
-    $ BOARD=samr21-xpro make -C examples/suit_update clean flash -j4
+    $ BOARD=samr21-xpro make -C examples/advanced_examples/suit_update clean flash -j4
 
 This command also generates the cryptographic keys (private/public) used to
 sign and verify the manifest and images. See the "Key generation" section in
@@ -58,7 +58,7 @@ interface:
 
 In another terminal, run:
 
-    $ BOARD=samr21-xpro make -C examples/suit_update/ term
+    $ BOARD=samr21-xpro make -C examples/advanced_examples/suit_update/ term
 
 ### Alternative: Setup a wireless device behind a border router
 [setup-wireless]: #Setup-a-wireless-device-behind-a-border-router
@@ -84,10 +84,10 @@ your make commands with it (for the BR as well as the device), e.g.:
      $ USEMODULE+=nimble_autoconn_ipsp make BOARD=<BR board>
 
 Plug the BR board on the computer and flash the
-[gnrc_border_router](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_border_router)
+[gnrc_border_router](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router)
 application on it:
 
-    $ make BOARD=<BR board> -C examples/gnrc_border_router flash
+    $ make BOARD=<BR board> -C examples/networking/gnrc_borader_router flash
 
 In on terminal, start the network (assuming on the host the virtual port of the
 board is `/dev/ttyACM0`):
@@ -107,11 +107,11 @@ First un-comment L28 in the application [Makefile](Makefile) so `netdev_default`
 is included in the build. In this scenario the node will be connected through a border
 router. Ethos must be disabled in the firmware when building and flashing the firmware:
 
-    $ USE_ETHOS=0 BOARD=samr21-xpro make -C examples/suit_update clean flash -j4
+    $ USE_ETHOS=0 BOARD=samr21-xpro make -C examples/advanced_examples/suit_update clean flash -j4
 
 Open a serial terminal on the device to get its global address:
 
-    $ USE_ETHOS=0 BOARD=samr21-xpro make -C examples/suit_update term
+    $ USE_ETHOS=0 BOARD=samr21-xpro make -C examples/advanced_examples/suit_update term
 
 If the Border Router is already set up when opening the terminal you should get
 
@@ -150,13 +150,13 @@ the prefix (`2001:db8::`) and the EUI64 suffix, in this case `7b7e:3255:1313:8d9
 - Provision the wireless ble device:
 
 ```
-    $ CFLAGS=-DCONFIG_GNRC_IPV6_NIB_SLAAC=1 USEMODULE+=nimble_autoconn_ipsp USE_ETHOS=0 BOARD=nrf52dk make -C examples/suit_update clean flash -j4
+    $ CFLAGS=-DCONFIG_GNRC_IPV6_NIB_SLAAC=1 USEMODULE+=nimble_autoconn_ipsp USE_ETHOS=0 BOARD=nrf52dk make -C examples/advanced_examples/suit_update clean flash -j4
 ```
 
 - Open a serial terminal on the device to get its local address:
 
 ```
-    $ USE_ETHOS=0 BOARD=nrf52dk make -C examples/suit_update term
+    $ USE_ETHOS=0 BOARD=nrf52dk make -C examples/advanced_examples/suit_update term
 ```
 
     ...
@@ -294,20 +294,20 @@ For this example, aiocoap-fileserver serves the files via CoAP.
 
 - To publish an update for a node in wired mode (behind ethos):
 
-      $ BOARD=samr21-xpro SUIT_COAP_SERVER=[2001:db8::1] make -C examples/suit_update suit/publish
+      $ BOARD=samr21-xpro SUIT_COAP_SERVER=[2001:db8::1] make -C examples/advanced_examples/suit_update suit/publish
 
 - To publish an update for a node in wireless mode (behind a border router):
 
-      $ BOARD=samr21-xpro USE_ETHOS=0 SUIT_COAP_SERVER=[2001:db8::1] make -C examples/suit_update suit/publish
+      $ BOARD=samr21-xpro USE_ETHOS=0 SUIT_COAP_SERVER=[2001:db8::1] make -C examples/advanced_examples/suit_update suit/publish
 
 This publishes into the server a new firmware for a samr21-xpro board. You should
 see 6 pairs of messages indicating where (filepath) the file was published and
 the corresponding coap resource URI
 
     ...
-    published "${RIOTBASE}/examples/suit_update/bin/samr21-xpro/suit_files/riot.suit.1632124156.bin"
+    published "${RIOTBASE}/examples/advanced_examples/suit_update/bin/samr21-xpro/suit_files/riot.suit.1632124156.bin"
        as "coap://[2001:db8::1]/fw/suit_update/samr21-xpro/riot.suit.1632124156.bin"
-    published "${RIOTBASE}/examples/suit_update/bin/samr21-xpro/suit_files/riot.suit.latest.bin"
+    published "${RIOTBASE}/examples/advanced_examples/suit_update/bin/samr21-xpro/suit_files/riot.suit.latest.bin"
        as "coap://[2001:db8::1]/fw/suit_update/samr21-xpro/riot.suit.latest.bin"
     ...
 
@@ -357,11 +357,11 @@ SUIT_CLIENT=[2001:db8::7b7e:3255:1313:8d96].
 
 - In wired mode:
 
-      $ SUIT_COAP_SERVER=[2001:db8::1] SUIT_CLIENT=[fe80::7b7e:3255:1313:8d96%riot] BOARD=samr21-xpro make -C examples/suit_update suit/notify
+      $ SUIT_COAP_SERVER=[2001:db8::1] SUIT_CLIENT=[fe80::7b7e:3255:1313:8d96%riot] BOARD=samr21-xpro make -C examples/advanced_examples/suit_update suit/notify
 
 - In wireless mode:
 
-      $ SUIT_COAP_SERVER=[2001:db8::1] SUIT_CLIENT=[2001:db8::7b7e:3255:1313:8d96] BOARD=samr21-xpro make -C examples/suit_update suit/notify
+      $ SUIT_COAP_SERVER=[2001:db8::1] SUIT_CLIENT=[2001:db8::7b7e:3255:1313:8d96] BOARD=samr21-xpro make -C examples/advanced_examples/suit_update suit/notify
 
 
 This notifies the node of a new available manifest. Once the notification is
@@ -455,7 +455,7 @@ The flash memory will be divided in the following way:
 The riotboot part of the flash will not be changed during suit_updates but
 be flashed a first time with at least one slot with suit_capable fw.
 
-    $ BOARD=samr21-xpro make -C examples/suit_update clean flash
+    $ BOARD=samr21-xpro make -C examples/advanced_examples/suit_update clean flash
 
 When calling make with the `flash` argument it will flash the bootloader
 and then to slot0 a copy of the firmware you intend to build.
@@ -504,7 +504,7 @@ updatable RIOT image with `riotboot` or `suit/publish` make targets.
 
 This is simply done using the `suit/genkey` make target:
 
-    $ BOARD=samr21-xpro make -C examples/suit_update suit/genkey
+    $ BOARD=samr21-xpro make -C examples/advanced_examples/suit_update suit/genkey
 
 You will get this message in the terminal:
 
@@ -637,7 +637,7 @@ To run the test,
 - compile and flash the application and bootloader:
 
 ```
-    $ make -C examples/suit_update clean all flash -j4
+    $ make -C examples/advanced_examples/suit_update clean all flash -j4
 ```
 
 - [set up the network][setup-wired-network] (in another shell):
@@ -649,5 +649,5 @@ To run the test,
 - run the test:
 
 ```
-    $ make -C examples/suit_update test-with-config
+    $ make -C examples/advanced_examples/suit_update test-with-config
 ```

--- a/examples/advanced_examples/suit_update/README.native.md
+++ b/examples/advanced_examples/suit_update/README.native.md
@@ -31,7 +31,7 @@ $ aiocoap-fileserver coaproot
 
 3. Build and start the native instance:
 ```
-$ BOARD=native make -C examples/suit_update all term
+$ BOARD=native make -C examples/advanced_examples/suit_update all term
 ```
    and add an address from the same range to the interface in RIOT
 ```console
@@ -135,13 +135,13 @@ Before the natice instance can be started, it must be compiled first.
 Compilation can be started from the root of your RIOT directory with:
 
 ```
-$ BOARD=native make -C examples/suit_update
+$ BOARD=native make -C examples/advanced_examples/suit_update
 ```
 
 Then start the example with:
 
 ```console
-$ BOARD=native make -C examples/suit_update term
+$ BOARD=native make -C examples/advanced_examples/suit_update term
 ```
 
 This starts an instance of the suit_update example as a process on your

--- a/examples/essentials/default/README.md
+++ b/examples/essentials/default/README.md
@@ -1,4 +1,4 @@
-examples/default
+examples/essentials/default
 ================
 This application is a showcase for RIOT's hardware support. Using it
 for your board, you should be able to interactively use any hardware

--- a/examples/networking/coap/gcoap/README-slip.md
+++ b/examples/networking/coap/gcoap/README-slip.md
@@ -64,4 +64,4 @@ Ping the TUN interface from the router mote, via the BR:
 
     ping bbbb::1
 
-[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_border_router    "SLIP instructions"
+[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router    "SLIP instructions"

--- a/examples/networking/coap/gcoap/README.md
+++ b/examples/networking/coap/gcoap/README.md
@@ -93,5 +93,5 @@ implementations:
 
 
 [1]: https://tools.ietf.org/html/rfc7252    "CoAP spec"
-[2]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking    "instructions"
-[3]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_border_router    "SLIP instructions"
+[2]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_networking    "instructions"
+[3]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router    "SLIP instructions"

--- a/examples/networking/gnrc_networking/gnrc_border_router/README.md
+++ b/examples/networking/gnrc_networking/gnrc_border_router/README.md
@@ -123,7 +123,7 @@ This is done through the same serial interface.
 By typing `help` you will get the list of available shell commands.
 
 At this point you should be able to ping motes using their global address.
-For instance, if you use the [`gnrc_networking`](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking) example on the mote, you can
+For instance, if you use the [`gnrc_networking`](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_networking) example on the mote, you can
 ping it from your machine with:
 
 ```

--- a/examples/networking/misc/lorawan/README.md
+++ b/examples/networking/misc/lorawan/README.md
@@ -83,21 +83,21 @@ for that device.
 
 1. flash device with appropriate keys and test
 
-    $ DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> make -C examples/lorawan/ flash test
+    $ DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> make -C examples/networking/misc/lorawan/ flash test
 
 #### With iotlab
 
 1. setup the iotlab experiment:
 
-    $ make -C examples/lorawan/ iotlab-exp
+    $ make -C examples/networking/misc/lorawan/ iotlab-exp
 
 2. flash device, set appropriate keys and test
 
-    $ DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> IOTLAB_NODE=auto make -C examples/lorawan/ flash test
+    $ DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> IOTLAB_NODE=auto make -C examples/networking/misc/lorawan/ flash test
 
 3. stop the iotlab experiment:
 
-    $ make -C examples/lorawan/ iotlab-stop
+    $ make -C examples/networking/misc/lorawan/ iotlab-stop
 
 _note_: if you have multiple running experiments you will need to set `IOTLAB_EXP_ID`
         to the appropriate experiment, when using the `iotlab-exp` you will see a:

--- a/examples/networking/misc/lwm2m/README.md
+++ b/examples/networking/misc/lwm2m/README.md
@@ -89,7 +89,7 @@ The server address is set by the application, during the instantiation of the Se
 It can be set via `menuconfig` or the environmental variable `LWM2M_SERVER_URI`. It should be
 reachable from the node, e.g. either running on native with a tap interface or as a mote connected
 to a
-[border router](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_border_router).
+[border router](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router).
 
 Also, if a bootstrap server is being used, it should be configured in the application via
 `menuconfig` or setting the environmental variable `LWM2M_SERVER_BOOTSTRAP` to 1. This information

--- a/makefiles/arch/native.inc.mk
+++ b/makefiles/arch/native.inc.mk
@@ -72,7 +72,7 @@ LINKFLAGS += -T$(RIOTBASE)/cpu/native/ldscripts/xfa.ld
 
 # fix this warning:
 # ```
-# /usr/bin/ld: examples/hello-world/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
+# /usr/bin/ld: examples/essentials/hello-world/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
 # /usr/bin/ld: warning: creating DT_TEXTREL in a PIE
 # ```
 LINKFLAGS += -no-pie

--- a/makefiles/tests/boards_supported/README.md
+++ b/makefiles/tests/boards_supported/README.md
@@ -9,7 +9,7 @@ especially true since this list is used by the CI to check which boards to build
 Right now, only a single test case is added: It will run the logic behind
 `make info-boards-supported` without any modules used other than the default modules and subtracts
 the result from the list of all available boards. The resulting difference is the set of boards
-which will never be build by the CI - not even for `examples/hello-world`. If this result is empty,
+which will never be build by the CI - not even for `examples/essentials/hello-world`. If this result is empty,
 the test succeeds. Otherwise the list of never build boards will be printed and the test fails.
 
 It is intended that some more advanced unit tests will be added later on.

--- a/pkg/cryptoauthlib/doc.txt
+++ b/pkg/cryptoauthlib/doc.txt
@@ -28,7 +28,7 @@
  * config zone, to lock the config zone (this will lock the config zone permanently
  * and cannot be undone) and to check whether config and data zone are locked.
  * The shell handler is enabled, if cryptoauthlib is included as a package in the
- * Makefile of an application that also includes the shell (e.g. examples/default).
+ * Makefile of an application that also includes the shell (e.g. examples/essentials/default).
  *
  * ### No poll mode
  *
@@ -84,7 +84,7 @@
  *
  * If you want to use more than one device, the best way is to create a file called
  * `custom_atca_params.h` in your application folder (you can see an example of this in
- * `examples/psa_crypto`).
+ * `examples/advanced_examples/psa_crypto`).
  *
  * In your custom file you can now add a second device to `ATCA_PARAMS`:
  * @code
@@ -232,7 +232,7 @@
  *                              { ATCA_SLOTS_DEVX }
  * @endcode
  *
- * A usage example for this can be found in `examples/psa_crypto`.
+ * A usage example for this can be found in `examples/advanced_examples/psa_crypto`.
  *
  * ## Troubleshooting
  *

--- a/pkg/micropython/doc.txt
+++ b/pkg/micropython/doc.txt
@@ -27,7 +27,7 @@
  *
  * Example on the command line:
  * ```
- * MP_RIOT_HEAPSIZE=2048 make -C examples/micropython
+ * MP_RIOT_HEAPSIZE=2048 make -C examples/language_bindings/community_supported/micropython
  * ```
  *
  * ## Implementation details
@@ -45,8 +45,8 @@
  *
  * Steps:
  *
- * 1. make -Cexamples/micropython flash
- * 2. cd examples/micropython/bin/pkg/${BOARD}/micropython
+ * 1. make -Cexamples/language_bindings/community_supported/micropython flash
+ * 2. cd examples/language_bindings/community_supported/micropython/bin/pkg/${BOARD}/micropython
  * 3. git apply ports/riot/slow_uart_writes.patch
  * 4. cd tests
  * 5. ./run-tests --target pyboard --device ${PORT}
@@ -82,6 +82,6 @@
  *
  * ## How to use
  *
- * See examples/micropython for example code.
+ * See examples/language_bindings/community_supported/micropython for example code.
  *
  */

--- a/pkg/nimble/README.ipv6-over-ble.md
+++ b/pkg/nimble/README.ipv6-over-ble.md
@@ -25,7 +25,7 @@ following:
 
 ## Preparing the RIOT node
 
-First, you compile and flash the `examples/gnrc_networking` application to your
+First, you compile and flash the `examples/networking/gnrc_networking/gnrc_networking` application to your
 RIOT device. When doing this, make sure to enable SLAAC
 (`CFLAGS=-DCONFIG_GNRC_IPV6_NIB_SLAAC=1`), see note above.
 

--- a/pkg/uwb-core/doc.txt
+++ b/pkg/uwb-core/doc.txt
@@ -90,7 +90,7 @@ is considered awake.
 The following can be wrapped into a timer callback to setup a blinking tag.
 
 For more examples check the [uwb-apps](https://github.com/Decawave/uwb-apps)
-repository as well as [examples/twr_aloha](https://github.com/RIOT-OS/RIOT/tree/master/examples/twr-aloha)
+repository as well as [examples/advanced_examples/twr_aloha](https://github.com/RIOT-OS/RIOT/tree/master/examples/twr-aloha)
 
 ## Watchout!
 

--- a/pkg/wamr/doc.txt
+++ b/pkg/wamr/doc.txt
@@ -30,7 +30,7 @@
  *
  * WASM files can be linked to use just a part of the first page.
  * In this case the VM can be run with less ram.
- * (see `wasm_sample/Makefile` in `examples/wasm` for linker options to help with this)
+ * (see `wasm_sample/Makefile` in `examples/language_bindings/community_supported/wasm` for linker options to help with this)
  * While running the example configured with 8KiB Heap and 8KiB Stack,
  * ~24KiB of System Heap are used.
  * The thread, the WAMR interpreter (iwasm) is executed in,
@@ -40,7 +40,7 @@
  * ## building wasm-bytecode
  *
  * `clang` and `wasm-ld` of the *same version* must be used
- * The Makefile in `examples/wasm/wasm_sample/Makefile` will try to guess
+ * The Makefile in `examples/language_bindings/community_supported/wasm/wasm_sample/Makefile` will try to guess
  * a matching clang, wasm-ld pair, if they do not match linking will fail.
  *
  * ## Configuration
@@ -55,7 +55,7 @@
  * WAMR should be used using the functions provided by the WAMR project their API-headers
  * they can be found in `<RIOT>/build/pkg/wamr/core/iwasm/include/`.
  * pkg/wamr adds no RIOT specific API to that.
- * For simple usages like in the example `iwasm.c` in `examples/wasm` might be useful and
+ * For simple usages like in the example `iwasm.c` in `examples/language_bindings/community_supported/wasm` might be useful and
  * if used should be copied and adapt to the application need.
  *
  * While WebAssembly does not define a set native functions. WAMR provides its own builtin-libc.

--- a/pkg/wolfssl/doc.txt
+++ b/pkg/wolfssl/doc.txt
@@ -146,7 +146,7 @@
  *
  * DTLS Client and Server Example
  * DTLS example over GNRC UDP/IP stack.
- * See documentation in `examples/dtls-wolfssl/README.md`
+ * See documentation in `examples/networking/dtls/dtls-wolfssl/README.md`
  *
  * QUESTIONS / CONCERNS / FEEDBACK:
  *

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -44,7 +44,7 @@
  *  - by passing them via the `CFLAGS` variable on the build command line:
  *
  * ```
- * CFLAGS=-DBMP180_PARAM_OVERSAMPLING=1 USEMODULE=bmp180 make BOARD=arduino-zero -C examples/default
+ * CFLAGS=-DBMP180_PARAM_OVERSAMPLING=1 USEMODULE=bmp180 make BOARD=arduino-zero -C examples/essentials/default
  * ```
  *
  * - by setting the `CFLAGS` variable in the application `Makefile`:

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -71,7 +71,7 @@ extern "C" {
  */
 /**
  * @brief   Default UDP port to listen on. Usage can be found in
- *          examples/asymcute_mqttsn. Application code is expected to use this
+ *          examples/networking/mqtt/asymcute_mqttsn. Application code is expected to use this
  *          macro to assign the default port.
  */
 #ifndef CONFIG_ASYMCUTE_DEFAULT_PORT

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -106,7 +106,7 @@ extern "C" {
  */
 /**
  * @brief   Default UDP port to listen on (also used as SRC port). Usage can be
- *          found in examples/emcute_mqttsn. Application code is expected to use
+ *          found in examples/networking/mqtt/emcute_mqttsn. Application code is expected to use
  *          this macro to assign the default port.
  */
 #ifndef CONFIG_EMCUTE_DEFAULT_PORT

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -65,7 +65,7 @@
  * reading the request, the callback must use functions provided by gcoap to
  * format the response, as described below. The callback *must* read the request
  * thoroughly before calling the functions, because the response buffer likely
- * reuses the request buffer. See `examples/gcoap/client.c` for a simple
+ * reuses the request buffer. See `examples/networking/coap/gcoap/client.c` for a simple
  * example of a callback.
  *
  * Here is the expected sequence for a callback function:
@@ -105,7 +105,7 @@
  *
  * Client operation includes two phases: creating and sending a request, and
  * handling the response asynchronously in a client supplied callback. See
- * `examples/gcoap/client.c` for a simple example of sending a request and
+ * `examples/networking/coap/gcoap/client.c` for a simple example of sending a request and
  * reading the response.
  *
  * ### Creating a request ###
@@ -260,7 +260,7 @@
  *
  * The client requests a specific blockwise payload from the overall body by
  * writing a Block2 option in the request. See _resp_handler() in the
- * [gcoap](https://github.com/RIOT-OS/RIOT/blob/master/examples/gcoap/client.c)
+ * [gcoap](https://github.com/RIOT-OS/RIOT/blob/master/examples/networking/coap/gcoap/client.c)
  * example in the RIOT distribution, which implements the sequence described
  * below.
  *

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -245,7 +245,7 @@ static inline bool gnrc_netif_netdev_legacy_api(gnrc_netif_t *netif)
 {
     if (!IS_USED(MODULE_NETDEV_NEW_API) && !IS_USED(MODULE_NETDEV_LEGACY_API)) {
         /* this should only happen for external netdevs or when no netdev is
-         * used (e.g. examples/gcoap can be used without any netdev, as still
+         * used (e.g. examples/networking/coap/gcoap can be used without any netdev, as still
          * CoAP requests to ::1 can be send */
         return true;
     }

--- a/sys/include/stdio_nimble.h
+++ b/sys/include/stdio_nimble.h
@@ -10,7 +10,7 @@
  * @defgroup     sys_stdio_nimble STDIO over NimBLE
  * @ingroup      sys_stdio
  *
- * @experimental This feature is experimental as some use-cases, such as examples/twr_aloha, show
+ * @experimental This feature is experimental as some use-cases, such as examples/advanced_examples/twr_aloha, show
  *               unexpected behaviour.
  *
  * @brief        Standard input/output backend using NimBLE.

--- a/sys/net/application_layer/asymcute/Kconfig
+++ b/sys/net/application_layer/asymcute/Kconfig
@@ -13,7 +13,7 @@ config ASYMCUTE_DEFAULT_PORT
     help
         Default UDP port to listen on (also used as SRC port). This will write
         to macro 'CONFIG_ASYMCUTE_DEFAULT_PORT'. Usage can be found in
-        examples/asymcute_mqttsn
+        examples/networking/mqtt/asymcute_mqttsn
 
 config ASYMCUTE_BUFSIZE
     int "Size of buffer used for receive and request buffers"

--- a/sys/net/application_layer/emcute/Kconfig
+++ b/sys/net/application_layer/emcute/Kconfig
@@ -13,7 +13,7 @@ config EMCUTE_DEFAULT_PORT
     help
         Default UDP port to listen on (also used as SRC port). This will write
         to macro 'CONFIG_EMCUTE_DEFAULT_PORT'. Usage can be found in
-        examples/emcute_mqttsn.
+        examples/networking/mqtt/emcute_mqttsn.
 
 config EMCUTE_BUFSIZE
     int "Buffer size used for TX and RX buffers"

--- a/sys/psa_crypto/doc.txt
+++ b/sys/psa_crypto/doc.txt
@@ -24,7 +24,7 @@
  * without exposing them to applications. To learn how to use keys with PSA,
  * read [Using Keys](#using-keys).
  *
- * A basic usage and configuration example can be found in `examples/psa_crypto`.
+ * A basic usage and configuration example can be found in `examples/advanced_examples/psa_crypto`.
  * For more usage instructions, please read the documentation.
  *
  * If you want to add your own crypto backend, see [Porting Guide](#porting-guide).
@@ -143,7 +143,7 @@
  * Configuration {#configuration}
  * ===
  * Currently there are two ways to configure PSA Crypto: Kconfig and Makefiles. An example for both
- * can be found in `RIOT/examples/psa_crypto`.
+ * can be found in `RIOT/examples/advanced_examples/psa_crypto`.
  *
  * ## Kconfig
  * We recommend using Kconfig and choosing your features in `menuconfig`.
@@ -164,7 +164,7 @@
  * configurations.
  *
  * Alternatively you can create an `app.config.test` file in your application folder
- * and choose your symbols there (see `examples/psa_crypto`).
+ * and choose your symbols there (see `examples/advanced_examples/psa_crypto`).
  *
  * In the `app.config.test` file, modules can be chosen with the following syntax:
  * `CONFIG_MODULE_<MODULENAME>=y`, as shown below.
@@ -389,7 +389,7 @@
  * Secure Elements {#secure-elements}
  * ===
  *
- * An example showing the use of SEs can be found in `examples/psa_crypto`.
+ * An example showing the use of SEs can be found in `examples/advanced_examples/psa_crypto`.
  *
  * To use secure elements, you first need to assign a static location value to each device,
  * so PSA can find it. If you only use one device, you can use

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/README.md
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/README.md
@@ -5,4 +5,4 @@ so SFR with different CongURE implementations can be tested. When `CONGURE_IMPL`
 is not set in the environment, `gnrc_sixlowpan_frag_sfr_congure_sfr` is used,
 other implementations can be used with `congure_<impl>`.
 
-[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking
+[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_networking/gnrc_networking

--- a/tests/net/gnrc_udp/README.md
+++ b/tests/net/gnrc_udp/README.md
@@ -8,4 +8,4 @@ The server is also modified as it outputs the number of currently received
 packets when a new packet is received instead of the content of the new packet.
 This counter can be reset using `udp reset`
 
-[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking
+[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_networking/gnrc_networking

--- a/tests/pkg/semtech-loramac/README.md
+++ b/tests/pkg/semtech-loramac/README.md
@@ -261,7 +261,7 @@ for ABP. The test assumes that both devices have the same Application EUI.
 
 3. stop the iotlab experiment:
 
-    $ make -C examples/lorawan/ iotlab-stop
+    $ make -C examples/networking/misc/lorawan/ iotlab-stop
 
 _note_: if you have multiple running experiments you will need to set `IOTLAB_EXP_ID`
         to the appropriate experiment, when using the `iotlab-exp` you will see a:

--- a/tests/pkg/tinydtls_sock_async/README.md
+++ b/tests/pkg/tinydtls_sock_async/README.md
@@ -39,4 +39,4 @@ DTLS sock acts as a wrapper for the underlying DTLS stack and as such, the
 constraints that applies specifically to the stack are also applied here.
 For tinydtls, please refer to [dtls-echo README][1].
 
-[1]: https://github.com/RIOT-OS/RIOT/blob/master/examples/dtls-echo/README.md
+[1]: https://github.com/RIOT-OS/RIOT/blob/master/examples/networking/dtls/dtls-echo/README.md

--- a/tests/riotboot_flashwrite/README.md
+++ b/tests/riotboot_flashwrite/README.md
@@ -27,7 +27,7 @@ Then provide de device and test:
 On another device setup a BR and start `start_network.sh` on that device serial
 port.
 
-    $ BOARD=<board> make -C examples/gnrc_border_router flash
+    $ BOARD=<board> make -C examples/networking/gnrc_networking/gnrc_borader_router flash
 
     $ sudo dist/tools/ethos/start_network.sh /dev/ttyACMx riot0 2001:db8::/64
 

--- a/tests/sys/psa_crypto_cipher/README.md
+++ b/tests/sys/psa_crypto_cipher/README.md
@@ -1,4 +1,4 @@
 # PSA Crypto Cipher Test
 
 This is a configuration test for only the cipher of the PSA crypto module.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_cipher/example_cipher_aes_128.c
+++ b/tests/sys/psa_crypto_cipher/example_cipher_aes_128.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA cipher configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_cipher/example_cipher_chacha20.c
+++ b/tests/sys/psa_crypto_cipher/example_cipher_chacha20.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA cipher configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_ecdsa/README.md
+++ b/tests/sys/psa_crypto_ecdsa/README.md
@@ -1,4 +1,4 @@
 # PSA Crypto ECDSA Test
 
 This is a configuration test for only the ecdsa of the PSA crypto module.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_ecdsa/example_ecdsa_p256.c
+++ b/tests/sys/psa_crypto_ecdsa/example_ecdsa_p256.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA ECDSA configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_eddsa/README.md
+++ b/tests/sys/psa_crypto_eddsa/README.md
@@ -1,4 +1,4 @@
 # PSA Crypto EDDSA Test
 
 This is a configuration test for only the eddsa of the PSA crypto module.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_eddsa/example_eddsa.c
+++ b/tests/sys/psa_crypto_eddsa/example_eddsa.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA EDDSA configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_hashes/README.md
+++ b/tests/sys/psa_crypto_hashes/README.md
@@ -1,4 +1,4 @@
 # PSA Crypto Hashes Test
 
 This is a configuration test for only the hashes of the PSA crypto module.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_hashes/example_hash.c
+++ b/tests/sys/psa_crypto_hashes/example_hash.c
@@ -12,7 +12,7 @@
  * @{
  *
  * @brief       Tests the PSA hash configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_mac/README.md
+++ b/tests/sys/psa_crypto_mac/README.md
@@ -1,4 +1,4 @@
 # PSA Crypto Mac Test
 
 This is a configuration test for only the mac of the PSA crypto module.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_mac/example_hmac_sha256.c
+++ b/tests/sys/psa_crypto_mac/example_hmac_sha256.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA HMAC SHA256 configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_se/README.md
+++ b/tests/sys/psa_crypto_se/README.md
@@ -1,4 +1,4 @@
 # PSA Crypto Secure Element Test
 
 This is a configuration test for all PSA crypto modules using a secure element.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_se/example_cipher_aes_128.c
+++ b/tests/sys/psa_crypto_se/example_cipher_aes_128.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA secure element configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_se/example_ecdsa_p256.c
+++ b/tests/sys/psa_crypto_se/example_ecdsa_p256.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA secure element configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_se/example_hmac_sha256.c
+++ b/tests/sys/psa_crypto_se/example_hmac_sha256.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA secure element configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_se_cipher/README.md
+++ b/tests/sys/psa_crypto_se_cipher/README.md
@@ -2,4 +2,4 @@
 
 This is a configuration test for only the cipher of the PSA crypto module using
 secure element.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_se_cipher/example_cipher_aes_128.c
+++ b/tests/sys/psa_crypto_se_cipher/example_cipher_aes_128.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA secure element cipher configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_se_ecdsa/README.md
+++ b/tests/sys/psa_crypto_se_ecdsa/README.md
@@ -2,4 +2,4 @@
 
 This is a configuration test for only the ecdsa of the PSA crypto module using
 secure element.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_se_ecdsa/example_ecdsa_p256.c
+++ b/tests/sys/psa_crypto_se_ecdsa/example_ecdsa_p256.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA secure element ECDSA configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>

--- a/tests/sys/psa_crypto_se_mac/README.md
+++ b/tests/sys/psa_crypto_se_mac/README.md
@@ -2,4 +2,4 @@
 
 This is a configuration test for only the mac of the PSA crypto module using
 secure element.
-It is based off the [psa_crypto example](../../../examples/psa_crypto/README.md).
+It is based off the [psa_crypto example](../../../examples/advanced_examples/psa_crypto/README.md).

--- a/tests/sys/psa_crypto_se_mac/example_hmac_sha256.c
+++ b/tests/sys/psa_crypto_se_mac/example_hmac_sha256.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @brief       Tests the PSA secure element HMAC SHA256 configurations
- *              Contents have been copied from `examples/psa_crypto`
+ *              Contents have been copied from `examples/advanced_examples/psa_crypto`
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>


### PR DESCRIPTION
adapt to folder structure from #21135


### Contribution description

the newly merged #21135 gives a structure to examples, but misses to update the references to them in the documentation.

This PR tries to catch as much as possible and rename them accordingly. No 100% coverage guarantees since it involved some manual search-and-replace.


### Testing procedure

Carefully check the changes for spelling mistakes and strange changes.

### Issues/PRs references

Follow-up of #21135 by @AnnsAnns 