### PR TITLE
doc, buildsystem: Add a Version Check for Doxygen, Fix doc* Target Execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,11 @@ all: welcome
 	@echo ""
 	@exit 1
 
-doc:
+doc doc-man doc-latex:
 	@./dist/tools/features_yaml2mx/features_yaml2mx.py \
 		features.yaml \
 		--output-md doc/doxygen/src/feature_list.md
-	"$(MAKE)" -BC doc/doxygen
-
-doc-man:
-	"$(MAKE)" -BC doc/doxygen man
-
-doc-latex:
-	"$(MAKE)" -BC doc/doxygen latex
+	"$(MAKE)" -BC doc/doxygen $@
 
 docclean:
 	"$(MAKE)" -BC doc/doxygen clean

--- a/Makefile.include
+++ b/Makefile.include
@@ -602,7 +602,7 @@ include $(RIOTMAKE)/bindist.inc.mk
 include $(RIOTMAKE)/modules.inc.mk
 
 
-.PHONY: all link clean flash flash-only termdeps term doc debug debug-server reset objdump help info-modules
+.PHONY: all link clean flash flash-only termdeps term doc doc-man doc-latex debug debug-server reset objdump help info-modules
 .PHONY: print-size elffile lstfile binfile hexfile flashfile cosy
 .PHONY: ..in-docker-container
 
@@ -879,8 +879,8 @@ cleanterm: $(TERMDEPS)
 list-ttys:
 	$(Q)$(RIOTTOOLS)/usb-serial/ttys.py
 
