### PR TITLE
doc: hack to hide doc.md files until doxygen gets fixed

### DIFF
--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -522,3 +522,11 @@ table.retval > tbody > tr > td.paramname {
 blockquote {
   background-color: #eadde1;
 }
+/* HACK: doc.md files are processed correctly, but additionally add an empty page,
+ * see https://github.com/doxygen/doxygen/issues/9437
+ * and https://github.com/RIOT-OS/RIOT/issues/21220#issuecomment-2701284183
+ * can be removed as soon as the doxygen issue is fixed */
+li:has(> .item a[class^="md_"][class$="doc.html"]),
+tr:has(> .entry a[href^="md_"][href$="doc.html"]) {
+    display: none;
+}


### PR DESCRIPTION
### Contribution description

As found out in https://github.com/RIOT-OS/RIOT/issues/21220#issuecomment-2700537054, doxygen currently adds empty pages for each markdown file it encounters.

Since we still plan to move towards `doc.md` files, apply a CSS hack to hide those, until the issue is fixed upstream in https://github.com/doxygen/doxygen/issues/9437

### Testing procedure

Check CI generated documentation.
