### PR TITLE
doc/porting-boards: Fix Doxygen Comment Block Style

### DIFF
--- a/doc/doxygen/src/porting-boards.md
+++ b/doc/doxygen/src/porting-boards.md
@@ -227,24 +227,24 @@ any browser.
 
 ```
 /**
-@defgroup    boards_foo FooBoard
-@ingroup     boards
-@brief       Support for the foo board
-@author      FooName BarName <foo.bar@baz.com>
-
-### User Interface
-
-  ....
-
-### Using UART
-
-  ...
-
-### Flashing the device
-
-  ...
-
-*/
+ * @defgroup    boards_foo FooBoard
+ * @ingroup     boards
+ * @brief       Support for the foo board
+ * @author      FooName BarName <foo.bar@baz.com>
+ *
+ * ### User Interface
+ *
+ *  ...
+ *
+ * ### Using UART
+ *
+ *  ...
+ *
+ * ### Flashing the device
+ *
+ *  ...
+ *
+ */
 ```
 
 # Helper tools


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As described in Issue #21220, many `doc.txt` files use the comment block of Doxygen incorrectly, possibly leading to weird side effects with asterisks used for bold/italic/...
The example in the `Porting Boards` tutorial also has the incorrect comment block style and this PR aims to fix that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Current Master:
![image](https://github.com/user-attachments/assets/841fe35c-7fd7-4ba0-a416-380cc809911b)

This PR:
![image](https://github.com/user-attachments/assets/b24741b6-e328-415a-9686-06097225369e)

### Testing procedure

Generate the documentation and check if everything looks good.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Details described in #21220.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
