### PR TITLE
cpu/stm32{f3,l4,wb,wl}: Replace ztimer with busy_wait, fix VBat sampling time and {wl only} fix initialization sequence

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -78,13 +78,6 @@ ifneq (,$(filter periph_rtc_mem,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtc
 endif
 
-ifneq (,$(filter periph_adc,$(FEATURES_USED)))
-  ifneq (,$(filter f3 l4 wb wl, $(CPU_FAM)))
-    USEMODULE += ztimer
-    USEMODULE += ztimer_msec
-  endif
-endif
-
 ifneq (,$(filter periph_can,$(FEATURES_USED)))
   ifneq (,$(filter g4,$(CPU_FAM)))
 	USEMODULE += fdcan

--- a/cpu/stm32/periph/adc_f3.c
+++ b/cpu/stm32/periph/adc_f3.c
@@ -19,11 +19,11 @@
  * @}
  */
 
+#include "busy_wait.h"
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
-#include "ztimer.h"
 #include "periph/vbat.h"
 
 #define SMP_MIN         (0x2) /*< Sampling time for slow channels
@@ -143,13 +143,7 @@ int adc_init(adc_t line)
     if (!(dev(line)->CR & ADC_CR_ADEN)) {
         /* Enable ADC internal voltage regulator and wait for startup period */
         dev(line)->CR |= ADC_CR_ADVREGEN;
-#if IS_USED(MODULE_ZTIMER_USEC)
-        ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
-#else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
-#endif
+        busy_wait_us(ADC_T_ADCVREG_STUP_US * 2);
 
         if (dev(line)->DIFSEL & (1 << adc_config[line].chan)) {
             /* Configure calibration for differential inputs */

--- a/cpu/stm32/periph/adc_l4_wb.c
+++ b/cpu/stm32/periph/adc_l4_wb.c
@@ -21,12 +21,12 @@
  * @}
  */
 
+#include "busy_wait.h"
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
 #include "periph/vbat.h"
-#include "ztimer.h"
 
 /**
  * @brief Not all STM32 L4 boards have 3 ADC devices
@@ -171,13 +171,7 @@ int adc_init(adc_t line)
 
         /* enable ADC internal voltage regulator and wait for startup period */
         dev(line)->ADC_CR_REG |= (ADC_CR_ADVREGEN);
-#if IS_USED(MODULE_ZTIMER_USEC)
-        ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
-#else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
-#endif
+        busy_wait_us(ADC_T_ADCVREG_STUP_US * 2);
 
         /* configure calibration for single ended input */
         dev(line)->ADC_CR_REG &= ~(ADC_CR_ADCALDIF);

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -148,8 +148,14 @@ int adc_init(adc_t line)
         /* set sequence length to 1 conversion */
         ADC->CFGR1 &= ~ADC_CFGR1_CONT;
 
-        /* Sampling time of 3.5 ADC clocks for all channels*/
+        /* Set Sampling Time Register 1 to 3.5 ADC Cycles for all GPIO-Channels
+         * and Sampling Time Register 2 to 39.5 ADC Cycles for VBat. Set the
+         * VBat channel to use Sampling Time Register 2. */
         ADC->SMPR = ADC_SMPR_SMP1_0;
+        if (IS_USED(MODULE_PERIPH_VBAT)) {
+            ADC->SMPR |= ADC_SMPR_SMP2_2 | ADC_SMPR_SMP2_0 |
+                         (1 << (adc_config[VBAT_ADC].chan+ ADC_SMPR_SMPSEL_Pos));
+        }
     }
 
     /* free the device again */

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -25,10 +25,10 @@
 
 #include "cpu.h"
 #include "mutex.h"
+#include "busy_wait.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
 #include "periph/vbat.h"
-#include "ztimer.h"
 
 /**
  * @brief   Default VBAT undefined value
@@ -83,13 +83,7 @@ int adc_init(adc_t line)
 
         /* enable ADC internal voltage regulator and wait for startup period */
         ADC->CR |= (ADC_CR_ADVREGEN);
-#if IS_USED(MODULE_ZTIMER_USEC)
-        ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
-#else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
-#endif
+        busy_wait(ADC_T_ADCVREG_STUP_US * 2);
 
         /* ´start automatic calibration and wait for it to complete */
         ADC->CR |= ADC_CR_ADCAL;

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -37,6 +37,13 @@
 #define VBAT_ADC    ADC_UNDEF
 #endif
 
+/* ADC register CR bits with HW property "rs":
+ * Software can read as well as set this bit. We want to avoid writing a status
+ * bit with a Read-Modify-Write cycle and accidentally setting other status
+ * bits as well. Writing '0' has no effect on the bit value. */
+#define ADC_CR_BITS_PROPERTY_RS (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART \
+                                | ADC_CR_ADDIS | ADC_CR_ADEN)
+
 /**
  * @brief   Allocate lock for the ADC device
  *
@@ -56,6 +63,54 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
+static int _enable_adc(void)
+{
+    /* check if the ADC is not already enabled */
+    if (ADC->CR & ADC_CR_ADEN) {
+        return 0;
+    }
+
+    /* ensure the prerequisites are right */
+    if (ADC->CR & (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART | ADC_CR_ADDIS)) {
+        return -1;
+    }
+
+    /* clear ADRDY by writing to it */
+    ADC->ISR |= ADC_ISR_ADRDY;
+
+    /* enable the ADC and wait for the READY flag */
+    ADC->CR = (ADC->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADEN;
+
+    while (!(ADC->ISR & ADC_ISR_ADRDY)) {}
+
+    return 0;
+}
+
+static int _disable_adc(void)
+{
+    /* check if disable is going on or ADC is disabled already */
+    if ((ADC->CR & ADC_CR_ADDIS) || !(ADC->CR & ADC_CR_ADEN)) {
+        while (ADC->CR & ADC_CR_ADDIS) {}
+        return 0;
+    }
+
+    /* make sure no conversion is going on and stop it if it is */
+    if (ADC->CR & ADC_CR_ADSTART) {
+        ADC->CR = (ADC->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADSTP;
+
+        while (ADC->CR & ADC_CR_ADSTP) {}
+    }
+
+    /* disable the ADC and wait until is is disabled*/
+    ADC->CR = (ADC->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADDIS;
+    while (!(ADC->CR & ADC_CR_ADEN)) {}
+
+    /* clear the ADRDY bit by writing 1 to it */
+    ADC->ISR |= ADC_ISR_ADRDY;
+
+    return 0;
+}
+
 int adc_init(adc_t line)
 {
     /* check if the line is valid */
@@ -71,8 +126,9 @@ int adc_init(adc_t line)
         gpio_init_analog(adc_config[line].pin);
     }
 
-    /* init ADC line only if it wasn't already initialized */
-    if (!(ADC->CR & (ADC_CR_ADEN))) {
+    /* init ADC line only if it wasn't already initialized. Check a register
+     * set by the initialization which has a reset value of 0 */
+    if (ADC->SMPR == 0) {
 
         /* set prescaler to 0 to let the ADC run with maximum speed */
         ADC_COMMON->CCR &= ~(ADC_CCR_PRESC);
@@ -82,25 +138,18 @@ int adc_init(adc_t line)
         ADC->CFGR2 |= ADC_CFGR2_CKMODE_0;
 
         /* enable ADC internal voltage regulator and wait for startup period */
-        ADC->CR |= (ADC_CR_ADVREGEN);
+        ADC->CR = (ADC->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADVREGEN;
         busy_wait(ADC_T_ADCVREG_STUP_US * 2);
 
-        /* ´start automatic calibration and wait for it to complete */
-        ADC->CR |= ADC_CR_ADCAL;
+        /* start automatic calibration and wait for it to complete */
+        ADC->CR = (ADC->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADCAL;
         while (ADC->CR  & ADC_CR_ADCAL) {}
-
-        /* clear ADRDY by writing it*/
-        ADC->ISR |= (ADC_ISR_ADRDY);
-
-        /* enable ADC and wait for it to be ready */
-        ADC->CR |= (ADC_CR_ADEN);
-        while ((ADC->ISR & ADC_ISR_ADRDY) == 0) {}
 
         /* set sequence length to 1 conversion */
         ADC->CFGR1 &= ~ADC_CFGR1_CONT;
 
         /* Sampling time of 3.5 ADC clocks for all channels*/
-        ADC->SMPR = 0x0101;
+        ADC->SMPR = ADC_SMPR_SMP1_0;
     }
 
     /* free the device again */
@@ -134,8 +183,14 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     /* specify channel for regular conversion */
     ADC->CHSELR = (1 << adc_config[line].chan);
 
+    /* check if the ADC was enabled successfully */
+    if (_enable_adc() == -1) {
+        done();
+        return -1;
+    }
+
     /* start conversion and wait for it to complete */
-    ADC->CR |= ADC_CR_ADSTART;
+    ADC->CR = (ADC->CR & ~ADC_CR_BITS_PROPERTY_RS) | ADC_CR_ADSTART;
     while (!(ADC->ISR & ADC_ISR_EOC)) {}
 
     /* read the sample */
@@ -146,8 +201,14 @@ int32_t adc_sample(adc_t line, adc_res_t res)
         vbat_disable();
     }
 
-    /* free the device again */
+    /* disable, unlock and power off the device again */
+    int ret = _disable_adc();
     done();
 
-    return sample;
+    if (ret == -1) {
+        return -1;
+    }
+    else {
+        return sample;
+    }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes some issues with the ADC of the STM32WL55 and the ADC of the STM32F3, L4 and WB series.

1) All: The ADC initialization routine used `ztimer` for an uncritical delay, which caused issues (a crash) when it was called from the early reset vector to check the battery status. I explained it here in greater detail: https://github.com/RIOT-OS/RIOT/pull/21235#issuecomment-2675469788
Using ztimer for an uncritical delay is not really necessary, especially since the intended delay is 20µs and if only `ZTIMER_MSEC` was available instead of `ZTIMER_USEC`, the delay was extended to 1ms.
I replaced it with busy_wait and added a factor of 2, because busy_wait is not really accurate. We can wait longer, but we shouldn't push our luck by waiting shorter.
This was present in the F3, L4, WB and WL series.

2) All: Reading out the VBat voltage takes some time for the analog switch to fully switch. This was not taken into consideration, leading to incorrect voltage readings. This PR conditionally increases the sample time when the VBat module is used.

3) WL55: Similar to the L0, L1 and F0/G0/C0 ADC implementations, the initialization order was incorrect. The resolution setting will be ignored when the ADC is already enabled, as described in the Errata [1].
I adapted the `_adc_enable` and `_adc_disable` functions from PR #21230. At this moment it is a bit pointless to have `_disable_adc` return something, but in the future someone (maybe me) wants to add a timeout to the somewhat dangerous infinite while loops and then it makes sense to have the return in place already.
Also I changed the `is the ADC already initialized?`-test from checked the `ADEN` bit to checking if the sampling time has already been set.
This should work without issues since the reset value for this register is 0.

4) WL55: (No fix but an improvement) Similar to the F0/G0/C0 PR from #21230, I added the RS-register guard to avoid setting or resetting a flag that shouldn't be touched.
The issue here is that sometimes a flag is set by writing a 1 to it (typical behavior) and sometimes it is reset by writing a 1 to it. A typical RMW-cycle could potentially reset a flag, which is why the original STM32-HAL uses these guards.
The older documentation does not say that this is required, but it can't hurt. The initialization is not really time critical so we don't have to save cycles.


