### PR TITLE
dist/tools/uf2: integrate flashing of adafruit bootloader

### DIFF
--- a/dist/tools/adafruit_nrf52_bootloader/Makefile
+++ b/dist/tools/adafruit_nrf52_bootloader/Makefile
@@ -1,0 +1,39 @@
+PKG_NAME=adafruit_nrf52_bootloader
+PKG_URL=https://github.com/adafruit/Adafruit_nRF52_Bootloader.git
+# 0.9.2
+PKG_VERSION=eefbe6bda98b80cb296e2f1bb1c982d58fe4c12d
+PKG_LICENSE=MIT
+
+PKG_CUSTOM_PREPARED = custom-prepare
+
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+PKGDIRBASE ?= $(BUILD_DIR)/pkg
+
+ifeq (,$(BOARD))
+  $(error BOARD not defined)
+endif
+
+ifeq (,$(PORT))
+  $(error PORT not defined)
+endif
+
+ADA_BOARD_feather-nrf52840-sense := feather_nrf52840_sense
+ADA_BOARD_feather-nrf52840 := feather_nrf52840_express
+ADA_BOARD_seeedstudio-xiao-nrf52840 := xiao_nrf52840_ble
+
+ADA_BOARD := $(ADA_BOARD_$(BOARD))
+
+ifeq (,$(ADA_BOARD))
+  $(error unsupported BOARD)
+endif
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+custom-prepare:
+	@$(GIT_IN_PKG) submodule update --init
+
+flash: $(PKG_PREPARED)
+	"$(MAKE)" BOARD="$(ADA_BOARD)" SERIAL="$(PORT)" -C "$(PKG_SOURCE_DIR)" clean flash-dfu

--- a/dist/tools/uf2/nrf52_softdevice_check.sh
+++ b/dist/tools/uf2/nrf52_softdevice_check.sh
@@ -45,10 +45,12 @@ fi
 if [ "${SOFTDEVICE}" = "not found" ] && [ "${UF2_SOFTDEV}" != "DROP" ]; then
     echo -e "\033[0;31mNo SoftDevice present on the device, but the compilation is set" \
     "to expect a SoftDevice."
+    echo -e "RIOT will now try to install the SoftDevice for you."
     echo -e "For more information see:" \
-    "https://doc.riot-os.org/group__boards__common__adafruit-nrf52-bootloader.html#ada-nrf52-update"\
-    "\033[0m"
-    exit 1
+    "https://doc.riot-os.org/group__boards__common__adafruit-nrf52-bootloader.html#ada-nrf52-update"
+    echo -e "Press enter to continue or CTRL-C to abort.\033[0m"
+    read -r
+    env CFLAGS= make -C "${RIOTTOOLS}/adafruit_nrf52_bootloader" flash || exit 1
 fi
 
 # Extract the actual SoftDevice version and compare it to the requested one

--- a/makefiles/tools/uf2conv.inc.mk
+++ b/makefiles/tools/uf2conv.inc.mk
@@ -10,7 +10,8 @@ PREFLASH_DELAY ?= 2
 # Execute the SoftDevice check. It verifies that the SoftDevice is present if
 # needed, that the versions match and that it is not accidentally overridden.
 uf2-softdevice-check:
-	@UF2_SOFTDEV=$(UF2_SOFTDEV) $(RIOTTOOLS)/uf2/nrf52_softdevice_check.sh
+	@env BOARD=$(BOARD) PORT=$(PORT) UF2_SOFTDEV=$(UF2_SOFTDEV)\
+		$(RIOTTOOLS)/uf2/nrf52_softdevice_check.sh
 	@if [ $$? -ne 0 ]; then \
 		exit 1; \
   fi


### PR DESCRIPTION
### Contribution description

Since #21281, boards using the adafruit nrf52 uf2 bootloader will default to keeping the SoftDevice (although not using it) and are checked to have the expected SoftDevice version present. If it is not, a warning is presented to the user requiring them to (re)install the bootloader manually.

This PR offers an automated way of installing the bootloader. Currently it doesn't work as intended though since the bootloader is for some reason required to be flashed twice (for the softdevice to be properly installed), and a second flashing fails unless the board was power-cycled in-between. We could certainly add interactive instructions for the user, but maybe there is a better way?

Also, the `flash-dfu` command requires `pip3 install --user adafruit-nrfutil` which is currently not checked for nor installed automatically. Maybe `pipx` would be an option.

Would be nice to have some kind of solution before the next RIOT release though, as previous users will otherwise need to perform the inconvenient manual bootloader reflash.


### Testing procedure

1. `make -C examples/basic/hello-world BOARD=feather-nrf52840-sense UF2_SOFTDEV=DROP flash`, press enter to continue.
2. `make -C examples/basic/hello-world BOARD=feather-nrf52840-sense flash`, press enter to continue and install the bootloader.


### Issues/PRs references

Follow-up of #21281.
