### PR TITLE
gnrc_netapi: warn about lost packets

### DIFF
--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include "log.h"
 #include "mbox.h"
 #include "msg.h"
 #include "net/gnrc/netreg.h"
@@ -55,14 +56,15 @@ int _gnrc_netapi_get_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
 
 int _gnrc_netapi_send_recv(kernel_pid_t pid, gnrc_pktsnip_t *pkt, uint16_t type)
 {
-    msg_t msg;
     /* set the outgoing message's fields */
-    msg.type = type;
-    msg.content.ptr = (void *)pkt;
+    msg_t msg = {
+        .type = type,
+        .content.ptr = pkt,
+    };
     /* send message */
     int ret = msg_try_send(&msg, pid);
     if (ret < 1) {
-        DEBUG("gnrc_netapi: dropped message to %" PRIkernel_pid " (%s)\n", pid,
+        LOG_WARNING("gnrc_netapi: dropped message to %" PRIkernel_pid " (%s)\n", pid,
               (ret == 0) ? "receiver queue is full" : "invalid receiver");
     }
     return ret;
@@ -71,14 +73,15 @@ int _gnrc_netapi_send_recv(kernel_pid_t pid, gnrc_pktsnip_t *pkt, uint16_t type)
 #ifdef MODULE_GNRC_NETAPI_MBOX
 static inline int _snd_rcv_mbox(mbox_t *mbox, uint16_t type, gnrc_pktsnip_t *pkt)
 {
-    msg_t msg;
     /* set the outgoing message's fields */
-    msg.type = type;
-    msg.content.ptr = (void *)pkt;
+    msg_t msg = {
+        .type = type,
+        .content.ptr = pkt,
+    };
     /* send message */
     int ret = mbox_try_put(mbox, &msg);
     if (ret < 1) {
-        DEBUG("gnrc_netapi: dropped message to %p (was full)\n", (void*)mbox);
+        LOG_WARNING("gnrc_netapi: dropped message to %p (was full)\n", (void*)mbox);
     }
     return ret;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`sock_async` prints a warning about lost packets, also do this when no async is enabled.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
