### PR TITLE
tests/sys/suit_manifest: remove unnecessary custom native board

### DIFF
--- a/tests/sys/suit_manifest/Makefile
+++ b/tests/sys/suit_manifest/Makefile
@@ -25,11 +25,6 @@ BLOBS += $(MANIFEST_DIR)/file2.bin
 
 CFLAGS += -DCONFIG_SUIT_COMPONENT_MAX=2
 
-# Use a version of 'native' that includes flash page support
-ifneq (,$(filter native native64,$(BOARD)))
-  EXTERNAL_BOARD_DIRS = $(CURDIR)/native_flashpage
-endif
-
 FEATURES_REQUIRED += periph_flashpage
 
 TEST_DATA = $(MANIFEST_DIR)/created

--- a/tests/sys/suit_manifest/native_flashpage/native/Makefile
+++ b/tests/sys/suit_manifest/native_flashpage/native/Makefile
@@ -1,3 +1,0 @@
-DIRS += $(RIOTBOARD)/native
-
-include $(RIOTBASE)/Makefile.base

--- a/tests/sys/suit_manifest/native_flashpage/native/Makefile.dep
+++ b/tests/sys/suit_manifest/native_flashpage/native/Makefile.dep
@@ -1,1 +1,0 @@
-include $(RIOTBOARD)/native/Makefile.dep

--- a/tests/sys/suit_manifest/native_flashpage/native/Makefile.features
+++ b/tests/sys/suit_manifest/native_flashpage/native/Makefile.features
@@ -1,3 +1,0 @@
-FEATURES_PROVIDED += periph_flashpage
-
-include $(RIOTBOARD)/native/Makefile.features

--- a/tests/sys/suit_manifest/native_flashpage/native/Makefile.include
+++ b/tests/sys/suit_manifest/native_flashpage/native/Makefile.include
@@ -1,8 +1,0 @@
-CFLAGS += -DFLASHPAGE_SIZE=256
-CFLAGS += -DFLASHPAGE_NUMOF=16
-
-# We must duplicate the include done by $(RIOTBASE)/Makefile.include
-# to also include the main board header
-INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/native/include))
-
-include $(RIOTBOARD)/native/Makefile.include


### PR DESCRIPTION
### Contribution description

`tests/sys/suit_manifest` uses a custom `native` board with `periph_flashpage`. Both our native boards support this feature in tree since #15935. We can thus drop the custom board.


### Testing procedure

Building and running the test on both `native` and `native64` should still succeed:

`make -C tests/sys/suit_manifest BOARD=native clean all test`

`make -C tests/sys/suit_manifest BOARD=native64 clean all test`


### Issues/PRs references

Noticed while working on #21242 
