### PR TITLE
boards/seeedstudio-xiao-nrf52840: configure SAUL LEDs as inverted

### DIFF
--- a/boards/seeedstudio-xiao-nrf52840/include/gpio_params.h
+++ b/boards/seeedstudio-xiao-nrf52840/include/gpio_params.h
@@ -35,19 +35,19 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name  = "LED Red (USR/D11)",
         .pin   = LED0_PIN,
         .mode  = GPIO_OUT,
-        .flags = (SAUL_GPIO_INIT_CLEAR),
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
         .name  = "LED Green (USR/D13)",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
-        .flags = (SAUL_GPIO_INIT_CLEAR),
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
     {
         .name  = "LED Blue (USR/D12)",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
-        .flags = (SAUL_GPIO_INIT_CLEAR),
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
 };
 


### PR DESCRIPTION
### Contribution description

The LEDs on the Seeedstudio XIAO nrf52840 are not configured correctly in SAUL.

### Testing procedure

`make -C examples/basic/default BOARD=seeedstudio-xiao-nrf52840 flash term`

on `master`, the three LED colors (marked as USR) will light up on init, while `saul read {0,1,2}` will return `0`. With this PR, all LEDs will be off on init and match the saul reading.


### Issues/PRs references

Found while testing #21281 
