### PR TITLE
treewide: fixing order of doxygen tags and header guards

### DIFF
--- a/drivers/include/ad7746.h
+++ b/drivers/include/ad7746.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AD7746_H
+#define AD7746_H
+
 /**
  * @defgroup   drivers_ad7746 AD7746 Capacitance-to-digital converter driver
  * @ingroup    drivers_sensors
@@ -40,9 +43,6 @@
  *
  * @author     Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef AD7746_H
-#define AD7746_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -331,5 +331,5 @@ int ad7746_set_cap_sr(const ad7746_t *dev, ad7746_cap_sample_rate_t sr);
 }
 #endif
 
-#endif /* AD7746_H */
 /** @} */
+#endif /* AD7746_H */

--- a/drivers/include/adcxx1c.h
+++ b/drivers/include/adcxx1c.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ADCXX1C_H
+#define ADCXX1C_H
+
 /**
  * @defgroup   drivers_adcxx1c ADCXX1C ADC device driver
  * @ingroup    drivers_sensors
@@ -22,9 +25,6 @@
  *
  * @author     Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef ADCXX1C_H
-#define ADCXX1C_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -181,5 +181,5 @@ int adcxx1c_get_and_clear_alert(const adcxx1c_t *dev);
 }
 #endif
 
-#endif /* ADCXX1C_H */
 /** @} */
+#endif /* ADCXX1C_H */

--- a/drivers/include/ads101x.h
+++ b/drivers/include/ads101x.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef ADS101X_H
+#define ADS101X_H
+
 /**
  * @defgroup   drivers_ads101x ADS101x/111x ADC device driver
  * @ingroup    drivers_sensors
@@ -27,9 +30,6 @@
  * @author     Vincent Dupont <vincent@otakeys.com>
  * @author     Matthew Blue <matthew.blue.neuro@gmail.com>
  */
-
-#ifndef ADS101X_H
-#define ADS101X_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -181,5 +181,5 @@ int ads101x_set_alert_parameters(const ads101x_alert_t *dev,
 }
 #endif
 
-#endif /* ADS101X_H */
 /** @} */
+#endif /* ADS101X_H */

--- a/drivers/include/adt7310.h
+++ b/drivers/include/adt7310.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ADT7310_H
+#define ADT7310_H
+
 /**
  * @defgroup    drivers_adt7310 ADT7310 SPI temperature sensor
  * @ingroup     drivers_sensors
@@ -46,9 +49,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef ADT7310_H
-#define ADT7310_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -177,5 +177,5 @@ float adt7310_read_float(const adt7310_t *dev);
 }
 #endif
 
-#endif /* ADT7310_H */
 /** @} */
+#endif /* ADT7310_H */

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ADXL345_H
+#define ADXL345_H
+
 /**
  * @defgroup    drivers_adxl345 ADXL345 3-Axis accelerometer
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author     Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef ADXL345_H
-#define ADXL345_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -245,5 +245,5 @@ void adxl345_set_fifo_mode(const adxl345_t *dev, uint8_t mode,
 }
 #endif
 
-#endif /* ADXL345_H */
 /** @} */
+#endif /* ADXL345_H */

--- a/drivers/include/aip31068.h
+++ b/drivers/include/aip31068.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AIP31068_H
+#define AIP31068_H
+
 /**
  * @defgroup    drivers_aip31068 AIP31068 I2C LCD controller
  * @ingroup     drivers_display
@@ -16,9 +19,6 @@
  * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @file
  */
-
-#ifndef AIP31068_H
-#define AIP31068_H
 
 #ifdef __cplusplus
 extern "C"
@@ -422,5 +422,5 @@ int aip31068_print_char(aip31068_t *dev, char c);
 }
 #endif
 
-#endif /* AIP31068_H */
 /** @} */
+#endif /* AIP31068_H */

--- a/drivers/include/apa102.h
+++ b/drivers/include/apa102.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef APA102_H
+#define APA102_H
+
 /**
  * @defgroup    drivers_apa102 APA102 RGB LED
  * @ingroup     drivers_actuators
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef APA102_H
-#define APA102_H
 
 #include "color.h"
 #include "periph/gpio.h"
@@ -68,5 +68,5 @@ void apa102_load_rgba(const apa102_t *dev, const color_rgba_t vals[]);
 }
 #endif
 
-#endif /* APA102_H */
 /** @} */
+#endif /* APA102_H */

--- a/drivers/include/apds99xx.h
+++ b/drivers/include/apds99xx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef APDS99XX_H
+#define APDS99XX_H
+
 /**
  * @defgroup    drivers_apds99xx APDS99XX proximity and ambient light sensors
  * @ingroup     drivers_sensors
@@ -198,9 +201,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  */
-
-#ifndef APDS99XX_H
-#define APDS99XX_H
 
 #ifdef __cplusplus
 extern "C"
@@ -683,5 +683,5 @@ int apds99xx_int_source(apds99xx_t *dev, apds99xx_int_source_t* src);
 }
 #endif
 
-#endif /* APDS99XX_H */
 /** @} */
+#endif /* APDS99XX_H */

--- a/drivers/include/arduino_pinmap.h
+++ b/drivers/include/arduino_pinmap.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
 /**
  * @ingroup     drivers
  * @{
@@ -17,9 +20,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
  */
-
-#ifndef ARDUINO_PINMAP_H
-#define ARDUINO_PINMAP_H
 
 #include "arduino_iomap.h"
 
@@ -34,5 +34,5 @@ extern "C" {
 }
 #endif
 
-#endif /* ARDUINO_PINMAP_H */
 /** @} */
+#endif /* ARDUINO_PINMAP_H */

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AT_H
+#define AT_H
+
 /**
  * @defgroup    drivers_at AT (Hayes) command set library
  * @ingroup     drivers_misc
@@ -110,9 +113,6 @@
  * @brief       AT (Hayes) library interface
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef AT_H
-#define AT_H
 
 #include <stdint.h>
 #include <unistd.h>
@@ -662,5 +662,5 @@ void at_postprocess_urc_all(at_dev_t *dev, char *buf);
 }
 #endif
 
-#endif /* AT_H */
 /** @} */
+#endif /* AT_H */

--- a/drivers/include/at24cxxx.h
+++ b/drivers/include/at24cxxx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AT24CXXX_H
+#define AT24CXXX_H
+
 /**
  * @defgroup    drivers_at24cxxx AT24CXXX EEPROM unit
  * @ingroup     drivers_misc
@@ -64,9 +67,6 @@
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  *
  */
-
-#ifndef AT24CXXX_H
-#define AT24CXXX_H
 
 #include <stdint.h>
 
@@ -240,5 +240,5 @@ int at24cxxx_disable_write_protect(const at24cxxx_t *dev);
 }
 #endif
 
-#endif /* AT24CXXX_H */
 /** @} */
+#endif /* AT24CXXX_H */

--- a/drivers/include/at24mac.h
+++ b/drivers/include/at24mac.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AT24MAC_H
+#define AT24MAC_H
+
 /**
  * @defgroup    drivers_at24mac AT24MAC unique ID chip
  * @ingroup     drivers_misc
@@ -16,9 +19,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef AT24MAC_H
-#define AT24MAC_H
 
 #include <stdint.h>
 #include "net/eui48.h"
@@ -101,5 +101,5 @@ at24mac_type_t at24mac_get_type(at24mac_t dev);
 }
 #endif
 
-#endif /* AT24MAC_H */
 /** @} */
+#endif /* AT24MAC_H */

--- a/drivers/include/at25xxx/mtd.h
+++ b/drivers/include/at25xxx/mtd.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AT25XXX_MTD_H
+#define AT25XXX_MTD_H
+
 /**
  * @defgroup    drivers_mtd_at25xxx MTD wrapper for AT25xxx family of SPI-EEPROMs
  * @ingroup     drivers_storage
@@ -18,9 +21,6 @@
  *
  * @author      Johannes Koster <johannes.koster@ml-pa.com>
  */
-
-#ifndef AT25XXX_MTD_H
-#define AT25XXX_MTD_H
 
 #include <stdint.h>
 
@@ -52,5 +52,5 @@ extern const mtd_desc_t mtd_at25xxx_driver;
 }
 #endif
 
-#endif /* AT25XXX_MTD_H */
 /** @} */
+#endif /* AT25XXX_MTD_H */

--- a/drivers/include/at30tse75x.h
+++ b/drivers/include/at30tse75x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef AT30TSE75X_H
+#define AT30TSE75X_H
+
 /**
  * @defgroup    drivers_at30tse75x AT30TSE75x temperature sensor with EEPROM
  * @ingroup     drivers_sensors
@@ -21,9 +24,6 @@
  *
  * @author      Daniel Krebs <github@daniel-krebs.net>
  */
-
-#ifndef AT30TSE75X_H
-#define AT30TSE75X_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -300,5 +300,5 @@ int at30tse75x_get_temperature(const at30tse75x_t* dev, float* temperature);
 }
 #endif
 
-#endif /* AT30TSE75X_H */
 /** @} */
+#endif /* AT30TSE75X_H */

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef AT86RF215_H
+#define AT86RF215_H
+
 /**
  * @defgroup    drivers_at86rf215 AT86RF215 based drivers
  * @ingroup     drivers_netdev
@@ -19,9 +22,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef AT86RF215_H
-#define AT86RF215_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -682,5 +682,5 @@ void at86rf215_disable_batmon(at86rf215_t *dev);
 }
 #endif
 
-#endif /* AT86RF215_H */
 /** @} */
+#endif /* AT86RF215_H */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef AT86RF2XX_H
+#define AT86RF2XX_H
+
 /**
  * @defgroup    drivers_at86rf2xx AT86RF2xx based drivers
  * @ingroup     drivers_netdev
@@ -25,9 +28,6 @@
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef AT86RF2XX_H
-#define AT86RF2XX_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -595,5 +595,5 @@ void at86rf2xx_disable_smart_idle(at86rf2xx_t *dev);
 }
 #endif
 
-#endif /* AT86RF2XX_H */
 /** @} */
+#endif /* AT86RF2XX_H */

--- a/drivers/include/ata8520e.h
+++ b/drivers/include/ata8520e.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ATA8520E_H
+#define ATA8520E_H
+
 /**
  * @defgroup    drivers_ata8520e Microchip ATA8520E transceiver
  * @ingroup     drivers_netdev
@@ -21,9 +24,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef ATA8520E_H
-#define ATA8520E_H
 
 #include <stdint.h>
 #include <inttypes.h>
@@ -239,5 +239,5 @@ int ata8520e_send_bit(ata8520e_t *dev, bool bit);
 }
 #endif
 
-#endif /* ATA8520E_H */
 /** @} */
+#endif /* ATA8520E_H */

--- a/drivers/include/atwinc15x0.h
+++ b/drivers/include/atwinc15x0.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ATWINC15X0_H
+#define ATWINC15X0_H
+
 /**
  * @ingroup     drivers_netdev
  * @brief       Netdev Driver for the Microchip ATWINC15x0 WiFi Module
@@ -16,9 +19,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef ATWINC15X0_H
-#define ATWINC15X0_H
 
 #include "bsp/include/nm_bsp.h"
 #include "net/ethernet.h"
@@ -113,5 +113,5 @@ void atwinc15x0_setup(atwinc15x0_t *dev, const atwinc15x0_params_t *params, uint
 }
 #endif
 
-#endif /* ATWINC15X0_H */
 /** @} */
+#endif /* ATWINC15X0_H */

--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BH1750FVI_H
+#define BH1750FVI_H
+
 /**
  * @defgroup    drivers_bh1750fvi BH1750FVI Light Sensor
  * @ingroup     drivers_sensors
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef BH1750FVI_H
-#define BH1750FVI_H
 
 #include "periph/i2c.h"
 
@@ -99,5 +99,5 @@ uint16_t bh1750fvi_sample(const bh1750fvi_t *dev);
 }
 #endif
 
-#endif /* BH1750FVI_H */
 /** @} */
+#endif /* BH1750FVI_H */

--- a/drivers/include/bh1900nux.h
+++ b/drivers/include/bh1900nux.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BH1900NUX_H
+#define BH1900NUX_H
+
 /**
  * @defgroup    drivers_bh1900nux BH1900NUX Temperature sensor
  * @ingroup     drivers_sensors
@@ -17,9 +20,6 @@
  *
  * @author      Wouter Symons <wsymons@nalys-group.com>
  */
-
-#ifndef BH1900NUX_H
-#define BH1900NUX_H
 
 #include "periph/i2c.h"
 
@@ -115,5 +115,5 @@ int bh1900nux_read(const bh1900nux_t *dev,  int16_t *temp);
 }
 #endif
 
-#endif /* BH1900NUX_H */
 /** @} */
+#endif /* BH1900NUX_H */

--- a/drivers/include/bme680.h
+++ b/drivers/include/bme680.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef BME680_H
+#define BME680_H
+
 /**
  * @defgroup    drivers_bme680 BME680 Temperature/Humidity/Pressure/Gas sensor
  * @ingroup     drivers_sensors
@@ -104,9 +107,6 @@
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef BME680_H
-#define BME680_H
 
 #include "periph/i2c.h"
 #include "periph/spi.h"
@@ -321,5 +321,5 @@ int bme680_set_ambient_temp(bme680_t* dev, int8_t temp);
 }
 #endif
 
-#endif /* BME680_H */
 /** @} */
+#endif /* BME680_H */

--- a/drivers/include/bmp180.h
+++ b/drivers/include/bmp180.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BMP180_H
+#define BMP180_H
+
 /**
  * @defgroup    drivers_bmp180 BMP180 temperature and pressure sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef BMP180_H
-#define BMP180_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -138,5 +138,5 @@ uint32_t bmp180_sealevel_pressure(const bmp180_t *dev, int16_t altitude);
 }
 #endif
 
-#endif /* BMP180_H */
 /** @} */
+#endif /* BMP180_H */

--- a/drivers/include/bmx055.h
+++ b/drivers/include/bmx055.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BMX055_H
+#define BMX055_H
+
 /**
  * @defgroup    drivers_bmx055 BMX055 9-axis sensor
  * @ingroup     drivers_sensors
@@ -22,9 +25,6 @@
  *
  * @author      Semjon Kerner <semjon.kerner@fu-berlin.de>
  */
-
-#ifndef BMX055_H
-#define BMX055_H
 
 #include <stdint.h>
 
@@ -199,5 +199,5 @@ int bmx055_gyro_read(const bmx055_t *dev, int16_t *data);
 }
 #endif
 
-#endif /* BMX055_H */
 /** @} */
+#endif /* BMX055_H */

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef BMX280_H
+#define BMX280_H
+
 /**
  * @defgroup    drivers_bmx280 BMP280/BME280 temperature, pressure and humidity sensor
  * @ingroup     drivers_sensors
@@ -69,9 +72,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef BMX280_H
-#define BMX280_H
 
 #include <stdint.h>
 #include "saul.h"
@@ -307,5 +307,5 @@ uint16_t bme280_read_humidity(bmx280_t *dev);
 }
 #endif
 
-#endif /* BMX280_H */
 /** @} */
+#endif /* BMX280_H */

--- a/drivers/include/bq2429x.h
+++ b/drivers/include/bq2429x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BQ2429X_H
+#define BQ2429X_H
+
 /**
  * @defgroup    drivers_bq2429x BQ2429x
  * @ingroup     drivers_power
@@ -46,9 +49,6 @@
  *
  * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
  */
-
-#ifndef BQ2429X_H
-#define BQ2429X_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -499,5 +499,5 @@ int bq2429x_get_vreg(const bq2429x_t *dev,
 }
 #endif
 
-#endif /* BQ2429X_H */
 /** @} */
+#endif /* BQ2429X_H */

--- a/drivers/include/can/can_trx.h
+++ b/drivers/include/can/can_trx.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CAN_CAN_TRX_H
+#define CAN_CAN_TRX_H
 /**
  * @defgroup    drivers_can_trx CAN transceiver interface
  * @ingroup     drivers_can
@@ -18,8 +20,6 @@
  * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-#ifndef CAN_CAN_TRX_H
-#define CAN_CAN_TRX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,5 +101,5 @@ int can_trx_set_mode(can_trx_t *dev, can_trx_mode_t mode);
 }
 #endif
 
-#endif /* CAN_CAN_TRX_H */
 /** @} */
+#endif /* CAN_CAN_TRX_H */

--- a/drivers/include/can/candev.h
+++ b/drivers/include/can/candev.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef CAN_CANDEV_H
+#define CAN_CANDEV_H
+
 /**
  * @defgroup    drivers_candev CAN device driver interface
  * @ingroup     drivers_can
@@ -20,9 +23,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
-
-#ifndef CAN_CANDEV_H
-#define CAN_CANDEV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -177,5 +177,5 @@ typedef struct candev_driver {
 }
 #endif
 
-#endif /* CAN_CANDEV_H */
 /** @} */
+#endif /* CAN_CANDEV_H */

--- a/drivers/include/candev_mcp2515.h
+++ b/drivers/include/candev_mcp2515.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CANDEV_MCP2515_H
+#define CANDEV_MCP2515_H
+
 /**
  * @defgroup    drivers_mcp2515 MCP2515
  * @ingroup     drivers_can
@@ -21,9 +24,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Wouter Symons <wosym@airsantelmo.com>
  */
