### PR TITLE
gnrc_netif_raw: don't interpret content if rawmode is enabled

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -94,15 +94,17 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         gnrc_pktbuf_realloc_data(pkt, nread);
     }
 
-    switch (_get_version(pkt->data)) {
+    if (!(netif->flags & GNRC_NETIF_FLAGS_RAWMODE)) {
+        switch (_get_version(pkt->data)) {
 #ifdef MODULE_GNRC_IPV6
-    case IP_VERSION6:
-        pkt->type = GNRC_NETTYPE_IPV6;
-        break;
+        case IP_VERSION6:
+            pkt->type = GNRC_NETTYPE_IPV6;
+            break;
 #endif
-    default:
-        /* leave UNDEF */
-        break;
+        default:
+            /* leave UNDEF */
+            break;
+        }
     }
     return pkt;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

set the interface into raw mode with e.g. `ifconfig <iface> set raw` or via netapi by setting `NETOPT_RAWMODE`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
