### PR TITLE
doc: Use the correct Doxygen Logo File Type in the Footer

### DIFF
--- a/doc/doxygen/footer.html
+++ b/doc/doxygen/footer.html
@@ -1,7 +1,7 @@
     <div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
         <ul>
             <li class="footer">Generated on $datetime by <a href="http://www.doxygen.org/index.html">
-                       <img class="footer" src="doxygen.png" alt="doxygen"></a> $doxygenversion</li>
+                       <img class="footer" src="doxygen.svg" alt="doxygen" style="height: 1.5em;"></a> $doxygenversion</li>
         </ul>
     </div>
     <!-- Include all compiled plugins (below), or include individual files as needed -->


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Apparently Doxygen changed the default file type from PNG to SVG at some point and the footer was never updated, leading to the ugly "image not found" symbol in the footer.
The SVG file is already present and accessible on the webserver ( https://doc.riot-os.org/doxygen.svg ) but not in the `footer.html`.

Current state:
![image](https://github.com/user-attachments/assets/eacef3e0-5873-4583-829f-47f901c7b4b1)

![image](https://github.com/user-attachments/assets/bdb5baa9-5ab6-4602-898e-f14f51eda6ee)

With this PR:
![image](https://github.com/user-attachments/assets/a936084a-a27f-43ca-bc2b-b388d0b44db0)


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

~~Check that the generated documentation contains the logo in the footer.~~

Apparently the old doxygen version (1.9.1) in the CI container has some issues displaying the SVG, because there is no size specification:
![image](https://github.com/user-attachments/assets/7ff61480-c14f-4560-a3b0-e937314338fd)

In newer Doxygen versions (1.12.0), the CSS settings for the footer were extended:
![image](https://github.com/user-attachments/assets/74de620e-0c92-4a11-bca8-23b7b8b5d8d1)

So you have test it locally, wait for the CI container to be updated or just trust me :D

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
