### PR TITLE
examples/sniffer: enable promiscuous, disable auto-ack

### DIFF
--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -1091,7 +1091,7 @@ static void _isr(netdev_t *netdev)
 
     /* check if the received packet has the ACK request bit set */
     bool rx_ack_req;
-    if (bb_irq_mask & BB_IRQ_RXFE) {
+    if ((bb_irq_mask & BB_IRQ_RXFE) && (dev->flags & AT86RF215_OPT_AUTOACK)) {
         rx_ack_req = at86rf215_reg_read(dev, dev->BBC->RG_FBRXS) & IEEE802154_FCF_ACK_REQ;
     } else {
         rx_ack_req = 0;

--- a/examples/networking/misc/sniffer/main.c
+++ b/examples/networking/misc/sniffer/main.c
@@ -128,6 +128,15 @@ int main(void)
     dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
+    /* put all interfaces in promiscuous mode, disable sending ACKs */
+    gnrc_netif_t *netif = NULL;
+    while ((netif = gnrc_netif_iter(netif))) {
+        const netopt_enable_t enable = NETOPT_ENABLE;
+        const netopt_enable_t disable = NETOPT_DISABLE;
+        gnrc_netapi_set(netif->pid, NETOPT_PROMISCUOUSMODE, 0, &enable, sizeof(enable));
+        gnrc_netapi_set(netif->pid, NETOPT_AUTOACK, 0, &disable, sizeof(disable));
+    }
+
     /* start the shell */
     puts("All ok, starting the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The sniffer should put network interfaces into promiscuous mode so they don't ifilter traffic.
It should also disable sending ACK messages for incomming frames.


### Testing procedure

![image](https://github.com/user-attachments/assets/da87def5-ad03-45d3-9e40-471b3e5ffea2)

We now see all traffic between nodes.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