-
-#ifndef CANDEV_MCP2515_H
-#define CANDEV_MCP2515_H
 
 #include <stdbool.h>
 
@@ -132,5 +132,5 @@ void candev_mcp2515_init(candev_mcp2515_t *dev,
 }
 #endif
 
-#endif /* CANDEV_MCP2515_H */
 /** @} */
+#endif /* CANDEV_MCP2515_H */

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -9,6 +9,9 @@
  * details.
  */
 
+#ifndef CC110X_H
+#define CC110X_H
+
 /**
  * @defgroup    drivers_cc110x CC1100/CC1100e/CC1101 Sub-GHz transceiver driver
  * @ingroup     drivers_netdev
@@ -190,9 +193,6 @@
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef CC110X_H
-#define CC110X_H
 
 #include <stdint.h>
 
@@ -652,5 +652,5 @@ void cc110x_sleep(cc110x_t *dev);
 }
 #endif
 
-#endif /* CC110X_H */
 /** @} */
+#endif /* CC110X_H */

--- a/drivers/include/cc1xxx_common.h
+++ b/drivers/include/cc1xxx_common.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef CC1XXX_COMMON_H
+#define CC1XXX_COMMON_H
 /**
  * @defgroup    drivers_cc1xxx CC1100/CC1100e/CC1101/CC1200 common code
  * @ingroup     drivers_netdev
@@ -55,8 +57,6 @@
  * more users of this adaption layer are added, this behaviour might needs to be
  * more generalized.
  */
-#ifndef CC1XXX_COMMON_H
-#define CC1XXX_COMMON_H
 
 #include "net/gnrc/netif.h"
 
@@ -145,5 +145,5 @@ void cc1xxx_eui_get(const netdev_t *dev, uint8_t *eui);
 }
 #endif
 
-#endif /* CC1XXX_COMMON_H */
 /** @} */
+#endif /* CC1XXX_COMMON_H */

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CC2420_H
+#define CC2420_H
+
 /**
  * @defgroup    drivers_cc2420 CC2420 radio driver
  * @ingroup     drivers_netdev
@@ -17,9 +20,6 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef CC2420_H
-#define CC2420_H
 
 #include <stdint.h>
 
@@ -302,5 +302,5 @@ int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info);
 }
 #endif
 
-#endif /* CC2420_H */
 /** @} */
+#endif /* CC2420_H */

--- a/drivers/include/ccs811.h
+++ b/drivers/include/ccs811.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CCS811_H
+#define CCS811_H
+
 /**
  * @ingroup     drivers_ccs811
  * @brief       Device Driver for AMS CCS811 digital gas sensor
@@ -13,9 +16,6 @@
  * @file
  * @{
  */
-
-#ifndef CCS811_H
-#define CCS811_H
 
 #include <stdint.h>
 #include "periph/gpio.h"
@@ -403,5 +403,5 @@ int ccs811_set_baseline (const ccs811_t *dev, uint16_t baseline);
 }
 #endif
 
-#endif /* CCS811_H */
 /** @} */
+#endif /* CCS811_H */

--- a/drivers/include/cst816s.h
+++ b/drivers/include/cst816s.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CST816S_H
+#define CST816S_H
+
 /**
  * @defgroup    drivers_cst816s Cst816S touch screen driver
  *
@@ -37,9 +40,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef CST816S_H
-#define CST816S_H
 
 #include <stdint.h>
 
@@ -157,5 +157,5 @@ int cst816s_read(const cst816s_t *dev, cst816s_touch_data_t *data);
 }
 #endif
 
-#endif /* CST816S_H */
 /** @} */
+#endif /* CST816S_H */

--- a/drivers/include/dac_dds.h
+++ b/drivers/include/dac_dds.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DAC_DDS_H
+#define DAC_DDS_H
+
 /**
  * @defgroup    drivers_dac_dds DAC Direct Digital Synthesis
  * @ingroup     drivers_periph_dac
@@ -35,9 +38,6 @@
  *
  * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
  */
-
-#ifndef DAC_DDS_H
-#define DAC_DDS_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -160,5 +160,5 @@ void dac_dds_stop(dac_dds_t dac);
 }
 #endif
 
-#endif /* DAC_DDS_H */
 /** @} */
+#endif /* DAC_DDS_H */

--- a/drivers/include/dcf77.h
+++ b/drivers/include/dcf77.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DCF77_H
+#define DCF77_H
+
 /**
  * @defgroup    drivers_dcf77 DCF77 long wave receiver with 77,5 kHz
  * @ingroup     drivers_sensors
@@ -18,9 +21,6 @@
  *
  * @author      Michel Gerlach <michel.gerlach@haw-hamburg.de>
  */
-
-#ifndef DCF77_H
-#define DCF77_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -117,5 +117,5 @@ void dcf77_set_tick_cb(dcf77_t *dev, dcf77_tick_cb_t cb, void *arg);
 }
 #endif
 
-#endif /* DCF77_H */
 /** @} */
+#endif /* DCF77_H */

--- a/drivers/include/dfplayer.h
+++ b/drivers/include/dfplayer.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DFPLAYER_H
+#define DFPLAYER_H
+
 /**
  * @defgroup    drivers_dfplayer DFPlayer Mini MP3 Player
  * @ingroup     drivers_multimedia
@@ -173,9 +176,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef DFPLAYER_H
-#define DFPLAYER_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -773,5 +773,5 @@ static inline void dfplayer_source_set_rm(dfplayer_source_set_t *set,
 /* Include implementation of the static inline functions */
 #include "dfplayer_implementation.h"
 
-#endif /* DFPLAYER_H */
 /** @} */
+#endif /* DFPLAYER_H */

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef DHT_H
+#define DHT_H
+
 /**
  * @defgroup    drivers_dht DHT Family of Humidity and Temperature Sensors
  * @ingroup     drivers_sensors
@@ -27,9 +30,6 @@
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef DHT_H
-#define DHT_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -134,5 +134,5 @@ int dht_read(dht_t *dev, int16_t *temp, int16_t *hum);
 }
 #endif
 
-#endif /* DHT_H */
 /** @} */
+#endif /* DHT_H */

--- a/drivers/include/diskio.h
+++ b/drivers/include/diskio.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef DISKIO_H
+#define DISKIO_H
+
 /**
  * @defgroup    drivers_diskio Disk IO Driver
  * @ingroup     drivers_storage
@@ -18,9 +21,6 @@
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
-
-#ifndef DISKIO_H
-#define DISKIO_H
 
 #include <stdint.h>
 
@@ -158,5 +158,5 @@ diskio_result_t mci_ioctl(unsigned char ctrl, void *buff);
 }
 #endif
 
-#endif /* DISKIO_H */
 /** @} */
+#endif /* DISKIO_H */

--- a/drivers/include/disp_dev.h
+++ b/drivers/include/disp_dev.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DISP_DEV_H
+#define DISP_DEV_H
+
 /**
  * @defgroup    drivers_disp_dev Display device generic API
  * @ingroup     drivers_display
@@ -16,9 +19,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef DISP_DEV_H
-#define DISP_DEV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -206,5 +206,5 @@ static inline void disp_dev_backlight_off(void)
 }
 #endif
 
-#endif /* DISP_DEV_H */
 /** @} */
+#endif /* DISP_DEV_H */

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef DOSE_H
+#define DOSE_H
+
 /**
  * @defgroup    drivers_dose Differentially Operated Serial Ethernet
  * @ingroup     drivers_netdev
@@ -70,9 +73,6 @@
  *
  * @author      Juergen Fitschen <me@jue.yt>
  */
-
-#ifndef DOSE_H
-#define DOSE_H
 
 #include "chunked_ringbuffer.h"
 #include "periph/uart.h"
@@ -233,5 +233,5 @@ void dose_setup(dose_t *dev, const dose_params_t *params, uint8_t index);
 #ifdef __cplusplus
 }
 #endif
-#endif /* DOSE_H */
 /** @} */
+#endif /* DOSE_H */

--- a/drivers/include/ds1307.h
+++ b/drivers/include/ds1307.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef DS1307_H
+#define DS1307_H
 /**
  * @defgroup    drivers_ds1307  DS1307 RTC
  * @ingroup     drivers_sensors
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef DS1307_H
-#define DS1307_H
 
 #include <stdbool.h>
 #include <time.h>
@@ -157,5 +157,5 @@ int ds1307_get_sqw_mode(const ds1307_t *dev);
 }
 #endif
 
-#endif /* DS1307_H */
 /** @} */
+#endif /* DS1307_H */

--- a/drivers/include/ds18.h
+++ b/drivers/include/ds18.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DS18_H
+#define DS18_H
+
 /**
  * @defgroup    drivers_ds18 DS18 temperature sensor driver
  * @ingroup     drivers_sensors
@@ -34,9 +37,6 @@
  *
  * @author      Frits Kuipers <frits.kuipers@gmail.com>
  */
-
-#ifndef DS18_H
-#define DS18_H
 
 #include <stdint.h>
 

--- a/drivers/include/ds3231.h
+++ b/drivers/include/ds3231.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DS3231_H
+#define DS3231_H
+
 /**
  * @defgroup    drivers_ds3231 DS3231 Real Time Clock
  * @ingroup     drivers_sensors
@@ -27,9 +30,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef DS3231_H
-#define DS3231_H
 
 #include <time.h>
 #include <errno.h>
@@ -312,5 +312,5 @@ int ds3231_disable_bat(const ds3231_t *dev);
 }
 #endif
 
-#endif /* DS3231_H */
 /** @} */
+#endif /* DS3231_H */

--- a/drivers/include/ds3234.h
+++ b/drivers/include/ds3234.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DS3234_H
+#define DS3234_H
+
 /**
  * @defgroup    drivers_ds3234  DS3234 Extremely Accurate SPI RTC
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef DS3234_H
-#define DS3234_H
 
 #include <periph/gpio.h>
 #include <periph/spi.h>
@@ -66,5 +66,5 @@ int ds3234_pps_init(const ds3234_params_t *params);
 }
 #endif
 
-#endif /* DS3234_H */
 /** @} */
+#endif /* DS3234_H */

--- a/drivers/include/ds75lx.h
+++ b/drivers/include/ds75lx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DS75LX_H
+#define DS75LX_H
+
 /**
  * @defgroup    drivers_ds75lx Maxim DS75LX temperature sensor
  * @ingroup     drivers_sensors
@@ -19,9 +22,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef DS75LX_H
-#define DS75LX_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -110,5 +110,5 @@ int ds75lx_shutdown(const ds75lx_t *dev);
 }
 #endif
 
-#endif /* DS75LX_H */
 /** @} */
+#endif /* DS75LX_H */

--- a/drivers/include/dsp0401.h
+++ b/drivers/include/dsp0401.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DSP0401_H
+#define DSP0401_H
+
 /**
  * @defgroup    drivers_dsp0401 DSP0401
  * @ingroup     drivers_display
@@ -17,9 +20,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef DSP0401_H
-#define DSP0401_H
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -103,5 +103,5 @@ void dsp0401_scroll_text(const dsp0401_t *dev, char *text, uint16_t delay);
 }
 #endif
 
-#endif /* DSP0401_H */
 /** @} */
+#endif /* DSP0401_H */

--- a/drivers/include/dynamixel.h
+++ b/drivers/include/dynamixel.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef DYNAMIXEL_H
+#define DYNAMIXEL_H
+
 /**
  * @defgroup    drivers_dynamixel Dynamixel driver
  * @ingroup     drivers_actuators
@@ -20,9 +23,6 @@
  *
  * @author      Loïc Dauphin <loic.dauphin@inria.fr>
  */
-
-#ifndef DYNAMIXEL_H
-#define DYNAMIXEL_H
 
 #include <stdlib.h>
 #include <stdbool.h>
@@ -167,5 +167,5 @@ int dynamixel_read(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *dat
 }
 #endif
 
-#endif /* DYNAMIXEL_H */
 /** @} */
+#endif /* DYNAMIXEL_H */

--- a/drivers/include/edbg_eui.h
+++ b/drivers/include/edbg_eui.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EDBG_EUI_H
+#define EDBG_EUI_H
+
 /**
  * @defgroup    drivers_edbg_eui Driver for getting MAC address out of Atmel EDBG
  * @ingroup     drivers_misc
@@ -16,9 +19,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef EDBG_EUI_H
-#define EDBG_EUI_H
 
 #include <stdint.h>
 #include "net/eui64.h"
@@ -43,5 +43,5 @@ int edbg_get_eui64(eui64_t *addr);
 }
 #endif
 
-#endif /* EDBG_EUI_H */
 /** @} */
+#endif /* EDBG_EUI_H */

--- a/drivers/include/enc28j60.h
+++ b/drivers/include/enc28j60.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ENC28J60_H
+#define ENC28J60_H
+
 /**
  * @defgroup    drivers_enc28j60 ENC28J60
  * @ingroup     drivers_netdev
@@ -18,9 +21,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef ENC28J60_H
-#define ENC28J60_H
 
 #include <stdint.h>
 
@@ -67,5 +67,5 @@ void enc28j60_setup(enc28j60_t *dev, const enc28j60_params_t *params, uint8_t in
 }
 #endif
 
-#endif /* ENC28J60_H */
 /** @} */
+#endif /* ENC28J60_H */

--- a/drivers/include/encx24j600.h
+++ b/drivers/include/encx24j600.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ENCX24J600_H
+#define ENCX24J600_H
+
 /**
  * @defgroup    drivers_encx24j600 ENCX24J600
  * @ingroup     drivers_netdev
@@ -17,9 +20,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ENCX24J600_H
-#define ENCX24J600_H
 
 #include "mutex.h"
 #include "periph/spi.h"
@@ -67,5 +67,5 @@ void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params, uint
 #ifdef __cplusplus
 }
 #endif
-#endif /* ENCX24J600_H */
 /** @} */
+#endif /* ENCX24J600_H */

--- a/drivers/include/epd_bw_spi.h
+++ b/drivers/include/epd_bw_spi.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EPD_BW_SPI_H
+#define EPD_BW_SPI_H
+
 /**
  * @defgroup    drivers_epd_bw_spi Generic black/white e-paper/e-ink SPI display driver.
  * @ingroup     drivers_display
@@ -28,9 +31,6 @@
  *
  * @author      Silke Hofstra <silke@slxh.eu>
  */
-
-#ifndef EPD_BW_SPI_H
-#define EPD_BW_SPI_H
 
 #include "periph/spi.h"
 #include "periph/gpio.h"
@@ -270,5 +270,5 @@ void epd_bw_spi_swreset(epd_bw_spi_t *dev);
 #ifdef __cplusplus
 }
 #endif
-#endif /* EPD_BW_SPI_H */
 /** @} */
+#endif /* EPD_BW_SPI_H */

--- a/drivers/include/epd_bw_spi_disp_dev.h
+++ b/drivers/include/epd_bw_spi_disp_dev.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EPD_BW_SPI_DISP_DEV_H
+#define EPD_BW_SPI_DISP_DEV_H
+
 /**
  * @ingroup     drivers_epd_bw_spi
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Silke Hofstra <silke@slxh.eu>
  */
-
-#ifndef EPD_BW_SPI_DISP_DEV_H
-#define EPD_BW_SPI_DISP_DEV_H
 
 #include "disp_dev.h"
 
@@ -34,5 +34,5 @@ extern const disp_dev_driver_t epd_bw_spi_disp_dev_driver;
 }
 #endif
 
-#endif /* EPD_BW_SPI_DISP_DEV_H */
 /** @} */
+#endif /* EPD_BW_SPI_DISP_DEV_H */

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ETHOS_H
+#define ETHOS_H
+
 /**
  * @defgroup    drivers_ethos_stdio   STDIO via ethos
  * @ingroup     sys_stdio
@@ -32,9 +35,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ETHOS_H
-#define ETHOS_H
 
 #include <stdbool.h>
 
@@ -163,5 +163,5 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
 #ifdef __cplusplus
 }
 #endif
-#endif /* ETHOS_H */
 /** @} */
+#endif /* ETHOS_H */

--- a/drivers/include/feetech.h
+++ b/drivers/include/feetech.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef FEETECH_H
+#define FEETECH_H
+
 /**
  * @defgroup    drivers_feetech Feetech driver
  * @ingroup     drivers_actuators
@@ -20,9 +23,6 @@
  *
  * @author      Loïc Dauphin <loic.dauphin@inria.fr>
  */
-
-#ifndef FEETECH_H
-#define FEETECH_H
 
 #include <stdlib.h>
 
@@ -166,5 +166,5 @@ int feetech_read(const feetech_t *device, feetech_addr_t addr, uint8_t *data, si
 }
 #endif
 
-#endif /* FEETECH_H */
 /** @} */
+#endif /* FEETECH_H */

--- a/drivers/include/ft5x06.h
+++ b/drivers/include/ft5x06.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FT5X06_H
+#define FT5X06_H
+
 /**
  * @defgroup    drivers_ft5x06 FocalTech FT5x06 touch panel driver
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef FT5X06_H
-#define FT5X06_H
 
 #include <stdint.h>
 
@@ -185,5 +185,5 @@ int ft5x06_read_touch_gesture(const ft5x06_t *dev, ft5x06_touch_gesture_t *gestu
 }
 #endif
 
-#endif /* FT5X06_H */
 /** @} */
