### PR TITLE
doc: remove documentation on deprecated RIOT_FILE_* macros

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -66,23 +66,9 @@
  *          source compiles, however, the including `*.c`/`*.cpp` file will be
  *          substituted.
  * @see     `__FILE__` for absolute filenames that also work with *.h files
- * @see     @ref RIOT_FILE_NOPATH
  */
 #if DOXYGEN
 #   define RIOT_FILE_RELATIVE
-#endif
-
-/**
- * @def RIOT_FILE_NOPATH
- * @brief   Provides the current filename without the parent directory path
- * @warning This only works within `*.c` and `*.cpp` files. For `*.h`/`*.hpp` files the
- *          source compiles, however, the including `*.c`/`*.cpp` file will be
- *          substituted.
- * @see     `__FILE__` for absolute filenames that also work with *.h files
- * @see     @ref RIOT_FILE_RELATIVE
- */
-#if DOXYGEN
-#   define RIOT_FILE_NOPATH
 #endif
 
 /**

--- a/doc.txt
+++ b/doc.txt
@@ -60,18 +60,6 @@
 #endif
 
 /**
- * @def RIOT_FILE_RELATIVE
- * @brief   Provides the current filename relative to the RIOT base directory (RIOTBASE)
- * @warning This only works within `*.c` and `*.cpp` files. For `*.h`/`*.hpp` files the
- *          source compiles, however, the including `*.c`/`*.cpp` file will be
- *          substituted.
- * @see     `__FILE__` for absolute filenames that also work with *.h files
- */
-#if DOXYGEN
-#   define RIOT_FILE_RELATIVE
-#endif
-
-/**
  * @def CONFIG_THREAD_NAMES
  * @brief   This global macro enable storage of thread names to help developers.
  *

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -2305,7 +2305,8 @@ PREDEFINED             = DOXYGEN \
                          MODULE_GNRC_SIXLOWPAN \
                          MODULE_GNRC_SIXLOWPAN_ND_ROUTER \
                          MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER \
-                         MODULE_GNRC_UDP
+                         MODULE_GNRC_UDP \
+                         RIOT_FILE_RELATIVE
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -2305,8 +2305,7 @@ PREDEFINED             = DOXYGEN \
                          MODULE_GNRC_SIXLOWPAN \
                          MODULE_GNRC_SIXLOWPAN_ND_ROUTER \
                          MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER \
-                         MODULE_GNRC_UDP \
-                         RIOT_FILE_RELATIVE
+                         MODULE_GNRC_UDP
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
### Contribution description

#21170 added documentation about `RIOT_FILE_RELATIVE` and `RIOT_FILE_NOPATH` which were already considered obsolete in #18936. Instead of going through the deprecation hoops I'd propose to just revert these commits before the next release.


### Issues/PRs references

Reverts #21170.
