### PR TITLE
buildsystem: Fix `boards/Makefile.features` Inclusion

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -4,15 +4,15 @@
 # variables in their Makefile.features.
 # This makes them available when setting features based on CPU_MODEL in the cpu
 # Makefile.features and also during dependency resolution.
+#
+# Board features defined by common code in `boards/common` are processed
+# during the dependency resolution, since they depend on the USEMODULE.
 
 # Transition:
 #   Moving 'CPU/CPU_MODEL' to Makefile.features is an ongoing work and may not
 #   reflect the state of all boards for the moment.
 
 include $(BOARDDIR)/Makefile.features
-
-# include global Makefile.features for `boards` modules
-include $(RIOTBOARD)/Makefile.features
 
 # Sanity check
 ifeq (,$(CPU))

--- a/makefiles/dependency_resolution.inc.mk
+++ b/makefiles/dependency_resolution.inc.mk
@@ -17,6 +17,10 @@ OLD_STATE := $(USEMODULE) $(USEPKG) $(FEATURES_USED)
 # pull in dependencies of the currently used modules and pkgs
 include $(RIOTBASE)/Makefile.dep
 
+# include the global board features before the feature check as they depend
+# on the USEMODULE, which is present after the `Makefile.dep` resolution
+include $(RIOTBOARD)/Makefile.features
+
 # check if required features are provided and update $(FEATURES_USED)
 include $(RIOTMAKE)/features_check.inc.mk
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

During the development of #21332 I noticed that the `boards/Makefile.features` I introduced in #21327 does not work and unfortunately it is unlikely to ever work, because it suffers from the classic hen-and-egg problem.

The `$(RIOTBASE)/Makefile.features` (which includes $(RIOTBASE)/boards/Makefile.features) is included before the `$(RIOTBASE)/Makefile.dep` is included in the dependency check and before the dependencies are resolved, the Make system will check that there are not feature conflicts or errors.
https://github.com/RIOT-OS/RIOT/blob/e85269a830af1fb181db047964b4ce1b9198f1fa/Makefile.include#L407-L408

https://github.com/RIOT-OS/RIOT/blob/e85269a830af1fb181db047964b4ce1b9198f1fa/Makefile.include#L428-L429

https://github.com/RIOT-OS/RIOT/blob/e85269a830af1fb181db047964b4ce1b9198f1fa/Makefile.include#L437-L438


While it would be tempting to move the include of `$(RIOTBASE)/boards/Makefile.features` after the dependency resolution, this won't work because the feature check already failed at that point. I added a `$(warning $(USEMODULE))` to the `boards/Makefile.features` and as you can see, the `boards_common_adafruit-nrf52-bootloader` USEMODULE is not set yet.
That obviously makes a `ifdef` that depends on the USEMODULES kind of pointless.
```
cbuec@W11nMate:~/RIOTstuff/riot-boards-common/RIOT$ BOARD=feather-nrf52840 make -C tests/sys/shell
make: Entering directory '/home/cbuec/RIOTstuff/riot-boards-common/RIOT/tests/sys/shell'
/home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards/Makefile.features:3: app_metadata shell_cmds_default ps ztimer_msec shell_builtin_cmd_help_json
Building application "tests_shell" for "feather-nrf52840" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-boards-common/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards
...
```

The other tempting solution would be to move the dependency resolution before the feature check, however the dependency resolution depends on the features being set.

Therefore the not-super-elegant solution is to include the `boards/Makefile.features` during the dependency resolution.
Since the dependency resolution runs in a loop until all features are stable, this works as expected and the `boards_common_adafruit-nrf52-bootloader` is part of the USEMODULES after the second run of the dependency resolution:

