### PR TITLE
cpu/stm32{f0,g0,c0}: fix ADC initialization sequence

### DIFF
--- a/cpu/stm32/periph/adc_f0_g0_c0.c
+++ b/cpu/stm32/periph/adc_f0_g0_c0.c
@@ -24,12 +24,21 @@
 #include "periph/adc.h"
 #include "periph/vbat.h"
 
+#include "busy_wait.h"
+
 /**
  * @brief   Default VBAT undefined value
  */
 #ifndef VBAT_ADC
 #define VBAT_ADC    ADC_UNDEF
 #endif
+
+/* ADC register CR bits with HW property "rs":
+ * Software can read as well as set this bit. We want to avoid writing a status
+ * bit with a Read-Modify-Write cycle and accidentally setting other status
+ * bits as well. Writing '0' has no effect on the bit value. */
+#define ADC_CR_BITS_PROPERTY_RS (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART \
+                                | ADC_CR_ADDIS | ADC_CR_ADEN)
 
 /**
  * @brief   Allocate lock for the ADC device
@@ -60,6 +69,53 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
+static int _enable_adc(void)
+{
+    /* check if the ADC is not already enabled */
+    if (ADC1->CR & ADC_CR_ADEN) {
+        return 0;
+    }
+
+    /* ensure the prerequisites are right */
+    if (ADC1->CR & (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART | ADC_CR_ADDIS)) {
+        return -1;
+    }
+
+    /* enable the ADC and wait for the READY flag */
+    ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADEN;
+
+    while (!(ADC1->ISR & ADC_ISR_ADRDY)) {
+        /* the calibration logic can reset the ADEN flag, so keep enabling it */
+        if (!(ADC1->CR & ADC_CR_ADEN)) {
+            ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADEN;
+        }
+    }
+
+    return 0;
+}
+
+static int _disable_adc(void)
+{
+    /* check if disable is going on or ADC is disabled already */
+    if ((ADC1->CR & ADC_CR_ADDIS) || !(ADC1->CR & ADC_CR_ADEN)) {
+        while (ADC1->CR & ADC_CR_ADDIS) {}
+        return 0;
+    }
+
+    /* make sure no conversion is going on and stop it if it is */
+    if (ADC1->CR & ADC_CR_ADSTART) {
+        ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADSTP;
+
+        while (ADC1->CR & ADC_CR_ADSTP) {}
+    }
+
+    /* disable the ADC and wait until is is disabled*/
+    ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADDIS;
+    while (!(ADC1->CR & ADC_CR_ADEN)) {}
+
+    return 0;
+}
+
 int adc_init(adc_t line)
 {
     /* make sure the given line is valid */
@@ -67,29 +123,73 @@ int adc_init(adc_t line)
         return -1;
     }
 
-    /* lock and power on the device */
+    /* lock and power on the device, but keep it disabled */
     prep();
+    _disable_adc();
+
     /* configure the pin */
     if (adc_config[line].pin != GPIO_UNDEF) {
         gpio_init_analog(adc_config[line].pin);
     }