+#endif /* FT5X06_H */

--- a/drivers/include/fxos8700.h
+++ b/drivers/include/fxos8700.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FXOS8700_H
+#define FXOS8700_H
+
 /**
  * @defgroup    drivers_fxos8700 FXOS8700 3-axis accelerometer/magnetometer
  * @ingroup     drivers_sensors
@@ -24,9 +27,6 @@
  * @author      Michael Andersen <m.andersen@cs.berkeley.edu>
  * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
  */
-
-#ifndef FXOS8700_H
-#define FXOS8700_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -167,5 +167,5 @@ int fxos8700_read_cached(const void* dev, fxos8700_measurement_t* acc, fxos8700_
 }
 #endif
 
-#endif /* FXOS8700_H */
 /** @} */
+#endif /* FXOS8700_H */

--- a/drivers/include/gp2y10xx.h
+++ b/drivers/include/gp2y10xx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef GP2Y10XX_H
+#define GP2Y10XX_H
+
 /**
  * @defgroup   drivers_gp2y10xx GP2Y10xx Optical Dust Sensor device driver
  * @ingroup    drivers_sensors
@@ -33,9 +36,6 @@
  *
  * @author     Jean Pierre Dudey <jeandudey@hotmail.com>
  */
-
-#ifndef GP2Y10XX_H
-#define GP2Y10XX_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -124,5 +124,5 @@ int gp2y10xx_read_density(const gp2y10xx_t *dev, uint16_t *density);
 }
 #endif
 
-#endif /* GP2Y10XX_H */
 /** @} */
+#endif /* GP2Y10XX_H */

--- a/drivers/include/grove_ledbar.h
+++ b/drivers/include/grove_ledbar.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef GROVE_LEDBAR_H
+#define GROVE_LEDBAR_H
+
 /**
  * @defgroup    drivers_grove_ledbar Grove ledbar
  * @ingroup     drivers_actuators
@@ -20,9 +23,6 @@
  *
  * @author      Sebastian Meiling <s@mlng.net>
  */
-
-#ifndef GROVE_LEDBAR_H
-#define GROVE_LEDBAR_H
 
 #include <stdint.h>
 
@@ -90,5 +90,5 @@ void grove_ledbar_clear(grove_ledbar_t *dev);
 }
 #endif
 
-#endif /* GROVE_LEDBAR_H */
 /** @} */
+#endif /* GROVE_LEDBAR_H */

--- a/drivers/include/hd44780.h
+++ b/drivers/include/hd44780.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef HD44780_H
+#define HD44780_H
 /**
  * @defgroup    drivers_hd44780 HD44780 LCD driver
  * @ingroup     drivers_display
@@ -20,8 +22,6 @@
  *
  * @author      Sebastian Meiling <s@mlng.net>
  */
-#ifndef HD44780_H
-#define HD44780_H
 
 #include <stdint.h>
 
@@ -209,5 +209,5 @@ void hd44780_print(const hd44780_t *dev, const char *data);
 }
 #endif
 
-#endif /* HD44780_H */
 /** @} */
+#endif /* HD44780_H */

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef HDC1000_H
+#define HDC1000_H
+
 /**
  * @defgroup    drivers_hdc1000 HDC1000 Humidity and Temperature Sensor
  * @ingroup     drivers_sensors
@@ -37,9 +40,6 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef HDC1000_H
-#define HDC1000_H
 
 #include <stdint.h>
 
@@ -187,5 +187,5 @@ int hdc1000_read_cached(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
 }
 #endif
 
-#endif /* HDC1000_H */
 /** @} */
+#endif /* HDC1000_H */

--- a/drivers/include/hih6130.h
+++ b/drivers/include/hih6130.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HIH6130_H
+#define HIH6130_H
+
 /**
  * @defgroup    drivers_hih6130 HIH6130 humidity and temperature sensor
  * @ingroup     drivers_sensors
@@ -19,9 +22,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef HIH6130_H
-#define HIH6130_H
 
 #include <stdint.h>
 
@@ -66,5 +66,5 @@ int hih6130_get_humidity_temperature(const hih6130_t *dev,
 }
 #endif
 
-#endif /* HIH6130_H */
 /** @} */
+#endif /* HIH6130_H */

--- a/drivers/include/hm330x.h
+++ b/drivers/include/hm330x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HM330X_H
+#define HM330X_H
+
 /**
  * @defgroup    drivers_hm330x HM330X Laser Particulate Matter Sensor
  * @ingroup     drivers_sensors
@@ -29,9 +32,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef HM330X_H
-#define HM330X_H
 
 #include "periph/i2c.h"
 #include "periph/gpio.h"
@@ -138,5 +138,5 @@ void hm330x_wakeup(hm330x_t *dev);
 }
 #endif
 
-#endif /* HM330X_H */
 /** @} */
+#endif /* HM330X_H */

--- a/drivers/include/hmc5883l.h
+++ b/drivers/include/hmc5883l.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HMC5883L_H
+#define HMC5883L_H
+
 /**
  * @defgroup    drivers_hmc5883l HMC5883L 3-axis digital compass
  * @ingroup     drivers_sensors
@@ -28,9 +31,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  */
-
-#ifndef HMC5883L_H
-#define HMC5883L_H
 
 #ifdef __cplusplus
 extern "C"
@@ -292,5 +292,5 @@ int hmc5883l_power_up(hmc5883l_t *dev);
 }
 #endif
 
-#endif /* HMC5883L_H */
 /** @} */
+#endif /* HMC5883L_H */

--- a/drivers/include/hsc.h
+++ b/drivers/include/hsc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HSC_H
+#define HSC_H
+
 /**
  * @defgroup    drivers_hsc HSC temperature and pressure sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Quang Pham <phhr_quang@live.com>
  */
-
-#ifndef HSC_H
-#define HSC_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -99,5 +99,5 @@ int hsc_read_pressure(const hsc_t *dev, int32_t *dest);
 }
 #endif
 
-#endif /* HSC_H */
 /** @} */
+#endif /* HSC_H */

--- a/drivers/include/hts221.h
+++ b/drivers/include/hts221.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HTS221_H
+#define HTS221_H
+
 /**
  * @defgroup    drivers_hts221 ST HTS221 digital Humidity Sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Sebastian Meiling <s@mlng.net>
  */
-
-#ifndef HTS221_H
-#define HTS221_H
 
 #include <stdint.h>
 
@@ -165,5 +165,5 @@ int hts221_read_temperature(const hts221_t *dev, int16_t *val);
 }
 #endif
 
-#endif /* HTS221_H */
 /** @} */
+#endif /* HTS221_H */

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef ILI9341_H
+#define ILI9341_H
+
 /**
  * @defgroup    drivers_ili9341 ILI9341 display driver
  * @ingroup     drivers_display
@@ -28,9 +31,6 @@
  * certainly can't use DMA anymore, every short has to be converted before
  * transfer.
  */
-
-#ifndef ILI9341_H
-#define ILI9341_H
 
 #include "lcd.h"
 
@@ -104,5 +104,5 @@ extern const lcd_driver_t lcd_ili9341_driver;
 #ifdef __cplusplus
 }
 #endif
-#endif /* ILI9341_H */
 /** @} */
+#endif /* ILI9341_H */

--- a/drivers/include/ina2xx.h
+++ b/drivers/include/ina2xx.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef INA2XX_H
+#define INA2XX_H
+
 /**
  * @defgroup    drivers_ina2xx INA2XX current/power monitor
  * @ingroup     drivers_sensors
@@ -43,9 +46,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef INA2XX_H
-#define INA2XX_H
 
 #include <stdint.h>
 
@@ -256,5 +256,5 @@ int ina2xx_read_power(const ina2xx_t *dev, uint32_t *power);
 }
 #endif
 
-#endif /* INA2XX_H */
 /** @} */
+#endif /* INA2XX_H */

--- a/drivers/include/ina3221.h
+++ b/drivers/include/ina3221.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef INA3221_H
+#define INA3221_H
+
 /**
  * @defgroup    drivers_ina3221 INA3221 current/power monitor
  * @ingroup     drivers_sensors
@@ -66,9 +69,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-
-#ifndef INA3221_H
-#define INA3221_H
 
 #include <assert.h>
 #include <errno.h>
@@ -1103,5 +1103,5 @@ void ina3221_calculate_power_uw(ina3221_ch_t ch,
 }
 #endif
 
-#endif /* INA3221_H */
 /** @} */
+#endif /* INA3221_H */

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef IO1_XPLAINED_H
+#define IO1_XPLAINED_H
+
 /**
  * @defgroup    drivers_io1_xplained Atmel IO1 Xplained Extension board
  * @ingroup     drivers_sensors
@@ -36,9 +39,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef IO1_XPLAINED_H
-#define IO1_XPLAINED_H
 
 #include "saul.h"
 #include "at30tse75x.h"
@@ -108,5 +108,5 @@ int io1_xplained_read_light_level(uint16_t *light);
 }
 #endif
 
-#endif /* IO1_XPLAINED_H */
 /** @} */
+#endif /* IO1_XPLAINED_H */

--- a/drivers/include/ir_nec.h
+++ b/drivers/include/ir_nec.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef IR_NEC_H
+#define IR_NEC_H
+
 /**
  * @defgroup    drivers_ir_nec IR NEC Remote receiver
  * @ingroup     drivers_misc
@@ -17,9 +20,6 @@
  *
  * @author      Dario Petrillo <dario.pk1@gmail.com>
  */
-
-#ifndef IR_NEC_H
-#define IR_NEC_H
 
 #include <stdint.h>
 
@@ -84,5 +84,5 @@ int ir_nec_read(ir_nec_t *dev, ir_nec_cmd_t *command);
 }
 #endif
 
-#endif /* IR_NEC_H */
 /** @} */
+#endif /* IR_NEC_H */

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ISL29020_H
+#define ISL29020_H
+
 /**
  * @defgroup    drivers_isl29020 ISL29020 light sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef ISL29020_H
-#define ISL29020_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -129,5 +129,5 @@ int isl29020_disable(const isl29020_t *dev);
 }
 #endif
 
-#endif /* ISL29020_H */
 /** @} */
+#endif /* ISL29020_H */

--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef ISL29125_H
+#define ISL29125_H
+
 /**
  * @defgroup    drivers_isl29125 ISL29125 RGB light sensor
  * @ingroup     drivers_sensors
@@ -44,9 +47,6 @@
  * @author      Martin Heusmann <martin.heusmann@haw-hamburg.de>
  * @author      Cenk Gündoğan <mail-github@cgundogan.de>
  */
-
-#ifndef ISL29125_H
-#define ISL29125_H
 
 #include <stdint.h>
 
@@ -214,5 +214,5 @@ int isl29125_read_irq_status(const isl29125_t *dev);
 }
 #endif
 
-#endif /* ISL29125_H */
 /** @} */
+#endif /* ISL29125_H */

--- a/drivers/include/itg320x.h
+++ b/drivers/include/itg320x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ITG320X_H
+#define ITG320X_H
+
 /**
  * @defgroup    drivers_itg320x ITG320X 3-axis gyroscope
  * @ingroup     drivers_sensors
@@ -36,9 +39,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef ITG320X_H
-#define ITG320X_H
 
 #ifdef __cplusplus
 extern "C"
@@ -312,5 +312,5 @@ int itg320x_power_up(itg320x_t *dev);
 }
 #endif
 
-#endif /* ITG320X_H */
 /** @} */
+#endif /* ITG320X_H */

--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef JC42_H
+#define JC42_H
+
 /**
  * @defgroup    drivers_jc42 JC42 compliant temperature sensor driver
  * @ingroup     drivers_sensors
@@ -29,9 +32,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef JC42_H
-#define JC42_H
 
 #include "periph/i2c.h"
 #include "saul.h"
@@ -120,5 +120,5 @@ int jc42_get_temperature(const jc42_t* dev, int16_t* temperature);
 }
 #endif
 
-#endif /* JC42_H */
 /** @} */
+#endif /* JC42_H */

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef KW2XRF_H
+#define KW2XRF_H
+
 /**
  * @defgroup    drivers_kw2xrf KW2x radio-driver
  * @ingroup     drivers_netdev
@@ -19,9 +22,6 @@
  * @author      Jonas Remmert <j.remmert@phytec.de>
  * @author      Sebastian Meiling <s@mlng.net>
  */
-
-#ifndef KW2XRF_H
-#define KW2XRF_H
 
 #include <stdint.h>
 
@@ -173,5 +173,5 @@ void kw2xrf_radio_hal_irq_handler(void *dev);
 }
 #endif
 
-#endif /* KW2XRF_H */
 /** @} */
+#endif /* KW2XRF_H */

--- a/drivers/include/kw41zrf.h
+++ b/drivers/include/kw41zrf.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef KW41ZRF_H
+#define KW41ZRF_H
+
 /**
  * @defgroup    drivers_kw41zrf KW41Z radio-driver
  * @ingroup     drivers_netdev
@@ -17,9 +20,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef KW41ZRF_H
-#define KW41ZRF_H
 
 #include <stdint.h>
 
@@ -165,5 +165,5 @@ int kw41zrf_reset(kw41zrf_t *dev);
 }
 #endif
 
-#endif /* KW41ZRF_H */
 /** @} */
+#endif /* KW41ZRF_H */

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef L3G4200D_H
+#define L3G4200D_H
+
 /**
  * @defgroup    drivers_l3g4200d L3G4200D gyroscope
  * @ingroup     drivers_sensors
@@ -23,9 +26,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef L3G4200D_H
-#define L3G4200D_H
 
 #include <stdint.h>
 
@@ -158,5 +158,5 @@ int l3g4200d_disable(const l3g4200d_t *dev);
 }
 #endif
 
-#endif /* L3G4200D_H */
 /** @} */
+#endif /* L3G4200D_H */

--- a/drivers/include/l3gxxxx.h
+++ b/drivers/include/l3gxxxx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef L3GXXXX_H
+#define L3GXXXX_H
+
 /**
  * @defgroup    drivers_l3gxxxx L3Gxxxx 3-axis gyroscope sensor family
  * @ingroup     drivers_sensors
@@ -956,9 +959,6 @@
  * @file
  * @brief       Device Driver for ST L3Gxxxx 3-axis gyroscope sensor family
  */
-
-#ifndef L3GXXXX_H
-#define L3GXXXX_H
 
 #ifdef __cplusplus
 extern "C"
@@ -1995,5 +1995,5 @@ int l3gxxxx_reg_read(const l3gxxxx_t *dev,
 }
 #endif
 
-#endif /* L3GXXXX_H */
 /** @} */
+#endif /* L3GXXXX_H */

--- a/drivers/include/lc709203f.h
+++ b/drivers/include/lc709203f.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LC709203F_H
+#define LC709203F_H
+
 /**
  * @defgroup    drivers_lc709203f LC709203F
  * @ingroup     drivers_sensors
@@ -18,9 +21,6 @@
  * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
-
-#ifndef LC709203F_H
-#define LC709203F_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -384,5 +384,5 @@ void lc709203f_set_status_bit(const lc709203f_t *dev, const lc709203f_temp_obtai
 }
 #endif
 
-#endif /* LC709203F_H */
 /** @} */
+#endif /* LC709203F_H */

--- a/drivers/include/lcd.h
+++ b/drivers/include/lcd.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef LCD_H
+#define LCD_H
+
 /**
  * @defgroup    drivers_lcd LCD display driver
  * @ingroup     drivers_display
@@ -43,9 +46,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  *
  */
-
-#ifndef LCD_H
-#define LCD_H
 
 #include "board.h"
 #include "mutex.h"
@@ -493,5 +493,5 @@ extern const lcd_ll_par_driver_t lcd_ll_par_driver;
 #ifdef __cplusplus
 }
 #endif
-#endif /* LCD_H */
 /** @} */
+#endif /* LCD_H */

--- a/drivers/include/led.h
+++ b/drivers/include/led.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LED_H
+#define LED_H
+
 /**
  * @defgroup    drivers_led Control on-board LEDs
  * @ingroup     drivers_actuators
@@ -28,9 +31,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef LED_H
-#define LED_H
 
 #include "board.h"
 
@@ -208,5 +208,5 @@ static inline void led_toggle(unsigned id)
 }
 #endif
 
-#endif /* LED_H */
 /** @} */
+#endif /* LED_H */

--- a/drivers/include/lis2dh12.h
+++ b/drivers/include/lis2dh12.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LIS2DH12_H
+#define LIS2DH12_H
+
 /**
  * @defgroup    drivers_lis2dh12 LIS2DH12 Accelerometer
  * @ingroup     drivers_sensors
@@ -32,9 +35,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef LIS2DH12_H
-#define LIS2DH12_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -503,5 +503,5 @@ int lis2dh12_poweroff(const lis2dh12_t *dev);
 }
 #endif
 
-#endif /* LIS2DH12_H */
 /** @} */
+#endif /* LIS2DH12_H */

