### PR TITLE
sys/net/nanocoap: fix dereferencing a null pointer

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -528,7 +528,8 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
     if (retval < 0) {
         /* handlers were not able to process this, so we reply with a RST,
          * unless we got a multicast message */
-        if (!sock_udp_ep_is_multicast(coap_request_ctx_get_local_udp(ctx))) {
+        const sock_udp_ep_t *local = coap_request_ctx_get_local_udp(ctx);
+        if (!local || !sock_udp_ep_is_multicast(local)) {
             return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
         }
     }


### PR DESCRIPTION
### Contribution description

`coap_request_ctx_get_local()` may return `NULL` depending on module selection. If it does, we cannot pass `NULL` to
`sock_udp_ep_is_multicast()`.

This changes the code assume the request is not received via multicast when module `sock_aux_local` is not in use.

When the user binds the CoAP server to multiple endpoints (as needed for using multicast), it is required that `sock_aux_local` is in use anyway, as otherwise the server may not respond using the endpoint it received the request on. (That in turn would render the client unable to correlate the response to the request.)

### Testing procedure

Change the nanocoap server example so that `sock_aux_local` is not used and that a resource handler returns an error. With `master`, this will cause a `NULL` pointer to be dereferenced.

### Issues/PRs references

None