### PR TITLE
gnrc_pktshark: add new module to pretty-print network traffic

### DIFF
--- a/examples/networking/gnrc/networking/Makefile
+++ b/examples/networking/gnrc/networking/Makefile
@@ -21,6 +21,7 @@ USEMODULE += auto_init_gnrc_rpl
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += shell_cmd_gnrc_udp
+USEMODULE += gnrc_pktshark_default
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_cmds_default

--- a/examples/networking/gnrc/networking/Makefile.ci
+++ b/examples/networking/gnrc/networking/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    airfy-beacon \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
@@ -7,15 +8,18 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atmega8 \
-    atxmega-a3bu-xplained \
     blackpill-stm32f103c8 \
     bluepill-stm32f030c8 \
     bluepill-stm32f103c8 \
+    calliope-mini \
     derfmega128 \
     i-nucleo-lrwan1 \
+    im880b \
+    microbit \
     microduino-corerf \
     msb-430 \
     msb-430h \
+    nrf51dongle \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \
@@ -43,6 +47,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32mp157c-dk2 \
     telosb \
     weact-g030f6 \
+    yunjia-nrf51822 \
     z1 \
     zigduino \
     #

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -188,6 +188,17 @@ PSEUDOMODULES += gnrc_nettype_udp
 ## @}
 ## @}
 
+## @addtogroup	net_gnrc_pktshark
+## @{
+## @brief	Enable parsing of IPv6 encapsulated IPv4 packets
+PSEUDOMODULES += gnrc_pktshark_4in6
+## @brief	Enable parsing of CoAP messages
+PSEUDOMODULES += gnrc_pktshark_coap
+## @brief	Enable parsing of default protocols
+PSEUDOMODULES += gnrc_pktshark_default
+## @brief	Enable parsing of ICMPv6 messages
+PSEUDOMODULES += gnrc_pktshark_icmpv6
+## @}
 
 PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
@@ -403,6 +414,7 @@ PSEUDOMODULES += shell_cmd_gnrc_netif
 PSEUDOMODULES += shell_cmd_gnrc_netif_lora
 PSEUDOMODULES += shell_cmd_gnrc_netif_lorawan
 PSEUDOMODULES += shell_cmd_gnrc_pktbuf
+PSEUDOMODULES += shell_cmd_gnrc_pktshark
 PSEUDOMODULES += shell_cmd_gnrc_rpl
 PSEUDOMODULES += shell_cmd_gnrc_sixlowpan_ctx
 PSEUDOMODULES += shell_cmd_gnrc_sixlowpan_frag_stats

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -763,6 +763,14 @@ void ipv6_addr_print(const ipv6_addr_t *addr);
 void ipv6_addrs_print(const ipv6_addr_t *addrs, size_t num,
                       const char *separator);
 
+/**
+ * @brief Print IPv6 prefix to stdout
+ *
+ * @param[in]   prefix  Pointer to ipv6_addr_t to print
+ * @param[in]   bits    IPv6 prefix bits
+ */
+void ipv6_prefix_print(const ipv6_addr_t *prefix, uint8_t bits);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -844,7 +844,9 @@ static inline bool sock_udp_ep_is_v6(const sock_udp_ep_t *ep)
 #endif
 }
 
+#if defined(MODULE_SOCK) || defined(MODULE_SOCK_UDP)
 #include "sock_types.h"
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -73,6 +73,9 @@ endif
 ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
   DIRS += pktdump
 endif
+ifneq (,$(filter gnrc_pktshark,$(USEMODULE)))
+  DIRS += pktshark
+endif
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   DIRS += routing/rpl
 endif

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -441,6 +441,36 @@ ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
   USEMODULE += od
 endif
 
+ifneq (,$(filter gnrc_pktshark_%,$(USEMODULE)))
+  USEMODULE += gnrc_pktshark
+endif
+
+ifneq (,$(filter gnrc_pktshark_default,$(USEMODULE)))
+  USEMODULE += gnrc_pktshark_coap
+  USEMODULE += gnrc_pktshark_icmpv6
+  USEMODULE += gnrc_pktshark_4in6
+endif
+
+ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
+  USEMODULE += shell_cmd_gnrc_pktshark
+endif
+
+ifneq (,$(filter auto_init_gnrc_pktshark,$(USEMODULE)))
+  USEMODULE += gnrc_pktshark
+endif
+
+ifneq (,$(filter gnrc_pktshark,$(USEMODULE)))
+  USEMODULE += ipv4_addr
+  USEMODULE += fmt
+  USEMODULE += gnrc_pktbuf
+  USEMODULE += od
+endif
+
+ifneq (,$(filter gnrc_pktshark_coap,$(USEMODULE)))
+  USEMODULE += nanocoap
+  USEMODULE += sock_udp
+endif
+
 ifneq (,$(filter gnrc,$(USEMODULE)))
   USEMODULE += gnrc_netapi
   USEMODULE += gnrc_netreg

