### PR TITLE
cpu/esp32: fix bus_width in periph_sdmmc

### DIFF
--- a/cpu/esp32/periph/sdmmc.c
+++ b/cpu/esp32/periph/sdmmc.c
@@ -217,8 +217,6 @@ static void _init(sdmmc_dev_t *sdmmc_dev)
     else {
         sdmmc_dev->present = true;
     }
-
-    sdmmc_dev->bus_width = SDMMC_BUS_WIDTH_1BIT; // SDMMC_BUS_WIDTH_4BIT;
 }
 
 static int _send_cmd(sdmmc_dev_t *sdmmc_dev, sdmmc_cmd_t cmd_idx, uint32_t arg,


### PR DESCRIPTION
### Contribution description

This PR removes a small leftover found when migrating the code to ESP-IDF v5.4 which was used for debugging during the development of `cpu/esp32/periph/sdmmc`. It fixes the setting of the bus width which was hardcoded down to 1 bit by this left over.

### Testing procedure

Compilation has to succeed.

The fix has been tested successfully with `tests/driver/sdmmc` for:

- esp32-wrover-kit
- esp32s3-usb-otg

### Issues/PRs references