### Testing procedure

WL55: The testing procedure is a bit of a hen-egg-problem, because for some reason the Nucleo-WL55 did not have the ADC lines configured, so PR #21235 has to be applied as well as this one. I recommend checking out PR #21235 and manually copying `cpu/stm32/periph/adc_wl.c` from this PR.

F3, L4, WB: The tests can be run without any further modifications.

The first part of this PR can be easily tested with `tests/periph/vbat` with `BOARD=nucleo-wl55jc make -C tests/periph/vbat flash term`.

With current master (F3, L4, WB, WL):
```
0x8001741 => *** RIOT kernel panic:
FAILED ASSERTION.

*** halted.
```

With this PR (before applying the fix for VBat):
```
main(): This is RIOT! (Version: 2025.04-devel-142-g04340-nucleo-wl55jc-ADC)

RIOT backup battery monitoring test

This test will sample the backup battery once a second


VBAT: 386[mV]
VBAT: 1598[mV]
VBAT: 1658[mV]
VBAT: 1670[mV]
VBAT: 1668[mV]
VBAT: 1668[mV]
VBAT: 1670[mV]
VBAT: 1665[mV]
...
```

With this PR (after applying the fix):
```
main(): This is RIOT! (Version: 2024.04-devel-2120-ge787a-pr/fix_stm32wl_adc)

RIOT backup battery monitoring test

This test will sample the backup battery once a second


VBAT: 3304[mV]
VBAT: 3304[mV]
VBAT: 3300[mV]
VBAT: 3302[mV]
VBAT: 3304[mV]
VBAT: 3302[mV]
```

