### PR TITLE
boards: introduce `stdio_default`

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -2,6 +2,11 @@
 -include $(APPDIR)/Makefile.board.dep
 -include $(APPDIR)/Makefile.$(TOOLCHAIN).dep
 
+# select default stdio provider if no other is selected
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_default
+endif
+
 # include board dependencies
 -include $(BOARDDIR)/Makefile.dep
 

--- a/boards/common/esp32s3/stdio_esp32s3_default.dep.mk
+++ b/boards/common/esp32s3/stdio_esp32s3_default.dep.mk
@@ -1,0 +1,19 @@
+ifneq (,$(filter stdio_default,$(USEMODULE)))
+  ifneq (,$(filter usbus,$(USEMODULE)))
+    USEMODULE += stdio_cdc_acm
+    FEATURES_REQUIRED += highlevel_stdio
+  else ifneq (,$(filter tinyusb_device,$(USEMODULE)))
+    USEMODULE += stdio_tinyusb_cdc_acm
+    FEATURES_REQUIRED += highlevel_stdio
+  else
+    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+    # and neither USBUS nor tinyusb_device are used
+    USEMODULE += stdio_usb_serial_jtag
+  endif
+  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+  # since there should be a CDC ACM interface in any case. This is necessary,
+  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+  # was previously used.
+  USEMODULE += usb_board_reset
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
+endif

--- a/boards/common/makefiles/stdio_cdc_acm.dep.mk
+++ b/boards/common/makefiles/stdio_cdc_acm.dep.mk
@@ -1,4 +1,4 @@
-ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   ifneq (,$(filter tinyusb_device,$(USEMODULE))$(filter tinyusb,$(USEPKG)))
     # Use stdio_tinyusb_cdc_acm only if no other stdio is requested explicitly
     # and tinyusb_device is used for any other reason

--- a/boards/common/makefiles/stdio_tinyusb_cdc_acm.dep.mk
+++ b/boards/common/makefiles/stdio_tinyusb_cdc_acm.dep.mk
@@ -1,4 +1,4 @@
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   # Use stdio_tinyusb_cdc_acm only if no other stdio is requested explicitly.
   # and usbus is used for any other reason
   ifneq (,$(filter usbus,$(USEMODULE)))

--- a/boards/esp32c3-wemos-mini/Makefile.dep
+++ b/boards/esp32c3-wemos-mini/Makefile.dep
@@ -1,4 +1,4 @@
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_usb_serial_jtag
 endif
 

--- a/boards/esp32s3-box/Makefile.dep
+++ b/boards/esp32s3-box/Makefile.dep
@@ -1,13 +1,15 @@
-ifeq (,$(filter stdio_% slipdev_stdio usbus usbus% tinyusb_device,$(USEMODULE)))
-  # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-  # and neither USBUS nor tinyusb_device are used
-  USEMODULE += stdio_usb_serial_jtag
-  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-  # since there should be a CDC ACM interface in any case. This is necessary,
-  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-  # was previously used.
-  USEMODULE += usb_board_reset
-  # include $(RIOTMAKE)/tools/usb_board_reset.mk
+ifneq (,$(filter stdio_default,$(USEMODULE)))
+  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
+    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+    # and neither USBUS nor tinyusb_device are used
+    USEMODULE += stdio_usb_serial_jtag
+    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+    # since there should be a CDC ACM interface in any case. This is necessary,
+    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+    # was previously used.
+    USEMODULE += usb_board_reset
+    # include $(RIOTMAKE)/tools/usb_board_reset.mk
+  endif
 endif
 
 ifneq (,$(filter disp_dev,$(USEMODULE)))

--- a/boards/esp32s3-box/Makefile.dep
+++ b/boards/esp32s3-box/Makefile.dep
@@ -1,17 +1,3 @@
-ifneq (,$(filter stdio_default,$(USEMODULE)))
-  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
-    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-    # and neither USBUS nor tinyusb_device are used
-    USEMODULE += stdio_usb_serial_jtag
-    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-    # since there should be a CDC ACM interface in any case. This is necessary,
-    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-    # was previously used.
-    USEMODULE += usb_board_reset
-    # include $(RIOTMAKE)/tools/usb_board_reset.mk
-  endif
-endif
-
 ifneq (,$(filter disp_dev,$(USEMODULE)))
   USEMODULE += ili9341
 endif