-    /* reset configuration */
-    ADC1->CFGR2 = 0;
+
+    /* init ADC only if it wasn't already initialized. Check a register
+     * set by the initialization which has a reset value of 0 */
+    if (ADC1->SMPR == 0) {
+
+        /* reset configuration, including ADC_CFGR1_DMAEN | ADC_CFGR1_DMACFG | ADC_CFGR1_AUTOFF */
+        ADC1->CFGR1 = 0;
+        ADC1->CFGR2 = 0;
+
+        /* Calibration procedure according to:
+        * - RM0360 section 12.3.2 for the STM32F0
+        * - RM0454 section 14.3.3 for the STM32G0
+        * - RM0490 section 16.4.3 for the STM32C0 */
+
+        /* only enable the ADC voltage regulator if the chip has one (STM32F0 does not) */
 #if defined(ADC_CR_ADVREGEN)
-    /* calibrate ADC, per RM0454 section 14.3.3 */
-    /* 1. ensure ADEN=0, ADVREGEN=1, DMAEN=0 */
-    ADC1->CR |= ADC_CR_ADVREGEN;
-    ADC1->CR &= ~(ADC_CR_ADCAL | ADC_CR_ADEN );
-    ADC1->CFGR1 &= ~(ADC_CFGR1_DMAEN);
-    /* 2. Set ADCAL=1 */
-    ADC1->CR |= ADC_CR_ADCAL;
-    /* 3. Wait for ADCAL=0 (or EOCAL=1) */
-    while ((ADC1->ISR & ADC_ISR_EOCAL)) {}
+        ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADVREGEN;
+
+        /* wait for t_ADCVREG_STUP = 20us with some headroom due to busy_wait_us being inaccurate */
+        busy_wait_us(100);
 #endif
-    /* enable device */
-    ADC1->CR = ADC_CR_ADEN;
-    /* configure sampling time to save value */
-    ADC1->SMPR = 0x3;       /* 28.5 ADC clock cycles */
+
+        /* the STM32C0 requires an averaging of eight calibration values */
+#if defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32G0)
+        uint32_t calfact = 0;
+
+        for (uint32_t i = 8; i > 0; i--) {
+            /* perform a calibration and wait for the flag to clear */
+            ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADCAL;
+            while (ADC1->CR & ADC_CR_ADCAL) {}
+
+            calfact += ADC1->CALFACT;
+        }
+        /* round up to the nearest integer */
+        calfact = (calfact + 4) / 8;
+
+        /* enable the ADC to write the calibration factor and wait before writing and disabling */
+        if (_enable_adc() == -1) {
+            return -1;
+        }
+        busy_wait_us(100);
+
+        /* apply the calibration factor and mask it in case it is bigger than 0x7F */
+        ADC1->CALFACT = calfact & ADC_CALFACT_CALFACT;
+
+        _disable_adc();
+
+        /* configure sampling time to a safe value */
+        ADC1->SMPR = ADC_SMPR_SMP1_2 | ADC_SMPR_SMP1_0; /* 39.5 ADC clock cycles */
+#else
+        /* perform a calibration and wait for the flag to clear */
+        ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADCAL;
+        while (ADC1->CR & ADC_CR_ADCAL) {}
+
+        /* configure sampling time to safe value */
+        ADC1->SMPR = ADC_SMPR_SMP_1 | ADC_SMPR1_SMPR_0; /* 28.5 ADC clock cycles */
+#endif
+    }
+
     /* power off an release device for now */
     done();
 
@@ -107,24 +207,41 @@ int32_t adc_sample(adc_t line,  adc_res_t res)
 
     /* lock and power on the ADC device  */
     prep();
+
     /* check if this is the VBAT line */
     if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
         vbat_enable();
     }
+
     /* set resolution and channel */
     ADC1->CFGR1 = res;
     ADC1->CHSELR = (1 << adc_config[line].chan);
+
+    /* check if the ADC was enabled successfully */
+    if (_enable_adc() == -1) {
+        done();
+        return -1;
+    }
+
     /* start conversion and wait for results */
-    ADC1->CR |= ADC_CR_ADSTART;
+    ADC1->CR = (ADC1->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADSTART;
     while (!(ADC1->ISR & ADC_ISR_EOC)) {}
+
     /* read result */
     sample = (int)ADC1->DR;
+
     /* check if this is the VBAT line */
     if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
         vbat_disable();
     }
-    /* unlock and power off device again */
+
+    /* disable, unlock and power off device again */
+    int ret = _disable_adc();
     done();
 
-    return sample;
+    if (ret == -1) {
+        return -1;
+    } else {
+        return sample;
+    }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Most of the issue was described in #21222.
tl;dr: The initialization sequence was not entirely correct and at least for the STM32C0, changing the resolution did not work.

I rewrote the calibration and initialization sequence to follow the guides outlined in the reference manuals more closely.
It should be noted here that the reference manuals involve more steps and checks the newer the devices gets. The sequence for the F0 is very simple [1], for the G0 more complicated [2] and quite involved for the C0 [3].

~~Currently I don't have a STM32G0 nucleo, so the changes are untested for that family. Soon(ish) I'll buy one though.~~
It arrived and everything works as it should :)

