### PR TITLE
CI: build preview documentation with the same doxygen version as the website

### DIFF
--- a/.github/workflows/preview-documentation.yml
+++ b/.github/workflows/preview-documentation.yml
@@ -1,0 +1,33 @@
+name: preview-documentation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - master
+
+jobs:
+  create-documentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: OlegHahm/docker-doxygen
+          ref: master
+
+      - name: Build Docker image
+        run: docker build -t doxygen-image .
+
+      - name: Create documenation foder
+        run: mkdir docs
+
+      - name: Run Docker container
+        run: docker run -v ./docs:/var/data/html -e GIT_REPO="--branch $GITHUB_BASE_REF $GITHUB_SERVER_URL/$GITHUB_REPOSITORY" --rm doxygen-image /bin/sh -c 'echo $GIT_REPO > /var/data/config/git_repo && cat /var/data/config/git_repo && gen-doxygen'
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: docs


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently the preview documentation (e.g. [here](https://ci.riot-os.org/results/afb2703583b44652a83eebccd77ca365/doc-preview/)) is build with another doxygen version then the website (https://doc.riot-os.org/).  
To deploy the website this Dockerfile is used: [OlegHahm/docker-doxygen](https://github.com/OlegHahm/docker-doxygen), but to build the preview we use the [riot/murdock-scripts:latest](https://github.com/RIOT-OS/murdock-scripts/blob/master/Dockerfile) docker image. 
I think it would be best if both are build with the same image, so that the doxygen version  can be maintained in only one place. Therefor I added a github workflow, that uses the docker-doxygen image to build the documentation and publish it as an artifact.

**Limitations:** currently you can only preview the documentation locally, by downloading and unzipping the artifact. 
I am trying to figure out a good way to provide a preview, that one can view directly in the browser without downloading. (that's why it is in draft) 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

You can check how it would look like in this example PR in my fork: https://github.com/Baertig/RIOT/pull/1
(click on `checks` and then on `preview-documentation`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #21106 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