@@ -20,5 +6,5 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep
-include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/esp32s3-pros3/Makefile.dep
+++ b/boards/esp32s3-pros3/Makefile.dep
@@ -1,20 +1,6 @@
-ifneq (,$(filter stdio_default,$(USEMODULE)))
-  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
-    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-    # and neither USBUS nor tinyusb_device are used
-    USEMODULE += stdio_usb_serial_jtag
-    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-    # since there should be a CDC ACM interface in any case. This is necessary,
-    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-    # was previously used.
-    USEMODULE += usb_board_reset
-    include $(RIOTMAKE)/tools/usb_board_reset.mk
-  endif
-endif
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep
-include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/esp32s3-pros3/Makefile.dep
+++ b/boards/esp32s3-pros3/Makefile.dep
@@ -1,13 +1,15 @@
-ifeq (,$(filter stdio_% slipdev_stdio usbus usbus% tinyusb_device,$(USEMODULE)))
-  # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-  # and neither USBUS nor tinyusb_device are used
-  USEMODULE += stdio_usb_serial_jtag
-  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-  # since there should be a CDC ACM interface in any case. This is necessary,
-  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-  # was previously used.
-  USEMODULE += usb_board_reset
-  include $(RIOTMAKE)/tools/usb_board_reset.mk
+ifneq (,$(filter stdio_default,$(USEMODULE)))
+  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
+    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+    # and neither USBUS nor tinyusb_device are used
+    USEMODULE += stdio_usb_serial_jtag
+    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+    # since there should be a CDC ACM interface in any case. This is necessary,
+    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+    # was previously used.
+    USEMODULE += usb_board_reset
+    include $(RIOTMAKE)/tools/usb_board_reset.mk
+  endif
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))

--- a/boards/esp32s3-usb-otg/Makefile.dep
+++ b/boards/esp32s3-usb-otg/Makefile.dep
@@ -1,13 +1,15 @@
-ifeq (,$(filter stdio_% slipdev_stdio usbus usbus% tinyusb_device,$(USEMODULE)))
-  # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-  # and neither USBUS nor tinyusb_device are used
-  USEMODULE += stdio_usb_serial_jtag
-  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-  # since there should be a CDC ACM interface in any case. This is necessary,
-  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-  # was previously used.
-  USEMODULE += usb_board_reset
-  include $(RIOTMAKE)/tools/usb_board_reset.mk
+ifneq (,$(filter stdio_default,$(USEMODULE)))
+  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
+    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+    # and neither USBUS nor tinyusb_device are used
+    USEMODULE += stdio_usb_serial_jtag
+    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+    # since there should be a CDC ACM interface in any case. This is necessary,
+    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+    # was previously used.
+    USEMODULE += usb_board_reset
+    include $(RIOTMAKE)/tools/usb_board_reset.mk
+  endif
 endif
 
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep

--- a/boards/esp32s3-usb-otg/Makefile.dep
+++ b/boards/esp32s3-usb-otg/Makefile.dep
@@ -1,19 +1,5 @@
-ifneq (,$(filter stdio_default,$(USEMODULE)))
-  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
-    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-    # and neither USBUS nor tinyusb_device are used
-    USEMODULE += stdio_usb_serial_jtag
-    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-    # since there should be a CDC ACM interface in any case. This is necessary,
-    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-    # was previously used.
-    USEMODULE += usb_board_reset
-    include $(RIOTMAKE)/tools/usb_board_reset.mk
-  endif
-endif
-
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep
-include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
 
 # default to using fatfs on SD card
 ifneq (,$(filter vfs_default,$(USEMODULE)))

--- a/boards/esp32s3-wt32-sc01-plus/Makefile.dep
+++ b/boards/esp32s3-wt32-sc01-plus/Makefile.dep
@@ -1,19 +1,5 @@
-ifneq (,$(filter stdio_default,$(USEMODULE)))
-  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
-    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-    # and neither USBUS nor tinyusb_device are used
-    USEMODULE += stdio_usb_serial_jtag
-    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-    # since there should be a CDC ACM interface in any case. This is necessary,
-    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-    # was previously used.
-    USEMODULE += usb_board_reset
-    # include $(RIOTMAKE)/tools/usb_board_reset.mk
-  endif
-endif
-
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep
-include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
 
 # default to using fatfs on SD card
 ifneq (,$(filter vfs_default,$(USEMODULE)))