--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LIS3DH_H
+#define LIS3DH_H
+
 /**
  * @defgroup    drivers_lis3dh LIS3DH accelerometer
  * @ingroup     drivers_sensors
@@ -21,9 +24,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef LIS3DH_H
-#define LIS3DH_H
 
 #include <stdint.h>
 
@@ -905,5 +905,5 @@ int lis3dh_get_fifo_level(const lis3dh_t *dev);
 }
 #endif
 
-#endif /* LIS3DH_H */
 /** @} */
+#endif /* LIS3DH_H */

--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LIS3MDL_H
+#define LIS3MDL_H
+
 /**
  * @defgroup    drivers_lis3mdl LIS3MDL 3-axis magnetometer
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      René Herthel <rene-herthel@outlook.de>
  */
-
-#ifndef LIS3MDL_H
-#define LIS3MDL_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -158,5 +158,5 @@ void lis3mdl_disable(const lis3mdl_t *dev);
 }
 #endif
 
-#endif /* LIS3MDL_H */
 /** @} */
+#endif /* LIS3MDL_H */

--- a/drivers/include/lm75.h
+++ b/drivers/include/lm75.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LM75_H
+#define LM75_H
+
 /**
  * @ingroup     drivers_lm75
  *
@@ -22,9 +25,6 @@
  * @ingroup     drivers_sensors
  * @brief       Driver for the lm75 temperature sensors.
  */
-
-#ifndef LM75_H
-#define LM75_H
 
 #include <stdbool.h>
 #include "periph/i2c.h"
@@ -242,5 +242,5 @@ int lm75_low_power_mode(lm75_t *dev, uint16_t interval);
 }
 #endif
 
-#endif /* LM75_H */
 /** @} */
+#endif /* LM75_H */

--- a/drivers/include/lpd8808.h
+++ b/drivers/include/lpd8808.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LPD8808_H
+#define LPD8808_H
+
 /**
  * @defgroup    drivers_lpd8808 LPD8808 based LED Strip
  * @ingroup     drivers_actuators
@@ -26,9 +29,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef LPD8808_H
-#define LPD8808_H
 
 #include "color.h"
 #include "periph/gpio.h"
@@ -79,5 +79,5 @@ void lpd8808_load_rgb(const lpd8808_t *dev, color_rgb_t vals[]);
 }
 #endif
 
-#endif /* LPD8808_H */
 /** @} */
+#endif /* LPD8808_H */

--- a/drivers/include/lpsxxx.h
+++ b/drivers/include/lpsxxx.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef LPSXXX_H
+#define LPSXXX_H
+
 /**
  * @defgroup    drivers_lpsxxx LPS331AP/LPS25HB/LPS22HB Pressure Sensors Driver
  * @ingroup     drivers_sensors
@@ -25,9 +28,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef LPSXXX_H
-#define LPSXXX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -174,5 +174,5 @@ int lpsxxx_disable(const lpsxxx_t *dev);
 }
 #endif
 
-#endif /* LPSXXX_H */
 /** @} */
+#endif /* LPSXXX_H */

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LSM303DLHC_H
+#define LSM303DLHC_H
+
 /**
  * @defgroup    drivers_lsm303dlhc LSM303DLHC 3D accelerometer/magnetometer
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
-
-#ifndef LSM303DLHC_H
-#define LSM303DLHC_H
 
 #include <stdint.h>
 #include "periph/i2c.h"

--- a/drivers/include/lsm6dsxx.h
+++ b/drivers/include/lsm6dsxx.h
@@ -7,6 +7,9 @@
  *
  */
 
+#ifndef LSM6DSXX_H
+#define LSM6DSXX_H
+
 /**
  * @defgroup    drivers_lsm6dsxx LSM6DSXX 3D accelerometer/gyroscope
  * @ingroup     drivers_sensors
@@ -23,9 +26,6 @@
  * @author      Sebastian Meiling <s@mlng.net>
  *
  */
-
-#ifndef LSM6DSXX_H
-#define LSM6DSXX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -220,5 +220,5 @@ int lsm6dsxx_gyro_power_up(const lsm6dsxx_t *dev);
 }
 #endif
 
-#endif /* LSM6DSXX_H */
 /** @} */
+#endif /* LSM6DSXX_H */

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LTC4150_H
+#define LTC4150_H
+
 /**
  * @defgroup    drivers_ltc4150 LTC4150 coulomb counter
  * @ingroup     drivers_sensors
@@ -58,9 +61,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef LTC4150_H
-#define LTC4150_H
 
 #include <stdint.h>
 
@@ -343,5 +343,5 @@ void ltc4150_pulses2c(const ltc4150_dev_t *dev,
 }
 #endif
 
-#endif /* LTC4150_H */
 /** @} */
+#endif /* LTC4150_H */

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef MAG3110_H
+#define MAG3110_H
+
 /**
  * @defgroup    drivers_mag3110 MAG3110 3-Axis Digital Magnetometer
  * @ingroup     drivers_sensors
@@ -31,9 +34,6 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Sebastian Meiling <s@mlng.net>
  */
-
-#ifndef MAG3110_H
-#define MAG3110_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -224,5 +224,5 @@ int mag3110_read_dtemp(const mag3110_t *dev, int8_t *dtemp);
 }
 #endif
 
-#endif /* MAG3110_H */
 /** @} */
+#endif /* MAG3110_H */

--- a/drivers/include/matrix_keypad.h
+++ b/drivers/include/matrix_keypad.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MATRIX_KEYPAD_H
+#define MATRIX_KEYPAD_H
+
 /**
  * @defgroup    drivers_matrix_keypad Matrix Keypad
  * @ingroup     drivers_sensors
@@ -48,9 +51,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef MATRIX_KEYPAD_H
-#define MATRIX_KEYPAD_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -225,5 +225,5 @@ size_t matrix_keypad_scan(matrix_keypad_t *dev);
 }
 #endif
 
-#endif /* MATRIX_KEYPAD_H */
 /** @} */
+#endif /* MATRIX_KEYPAD_H */

--- a/drivers/include/max31855.h
+++ b/drivers/include/max31855.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MAX31855_H
+#define MAX31855_H
+
 /**
  * @defgroup    drivers_max31855 MAX31855 Thermocouple-to-Digital Converter driver
  * @ingroup     drivers_sensors
@@ -31,9 +34,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef MAX31855_H
-#define MAX31855_H
 
 /* Add header includes here */
 
@@ -131,5 +131,5 @@ void max31855_read_raw(max31855_t *dev, uint32_t *data);
 }
 #endif
 
-#endif /* MAX31855_H */
 /** @} */
+#endif /* MAX31855_H */

--- a/drivers/include/mcp47xx.h
+++ b/drivers/include/mcp47xx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MCP47XX_H
+#define MCP47XX_H
+
 /**
  * @defgroup    drivers_mcp47xx MCP47xx DAC with I2C interface
  * @ingroup     drivers_saul
@@ -103,9 +106,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  */
-
-#ifndef MCP47XX_H
-#define MCP47XX_H
 
 #ifdef __cplusplus
 extern "C"
@@ -345,5 +345,5 @@ uint8_t mcp47xx_dac_channels(mcp47xx_t *dev);
 }
 #endif
 
-#endif /* MCP47XX_H */
 /** @} */
+#endif /* MCP47XX_H */

--- a/drivers/include/mfrc522.h
+++ b/drivers/include/mfrc522.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MFRC522_H
+#define MFRC522_H
+
 /**
  * @defgroup drivers_mfrc522 MFRC522 RFID controller
  * @ingroup  drivers_actuators
@@ -34,9 +37,6 @@
  * @author   Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @file
  */
-
-#ifndef MFRC522_H
-#define MFRC522_H
 
 #ifdef __cplusplus
 extern "C"
@@ -874,5 +874,5 @@ bool mfrc522_pcd_perform_self_test(mfrc522_t *dev);
 }
 #endif
 
-#endif /* MFRC522_H */
 /** @} */
+#endif /* MFRC522_H */

--- a/drivers/include/mhz19.h
+++ b/drivers/include/mhz19.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef MHZ19_H
+#define MHZ19_H
+
 /**
  * @defgroup    drivers_mhz19 MH-Z19 CO2 sensor
  * @ingroup     drivers_sensors
@@ -34,9 +37,6 @@
  * @author      Christian Manal <manal@uni-bremen.de>
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  */
-
-#ifndef MHZ19_H
-#define MHZ19_H
 
 #include <stdbool.h>
 
@@ -153,5 +153,5 @@ void mhz19_calibrate_zero_point(mhz19_t *dev);
 }
 #endif
 
-#endif /* MHZ19_H */
 /** @} */
+#endif /* MHZ19_H */

--- a/drivers/include/mii.h
+++ b/drivers/include/mii.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef MII_H
+#define MII_H
+
 /**
  * @defgroup    drivers_mii     Ethernet Media-Independent Interface (MII)
  *                              Utilities
@@ -22,9 +25,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef MII_H
-#define MII_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -205,5 +205,5 @@ static inline bool mii_can_10_mbps_half_dp(uint16_t bmsr)
 }
 #endif
 
-#endif /* MII_H */
 /** @} */
+#endif /* MII_H */

--- a/drivers/include/mma7660.h
+++ b/drivers/include/mma7660.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MMA7660_H
+#define MMA7660_H
+
 /**
  * @defgroup    drivers_mma7660 MMA7660 Accelerometer
  * @ingroup     drivers_sensors
@@ -19,9 +22,6 @@
  *
  * @author      Michael Andersen <m.andersen@cs.berkeley.edu>
  */
-
-#ifndef MMA7660_H
-#define MMA7660_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -256,5 +256,5 @@ int mma7660_read_counts(const mma7660_t *dev, int8_t *x, int8_t *y, int8_t *z);
 }
 #endif
 
-#endif /* MMA7660_H */
 /** @} */
+#endif /* MMA7660_H */

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef MMA8X5X_H
+#define MMA8X5X_H
+
 /**
  * @defgroup    drivers_mma8x5x MMA8x5x Accelerometer
  * @ingroup     drivers_sensors
@@ -29,9 +32,6 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef MMA8X5X_H
-#define MMA8X5X_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -222,5 +222,5 @@ void mma8x5x_ack_int(const mma8x5x_t *dev);
 }
 #endif
 
-#endif /* MMA8X5X_H */
 /** @} */
+#endif /* MMA8X5X_H */

--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MOTOR_DRIVER_H
+#define MOTOR_DRIVER_H
+
 /**
  * @defgroup    drivers_motor DC Motor Driver
  * @ingroup     drivers_actuators
@@ -80,9 +83,6 @@
  *
  * @author      Gilles DOFFE <g.doffe@gmail.com>
  */
-
-#ifndef MOTOR_DRIVER_H
-#define MOTOR_DRIVER_H
 
 #include "periph/pwm.h"
 #include "periph/gpio.h"
@@ -235,5 +235,5 @@ void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id);
 }
 #endif
 
-#endif /* MOTOR_DRIVER_H */
 /** @} */
+#endif /* MOTOR_DRIVER_H */

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef MPL3115A2_H
+#define MPL3115A2_H
+
 /**
  * @defgroup    drivers_mpl3115a2 MPL3115A2 Pressure Sensor
  * @ingroup     drivers_sensors
@@ -27,9 +30,6 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Sebastian Meiling <s@mlng.net>
  */
-
-#ifndef MPL3115A2_H
-#define MPL3115A2_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -184,5 +184,5 @@ int mpl3115a2_read_temp(const mpl3115a2_t *dev, int16_t *temp);
 }
 #endif
 
-#endif /* MPL3115A2_H */
 /** @} */
+#endif /* MPL3115A2_H */

--- a/drivers/include/mpu9x50.h
+++ b/drivers/include/mpu9x50.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef MPU9X50_H
+#define MPU9X50_H
+
 /**
  * @defgroup    drivers_mpu9x50 MPU-9X50 (MPU9150 and MPU9250) accelerometer/magnetometer/gyroscope
  * @ingroup     drivers_sensors
@@ -22,9 +25,6 @@
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  * @author      Jannes Volkens <jannes.volkens@haw-hamburg.de>
  */
-
-#ifndef MPU9X50_H
-#define MPU9X50_H
 
 #include "periph/i2c.h"
 
@@ -308,5 +308,5 @@ int mpu9x50_set_compass_sample_rate(mpu9x50_t *dev, uint8_t rate);
 }
 #endif
 
-#endif /* MPU9X50_H */
 /** @} */
+#endif /* MPU9X50_H */

--- a/drivers/include/mq3.h
+++ b/drivers/include/mq3.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef MQ3_H
+#define MQ3_H
+
 /**
  * @defgroup    drivers_mq3 MQ-3 Alcohol Tester
  * @ingroup     drivers_sensors
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef MQ3_H
-#define MQ3_H
 
 #include "periph/adc.h"
 
@@ -77,5 +77,5 @@ int16_t mq3_read(const mq3_t *dev);
 }
 #endif
 
-#endif /* MQ3_H */
 /** @} */
+#endif /* MQ3_H */

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -7,6 +7,9 @@
  * details.
  */
 
+#ifndef MRF24J40_H
+#define MRF24J40_H
+
 /**
  * @defgroup    drivers_mrf24j40 MRF24J40 based drivers
  * @ingroup     drivers_netdev
@@ -66,9 +69,6 @@
  * @author      Neo Nenaco <neo@nenaco.de>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef MRF24J40_H
-#define MRF24J40_H
 
 #include <stdint.h>
 
@@ -404,5 +404,5 @@ int mrf24j40_init(mrf24j40_t *dev, const mrf24j40_params_t *params, ieee802154_d
 }
 #endif
 
-#endif /* MRF24J40_H */
 /** @} */
+#endif /* MRF24J40_H */

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_H
+#define MTD_H
+
 /**
  * @defgroup    drivers_mtd Memory Technology Device
  * @ingroup     drivers_storage
@@ -69,9 +72,6 @@
  * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef MTD_H
-#define MTD_H
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -544,5 +544,5 @@ static inline mtd_dev_t *mtd_dev_get(unsigned idx)
 }
 #endif
 
-#endif /* MTD_H */
 /** @} */
+#endif /* MTD_H */

--- a/drivers/include/mtd_at24cxxx.h
+++ b/drivers/include/mtd_at24cxxx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_AT24CXXX_H
+#define MTD_AT24CXXX_H
+
 /**
  * @defgroup    drivers_mtd_at24cxxx MTD wrapper for AT24cxxx family of I2C-EEPROMs
  * @ingroup     drivers_storage
@@ -19,9 +22,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-
-#ifndef MTD_AT24CXXX_H
-#define MTD_AT24CXXX_H
 
 #include "at24cxxx.h"
 #include "mtd.h"
@@ -63,5 +63,5 @@ extern const mtd_desc_t mtd_at24cxxx_driver;
 }
 #endif
 
-#endif /* MTD_AT24CXXX_H */
 /** @} */
+#endif /* MTD_AT24CXXX_H */

--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -5,6 +5,8 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef MTD_DEFAULT_H
+#define MTD_DEFAULT_H
 /**
  * @ingroup     drivers_mtd
  * @{
@@ -14,8 +16,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef MTD_DEFAULT_H
-#define MTD_DEFAULT_H
 
 #include "board.h"
 #include "modules.h"
@@ -60,5 +60,5 @@ static inline mtd_dev_t *mtd_default_get_dev(unsigned idx)
 }
 #endif
 
-#endif /* MTD_DEFAULT_H */
 /** @} */
+#endif /* MTD_DEFAULT_H */

--- a/drivers/include/mtd_emulated.h
+++ b/drivers/include/mtd_emulated.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef MTD_EMULATED_H
+#define MTD_EMULATED_H
 /**
  * @defgroup    drivers_mtd_emulated MTD wrapper for emulated MTD devices
  * @ingroup     drivers_mtd
@@ -16,8 +18,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-#ifndef MTD_EMULATED_H
-#define MTD_EMULATED_H
 
 #include <stdbool.h>
 
@@ -104,5 +104,5 @@ extern const mtd_desc_t _mtd_emulated_driver;
 }
 #endif
 
-#endif /* MTD_EMULATED_H */
 /** @} */
+#endif /* MTD_EMULATED_H */

--- a/drivers/include/mtd_flashpage.h
+++ b/drivers/include/mtd_flashpage.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_FLASHPAGE_H
+#define MTD_FLASHPAGE_H
+
 /**
  * @defgroup    drivers_mtd_flashpage MTD wrapper for Flashpage devices
  * @ingroup     drivers_storage
@@ -22,9 +25,6 @@
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef MTD_FLASHPAGE_H
-#define MTD_FLASHPAGE_H
 
 #include "mtd.h"
 #include "periph/flashpage.h"
@@ -117,5 +117,5 @@ extern mtd_dev_t *mtd_aux;
 }
 #endif
 
-#endif /* MTD_FLASHPAGE_H */
 /** @} */
+#endif /* MTD_FLASHPAGE_H */

