### PR TITLE
sys/shell: always default to CONFIG_SHELL_SHUTDOWN_ON_EXIT=0

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -68,20 +68,9 @@ extern "C" {
  */
 /**
  * @brief Shutdown RIOT on shell exit
- *
- * @note On native platform this option defaults to 1.
  */
 #ifndef CONFIG_SHELL_SHUTDOWN_ON_EXIT
-/* Some systems (e.g Ubuntu 20.04) close stdin on CTRL-D / EOF
- * That means we can't just re-start the shell.
- * Instead terminate RIOT, which is also the behavior a user would
- * expect from a CLI application.
- */
-#  if defined(CPU_NATIVE) && !IS_ACTIVE(MODULE_SHELL_LOCK)
-#    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 1
-#  else
-#    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 0
-#  endif
+#define CONFIG_SHELL_SHUTDOWN_ON_EXIT 0
 #endif
 
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

These days `native` is usually wrapped by `pyterm`. `pyterm` already takes care of handling ^D, so no need to handle this as a special case in `native`.


### Testing procedure

`examples/networking/misc/telnet_server` no longer exits when you press ctrl-d on the remote shell.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