--- a/sys/net/gnrc/pktshark/Makefile
+++ b/sys/net/gnrc/pktshark/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_pktshark
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktshark/gnrc_pktshark.c
+++ b/sys/net/gnrc/pktshark/gnrc_pktshark.c
@@ -1,0 +1,766 @@
+/*
+ * Copyright (C) 2025 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc_pktshark
+ * @{
+ *
+ * @file
+ * @brief       Pretty-printer for packages sent/received via netapi
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#include <errno.h>
+#include "auto_init_utils.h"
+#include "auto_init_priorities.h"
+#include "byteorder.h"
+#include "fmt.h"
+#include "thread.h"
+#include "msg.h"
+#include "net/gnrc.h"
+#include "net/icmpv6.h"
+#include "net/ipv6/addr.h"
+#include "net/ipv6/hdr.h"
+#include "net/sixlowpan/nd.h"
+#include "net/tcp.h"
+#include "net/udp.h"
+#include "net/sixlowpan.h"
+#include "net/nanocoap.h"
+#include "net/ipv4/hdr.h"
+#include "od.h"
+#include "shell.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   Default message queue size for the pktshark thread (as exponent of
+ *          2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
+ */
+#ifndef CONFIG_GNRC_PKTSHARK_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_PKTSHARK_MSG_QUEUE_SIZE_EXP  3
+#endif
+/** @} */
+
+/**
+ * @brief   Message queue size for the pktshark thread
+ */
+#ifndef GNRC_PKTSHARK_MSG_QUEUE_SIZE
+#define GNRC_PKTSHARK_MSG_QUEUE_SIZE  (1 << CONFIG_GNRC_PKTSHARK_MSG_QUEUE_SIZE_EXP)
+#endif
+
+/**
+ * @brief   Priority of the pktshark thread
+ */
+#ifndef GNRC_PKTSHARK_PRIO
+#define GNRC_PKTSHARK_PRIO               (THREAD_PRIORITY_MAIN - 1)
+#endif
+
+/**
+ * @brief   Stack size used for the pktshark thread
+ */
+#ifndef GNRC_PKTSHARK_STACKSIZE
+#define GNRC_PKTSHARK_STACKSIZE          THREAD_STACKSIZE_MAIN
+#endif
+
+/**
+ * @brief   PID of the pktshark thread
+ */
+static kernel_pid_t gnrc_pktshark_pid = KERNEL_PID_UNDEF;
+
+/**
+ * @brief   Stack for the pktshark thread
+ */
+static char _stack[GNRC_PKTSHARK_STACKSIZE];
+static msg_t _msg_queue[GNRC_PKTSHARK_MSG_QUEUE_SIZE];
+
+/* Iterator for NDP options in a packet */
+#define FOREACH_OPT(ndp_pkt, opt, icmpv6_len) \
+    for (opt = (ndp_opt_t *)(ndp_pkt + 1); \
+         icmpv6_len > 0; \
+         icmpv6_len -= (opt->len << 3), \
+         opt = (ndp_opt_t *)(((uint8_t *)opt) + (opt->len << 3)))
+
+static void _dump_rtr_sol(const ndp_rtr_sol_t *rtr_sol, size_t payload_len)
+{
+    print_str("Router Sol");
+
+    ndp_opt_t *opt;
+    FOREACH_OPT(rtr_sol, opt, payload_len) {
+        switch (opt->type) {
+        case NDP_OPT_SL2A:
+            print_str(" sl2a");
+            break;
+        default:
+            print_str(" opt=");
+            print_u32_dec(opt->type);
+        }
+    }
+}
+
+static void _dump_rtr_adv(const ndp_rtr_adv_t *rtr_adv, size_t payload_len)
+{
+    print_str("Router Adv");
+
+    ndp_opt_t *opt;
+    FOREACH_OPT(rtr_adv, opt, payload_len) {
+        switch (opt->type) {
+        case NDP_OPT_SL2A:
+            print_str(" sl2a");
+            break;
+        case NDP_OPT_MTU:
+            print_str(" mtu=");
+            const ndp_opt_mtu_t *mtuo = (void *)opt;
+            print_u32_dec(byteorder_ntohl(mtuo->mtu));
+            break;
+        case NDP_OPT_PI:
+            print_str("\n\t  pfx[");
+            const ndp_opt_pi_t *pio = (void *)opt;
+            if (pio->flags & NDP_OPT_PI_FLAGS_A) {
+                print_str("A");
+            }
+            if (pio->flags & NDP_OPT_PI_FLAGS_L) {
+                print_str("L");
+            }
+            print_str("]=");
+            ipv6_prefix_print(&pio->prefix, pio->prefix_len);
+            print_str(" ltime={");
+            print_u32_dec(byteorder_ntohl(pio->valid_ltime));
+            print_str(", ");
+            print_u32_dec(byteorder_ntohl(pio->pref_ltime));
+            print_str("}");
+            break;
+        case NDP_OPT_RI:
+            print_str("\n\t  route=");
+            const ndp_opt_ri_t *rio = (void *)opt;
+            ipv6_prefix_print(&rio->prefix, rio->prefix_len);
+            print_str(" ltime=");
+            print_u32_dec(byteorder_ntohl(rio->route_ltime));
+            break;
+        case NDP_OPT_6CTX:
+            print_str("\n\t  6ctx[");
+            const sixlowpan_nd_opt_6ctx_t *sixco = (void *)opt;
+            print_u32_dec(sixlowpan_nd_opt_6ctx_get_cid(sixco));
+            print_str("]=");
+            ipv6_prefix_print((ipv6_addr_t *)(sixco + 1), sixco->ctx_len);
+            print_str(" ltime=");
+            print_u32_dec(60 * byteorder_ntohs(sixco->ltime));
+            break;
+        case NDP_OPT_ABR:
+            print_str(" abr");
+            break;
+        case NDP_OPT_RDNSS:
+            print_str("\n\t  dns=");
+            const ndp_opt_rdnss_impl_t *rdnsso = (void *)opt;
+            unsigned addrs_num = (rdnsso->len - 1) / 2;
+            for (unsigned i = 0; i < addrs_num; i++) {
+                ipv6_addr_print(&rdnsso->addrs[i]);
+                if (i + 1 < addrs_num) {
+                    print_str(", ");
+                }
+            }
+            print_str(" ltime=");
+            print_u32_dec(byteorder_ntohl(rdnsso->ltime));
+            break;
+        default:
+            print_str(" opt=");
+            print_u32_dec(opt->type);
+        }
+    }
+
+    if (rtr_adv->ltime.u16) {
+        print_str("\n\t  default, ltime=");
+        print_u32_dec(byteorder_ntohs(rtr_adv->ltime));
+    }
+}
+
+static void _dump_nbr_sol(const ndp_nbr_sol_t *nbr_sol, size_t payload_len)
+{
+    print_str("Neighbor Sol (");
+    ipv6_addr_print(&nbr_sol->tgt);
+    print_str(")");
+
+    ndp_opt_t *opt;
+    FOREACH_OPT(nbr_sol, opt, payload_len) {
+        switch (opt->type) {
+        case NDP_OPT_SL2A:
+            print_str(" sl2a");
+            break;
+        case NDP_OPT_AR:
+            print_str(" ar");
+            break;
+        default:
+            print_str(" opt=");
+            print_u32_dec(opt->type);
+        }
+    }
+}
+
+static void _dump_nbr_adv(const ndp_nbr_adv_t *nbr_adv, size_t payload_len)
+{
+    print_str("Neighbor Adv (");
+    if (nbr_adv->flags & NDP_NBR_ADV_FLAGS_R) {
+        print_str("R");
+    }
+    if (nbr_adv->flags & NDP_NBR_ADV_FLAGS_S) {
+        print_str("S");
+    }
+    if (nbr_adv->flags & NDP_NBR_ADV_FLAGS_O) {
+        print_str("O");
+    }
+    if (nbr_adv->flags & NDP_NBR_ADV_FLAGS_MASK) {
+        print_str(" ");
+    }
+    ipv6_addr_print(&nbr_adv->tgt);
+    print_str(")");
+
+    ndp_opt_t *opt;
+    FOREACH_OPT(nbr_adv, opt, payload_len) {
+        switch (opt->type) {
+        case NDP_OPT_TL2A:
+            print_str(" tl2a");
+            break;
+        case NDP_OPT_AR:
+            print_str(" ar");
+            break;
+        default:
+            print_str(" opt=");
+            print_u32_dec(opt->type);
+        }
+    }
+}
+
+static void _dump_icmpv6_echo(const icmpv6_echo_t *echo, size_t payload_len)
+{
+    print_str(" seq=");
+    print_u32_dec(byteorder_ntohs(echo->seq));
+    print_str(" (");
+    print_u32_dec(payload_len);
+    print_str(" bytes)\n");
+}
+
+static void _dump_icmpv6(const icmpv6_hdr_t *hdr, size_t payload_len)
+{
+    print_str("\n\tICMPv6 ");
+
+    if (!IS_USED(MODULE_GNRC_PKTSHARK_ICMPV6)) {
+        goto _default;
+    }
+
+    switch (hdr->type) {
+    case ICMPV6_DST_UNR:
+        print_str("Destination unreachable");
+        break;
+    case ICMPV6_PKT_TOO_BIG:
+        print_str("Packet too big");
+        break;
+    case ICMPV6_TIME_EXC:
+        print_str("Timeout");
+        break;
+    case ICMPV6_ECHO_REQ:
+        print_str("PING");
+        _dump_icmpv6_echo((icmpv6_echo_t *)hdr, payload_len - sizeof(icmpv6_echo_t));
+        break;
+    case ICMPV6_ECHO_REP:
+        print_str("PONG");
+        _dump_icmpv6_echo((icmpv6_echo_t *)hdr, payload_len - sizeof(icmpv6_echo_t));
+        break;
+    case ICMPV6_RTR_SOL:
+        _dump_rtr_sol((ndp_rtr_sol_t *)hdr, payload_len - sizeof(ndp_rtr_sol_t));
+        break;
+    case ICMPV6_RTR_ADV:
+        _dump_rtr_adv((ndp_rtr_adv_t *)hdr, payload_len - sizeof(ndp_rtr_adv_t));
+        break;
+    case ICMPV6_NBR_SOL:
+        _dump_nbr_sol((ndp_nbr_sol_t *)hdr, payload_len - sizeof(ndp_nbr_sol_t));
+        break;
+    case ICMPV6_NBR_ADV:
+        _dump_nbr_adv((ndp_nbr_adv_t *)hdr, payload_len - sizeof(ndp_nbr_adv_t));
+        break;
+    case 143:
+        print_str("Multicast Listener Report v2");
+        break;
+    default:
+    _default:
+        print_str("msg type ");
+        print_u32_dec(hdr->type);
+        print_str(" (");
+        print_u32_dec(payload_len);
+        print_str(" bytes)\n");
+    }
+    print_str("\n");
+}
+
+static void _print_coap_block(coap_pkt_t *pkt, uint16_t option)
+{
+    coap_block1_t block;
+    coap_get_block(pkt, &block, option);
+
+    if (option == COAP_OPT_BLOCK1) {
+        print_str(" B1[");
+    } else {
+        print_str(" B2[");
+    }
+    print_u32_dec(block.blknum);
+    print_str(".");
+    print_u32_dec(coap_szx2size(block.szx));
+
+    if (block.more) {
+        print_str(" M");
+    }
+
+    print_str("]");
+}
+
+static void _print_coap_format(unsigned format)
+{
+    print_str(" ");
+    switch (format) {
+    case COAP_FORMAT_TEXT:
+        print_str("text/plain");
+        break;
+    case COAP_FORMAT_LINK:
+        print_str("application/link-format");
+        break;
+    case COAP_FORMAT_JSON:
+        print_str("application/json");
+        break;
+    case COAP_FORMAT_CBOR:
+        print_str("application/cbor");
+        break;
+    case COAP_FORMAT_OCTET:
+        print_str("application/octet-stream");
+        break;
+    default:
+        print_str("fmt=");
+        print_u32_dec(format);
+        break;
+    }
+}
+
+static bool _dump_coap(const void *buf, size_t len)
+{
+    if (!IS_USED(MODULE_GNRC_PKTSHARK_COAP)) {
+        return false;
+    }
+
+    coap_pkt_t pkt;
+    if (coap_parse(&pkt, (void *)buf, len) < 0) {
+        return false;
+    }
+
+    static const char *coap_method_str[] = {
+        [COAP_CODE_EMPTY]  = "EMPTY",
+        [COAP_METHOD_GET]  = "GET",
+        [COAP_METHOD_POST] = "POST",
+        [COAP_METHOD_PUT]  = "PUT",
+        [COAP_METHOD_DELETE] = "DELETE",
+    };
+
+    static const char *coap_type_str[] = {
+        [COAP_TYPE_CON] = "CON",
+        [COAP_TYPE_NON] = "NON",
+        [COAP_TYPE_ACK] = "ACK",
+        [COAP_TYPE_RST] = "RST",
+    };
+
+    print_str("\tCoAP ");
+    print_str(coap_type_str[coap_get_type(&pkt)]);
+    print_str(" ");
+    if (coap_get_code_class(&pkt) == 0) {
+        print_str(coap_method_str[coap_get_code_raw(&pkt)]);
+    } else {
+        print_u32_dec(coap_get_code_decimal(&pkt));
+    }
+
+    print_str(" id=");
+    print_u32_dec(coap_get_id(&pkt));
+
+    if (coap_get_token_len(&pkt)) {
+        print_str(" tkn=");
+        print_bytes_hex(coap_get_token(&pkt), coap_get_token_len(&pkt));
+    }
+
+    /* parse CoAP options */
+    coap_optpos_t opt = {
+        .offset = coap_get_total_hdr_len(&pkt)
+    };
+    uint8_t *value;
+    unsigned old_opt = 0;
+    int opt_len;
+    bool print_fmt = false;
+    while ((opt_len = coap_opt_get_next(&pkt, &opt, &value, false)) >= 0) {
+        const bool first_of_a_kind = opt.opt_num != old_opt;
+        switch (opt.opt_num) {
+        case COAP_OPT_URI_HOST:
+            print_str(" host=");
+            print((char *)value, opt_len);
+            break;
+        case COAP_OPT_URI_PATH:
+            if (first_of_a_kind) {
+                print_str(" ");
+            }
+            print_str("/");
+            print((char *)value, opt_len);
+            break;
+        case COAP_OPT_URI_QUERY:
+            print_str(first_of_a_kind ? "?" : "&");
+            print((char *)value, opt_len);
+            break;
+        case COAP_OPT_CONTENT_FORMAT:
+            print_fmt = true;
+            break;
+        case COAP_OPT_BLOCK1:
+        case COAP_OPT_BLOCK2:
+            _print_coap_block(&pkt, opt.opt_num);
+            break;
+        case COAP_OPT_NO_RESPONSE:
+            print_str(" no-resp");
+            break;
+        case COAP_OPT_OBSERVE:
+            print_str(" obs=");
+            print_bytes_hex(value, opt_len);
+            break;
+        case COAP_OPT_ETAG:
+            print_str(" etag=");
+            print_bytes_hex(value, opt_len);
+            break;
+        case COAP_OPT_REQUEST_TAG:
+            print_str(" rtag=");
+            print_bytes_hex(value, opt_len);
+            break;
+        default:
+            print_str(" opt=");
+            print_u32_dec(opt.opt_num);
+            break;
+        }
+        old_opt = opt.opt_num;
+    }
+
+    if (print_fmt) {
+        _print_coap_format(coap_get_content_type(&pkt));
+    }
+
+    print_str(" (");
+    print_u32_dec(pkt.payload_len);
+    print_str(" bytes)\n");
+
+    return true;
+}
+
+static bool _try_parse_udp(uint16_t port, const void *payload, size_t payload_len)
+{
+    switch (port) {
+    case COAP_PORT:
+        if (_dump_coap(payload, payload_len)) {
+            return true;
+        }
+        break;
+    }
+
+    return false;
+}
+
+static void _dump_udp(const udp_hdr_t *hdr, size_t payload_len, gnrc_pktsnip_t *next)
+{
+    const void *payload;
+
+    if (next) {
+        payload     = next->data;
+        payload_len = next->size;
+    } else {
+        payload = hdr + 1;
+    }
+
+    print_str("  UDP [");
+    print_u32_dec(byteorder_ntohs(hdr->src_port));
+    print_str(" -> ");
+    print_u32_dec(byteorder_ntohs(hdr->dst_port));
+    print_str("]\n");
+
+    /* we can be either client or server */
+    if (_try_parse_udp(byteorder_ntohs(hdr->src_port), payload, payload_len) ||
+        _try_parse_udp(byteorder_ntohs(hdr->dst_port), payload, payload_len)) {
+        return;
+    }
+
+    print_str("\t(");
+    print_u32_dec(payload_len);
+    print_str(" bytes)\n");
+}
+
+static void _dump_tcp(const tcp_hdr_t *hdr, size_t payload_len)
+{
+    print_str("  TCP [");
+    print_u32_dec(byteorder_ntohs(hdr->src_port));
+    print_str(" -> ");
+    print_u32_dec(byteorder_ntohs(hdr->dst_port));
+    print_str("]\n");
+
+    /* TODO: parse TCP protocols */
+
+    printf("\t(");
+    print_u32_dec(payload_len);
+    print_str(" bytes)\n");
+}
+
+static bool _is_extopt(uint8_t next_header)
+{
+    switch (next_header) {
+    case PROTNUM_IPV6_EXT_HOPOPT:
+        print_str(" hopopt");
+        return true;
+    case PROTNUM_IPV6_EXT_RH:
+        print_str(" rh");
+        return true;
+    case PROTNUM_IPV6_EXT_FRAG:
+        print_str(" frag");
+        return true;
+    case PROTNUM_IPV6_EXT_ESP:
+        print_str(" esp");
+        return true;
+    case PROTNUM_IPV6_EXT_AH:
+        print_str(" ah");
+        return true;
+    case PROTNUM_IPV6_EXT_DST:
+        print_str(" dst");
+        return true;
+    case PROTNUM_IPV6_EXT_MOB:
+        print_str(" mob");
+        return true;
+    }
+
+    return false;
+}
+
+static void _dump_ipv4(const ipv4_hdr_t *hdr, size_t payload_len, bool rx)
+{
+    const ipv4_addr_t *me = rx ? &hdr->dst : &hdr->src;
+    const ipv4_addr_t *they = rx ? &hdr->src : &hdr->dst;
+    const void *payload = hdr + 1;
+
+    ipv4_addr_print(me);
+    print_str(rx ? " <= " : " => ");
+    ipv4_addr_print(they);
+
+    switch (hdr->protocol) {
+    case PROTNUM_UDP:
+        _dump_udp(payload, payload_len - sizeof(udp_hdr_t), NULL);
+        break;
+    case PROTNUM_TCP:
+        _dump_tcp(payload, payload_len - sizeof(tcp_hdr_t));
+        break;
+    default:
+        print_str("\tunknown protocol ");
+        print_u32_dec(hdr->protocol);
+        printf(" (");
+        print_u32_dec(payload_len);
+        print_str(" bytes)\n");
+    }
+}
+
+static void _dump_ipv6(const ipv6_hdr_t *hdr, size_t payload_len, bool rx)
+{
+    const ipv6_addr_t *me = rx ? &hdr->dst : &hdr->src;
+    const ipv6_addr_t *they = rx ? &hdr->src : &hdr->dst;
+
+    ipv6_addr_print(me);
+    print_str(rx ? " <= " : " => ");
+    ipv6_addr_print(they);
+
+    if (payload_len) {
+        const void *payload = hdr + 1;
+        uint8_t next_header = hdr->nh;
+
+        /* skip IPv6 extension headers */
+        while (_is_extopt(next_header)) {
+            const struct {
+                uint8_t nh;
+                uint8_t opt_len;
+            } *extopt = payload;
+
+            next_header = extopt->nh;
+            payload = (uint8_t *)payload + extopt->opt_len + 8;
+            payload_len -= extopt->opt_len + 8;
+        }
+
+        switch (next_header) {
+        case PROTNUM_ICMPV6:
+            _dump_icmpv6(payload, payload_len);
+            break;
+        case PROTNUM_UDP:
+            _dump_udp(payload, payload_len - sizeof(udp_hdr_t), NULL);
+            break;
+        case PROTNUM_TCP:
+            _dump_tcp(payload, payload_len - sizeof(tcp_hdr_t));
+            break;
+        case PROTNUM_IPV4:
+            if (IS_USED(MODULE_GNRC_PKTSHARK_4IN6)) {
+                /* 4in6 */
+                print_str("\n\t");
+                _dump_ipv4(payload, payload_len - sizeof(ipv4_hdr_t), rx);
+                break;
+            }
+            /* fall-through */
+        default:
+            print_str("\tunknown next header type ");
+            print_u32_dec(next_header);
+            print_str("\n");
+        }
+    }
+}
+
+static void _dump_snip(gnrc_pktsnip_t *pkt, bool rx)
+{
+    if (pkt->type <= 0) {
+        return;
+    }
+
+    switch (pkt->type) {
+    case GNRC_NETTYPE_IPV6:
+        _dump_ipv6(pkt->data, pkt->size - sizeof(ipv6_hdr_t), rx);
+        break;
+#ifdef MODULE_GNRC_NETTYPE_ICMPV6
+    case GNRC_NETTYPE_ICMPV6:
+        _dump_icmpv6(pkt->data, pkt->size);
+        break;
+#endif
+#ifdef MODULE_GNRC_NETTYPE_UDP
+    case GNRC_NETTYPE_UDP:
+        _dump_udp(pkt->data, pkt->size - sizeof(udp_hdr_t), pkt->next);
+        break;
+#endif
+#ifdef MODULE_GNRC_NETTYPE_TCP
+    case GNRC_NETTYPE_TCP:
+        _dump_tcp(pkt->data, pkt->size - sizeof(tcp_hdr_t));
+        break;
+#endif
+    default:
+        print_str("\tunknown type ");
+        print_u32_dec(pkt->type);
+        print_str("\n");
+        break;
+    }
+}
+
+static void _dump(gnrc_pktsnip_t *pkt, bool rx)
+{
+    gnrc_pktsnip_t *snip = pkt;
+    gnrc_pktsnip_t *netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
+
+    print_str("\n");
+    if (netif) {
+        gnrc_netif_hdr_t *hdr = netif->data;
+        print_u32_dec(hdr->if_pid);
+        print_str(") ");
+    }
+
+    while (snip != NULL) {
+        _dump_snip(snip, rx);
+        snip = snip->next;
+    }
+
+    gnrc_pktbuf_release(pkt);
+}
+
+static void *_eventloop(void *arg)
+{
+    (void)arg;
+    msg_t msg, reply;
+
+    /* setup the message queue */
+    msg_init_queue(_msg_queue, GNRC_PKTSHARK_MSG_QUEUE_SIZE);
+
+    reply.content.value = (uint32_t)(-ENOTSUP);
+    reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+
+    while (1) {
+        msg_receive(&msg);
+
+        switch (msg.type) {
+            case GNRC_NETAPI_MSG_TYPE_RCV:
+                _dump(msg.content.ptr, true);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_SND:
+                _dump(msg.content.ptr, false);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_GET:
+            case GNRC_NETAPI_MSG_TYPE_SET:
+                msg_reply(&msg, &reply);
+                break;
+            default:
+                puts("gnrc_pktshark: received something unexpected");
+                break;
+        }
+    }
+
+    /* never reached */
+    return NULL;
+}
+
+static void _set_capture(bool enable)
+{
+    static gnrc_netreg_entry_t dump;
+
+    assume(gnrc_pktshark_pid != KERNEL_PID_UNDEF);
+    if (enable && !dump.target.pid) {
+        dump = (gnrc_netreg_entry_t) {
+            .target = {
+                .pid = gnrc_pktshark_pid,
+            },
+            .demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL,
+        };
+        gnrc_netreg_register(GNRC_NETTYPE_IPV6, &dump);
+    } else if (!enable && dump.target.pid) {
+        gnrc_netreg_unregister(GNRC_NETTYPE_IPV6, &dump);
+        dump.target.pid = 0;
+    }
+}
+
+static void gnrc_pktshark_init(void)
+{
+    gnrc_pktshark_pid = thread_create(_stack, sizeof(_stack), GNRC_PKTSHARK_PRIO, 0,
+                                      _eventloop, NULL, "pktshark");
+    if (IS_USED(MODULE_AUTO_INIT_GNRC_PKTSHARK)) {
+        _set_capture(true);
+    }
+}
+AUTO_INIT(gnrc_pktshark_init, AUTO_INIT_PRIO_MOD_GNRC_PKTSHARK);
+
+#ifdef MODULE_SHELL_CMD_GNRC_PKTSHARK
+static int cmd_pktshark(int argc, char **argv)
+{
+    if (argc < 2) {
+        goto usage;
+    }
+
+    if (!strcmp("off", argv[1])) {
+        _set_capture(0);
+        return 0;
+    }
+    if (!strcmp("on", argv[1])) {
+        _set_capture(1);
+        return 0;
+    }
+
+usage:
+    printf("usage: %s <on|off>\n", argv[0]);
+    return -1;
+}
+SHELL_COMMAND(pktshark, "pretty-print network traffic", cmd_pktshark);
+#endif

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -173,6 +173,19 @@ void ipv6_addrs_print(const ipv6_addr_t *addrs, size_t num,
     }
 }
 
