### PR TITLE
cpu/esp_common: fix dependency resolution for lwIP

### DIFF
--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -44,7 +44,7 @@ ifneq (,$(filter esp_wifi_enterprise,$(USEMODULE)))
 endif
 
 ifneq (,$(filter netdev_default,$(USEMODULE)))
-  ifneq (,$(filter lwip,$(USEMODULE)))
+  ifneq (,$(filter lwip_arp,$(USEMODULE)))
     # for lwip, use esp_wifi as default netdev if no other netdev is enabled
     ifeq (,$(filter esp_eth,$(USEMODULE)))
       USEMODULE += esp_wifi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There is no `lwip` module that gets selected, use `lwip_arp` as that seems to be the part that doesn't like `esp_now` that gets otherwise selected.


### Testing procedure

Compile e.g. `examples/networking/coap/gcoap` with `LWIP_IPV4=1` for any esp* board.
On `master` you will get

```
In file included from /home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:71:0:
/home/benpicco/dev/RIOT/build/pkg/lwip/src/include/lwip/acd.h:97:48: error: 'struct etharp_hdr' declared inside parameter list [-Werror]
 void acd_arp_reply(struct netif *netif, struct etharp_hdr *hdr);
                                                ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/include/lwip/acd.h:97:48: error: its scope is only this definition or declaration, which is probably not what you want [-Werror]
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c: In function 'acd_tmr':
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:264:13: error: implicit declaration of function 'etharp_acd_probe' [-Werror=implicit-function-declaration]
             etharp_acd_probe(netif, &acd->ipaddr);
             ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:298:13: error: implicit declaration of function 'etharp_acd_announce' [-Werror=implicit-function-declaration]
             etharp_acd_announce(netif, &acd->ipaddr);
             ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c: At top level:
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:376:43: error: 'struct etharp_hdr' declared inside parameter list [-Werror]
 acd_arp_reply(struct netif *netif, struct etharp_hdr *hdr)
                                           ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:376:1: error: conflicting types for 'acd_arp_reply'
 acd_arp_reply(struct netif *netif, struct etharp_hdr *hdr)
 ^
In file included from /home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:71:0:
/home/benpicco/dev/RIOT/build/pkg/lwip/src/include/lwip/acd.h:97:6: note: previous declaration of 'acd_arp_reply' was here
 void acd_arp_reply(struct netif *netif, struct etharp_hdr *hdr);
      ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c: In function 'acd_arp_reply':
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:380:19: error: storage size of 'netifaddr' isn't known
   struct eth_addr netifaddr;
                   ^
In file included from /home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:64:0:
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:381:42: error: 'ETH_HWADDR_LEN' undeclared (first use in this function)
   SMEMCPY(netifaddr.addr, netif->hwaddr, ETH_HWADDR_LEN);
                                          ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/include/lwip/opt.h:145:56: note: in definition of macro 'SMEMCPY'
 #define SMEMCPY(dst,src,len)            memcpy(dst,src,len)
                                                        ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:381:42: note: each undeclared identifier is reported only once for each function it appears in
   SMEMCPY(netifaddr.addr, netif->hwaddr, ETH_HWADDR_LEN);
                                          ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/include/lwip/opt.h:145:56: note: in definition of macro 'SMEMCPY'
 #define SMEMCPY(dst,src,len)            memcpy(dst,src,len)
                                                        ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:387:3: error: implicit declaration of function 'IPADDR_WORDALIGNED_COPY_TO_IP4_ADDR_T' [-Werror=implicit-function-declaration]
   IPADDR_WORDALIGNED_COPY_TO_IP4_ADDR_T(&sipaddr, &hdr->sipaddr);
   ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:387:55: error: dereferencing pointer to incomplete type 'struct etharp_hdr'
   IPADDR_WORDALIGNED_COPY_TO_IP4_ADDR_T(&sipaddr, &hdr->sipaddr);
                                                       ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:413:15: error: implicit declaration of function 'eth_addr_eq' [-Werror=implicit-function-declaration]
              !eth_addr_eq(&netifaddr, &hdr->shwaddr))) {
               ^
/home/benpicco/dev/RIOT/build/pkg/lwip/src/core/ipv4/acd.c:380:19: error: unused variable 'netifaddr' [-Werror=unused-variable]
   struct eth_addr netifaddr;
                   ^
cc1: all warnings being treated as errors

```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