<hr/>

The second part of this PR can be tested with `tests/periph/adc` with with `BOARD=nucleo-wl55jc make -C tests/periph/adc flash term`.

With master:
```
main(): This is RIOT! (Version: 2025.04-devel-142-g04340-nucleo-wl55jc-ADC)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
6 to 16-bit resolution and print the sampled results to STDOUT.
Not all MCUs support all resolutions, unsupported resolutions
are printed as -1.

Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
Successfully initialized ADC_LINE(6)
ADC_LINE(0): 4095 4095 4095 4094    -1    -1
ADC_LINE(1): 1675 1572 1554 1550    -1    -1
ADC_LINE(2): 1335 1503 1542 1561    -1    -1
ADC_LINE(3): 2086 1902 1750 1703    -1    -1
ADC_LINE(4): 1483 1533 1546 1558    -1    -1
ADC_LINE(5): 1473 1526 1538 1550    -1    -1
ADC_LINE(6): 440 156   39    0    -1    -1

ADC_LINE(0): 4095 4095 4095 4094    -1    -1
ADC_LINE(1): 1834 1609 1560 1551    -1    -1
ADC_LINE(2): 1457 1535 1551 1563    -1    -1
ADC_LINE(3): 1663 1674 1679 1680    -1    -1
ADC_LINE(4): 1543 1557 1560 1563    -1    -1
ADC_LINE(5): 1523 1539 1551 1553    -1    -1
ADC_LINE(6): 423 143   34    0    -1    -1
```

