### PR TITLE
makefiles: bump riotdocker [backport 2025.01]

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 045fd7eb54ccba2d5f4c06e8619bb1d5cd20ef96da8c6d4b7c1f9127e70adfff
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 0993a39a90e0b573637ea488d51fb33ba1cbeacbfbae4a27cca2091d0873d383
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
# Backport of #21258

### Contribution description

After https://github.com/RIOT-OS/riotdocker/pull/257 as requested by CI in https://github.com/RIOT-OS/RIOT/actions/runs/13591031011


### Testing procedure

static tests should succeed

