### PR TITLE
sys/net/gnrc/netif: pktqueue: don't clash with `GNRC_NETIF_FLAGS_6LO_HC`

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -91,12 +91,6 @@ enum {
 #define GNRC_NETIF_FLAGS_IPV6_ADV_O_FLAG           (0x00000080U)
 
 /**
- * @brief   Used when module gnrc_netif_pktq is used to indicate that
- *          @ref gnrc_netif_t::tx_pkt is from the packet queue.
- */
-#define GNRC_NETIF_FLAGS_TX_FROM_PKTQUEUE          (0x00000100U)
-
-/**
  * @brief   This interface uses 6Lo header compression
  *
  * @see [RFC 6282](https://tools.ietf.org/html/rfc6282)
@@ -145,6 +139,13 @@ enum {
  * @brief   Network interface is configured in raw mode
  */
 #define GNRC_NETIF_FLAGS_RAWMODE                   (0x00010000U)
+
+/**
+ * @brief   Used when module gnrc_netif_pktq is used to indicate that
+ *          @ref gnrc_netif_t::tx_pkt is from the packet queue.
+ */
+#define GNRC_NETIF_FLAGS_TX_FROM_PKTQUEUE          (0x00020000U)
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Both `GNRC_NETIF_FLAGS_6LO_HC` and `GNRC_NETIF_FLAGS_TX_FROM_PKTQUEUE` were using the same flag.
This meant that IPHC was always unset after a queued send (because `GNRC_NETIF_FLAGS_TX_FROM_PKTQUEUE` gets set/unset then).


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