Tested with:
- [X] Nucleo-F030R8
- [X] Nucleo-G071RB (with #20971)
- [X] Nucleo-C031C6 (with #20971)
- [X] Nucleo-C071RB (with #20939 and #20971)

Additional Tests:
- [x] Test the STM32G0 with `periph_vbat` enabled.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

~~I recommend to apply #21223 as well to check all resolutions at once.~~ The updated test is now in master and I rebased this PR.
For some STM32C0xx boards, PR #20939 has to be applied with my proposed changes as well if you want to use the NUCLEO-C071 (not really convenient). The NUCLEO-C031 is supported by master already.
In both cases, PR #20971 has to be applied to set the correct values to the resolution register.

You can simply use the adc test `BOARD=nucleo-f030r8 make flash term`.


Before this PR with the STM32C071RB (Pin A0 connected to 3.3V, all samples have the same resolution):
```
main(): This is RIOT! (Version: 2024.10-devel-351-gbf1684-stm32c0-additions)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
6 to 16-bit resolution and print the sampled results to STDOUT.
Not all MCUs support all resolutions, unsupported resolutions
are printed as -1.

Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
ADC_LINE(0): 1680 4095 4095 4094    -1    -1
ADC_LINE(1): 1563 1161  958  859    -1    -1
ADC_LINE(2): 1125 1016  959  937    -1    -1
ADC_LINE(3): 1032 970  934  919    -1    -1
ADC_LINE(4): 1024 962  928  914    -1    -1
ADC_LINE(5): 1082 1026 1005  985    -1    -1

ADC_LINE(0): 4095 4095 4095 4095    -1    -1
ADC_LINE(1): 1345 1038  905  840    -1    -1
ADC_LINE(2): 923 921  923  924    -1    -1
ADC_LINE(3): 885 900  907  908    -1    -1
ADC_LINE(4): 954 925  912  907    -1    -1
ADC_LINE(5): 961 967  969  972    -1    -1

ADC_LINE(0): 4095 4095 4095 4095    -1    -1
ADC_LINE(1): 1373 1051  909  842    -1    -1
ADC_LINE(2): 971 941  931  926    -1    -1
ADC_LINE(3): 920 913  912  911    -1    -1
ADC_LINE(4): 963 927  914  909    -1    -1
ADC_LINE(5): 956 967  969  971    -1    -1
```

With this PR on STM32F030R8 and STM32C071RB (Pin A3 connected to +3.3V, samples have different resolution):
```
ADC_LINE(0): 31 1òmain(): This is RIOT! (Version: 2024.04-devel-2100-gc6897-pr/stm32f0g0c0_adc)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
6 to 16-bit resolution and print the sampled results to STDOUT.
Not all MCUs support all resolutions, unsupported resolutions
are printed as -1.

Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
ADC_LINE(0): 14  80  383 1688    -1    -1
ADC_LINE(1): 30 118  473 1887    -1    -1
ADC_LINE(2): 17  83  369 1593    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1
ADC_LINE(4): 37 134  509 1961    -1    -1
ADC_LINE(5): 31 121  477 1913    -1    -1

ADC_LINE(0): 30 119  474 1896    -1    -1
ADC_LINE(1): 32 122  481 1902    -1    -1
ADC_LINE(2): 17  82  367 1580    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1
ADC_LINE(4): 36 134  506 1951    -1    -1
ADC_LINE(5): 31 121  474 1911    -1    -1

ADC_LINE(0): 31 122  478 1907    -1    -1
ADC_LINE(1): 32 123  482 1912    -1    -1
ADC_LINE(2): 17  81  364 1579    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1
ADC_LINE(4): 36 133  507 1951    -1    -1
ADC_LINE(5): 31 122  479 1908    -1    -1

```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #21222.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

[1] https://www.st.com/resource/en/reference_manual/rm0360-stm32f030x4x6x8xc-and-stm32f070x6xb-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p. 185 section 12.3.2 and 12.3.3
[2] https://www.st.com/resource/en/reference_manual/rm0454-stm32g0x0-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p. 278 section 14.3.3 and 14.3.4
[3] https://www.st.com/resource/en/reference_manual/rm0490-stm32c0-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf p. 290 section 16.4.3 and section 16.4.4