### PR TITLE
boards/nucleo-f746zg: board doc update

### DIFF
--- a/boards/nucleo-f746zg/doc.md
+++ b/boards/nucleo-f746zg/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f746zg STM32 Nucleo-F746ZG
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F746ZG
@@ -47,5 +46,3 @@ make BOARD=nucleo-f746zg PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
       can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-f746zg/doc.txt
+++ b/boards/nucleo-f746zg/doc.txt
@@ -8,6 +8,10 @@
 The Nucleo-F746ZG is a board from ST's Nucleo family supporting ARM Cortex-M7
 STM32F746ZG microcontroller with 320KiB of RAM and 1 MiB of Flash.
 
+## Pinout
+
+@image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the Nucleo-F746ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50%
+
 ## Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.

--- a/boards/nucleo-f746zg/doc.txt
+++ b/boards/nucleo-f746zg/doc.txt
@@ -12,6 +12,29 @@ STM32F746ZG microcontroller with 320KiB of RAM and 1 MiB of Flash.
 
 @image html pinouts/nucleo-f207zg-and-more.svg "Pinout for the Nucleo-F746ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50%
 
+### MCU
+
+| MCU        |    STM32F746ZG      |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M7       |
+| Vendor     | ST Microelectronics |
+| RAM        | 320KiB              |
+| Flash      | 1MiB                |
+| Frequency  | up to 216MHz        |
+| FPU        | yes                 |
+| Timers     | 18 (12x 16-bit, 2x 32, 1x RTC, 1x Systick, 2x Watchdog) |
+| ADC        | 3x 12-bit (24 channels) |
+| UARTs      | 4 (four USARTs/UARTs) |
+| SPIs       | 6                   |
+| CANs       | 2                   |
+| RTC        | 1                   |
+| I2Cs       | 4                   |
+| Vcc        | 1.7V - 3.6V         |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f746zg.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0385-stm32f75xxx-and-stm32f74xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0253-stm32f7-series-and-stm32h7-series-cortexm7-processor-programming-manual-stmicroelectronics.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00244518-stm32-nucleo-144-boards-stmicroelectronics.pdf) |
+
 ## Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.


### PR DESCRIPTION
### Contribution description

This PR updates `nucleo-f746zg` board doc page, by:
- adding board pinout,
- adding MCU table,
- renaming doc.txt to doc.md accordingly to the PR #21255.

### Testing procedure

Generate doc and check if everything looks good:

```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-f746zg.html 
```

### Issues/PRs references

PR #21255