### PR TITLE
drivers/{mtd_sdmmc,sdmmc}: reinit card

### DIFF
--- a/drivers/mtd_sdmmc/mtd_sdmmc.c
+++ b/drivers/mtd_sdmmc/mtd_sdmmc.c
@@ -41,8 +41,7 @@ static int mtd_sdmmc_init(mtd_dev_t *dev)
     /* get the SDMMC device descriptor from SDMMC peripheral index */
     mtd_sd->sdmmc = sdmmc_get_dev(mtd_sd->sdmmc_idx);
 
-    if ((mtd_sd->sdmmc->init_done == true) ||
-        (sdmmc_card_init(mtd_sd->sdmmc) == 0)) {
+    if (sdmmc_card_init(mtd_sd->sdmmc) == 0) {
         /* erasing whole sectors is handled internally by the card so you can
            delete single blocks (i.e. pages) */
         dev->pages_per_sector = 1;

--- a/drivers/sdmmc/sdmmc.c
+++ b/drivers/sdmmc/sdmmc.c
@@ -338,6 +338,8 @@ int sdmmc_card_init(sdmmc_dev_t *dev)
     assert(dev);
     assert(dev->driver);
 
+    dev->init_done = false;
+
     /* use driver's card_init function if it defines its own */
     if (dev->driver->card_init) {
         return dev->driver->card_init(dev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Do not rely on `init_done` of `sdmmc_dev_t` because it could have been repowered (properly or improperly).

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
