### PR TITLE
sys/net/nanocoap: fix API inconsistency

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -2278,8 +2278,7 @@ ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c);
  * @param[in]   code        reply code (e.g., COAP_CODE_204)
  * @param[out]  buf         buffer to write reply to
  * @param[in]   len         size of @p buf
- * @param[in]   ct          content type of payload
- *                          if ct < 0 this will be ignored
+ * @param[in]   ct          content type of payload or @ref COAP_FORMAT_NONE
  * @param[out]  payload     Will be set to the start of the payload inside
  *                          @p buf.
  *                          May be set to NULL if no payload response is
@@ -2292,8 +2291,7 @@ ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c);
  * @returns     -ENOSPC if @p buf too small
  */
 ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
-                                void *buf, size_t len,
-                                int ct,
+                                void *buf, size_t len, uint16_t ct,
                                 void **payload, size_t *payload_len_max);
 
 /**
@@ -2309,7 +2307,7 @@ ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
  * @param[in]   code        reply code (e.g., COAP_CODE_204)
  * @param[out]  buf         buffer to write reply to
  * @param[in]   len         size of @p buf
- * @param[in]   ct          content type of payload
+ * @param[in]   ct          content type of payload or @ref COAP_FORMAT_NONE
  * @param[in]   payload     ptr to payload
  * @param[in]   payload_len length of payload
  *
@@ -2320,7 +2318,7 @@ ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
 ssize_t coap_reply_simple(coap_pkt_t *pkt,
                           unsigned code,
                           uint8_t *buf, size_t len,
-                          unsigned ct,
+                          uint16_t ct,
                           const void *payload, size_t payload_len);
 
 /**

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -578,7 +578,7 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_
 
 ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
                                 void *buf, size_t len,
-                                int ct,
+                                uint16_t ct,
                                 void **payload, size_t *payload_len_max)
 {
     uint8_t *bufpos = buf;
@@ -631,7 +631,7 @@ ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
     }
 
     if (payload) {
-        if (ct >= 0) {
+        if (ct != COAP_FORMAT_NONE) {
             bufpos += coap_put_option_ct(bufpos, 0, ct);
         }
         *bufpos++ = COAP_PAYLOAD_MARKER;
@@ -649,7 +649,7 @@ ssize_t coap_build_reply_header(coap_pkt_t *pkt, unsigned code,
 ssize_t coap_reply_simple(coap_pkt_t *pkt,
                           unsigned code,
                           uint8_t *buf, size_t len,
-                          unsigned ct,
+                          uint16_t ct,
                           const void *payload, size_t payload_len)
 {
     void *payload_start;


### PR DESCRIPTION
### Contribution description

For in-band signalling that a content format is not valid / present, the magic number `COAP_FORMAT_NONE` was introduced and the type `uint16_t` was used. Some APIs however used different in-band signalling values and types:

- coap_reply_simple(): No signal available, `unsigned int`
- coap_build_reply_header(): negative values, `int` (Using `int` would prevent using larger content format numbers on 8-bit and 16-bit archs, where `int` and `int16_t` have the same range.)

This changes the behavior to consistently use `COAP_FORMAT_NONE` as "no content format" signal and `uint16_t` as type.

### Testing procedure

- Using `coap_reply_simple()` with `COAP_FORMAT_NONE` should now allow using no content format in the reply

### Issues/PRs references

None