### PR TITLE
docs: Switch out pkg reference link

### DIFF
--- a/pkg/doc.txt
+++ b/pkg/doc.txt
@@ -79,7 +79,7 @@
  * if one is working on new packages that aren't ready to be committed to
  * upstream or if an application needs its own unique packages. For this, one
  * can use the `EXTERNAL_PKG_DIRS` make variable. It works similar to the way
- * [external modules](src/creating-modules.html#modules-outside-of-riotbase) are
+ * [external modules](@ref modules-outside-of-riotbase) are
  * handled. In your application's Makefile, in addition to adding the package
  * name to `USEPKG` as shown above, add the path to a folder that contains your
  * external packages:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently the pkg documentation @ https://doc.riot-os.org/group__pkg.html has a link that is supposed to point to https://doc.riot-os.org/creating-modules.html#modules-outside-of-riotbase but on the Doxygen Output it simply creates a dead (and confusing) link to https://doc.riot-os.org/src/creating-modules.html#modules-outside-of-riotbase.

Simply replacing it with the full link should cover both people using the doxygen documentation and people checking out the doc.txt itself.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
