### PR TITLE
cpu/nrf5*: mark and resolve radio conflict

### DIFF
--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -17,6 +17,10 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter nrfble,$(USEMODULE)))
+  FEATURES_REQUIRED += radio_nrfble
+endif
+
 # The nrf52832 requires gpio IRQ with SPI to work around errata 58
 ifneq (,$(filter nrf52832xxaa,$(CPU_MODEL)))
   ifneq (,$(filter periph_spi,$(USEMODULE)))

--- a/cpu/nrf52/Makefile.nrf802154.dep
+++ b/cpu/nrf52/Makefile.nrf802154.dep
@@ -1,5 +1,5 @@
 ifneq (,$(filter netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nimble_% nrfmin,$(USEMODULE)))
+  ifeq (,$(filter nimble_% nrfmin nrfble,$(USEMODULE)))
     USEMODULE += nrf802154
   endif
 endif

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -37,4 +37,7 @@ ifeq (,$(filter nrf9160 nrf5340_app,$(CPU_MODEL)))
   FEATURES_PROVIDED += netif
 endif
 
+FEATURES_CONFLICT += radio_nrf802154:radio_nrfble radio_nrf802154:radio_nrfmin radio_nrfble:radio_nrfmin
+FEATURES_CONFLICT_MSG += "Multiplexing the nRF radio between different radio modes is not supported."
+
 include $(RIOTCPU)/cortexm_common/Makefile.features


### PR DESCRIPTION
### Contribution description

RIOT does not support multiplexing the nrf radio between BLE and 802.15.4 modes. Currently, if `nrfble` was selected, `netdev_default` would still select `nrf802154` and the feature conflict would not be noted.

### Testing procedure

1. `USEMODULE="netdev_default nrfble" make -C examples/basic/hello-world BOARD=nrf52840dk all`
2. `USEMODULE="nrf52840 nrfble" make -C examples/basic/hello-world BOARD=nrf52840dk all`

On `master` both just report linker issues.

With this PR, 1 will build successfully without automatically selecting `nrf802154` and 2 will report the feature conflict.

### Issues/PRs references

Noticed while testing #20996 
