### PR TITLE
boards/feather-m0*: Update Default Bootloader to UF2

### DIFF
--- a/boards/feather-m0-lora/doc.md
+++ b/boards/feather-m0-lora/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_feather-m0-lora Adafruit Feather M0 LoRa
 @ingroup     boards
 @brief       Support for the Adafruit Feather M0 LoRa.
@@ -8,5 +7,3 @@
 The board is a variant of the @ref boards_feather-m0 board with
 a LoRa module on board. Please see @ref boards_feather-m0 for detailed
 information about the board and how to flash it.
-
-*/

--- a/boards/feather-m0-wifi/doc.md
+++ b/boards/feather-m0-wifi/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_feather-m0-wifi Adafruit Feather M0 WiFi
 @ingroup     boards
 @brief       Support for the Adafruit Feather M0 WiFi.
@@ -8,5 +7,3 @@
 The board is a variant of the @ref boards_feather-m0 board with
 a WiFi interface on board. Please see @ref boards_feather-m0 for detailed
 information about the board and how to flash it.
-
-*/

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -1,3 +1,8 @@
+# Boards after around 2018 use the more modern UF2 bootloader.
+# Comment out for the old BOSSA bootloader or upgrade to
+# the UF2 bootloader.
+CFLAGS += -DBOOTLOADER_UF2
+
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model

--- a/boards/feather-m0/doc.md
+++ b/boards/feather-m0/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_feather-m0 Adafruit Feather M0
 @ingroup     boards
 @brief       Support for the Adafruit Feather M0.
@@ -94,4 +93,3 @@ STDIO of RIOT is directly available over the USB port.
 The `TERM_DELAY` environment variable can be used to add a delay (in second)
 before opening the serial terminal. The default value is 2s which should be
 enough in most of the situation.
- */

--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -52,6 +52,14 @@ Example with `hello-world` application:
           bootloader mode by double tapping the reset button before running the
           flash command.
 
+@note     Adafruit changed the bootloader from the old BOSSA bootloader to the
+          more modern UF2 bootloader around 2018. If you have a very old board,
+          it is recommended to upgrade the bootloader to the new UF2
+          bootloader. Otherwise the bootloader has to be enabled by double
+          tapping the reset button.<br/>
+          Upgrade instructions can be found at Adafruit:
+          https://learn.adafruit.com/installing-circuitpython-on-samd21-boards/installing-the-uf2-bootloader
+
 ### Using the WiFi interface
 
 To enable the WiFi interface of the Feather M0 WiFi variant of the board


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Around 2018, Adafruit changed the default bootloader from BOSSA to UF2. While the UF2 bootloader is backwards compatible to the BOSSA protocol, the Double Tap Magic Number has to be changed. In RIOT this can be done with the `BOOTLOADER_UF2` flag.
I wrote everything about this in great detail in #17722.

The note got extended to notify users about the change in case they have a very old board.
![image](https://github.com/user-attachments/assets/2c6b0393-11d9-489c-b4a5-145528ff712a)

Furthermore I used the opportunity to change the `doc.txt` files to Markdown format as discussed in #21220.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check the documentation.

Make sure the flashing works now for an application of your choice.
```
~/riot-feather/RIOT/tests/sys/shell$ BOARD=feather-m0 make flash -j12
Building application "tests_shell" for "feather-m0" with CPU "samd21".

stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 2
"make" -C /home/chris/riot-feather/RIOT/pkg/cmsis/ 
...
"make" -C /home/chris/riot-feather/RIOT/sys/usb/usbus/cdc/acm
   text	   data	    bss	    dec	    hex	filename
  25844	    176	   4892	  30912	   78c0	/home/chris/riot-feather/RIOT/tests/sys/shell/bin/feather-m0/tests_shell.elf
/home/chris/riot-feather/RIOT/dist/tools/bossa-1.9/bossac -p /dev/ttyACM0 -o 0x2000 -e -i -w -v -b -R /home/chris/riot-feather/RIOT/tests/sys/shell/bin/feather-m0/tests_shell.bin
Device       : ATSAMD21x18
Version      : v1.1 [Arduino:XYZ] Apr 10 2020 13:40:42
Address      : 0x0
Pages        : 4096
Page Size    : 64 bytes
Total Size   : 256KB
Planes       : 1
Lock Regions : 16
Locked       : none
Security     : false
BOD          : true
BOR          : true
Erase flash

Done in 0.842 seconds
Write 26020 bytes to flash (407 pages)
[==============================] 100% (407/407 pages)
Done in 0.155 seconds
Verify 26020 bytes of flash
[==============================] 100% (407/407 pages)
Verify successful
Done in 0.278 seconds
Set boot flash true
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #17722.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
