### PR TITLE
examples/nanocoap_server: enable LWIP IPv4 

### DIFF
--- a/examples/networking/coap/nanocoap_server/Makefile
+++ b/examples/networking/coap/nanocoap_server/Makefile
@@ -27,6 +27,10 @@ else
 
     USEMODULE += lwip_arp
     USEMODULE += lwip_ipv4
+    USEMODULE += netdev_legacy_api
+
+# If this module will be disabled, example set IPv4 192.168.100.150 address.
+    USEMODULE += lwip_dhcp_auto
     CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
 
     USEMODULE += random

--- a/examples/networking/coap/nanocoap_server/Makefile
+++ b/examples/networking/coap/nanocoap_server/Makefile
@@ -7,15 +7,40 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../../..
 
+# use GNRC by default
+LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 0
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_default
+
+ifeq (,$(filter 1, $(LWIP_IPV4) $(LWIP_IPV6)))
+  USEMODULE += auto_init_gnrc_netif
+  # Specify the mandatory networking modules
+  USEMODULE += gnrc_ipv6_default
+  # Additional networking modules that can be dropped if not needed
+  USEMODULE += gnrc_icmpv6_echo
+else
+  ifeq (1,$(LWIP_IPV4))
+    USEMODULE += ipv4_addr
+
+    USEMODULE += lwip_arp
+    USEMODULE += lwip_ipv4
+    CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
+
+    USEMODULE += random
+  endif
+
+  ifeq (1,$(LWIP_IPV6))
+    USEMODULE += ipv6_addr
+
+    USEMODULE += lwip_ipv6
+    USEMODULE += lwip_ipv6_autoconfig
+  endif
+endif
+
 USEMODULE += sock_udp
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
 
 USEMODULE += nanocoap_sock
 USEMODULE += nanocoap_resources

--- a/examples/networking/coap/nanocoap_server/README.md
+++ b/examples/networking/coap/nanocoap_server/README.md
@@ -2,7 +2,7 @@ nanocoap server example
 =======================
 
 This application is meant to get you started with implementing a CoAP server on RIOT.
-It uses the GNRC network stack through RIOT's
+It uses the GNRC or LWIP (including IPv4) network stack through RIOT's
 [sock API](http://doc.riot-os.org/group__net__sock.html).
 
 Usage
@@ -31,34 +31,36 @@ The application is now listening on all it's configured IP addresses.
 
 Now find out its link\_layer address:
 
-
 ```
 $ make term
-/home/aabadie/riot/examples/nanocoap_server/bin/native/nanocoapcoap_server.elf tap0
 RIOT native interrupts/signals initialized.
-LED_GREEN_OFF
-LED_RED_ON
 RIOT native board initialized.
 RIOT native hardware initialization complete.
 
-main(): This is RIOT! (Version: 2015.12-devel-632-g8f451-booze-master)
+main(): This is RIOT! (Version: 2024.04-devel-2305-g5f08f5-examples-nanocoap-lwip)
 RIOT nanocoap example application
 Waiting for address autoconfiguration...
-Configured network interfaces:
-Iface  5   HWaddr: 96:3c:18:1e:26:f7
-
-           MTU:1500  HL:64  RTR  RTR_ADV
-           Source address length: 6
-           Link type: wired
-           inet6 addr: ff02::1/128  scope: local [multicast]
-           inet6 addr: fe80::e42a:1aff:feca:10ec/64  scope: local
-           inet6 addr: ff02::1:ffca:10ec/128  scope: local [multicast]
-           inet6 addr: ff02::2/128  scope: local [multicast]
-           inet6 addr: 2001:db8:1:0:e42a:1aff:feca:10ec/64  scope: global
+{"IPv6 addresses": ["fe80::8c9d:7dff:fea1:fdcd"]}
 ```
 
-The link-layer address in this case is "fe80::e42a:1aff:feca:10ec", the only
-"scope: local" address set.
+The link-layer address in this case is "fe80::8c9d:7dff:fea1:fdcd".
+
+Usage - IPv4
+============
+Enable LWIP IPv4 setting `LWIP_IPV4 ?= 1` in `Makefile`.
+
+Run program and set IPv4 will be presented in the output:
+
+```
+RIOT native interrupts/signals initialized.
+RIOT native board initialized.
+RIOT native hardware initialization complete.
+
+main(): This is RIOT! (Version: 2024.04-devel-2305-g5f08f5-examples-nanocoap-lwip)
+RIOT nanocoap example application
+Waiting for address autoconfiguration...
+{"IPv4 addresses": ["192.168.100.150"]}
+```
 
 Testing
 =======

--- a/examples/networking/coap/nanocoap_server/main.c
+++ b/examples/networking/coap/nanocoap_server/main.c
@@ -24,6 +24,7 @@
 
 #ifdef MODULE_LWIP_IPV4
 #include "lwip/netif.h"
+#include <arpa/inet.h>
 #endif
 
 #define COAP_INBUF_SIZE (256U)
@@ -53,13 +54,20 @@ int main(void)
 
     sys_lock_tcpip_core();
     struct netif *iface = netif_find("ET0aa");
+
+#ifndef MODULE_LWIP_DHCP_AUTO
     ip4_addr_t ip, subnet;
     ip.addr = _TEST_ADDR4_LOCAL;
     subnet.addr = _TEST_ADDR4_MASK;
     netif_set_addr(iface, &ip, &subnet, NULL);
+#endif
     sys_unlock_tcpip_core();
 
-    printf("{\"IPv4 addresses\": [\"192.168.100.150\"]}\n");
+    /* print network addresses */
+    printf("{\"IPv4 addresses\": [\"");
+    char buffer[16];
+    inet_ntop(AF_INET, netif_ip_addr4(iface), buffer, 16);
+    printf("%s\"]}\n", buffer);
 
     /* initialize nanocoap server instance for IPv4*/
     uint8_t buf[COAP_INBUF_SIZE];


### PR DESCRIPTION
### Contribution description

This PR enables LWIP IPv4 in `nanocoap_server`, as we have IPv4 enable in `tests/nanocoap_cli` (see PR #21314).

### Testing procedure

Enable LWIP IPv4 in `Makefile` by setting `LWIP_IPV4 ?= 1`, compile and execute example:

```
make all
./bin/native/nanocoap_server.elf tap0
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2024.04-devel-2305-g5f08f5-examples-nanocoap-lwip)
RIOT nanocoap example application
Waiting for address autoconfiguration...
{"IPv4 addresses": ["192.168.100.150"]}
```
Test if example responds to coap messages, for example:
```
$ coap-client-notls -m GET coap://192.168.100.150/riot/board
native
$ coap-client-notls -m GET coap://192.168.100.150/riot/ver
This is RIOT (Version: 2024.04-devel-2305-g5f08f5-examples-nanocoap-lwip) running on a native board with a native MCU.
```

### Issues/PRs references

PR #21314 