### PR TITLE
tests/pkg/relic: add Paillier encryption tests

### DIFF
--- a/tests/pkg/relic/main.c
+++ b/tests/pkg/relic/main.c
@@ -29,6 +29,8 @@ static void setUp(void)
 {
     /* Initialize RELIC */
     TEST_ASSERT_EQUAL_INT(RLC_OK, core_init());
+
+    pc_param_set_any();
 }
 
 static void tearDown(void)
@@ -128,10 +130,80 @@ static void tests_relic_ecdh(void)
 
 }
 
+static void tests_relic_paillier_encryption(void)
+{
+    /*  The following is an example for doing Paillier key pair generation
+        and simple data encryption.
+    */
+    bn_t priv, pub, plain, enc, dec;
+
+    bn_null(priv);
+    bn_new(priv);
+
+    bn_null(pub);
+    bn_new(pub);
+
+    bn_null(plain);
+    bn_new(plain);
+
+    bn_null(enc);
+    bn_new(enc);
+
+    bn_null(dec);
+    bn_new(dec);
+
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_gen(pub, priv, 512));
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("RELIC Paillier - key pair generation successeful\n");
+    printf("private key: ");
+    bn_print(priv);
+    printf("\n");
+    printf("public key:  ");
+    bn_print(pub);
+    printf("\n");
+#endif
+
+    bn_rand(plain, RLC_POS, 510);
+
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_enc(enc, plain, pub, 1));
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("RELIC Paillier -  data encryption successful\n");
+    printf("plain text: ");
+    bn_print(plain);
+    printf("\n");
+    printf("encrypted data:  ");
+    bn_print(enc);
+    printf("\n");
+#endif
+
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_dec(dec, enc, pub, priv, 1));
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("decrypted data: ");
+    bn_print(dec);
+    printf("\n");
+#endif
+
+    TEST_ASSERT_EQUAL_INT(RLC_EQ, bn_cmp(plain, dec));
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("\nRELIC Paillier encryption test successful\n");
+#endif
+
+    bn_free(pub);
+    bn_free(priv);
+    bn_free(plain);
+    bn_free(enc);
+    bn_free(dec);
+}
+
 TestRef tests_relic(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(tests_relic_ecdh)
+        new_TestFixture(tests_relic_ecdh),
+        new_TestFixture(tests_relic_paillier_encryption)
     };
 
     EMB_UNIT_TESTCALLER(RELICTest, setUp, tearDown, fixtures);

--- a/tests/pkg/relic/main.c
+++ b/tests/pkg/relic/main.c
@@ -199,11 +199,117 @@ static void tests_relic_paillier_encryption(void)
     bn_free(dec);
 }
 
+static void tests_relic_paillier_encrypted_addition(void)
+{
+    /*  The following is an example for doing Paillier key pair generation
+        and addition of two encrypted numbers.
+    */
+    bn_t priv, pub, a, b, enc_a, enc_b, dec, tmp, tmp2, sum;
+
+    bn_null(priv);
+    bn_new(priv);
+
+    bn_null(pub);
+    bn_new(pub);
+
+    bn_null(a);
+    bn_new(a);
+
+    bn_null(b);
+    bn_new(b);
+
+    bn_null(enc_a);
+    bn_new(enc_a);
+
+    bn_null(enc_b);
+    bn_new(enc_b);
+
+    bn_null(sum);
+    bn_new(sum);
+
+    bn_null(dec);
+    bn_new(dec);
+
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_gen(pub, priv, 512));
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("\n");
+    printf("RELIC Paillier - key pair generation successeful\n");
+    printf("private key: ");
+    bn_print(priv);
+    printf("\n");
+    printf("public key:  ");
+    bn_print(pub);
+    printf("\n");
+#endif
+
+    bn_rand(a, RLC_POS, 32);
+    bn_rand(b, RLC_POS, 32);
+
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_enc(enc_a, a, pub, 1));
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_enc(enc_b, b, pub, 1));
+
+    bn_add(sum, a, b);
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("RELIC Paillier -  data encryption successful\n");
+    printf("a: ");
+    bn_print(a);
+    printf("\n");
+    printf("encrypted data: ");
+    bn_print(enc_a);
+    printf("\n");
+    printf("b: ");
+    bn_print(b);
+    printf("\n");
+    printf("encrypted data: ");
+    bn_print(enc_b);
+    printf("\n");
+    printf("a + b: ");
+    bn_print(sum);
+    printf("\n");
+#endif
+
+    bn_mul(tmp, enc_a, enc_b);
+    bn_sqr(tmp2, pub);
+    bn_mod(tmp, tmp, tmp2);
+
+    TEST_ASSERT_EQUAL_INT(RLC_OK, cp_ghpe_dec(dec, tmp, pub, priv, 1));
+
+    TEST_ASSERT_EQUAL_INT(RLC_EQ, bn_cmp(sum, dec));
+
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("RELIC Paillier -  addition of encrypted data successful\n");
+    printf("encrypted a+b = ");
+    bn_print(tmp);
+    printf("decrypted a+b: ");
+    bn_print(dec);
+    printf("\n");
+#endif
+
+#if (TEST_RELIC_SHOW_OUTPUT == 1)
+    printf("\nRELIC Paillier encrypted addition test successful\n");
+#endif
+
+    bn_free(pub);
+    bn_free(priv);
+    bn_free(a);
+    bn_free(b);
+    bn_free(enc_a);
+    bn_free(enc_b);
+    bn_free(sum);
+    bn_free(dec);
+    bn_free(tmp);
+    bn_free(tmp2);
+}
+
 TestRef tests_relic(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(tests_relic_ecdh),
-        new_TestFixture(tests_relic_paillier_encryption)
+        new_TestFixture(tests_relic_paillier_encryption),
+        new_TestFixture(tests_relic_paillier_encrypted_addition)
     };
 
     EMB_UNIT_TESTCALLER(RELICTest, setUp, tearDown, fixtures);


### PR DESCRIPTION
### Contribution description

This PR adds two tests to Relic library, concerning Paillier encryption:
- generation of Paillier public key pair and simple encryption and decryption,
- generation of Paillier public key pair, data encryption and addition of encrypted data.

Unfortunately, currently only 512 bit Paillier encryption works - in following weeks I try to figure out why longer keys leads to 
stack smashing. I tested native with 256 MiB of memory and stack smashing error appears. 

### Testing procedure

Run `tests/pkg/relic` and check if all tests are successful.

### Issues/PRs references

None