--- a/drivers/include/mtd_mapper.h
+++ b/drivers/include/mtd_mapper.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_MAPPER_H
+#define MTD_MAPPER_H
+
 /**
  * @defgroup    drivers_mtd_mapper  MTD address mapper
  * @ingroup     drivers_storage
@@ -59,9 +62,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef MTD_MAPPER_H
-#define MTD_MAPPER_H
-
 #include <stdint.h>
 #include <stdbool.h>
 #include "mtd.h"
@@ -109,5 +109,5 @@ extern const mtd_desc_t mtd_mapper_driver;
 }
 #endif
 
-#endif /* MTD_MAPPER_H */
 /** @} */
+#endif /* MTD_MAPPER_H */

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_SDCARD_H
+#define MTD_SDCARD_H
+
 /**
  * @defgroup    drivers_mtd_sdcard MTD wrapper for SPI SD Cards
  * @ingroup     drivers_storage
@@ -18,9 +21,6 @@
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
-
-#ifndef MTD_SDCARD_H
-#define MTD_SDCARD_H
 
 #include <stdint.h>
 
@@ -72,5 +72,5 @@ extern const mtd_desc_t mtd_sdcard_driver;
 }
 #endif
 
-#endif /* MTD_SDCARD_H */
 /** @} */
+#endif /* MTD_SDCARD_H */

--- a/drivers/include/mtd_sdmmc.h
+++ b/drivers/include/mtd_sdmmc.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_SDMMC_H
+#define MTD_SDMMC_H
+
 /**
  * @defgroup    drivers_mtd_sdmmc MTD wrapper for SD/MMC devices
  * @ingroup     drivers_storage
@@ -20,9 +23,6 @@
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef MTD_SDMMC_H
-#define MTD_SDMMC_H
 
 #include <stdint.h>
 
@@ -54,5 +54,5 @@ extern const mtd_desc_t mtd_sdmmc_driver;
 }
 #endif
 
-#endif /* MTD_SDMMC_H */
 /** @} */
+#endif /* MTD_SDMMC_H */

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef MTD_SPI_NOR_H
+#define MTD_SPI_NOR_H
+
 /**
  * @defgroup    drivers_mtd_spi_nor Serial NOR flash
  * @ingroup     drivers_storage
@@ -20,9 +23,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef MTD_SPI_NOR_H
-#define MTD_SPI_NOR_H
 
 #include <stdint.h>
 
@@ -184,5 +184,5 @@ extern const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default_4bytes;
 }
 #endif
 
-#endif /* MTD_SPI_NOR_H */
 /** @} */
+#endif /* MTD_SPI_NOR_H */

--- a/drivers/include/my9221.h
+++ b/drivers/include/my9221.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MY9221_H
+#define MY9221_H
+
 /**
  * @defgroup    drivers_my9221 MY9221 LED controller
  * @ingroup     drivers_actuators
@@ -17,9 +20,6 @@
  *
  * @author      Sebastian Meiling <s@mlng.net>
  */
-
-#ifndef MY9221_H
-#define MY9221_H
 
 #include <stdint.h>
 
@@ -125,5 +125,5 @@ void my9221_toggle_led(my9221_t *dev, const uint8_t led);
 }
 #endif
 
-#endif /* MY9221_H */
 /** @} */
+#endif /* MY9221_H */

--- a/drivers/include/ncv7356.h
+++ b/drivers/include/ncv7356.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NCV7356_H
+#define NCV7356_H
 /**
 * @defgroup    drivers_ncv7356 NCV7356 Single Wire CAN Transceiver
 * @ingroup     drivers_can
@@ -29,8 +31,6 @@
  * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-#ifndef NCV7356_H
-#define NCV7356_H
 
 #include <stdio.h>
 
@@ -92,5 +92,5 @@ extern const trx_driver_t ncv7356_driver;
 }
 #endif
 
-#endif /* NCV7356_H */
 /** @} */
+#endif /* NCV7356_H */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -9,6 +9,9 @@
  * more details.
  */
 
+#ifndef NET_NETDEV_H
+#define NET_NETDEV_H
+
 /**
  * @defgroup    drivers_netdev_api Netdev - Network Device Driver API
  * @ingroup     drivers_netdev
@@ -186,9 +189,6 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_NETDEV_H
-#define NET_NETDEV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -669,5 +669,5 @@ static inline void netdev_trigger_event_isr(netdev_t *netdev)
 }
 #endif
 
-#endif /* NET_NETDEV_H */
 /** @} */
+#endif /* NET_NETDEV_H */

--- a/drivers/include/net/netdev/ble.h
+++ b/drivers/include/net/netdev/ble.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NETDEV_BLE_H
+#define NET_NETDEV_BLE_H
+
 /**
  * @defgroup    drivers_netdev_ble netdev BLE mode
  * @ingroup     drivers_netdev_api
@@ -73,9 +76,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_NETDEV_BLE_H
-#define NET_NETDEV_BLE_H
 
 #include "net/netdev.h"
 
@@ -196,5 +196,5 @@ static inline void netdev_ble_stop(netdev_t *dev)
 }
 #endif
 
-#endif /* NET_NETDEV_BLE_H */
 /** @} */
+#endif /* NET_NETDEV_BLE_H */

--- a/drivers/include/net/netdev/eth.h
+++ b/drivers/include/net/netdev/eth.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_NETDEV_ETH_H
+#define NET_NETDEV_ETH_H
+
 /**
  * @defgroup    drivers_netdev_eth Ethernet drivers
  * @ingroup     drivers_netdev_api
@@ -16,9 +19,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef NET_NETDEV_ETH_H
-#define NET_NETDEV_ETH_H
 
 #include <stdint.h>
 
@@ -82,5 +82,5 @@ int netdev_eth_set(netdev_t *dev, netopt_t opt, const void *value, size_t value_
 }
 #endif
 
-#endif /* NET_NETDEV_ETH_H */
 /** @} */
+#endif /* NET_NETDEV_ETH_H */

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NETDEV_IEEE802154_H
+#define NET_NETDEV_IEEE802154_H
 /**
  * @defgroup    drivers_netdev_ieee802154 802.15.4 radio drivers
  * @ingroup     drivers_netdev_api
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_NETDEV_IEEE802154_H
-#define NET_NETDEV_IEEE802154_H
 
 #include "net/eui_provider.h"
 #include "net/ieee802154.h"
@@ -286,5 +286,5 @@ static inline void netdev_ieee802154_setup(netdev_ieee802154_t *dev)
 }
 #endif
 
-#endif /* NET_NETDEV_IEEE802154_H */
 /** @} */
+#endif /* NET_NETDEV_IEEE802154_H */

--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#ifndef NET_NETDEV_IEEE802154_SUBMAC_H
+#define NET_NETDEV_IEEE802154_SUBMAC_H
 /**
  * @defgroup     drivers_netdev_ieee802154_submac IEEE802.15.4 SubMAC netdev layer
  * @ingroup      drivers_netdev_api
@@ -19,8 +21,6 @@
  *
  * @author       José I. Alamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef NET_NETDEV_IEEE802154_SUBMAC_H
-#define NET_NETDEV_IEEE802154_SUBMAC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +69,5 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac);
 }
 #endif
 
-#endif /* NET_NETDEV_IEEE802154_SUBMAC_H */
 /** @} */
+#endif /* NET_NETDEV_IEEE802154_SUBMAC_H */

--- a/drivers/include/net/netdev/layer.h
+++ b/drivers/include/net/netdev/layer.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef NET_NETDEV_LAYER_H
+#define NET_NETDEV_LAYER_H
+
 /**
  * @ingroup     drivers_netdev_api
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef NET_NETDEV_LAYER_H
-#define NET_NETDEV_LAYER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -140,5 +140,5 @@ void netdev_event_cb_pass(netdev_t *dev, netdev_event_t event);
 }
 #endif
 
-#endif /* NET_NETDEV_LAYER_H */
 /** @} */
+#endif /* NET_NETDEV_LAYER_H */

--- a/drivers/include/net/netdev/lora.h
+++ b/drivers/include/net/netdev/lora.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_NETDEV_LORA_H
+#define NET_NETDEV_LORA_H
+
 /**
  * @defgroup    drivers_netdev_lora LoRa drivers
  * @ingroup     drivers_netdev_api
@@ -16,9 +19,6 @@
  *
  * @author      José Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef NET_NETDEV_LORA_H
-#define NET_NETDEV_LORA_H
 
 #include <stdint.h>
 
@@ -40,5 +40,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_NETDEV_LORA_H */
 /** @} */
+#endif /* NET_NETDEV_LORA_H */

--- a/drivers/include/net/netdev/wifi.h
+++ b/drivers/include/net/netdev/wifi.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_NETDEV_WIFI_H
+#define NET_NETDEV_WIFI_H
+
 /**
  * @defgroup    drivers_netdev_wifi Wi-Fi drivers
  * @ingroup     drivers_netdev_api
@@ -16,9 +19,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
  */
-
-#ifndef NET_NETDEV_WIFI_H
-#define NET_NETDEV_WIFI_H
 
 #include "net/ethernet/hdr.h"
 #include "net/netopt.h"
@@ -205,5 +205,5 @@ typedef void (*wifi_on_disconnect_result_t) (void *netif, const wifi_disconnect_
 }
 #endif
 
-#endif /* NET_NETDEV_WIFI_H */
 /** @} */
+#endif /* NET_NETDEV_WIFI_H */

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef NRF24L01P_H
+#define NRF24L01P_H
+
 /**
  * @defgroup    drivers_nrf24l01p NRF24L01+ driver interface
  * @ingroup     drivers_netdev
@@ -19,9 +22,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  */
-
-#ifndef NRF24L01P_H
-#define NRF24L01P_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -625,5 +625,5 @@ void nrf24l01p_rx_cb(void *arg);
 }
 #endif
 
-#endif /* NRF24L01P_H */
 /** @} */
+#endif /* NRF24L01P_H */

--- a/drivers/include/nrf24l01p_ng.h
+++ b/drivers/include/nrf24l01p_ng.h
@@ -5,6 +5,8 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef NRF24L01P_NG_H
+#define NRF24L01P_NG_H
 /**
  * @defgroup    drivers_nrf24l01p_ng NRF24L01+ (NG) 2.4 GHz trasceiver driver
  * @ingroup     drivers_netdev
@@ -18,8 +20,6 @@
  *
  * @author  Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-#ifndef NRF24L01P_NG_H
-#define NRF24L01P_NG_H
 
 #include <stdint.h>
 
@@ -475,5 +475,5 @@ void nrf24l01p_ng_print_dev_info(const nrf24l01p_ng_t *dev);
 }
 #endif
 
-#endif /* NRF24L01P_NG_H */
 /** @} */
+#endif /* NRF24L01P_NG_H */

--- a/drivers/include/nvram-spi.h
+++ b/drivers/include/nvram-spi.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef NVRAM_SPI_H
+#define NVRAM_SPI_H
+
 /**
  * @ingroup     drivers_nvram
  * @{
@@ -19,9 +22,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef NVRAM_SPI_H
-#define NVRAM_SPI_H
 
 #include <stdint.h>
 #include "nvram.h"
@@ -64,5 +64,5 @@ int nvram_spi_init(nvram_t *dev, nvram_spi_params_t *spi_params, size_t size);
 }
 #endif
 
-#endif /* NVRAM_SPI_H */
 /** @} */
+#endif /* NVRAM_SPI_H */

--- a/drivers/include/nvram.h
+++ b/drivers/include/nvram.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef NVRAM_H
+#define NVRAM_H
+
 /**
  * @defgroup    drivers_nvram Non-volatile RAM
  * @ingroup     drivers_storage
@@ -23,9 +26,6 @@
  * @brief       Generic non-volatile RAM driver interface
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef NVRAM_H
-#define NVRAM_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -91,5 +91,5 @@ extern const vfs_file_ops_t nvram_vfs_ops;
 }
 #endif
 
-#endif /* NVRAM_H */
 /** @} */
+#endif /* NVRAM_H */

--- a/drivers/include/opt3001.h
+++ b/drivers/include/opt3001.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef OPT3001_H
+#define OPT3001_H
+
 /**
  * @defgroup    drivers_opt3001 OPT3001 Ambient Light Sensor
  * @ingroup     drivers_sensors
@@ -38,9 +41,6 @@
  *
  * @author      Jannes Volkens <jannes.volkens@haw-hamburg.de>
  */
-
-#ifndef OPT3001_H
-#define OPT3001_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -163,5 +163,5 @@ int opt3001_read_lux(const opt3001_t *dev, uint32_t *convl);
 }
 #endif
 
-#endif /* OPT3001_H */
 /** @} */
+#endif /* OPT3001_H */

--- a/drivers/include/pca9633.h
+++ b/drivers/include/pca9633.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PCA9633_H
+#define PCA9633_H
+
 /**
  * @defgroup    drivers_pca9633 PCA9633 I2C PWM controller
  * @ingroup     drivers_actuators
@@ -16,9 +19,6 @@
  * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @file
  */
-
-#ifndef PCA9633_H
-#define PCA9633_H
 
 #ifdef __cplusplus
 extern "C"
@@ -333,5 +333,5 @@ void pca9633_set_group_control_mode(pca9633_t* dev,
 }
 #endif
 
-#endif /* PCA9633_H */
 /** @} */
+#endif /* PCA9633_H */

--- a/drivers/include/pca9685.h
+++ b/drivers/include/pca9685.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PCA9685_H
+#define PCA9685_H
+
 /**
  * @defgroup    drivers_pca9685 PCA9685 I2C PWM controller
  * @ingroup     drivers_actuators
@@ -80,9 +83,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  */
-
-#ifndef PCA9685_H
-#define PCA9685_H
 
 #ifdef __cplusplus
 extern "C"
@@ -318,5 +318,5 @@ static inline uint8_t pca9685_pwm_channels(pca9685_t *dev)
 }
 #endif
 
-#endif /* PCA9685_H */
 /** @} */
+#endif /* PCA9685_H */

--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PCD8544_H
+#define PCD8544_H
+
 /**
  * @defgroup    drivers_pcd8544 PCD8544 LCD driver
  * @ingroup     drivers_display
@@ -18,9 +21,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PCD8544_H
-#define PCD8544_H
 
 #include <stdint.h>
 
@@ -198,5 +198,5 @@ void pcd8544_riot(const pcd8544_t *dev);
 }
 #endif
 
-#endif /* PCD8544_H */
 /** @} */
+#endif /* PCD8544_H */

--- a/drivers/include/pcf857x.h
+++ b/drivers/include/pcf857x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PCF857X_H
+#define PCF857X_H
+
 /**
  * @defgroup    drivers_pcf857x PCF857X I2C I/O expanders
  * @ingroup     drivers_misc
@@ -236,9 +239,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  */
-
-#ifndef PCF857X_H
-#define PCF857X_H
 
 #ifdef __cplusplus
 extern "C"
@@ -601,5 +601,5 @@ void pcf857x_gpio_irq_disable(pcf857x_t *dev, uint8_t pin);
 }
 #endif
 
-#endif /* PCF857X_H */
 /** @} */
+#endif /* PCF857X_H */

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_ADC_H
+#define PERIPH_ADC_H
+
 /**
  * @defgroup    drivers_periph_adc ADC
  * @ingroup     drivers_periph
@@ -51,9 +54,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_ADC_H
-#define PERIPH_ADC_H
 
 #include <limits.h>
 #include <stdint.h>
@@ -159,5 +159,5 @@ void adc_continuous_stop(void);
 }
 #endif
 
-#endif /* PERIPH_ADC_H */
 /** @} */
+#endif /* PERIPH_ADC_H */

--- a/drivers/include/periph/can.h
+++ b/drivers/include/periph/can.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_CAN_H
+#define PERIPH_CAN_H
+
 /**
  * @defgroup    drivers_periph_can CAN
  * @ingroup     drivers_periph
@@ -25,9 +28,6 @@
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef PERIPH_CAN_H
-#define PERIPH_CAN_H
 
 #include "periph_cpu.h"
 #include "can/candev.h"
@@ -62,5 +62,5 @@ void can_init(can_t *dev, const can_conf_t *conf);
 }
 #endif
 
-#endif /* PERIPH_CAN_H */
 /** @} */
+#endif /* PERIPH_CAN_H */

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_CPUID_H
+#define PERIPH_CPUID_H
+
 /**
  * @defgroup    drivers_periph_cpuid CPUID
  * @ingroup     drivers_periph
@@ -30,9 +33,6 @@
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-
-#ifndef PERIPH_CPUID_H
-#define PERIPH_CPUID_H
 
 #include "periph_cpu.h"
 
@@ -62,5 +62,5 @@ void cpuid_get(void *id);
 }
 #endif
 
-#endif /* PERIPH_CPUID_H */
 /** @} */
+#endif /* PERIPH_CPUID_H */

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_DAC_H
+#define PERIPH_DAC_H
+
 /**
  * @defgroup    drivers_periph_dac DAC
  * @ingroup     drivers_periph
@@ -46,9 +49,6 @@
  * @author      Simon Brummer <simon.brummer@haw-hamburg.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_DAC_H
-#define PERIPH_DAC_H
 
 #include <stdint.h>
 #include <limits.h>
@@ -133,5 +133,5 @@ void dac_poweroff(dac_t line);
 }
 #endif
 
-#endif /* PERIPH_DAC_H */
 /** @} */
+#endif /* PERIPH_DAC_H */

