### PR TITLE
treewide: fix double the in doc and comments

### DIFF
--- a/boards/common/esp8266/include/board_modules.h
+++ b/boards/common/esp8266/include/board_modules.h
@@ -41,7 +41,7 @@ extern "C" {
  *
  * Configuration for the ENC28J60 interface when module ```enc28j60``` is used.
  *
- * SPI_DEV(0) is always used for the the module. The only configurations that
+ * SPI_DEV(0) is always used for the module. The only configurations that
  * can be overridden by \ref esp8266_application_specific_board_configuration
  * "Application Specific Board Configuration" are the CS, INT and RESET signals.
  *
@@ -70,7 +70,7 @@ extern "C" {
  *
  * Configuration for the MRF24J40 interface when module ```mrf24j40``` is used.
  *
- * SPI_DEV(0) is always used for the the module. The only configurations that
+ * SPI_DEV(0) is always used for the module. The only configurations that
  * can be overridden by \ref esp8266_application_specific_board_configuration
  * "Application Specific Board Configuration" are the CS, INT and RESET signals.
  *

--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -90,7 +90,7 @@ Pin 1 is on the top-left side with only 6 contacts.
 |                  | SPI        | partially | Only master mode                                               |
 |                  | Timer      | yes       |                                                                |
 |                  | UART       | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
-| SPI NOR Flash    | IS25LQ020B | yes       | 2MBit flash. Can be used with the the MTD API.                 |
+| SPI NOR Flash    | IS25LQ020B | yes       | 2MBit flash. Can be used with the MTD API.                     |
 
 ## Board configuration
 

--- a/boards/spark-core/doc.txt
+++ b/boards/spark-core/doc.txt
@@ -66,7 +66,7 @@ now replug the usb cable and flash.
 To flash RIOT to the spark core you need to install `dfu-util` (tested with
 0.7 and 0.8).
 
-Power the device and press the the `mode` button until the LED flashes
+Power the device and press the `mode` button until the LED flashes
 yellow/orange: now the device is ready to get flashed.
 
 # Firmware upgrade

--- a/boards/stm32l496g-disco/include/periph_conf.h
+++ b/boards/stm32l496g-disco/include/periph_conf.h
@@ -86,7 +86,7 @@ static const dma_conf_t dma_config[] = {
  * channel 0.
  *
  * The V_REF+ pin is not connected to an external reference voltage on the
- * board by default. Instead the the VREFBUF must be used (`VREFBUF_ENABLE=1`).
+ * board by default. Instead the VREFBUF must be used (`VREFBUF_ENABLE=1`).
  * The output voltage of VREF is around 2.048 V in this case.
  *
  * If an external reference voltage is used as V_REF+, either by soldering
@@ -146,7 +146,7 @@ static const adc_conf_t adc_config[] = {
  * @name    DAC configuration
  *
  * The V_REF+ pin is not connected to an external reference voltage on the
- * board by default. Instead the the VREFBUF must be used (`VREFBUF_ENABLE=1`).
+ * board by default. Instead the VREFBUF must be used (`VREFBUF_ENABLE=1`).
  * The output voltage of VREF is around 2.048 V in this case.
  *
  * @{

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -30,7 +30,7 @@ extern "C" {
  * usage, we define the default stack size values here centrally for all CPU
  * implementations.
  *
- * If needed, you can overwrite these values the the `cpu_conf.h` file of the
+ * If needed, you can overwrite these values the `cpu_conf.h` file of the
  * specific CPU implementation.
  *
  * @todo Adjust values for Cortex-M4F with FPU?

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -727,7 +727,7 @@ ESP-IDF SDK provides a complex heap implementation that supports multiple heap
 segments in different memory areas such as DRAM, IRAM, and PSRAM. Whenever you
 want to use these memory areas as heap, you have to use the heap implementation
 from the ESP-IDF SDK. ESP-IDF heap is not used by default. To use it, it has to
-be enabled by the the makefile of the application:
+be enabled by the makefile of the application:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_heap
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -256,7 +256,7 @@ static int _esp_eth_send(netdev_t *netdev, const iolist_t *iolist)
 
     int ret = 0;
 
-    /* send the the packet to the peer(s) mac address */
+    /* send the packet to the peer(s) mac address */
     if (esp_eth_transmit(dev->eth_driver, dev->tx_buf, dev->tx_len) == ESP_OK) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
     }

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -663,7 +663,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 #ifdef MODULE_ESP_WIFI_AP
     if (esp_wifi_internal_tx(WIFI_IF_AP, dev->tx_buf, dev->tx_len) == ESP_OK) {
 #else /* MODULE_ESP_WIFI_AP */
-    /* send the the packet to the peer(s) mac address */
+    /* send the packet to the peer(s) mac address */
     if (esp_wifi_internal_tx(WIFI_IF_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
 #endif
 #ifndef CPU_ESP8266

--- a/cpu/kinetis/include/bme.h
+++ b/cpu/kinetis/include/bme.h
@@ -56,7 +56,7 @@ extern "C"
  *
  * @param[in]  ptr   Pointer to target register
  * @param[in]  bit   Location of the LSB of the bitfield within the register
- * @param[in]  width Width of the the bitfield, in bits
+ * @param[in]  width Width of the bitfield, in bits
  *
  * @return   bitfield address as an uintptr_t
  */
@@ -76,7 +76,7 @@ static inline volatile void *bme_bf_addr(volatile void *ptr, uintptr_t bit, uint
  *
  * @param[in]  ptr   Pointer to target register
  * @param[in]  bit   Location of the LSB of the bitfield within the register
- * @param[in]  width Width of the the bitfield, in bits
+ * @param[in]  width Width of the bitfield, in bits
  *
  * @return bitfield extracted as a (modifiable) lvalue
  */
@@ -96,7 +96,7 @@ static inline volatile uint32_t *bme_bitfield32(volatile uint32_t *ptr, uint8_t 
  *
  * @param[in]  ptr   Pointer to target register
  * @param[in]  bit   Location of the LSB of the bitfield within the register
- * @param[in]  width Width of the the bitfield, in bits
+ * @param[in]  width Width of the bitfield, in bits
  *
  * @return bitfield extracted as a (modifiable) lvalue
  */
@@ -116,7 +116,7 @@ static inline volatile uint16_t *bme_bitfield16(volatile uint16_t *ptr, uint8_t 
  *
  * @param[in]  ptr   Pointer to target register
  * @param[in]  bit   Location of the LSB of the bitfield within the register
- * @param[in]  width Width of the the bitfield, in bits
+ * @param[in]  width Width of the bitfield, in bits
  *
  * @return bitfield extracted as a (modifiable) lvalue
  */

--- a/cpu/kinetis/include/cpu_conf_kinetis_k.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_k.h
@@ -123,7 +123,7 @@
 /**
  * @name Hardware random number generator module configuration
  *
- *       For K64F SCG3 or SCG6 can be used depending on if the the
+ *       For K64F SCG3 or SCG6 can be used depending on if the
  *       peripheral is accessed through AIPS-lite0 or AIPS-lite1.
  *       For K64F RNGA is only mapped to SCG6.
  * @{

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -568,7 +568,7 @@ static int _atwinc15x0_send(netdev_t *netdev, const iolist_t *iolist)
         }
     }
 
-    /* send the the packet */
+    /* send the packet */
     if (m2m_wifi_send_ethernet_pkt(atwinc15x0_eth_buf, tx_len) == M2M_SUCCESS) {
         return tx_len;
     }

--- a/drivers/include/hmc5883l.h
+++ b/drivers/include/hmc5883l.h
@@ -15,7 +15,7 @@
  * The driver implements basic polling mode. The application can use
  * different approaches to get new data, either
  *
- * - using the #hmc5883l_read function at a lower rate than the the DOR, or
+ * - using the #hmc5883l_read function at a lower rate than the DOR, or
  * - using the data-ready interrupt (**DRDY**), see #hmc5883l_init_int.
  *
  * The data-ready interrupt (**DRDY**) is only be available when module

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -33,7 +33,7 @@
  * pin can thus be described by its port/pin tuple. To access a pin, the
  * @p GPIO_PIN(port, pin) macro should be used. For example: If your platform has
  * a pin PB22, it will be port=1 and pin=22. The @p GPIO_PIN macro should be
- * overridden by a MCU, to allow for efficient encoding of the the port/pin tuple.
+ * overridden by a MCU, to allow for efficient encoding of the port/pin tuple.
  * For example, on many platforms it is possible to `OR` the pin number with the
  * corresponding ports base register address. This allows for efficient decoding
  * of pin number and base address without the need of any address lookup.

--- a/examples/advanced_examples/suit_update/README.hardware.md
+++ b/examples/advanced_examples/suit_update/README.hardware.md
@@ -531,7 +531,7 @@ Finally when:
     $ sudo ip address add 2001:db8::1/128 dev riot0
 
 We are adding a routable address to the riot0 tap interface. The device can
-now send messages to the the coap server through the riot0 tap interface. You could
+now send messages to the coap server through the riot0 tap interface. You could
 use a different address for the coap server as long as you also add a routable
 address, so:
 

--- a/pkg/opendsme/include/opendsme/opendsme.h
+++ b/pkg/opendsme/include/opendsme/opendsme.h
@@ -85,7 +85,7 @@
  * superframes per multisuperframe.
  *
  * Joining devices scan for beacons and perform the association procedure with
- * the the (PAN) coordinator. On success, the device is ready to communicate with
+ * the (PAN) coordinator. On success, the device is ready to communicate with
  * other devices in the DSME network.
  * To extend the network, coordinator devices can associate to any other
  * coordinator (including the PAN coordinator) and start emitting beacons in a

--- a/sys/include/congure/test.h
+++ b/sys/include/congure/test.h
@@ -224,7 +224,7 @@ int congure_test_call_inter_msg_interval(int argc, char **argv);
 int congure_test_add_msg(int argc, char **argv);
 
 /**
- * @brief   Resets the the message pool and messages list for
+ * @brief   Resets the message pool and messages list for
  *          `cong_report msgs_lost` and `cong_report msgs_timeout`.
  *
  * @param[in] argc  Number of @p argv. Needs to be at least 1.

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -89,7 +89,7 @@ int aes_init(cipher_context_t *context, const uint8_t *key, uint8_t keySize);
  * @brief   encrypts one plainBlock-block and saves the result in cipherblock.
  *          encrypts one blocksize long block of plaintext pointed to by
  *          plainBlock to one blocksize long block of ciphertext which will be
- *          written to the the memory-area pointed to by cipherBlock
+ *          written to the memory-area pointed to by cipherBlock
  *
  * @param       context       the cipher_context_t-struct to use for this
  *                            encryption

--- a/sys/include/net/gnrc/netif/6lo.h
+++ b/sys/include/net/gnrc/netif/6lo.h
@@ -30,7 +30,7 @@ extern "C" {
  * @anchor  net_gnrc_netif_6lo_local_flags
  * @see     gnrc_netif_6lo_t::local_flags
  *
- * Like the the capability flags in the [6LoWPAN Capability Indication Option
+ * Like the capability flags in the [6LoWPAN Capability Indication Option
  * (6CIO)](https://tools.ietf.org/html/rfc7400#section-3.3) are less about
  * hardware capabilities than about the implementation status within the
  * network. For the flags in this group it is currently undefined how to

--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -80,7 +80,7 @@ bool gnrc_rpl_instance_remove_by_id(uint8_t instance_id);
 /**
  * @brief   Remove a RPL instance with the pointer @p inst.
  *
- * @param[in] inst     Pointer to the the RPL instance to remove.
+ * @param[in] inst     Pointer to the RPL instance to remove.
  *
  * @return  true, on success.
  * @return  false, otherwise.

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -256,7 +256,7 @@ void gnrc_sixlowpan_frag_rb_gc(void);
  *
  * @return  >0, when the datagram in @p rbuf was complete and dispatched.
  * @return  0, when the datagram in @p rbuf is not complete.
- * @return  -1, if the the reassembled datagram was not dispatched. @p rbuf is
+ * @return  -1, if the reassembled datagram was not dispatched. @p rbuf is
  *          destroyed either way.
  */
 int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf,

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -220,7 +220,7 @@ char phydat_prefix_from_scale(int8_t scale);
  * Inserts the @p values in the given @p dat so that all @p dim values in
  * @p values fit inside the limits of the data type,
  * [@ref PHYDAT_MIN, @ref PHYDAT_MAX], and updates the stored scale factor.
- * The @ref phydat_t::scale member in @p dat is used as the the original scale
+ * The @ref phydat_t::scale member in @p dat is used as the original scale
  * of the @p values.
  * The value is rounded to the nearest integer if possible, otherwise away from
  * zero. E.g. `0.5` and `0.6` are rounded to `1`, `0.4` and `-0.4` are rounded

--- a/sys/include/sys/bus.h
+++ b/sys/include/sys/bus.h
@@ -59,7 +59,7 @@ extern msg_bus_t _sys_bus[SYS_BUS_NUMOF];
 /**
  * @brief Get a System Bus for a category of events.
  *
- * @param[in] bus           The event category of the the user
+ * @param[in] bus           The event category of the user
  *                          is interested in
  *
  * @return                  The message bus for those events

--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -493,7 +493,7 @@ off_t lseek(int fd, _off_t off, int whence)
 }
 
 /**
- * @brief Sets the file position indicator to the the beginning of the file.
+ * @brief Sets the file position indicator to the beginning of the file.
  *
  * @param[in]  stream   open file descriptor obtained from @c fopen()
  */

--- a/sys/psa_crypto/doc.txt
+++ b/sys/psa_crypto/doc.txt
@@ -432,7 +432,7 @@
  * CONFIG_PSA_SECURE_ELEMENT_ATECCX08A_ECC_P256=y
  * @endcode
  *
- * or added to the the Makefile:
+ * or added to the Makefile:
  * @code
  * USEMODULE += psa_secure_element
  * USEMODULE += psa_secure_element_ateccx08a        // device example

--- a/tests/drivers/hmc5883l/README.md
+++ b/tests/drivers/hmc5883l/README.md
@@ -14,7 +14,7 @@ default configuration parameters.
 
 The application can use different approaches to get new data:
 
-- using the #hmc5883l_read function at a lower rate than the the DOR
+- using the #hmc5883l_read function at a lower rate than the DOR
 - using the data-ready interrupt (**DRDY**), see #hmc5883l_init_int.
 
 To use the data-ready interrupt (**DRDY**), the application has to enable

--- a/tests/drivers/hmc5883l/main.c
+++ b/tests/drivers/hmc5883l/main.c
@@ -22,7 +22,7 @@
  *
  * The application can use different approaches to get new data:
  *
- * - using the #hmc5883l_read function at a lower rate than the the DOR
+ * - using the #hmc5883l_read function at a lower rate than the DOR
  * - using the data-ready interrupt (**DRDY**), see #hmc5883l_init_int.
  *
  * To use the data-ready interrupt (**DRDY), the application has to enable


### PR DESCRIPTION
### Contribution description

In PR #21208 I fix double the - `the the` small typo in ztimer documentation. I checked the whole RIOT project and find much more appearance of this typo. This PR should fix all that small typos.

### Testing procedure

Looking at the changes with the successful generation of documentation and Murdock test pass should be enough - as I only touch doxygen and comments.

### Issues/PRs references

PR #21208