### PR TITLE
pyterm: send SIGINT to the subprocess' child

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -38,8 +38,10 @@ import argparse
 import re
 import codecs
 import platform
+import psutil
 
 from subprocess import Popen, PIPE
+from signal import SIGINT
 
 try:
     serial.Serial
@@ -388,6 +390,14 @@ class SerCmd(cmd.Cmd):
 
         if self.tcp_serial:
             self.ser.close()
+        # When a subprocess has been spawned, we want to send a SIGINT to all
+        # child processes
+        if self.process:
+            parent = psutil.Process(self.ser.pid)
+            children = parent.children(recursive=True)
+            for child in children:
+                os.kill(child.pid, SIGINT)
+            self.ser.send_signal(SIGINT)
         return True
 
     def do_PYTERM_save(self, line):


### PR DESCRIPTION
### Contribution description

Upon terminating pyterm any potentially spawned process (such as RIOT native) should be terminated as well. This could be done via sending a `SIGINT` to these processes.


### Testing procedure

Run any arbitrary RIOT application for RIOT native via `make term` and terminate `pyterm` (via `/exit` or `^C`).

Check if all RIOT native processes have been terminated.


### Issues/PRs references

Fixes #21307