--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_EEPROM_H
+#define PERIPH_EEPROM_H
+
 /**
  * @defgroup    drivers_periph_eeprom EEPROM driver
  * @ingroup     drivers_periph
@@ -18,9 +21,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *
  */
-
-#ifndef PERIPH_EEPROM_H
-#define PERIPH_EEPROM_H
 
 #include <stdint.h>
 
@@ -120,5 +120,5 @@ size_t eeprom_erase(void);
 }
 #endif
 
-#endif /* PERIPH_EEPROM_H */
 /** @} */
+#endif /* PERIPH_EEPROM_H */

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_FLASHPAGE_H
+#define PERIPH_FLASHPAGE_H
+
 /**
  * @defgroup    drivers_periph_flashpage Flash page driver
  * @ingroup     drivers_periph
@@ -44,9 +47,6 @@
  * @author      Federico Pellegrin <fede@evolware.org>
  *
  */
-
-#ifndef PERIPH_FLASHPAGE_H
-#define PERIPH_FLASHPAGE_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -423,5 +423,5 @@ int flashpage_rwwee_write_and_verify(unsigned page, const void *data);
 }
 #endif
 
-#endif /* PERIPH_FLASHPAGE_H */
 /** @} */
+#endif /* PERIPH_FLASHPAGE_H */

--- a/drivers/include/periph/freqm.h
+++ b/drivers/include/periph/freqm.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_FREQM_H
+#define PERIPH_FREQM_H
+
 /**
  * @defgroup    drivers_periph_freqm FREQM
  * @ingroup     drivers_periph
@@ -24,9 +27,6 @@
  *
  * @author      Urs Gompper <urs.gompper@ml-pa.com>
  */
-
-#ifndef PERIPH_FREQM_H
-#define PERIPH_FREQM_H
 
 #include <errno.h>
 #include <mutex.h>

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_GPIO_H
+#define PERIPH_GPIO_H
+
 /**
  * @defgroup    drivers_periph_gpio GPIO
  * @ingroup     drivers_periph
@@ -71,9 +74,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_GPIO_H
-#define PERIPH_GPIO_H
 
 #include <limits.h>
 #include <stdbool.h>
@@ -286,5 +286,5 @@ static inline int gpio_is_valid(gpio_t gpio)
 }
 #endif
 
-#endif /* PERIPH_GPIO_H */
 /** @} */
+#endif /* PERIPH_GPIO_H */

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_GPIO_LL_H
+#define PERIPH_GPIO_LL_H
+
 /**
  * @defgroup    drivers_periph_gpio_ll GPIO Low-Level API
  * @ingroup     drivers_periph
@@ -65,9 +68,6 @@
  * @warning     This API is not stable yet and intended for internal use only as
  *              of now.
  */
-
-#ifndef PERIPH_GPIO_LL_H
-#define PERIPH_GPIO_LL_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -1005,5 +1005,5 @@ static inline void gpio_ll_switch_dir_input(gpio_port_t port, uword_t inputs)
 #endif
 /** @} */
 
-#endif /* PERIPH_GPIO_LL_H */
 /** @} */
+#endif /* PERIPH_GPIO_LL_H */

--- a/drivers/include/periph/gpio_ll_irq.h
+++ b/drivers/include/periph/gpio_ll_irq.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_GPIO_LL_IRQ_H
+#define PERIPH_GPIO_LL_IRQ_H
+
 /**
  * @defgroup    drivers_periph_gpio_ll_irq  IRQ Support in Peripheral GPIO Low-Level API
  * @ingroup     drivers_periph_gpio_ll
@@ -41,9 +44,6 @@
  * @warning     This API is not stable yet and intended for internal use only
  *              as of now.
  */
-
-#ifndef PERIPH_GPIO_LL_IRQ_H
-#define PERIPH_GPIO_LL_IRQ_H
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -177,5 +177,5 @@ void gpio_ll_irq_off(gpio_port_t port, uint8_t pin);
 }
 #endif
 
-#endif /* PERIPH_GPIO_LL_IRQ_H */
 /** @} */
+#endif /* PERIPH_GPIO_LL_IRQ_H */

--- a/drivers/include/periph/gpio_util.h
+++ b/drivers/include/periph/gpio_util.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_GPIO_UTIL_H
+#define PERIPH_GPIO_UTIL_H
+
 /**
  * @defgroup   gpio_util GPIO I/O Utils
  * @ingroup    drivers_periph_gpio
@@ -18,9 +21,6 @@
  *
  * @author     Philipp-Alexander Blum <philipp-blum@jakiku.de>
  */
-
-#ifndef PERIPH_GPIO_UTIL_H
-#define PERIPH_GPIO_UTIL_H
 
 #include "gpio.h"
 
@@ -43,5 +43,5 @@ uint8_t gpio_util_shiftin(gpio_t data_pin, gpio_t clock_pin);
 #ifdef __cplusplus
 }
 #endif
-#endif /* PERIPH_GPIO_UTIL_H */
 /** @} */
+#endif /* PERIPH_GPIO_UTIL_H */

--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_HWRNG_H
+#define PERIPH_HWRNG_H
+
 /**
  * @defgroup    drivers_periph_hwrng HWRNG Abstraction
  * @ingroup     drivers_periph
@@ -37,9 +40,6 @@
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_HWRNG_H
-#define PERIPH_HWRNG_H
 
 #include <stdint.h>
 
@@ -73,5 +73,5 @@ void hwrng_read(void *buf, unsigned int num);
 }
 #endif
 
-#endif /* PERIPH_HWRNG_H */
 /** @} */
+#endif /* PERIPH_HWRNG_H */

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_I2C_H
+#define PERIPH_I2C_H
+
 /**
  * @defgroup    drivers_periph_i2c I2C
  * @ingroup     drivers_periph
@@ -110,9 +113,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
-
-#ifndef PERIPH_I2C_H
-#define PERIPH_I2C_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -496,5 +496,5 @@ int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
 }
 #endif
 
-#endif /* PERIPH_I2C_H */
 /** @} */
+#endif /* PERIPH_I2C_H */

--- a/drivers/include/periph/init.h
+++ b/drivers/include/periph/init.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_INIT_H
+#define PERIPH_INIT_H
+
 /**
  * @defgroup    drivers_periph_init Common peripheral initialization
  * @ingroup     drivers_periph
@@ -21,9 +24,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_INIT_H
-#define PERIPH_INIT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,5 +47,5 @@ void periph_init(void);
 }
 #endif
 
-#endif /* PERIPH_INIT_H */
 /** @} */
+#endif /* PERIPH_INIT_H */

--- a/drivers/include/periph/pio.h
+++ b/drivers/include/periph/pio.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_PIO_H
+#define PERIPH_PIO_H
+
 /**
  * @defgroup    drivers_periph_pio Programmable IO (PIO)
  * @ingroup     drivers_periph
@@ -40,9 +43,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-
-#ifndef PERIPH_PIO_H
-#define PERIPH_PIO_H
 
 #include <stdbool.h>
 
@@ -181,5 +181,5 @@ void pio_free_program(pio_t pio, pio_program_t *prog);
 }
 #endif
 
-#endif /* PERIPH_PIO_H */
 /** @} */
+#endif /* PERIPH_PIO_H */

--- a/drivers/include/periph/pio/i2c.h
+++ b/drivers/include/periph/pio/i2c.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_PIO_I2C_H
+#define PERIPH_PIO_I2C_H
+
 /**
  * @defgroup    drivers_periph_pio_i2c PIO I2C program
  * @ingroup     drivers_periph
@@ -19,9 +22,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-
-#ifndef PERIPH_PIO_I2C_H
-#define PERIPH_PIO_I2C_H
 
 #include "periph/i2c.h"
 #include "periph/pio.h"
@@ -314,5 +314,5 @@ static inline int pio_i2c_write_reg(pio_t pio, pio_sm_t sm, uint16_t addr,
 #ifdef __cplusplus
 }
 #endif
-#endif /* PERIPH_PIO_I2C_H */
 /** @} */
+#endif /* PERIPH_PIO_I2C_H */

--- a/drivers/include/periph/pm.h
+++ b/drivers/include/periph/pm.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_PM_H
+#define PERIPH_PM_H
+
 /**
  * @defgroup    drivers_periph_pm Power Management
  * @ingroup     drivers_periph
@@ -20,9 +23,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef PERIPH_PM_H
-#define PERIPH_PM_H
 
 #include "periph_cpu.h"
 
@@ -55,5 +55,5 @@ void pm_set_lowest(void);
 }
 #endif
 
-#endif /* PERIPH_PM_H */
 /** @} */
+#endif /* PERIPH_PM_H */

--- a/drivers/include/periph/ptp.h
+++ b/drivers/include/periph/ptp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_PTP_H
+#define PERIPH_PTP_H
+
 /**
  * @defgroup    drivers_periph_ptp  PTP-Clock
  * @ingroup     drivers_periph
@@ -52,9 +55,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef PERIPH_PTP_H
-#define PERIPH_PTP_H
 
 #include <stdint.h>
 
@@ -404,5 +404,5 @@ static inline void ptp_timer_set_absolute_u64(uint64_t target)
 }
 #endif
 
-#endif /* PERIPH_PTP_H */
 /** @} */
+#endif /* PERIPH_PTP_H */

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_PWM_H
+#define PERIPH_PWM_H
+
 /**
  * @defgroup    drivers_periph_pwm PWM
  * @ingroup     drivers_periph
@@ -57,9 +60,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_PWM_H
-#define PERIPH_PWM_H
 
 #include <stdint.h>
 #include <limits.h>
@@ -186,5 +186,5 @@ void pwm_poweroff(pwm_t dev);
 }
 #endif
 
-#endif /* PERIPH_PWM_H */
 /** @} */
+#endif /* PERIPH_PWM_H */

--- a/drivers/include/periph/qdec.h
+++ b/drivers/include/periph/qdec.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_QDEC_H
+#define PERIPH_QDEC_H
+
 /**
  * @defgroup    drivers_periph_qdec Quadrature Decoder (QDEC)
  * @ingroup     drivers_periph
@@ -73,9 +76,6 @@
  *
  * @author      Gilles DOFFE <gdoffe@gmail.com>
  */
-
-#ifndef PERIPH_QDEC_H
-#define PERIPH_QDEC_H
 
 #include <stdint.h>
 #include <limits.h>
@@ -199,5 +199,5 @@ void qdec_stop(qdec_t qdec);
 }
 #endif
 
-#endif /* PERIPH_QDEC_H */
 /** @} */
+#endif /* PERIPH_QDEC_H */

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef PERIPH_RTC_H
+#define PERIPH_RTC_H
+
 /**
  * @defgroup    drivers_periph_rtc RTC
  * @ingroup     drivers_periph
@@ -33,9 +36,6 @@
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
-
-#ifndef PERIPH_RTC_H
-#define PERIPH_RTC_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -153,5 +153,5 @@ void rtc_poweroff(void);
 }
 #endif
 
-#endif /* PERIPH_RTC_H */
 /** @} */
+#endif /* PERIPH_RTC_H */

--- a/drivers/include/periph/rtc_mem.h
+++ b/drivers/include/periph/rtc_mem.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef PERIPH_RTC_MEM_H
+#define PERIPH_RTC_MEM_H
+
 /**
  * @defgroup    drivers_periph_rtc_mem Low-Power RTC Memory
  * @ingroup     drivers_periph_rtc
@@ -20,9 +23,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef PERIPH_RTC_MEM_H
-#define PERIPH_RTC_MEM_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -66,5 +66,5 @@ void rtc_mem_write(unsigned offset, const void *data, size_t len);
 }
 #endif
 
-#endif /* PERIPH_RTC_MEM_H */
 /** @} */
+#endif /* PERIPH_RTC_MEM_H */

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef PERIPH_RTT_H
+#define PERIPH_RTT_H
+
 /**
  * @defgroup    drivers_periph_rtt RTT
  * @ingroup     drivers_periph
@@ -34,9 +37,6 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_RTT_H
-#define PERIPH_RTT_H
 
 #include <stdint.h>
 
@@ -240,5 +240,5 @@ void rtt_poweroff(void);
 }
 #endif
 
-#endif /* PERIPH_RTT_H */
 /** @} */
+#endif /* PERIPH_RTT_H */

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_SPI_H
+#define PERIPH_SPI_H
+
 /**
  * @defgroup    drivers_periph_spi SPI
  * @ingroup     drivers_periph
@@ -62,9 +65,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_SPI_H
-#define PERIPH_SPI_H
 
 #include <endian.h>
 #include <errno.h>
@@ -453,5 +453,5 @@ static inline uint16_t spi_transfer_u16_be(spi_t bus, spi_cs_t cs, bool cont, ui
 }
 #endif
 
-#endif /* PERIPH_SPI_H */
 /** @} */
+#endif /* PERIPH_SPI_H */

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_TIMER_H
+#define PERIPH_TIMER_H
+
 /**
  * @defgroup    drivers_periph_timer Timer
  * @ingroup     drivers_periph
@@ -29,9 +32,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_TIMER_H
-#define PERIPH_TIMER_H
 
 #include <limits.h>
 #include <stdint.h>
@@ -333,5 +333,5 @@ bool timer_poll_channel(tim_t dev, int channel);
 }
 #endif
 
-#endif /* PERIPH_TIMER_H */
 /** @} */
+#endif /* PERIPH_TIMER_H */

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_UART_H
+#define PERIPH_UART_H
+
 /**
  * @defgroup    drivers_periph_uart UART
  * @ingroup     drivers_periph
@@ -54,9 +57,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_UART_H
-#define PERIPH_UART_H
 
 #include <errno.h>
 #include <limits.h>
@@ -447,5 +447,5 @@ void uart_disable_tx(uart_t uart);
 }
 #endif
 
-#endif /* PERIPH_UART_H */
 /** @} */
+#endif /* PERIPH_UART_H */

--- a/drivers/include/periph/usbdev.h
+++ b/drivers/include/periph/usbdev.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for
  * more details.
  */
+#ifndef PERIPH_USBDEV_H
+#define PERIPH_USBDEV_H
+
 /**
  * @defgroup    drivers_periph_usbdev usbdev - USB Device Driver API
  * @ingroup     drivers_periph
@@ -71,9 +74,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef PERIPH_USBDEV_H
-#define PERIPH_USBDEV_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -687,5 +687,5 @@ static inline int usbdev_ep_xmit(usbdev_ep_t *ep, uint8_t *buf, size_t len)
 }
 #endif
 
-#endif /* PERIPH_USBDEV_H */
 /** @} */
+#endif /* PERIPH_USBDEV_H */

--- a/drivers/include/periph/vbat.h
+++ b/drivers/include/periph/vbat.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_VBAT_H
+#define PERIPH_VBAT_H
+
 /**
  * @defgroup    drivers_periph_vbat backup battery monitoring
  * @ingroup     drivers_periph
@@ -29,9 +32,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-
-#ifndef PERIPH_VBAT_H
-#define PERIPH_VBAT_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -68,5 +68,5 @@ bool vbat_is_empty(void);
 }
 #endif
 
-#endif /* PERIPH_VBAT_H */
 /** @} */
+#endif /* PERIPH_VBAT_H */

--- a/drivers/include/periph/wdt.h
+++ b/drivers/include/periph/wdt.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef PERIPH_WDT_H
+#define PERIPH_WDT_H
+
 /**
  * @defgroup    drivers_periph_wdt WDT
  * @ingroup     drivers_periph
@@ -203,9 +206,6 @@
  *              Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
 
-#ifndef PERIPH_WDT_H
-#define PERIPH_WDT_H
-
 #include <stdint.h>
 #include "periph_cpu.h"
 
@@ -367,5 +367,5 @@ void wdt_setup_reboot_with_callback(uint32_t min_time, uint32_t max_time,
 }
 #endif
 
-#endif /* PERIPH_WDT_H */
 /** @} */
+#endif /* PERIPH_WDT_H */

--- a/drivers/include/ph_oem.h
+++ b/drivers/include/ph_oem.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PH_OEM_H
+#define PH_OEM_H
+
 /**
  * @defgroup    drivers_ph_oem pH OEM sensor device driver
  * @ingroup     drivers_sensors
@@ -46,9 +49,6 @@
 
  * @author      Igor Knippenberg <igor.knippenberg@gmail.com>
  */
-
-#ifndef PH_OEM_H
-#define PH_OEM_H
 
 #ifdef __cplusplus
 extern "C"
@@ -358,5 +358,5 @@ int ph_oem_read_ph(const ph_oem_t *dev, uint16_t *ph_value);
 }
 #endif
 
-#endif /* PH_OEM_H */
 /** @} */
+#endif /* PH_OEM_H */

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PIR_H
+#define PIR_H
+
 /**
  * @defgroup    drivers_pir PIR Motion Sensor
  * @ingroup     drivers_sensors
@@ -18,9 +21,6 @@
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
  */
-
-#ifndef PIR_H
-#define PIR_H
 
 #include "sched.h"
 #include "periph/gpio.h"
@@ -141,5 +141,5 @@ int pir_register_thread(pir_t *dev);
 }
 #endif
 
-#endif /* PIR_H */
 /** @} */
