### PR TITLE
tests/adc: always test all resolutions

### DIFF
--- a/tests/periph/adc/README.md
+++ b/tests/periph/adc/README.md
@@ -6,8 +6,12 @@ continuously streamed to std-out.
 Background
 ==========
 This test application will initialize each configured ADC lines to sample with
-10-bit accuracy. Once configured the application will continuously convert each
-available channel and print the conversion results to std-out.
+6 to 16-bit accuracy. Once configured the application will continuously convert
+each available channel with each available resolution and print the conversion
+results to std-out.
+
+Not all MCUs support all resolutions and unsupported resolutions should be
+printed as -1.
 
 For verification of the output connect the ADC pins to known voltage levels
 and compare the output.

--- a/tests/periph/adc/main.c
+++ b/tests/periph/adc/main.c
@@ -23,16 +23,15 @@
 #include "ztimer.h"
 #include "periph/adc.h"
 
-#define RES             ADC_RES_10BIT
 #define DELAY_MS        100U
 
 int main(void)
 {
-    int sample = 0;
-
     puts("\nRIOT ADC peripheral driver test\n");
     puts("This test will sample all available ADC lines once every 100ms with\n"
-         "a 10-bit resolution and print the sampled results to STDIO\n\n");
+         "6 to 16-bit resolution and print the sampled results to STDOUT.\n"
+         "Not all MCUs support all resolutions, unsupported resolutions\n"
+         "are printed as -1.\n");
 
     /* initialize all available ADC lines */
     for (unsigned i = 0; i < ADC_NUMOF; i++) {
@@ -46,13 +45,17 @@ int main(void)
 
     while (1) {
         for (unsigned i = 0; i < ADC_NUMOF; i++) {
-            sample = adc_sample(ADC_LINE(i), RES);
-            if (sample < 0) {
-                printf("ADC_LINE(%u): selected resolution not applicable\n", i);
-            } else {
-                printf("ADC_LINE(%u): %i\n", i, sample);
-            }
+            int sample6  = adc_sample(ADC_LINE(i), ADC_RES_6BIT);
+            int sample8  = adc_sample(ADC_LINE(i), ADC_RES_8BIT);
+            int sample10 = adc_sample(ADC_LINE(i), ADC_RES_10BIT);
+            int sample12 = adc_sample(ADC_LINE(i), ADC_RES_12BIT);
+            int sample14 = adc_sample(ADC_LINE(i), ADC_RES_14BIT);
+            int sample16 = adc_sample(ADC_LINE(i), ADC_RES_16BIT);
+
+            printf("ADC_LINE(%u): %2i %3i %4i %4i %5i %5i\n", i, sample6, sample8, sample10,
+                   sample12, sample14, sample16);
         }
+        putchar('\n');
         ztimer_sleep(ZTIMER_MSEC, DELAY_MS);
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

During my work on the STM32 ADC, I struggled with the original `tests/periph/adc` test, since it only samples at 10 bit and has to be recompiled for different resolutions.
The changes were already discussed in #20780.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Get your favorite devboard with an ADC (some STM32s like F0,G0,C0 might show weird values due to #21222) and run the test with `BOARD=nucleo-l073rz make -C tests/periph/adc flash term`.

You should see the new output from the test with all resolutions. Keep a jumper wire at hand to set the analog inputs to ground and VCC to see that they are at the appropriate values.

This is the new output with this PR:
```
main(): This is RIOT! (Version: 2024.04-devel-2100-g1cb67-pr/adc_test)<\n>
<\n>
RIOT ADC peripheral driver test<\n>
<\n>
This test will sample all available ADC lines once every 100ms with<\n>
6 to 16-bit resolution and print the sampled results to STDOUT.<\n>
Not all MCUs support all resolutions, unsupported resolutions<\n>
are printed as -1.<\n>
<\n>
Successfully initialized ADC_LINE(0)<\n>
Successfully initialized ADC_LINE(1)<\n>
Successfully initialized ADC_LINE(2)<\n>
Successfully initialized ADC_LINE(3)<\n>
Successfully initialized ADC_LINE(4)<\n>
Successfully initialized ADC_LINE(5)<\n>
ADC_LINE(0):  1   1    3    8    -1    -1<\n>
ADC_LINE(1): 63 255 1023 4095    -1    -1<\n>
ADC_LINE(2): 10  21   44   90    -1    -1<\n>
ADC_LINE(3):  7  32  131  529    -1    -1<\n>
ADC_LINE(4):  7  32  134  541    -1    -1<\n>
ADC_LINE(5):  8  33  129  520    -1    -1<\n>
<\n>
ADC_LINE(0):  0   1    2    8    -1    -1<\n>
ADC_LINE(1): 63 255 1023 4095    -1    -1<\n>
ADC_LINE(2):  9  20   42   87    -1    -1<\n>
ADC_LINE(3):  7  32  130  528    -1    -1<\n>
ADC_LINE(4):  7  32  134  535    -1    -1<\n>
ADC_LINE(5):  7  33  131  515    -1    -1<\n>
<\n>
ADC_LINE(0):  0   1    2    9    -1    -1<\n>
ADC_LINE(1): 63 255 1023 4095    -1    -1<\n>
ADC_LINE(2):  9  20   43   88    -1    -1<\n>
ADC_LINE(3):  7  31  131  528    -1    -1<\n>
ADC_LINE(4):  7  32  132  535    -1    -1<\n>
ADC_LINE(5):  7  33  133  518    -1    -1<\n>
...
```

This is the output from current master:
```
main(): This is RIOT! (Version: 2024.04-devel-2099-gcdceb)<\n>
<\n>
RIOT ADC peripheral driver test<\n>
<\n>
This test will sample all available ADC lines once every 100ms with<\n>
a 10-bit resolution and print the sampled results to STDIO<\n>
<\n>
<\n>
Successfully initialized ADC_LINE(0)<\n>
Successfully initialized ADC_LINE(1)<\n>
Successfully initialized ADC_LINE(2)<\n>
Successfully initialized ADC_LINE(3)<\n>
Successfully initialized ADC_LINE(4)<\n>
Successfully initialized ADC_LINE(5)<\n>
ADC_LINE(0): 17<\n>
ADC_LINE(1): 1023<\n>
ADC_LINE(2): 169<\n>
ADC_LINE(3): 134<\n>
ADC_LINE(4): 123<\n>
ADC_LINE(5): 129<\n>
ADC_LINE(0): 14<\n>
ADC_LINE(1): 1023<\n>
ADC_LINE(2): 167<\n>
ADC_LINE(3): 126<\n>
ADC_LINE(4): 123<\n>
ADC_LINE(5): 126<\n>
ADC_LINE(0): 14<\n>
ADC_LINE(1): 1023<\n>
ADC_LINE(2): 169<\n>
ADC_LINE(3): 129<\n>
ADC_LINE(4): 121<\n>
ADC_LINE(5): 123<\n>
...
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

See also #20780.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