```
cbuec@W11nMate:~/RIOTstuff/riot-boards-common/RIOT$ BOARD=feather-nrf52840 make -C tests/sys/shell
make: Entering directory '/home/cbuec/RIOTstuff/riot-boards-common/RIOT/tests/sys/shell'
/home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards/Makefile.features:3: app_metadata board board_common_init core core_init core_lib core_msg core_panic core_thread cpu libc ps shell_builtin_cmd_help_json shell_cmds_default sys test_utils_interactive_sync test_utils_print_stack_usage ztimer_msec stdio_default boards_common_adafruit-nrf52-bootloader nrf52_vectors nrf5x_common_periph cpu_common cortexm_common cortexm_common_periph periph malloc_thread_safe shell_cmds shell stdio_uart stdio ztimer_core ztimer_extend ztimer ztimer_periph_rtt stdin stdio_cdc_acm usb_board_reset stdin shell_cmd_sys shell_cmd_app_metadata shell_cmd_ps app_metadata ps ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt
/home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards/Makefile.features:3: app_metadata board board_common_init boards_common_adafruit-nrf52-bootloader core core_init core_lib core_msg core_panic core_thread cortexm_common cortexm_common_periph cpu cpu_common frac libc malloc_thread_safe newlib nrf52_vectors nrf5x_common_periph periph periph_common periph_gpio periph_pm periph_rtt periph_uart ps shell shell_builtin_cmd_help_json shell_cmd_app_metadata shell_cmd_ps shell_cmd_sys shell_cmds shell_cmds_default stdin stdio stdio_cdc_acm stdio_default stdio_uart sys test_utils_interactive_sync test_utils_print_stack_usage usb_board_reset ztimer ztimer_convert ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_msec ztimer_periph_rtt boards_common_adafruit-nrf52-bootloader nrf52_vectors nrf5x_common_periph cpu_common cortexm_common cortexm_common_periph periph malloc_thread_safe newlib_syscalls_default div shell_cmds shell stdio isrpipe stdio_dispatch usbus_cdc_acm isrpipe stdio_available stdio_uart_rx isrpipe stdio_uart stdio_available usbus core_thread_flags event luid fmt tsrb ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt stdin stdio_cdc_acm usb_board_reset core_thread_flags tsrb stdin shell_cmd_sys shell_cmd_app_metadata shell_cmd_pm shell_cmd_ps app_metadata ps ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt
/home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards/Makefile.features:3: app_metadata board board_common_init boards_common_adafruit-nrf52-bootloader core core_init core_lib core_msg core_panic core_thread core_thread_flags cortexm_common cortexm_common_periph cpu cpu_common div event fmt frac isrpipe libc luid malloc_thread_safe newlib newlib_syscalls_default nrf52_vectors nrf5x_common_periph periph periph_common periph_cpuid periph_gpio periph_gpio_ll_disconnect periph_gpio_ll_input_pull_down periph_gpio_ll_input_pull_up periph_gpio_ll_irq_edge_triggered_both periph_gpio_ll_irq_unmask periph_gpio_ll_open_drain periph_gpio_ll_open_drain_pull_up periph_gpio_ll_open_source periph_gpio_ll_open_source_pull_down periph_pm periph_rtt periph_uart periph_usbdev ps shell shell_builtin_cmd_help_json shell_cmd_app_metadata shell_cmd_pm shell_cmd_ps shell_cmd_sys shell_cmds shell_cmds_default stdin stdio stdio_available stdio_cdc_acm stdio_default stdio_dispatch stdio_uart stdio_uart_rx sys test_utils_interactive_sync test_utils_print_stack_usage tsrb usb_board_reset usbus usbus_cdc_acm ztimer ztimer_convert ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_msec ztimer_periph_rtt boards_common_adafruit-nrf52-bootloader nrf52_vectors nrf5x_common_periph cpu_common cortexm_common cortexm_common_periph periph malloc_thread_safe div shell_cmds shell stdio isrpipe stdio_dispatch usbus_cdc_acm isrpipe stdio_available stdio_uart_rx isrpipe stdio_uart stdio_available usbus core_thread_flags event luid fmt tsrb ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt stdin periph_usbdev_clk stdio_cdc_acm usb_board_reset core_thread_flags tsrb stdin shell_cmd_sys shell_cmd_app_metadata shell_cmd_pm shell_cmd_ps app_metadata ps ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt
/home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards/Makefile.features:3: app_metadata board board_common_init boards_common_adafruit-nrf52-bootloader core core_init core_lib core_msg core_panic core_thread core_thread_flags cortexm_common cortexm_common_periph cpu cpu_common div event fmt frac isrpipe libc luid malloc_thread_safe newlib newlib_syscalls_default nrf52_vectors nrf5x_common_periph periph periph_common periph_cpuid periph_gpio periph_gpio_ll_disconnect periph_gpio_ll_input_pull_down periph_gpio_ll_input_pull_up periph_gpio_ll_irq_edge_triggered_both periph_gpio_ll_irq_unmask periph_gpio_ll_open_drain periph_gpio_ll_open_drain_pull_up periph_gpio_ll_open_source periph_gpio_ll_open_source_pull_down periph_pm periph_rtt periph_uart periph_usbdev periph_usbdev_clk ps shell shell_builtin_cmd_help_json shell_cmd_app_metadata shell_cmd_pm shell_cmd_ps shell_cmd_sys shell_cmds shell_cmds_default stdin stdio stdio_available stdio_cdc_acm stdio_default stdio_dispatch stdio_uart stdio_uart_rx sys test_utils_interactive_sync test_utils_print_stack_usage tsrb usb_board_reset usbus usbus_cdc_acm ztimer ztimer_convert ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_msec ztimer_periph_rtt boards_common_adafruit-nrf52-bootloader nrf52_vectors nrf5x_common_periph cpu_common cortexm_common cortexm_common_periph periph malloc_thread_safe div shell_cmds shell stdio isrpipe stdio_dispatch usbus_cdc_acm isrpipe stdio_available stdio_uart_rx isrpipe stdio_uart stdio_available usbus core_thread_flags event luid fmt tsrb ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt stdin periph_usbdev_clk stdio_cdc_acm usb_board_reset core_thread_flags tsrb stdin shell_cmd_sys shell_cmd_app_metadata shell_cmd_pm shell_cmd_ps app_metadata ps ztimer_core ztimer_convert_frac ztimer_convert_shift ztimer_core ztimer_extend ztimer_convert frac ztimer ztimer_periph_rtt
Building application "tests_shell" for "feather-nrf52840" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-boards-common/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-boards-common/RIOT/boards/common/adafruit-nrf52-bootloader
...
```


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Testing this is a bit abstract as no board uses the global `boards/Makefile.features` yet, but I added this line to the `boards/Makefile.features`, which prints the `$(USEMODULE)` variable.
```
# SORT THIS ALPHABETICALLY BY COMMON BOARD NAME!

$(warning $(USEMODULE))
```

You can test it with every application you like, I used the `tests/sys/shell` and the `feather-nrf52840` board.
You can test it with every board that uses the `adafruit-nrf52-bootloader` and you don't even have to have the actual board for testing this change.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes a bug introduced by #21327.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