-doc:
-	$(MAKE) -BC $(RIOTBASE) doc
+doc doc-man doc-latex:
+	$(MAKE) -C $(RIOTBASE) $@
 
 debug: $(DEBUGDEPS)
 	$(call check_cmd,$(DEBUGGER),Debug program)

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -1,4 +1,6 @@
-RIOTBASE=$(shell git rev-parse --show-toplevel)
+RIOTBASE  = $(shell git rev-parse --show-toplevel)
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
 # Generate list of quoted absolute include paths. Evaluated in riot.doxyfile.
 export STRIP_FROM_INC_PATH_LIST=$(shell \
     git ls-tree -dr --full-tree --name-only HEAD core drivers sys |\
@@ -9,10 +11,35 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
 # It can also be installed in ubuntu with the `node-less` package
 LESSC ?= lessc
 
-DOCUMENTATION_FORMAT ?= html
+# Extract the documentation type that is to be generated and export it for
+# the doxygen Makefile
+ifneq (,$(filter doc,$(MAKECMDGOALS)))
+  DOCUMENTATION_FORMAT := html
+else ifneq (,$(filter doc-%,$(MAKECMDGOALS)))
+  DOCUMENTATION_FORMAT := $(patsubst doc-%,%,$(filter doc-%, $(MAKECMDGOALS)))
+endif
 
-.PHONY: doc
-doc: $(DOCUMENTATION_FORMAT)
+# Check that the doxygen version is not too old to avoid
+# certain bugs that were fixed in later revisions. Especially
+# Debian-based distributions tend to have very old versions.
+DOXYGEN_MIN_VERSION = 1.14.0
+
+# Strip the commit hash that is sometimes present after the
+# version number.
+DOXYGEN_VERSION = $(shell doxygen --version | cut -d ' ' -f1)
+
+# include color echo macros
+include $(RIOTMAKE)/utils/ansi.mk
+include $(RIOTMAKE)/color.inc.mk
+
+.PHONY: doc doc-man doc-latex
+doc doc-man doc-latex: $(DOCUMENTATION_FORMAT)
+	@if [ "`{ echo "$(DOXYGEN_MIN_VERSION)"; echo "$(DOXYGEN_VERSION)"; } | \
+		sort -V | head -n1`" != "$(DOXYGEN_MIN_VERSION)" ]; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Warning: Doxygen version $(DOXYGEN_VERSION) is too old." \
+		"It is recommended to use at least version $(DOXYGEN_MIN_VERSION)" \
+		"to avoid incorrectly formatted output.$(COLOR_RESET)"; \
+	fi
 
 # by marking html as phony we force make to re-run Doxygen even if the directory exists.
 .PHONY: html
@@ -28,6 +55,8 @@ check: src/changelog.md src/coc.md src/governance.md
 .PHONY: man
 man: src/changelog.md src/coc.md src/governance.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
+	@echo ""
+	@echo "RIOT documentation successfully generated at file://$(RIOTBASE)/doc/doxygen/man/man3"
 
 src/css/riot.css: src/css/riot.less src/css/variables.less
 	@$(LESSC) $< $@
@@ -48,6 +77,8 @@ src/governance.md: ../../GOVERNANCE.md
 .PHONY:
 latex: src/changelog.md src/coc.md src/governance.md
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
+	@echo ""
+	@echo "RIOT documentation successfully generated at file://$(RIOTBASE)/doc/doxygen/latex/index.tex"
 
 clean:
 	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md src/coc.md src/governance.md


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Doxygen receives a lot of updates (and lately some updates that fixed issues found when generating the RIOT documentation) and releases happen more recently than a couple of years ago.
Unfortunately some (*cough* debian based) distributions don't update it. Ubuntu 22.04 LTS for example will probably be forever stuck at version 1.9.1 from 2021.

To avoid issues with malformatted documentation due to an outdated Doxygen version, this PR adds a warning if the Doxygen version is too old. The warning is delibrately put at the end of the Make process due to the wall of warnings generated by Doxygen.

Request for comments: I don't think the solution with `awk` is super pretty, but doing stuff like that with Make is quite annoying. Another option would be to have a dedicated `check_version.sh`.

It probably makes sense to wait with merging this until after Doxygen 1.14.0 is released. But on the other hand, the note is still valid, even before the release 🤷‍♂️ 

<hr/>

During the development of this PR, some issues with the build system surfaced regarding the `doc` and `doc-` targets. The `buildsystem: fix execution of doc targets` commit fixes that. The details are outlined in issue #21278.

### Testing procedure

Run `make doc` on a machine with a current release version of Doxygen (1.14.0 is not released yet) and observe the output:
```
~/RIOTstuff/riot-debug-doc/RIOT/doc/doxygen$ make doc
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
...
/home/cbuec/RIOTstuff/riot-debug-doc/RIOT/sys/include/net/gnrc/netif/pktq/type.h:13: warning: Potential recursion while resolving \ref command!
/home/cbuec/RIOTstuff/riot-debug-doc/RIOT/sys/include/net/gnrc/netif/pktq.h:14: warning: Potential recursion while resolving \ref command!

RIOT documentation successfully generated at file:///home/cbuec/RIOTstuff/riot-debug-doc/RIOT/doc/doxygen/html/index.html
Warning: Doxygen version 1.12.0 is too old. It is recommended to use at least version 1.14.0 to avoid incorrectly formatted output.
```

If you updated to the latest master branch of Doxygen and compiled it yourself, the warning will not be generated:
```
~/RIOTstuff/riot-debug-doc/RIOT/doc/doxygen$ make doc
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
...
/home/cbuec/RIOTstuff/riot-debug-doc/RIOT/sys/include/net/gnrc/netif/pktq/type.h:13: warning: Potential recursion while resolving \ref command!
/home/cbuec/RIOTstuff/riot-debug-doc/RIOT/sys/include/net/gnrc/netif/pktq.h:14: warning: Potential recursion while resolving \ref command!

RIOT documentation successfully generated at file:///home/cbuec/RIOTstuff/riot-debug-doc/RIOT/doc/doxygen/html/index.html
```

<hr/>

The second part of this PR can be tested with the following commands:

Current master:
```
~/RIOTstuff/riot-vanilla/RIOT$ make -C examples/basic/hello-world doc
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/basic/hello-world'
make -BC /home/cbuec/RIOTstuff/riot-vanilla/RIOT doc
*** ERROR: unrecognized target "makefiles/color.inc.mk"

Welcome to RIOT - The friendly OS for IoT!

You executed 'make' from the base directory.
Usually, you should run 'make' in your application's directory instead.

Please see our Quick Start Guide at:
    https://doc.riot-os.org/getting-started.html
You can ask questions or discuss with other users on our forum:
    https://forum.riot-os.org

Available targets for the RIOT base directory include:
 generate-{board,driver,example,module,pkg,test,features}
 info-{applications,boards,emulated-boards} info-applications-supported-boards
 print-versions
 clean distclean pkg-clean
 doc doc-{man,latex}

==> tl;dr Try running:
    cd examples/basic/default
    make BOARD=<INSERT_BOARD_NAME>
make[1]: *** [Makefile:83: makefiles/color.inc.mk] Error 1
make: *** [/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/basic/hello-world/../../../Makefile.include:883: doc] Error 2
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/basic/hello-world'
```

```
~/RIOTstuff/riot-vanilla/RIOT$ make -C examples/basic/hello-world doc-man
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/basic/hello-world'
make: *** No rule to make target 'doc-man'.  Stop.
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/basic/hello-world'
```

This PR:
```
~/RIOTstuff/riot-debug-doc/RIOT$ make -C examples/basic/hello-world doc
make: Entering directory '/home/cbuec/RIOTstuff/riot-debug-doc/RIOT/examples/basic/hello-world'
make -C /home/cbuec/RIOTstuff/riot-debug-doc/RIOT doc
"make" -BC doc/doxygen doc
awk 'NR == 1 {print $0,"{#coc}"} NR > 1 {print $0}' ../../CODE_OF_CONDUCT.md > src/coc.md
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
...
```

```
~/RIOTstuff/riot-debug-doc/RIOT$ make -C examples/basic/hello-world doc-man
make: Entering directory '/home/cbuec/RIOTstuff/riot-debug-doc/RIOT/examples/basic/hello-world'
make -C /home/cbuec/RIOTstuff/riot-debug-doc/RIOT doc-man
"make" -BC doc/doxygen doc-man
awk 'NR == 1 {print $0,"{#coc}"} NR > 1 {print $0}' ../../CODE_OF_CONDUCT.md > src/coc.md
( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
...
```

### Issues/PRs references

Related to the work in #21106 and #21220.

Fixes #21278.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