+#endif /* PIR_H */

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PN532_H
+#define PN532_H
+
 /**
  * @defgroup    drivers_pn532 PN532 NFC Reader
  * @ingroup     drivers_netdev
@@ -17,9 +20,6 @@
  *
  * @author      Víctor Ariño <victor.arino@triagnosys.com>
  */
-
-#ifndef PN532_H
-#define PN532_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -391,5 +391,5 @@ void pn532_release_passive(pn532_t *dev, unsigned target_id);
 }
 #endif
 
-#endif /* PN532_H */
 /** @} */
+#endif /* PN532_H */

--- a/drivers/include/pulse_counter.h
+++ b/drivers/include/pulse_counter.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PULSE_COUNTER_H
+#define PULSE_COUNTER_H
+
 /**
  * @defgroup    drivers_pulse_counter Pulse counter
  * @ingroup     drivers_sensors
@@ -21,9 +24,6 @@
  *
  * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
  */
-
-#ifndef PULSE_COUNTER_H
-#define PULSE_COUNTER_H
 
 #include <stdint.h>
 #ifdef __cplusplus
@@ -92,5 +92,5 @@ void pulse_counter_reset(pulse_counter_t *dev);
 }
 #endif
 
-#endif /* PULSE_COUNTER_H */
 /** @} */
+#endif /* PULSE_COUNTER_H */

--- a/drivers/include/qmc5883l.h
+++ b/drivers/include/qmc5883l.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef QMC5883L_H
+#define QMC5883L_H
+
 /**
  * @defgroup    drivers_qmc5883l QMC5883L 3-Axis Digital Magnetic Sensor
  * @ingroup     drivers_sensors
@@ -51,9 +54,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef QMC5883L_H
-#define QMC5883L_H
 
 #ifdef __cplusplus
 extern "C"
@@ -303,5 +303,5 @@ int qmc5883l_irq_disable(const qmc5883l_t *dev);
 }
 #endif
 
-#endif /* QMC5883L_H */
 /** @} */
+#endif /* QMC5883L_H */

--- a/drivers/include/rn2xx3.h
+++ b/drivers/include/rn2xx3.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef RN2XX3_H
+#define RN2XX3_H
+
 /**
  * @defgroup    drivers_rn2xx3 RN2483/RN2903 LoRa module driver
  * @ingroup     drivers_netdev
@@ -17,9 +20,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef RN2XX3_H
-#define RN2XX3_H
 
 #include <stdint.h>
 
@@ -701,5 +701,5 @@ void rn2xx3_sys_set_sleep_duration(rn2xx3_t *dev, uint32_t sleep);
 }
 #endif
 
-#endif /* RN2XX3_H */
 /** @} */
+#endif /* RN2XX3_H */

--- a/drivers/include/rtt_rtc.h
+++ b/drivers/include/rtt_rtc.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef RTT_RTC_H
+#define RTT_RTC_H
+
 /**
  * @defgroup    drivers_rtt_rtc     RTC emulation on top of a RTT
  * @ingroup     drivers_periph_rtc
@@ -17,9 +20,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef RTT_RTC_H
-#define RTT_RTC_H
 
 #include <stdint.h>
 
@@ -57,5 +57,5 @@ void rtt_rtc_gettimeofday(uint32_t *s, uint32_t *us);
 }
 #endif
 
-#endif /* RTT_RTC_H */
 /** @} */
+#endif /* RTT_RTC_H */

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SAUL_H
+#define SAUL_H
+
 /**
  * @defgroup    drivers_saul [S]ensor [A]ctuator [U]ber [L]ayer
  * @ingroup     drivers
@@ -44,9 +47,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef SAUL_H
-#define SAUL_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -356,5 +356,5 @@ ssize_t saul_class_write(char *dest, size_t max_size, uint8_t class_id);
 }
 #endif
 
-#endif /* SAUL_H */
 /** @} */
+#endif /* SAUL_H */

--- a/drivers/include/saul/bat_voltage.h
+++ b/drivers/include/saul/bat_voltage.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SAUL_BAT_VOLTAGE_H
+#define SAUL_BAT_VOLTAGE_H
+
 /**
  * @ingroup     drivers_saul
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Martine S. Lenders <martine.lenders@tu-dresden.de>
  */
-
-#ifndef SAUL_BAT_VOLTAGE_H
-#define SAUL_BAT_VOLTAGE_H
 
 #include <stdint.h>
 
@@ -49,5 +49,5 @@ typedef struct {
 }
 #endif
 
-#endif /* SAUL_BAT_VOLTAGE_H */
 /** @} */
+#endif /* SAUL_BAT_VOLTAGE_H */

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SAUL_PERIPH_H
+#define SAUL_PERIPH_H
+
 /**
  * @ingroup     drivers_saul
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef SAUL_PERIPH_H
-#define SAUL_PERIPH_H
 
 #if MODULE_SAUL_GPIO || DOXYGEN
 #include "periph/gpio.h"
@@ -179,5 +179,5 @@ typedef struct {
 }
 #endif
 
-#endif /* SAUL_PERIPH_H */
 /** @} */
+#endif /* SAUL_PERIPH_H */

--- a/drivers/include/screen_dev.h
+++ b/drivers/include/screen_dev.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SCREEN_DEV_H
+#define SCREEN_DEV_H
+
 /**
  * @defgroup    drivers_screen_dev Screen device generic API
  * @ingroup     drivers_display
@@ -31,9 +34,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef SCREEN_DEV_H
-#define SCREEN_DEV_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,5 +58,5 @@ typedef struct {
 }
 #endif
 
-#endif /* SCREEN_DEV_H */
 /** @} */
+#endif /* SCREEN_DEV_H */

--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SDCARD_SPI_H
+#define SDCARD_SPI_H
+
 /**
  * @defgroup    drivers_sdcard_spi SPI SD Card driver
  * @ingroup     drivers_storage
@@ -18,9 +21,6 @@
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
-
-#ifndef SDCARD_SPI_H
-#define SDCARD_SPI_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -280,5 +280,5 @@ uint64_t sdcard_spi_get_capacity(sdcard_spi_t *card);
 }
 #endif
 
-#endif /* SDCARD_SPI_H */
 /** @} */
+#endif /* SDCARD_SPI_H */

--- a/drivers/include/sdmmc/sdmmc.h
+++ b/drivers/include/sdmmc/sdmmc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SDMMC_SDMMC_H
+#define SDMMC_SDMMC_H
+
 /**
  * @defgroup    drivers_sdmmc    SDIO/SD/MMC Device API (SDMMC)
  * @ingroup     drivers_periph
@@ -123,9 +126,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef SDMMC_SDMMC_H
-#define SDMMC_SDMMC_H
 
 #include <errno.h>
 

--- a/drivers/include/sdp3x.h
+++ b/drivers/include/sdp3x.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef SDP3X_H
+#define SDP3X_H
+
 /**
  * @defgroup    drivers_sdp3x SDP3x temperature and differential pressure sensor
  * @ingroup     drivers_sensors
@@ -18,9 +21,6 @@
  * @author      Nishchay Agrawal <f2016088@pilani.bits-pilani.ac.in>
  * @}
  */
-
-#ifndef SDP3X_H
-#define SDP3X_H
 
 #include "saul.h"
 #include "xtimer.h"

--- a/drivers/include/sds011.h
+++ b/drivers/include/sds011.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SDS011_H
+#define SDS011_H
+
 /**
  * @defgroup    drivers_sds011 SDS011 Laser Dust Sensor
  * @ingroup     drivers_sensors
@@ -17,9 +20,6 @@
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
-
-#ifndef SDS011_H
-#define SDS011_H
 
 #include <stdbool.h>
 
@@ -313,5 +313,5 @@ int sds011_set_dev_id(sds011_t *dev, uint16_t sens_dev_id);
 }
 #endif
 
-#endif /* SDS011_H */
 /** @} */
+#endif /* SDS011_H */

--- a/drivers/include/seesaw_soil.h
+++ b/drivers/include/seesaw_soil.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SEESAW_SOIL_H
+#define SEESAW_SOIL_H
+
 /**
  * @defgroup    drivers_seesaw_soil Adafruit Seesaw Soil Moisture and Temperature Sensor
  * @ingroup     drivers_sensors
@@ -22,9 +25,6 @@
  *
  * @author      Viktor Gal <viktor.gal@maeth.com>
  */
-
-#ifndef SEESAW_SOIL_H
-#define SEESAW_SOIL_H
 
 #include <stdint.h>
 
@@ -115,5 +115,5 @@ int seesaw_soil_moisture(const seesaw_soil_t *dev, uint16_t *moist);
 }
 #endif
 
-#endif /* SEESAW_SOIL_H */
 /** @} */
+#endif /* SEESAW_SOIL_H */

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -8,6 +8,9 @@
  * details.
  */
 
+#ifndef SERVO_H
+#define SERVO_H
+
 /**
  * @defgroup    drivers_servo Servo Motor Driver
  * @ingroup     drivers_actuators
@@ -38,9 +41,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef SERVO_H
-#define SERVO_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -232,5 +232,5 @@ void servo_set(servo_t *dev, uint8_t pos);
 }
 #endif
 
-#endif /* SERVO_H */
 /** @} */
+#endif /* SERVO_H */

--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SGP30_H
+#define SGP30_H
+
 /**
  * @defgroup    drivers_sgp30 SGP30 Gas Sensor
  * @ingroup     drivers_sensors
@@ -42,9 +45,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef SGP30_H
-#define SGP30_H
 
 #include "periph/i2c.h"
 #include "ztimer.h"
@@ -251,5 +251,5 @@ int sgp30_read_raw_measurements(sgp30_t *dev, sgp30_raw_data_t *data);
 }
 #endif
 
-#endif /* SGP30_H */
 /** @} */
+#endif /* SGP30_H */

--- a/drivers/include/sht1x.h
+++ b/drivers/include/sht1x.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef SHT1X_H
+#define SHT1X_H
+
 /**
  * @defgroup    drivers_sht1x SHT10/SHT11/SHT15 Humidity and Temperature Sensor
  * @ingroup     drivers_sensors
@@ -19,9 +22,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef SHT1X_H
-#define SHT1X_H
 
 #include <stdint.h>
 #include <periph/gpio.h>
@@ -183,5 +183,5 @@ int sht1x_reset(sht1x_dev_t *dev);
 }
 #endif
 
-#endif /* SHT1X_H */
 /** @} */
+#endif /* SHT1X_H */

--- a/drivers/include/sht2x.h
+++ b/drivers/include/sht2x.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef SHT2X_H
+#define SHT2X_H
+
 /**
  * @defgroup    drivers_sht2x SHT2x Humidity and Temperature sensor
  * @ingroup     drivers_sensors
@@ -22,9 +25,6 @@
  * @author      George Psimenos <gp7g14@soton.ac.uk>
  * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
  */
-
-#ifndef SHT2X_H
-#define SHT2X_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -193,5 +193,5 @@ int sht2x_write_userreg(const sht2x_t *dev, uint8_t userreg);
 }
 #endif
 
-#endif /* SHT2X_H */
 /** @} */
+#endif /* SHT2X_H */

--- a/drivers/include/sht3x.h
+++ b/drivers/include/sht3x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SHT3X_H
+#define SHT3X_H
+
 /**
  * @ingroup     drivers_sht3x
  * @brief       Device Driver for Sensirion SHT30/SHT31/SHT35 Humidity and Temperature Sensors
@@ -13,9 +16,6 @@
  * @file
  * @{
  */
-
-#ifndef SHT3X_H
-#define SHT3X_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -163,5 +163,5 @@ int sht3x_read (sht3x_dev_t* dev, int16_t* temp, int16_t* hum);
 }
 #endif
 
-#endif /* SHT3X_H */
 /** @} */
+#endif /* SHT3X_H */

--- a/drivers/include/shtcx.h
+++ b/drivers/include/shtcx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SHTCX_H
+#define SHTCX_H
+
 /**
  * @defgroup    drivers_shtcx SHTCX Temperature and humidity sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
-
-#ifndef SHTCX_H
-#define SHTCX_H
 
 #include <stdint.h>
 #include "saul.h"
@@ -123,5 +123,5 @@ int8_t shtcx_reset(const shtcx_t *dev);
 }
 #endif
 
-#endif /* SHTCX_H */
 /** @} */
+#endif /* SHTCX_H */

--- a/drivers/include/si1133.h
+++ b/drivers/include/si1133.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef SI1133_H
+#define SI1133_H
+
 /**
  * @defgroup    drivers_si1133 Si1133 UV Index/Ambient Light Sensor with I2C
  * @ingroup     drivers_sensors
@@ -27,9 +30,6 @@
  *
  * @author      iosabi <iosabi@protonmail.com>
  */
-
-#ifndef SI1133_H
-#define SI1133_H
 
 #include "periph/i2c.h"
 
@@ -206,5 +206,5 @@ si1133_ret_code_t si1133_capture_sensors(si1133_t *dev, int32_t *values,
 }
 #endif
 
-#endif /* SI1133_H */
 /** @} */
+#endif /* SI1133_H */

--- a/drivers/include/si114x.h
+++ b/drivers/include/si114x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SI114X_H
+#define SI114X_H
+
 /**
  * @defgroup    drivers_si114x Si1145/6/7 UV/Ambient light/Proximity sensors
  * @ingroup     drivers_sensors
@@ -21,9 +24,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *              Bas Stottelaar <basstottelaar@gmail.com>
  */
-
-#ifndef SI114X_H
-#define SI114X_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -139,5 +139,5 @@ uint8_t si114x_read_response(si114x_t *dev);
 }
 #endif
 
-#endif /* SI114X_H */
 /** @} */
+#endif /* SI114X_H */

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SI70XX_H
+#define SI70XX_H
+
 /**
  * @defgroup    drivers_si70xx Si7006/13/20/21/5x temperature and humidity sensors
  * @ingroup     drivers_sensors
@@ -29,9 +32,6 @@
  *
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  */
-
-#ifndef SI70XX_H
-#define SI70XX_H
 
 #include "periph/i2c.h"
 
@@ -150,5 +150,5 @@ uint8_t si70xx_get_revision(const si70xx_t *dev);
 }
 #endif
 
-#endif /* SI70XX_H */
 /** @} */
+#endif /* SI70XX_H */

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef SLIPDEV_H
+#define SLIPDEV_H
 /**
  * @defgroup    drivers_slipdev_stdio   STDIO via SLIP
  * @ingroup     sys_stdio
@@ -33,8 +35,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef SLIPDEV_H
-#define SLIPDEV_H
 
 #include <stdint.h>
 
@@ -148,5 +148,5 @@ void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index
 }
 #endif
 
-#endif /* SLIPDEV_H */
 /** @} */
+#endif /* SLIPDEV_H */

--- a/drivers/include/sm_pwm_01c.h
+++ b/drivers/include/sm_pwm_01c.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SM_PWM_01C_H
+#define SM_PWM_01C_H
+
 /**
  * @defgroup    drivers_sm_pwm_01c SM_PWM_01C dust sensor
  * @ingroup     drivers_sensors
@@ -34,9 +37,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef SM_PWM_01C_H
-#define SM_PWM_01C_H
 
 #include <inttypes.h>
 
@@ -203,5 +203,5 @@ void sm_pwm_01c_read_data(sm_pwm_01c_t *dev, sm_pwm_01c_data_t *data);
 }
 #endif
 
-#endif /* SM_PWM_01C_H */
 /** @} */
+#endif /* SM_PWM_01C_H */

--- a/drivers/include/soft_spi.h
+++ b/drivers/include/soft_spi.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SOFT_SPI_H
+#define SOFT_SPI_H
+
 /**
  * @defgroup    drivers_soft_spi Soft SPI
  * @ingroup     drivers_soft_periph
@@ -24,9 +27,6 @@
  *
  * @author      Markus Blechschmidt <Markus.Blechschmidt@haw-hamburg.de>
  */
-
-#ifndef SOFT_SPI_H
-#define SOFT_SPI_H
 
 #include "periph/gpio.h"
 #include "periph/spi.h"
@@ -264,5 +264,5 @@ void soft_spi_transfer_regs(soft_spi_t bus, soft_spi_cs_t cs, uint8_t reg,
 }
 #endif
 
-#endif /* SOFT_SPI_H */
 /** @} */
+#endif /* SOFT_SPI_H */

--- a/drivers/include/soft_uart.h
+++ b/drivers/include/soft_uart.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SOFT_UART_H
+#define SOFT_UART_H
+
 /**
  * @defgroup    drivers_soft_uart Software UART
  * @ingroup     drivers_soft_periph
@@ -25,9 +28,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef SOFT_UART_H
-#define SOFT_UART_H
 
 #include "periph/gpio.h"
 #include "periph/uart.h"
@@ -137,5 +137,5 @@ void soft_uart_poweroff(soft_uart_t uart);
 }
 #endif
 
-#endif /* SOFT_UART_H */
 /** @} */
+#endif /* SOFT_UART_H */

--- a/drivers/include/sps30.h
+++ b/drivers/include/sps30.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef SPS30_H
+#define SPS30_H
+
 /**
  * @defgroup    drivers_sps30 SPS30 Particulate Matter Sensor
  * @ingroup     drivers_sensors
@@ -57,9 +60,6 @@
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
-
-#ifndef SPS30_H
-#define SPS30_H
 
 #include <stdbool.h>
 #include "periph/gpio.h"
@@ -308,5 +308,5 @@ int sps30_wakeup(const sps30_t *dev);
 #ifdef __cplusplus
 }
 #endif
-#endif /* SPS30_H */
 /** @} */
