### PR TITLE
cpu/sam0_common/flashpage: disable interrupts while writing

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -64,7 +64,7 @@ static inline void wait_nvm_is_ready(void)
 #endif
 }
 
-static void _unlock(void)
+static unsigned _unlock(void)
 {
     /* remove peripheral access lock for the NVMCTRL peripheral */
 #ifdef REG_PAC_WRCTRL
@@ -74,13 +74,14 @@ static void _unlock(void)
 #endif
 
     /* NVM reads could be corrupted when mixing NVM reads with Page Buffer writes. */
+    return irq_disable();
 #ifdef NVMCTRL_CTRLA_CACHEDIS1
     _NVMCTRL->CTRLA.reg |= NVMCTRL_CTRLA_CACHEDIS0
                         |  NVMCTRL_CTRLA_CACHEDIS1;
 #endif
 }
 
-static void _lock(void)
+static void _lock(unsigned state)
 {
     wait_nvm_is_ready();
 
@@ -100,6 +101,8 @@ static void _lock(void)
 #ifdef CMCC
     CMCC->MAINT0.reg |= CMCC_MAINT0_INVALL;
 #endif
+
+    irq_restore(state);
 }
 
 static void _cmd_clear_page_buffer(void)
@@ -236,7 +239,7 @@ static void _write_page(void* dst, const void *data, size_t len, void (*cmd_writ
     /* word align destination address */
     uint32_t *dst32 = (void*)((uintptr_t)dst & ~0x3);
 
-    _unlock();
+    unsigned state = _unlock();
     _cmd_clear_page_buffer();
 
     /* write the first, unaligned bytes */
@@ -263,7 +266,7 @@ static void _write_page(void* dst, const void *data, size_t len, void (*cmd_writ
     }
 
     cmd_write();
-    _lock();
+    _lock(state);
 }
 
 static void _erase_page(void* page, void (*cmd_erase)(void))
@@ -271,7 +274,7 @@ static void _erase_page(void* page, void (*cmd_erase)(void))
     uintptr_t page_addr = (uintptr_t)page;
 
     /* erase given page (the ADDR register uses 16-bit addresses) */
-    _unlock();
+    unsigned state = _unlock();
 
     /* ADDR drives the hardware (16-bit) address to the NVM when a command is executed using CMDEX.
      * 8-bit addresses must be shifted one bit to the right before writing to this register.
@@ -284,7 +287,7 @@ static void _erase_page(void* page, void (*cmd_erase)(void))
     _NVMCTRL->ADDR.reg = page_addr;
 
     cmd_erase();
-    _lock();
+    _lock(state);
 }
 
 static void _write_row(uint8_t *dst, const void *_data, size_t len, size_t chunk_size,


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This reverts commit fd49d16cbab8f9046374f07d2008c0fb2d2593ea.
Before, the MCU would hardfault somehwere in `_erase_page()`:

```c
void sam0_flashpage_aux_reset(const nvm_user_page_t *cfg)
{
    nvm_user_page_t old_cfg;

    if (cfg == NULL) {
        cfg = &old_cfg;
        memcpy(&old_cfg, (void*)NVMCTRL_USER, sizeof(*cfg));
    }

    _erase_page((void*)NVMCTRL_USER, _cmd_erase_aux);
    _write_row((void*)NVMCTRL_USER, cfg, sizeof(*cfg), AUX_CHUNK_SIZE, _cmd_write_aux);
}
```
I messed a bit around and looks like inserting some 100ms delay anywhere between `_unlock()` and `_lock()`  in `_erase_page()` also helps the issue. Hope this helps with further debugging.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

The reverted commit was introduced in #21043.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