With this PR:
```
main(): This is RIOT! (Version: 2025.04-devel-142-g04340-nucleo-wl55jc-ADC)

RIOT ADC peripheral driver test

This test will sample all available ADC lines once every 100ms with
6 to 16-bit resolution and print the sampled results to STDOUT.
Not all MCUs support all resolutions, unsupported resolutions
are printed as -1.

Successfully initialized ADC_LINE(0)
Successfully initialized ADC_LINE(1)
Successfully initialized ADC_LINE(2)
Successfully initialized ADC_LINE(3)
Successfully initialized ADC_LINE(4)
Successfully initialized ADC_LINE(5)
Successfully initialized ADC_LINE(6)
ADC_LINE(0): 19  85  348 1399    -1    -1
ADC_LINE(1): 19  84  340 1362    -1    -1
ADC_LINE(2): 20  86  347 1393    -1    -1
ADC_LINE(3): 32 104  394 1550    -1    -1
ADC_LINE(4): 21  86  347 1390    -1    -1
ADC_LINE(5): 63 255 1023 4095    -1    -1
ADC_LINE(6): 18  70  274 1075    -1    -1

ADC_LINE(0): 20  86  349 1400    -1    -1
ADC_LINE(1): 20  84  340 1364    -1    -1
ADC_LINE(2): 20  86  347 1393    -1    -1
ADC_LINE(3): 23  95  384 1538    -1    -1
ADC_LINE(4): 21  86  346 1390    -1    -1
ADC_LINE(5): 63 255 1023 4095    -1    -1
ADC_LINE(6): 18  70  275 1074    -1    -1

```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This has to be merged before #20971 can be merged (and tested...).

### See also

[1] https://www.st.com/resource/en/errata_sheet/es0500-stm32wl55xx-stm32wl54xx-device-errata-stmicroelectronics.pdf p.13 section 2.3.2

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