+#endif /* SPS30_H */

--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -7,6 +7,9 @@
  * details.
  */
 
+#ifndef SRF02_H
+#define SRF02_H
+
 /**
  * @defgroup    drivers_srf02 SRF02 ultrasonic range sensor
  * @ingroup     drivers_sensors
@@ -21,9 +24,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
  */
-
-#ifndef SRF02_H
-#define SRF02_H
 
 #include <stdint.h>
 #include "periph/i2c.h"
@@ -136,5 +136,5 @@ int srf02_set_addr(srf02_t *dev, uint8_t new_addr);
 }
 #endif
 
-#endif /* SRF02_H */
 /** @} */
+#endif /* SRF02_H */

--- a/drivers/include/srf04.h
+++ b/drivers/include/srf04.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SRF04_H
+#define SRF04_H
+
 /**
  * @defgroup    drivers_srf04 srf04 ultra sonic range finder
  * @ingroup     drivers_sensors
@@ -17,9 +20,6 @@
  *
  * @author      Semjon Kerner <semjon.kerner@fu-berlin.de>
  */
-
-#ifndef SRF04_H
-#define SRF04_H
 
 #include <stdint.h>
 #include <stdio.h>
@@ -106,5 +106,5 @@ int srf04_get_distance(const srf04_t *dev);
 }
 #endif
 
-#endif /* SRF04_H */
 /** @} */
+#endif /* SRF04_H */

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef SRF08_H
+#define SRF08_H
+
 /**
  * @defgroup    drivers_srf08 SRF08 ultrasonic range sensor
  * @ingroup     drivers_sensors
@@ -24,9 +27,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
  */
-
-#ifndef SRF08_H
-#define SRF08_H
 
 #include <stdint.h>
 #include "periph/i2c.h"

--- a/drivers/include/st77xx.h
+++ b/drivers/include/st77xx.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef ST77XX_H
+#define ST77XX_H
+
 /**
  * @defgroup    drivers_st77xx ST77xx display driver
  * @ingroup     drivers_display
@@ -49,9 +52,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef ST77XX_H
-#define ST77XX_H
 
 #include "lcd.h"
 
@@ -404,5 +404,5 @@ extern const lcd_driver_t lcd_st77xx_driver;
 #ifdef __cplusplus
 }
 #endif
-#endif /* ST77XX_H */
 /** @} */
+#endif /* ST77XX_H */

--- a/drivers/include/stmpe811.h
+++ b/drivers/include/stmpe811.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef STMPE811_H
+#define STMPE811_H
+
 /**
  * @defgroup    drivers_stmpe811 STMPE811 Touchscreen Controller
  * @ingroup     drivers_sensors
@@ -17,9 +20,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef STMPE811_H
-#define STMPE811_H
 
 #include "saul.h"
 #include "periph/gpio.h"
@@ -162,5 +162,5 @@ int stmpe811_read_touch_state(const stmpe811_t *dev, stmpe811_touch_state_t *sta
 }
 #endif
 
-#endif /* STMPE811_H */
 /** @} */
+#endif /* STMPE811_H */

--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SX126X_H
+#define SX126X_H
+
 /**
  * @defgroup    drivers_sx126x SX1261/2/8 and LLCC68 LoRa radio driver
  * @ingroup     drivers_netdev
@@ -17,9 +20,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef SX126X_H
-#define SX126X_H
 
 #include <assert.h>
 
@@ -305,5 +305,5 @@ void sx126x_set_lora_iq_invert(sx126x_t *dev, bool iq_invert);
 }
 #endif
 
-#endif /* SX126X_H */
 /** @} */
+#endif /* SX126X_H */

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef SX127X_H
+#define SX127X_H
+
 /**
  * @defgroup    drivers_sx127x Semtech SX1272 and SX1276 radios driver
  * @ingroup     drivers_netdev
@@ -55,9 +58,6 @@
  * @author      Eugene P. <ep@unwds.com>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef SX127X_H
-#define SX127X_H
 
 #include "timex.h"
 #include "ztimer.h"
@@ -683,5 +683,5 @@ void sx127x_set_freq_hop(sx127x_t *dev, bool freq_hop_on);
 }
 #endif
 
-#endif /* SX127X_H */
 /** @} */
+#endif /* SX127X_H */

--- a/drivers/include/sx1280.h
+++ b/drivers/include/sx1280.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef SX1280_H
+#define SX1280_H
+
 /**
  * @defgroup    drivers_sx1280 LoRa radio driver
  * @ingroup     drivers_netdev
@@ -20,9 +23,6 @@
  * @author      Aymeric Brochier <aymeric.brochier@univ-grenoble-alpes.fr>
  *
  */
-
-#ifndef SX1280_H
-#define SX1280_H
 
 #include <assert.h>
 
@@ -263,5 +263,5 @@ void sx1280_set_lora_iq_invert(sx1280_t *dev, bool iq_invert);
 }
 #endif
 
-#endif /* SX1280_H */
 /** @} */
+#endif /* SX1280_H */

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef TCS37727_H
+#define TCS37727_H
+
 /**
  * @defgroup    drivers_tcs37727 TCS37727 RGB Light Sensor
  * @ingroup     drivers_sensors
@@ -23,9 +26,6 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef TCS37727_H
-#define TCS37727_H
 
 #include <stdint.h>
 
@@ -148,5 +148,5 @@ void tcs37727_read(const tcs37727_t *dev, tcs37727_data_t *data);
 }
 #endif
 
-#endif /* TCS37727_H */
 /** @} */
+#endif /* TCS37727_H */

--- a/drivers/include/tja1042.h
+++ b/drivers/include/tja1042.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef TJA1042_H
+#define TJA1042_H
 /**
  * @defgroup    drivers_tja1042 TJA1042
  * @ingroup     drivers_can
@@ -20,8 +22,6 @@
  * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-#ifndef TJA1042_H
-#define TJA1042_H
 
 #include <stdio.h>
 
@@ -78,5 +78,5 @@ extern const trx_driver_t tja1042_driver;
 }
 #endif
 
-#endif /* TJA1042_H */
 /** @} */
+#endif /* TJA1042_H */

--- a/drivers/include/tmp00x.h
+++ b/drivers/include/tmp00x.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef TMP00X_H
+#define TMP00X_H
+
 /**
  * @defgroup    drivers_tmp00x TMP006/TMP007 Infrared Thermopile Sensor
  * @ingroup     drivers_sensors
@@ -76,9 +79,6 @@
  * @author      Sebastian Meiling <s@mlng.net>
  * @author      Jannes Volkens <jannes.volkens@haw-hamburg.de>
  */
-
-#ifndef TMP00X_H
-#define TMP00X_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -298,5 +298,5 @@ int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to);
 }
 #endif
 
-#endif /* TMP00X_H */
 /** @} */
+#endif /* TMP00X_H */

--- a/drivers/include/touch_dev.h
+++ b/drivers/include/touch_dev.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TOUCH_DEV_H
+#define TOUCH_DEV_H
+
 /**
  * @defgroup    drivers_touch_dev Touch device generic API
  * @ingroup     drivers_misc
@@ -16,9 +19,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef TOUCH_DEV_H
-#define TOUCH_DEV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -209,5 +209,5 @@ void touch_dev_set_touch_event_callback(const touch_dev_t *dev, touch_event_cb_t
 }
 #endif
 
-#endif /* TOUCH_DEV_H */
 /** @} */
+#endif /* TOUCH_DEV_H */

--- a/drivers/include/touch_dev_gestures.h
+++ b/drivers/include/touch_dev_gestures.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TOUCH_DEV_GESTURES_H
+#define TOUCH_DEV_GESTURES_H
+
 /**
  * @defgroup    drivers_touch_dev_gestures Touch device gesture recognition
  * @ingroup     drivers_misc
@@ -140,9 +143,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef TOUCH_DEV_GESTURES_H
-#define TOUCH_DEV_GESTURES_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -245,5 +245,5 @@ touch_dev_gesture_t touch_dev_recognize_gesture(touch_dev_gesture_ctx_t *ctx,
 }
 #endif
 
-#endif /* TOUCH_DEV_GESTURES_H */
 /** @} */
+#endif /* TOUCH_DEV_GESTURES_H */

--- a/drivers/include/tps6274x.h
+++ b/drivers/include/tps6274x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TPS6274X_H
+#define TPS6274X_H
+
 /**
  * @defgroup    drivers_tps6274x TPS6274x
  * @ingroup     drivers_power
@@ -18,9 +21,6 @@
  * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
-
-#ifndef TPS6274X_H
-#define TPS6274X_H
 
 #ifdef __cplusplus
 extern "C"
@@ -83,5 +83,5 @@ void tps6274x_load_ctrl(tps6274x_t *dev, int status);
 #ifdef __cplusplus
 }
 #endif
-#endif /* TPS6274X_H */
 /** @} */
+#endif /* TPS6274X_H */

--- a/drivers/include/tsl2561.h
+++ b/drivers/include/tsl2561.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TSL2561_H
+#define TSL2561_H
+
 /**
  * @defgroup    drivers_tsl2561 TSL2561 illuminance sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef TSL2561_H
-#define TSL2561_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -109,5 +109,5 @@ uint16_t tsl2561_read_illuminance(const tsl2561_t *dev);
 }
 #endif
 
-#endif /* TSL2561_H */
 /** @} */
+#endif /* TSL2561_H */

--- a/drivers/include/tsl4531x.h
+++ b/drivers/include/tsl4531x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TSL4531X_H
+#define TSL4531X_H
+
 /**
  * @defgroup    drivers_tsl4531x TSL4531x Illuminance sensor
  * @ingroup     drivers_sensors
@@ -37,9 +40,6 @@
  * @author      Juan I Carrano <j.carrano@fu-berlin.de>
  * @author      Daniel Petry <daniel.petry@fu-berlin.de>
  */
-
-#ifndef TSL4531X_H
-#define TSL4531X_H
 
 #include <stdint.h>
 
@@ -191,5 +191,5 @@ int tsl4531x_simple_read(tsl4531x_t *dev);
 }
 #endif
 
-#endif /* TSL4531X_H */
 /** @} */
+#endif /* TSL4531X_H */

--- a/drivers/include/usbdev_mock.h
+++ b/drivers/include/usbdev_mock.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef USBDEV_MOCK_H
+#define USBDEV_MOCK_H
+
 /**
  * @defgroup    drivers_usbdev_mock USBdev mockup device
  * @ingroup     drivers_misc
@@ -13,9 +16,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USBDEV_MOCK_H
-#define USBDEV_MOCK_H
 
 #include <stdint.h>
 
@@ -114,5 +114,5 @@ void usbdev_mock_setup(usbdev_mock_esr_cb_t esr_cb,
 }
 #endif
 
-#endif /* USBDEV_MOCK_H */
 /** @} */
+#endif /* USBDEV_MOCK_H */

--- a/drivers/include/usbdev_synopsys_dwc2.h
+++ b/drivers/include/usbdev_synopsys_dwc2.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef USBDEV_SYNOPSYS_DWC2_H
+#define USBDEV_SYNOPSYS_DWC2_H
+
 /**
  * @ingroup drivers_periph_usbdev
  * @{
@@ -17,9 +20,6 @@
  * @author  Koen Zandberg <koen@bergzand.net>
  * @author  Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef USBDEV_SYNOPSYS_DWC2_H
-#define USBDEV_SYNOPSYS_DWC2_H
 
 #include <stdint.h>
 
@@ -120,5 +120,5 @@ typedef struct {
 }
 #endif
 
-#endif /* USBDEV_SYNOPSYS_DWC2_H */
 /** @} */
+#endif /* USBDEV_SYNOPSYS_DWC2_H */

--- a/drivers/include/vcnl40x0.h
+++ b/drivers/include/vcnl40x0.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef VCNL40X0_H
+#define VCNL40X0_H
+
 /**
  * @defgroup    drivers_vcnl40x0 VCNL4010/VCNL4020/VCNL4040 Proximity and Ambient Light Sensors
  * @ingroup     drivers_sensors
@@ -19,9 +22,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef VCNL40X0_H
-#define VCNL40X0_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -145,5 +145,5 @@ uint16_t vcnl40x0_read_illuminance(const vcnl40x0_t *dev);
 }
 #endif
 
-#endif /* VCNL40X0_H */
 /** @} */
+#endif /* VCNL40X0_H */

--- a/drivers/include/veml6070.h
+++ b/drivers/include/veml6070.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef VEML6070_H
+#define VEML6070_H
+
 /**
  * @defgroup    drivers_veml6070 VEML6070 UV sensor
  * @ingroup     drivers_sensors
@@ -20,9 +23,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef VEML6070_H
-#define VEML6070_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -88,5 +88,5 @@ uint16_t veml6070_read_uv(const veml6070_t *dev);
 }
 #endif
 
-#endif /* VEML6070_H */
 /** @} */
+#endif /* VEML6070_H */

--- a/drivers/include/vl6180x.h
+++ b/drivers/include/vl6180x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef VL6180X_H
+#define VL6180X_H
+
 /**
  * @defgroup    drivers_vl6180x VL6180X Ranging and Ambient Light Sensing (ALS) module
  * @ingroup     drivers_sensors
@@ -389,9 +392,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @file
  */
-
-#ifndef VL6180X_H
-#define VL6180X_H
 
 #ifdef __cplusplus
 extern "C"
@@ -1072,5 +1072,5 @@ int vl6180x_reg_read(const vl6180x_t *dev,
 }
 #endif
 
-#endif /* VL6180X_H */
 /** @} */
+#endif /* VL6180X_H */

--- a/drivers/include/w5100.h
+++ b/drivers/include/w5100.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef W5100_H
+#define W5100_H
+
 /**
  * @defgroup    drivers_w5100 W5100 ethernet driver
  * @ingroup     drivers_netdev
@@ -30,9 +33,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef W5100_H
-#define W5100_H
 
 #include <stdint.h>
 
@@ -86,5 +86,5 @@ void w5100_setup(w5100_t *dev, const w5100_params_t *params, uint8_t index);
 }
 #endif
 
-#endif /* W5100_H */
 /** @} */
+#endif /* W5100_H */

--- a/drivers/include/w5500.h
+++ b/drivers/include/w5500.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef W5500_H
+#define W5500_H
+
 /**
  * @defgroup    drivers_w5500 W5500 ethernet driver
  * @ingroup     drivers_netdev
@@ -30,9 +33,6 @@
  *
  * @author      Stefan Schmidt <stemschmidt@gmail.com>
  */
-
-#ifndef W5500_H
-#define W5500_H
 
 #include <stdint.h>
 
@@ -86,5 +86,5 @@ void w5500_setup(w5500_t *dev, const w5500_params_t *params, uint8_t index);
 }
 #endif
 
-#endif /* W5500_H */
 /** @} */
+#endif /* W5500_H */

--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef WS281X_H
+#define WS281X_H
+
 /**
  * @defgroup    drivers_ws281x WS2812/SK6812 RGB LED (NeoPixel)
  * @ingroup     drivers_actuators
@@ -82,9 +85,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef WS281X_H
-#define WS281X_H
 
 #include <stdint.h>
 
@@ -252,5 +252,5 @@ static inline void ws281x_write(ws281x_t *dev)
 }
 #endif
 
-#endif /* WS281X_H */
 /** @} */
+#endif /* WS281X_H */

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef XBEE_H
+#define XBEE_H
+
 /**
  * @defgroup    drivers_xbee XBee driver
  * @ingroup     drivers_netdev
@@ -19,9 +22,6 @@
  * @author      Kévin Roussel <kevin.roussel@inria.fr>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef XBEE_H
-#define XBEE_H
 
 #include <stdint.h>
 
@@ -218,5 +218,5 @@ int xbee_parse_hdr(xbee_t *dev, const uint8_t *xhdr, xbee_l2hdr_t *l2hdr);
 }
 #endif
 
-#endif /* XBEE_H */
 /** @} */
+#endif /* XBEE_H */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Clang-format requires the header guard `#ifndef
#define HEADER_GUARD_H` to be outside of the doxygen documentation, that means outside the `@{ ... @}` block. If this is not done, then clang-format will indent all preprocessor directives after the `#ifndef`.
The problem is that the majority of RIOT's header files don't adhere to this order. They either have the header guard inside the doxygen block or the header guard starts correctly outside the doxygen block but the `#endif` directive is still inside the doxygen documentation.
To fix this inconsistency, I have written a python script that recursively scans all header files in a directory and rearranges the parts, so that the correct order is established.

The fix was only applied to the headers in `drivers/include/`, it can easily be applied to other parts of the code base.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Use my python script and change the path variable 'RIOT_PATH' in the script to whatever directory you want to recursively fix the header files. 

The script can be found [here](https://gist.github.com/KSKNico/0c088d957ff170739e7cb9d0a46fe582)


### Issues/PRs references

This is based on the fix in #20905 addressed by @mguetschow but with the added benefit of keeping the blocks balanced.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
