### PR TITLE
boards/nucleo*: Cleanup and Enhance the Documentation

### DIFF
--- a/boards/common/nucleo/flashing.doc.md
+++ b/boards/common/nucleo/flashing.doc.md
@@ -1,0 +1,33 @@
+@defgroup boards_common_nucleo_flashing Flashing the Nucleo
+@ingroup boards_common_nucleo32
+@ingroup boards_common_nucleo64
+@ingroup boards_common_nucleo144
+@brief Flashing ST Nucleo Development Boards
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command (replace the `xxxxx` with your Nucleo variant):
+
+```
+make BOARD=nucleo-xxxx PROGRAMMER=cpy2remed flash
+```
+
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
+
+## Flashing the Board Using OpenOCD
+
+The ST Nucleo64 board includes an on-board ST-LINK programmer and can be
+flashed using OpenOCD (use version 0.11.0 at least).
+
+To flash this board, just use the following command (replace the `xxxxx`
+with your Nucleo variant):
+
+```
+make BOARD=nucleo-xxxxx flash -C examples/basic/hello-world
+```

--- a/boards/common/nucleo144/doc.md
+++ b/boards/common/nucleo144/doc.md
@@ -1,0 +1,3 @@
+@defgroup    boards_common_nucleo144 STM32 Nucleo-144
+@ingroup     boards
+@brief       Support for STM32 Nucleo-144 boards

