### PR TITLE
boards/nucleo-f722ze: add ADC support

### DIFF
--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32f722ze
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -99,6 +99,10 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+static const adc_conf_t adc_config[] = {{}};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -99,7 +99,19 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
-static const adc_conf_t adc_config[] = {{}};
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3),  .dev = 2, .chan = 3},  /* ADC123_IN3 */
+    {GPIO_PIN(PORT_C, 0),  .dev = 2, .chan = 10}, /* ADC123_IN10 */
+    {GPIO_PIN(PORT_C, 3),  .dev = 2, .chan = 13}, /* ADC123_IN13 */
+    {GPIO_PIN(PORT_F, 3),  .dev = 2, .chan = 9},  /* ADC3_IN9    */
+    {GPIO_PIN(PORT_F, 5),  .dev = 2, .chan = 15}, /* ADC3_IN15   */
+    {GPIO_PIN(PORT_F, 10), .dev = 2, .chan = 8},  /* ADC3_IN8    */
+    {GPIO_UNDEF,           .dev = 0, .chan = 18}, /* VBAT */
+};
+
+#define VBAT_ADC            ADC_LINE(6) /**< VBAT ADC line */
+
+#define ADC_CLK_MAX         MHZ(36)     /**< Use a faster than default ADC clock */
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 


### PR DESCRIPTION
### Contribution description

This PR adds ADC support for `nucleo-f722ze`.

### Testing procedure

Flash the board using `tests/periph/adc` program. Check if measured values changes when A0-A5 pins are
connected to the 3,3V, GND or to the potentiometer.

Unfortunately I don't have access to this board and cannot check if everything is working.
@crasbe - you mentioned in the PR #20971 that you have this board but it lacks configuration. Could you test it?

### Issues/PRs references

PR #20971 