### PR TITLE
cpu/samd5x: add enable pin to CAN configuration

### DIFF
--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -77,13 +77,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name ATA6561 STANDBY pin definition
- * @{
- */
-#define AT6561_STBY_PIN            GPIO_PIN(PC, 13)
-/** @} */
-
-/**
  * @name MTD configuration
  * @{
  */

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -107,6 +107,13 @@ static const tc32_conf_t timer_config[] = {
 /** @} */
 
 /**
+ * @brief ATA6561 STANDBY pin definition
+ * @{
+ */
+#define AT6561_STBY_PIN            GPIO_PIN(PC, 13)
+/** @} */
+
+/**
  * @name CAN configuration
  * @{
  */
@@ -117,6 +124,9 @@ static const can_conf_t candev_conf[] = {
         .rx_pin = GPIO_PIN(PB, 13),
         .tx_pin = GPIO_PIN(PB, 12),
         .gclk_src = SAM0_GCLK_PERIPH,
+        .enable_pin = AT6561_STBY_PIN,
+        .enable_pin_mode = GPIO_OUT,
+        .enable_pin_active_low = true,
     }
 };
 

--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -95,8 +95,21 @@ typedef struct {
     gpio_t rx_pin;
     /** CAN Tx pin */
     gpio_t tx_pin;
+    /** CAN transceiver enable pin */
+    gpio_t enable_pin;
+    /** GPIO mode to use for @ref can_conf_t::enable_pin */
+    gpio_mode_t enable_pin_mode;
     /** GCLK source supplying the CAN controller */
     uint8_t gclk_src;
+    /**
+     * @brief Whether @ref can_conf_t::enable_pin is active-low
+     *
+     * If `true`, @ref can_conf_t::enable_pin is active-low will be set to
+     * LOW when active and HIGH when inactive. If `false`,
+     *  @ref can_conf_t::enable_pin will be set HIGH when active and LOW when
+     * inactive.
+     */
+     bool enable_pin_active_low;
 } can_conf_t;
 #define HAVE_CAN_CONF_T
 

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -352,20 +352,27 @@ void can_init(can_t *dev, const can_conf_t *conf)
 static void _dump_msg_ram_section(can_t *dev)
 {
     puts("start address|\tsize of section");
-    printf("Standard filters|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.std_filter),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.std_filter)));
-    printf("Extended filters|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.ext_filter),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.ext_filter)));
-    printf("Rx FIFO 0|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.rx_fifo_0),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.rx_fifo_0)));
-    printf("Rx FIFO 1|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.rx_fifo_1),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.rx_fifo_1)));
-    printf("Rx buffer|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.rx_buffer),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.rx_buffer)));
-    printf("Tx event FIFO|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.tx_event_fifo),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.tx_event_fifo)));
-    printf("Tx buffer|\t0x%08lx|\t%lu\n", (uint32_t)(dev->msg_ram_conf.tx_fifo_queue),
-                                        (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.tx_fifo_queue)));
+    printf("Standard filters|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+           (uint32_t)(dev->msg_ram_conf.std_filter),
+           (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.std_filter)));
+    printf("Extended filters|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+           (uint32_t)(dev->msg_ram_conf.ext_filter),
+           (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.ext_filter)));
+    printf("Rx FIFO 0|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+           (uint32_t)(dev->msg_ram_conf.rx_fifo_0),
+           (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.rx_fifo_0)));
+    printf("Rx FIFO 1|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+           (uint32_t)(dev->msg_ram_conf.rx_fifo_1),
+           (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.rx_fifo_1)));
+    printf("Rx buffer|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+            (uint32_t)(dev->msg_ram_conf.rx_buffer),
+            (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.rx_buffer)));
+    printf("Tx event FIFO|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+            (uint32_t)(dev->msg_ram_conf.tx_event_fifo),
+            (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.tx_event_fifo)));
+    printf("Tx buffer|\t0x%08" PRIx32 "|\t%" PRIu32 "\n",
+            (uint32_t)(dev->msg_ram_conf.tx_fifo_queue),
+            (uint32_t)(ARRAY_SIZE(dev->msg_ram_conf.tx_fifo_queue)));
 }
 
 static int _init(candev_t *candev)