+void ipv6_prefix_print(const ipv6_addr_t *pfx, uint8_t bits)
+{
+    ipv6_addr_t tmp = {};
+    ipv6_addr_init_prefix(&tmp, pfx, bits);
+    ipv6_addr_print(&tmp);
+    if (IS_USED(MODULE_FMT)) {
+        print_str("/");
+        print_u32_dec(bits);
+    } else {
+        printf("/%u", bits);
+    }
+}
+
 /**
  * @}
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Ever wondered what's going on on your system traffic wise but found `gnrc_pktdump` way too noisy and at the same time quite terse to use?

This adds a new module `gnrc_pktshark` that works just like `gnrc_pktdump`, but will only print (parsed) meta-data of packets.

Currently it's mostly just parsing and printing CoAP traffic, but it should be easy to add printers for other packets when the need arises to look deeper into them.

The idea is to have something like the `tcpdump` CLI output, just two lines per packet.

### Testing procedure

Just enable the `auto_init_gnrc_pktshark` module to auto-start it.
Alternatively, just enable the `gnrc_pktshark` module and enable/disable it with `pktshark on`/`pktshark off` at run-time.

```
2025-03-11 15:39:33,739 # fe80::7cd6:cdbb:77d4:d67e ⇒ ff02::2
2025-03-11 15:39:33,739 # 	ICMPv6 Router Sol
2025-03-11 15:39:33,739 # 
2025-03-11 15:39:33,740 # fe80::7cd6:cdbb:77d4:d67e ⇒ ff02::1a
2025-03-11 15:39:33,740 # 	ICMPv6 msg type 155 (4 bytes)
2025-03-11 15:39:33,740 # 
2025-03-11 15:39:33,741 # fe80::7cd6:cdbb:77d4:d67e ⇐ fe80::a4bd:21e5:ff5c:aec6
2025-03-11 15:39:33,741 # 	ICMPv6 Router Adv sl2a abr
2025-03-11 15:39:33,741 # 	  pfx[A]=2001:db8::/64 ltime={65518, 65518}
2025-03-11 15:39:33,741 # 	  6ctx[0]=2001:db8::/64 ltime=65520
2025-03-11 15:39:33,741 # 	  dns=2620:fe::fe ltime=4294966296
2025-03-11 15:39:33,741 # 	  default, ltime=1800
2025-03-11 15:39:33,741 # 
2025-03-11 15:39:33,742 # 2001:db8::7cd6:cdbb:77d4:d67e ⇒ fe80::a4bd:21e5:ff5c:aec6
2025-03-11 15:39:33,742 # 	ICMPv6 Neighbor Sol (fe80::a4bd:21e5:ff5c:aec6)
2025-03-11 15:39:33,742 # 
2025-03-11 15:39:33,742 # 2001:db8::7cd6:cdbb:77d4:d67e ⇐ 2001:db8::a4bd:21e5:ff5c:aec6
2025-03-11 15:39:33,742 # 	ICMPv6 Neighbor Adv (RS fe80::a4bd:21e5:ff5c:aec6) ar
2025-03-11 15:39:37,740 # 
2025-03-11 15:39:37,741 # 2001:db8::7cd6:cdbb:77d4:d67e ⇐ 2001:db8::a4bd:21e5:ff5c:aec6
2025-03-11 15:39:37,742 # 	ICMPv6 Neighbor Sol (2001:db8::7cd6:cdbb:77d4:d67e) sl2a
2025-03-11 15:39:37,742 # 
2025-03-11 15:39:37,742 # :: ⇒ 2001:db8::a4bd:21e5:ff5c:aec6
2025-03-11 15:39:37,742 # 	ICMPv6 Neighbor Adv (S 2001:db8::7cd6:cdbb:77d4:d67e)

2025-03-11 15:42:18,975 # ncget coap://[fdea:dbee:f::1]/
2025-03-11 15:42:18,976 # 
2025-03-11 15:42:18,977 # :: ⇒ fdea:dbee:f::1  UDP [59821 ↣ 5683]
2025-03-11 15:42:18,977 # 	CoAP CON GET id=15406 B2[0.64] (0 bytes)
2025-03-11 15:42:18,990 # 
2025-03-11 15:42:18,991 # 2001:db8::e87c:540d:fe83:ef65 ⇐ fdea:dbee:f::1  UDP [5683 ↣ 59821]
2025-03-11 15:42:18,991 # 	CoAP ACK 205 id=15406 opt=4 B2[0.64 M] application/link-format (64 bytes)
2025-03-11 15:42:18,992 # /.cargo/
2025-03-11 15:42:18,992 # /Makefile.features
2025-03-11 15:42:18,992 # /uncrustify-riot.cfg
2025-03-11 15:42:18,992 # 
2025-03-11 15:42:18,992 # :: ⇒ fdea:dbee:f::1  UDP [59821 ↣ 5683]
2025-03-11 15:42:18,993 # 	CoAP CON GET id=15407 B2[1.64] (0 bytes)
2025-03-11 15:42:21,872 # 
2025-03-11 15:42:21,874 # :: ⇒ fdea:dbee:f::1  UDP [59821 ↣ 5683]
2025-03-11 15:42:21,875 # 	CoAP CON GET id=15407 B2[1.64] (0 bytes)
2025-03-11 15:42:21,882 # 
2025-03-11 15:42:21,884 # 2001:db8::e87c:540d:fe83:ef65 ⇐ fdea:dbee:f::1  UDP [5683 ↣ 59821]
2025-03-11 15:42:21,886 # 	CoAP ACK 205 id=15407 opt=4 B2[1.64 M] application/link-format (64 bytes)
2025-03-11 15:42:21,887 # /kconfigs/
2025-03-11 15:42:21,887 # /.editorconfig
2025-03-11 15:42:21,889 # /Makefile.base
2025-03-11 15:42:21,889 # 
2025-03-11 15:42:21,890 # :: ⇒ fdea:dbee:f::1  UDP [59821 ↣ 5683]
2025-03-11 15:42:21,894 # 	CoAP CON GET id=15408 B2[2.64] (0 bytes)
2025-03-11 15:42:21,895 # 
2025-03-11 15:42:21,896 # 2001:db8::e87c:540d:fe83:ef65 ⇐ fdea:dbee:f::1  UDP [5683 ↣ 59821]
2025-03-11 15:42:21,898 # 	CoAP ACK 205 id=15407 opt=4 B2[1.64 M] application/link-format (64 bytes)
2025-03-11 15:42:21,898 # 
2025-03-11 15:42:21,899 # 2001:db8::e87c:540d:fe83:ef65 ⇐ fdea:dbee:f::1  UDP [5683 ↣ 59821]
2025-03-11 15:42:21,900 # 	CoAP ACK 205 id=15407 opt=4 B2[1.64 M] application/link-format (64 bytes)

```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
