### PR TITLE
nanocoap: avoid non `static` buffers of configurable size 

### DIFF
--- a/sys/include/net/nanocoap/link_format.h
+++ b/sys/include/net/nanocoap/link_format.h
@@ -45,12 +45,15 @@ typedef int (*coap_link_format_handler_t)(char *entry, void *ctx);
  * @param[in]   path    path of the resource
  * @param[in]   cb      Callback to execute for each resource entry
  * @param[in]   arg     Optional callback argument
+ * @param[out]  dirent_buf      Response buffer
+ * @param[in]   dirent_buf_len  Length of the response buffer
  *
  * @returns     0 on success
  * @returns     <0 on error
  */
 int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
-                             coap_link_format_handler_t cb, void *arg);
+                             coap_link_format_handler_t cb, void *arg,
+                             char *dirent_buf, size_t dirent_buf_len);
 
 /**
  * @brief   Downloads the resource behind @p url via blockwise GET
@@ -58,12 +61,15 @@ int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
  * @param[in]   url     URL to the resource
  * @param[in]   cb      Callback to execute for each resource entry
  * @param[in]   arg     Optional callback argument
+ * @param[out]  dirent_buf      Response buffer
+ * @param[in]   dirent_buf_len  Length of the response buffer
  *
  * @returns     0 on success
  * @returns     <0 on error
  */
 int nanocoap_link_format_get_url(const char *url,
-                                 coap_link_format_handler_t cb, void *arg);
+                                 coap_link_format_handler_t cb, void *arg,
+                                 char *dirent_buf, size_t dirent_buf_len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -211,6 +211,8 @@ typedef struct {
     nanocoap_socket_type_t type;            /**< Socket type (UDP, DTLS) */
 #endif
     uint16_t msg_id;                        /**< next CoAP message ID */
+    uint8_t hdr_buf[CONFIG_NANOCOAP_BLOCK_HEADER_MAX]; /**< buffer for CoAP header with options,
+                                                            token and payload marker */
 } nanocoap_sock_t;
 
 /**
@@ -555,14 +557,14 @@ static inline void nanocoap_sock_close(nanocoap_sock_t *sock)
  *
  * @param[in]   sock    socket to use for the request
  * @param[in]   path    remote path and query
- * @param[out]  buf     buffer to write response to
- * @param[in]   len     length of @p buffer
+ * @param[out]  response buffer to write response to
+ * @param[in]   len_max length of @p buffer
  *
  * @returns     length of response payload on success
  * @returns     @see nanocoap_sock_request_cb on error
  */
-ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf,
-                          size_t len);
+ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path,
+                          void *response, size_t len_max);
 
 /**
  * @brief   Simple non-confirmable GET

--- a/sys/net/application_layer/nanocoap/fs.c
+++ b/sys/net/application_layer/nanocoap/fs.c
@@ -30,6 +30,8 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+static char _dirent_buf[CONFIG_NANOCOAP_QS_MAX];
+
 static int nanocoap_fs_mount(vfs_mount_t *mountp)
 {
     nanocoap_fs_t *fs = mountp->private_data;
@@ -288,7 +290,8 @@ static int nanocoap_fs_readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
         .offset = dir->offset++,
     };
 
-    res = nanocoap_link_format_get(&fs->sock, dir->urlbuf, _dir_cb, &ctx);
+    res = nanocoap_link_format_get(&fs->sock, dir->urlbuf, _dir_cb, &ctx,
+                                   _dirent_buf, sizeof(_dirent_buf));
     if (res == -EINTR) {
         /* we use this to abort listing early */
         res = 1;

--- a/sys/net/application_layer/nanocoap/link_format.c
+++ b/sys/net/application_layer/nanocoap/link_format.c
@@ -85,13 +85,13 @@ static int _dirlist_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int m
 }
 
 int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
-                             coap_link_format_handler_t cb, void *arg)
+                             coap_link_format_handler_t cb, void *arg,
+                             char *dirent_buf, size_t dirent_buf_len)
 {
-    char buffer[CONFIG_NANOCOAP_QS_MAX];
     struct dir_list_ctx ctx = {
-        .buf = buffer,
-        .end = buffer + sizeof(buffer),
-        .cur = buffer,
+        .buf = dirent_buf,
+        .end = dirent_buf + dirent_buf_len,
+        .cur = dirent_buf,
         .cb = cb,
         .ctx = arg,
     };
@@ -99,7 +99,8 @@ int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
                                        _dirlist_cb, &ctx);
 }
 
-int nanocoap_link_format_get_url(const char *url, coap_link_format_handler_t cb, void *arg)
+int nanocoap_link_format_get_url(const char *url, coap_link_format_handler_t cb, void *arg,
+                                 char *dirent_buf, size_t dirent_buf_len)
 {
     nanocoap_sock_t sock;
     int res = nanocoap_sock_url_connect(url, &sock);
@@ -107,7 +108,7 @@ int nanocoap_link_format_get_url(const char *url, coap_link_format_handler_t cb,
         return res;
     }
 
-    res = nanocoap_link_format_get(&sock, sock_urlpath(url), cb, arg);
+    res = nanocoap_link_format_get(&sock, sock_urlpath(url), cb, arg, dirent_buf, dirent_buf_len);
     nanocoap_sock_close(&sock);
 
     return res;

--- a/tests/net/gcoap_fileserver/Makefile.ci
+++ b/tests/net/gcoap_fileserver/Makefile.ci
@@ -15,6 +15,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
     derfmega128 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
     im880b \
     m1284p \

--- a/tests/net/nanocoap_cli/Makefile.ci
+++ b/tests/net/nanocoap_cli/Makefile.ci
@@ -10,6 +10,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a1-xplained \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

How often have you been looking for a bug, and it felt like chasing a ghost because memory was messed up?
How often was it a buffer you have unsuspectingly increased in size, which was not `static`?
(The right answer is: Yes 😄) 
That's why non-`static` `uint8_t buffer[CONFIG_INCREASE_ON_DEMAND]` is likely a footgun. 

Most importantly, this PR makes that a response buffer for `nanocoap_link_format_get()` has to be user allocated.
I could have just made it `static`, but this would bring up a concurrency issue.

Secondly,  a buffer `[CONFIG_NANOCOAP_BLOCK_HEADER_MAX]` is added to `nanocoap_sock_t`.
This was before allocated in various `nanocoap` functions. I moved it to the socket because this is likely allocated in a user thread. Therefore the stack size of that user's thread is no longer our problem 😅. And not so unlikely, the user allocates the socket with `static`.
 
### Testing procedure

Start a CoAP fileserver: `aiocoap-fileserver --bind [::] .`
Flash a `sam54-xpro` and connect it via ethernet to the coap fileserver:
`USEMODULE+=nanocoap_vfs CFLAGS+=-DCONFIG_NANOCOAP_QS_MAX=1024 BOARD=same54-xpro make -C examples/networking/gnrc/gnrc_networking flash term PORT=/dev/ttyACM0`

On `master`: `ncget coap://[fe80::be63:bb80:6473:faa9]/` crashes on my setup.
On this banch it succeeds and prints the directory content.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
