### PR TITLE
sys/bcd: add bcd_buf_from_u32()

### DIFF
--- a/sys/bcd/Makefile
+++ b/sys/bcd/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/bcd/bcd.c
+++ b/sys/bcd/bcd.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_bcd
+ * @{
+ *
+ * @file
+ * @brief       Library to de- and encode binary coded decimals
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "bcd.h"
+#include <errno.h>
+#include <string.h>
+
+static inline uint8_t swap_nibbles(uint8_t b)
+{
+    return (b << 4) | (b >> 4);
+}
+
+int bcd_buf_from_u32(uint32_t val, void *dst, size_t len)
+{
+    uint8_t *tgt = dst;
+    uint8_t hex = 0;
+    uint8_t idx = 0;
+
+    memset(dst, 0, len);
+    len *= 2;
+
+    do {
+        hex <<= 4;
+        hex += val % 10;
+        val /= 10;
+        if (++idx % 2 == 0) {
+            *tgt++ = swap_nibbles(hex);
+            hex = 0;
+        }
+    } while (val && idx <= len);
+
+    if (idx > len) {
+        return -ENOBUFS;
+    }
+
+    if (idx % 2) {
+        *tgt++ = hex;
+    }
+
+    return (uintptr_t)tgt - (uintptr_t)dst;
+}

--- a/sys/include/bcd.h
+++ b/sys/include/bcd.h
@@ -20,6 +20,7 @@
 #ifndef BCD_H
 #define BCD_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -51,6 +52,22 @@ static inline uint8_t bcd_to_byte(uint8_t bcd)
     /* == (10 * (bcd >> 4)) + (bcd & 0xf) */
     return bcd - (6 * (bcd >> 4));
 }
+
+/**
+ * @brief   Convert a decimal value into a BCD buffer.
+ *          (This looks like the decimal integer value when printed as hex)
+ *
+ * This will e.g. turn the value 123 -> 0x123 (decimal: 291)
+ *
+ * @param[in]  val  Decimal value to print
+ * @param[out] dst  Destination buffer
+ * @param[in]  len  Size of the destination buffer
+ *
+ * @return number of bytes written
+ * @return -ENOBUFS if @p dst is not large enough
+ *         In that case the state of @p dst is undefined.
+ */
+int bcd_buf_from_u32(uint32_t val, void *dst, size_t len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -179,6 +179,14 @@ ssize_t strscpy(char *dest, const char *src, size_t count);
  */
 const void *memchk(const void *data, uint8_t c, size_t len);
 
+/**
+ * @brief   Reverse the order of bytes in a buffer
+ *
+ * @param[in, out]  buf     The buffer to reverse
+ * @param[in]       len     Size of the buffer
+ */
+void reverse_buf(void *buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/libc/string.c
+++ b/sys/libc/string.c
@@ -80,4 +80,15 @@ int __swprintf(string_writer_t *sw, FLASH_ATTR const char *restrict format, ...)
     return res;
 }
 
+void reverse_buf(void *buf, size_t len)
+{
+    uint8_t *cur = buf;
+    uint8_t *end = cur + len - 1;
+    while (cur < end) {
+        uint8_t tmp = *cur;
+        *cur++ = *end;
+        *end-- = tmp;
+    }
+}
+
 /** @} */

--- a/tests/unittests/tests-bcd/Makefile.include
+++ b/tests/unittests/tests-bcd/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += bcd

--- a/tests/unittests/tests-bcd/tests-bcd.c
+++ b/tests/unittests/tests-bcd/tests-bcd.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <errno.h>
 #include "embUnit.h"
 
 #include "bcd.h"
@@ -59,6 +60,31 @@ static void test_bcd_to_byte(void)
     TEST_ASSERT_EQUAL_INT(99, bcd_to_byte(0x99));
 }
 
