### PR TITLE
boards/nucleo-144: rename doc.txt to doc.md

### DIFF
--- a/boards/nucleo-f207zg/doc.md
+++ b/boards/nucleo-f207zg/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f207zg STM32 Nucleo-F207ZG
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F207ZG
@@ -89,4 +88,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F207ZG board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f303ze/doc.md
+++ b/boards/nucleo-f303ze/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f303ze STM32 Nucleo-F303ZE
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F303ZE
@@ -89,4 +88,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F303ZE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f412zg/doc.md
+++ b/boards/nucleo-f412zg/doc.md
@@ -1,4 +1,3 @@
-/**
  @defgroup    boards_nucleo-f412zg STM32 Nucleo-F412ZG
  @ingroup     boards_common_nucleo144
  @brief       Support for the STM32 Nucleo-F412ZG
@@ -47,5 +46,3 @@ make BOARD=nucleo-f412zg PROGRAMMER=cpy2remed flash
 @note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw
 -link007.html).
-
-*/

--- a/boards/nucleo-f429zi/doc.md
+++ b/boards/nucleo-f429zi/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f429zi STM32 Nucleo-F429ZI
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F429ZI
@@ -67,5 +66,3 @@ PD8 (USART3 TX) and PD9 (USART3 RX).
 
 @note Accordingly to the [MCU Datasheet](https://www.st.com/resource/en/datasheet/stm32f429zi.pdf)
 PD8 and PD9 pins are 5V tolerant (see table 10, page 62).
-
- */

--- a/boards/nucleo-f439zi/doc.md
+++ b/boards/nucleo-f439zi/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f439zi STM32 Nucleo-F439ZI
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F439ZI
@@ -57,5 +56,3 @@ provided by integrated ST-LINK programmer. ST-LINK is connected to the
 microcontroller USART3.
 
 The default baud rate is 115200.
-
- */

--- a/boards/nucleo-f446ze/doc.md
+++ b/boards/nucleo-f446ze/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f446ze STM32 Nucleo-F446ZE
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F446ZE
@@ -88,4 +87,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F446ZE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f722ze/doc.md
+++ b/boards/nucleo-f722ze/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f722ze STM32 Nucleo-F722ZE
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F722ZE
@@ -55,5 +54,3 @@ provided by integrated ST-LINK programmer. ST-LINK is connected to the
 microcontroller USART3.
 
 The default baud rate is 115200.
-
- */

--- a/boards/nucleo-f767zi/doc.md
+++ b/boards/nucleo-f767zi/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f767zi STM32 Nucleo-F767ZI
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F767ZI
@@ -47,5 +46,3 @@ make BOARD=nucleo-f767zi PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
       can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-l496zg/doc.md
+++ b/boards/nucleo-l496zg/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l496zg STM32 Nucleo-L496ZG
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-l496zg
@@ -46,5 +45,3 @@ make BOARD=nucleo-l496zg PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
       can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
-
- */

--- a/boards/nucleo-l4r5zi/doc.md
+++ b/boards/nucleo-l4r5zi/doc.md
@@ -1,7 +1,6 @@
-/**
- * @defgroup    boards_nucleo144-l4r5 STM32 Nucleo-L4R5ZI
- * @ingroup     boards_common_nucleo144
- * @brief       Support for the STM32 Nucleo-L4R5ZI
+@defgroup    boards_nucleo144-l4r5 STM32 Nucleo-L4R5ZI
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-L4R5ZI
 
 ## Overview
 
@@ -78,5 +77,3 @@ The default baud rate is 115 200.
 Use the `term` target to open a terminal:
 
     make BOARD=nucleo-l4r5zi -C examples/basic/hello-world term
-
- */

--- a/boards/nucleo-l552ze-q/doc.md
+++ b/boards/nucleo-l552ze-q/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l552ze-q STM32 Nucleo-L552ZE-Q
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-L552ZE-Q
@@ -99,4 +98,3 @@ PG7 and PG8 pins are 5V tolerant (see table 21, page 108).
 For using the ST Nucleo-L552ZE-Q board we recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-u575zi-q/doc.md
+++ b/boards/nucleo-u575zi-q/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-u575zi-q STM32 Nucleo-U575ZI-Q
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-U575ZI-Q
@@ -61,4 +60,3 @@ microcontroller USART1.
 The default baud rate is 115 200.
 
 If a physical connection to USART1 is needed, connect UART interface to pins PA9 (USART1 TX) and PA10 (USART1 RX).
-*/


### PR DESCRIPTION
### Contribution description

This PR renames remaining `doc.txt` files to `doc.md` for Nucleo-144 boards accordingly to the PR #21255. 

### Testing procedure

Generate doc and check if everything is OK.
```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-f207zg.html 
xdg-open ./doc/doxygen/html/group__boards__nucleo-f303ze.html 
etc ...
```
### Issues/PRs references

PR #21255