--- a/boards/esp32s3-wt32-sc01-plus/Makefile.dep
+++ b/boards/esp32s3-wt32-sc01-plus/Makefile.dep
@@ -1,13 +1,15 @@
-ifeq (,$(filter stdio_% slipdev_stdio usbus usbus% tinyusb_device,$(USEMODULE)))
-  # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
-  # and neither USBUS nor tinyusb_device are used
-  USEMODULE += stdio_usb_serial_jtag
-  # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
-  # since there should be a CDC ACM interface in any case. This is necessary,
-  # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
-  # was previously used.
-  USEMODULE += usb_board_reset
-  # include $(RIOTMAKE)/tools/usb_board_reset.mk
+ifneq (,$(filter stdio_default,$(USEMODULE)))
+  ifeq (,$(filter usbus usbus% tinyusb_device,$(USEMODULE)))
+    # Use stdio_usb_serial_jtag if no other stdio is requested explicitly
+    # and neither USBUS nor tinyusb_device are used
+    USEMODULE += stdio_usb_serial_jtag
+    # Even if only stdio_usb_serial_jtag is enabled, usb_board_reset is enabled
+    # since there should be a CDC ACM interface in any case. This is necessary,
+    # for example, to reset the board if stdio_cdc_acm or stdio_tinyusb_cdc_acm
+    # was previously used.
+    USEMODULE += usb_board_reset
+    # include $(RIOTMAKE)/tools/usb_board_reset.mk
+  endif
 endif
 
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep

--- a/boards/hamilton/Makefile.dep
+++ b/boards/hamilton/Makefile.dep
@@ -14,6 +14,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 # Use Segger's RTT unless another stdio_% is already used
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_rtt
 endif

--- a/boards/hip-badge/Makefile.dep
+++ b/boards/hip-badge/Makefile.dep
@@ -1,4 +1,4 @@
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_usb_serial_jtag
 endif
 

--- a/boards/pinetime/Makefile.dep
+++ b/boards/pinetime/Makefile.dep
@@ -1,5 +1,5 @@
 # Use Segger's RTT unless another stdio_% is already used
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_rtt
 endif
 

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -5,7 +5,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 # Use Segger's RTT unless another stdio_% is already used
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_rtt
 endif
 

--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -5,7 +5,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 # Use Segger's RTT unless another stdio_% is already used
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_rtt
 endif
 

--- a/cpu/arm7tdmi_gba/Makefile
+++ b/cpu/arm7tdmi_gba/Makefile
@@ -4,7 +4,7 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 
 DIRS = $(RIOTCPU)/arm7_common
 
-ifneq (,$(filter stdio_%,$(USEMODULE)))
+ifneq (,$(filter stdio_fb,$(USEMODULE)))
   DIRS += stdio_fb
 endif
 

--- a/cpu/arm7tdmi_gba/Makefile.dep
+++ b/cpu/arm7tdmi_gba/Makefile.dep
@@ -1,6 +1,6 @@
 USEMODULE += arm7_common
 
-ifeq (,$(filter stdio_%,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_fb
 endif
 

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -13,7 +13,7 @@ else
   endif
 endif
 
-ifeq (,$(filter stdio_%,$(USEMODULE)))
+ifneq (,$(filter stdio_default,$(USEMODULE)))
   USEMODULE += stdio_native
 endif
 

--- a/examples/networking/misc/telnet_server/Makefile
+++ b/examples/networking/misc/telnet_server/Makefile
@@ -34,6 +34,9 @@ USEMODULE += ps
 # Include the telnet server
 USEMODULE += stdio_telnet
 
+# select a 2nd stdio method
+USEMODULE += stdio_default
+
 # Enable faster re-connects
 CFLAGS += -DCONFIG_GNRC_TCP_EXPERIMENTAL_DYN_MSL_EN=1
 

--- a/examples/networking/misc/telnet_server/main.c
+++ b/examples/networking/misc/telnet_server/main.c
@@ -79,7 +79,6 @@ int main(void)
 
     /* start shell */
     printf("All up, awaiting connection on port %u\n", CONFIG_TELNET_PORT);
-    puts("Local shell disabled");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -488,6 +488,13 @@ PSEUDOMODULES += soft_uart_modecfg
 PSEUDOMODULES += stdin
 PSEUDOMODULES += stdio_available
 PSEUDOMODULES += stdio_cdc_acm
+## @defgroup sys_stdio_default	Default STDIO provider
+## @ingroup sys_stdio
+## @{
+## This module selects the default STDIO method of a given board.
+## It will be enabled by default if no other stdio method is selected.
+PSEUDOMODULES += stdio_default
+## @}
 PSEUDOMODULES += stdio_dispatch
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_nimble_debug

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -33,7 +33,7 @@ ifneq (,$(filter stdin,$(USEMODULE)))
   USEMODULE += isrpipe
 endif
 
-ifneq (1, $(words $(filter $(STDIO_MODULES),$(USEMODULE))))
+ifneq (1, $(words $(sort $(filter $(STDIO_MODULES),$(USEMODULE)))))
   USEMODULE += stdio_dispatch
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Much like `netdev_default` or `vfs_default`, this adds a pseudo-module `stdio_default` with which boards can define their preferred method of doing stdio.



### Testing procedure

`examples/networking/misc/telnet_server` is updated to select the telnet stdio method in addition to the default stdio method.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