+static void test_bcd_buf_from_u32(void)
+{
+    uint32_t buf = UINT32_MAX; /* test if full buffer gets written */
+
+    TEST_ASSERT_EQUAL_INT(1, bcd_buf_from_u32(0, &buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(0x0, buf);
+
+    TEST_ASSERT_EQUAL_INT(1, bcd_buf_from_u32(12, &buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(0x12, buf);
+
+    TEST_ASSERT_EQUAL_INT(2, bcd_buf_from_u32(123, &buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(0x123, buf);
+
+    TEST_ASSERT_EQUAL_INT(3, bcd_buf_from_u32(123456, &buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(0x123456, buf);
+
+    TEST_ASSERT_EQUAL_INT(4, bcd_buf_from_u32(12345678, &buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(0x12345678, buf);
+
+    TEST_ASSERT_EQUAL_INT(-ENOBUFS, bcd_buf_from_u32(123456789, &buf, sizeof(buf)));
+
+    /* test empty buffer */
+    TEST_ASSERT_EQUAL_INT(-ENOBUFS, bcd_buf_from_u32(0, NULL, 0));
+}
+
 Test *tests_bcd_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -68,6 +94,7 @@ Test *tests_bcd_tests(void)
         new_TestFixture(test_bcd_to_byte__zero),
         new_TestFixture(test_bcd_to_byte__greater_0x99),
         new_TestFixture(test_bcd_to_byte),
+        new_TestFixture(test_bcd_buf_from_u32),
     };
 
     EMB_UNIT_TESTCALLER(bcd_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-libc/tests-libc.c
+++ b/tests/unittests/tests-libc/tests-libc.c
@@ -75,6 +75,22 @@ static void test_libc_memchk(void)
     TEST_ASSERT(memchk(buffer, 0xff, sizeof(buffer)) == &buffer[5]);
 }
 
+static void test_libc_reverse_buf3(void)
+{
+    const char expected[3] = { 3, 2, 1 };
+    char buffer[3] = { 1, 2, 3 };
+    reverse_buf(buffer, sizeof(buffer));
+    TEST_ASSERT(!memcmp(buffer, expected, sizeof(buffer)));
+}
+
+static void test_libc_reverse_buf4(void)
+{
+    const char expected[4] = { 4, 3, 2, 1 };
+    char buffer[4] = { 1, 2, 3, 4 };
+    reverse_buf(buffer, sizeof(buffer));
+    TEST_ASSERT(!memcmp(buffer, expected, sizeof(buffer)));
+}
+
 /**
  * @name    Unit test ensuring `<endian.h>` is provided and correct across
  *          all platforms
@@ -138,6 +154,8 @@ Test *tests_libc_tests(void)
         new_TestFixture(test_libc_strscpy),
         new_TestFixture(test_libc_swprintf),
         new_TestFixture(test_libc_memchk),
+        new_TestFixture(test_libc_reverse_buf3),
+        new_TestFixture(test_libc_reverse_buf4),
         new_TestFixture(test_libc_endian),
     };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds two helper functions to the `string_utils` library:

 - a `reverse_buf()` that inverts the order of bytes in an array
 - a `bcd_buf_from_u32()` that takes a number `a` and calculates a number `a'` so that the hex string representation of `a'` is the same as the decimal string representation of `a`. e.g. ` bcd_buf_from_u32(123)` would produce `0x123`.  


### Testing procedure

This can be used to to generate pretty MAC / IP addresses from decimal serial numbers:

```C
static inline int _get_eui64(uint8_t index, eui64_t *addr)
{
    memset(addr, 0, sizeof(*addr));
    int res = bcd_buf_from_u32(device_get_serial(), addr, sizeof(*addr));
    if (res < 0) {
        return res;
    }
    addr->uint8[res] = index;
    reverse_buf(addr, sizeof(*addr));

    eui64_set_local(addr);
    return 0;
}

```

```
2025-03-20 10:43:11,323 # Iface  8  HWaddr: 17:12  Channel: 0  NID: 0x23  PHY: MR-O-QPSK 
2025-03-20 10:43:11,327 #            chip rate: 1000  rate mode: 2 
2025-03-20 10:43:11,331 #           Long HWaddr: 02:00:00:00:00:00:97:12 
2025-03-20 10:43:11,338 #            TX-Power: 3dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2025-03-20 10:43:11,344 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:2022  MTU:1280  HL:64  RTR  
2025-03-20 10:43:11,346 #           6LO  IPHC  
2025-03-20 10:43:11,349 #           Source address length: 8
2025-03-20 10:43:11,352 #           Link type: wireless
2025-03-20 10:43:11,357 #           inet6 addr: fe80::9712  scope: link  VAL
2025-03-20 10:43:11,361 #           inet6 addr: fd40::9712  scope: global  VAL
2025-03-20 10:43:11,364 #           inet6 group: ff02::2
2025-03-20 10:43:11,367 #           inet6 group: ff02::1
2025-03-20 10:43:11,370 #           inet6 group: ff02::1:ff00:9712
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
