### PR TITLE
boards/nucleo-f413zh: add MCU table, move to doc.md

### DIFF
--- a/boards/nucleo-f413zh/doc.md
+++ b/boards/nucleo-f413zh/doc.md
@@ -1,7 +1,6 @@
-/**
- @defgroup    boards_nucleo-f413zh STM32 Nucleo-F413ZH
- @ingroup     boards_common_nucleo144
- @brief       Support for the STM32 Nucleo-F413ZH
+@defgroup    boards_nucleo-f413zh STM32 Nucleo-F413ZH
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-F413ZH
 
 ## Overview
 
@@ -24,5 +23,3 @@ make BOARD=nucleo-f413zh PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-f413zh/doc.md
+++ b/boards/nucleo-f413zh/doc.md
@@ -5,11 +5,34 @@
 ## Overview
 
 The Nucleo-F413ZH is a board from ST's Nucleo family supporting ARM Cortex-M4
-STM32F413ZH microcontroller with 256KiB of RAM and 1MiB of Flash.
+STM32F413ZH microcontroller with 320KiB of RAM and 1.5MiB of Flash.
 
 ## Pinout
 
 @image html pinouts/nucleo-f412zg-and-f413zh.svg "Pinout for the nucleo-f413zh (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50%
+
+### MCU
+
+| MCU        |    STM32F413ZH      |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M4       |
+| Vendor     | ST Microelectronics |
+| RAM        | 320KiB              |
+| Flash      | 1.5MiB              |
+| Frequency  | up to 100MHz        |
+| FPU        | yes                 |
+| Timers     | 18 (12x 16-bit, 2x 32, 1x RTC, 1x Systick, 2x Watchdog) |
+| ADC        | 1x 12-bit (16 channels) |
+| UARTs      | 6 (four USARTs and two UARTs) |
+| SPIs       | 5                   |
+| CANs       | 3                   |
+| RTC        | 1                   |
+| I2Cs       | 4                   |
+| Vcc        | 1.7V - 3.6V         |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f413zh.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0430-stm32f413423-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00244518-stm32-nucleo-144-boards-stmicroelectronics.pdf) |
 
 ## Flashing the Board Using ST-LINK Removable Media
 


### PR DESCRIPTION
### Contribution description

This PR adds MCU table for `nucleo-f413zh` board. Moreover, it moves documentations from `doc.txt` do `doc.md` accordingly to the PR #21255.

### Testing procedure

Generate doc and check if everything looks good.

```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-f413zh.html 
```

### Issues/PRs references

PR #21255