### PR TITLE
sys/auto_init: fix documentation

### DIFF
--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -13,12 +13,12 @@
  * @ingroup     sys
  * @brief       Auto initialize modules
  *
- * This feature can be enabled in any application by adding the `auto_init`
- * module to the application's `Makefile`:
+ * This feature is automatically enabled and can be disabled in any application
+ * by disabling the `auto_init` module in the application's `Makefile`:
  *
- * ~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
- * USEMODULE += auto_init
- * ~~~~~~~~~~~~~~~~~~~~~~~
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * DISABLE_MODULE += auto_init
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * `auto_init` initializes any included module that provides
  * auto-initialization capabilities.


### PR DESCRIPTION
### Contribution description

`auto_init` is part of `DEFAULT_MODULE` and can be disabled in an application via `DISABLE_MODULE`

### Testing procedure

Check CI documentation output.


### Issues/PRs references

Noticed while working on #21322 
