### PR TITLE
core/thread: error in thread.c corrected

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -267,9 +267,9 @@ struct _thread {
  * @param[in] name      a human readable descriptor for the thread
  *
  * @return              PID of newly created task on success
- * @return              -EINVAL, if @p priority is greater than or equal to
- *                      @ref SCHED_PRIO_LEVELS
- * @return              -EOVERFLOW, if there are too many threads running already
+ * @retval  -EINVAL     @p priority is greater than or equal to
+ *                      @ref SCHED_PRIO_LEVELS or @p stacksize is too small
+ * @retval  -EOVERFLOW  there are too many threads running already
  */
 kernel_pid_t thread_create(char *stack,
                            int stacksize,

--- a/core/thread.c
+++ b/core/thread.c
@@ -160,6 +160,29 @@ void thread_yield(void)
     thread_yield_higher();
 }
 
+/*
+ * Example of insertion operations in the linked list
+ *   thread_add_to_list(list,new_node) //Prio4
+ *   list         list      new_node
+ *  +------+     +------+   +------+
+ *  |    + | ->  |    + |   | 4  + |
+ *  +----|-+     +----|-+   +----|-+
+ *       +-->NULL     +-----/\   +-->NULL
+ *  thread_add_to_list(list,higher_node) //Prio2(Higher)
+ *  list       new_node   higher_node
+ *  +------+   +------+   +------+
+ *  |    + |   | 4  + |   | 2  + |
+ *  +----|-+   +----|-+   +----|-+
+ *       |          +-->NULL   |
+ *       |      /\-------------+
+ *       +----------------/\
+ *  thread_add_to_list(list,lower_node) //Prio6(Lower)
+ *  list       new_node   lower_node
+ *  +------+   +------+   +------+
+ *  |    + |   | 4  + |   | 6  + |
+ *  +----|-+   +----|-+   +----|-+
+ *       +-----/\   +-----/\   +-->NULL
+ */
 void thread_add_to_list(list_node_t *list, thread_t *thread)
 {
     assert(thread->status < STATUS_ON_RUNQUEUE);

--- a/core/thread.c
+++ b/core/thread.c
@@ -132,7 +132,7 @@ int thread_wakeup(kernel_pid_t pid)
     else if (thread->status == STATUS_SLEEPING) {
         DEBUG("thread_wakeup: Thread is sleeping.\n");
 
-        sched_set_status(thread, STATUS_RUNNING);
+        sched_set_status(thread, STATUS_PENDING);
 
         irq_restore(old_state);
         sched_switch(thread->priority);

--- a/core/thread.c
+++ b/core/thread.c
@@ -240,6 +240,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
 
     if (stacksize < 0) {
         DEBUG("thread_create: stacksize is too small!\n");
+        return -EINVAL;
     }
     /* allocate our thread control block at the top of our stackspace. Cast to
      * (uintptr_t) intermediately to silence -Wcast-align. (We manually made

--- a/core/thread.c
+++ b/core/thread.c
@@ -373,10 +373,14 @@ static const char *state_names[STATUS_NUMOF] = {
 
 const char *thread_state_to_string(thread_status_t state)
 {
-    const char *name = state_names[state] ? state_names[state] : NULL;
+    const char *name =  NULL;
+    if (state < STATUS_NUMOF) {
+        name = state_names[state];
+    }
 
-    assert(name != NULL); /* if compiling with assertions, this is an error that
-                             indicates that the table above is incomplete */
+    /* if compiling with assertions, this is an error
+     * that indicates that the table above is incomplete */
+    assert(name != NULL);
 
     return (name != NULL) ? name : STATE_NAME_UNKNOWN;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Errors in thread.c corrected:
- in thread_wakeup() the status of the function to be woken up is incorrectly set to TASK_RUNNING. Instead the task should be set to STATUS_PENDING here, as only sched_run() is allowed to set a task to TASK_RUNNING.
- in thread_create() it is checked whether the stack is large enough, but instead of aborting the function if the stack is too small and thus preventing a buffer overflow, only a debug output is made. Return statement added
- in thread_state_to_string() it is not checked whether state is within the valid range, so that in the event of an error an invalid memory address is returned, which in turn leads to further invalid memory accesses when the string is output. thread_state_to_string() is used in particular by ps(). In the case of a corrupt thread context, which often occurred in my case due to the stack size being too small, thread_state_to_string() is called with an invalid status.

Other
- thread_add_to_list(): Adding the task to the linked list is graphically commented (If you are interested, I also prepared this for core\lib\include\list.h and core\lib\include\clist.h)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