@@ -592,9 +599,9 @@ static int _set_filter(candev_t *candev, const struct can_filter *filter)
         dev->msg_ram_conf.ext_filter[idx].XIDFE_1.reg |= CAN_XIDFE_1_EFT(CANDEV_SAMD5X_CLASSIC_FILTER);
         dev->msg_ram_conf.ext_filter[idx].XIDFE_0.reg |= CAN_XIDFE_0_EFID1(filter->can_id);
         dev->msg_ram_conf.ext_filter[idx].XIDFE_1.reg |= CAN_XIDFE_1_EFID2(filter->can_mask & CAN_EFF_MASK);
-        DEBUG("Extended filter element N°%d: F0 = 0x%08lx, F1 = 0x%08lx\n", idx,
-                                    (uint32_t)(dev->msg_ram_conf.ext_filter[idx].XIDFE_0.reg),
-                                    (uint32_t)(dev->msg_ram_conf.ext_filter[idx].XIDFE_1.reg));
+        DEBUG("Extended filter element N°%d: F0 = 0x%08" PRIx32 ", F1 = 0x%08" PRIx32 "\n",
+              idx, (uint32_t)(dev->msg_ram_conf.ext_filter[idx].XIDFE_0.reg),
+              (uint32_t)(dev->msg_ram_conf.ext_filter[idx].XIDFE_1.reg));
         _set_mode(dev->conf->can, MODE_INIT);
         /* Reject all extended frames that are not matching the filters applied */
         dev->conf->can->GFC.reg |= CAN_GFC_ANFE((uint32_t)CAN_REJECT);
@@ -632,8 +639,8 @@ static int _set_filter(candev_t *candev, const struct can_filter *filter)
                                                       | CAN_SIDFE_0_SFID1(filter->can_id & CAN_SFF_MASK)
                                                       | CAN_SIDFE_0_SFID2(filter->can_mask & CAN_SFF_MASK);
 
-        DEBUG("Standard filter element N°%d: S0 = 0x%08lx\n", idx,
-                                    (uint32_t)(dev->msg_ram_conf.std_filter[idx].SIDFE_0.reg));
+        DEBUG("Standard filter element N°%d: S0 = 0x%08" PRIx32 "\n",
+              (int)idx, (uint32_t)(dev->msg_ram_conf.std_filter[idx].SIDFE_0.reg));
         _set_mode(dev->conf->can, MODE_INIT);
         /* Reject all standard frames that are not matching the filters applied */
         dev->conf->can->GFC.reg |= CAN_GFC_ANFS((uint32_t)CAN_REJECT);
@@ -760,7 +767,7 @@ static void _isr(candev_t *candev)
     can_t *dev = container_of(candev, can_t, candev);
 
     uint32_t irq_reg = dev->conf->can->IR.reg;
-    DEBUG("isr: IR reg = 0x%08lx\n", irq_reg);
+    DEBUG("isr: IR reg = 0x%08" PRIx32 "\n", irq_reg);
 
     /* Interrupt triggered due to reception of CAN frame on Rx_FIFO_0 */
     if (irq_reg & CAN_IR_RF0N) {

--- a/tests/drivers/candev/main.c
+++ b/tests/drivers/candev/main.c
@@ -19,8 +19,6 @@
  * @}
  */
 
-#include <assert.h>
-#include <errno.h>
 #include <isrpipe.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -283,10 +281,6 @@ int main(void)
     puts("Initializing CAN periph device");
     can_init(&periph_dev, &(candev_conf[0]));
     candev = &(periph_dev.candev);
-#if defined(BOARD_SAME54_XPRO)
-    gpio_init(AT6561_STBY_PIN, GPIO_OUT);
-    gpio_clear(AT6561_STBY_PIN);
-#endif
 #elif defined(MODULE_MCP2515)
     puts("Initializing MCP2515");
     candev_mcp2515_init(&mcp2515_dev, &candev_mcp2515_conf[0]);


### PR DESCRIPTION
### Contribution description

This adds an enable pin to the SAMD5x CAN configuration and adds automatic power management to the CAN driver. For the SAME54-XPRO the enable pin configuration has been added and an ugly per-app hack has been dropped.

### Testing procedure

CAN communication on the SAME54-XPRO should still work:

```
make BOARD=same54-xpro -C tests/drivers/candev
```

Then use the shell to send and receive CAN frames. A [canable](https://canable.io/) or similar connected to the CAN bus of the SAME54-XPRO should be able to receive the frames send, and send frames that should be received by the shell app.

### Issues/PRs references

Supersedes https://github.com/RIOT-OS/RIOT/pull/21203 with a better approach.