--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -9,9 +9,7 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo144 STM32 Nucleo-144
- * @ingroup     boards
- * @brief       Support for STM32 Nucleo-144 boards
+ * @ingroup     boards_common_nucleo144
  * @{
  *
  * @file

--- a/boards/common/nucleo32/doc.md
+++ b/boards/common/nucleo32/doc.md
@@ -1,0 +1,3 @@
+@defgroup    boards_common_nucleo32 STM32 Nucleo-32
+@ingroup     boards
+@brief       Support for STM32 Nucleo-32 boards

--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo32 STM32 Nucleo-32
- * @ingroup     boards
- * @brief       Support for STM32 Nucleo-32 boards
+ * @ingroup     boards_common_nucleo32
  * @{
  *
  * @file

--- a/boards/common/nucleo64/doc.md
+++ b/boards/common/nucleo64/doc.md
@@ -1,0 +1,3 @@
+@defgroup boards_common_nucleo64 STM32 Nucleo-64
+@ingroup boards
+@brief Support for STM32 Nucleo-64 Boards

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo64 STM32 Nucleo-64
- * @ingroup     boards
- * @brief       Support for STM32 Nucleo-64 boards
+ * @ingroup     boards_common_nucleo64
  * @{
  *
  * @file

--- a/boards/nucleo-c031c6/doc.md
+++ b/boards/nucleo-c031c6/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-c031c6 STM32 Nucleo-C031C6
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-C031C6
@@ -48,5 +47,3 @@ make BOARD=nucleo-c031c6 PROGRAMMER=cpy2remed flash
 
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-c031c6/doc.md
+++ b/boards/nucleo-c031c6/doc.md
@@ -33,17 +33,8 @@ Cortex-M0+ STM32C031C6 microcontroller with 12KiB of RAM and 32KiB of Flash.
 | Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf) |
 | Board Manual   | [Board Manual](https://www.st.com/resource/en/user_manual/um2953-stm32-nucleo64-board-mb1717-stmicroelectronics.pdf) |
 
-## Flashing the Board Using ST-LINK Removable Media
+## Flashing the Board
 
-On-board ST-LINK programmer provides via composite USB device removable media.
-Copying the HEX file causes reprogramming of the board. This task
-could be performed manually; however, the cpy2remed (copy to removable
-media) PROGRAMMER script does this automatically. To program board in
-this manner, use the command:
-
-```
-make BOARD=nucleo-c031c6 PROGRAMMER=cpy2remed flash
-```
-
-@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+A detailed description about the flashing process can be found at the
+common [Flashing the Nucleo](@ref boards_common_nucleo_flashing) page.
+The board name for the Nucleo-C031C3 is `nucleo-c031c6`.

--- a/boards/nucleo-f030r8/doc.md
+++ b/boards/nucleo-f030r8/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f030r8 STM32 Nucleo-F030R8
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F030R8
@@ -87,4 +86,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F030R8 board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f070rb/doc.md
+++ b/boards/nucleo-f070rb/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f070rb STM32 Nucleo-F070RB
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F070RB
@@ -88,4 +87,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F070RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f091rc/doc.md
+++ b/boards/nucleo-f091rc/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f091rc STM32 Nucleo-F091RC
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F091RC
@@ -103,4 +102,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F091RC board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f103rb/doc.md
+++ b/boards/nucleo-f103rb/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f103rb STM32 Nucleo-F103RB
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F103RB
@@ -86,4 +85,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F103RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f302r8/doc.md
+++ b/boards/nucleo-f302r8/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f302r8 STM32 Nucleo-F302R8
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F302R8
@@ -88,4 +87,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 ## Supported Toolchains
 For using the ST Nucleo-F302R8 board we strongly recommend the usage of
 the [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded) toolchain.
- */

--- a/boards/nucleo-f303re/doc.md
+++ b/boards/nucleo-f303re/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f303re STM32 Nucleo-F303RE
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F303RE
@@ -89,4 +88,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F303RE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f334r8/doc.md
+++ b/boards/nucleo-f334r8/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f334r8 STM32 Nucleo-F334R8
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F334R8
@@ -97,4 +96,3 @@ The default baud rate is 115200.
 For using the ST Nucleo-F334R8 board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f401re/doc.md
+++ b/boards/nucleo-f401re/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f401re STM32 Nucleo-F401RE
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F401RE
@@ -103,4 +102,3 @@ manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf), section
 6.7.1.
 The other issue is, that revision `C-01` also has no 32kHz oscillator, so the
 RTC module of RIOT cannot be used.
- */

--- a/boards/nucleo-f410rb/doc.md
+++ b/boards/nucleo-f410rb/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f410rb STM32 Nucleo-F410RB
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F410RB
@@ -89,4 +88,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F410RB board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f411re/doc.md
+++ b/boards/nucleo-f411re/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f411re STM32 Nucleo-F411RE
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F411RE
@@ -88,4 +87,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F411RE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-f446re/doc.md
+++ b/boards/nucleo-f446re/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-f446re STM32 Nucleo-F446RE
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-F446RE
@@ -88,4 +87,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-F446RE board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-g070rb/doc.md
+++ b/boards/nucleo-g070rb/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-g070rb STM32 Nucleo-G070RB
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-G070RB
@@ -46,5 +45,3 @@ make BOARD=nucleo-g070rb PROGRAMMER=cpy2remed flash
 
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
-*/

--- a/boards/nucleo-g071rb/doc.md
+++ b/boards/nucleo-g071rb/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-g071rb STM32 Nucleo-G071RB
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-G071RB
@@ -46,5 +45,3 @@ make BOARD=nucleo-g071rb PROGRAMMER=cpy2remed flash
 
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-g431rb/doc.md
+++ b/boards/nucleo-g431rb/doc.md
@@ -1,54 +1,51 @@
-/**
-@defgroup    boards_nucleo-g474re STM32 Nucleo-G474RE
+@defgroup    boards_nucleo-g431rb STM32 Nucleo-G431RB
 @ingroup     boards_common_nucleo64
-@brief       Support for the STM32 Nucleo-G474RE
+@brief       Support for the STM32 Nucleo-G431RB
 
 ## Overview
 
-The Nucleo-G474RE is a board from ST's Nucleo family supporting a ARM
-Cortex-M4 STM32G474RE microcontroller with 128KiB of RAM and 512KiB of Flash.
+The Nucleo-G431RB is a board from ST's Nucleo family supporting a ARM
+Cortex-M4 STM32G431RB microcontroller with 32KiB of RAM and 128KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G4741RE (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
+@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G431RB (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
 
 ### MCU
 
-| MCU          | STM32G474RE
+| MCU          | STM32G431RB
 |:-------------|:--------------------|
 | Family       | ARM Cortex-M4       |
 | Vendor       | ST Microelectronics |
-| RAM          | 128KiB              |
-| Flash        | 512KiB              |
+| RAM          | 32KiB               |
+| Flash        | 128KiB              |
 | Frequency    | up to 170 MHz       |
-| Timers       | 17 (2x watchdog, 1 SysTick, 12x 16-bit and 2x 32-bit) |
-| ADCs         | 5x 12 bit (up to 26 channels) |
+| Timers       | 14 (2x watchdog, 1 SysTick, 10x 16-bit and 1 32-bit) |
+| ADCs         | 2x 12 bit (up to 23 channels) |
 | UARTs        | 5 (one UART, three USARTs and one Low-Power UART) |
-| I2Cs         | 4                   |
+| I2Cs         | 3                   |
 | SPIs         | 3                   |
-| CANs         | 3                   |
 | RTC          | 1                   |
-| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g474re.pdf)|
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g431rb.pdf)|
 | Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
 | Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
 | Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf)|
-
 
 ## Flashing the device
 
 ### Flashing the Board Using OpenOCD
 
-The ST Nucleo-G474RE board includes an on-board ST-LINK V3 programmer. The
+The ST Nucleo-G431RB board includes an on-board ST-LINK V3 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-g474re flash
+make BOARD=nucleo-g431rb flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-g474re debug
+make BOARD=nucleo-g431rb debug
 ```
 
 ### Flashing the Board Using ST-LINK Removable Media
@@ -59,7 +56,7 @@ could be performed manually; however, the cpy2remed (copy to removable
 media) PROGRAMMER script does this automatically. To program board in
 this manner, use the command:
 ```
-make BOARD=nucleo-g474re PROGRAMMER=cpy2remed flash
+make BOARD=nucleo-g431re PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
@@ -67,7 +64,6 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 
 ## Supported Toolchains
 
-For using the ST Nucleo-G474RE board we recommend the usage of the
+For using the ST Nucleo-G431RB board we recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-g474re/doc.md
+++ b/boards/nucleo-g474re/doc.md
@@ -1,52 +1,53 @@
-/**
-@defgroup    boards_nucleo-g431rb STM32 Nucleo-G431RB
+@defgroup    boards_nucleo-g474re STM32 Nucleo-G474RE
 @ingroup     boards_common_nucleo64
-@brief       Support for the STM32 Nucleo-G431RB
+@brief       Support for the STM32 Nucleo-G474RE
 
 ## Overview
 
-The Nucleo-G431RB is a board from ST's Nucleo family supporting a ARM
-Cortex-M4 STM32G431RB microcontroller with 32KiB of RAM and 128KiB of Flash.
+The Nucleo-G474RE is a board from ST's Nucleo family supporting a ARM
+Cortex-M4 STM32G474RE microcontroller with 128KiB of RAM and 512KiB of Flash.
 
 ## Pinout
 
-@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G431RB (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
+@image html pinouts/nucleo-g431rb-and-more.svg "Pinout for the Nucleo-G4741RE (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50%
 
 ### MCU
 
-| MCU          | STM32G431RB
+| MCU          | STM32G474RE
 |:-------------|:--------------------|
 | Family       | ARM Cortex-M4       |
 | Vendor       | ST Microelectronics |
-| RAM          | 32KiB               |
-| Flash        | 128KiB              |
+| RAM          | 128KiB              |
+| Flash        | 512KiB              |
 | Frequency    | up to 170 MHz       |
-| Timers       | 14 (2x watchdog, 1 SysTick, 10x 16-bit and 1 32-bit) |
-| ADCs         | 2x 12 bit (up to 23 channels) |
+| Timers       | 17 (2x watchdog, 1 SysTick, 12x 16-bit and 2x 32-bit) |
+| ADCs         | 5x 12 bit (up to 26 channels) |
 | UARTs        | 5 (one UART, three USARTs and one Low-Power UART) |
-| I2Cs         | 3                   |
+| I2Cs         | 4                   |
 | SPIs         | 3                   |
+| CANs         | 3                   |
 | RTC          | 1                   |
-| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g431rb.pdf)|
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g474re.pdf)|
 | Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
 | Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
 | Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf)|
+
 
 ## Flashing the device
 
 ### Flashing the Board Using OpenOCD
 
-The ST Nucleo-G431RB board includes an on-board ST-LINK V3 programmer. The
+The ST Nucleo-G474RE board includes an on-board ST-LINK V3 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
 installation instructions), you can flash the board simply by typing
 
 ```
-make BOARD=nucleo-g431rb flash
+make BOARD=nucleo-g474re flash
 ```
 and debug via GDB by simply typing
 ```
-make BOARD=nucleo-g431rb debug
+make BOARD=nucleo-g474re debug
 ```
 
 ### Flashing the Board Using ST-LINK Removable Media
@@ -57,7 +58,7 @@ could be performed manually; however, the cpy2remed (copy to removable
 media) PROGRAMMER script does this automatically. To program board in
 this manner, use the command:
 ```
-make BOARD=nucleo-g431re PROGRAMMER=cpy2remed flash
+make BOARD=nucleo-g474re PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
@@ -65,7 +66,6 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 
 ## Supported Toolchains
 
-For using the ST Nucleo-G431RB board we recommend the usage of the
+For using the ST Nucleo-G474RE board we recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-l053r8/doc.md
+++ b/boards/nucleo-l053r8/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l053r8 STM32 Nucleo-L053R8
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L053R8
@@ -47,5 +46,3 @@ make BOARD=nucleo-l053r8 PROGRAMMER=cpy2remed flash
 
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-l073rz/doc.md
+++ b/boards/nucleo-l073rz/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l073rz STM32 Nucleo-L073RZ
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L073RZ
@@ -47,5 +46,3 @@ make BOARD=nucleo-l073rz PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
       can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-l152re/doc.md
+++ b/boards/nucleo-l152re/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l152re STM32 Nucleo-L152RE
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L152RE
@@ -91,4 +90,3 @@ external UART adapter.
 1. connect your usb tty to the st-link header as marked
 ![st-link-header](https://cloud.githubusercontent.com/assets/56618/5190200/f36aafe0-74e3-11e4-96bd-f755dd2a8b01.png)
 2. done
- */

--- a/boards/nucleo-l433rc/doc.md
+++ b/boards/nucleo-l433rc/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l433rc STM32 Nucleo-L433RC
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L433RC
@@ -51,5 +50,3 @@ make BOARD=nucleo-l433rc PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-l452re/doc.md
+++ b/boards/nucleo-l452re/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l452re STM32 Nucleo-L452RE
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L452RE
@@ -47,5 +46,3 @@ make BOARD=nucleo-l452re PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
 can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-l476rg/doc.md
+++ b/boards/nucleo-l476rg/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-l476rg STM32 Nucleo-L476RG
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L476RG
@@ -72,4 +71,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-L476RG board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/nucleo-wl55jc/doc.md
+++ b/boards/nucleo-wl55jc/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nucleo-wl55jc STM32 Nucleo-WL55JC
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-W55JC
@@ -70,4 +69,3 @@ could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
 For using the ST Nucleo-wl55jc board we strongly recommend the usage of the
 [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
 toolchain.
- */

--- a/boards/p-nucleo-wb55/doc.md
+++ b/boards/p-nucleo-wb55/doc.md
@@ -1,6 +1,6 @@
-@defgroup    boards_p-nucleo-wb55 STM32 p-nucleo-wb55
-@ingroup     boards
-@brief       Support for the STM32 p-nucleo-wb55
+@defgroup    boards_p-nucleo-wb55 STM32 P-Nucleo-WB55
+@ingroup     boards_common_nucleo64
+@brief       Support for the STM32 P-Nucleo-WB55
 
 ## Overview
 

--- a/boards/p-nucleo-wb55/doc.md
+++ b/boards/p-nucleo-wb55/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_p-nucleo-wb55 STM32 p-nucleo-wb55
 @ingroup     boards
 @brief       Support for the STM32 p-nucleo-wb55
@@ -126,5 +125,3 @@ make BOARD=p-nucleo-wb55 -C examples/basic/hello-world term
 |                   | USB               | yes       |            |
 |                   | PWM               | yes       | dev 0/4 ch |
 |                   | AES               | no        |            |
-
-*/

--- a/boards/p-nucleo-wb55/doc.md
+++ b/boards/p-nucleo-wb55/doc.md
@@ -45,32 +45,11 @@ with 256KB of RAM and 1MB of ROM Flash.
 [Reference Manual]: https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf
 [User Manual]: https://www.st.com/content/ccc/resource/technical/document/user_manual/group1/13/58/22/1a/f2/ff/43/5c/DM00517423/files/DM00517423.pdf/jcr:content/translations/en.DM00517423.pdf
 
-## Flashing the device
+## Flashing the Board
 
-### Flashing the Board Using OpenOCD
-
-The ST p-nucleo-wb55 board includes an on-board ST-LINK programmer and can be
-flashed using OpenOCD (use version 0.11.0 at least).
-
-To flash this board, just use the following command:
-
-```
-make BOARD=p-nucleo-wb55 flash -C examples/basic/hello-world
-```
-
-### Flashing the Board Using ST-LINK Removable Media
-
-On-board ST-LINK programmer provides via composite USB device removable media.
-Copying the HEX file causes reprogramming of the board. This task could be
-performed manually; however, the cpy2remed (copy to removable media) PROGRAMMER
-script does this automatically. To program board in this manner, use the command:
-
-```
-make BOARD=p-nucleo-wb55 PROGRAMMER=cpy2remed flash
-```
-@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
--link007.html).
+A detailed description about the flashing process can be found at the
+common [Flashing the Nucleo](@ref boards_common_nucleo_flashing) page.
+The board name for the P-Nucleo-WB55 is `p-nucleo-wb55`.
 
 
 ## Accessing RIOT shell


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Inspired by the work of grouping common code and the new `*.doc.md` syntax, I started to deduplicate the documentation of the STM32 Nucleo boards.

This PR includes:
- [X] Add P-Nucleo-WB55 to Nucleo64 group
- [ ] Move Nucleo32 Boards to `doc.md` format
- [X] Move Nucleo64 Boards to `doc.md` format
- [ ] Move Nucleo144 Boards to `doc.md` format
- [X] Create common `doc.md` files for Nucleo32, Nucleo64 and Nucleo144
- [X] Don't show the content of `boards/common/nucleoXX/include/board.h` in the Nucleo32/64/144 group
- [ ] Add Nucleo-common information to these files (such as the LED0<->SPI issue raised in #21336 by @tanneberger).
- [X] Create a `boards/common/nucleo/flashing.doc.md` page that contains about the Flashing process.
- [ ] Replace the Flashing information for all Nucleo32 boards.
- [ ] Replace the Flashing information for all Nucleo64 boards.
- [ ] Replace the Flashing information for all Nucleo144 boards.
- [ ] ????

This is still a draft, but I would like to get some early comments about whether this is a good direction or not before I edit all the other files.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

Check that the documentation looks beautiful. Until #21319 is merged, you have to add `*.doc.md` to the `docs/doxygen/riot.doxyfile` in Line 930:
```diff
diff --git a/doc/doxygen/riot.doxyfile b/doc/doxygen/riot.doxyfile
index a579d57beb..a7765df70b 100644
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -928,6 +928,7 @@ INPUT_ENCODING         = UTF-8

 FILE_PATTERNS          = *.txt \
                          doc.md \
+                         *.doc.md \
                          *.h \
                          *.h.in \
                          *.hpp
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on #21319.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
