### PR TITLE
pkg/driver_cryptocell_310: replace deprecated RIOT_FILE_RELATIVE

### DIFF
--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/aes_common.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/aes_common.c
@@ -42,7 +42,7 @@ psa_status_t cryptocell_310_common_aes_setup(SaSiAesUserContext_t *ctx,
 
     if (!cryptocell_310_data_within_ram(iv) ||
         !cryptocell_310_data_within_ram(key_buffer)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 
@@ -84,7 +84,7 @@ psa_status_t cryptocell_310_common_aes_encrypt_decrypt(SaSiAesUserContext_t *ctx
     *output_length = output_size;
 
     if (!cryptocell_310_data_within_ram(input)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/cipher_chacha20.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/cipher_chacha20.c
@@ -43,7 +43,7 @@ psa_status_t psa_cipher_chacha20_encrypt(uint8_t *key_buffer,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     if (!cryptocell_310_data_within_ram(input)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 
@@ -91,7 +91,7 @@ psa_status_t psa_cipher_chacha20_decrypt(uint8_t *key_buffer,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     if (!cryptocell_310_data_within_ram(input)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_common.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_common.c
@@ -87,7 +87,7 @@ psa_status_t cryptocell_310_common_ecc_sign(const uint8_t *priv_key,
 
     if (!cryptocell_310_data_within_ram(priv_key) ||
         !cryptocell_310_data_within_ram(input)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 
@@ -131,7 +131,7 @@ psa_status_t cryptocell_310_common_ecc_verify(const uint8_t *pub_key,
     if (!cryptocell_310_data_within_ram(pub_key) ||
         !cryptocell_310_data_within_ram(input) ||
         !cryptocell_310_data_within_ram(signature)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_ed25519.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_ed25519.c
@@ -68,7 +68,7 @@ psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer, 
     CRYSError_t ret;
 
     if (!cryptocell_310_data_within_ram(priv_key_buffer)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 
@@ -108,7 +108,7 @@ psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
     if (!cryptocell_310_data_within_ram(priv_key_buffer) ||
         !cryptocell_310_data_within_ram(pub_key_buffer) ||
         !cryptocell_310_data_within_ram(input)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 
@@ -155,7 +155,7 @@ psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer,
     if (!cryptocell_310_data_within_ram(key_buffer) ||
         !cryptocell_310_data_within_ram(input) ||
         !cryptocell_310_data_within_ram(signature)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/hmac.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/hmac.c
@@ -43,7 +43,7 @@ psa_status_t psa_mac_compute_hmac_sha256(const psa_key_attributes_t *attributes,
 
     if (!cryptocell_310_data_within_ram(key_buffer) ||
         !cryptocell_310_data_within_ram(input)) {
-        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", RIOT_FILE_RELATIVE);
+        DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
         return PSA_ERROR_DATA_INVALID;
     }
 


### PR DESCRIPTION
### Contribution description

`RIOT_FILE_RELATIVE` is inferior to `__FILE__` according to #18936. Let's get rid of its usage in `pkg/driver_cryptocell_310`.

@Ollrogge not changing the appearance in `ctap_mem.c` as you are currently working on it. But maybe think about replacing it there, too.


### Issues/PRs references

#21320
