### PR TITLE
pkg/uwb-dw1000: Move `doc.txt` to `doc.md`, use the correct include type

### DIFF
--- a/pkg/uwb-dw1000/doc.md
+++ b/pkg/uwb-dw1000/doc.md
@@ -1,0 +1,6 @@
+@defgroup pkg_uwb_dw1000 Driver implementation for the uwb-core driver for Decawave DW1000 transceiver
+@ingroup  pkg
+@brief    uwb-core driver for Decawave DW1000 transceiver
+@see      https://github.com/Decawave/uwb-dw1000
+
+@includedoc pkg/uwb-dw1000/README.md

--- a/pkg/uwb-dw1000/doc.txt
+++ b/pkg/uwb-dw1000/doc.txt
@@ -1,8 +1,0 @@
-/**
- * @defgroup pkg_uwb_dw1000 Driver implementation for the uwb-core driver for Decawave DW1000 transceiver
- * @ingroup  pkg
- * @brief    uwb-core driver for Decawave DW1000 transceiver
- * @see      https://github.com/Decawave/uwb-dw1000
- *
- * @include pkg/uwb-dw1000/README.md
- */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR applies the migration from `doc.txt` to `doc.md` discussed in #21220.
Also it fixes the include, which showed the included `README.md` as a text/code block instead of properly parsing the Markdown.

Current master:
![Screenshot 2025-03-12 230602](https://github.com/user-attachments/assets/93239af2-0457-4f20-855b-0585e4663eb9)


With this PR:
![Screenshot 2025-03-12 230535](https://github.com/user-attachments/assets/dbe76030-f164-4ee8-aefc-427e39ce402c)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build the documentation and check that it looks alright.
NOTE: The Workflow CI still uses Doxygen 1.9.1, which does not handle the `includedoc` command properly, so the Markdown file is still not recognized.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

The include was corrected in #20440 (my second PR in RIOT actually :D ), but it still used the wrong include type (and Doxygen version < 1.10.0 did not successfully include Markdown files anyway).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
