### PR TITLE
cpu/esp32: Fixes of compile problems with GCC 14.2

### DIFF
--- a/cpu/esp32/Makefile
+++ b/cpu/esp32/Makefile
@@ -1,7 +1,7 @@
 # Define the module that is built:
 MODULE = cpu
 
-SRC = irq_arch.c startup.c syscalls.c
+SRC = irq_arch.c startup.c stdatomic.c syscalls.c
 
 # Add a list of subdirectories, that should also be built:
 DIRS += $(RIOTCPU)/esp_common

--- a/cpu/esp32/stdatomic.c
+++ b/cpu/esp32/stdatomic.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp_common
+ * @{
+ *
+ * @file
+ * @brief       Missing atomic built-in functions
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include <stdbool.h>
+
+__attribute__((weak))
+bool __atomic_test_and_set(volatile void *ptr, int memorder)
+{
+    return __atomic_exchange_1(ptr, true, memorder);
+}

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -25,6 +25,7 @@ else ifeq (esp32,$(CPU))
   # The ESP-IDF uses #include_next that causes errors when compiling with warnings
   # that are enabled by jerryscript build system so disable them for these CPUs:
   EXT_CFLAGS += -Wno-pedantic
+  EXT_CFLAGS += -Wno-maybe-uninitialized
 else ifeq (esp8266,$(CPU))
   # The esp8266 C newlib version 3.0.0 has errors when compiling with warnings
   # that are enabled by jerryscript build system so disable them for this cpu:

--- a/pkg/utensor/Makefile.include
+++ b/pkg/utensor/Makefile.include
@@ -10,4 +10,6 @@ CXXEXFLAGS += -Wno-sign-compare
 ifeq (llvm,$(TOOLCHAIN))
   CXXEXFLAGS += -Wno-unused-variable
   CXXEXFLAGS += -Wno-shift-count-negative
+else if (esp32,$(CPU))
+  CXXEXFLAGS += -Wno-shift-count-negative
 endif


### PR DESCRIPTION
### Contribution description

This PR provides some small fixes of compile problems with the latest Espressif toolchain (GCC v14.2).

### Testing procedure

Compilation with used Espressif toolchain (GCC v12.2) should still work in CI.

### Issues/PRs references
