### PR TITLE
sys/include: fix headers for clang-format

### DIFF
--- a/sys/include/analog_util.h
+++ b/sys/include/analog_util.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ANALOG_UTIL_H
+#define ANALOG_UTIL_H
+
 /**
  * @defgroup    sys_analog_util Analog data conversion utilities
  * @ingroup     sys
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef ANALOG_UTIL_H
-#define ANALOG_UTIL_H
 
 #include <stdint.h>
 
@@ -90,5 +90,5 @@ uint16_t dac_util_mapf(float value, float min, float max);
 }
 #endif
 
-#endif /* ANALOG_UTIL_H */
 /** @} */
+#endif /* ANALOG_UTIL_H */

--- a/sys/include/app_metadata.h
+++ b/sys/include/app_metadata.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef APP_METADATA_H
+#define APP_METADATA_H
+
 /**
  * @defgroup    sys_app_metadata app_metadata
  * @ingroup     sys
@@ -14,9 +17,6 @@
  *
  * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
  */
-
-#ifndef APP_METADATA_H
-#define APP_METADATA_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,5 @@ void app_metadata_print_json(void);
 }
 #endif
 
-#endif /* APP_METADATA_H */
 /** @} */
+#endif /* APP_METADATA_H */

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ARCHITECTURE_H
+#define ARCHITECTURE_H
+
 /**
  * @defgroup    sys_architecture    Platform-independent access to architecture
  *                                  details
@@ -20,9 +23,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef ARCHITECTURE_H
-#define ARCHITECTURE_H
 
 #include <stdint.h>
 #include <inttypes.h>
@@ -229,5 +229,5 @@ typedef uintptr_t   uinttxtptr_t;
 }
 #endif
 
-#endif /* ARCHITECTURE_H */
 /** @} */
+#endif /* ARCHITECTURE_H */

--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ATOMIC_UTILS_H
+#define ATOMIC_UTILS_H
+
 /**
  * @defgroup    sys_atomic_utils    Utility functions for atomic access
  * @ingroup     sys
@@ -132,9 +135,6 @@
  * @brief       API of the utility functions for atomic accesses
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef ATOMIC_UTILS_H
-#define ATOMIC_UTILS_H
 
 #include <stdint.h>
 
@@ -1391,5 +1391,5 @@ static inline uint64_t semi_atomic_fetch_and_u64(volatile uint64_t *dest,
 }
 #endif
 
-#endif /* ATOMIC_UTILS_H */
 /** @} */
+#endif /* ATOMIC_UTILS_H */

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef AUTO_INIT_H
+#define AUTO_INIT_H
+
 /**
  * @defgroup    sys_auto_init Auto-initialization
  * @ingroup     sys
@@ -104,9 +107,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef AUTO_INIT_H
-#define AUTO_INIT_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/auto_init_utils.h
+++ b/sys/include/auto_init_utils.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef AUTO_INIT_UTILS_H
+#define AUTO_INIT_UTILS_H
 /**
  * @defgroup    sys_auto_init_utils Utilities to influence the order of auto-initialized modules
  * @ingroup     sys
@@ -24,8 +26,6 @@
  * @experimental
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-#ifndef AUTO_INIT_UTILS_H
-#define AUTO_INIT_UTILS_H
 
 #include <stdint.h>
 #include "xfa.h"
@@ -97,5 +97,5 @@ typedef struct {
 }
 #endif
 
-#endif /* AUTO_INIT_UTILS_H */
 /** @} */
+#endif /* AUTO_INIT_UTILS_H */

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef BASE64_H
+#define BASE64_H
+
 /**
  * @defgroup    sys_base64 base64 encoder decoder
  * @ingroup     sys_serialization
@@ -16,9 +19,6 @@
  * @brief       encoding and decoding functions for base64
  * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  */
-
-#ifndef BASE64_H
-#define BASE64_H
 
 #include <stddef.h> /* for size_t */
 

--- a/sys/include/bcd.h
+++ b/sys/include/bcd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef BCD_H
+#define BCD_H
 /**
  * @defgroup    sys_bcd Binary coded decimal
  * @ingroup     sys
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef BCD_H
-#define BCD_H
 
 #include <stdint.h>
 
@@ -56,5 +56,5 @@ static inline uint8_t bcd_to_byte(uint8_t bcd)
 }
 #endif
 
-#endif /* BCD_H */
 /** @} */
+#endif /* BCD_H */

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BENCHMARK_H
+#define BENCHMARK_H
+
 /**
  * @defgroup    sys_benchmark Benchmark
  * @ingroup     sys
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef BENCHMARK_H
-#define BENCHMARK_H
 
 #include <stdint.h>
 
@@ -65,5 +65,5 @@ void benchmark_print_time(uint32_t time, unsigned long runs, const char *name);
 }
 #endif
 
-#endif /* BENCHMARK_H */
 /** @} */
+#endif /* BENCHMARK_H */

--- a/sys/include/bhp.h
+++ b/sys/include/bhp.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef BHP_H
+#define BHP_H
+
 /**
  * @defgroup     sys_bhp Bottom Half Processor
  * @ingroup      sys
@@ -25,9 +28,6 @@
  *
  * @author       José I. Alamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef BHP_H
-#define BHP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -86,5 +86,5 @@ static inline void bhp_set_cb(bhp_t *bhp, bhp_cb_t cb, void *ctx)
 }
 #endif
 
-#endif /* BHP_H */
 /** @} */
+#endif /* BHP_H */

--- a/sys/include/bhp/event.h
+++ b/sys/include/bhp/event.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef BHP_EVENT_H
+#define BHP_EVENT_H
+
 /**
  * @defgroup     sys_bhp_event Event based implementation of Bottom Half Processor
  * @ingroup      sys_bhp
@@ -15,9 +18,6 @@
  *
  * @author       José I. Alamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef BHP_EVENT_H
-#define BHP_EVENT_H
 
 #include "bhp.h"
 #include <event.h>
@@ -58,5 +58,5 @@ void bhp_event_isr_cb(void *bhp_event_ctx);
 }
 #endif
 
-#endif /* BHP_EVENT_H */
 /** @} */
+#endif /* BHP_EVENT_H */

--- a/sys/include/bhp/msg.h
+++ b/sys/include/bhp/msg.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef BHP_MSG_H
+#define BHP_MSG_H
+
 /**
  * @defgroup     sys_bhp_msg Message based implementation of Bottom Half Processor
  * @ingroup      sys_bhp
@@ -20,9 +23,6 @@
  *
  * @author       José I. Alamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef BHP_MSG_H
-#define BHP_MSG_H
 
 #include "msg.h"
 #include "thread.h"
@@ -102,5 +102,5 @@ static inline void bhp_msg_handler(msg_t *msg)
 }
 #endif
 
-#endif /* BHP_MSG_H */
 /** @} */
+#endif /* BHP_MSG_H */

--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BIT_H
+#define BIT_H
+
 /**
  * @ingroup     sys
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef BIT_H
-#define BIT_H
 
 #include <stdint.h>
 #include "cpu.h"
@@ -305,5 +305,5 @@ static inline bool bit_check8(volatile uint8_t *ptr, uint8_t bit)
 }
 #endif
 
-#endif /* BIT_H */
 /** @} */
+#endif /* BIT_H */

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BITFIELD_H
+#define BITFIELD_H
+
 /**
  * @defgroup    sys_bitfield Bitfields
  * @ingroup     sys
@@ -25,9 +28,6 @@
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
-
-#ifndef BITFIELD_H
-#define BITFIELD_H
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -108,6 +108,9 @@
  *
  */
 
+#ifndef BLOOM_H
+#define BLOOM_H
+
 /**
  * @defgroup    sys_bloom Bloom filter
  * @ingroup     sys
@@ -119,9 +122,6 @@
  *
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
-
-#ifndef BLOOM_H
-#define BLOOM_H
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/sys/include/busy_wait.h
+++ b/sys/include/busy_wait.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BUSY_WAIT_H
+#define BUSY_WAIT_H
+
 /**
  * @defgroup    busy_wait   Busy Waiting low-level helpers
  * @ingroup     sys
@@ -17,9 +20,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  * @{
  */
-
-#ifndef BUSY_WAIT_H
-#define BUSY_WAIT_H
 
 #include <stdint.h>
 #include "periph_conf.h"
@@ -85,5 +85,5 @@ static inline void busy_wait_us(unsigned usec)
 }
 #endif
 
-#endif /* BUSY_WAIT_H */
 /** @} */
+#endif /* BUSY_WAIT_H */

--- a/sys/include/byteorder.h
+++ b/sys/include/byteorder.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef BYTEORDER_H
+#define BYTEORDER_H
+
 /**
  * @ingroup     sys
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
-
-#ifndef BYTEORDER_H
-#define BYTEORDER_H
 
 #include <string.h>
 #include <stdint.h>
@@ -618,5 +618,5 @@ static inline void byteorder_htolebufll(uint8_t *buf, uint64_t val)
 }
 #endif
 
-#endif /* BYTEORDER_H */
 /** @} */
+#endif /* BYTEORDER_H */

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_CAN_H
+#define CAN_CAN_H
+
 /**
  * @defgroup    sys_can_dll Data Link Layer
  * @ingroup     sys_can
@@ -22,9 +25,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
-
-#ifndef CAN_CAN_H
-#define CAN_CAN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -183,6 +183,6 @@ typedef struct can_frame can_frame_t;
 }
 #endif
 
-#endif /* CAN_CAN_H */
-
 /** @} */
+
+#endif /* CAN_CAN_H */

--- a/sys/include/can/common.h
+++ b/sys/include/can/common.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_COMMON_H
+#define CAN_COMMON_H
+
 /**
  * @defgroup   sys_can_common  Common definitions
  * @ingroup    sys_can
@@ -22,9 +25,6 @@
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef CAN_COMMON_H
-#define CAN_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -171,5 +171,5 @@ typedef struct can_reg_entry {
 }
 #endif
 
-#endif /* CAN_COMMON_H */
 /** @} */
+#endif /* CAN_COMMON_H */

--- a/sys/include/can/conn/isotp.h
+++ b/sys/include/can/conn/isotp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CAN_CONN_ISOTP_H
+#define CAN_CONN_ISOTP_H
+
 /**
  * @ingroup    sys_can_conn
  * @{
@@ -16,9 +19,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  *
  */
-
-#ifndef CAN_CONN_ISOTP_H
-#define CAN_CONN_ISOTP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -198,5 +198,5 @@ int conn_can_isotp_select(conn_can_isotp_slave_t **conn, conn_can_isotp_t *maste
 }
 #endif
 
-#endif /* CAN_CONN_ISOTP_H */
 /** @} */
+#endif /* CAN_CONN_ISOTP_H */

--- a/sys/include/can/conn/raw.h
+++ b/sys/include/can/conn/raw.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CAN_CONN_RAW_H
+#define CAN_CONN_RAW_H
+
 /**
  * @defgroup    sys_can_conn Connection
  * @ingroup     sys_can
@@ -21,9 +24,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  *
  */
-
-#ifndef CAN_CONN_RAW_H
-#define CAN_CONN_RAW_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,5 +138,5 @@ int conn_can_raw_set_filter(conn_can_raw_t *conn, struct can_filter *filter, siz
 }
 #endif
 
-#endif /* CAN_CONN_RAW_H */
 /** @} */
+#endif /* CAN_CONN_RAW_H */

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_DEVICE_H
+#define CAN_DEVICE_H
+
 /**
  * @ingroup    sys_can_dll
  * @{
@@ -16,9 +19,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
-
-#ifndef CAN_DEVICE_H
-#define CAN_DEVICE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +122,6 @@ int can_device_calc_bittiming(uint32_t clock, const struct can_bittiming_const *
 }
 #endif
 
-#endif /* CAN_DEVICE_H */
-
 /** @} */
+
+#endif /* CAN_DEVICE_H */

--- a/sys/include/can/dll.h
+++ b/sys/include/can/dll.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_DLL_H
+#define CAN_DLL_H
+
 /**
  * @ingroup    sys_can_dll
  * @{
@@ -16,9 +19,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
-
-#ifndef CAN_DLL_H
-#define CAN_DLL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,6 +104,6 @@ int can_dll_dispatch_bus_off(kernel_pid_t pid);
 }
 #endif
 
-#endif /* CAN_DLL_H */
-
 /** @} */
+
+#endif /* CAN_DLL_H */

--- a/sys/include/can/isotp.h
+++ b/sys/include/can/isotp.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_ISOTP_H
+#define CAN_ISOTP_H
+
 /**
  * @defgroup    sys_can_isotp ISO transport protocol over CAN
  * @ingroup     sys_can
@@ -17,9 +20,6 @@
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef CAN_ISOTP_H
-#define CAN_ISOTP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -214,5 +214,5 @@ void isotp_free_rx(can_rx_data_t *rx);
 }
 #endif
 
-#endif /* CAN_ISOTP_H */
 /** @} */
+#endif /* CAN_ISOTP_H */

--- a/sys/include/can/pkt.h
+++ b/sys/include/can/pkt.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_PKT_H
+#define CAN_PKT_H
+
 /**
  * @ingroup    sys_can_dll
  * @{
@@ -16,9 +19,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Toon Stegen <toon.stegen@altran.com>
  */
-
-#ifndef CAN_PKT_H
-#define CAN_PKT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -143,5 +143,5 @@ void can_pkt_buf_free(void *data, size_t size);
 }
 #endif
 
-#endif /* CAN_PKT_H */
 /** @} */
+#endif /* CAN_PKT_H */

--- a/sys/include/can/raw.h
+++ b/sys/include/can/raw.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_RAW_H
+#define CAN_RAW_H
+
 /**
  * @ingroup    sys_can_dll
  * @{
@@ -20,9 +23,6 @@
  * @author      Toon Stegen <toon.stegen@altran.com>
  * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  */
-
-#ifndef CAN_RAW_H
-#define CAN_RAW_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -275,5 +275,5 @@ int raw_can_set_trx(int ifnum, can_trx_t *trx);
 }
 #endif
 
-#endif /* CAN_RAW_H */
 /** @} */
+#endif /* CAN_RAW_H */

--- a/sys/include/can/router.h
+++ b/sys/include/can/router.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef CAN_ROUTER_H
+#define CAN_ROUTER_H
+
 /**
  * @ingroup    sys_can_dll
  * @{
@@ -16,9 +19,6 @@
  * @author      Toon Stegen <toon.stegen@altran.com>
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef CAN_ROUTER_H
-#define CAN_ROUTER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -113,5 +113,5 @@ int can_router_dispatch_tx_error(can_pkt_t *pkt);
 }
 #endif
 
-#endif /* CAN_ROUTER_H */
 /** @} */
+#endif /* CAN_ROUTER_H */

--- a/sys/include/cb_mux.h
+++ b/sys/include/cb_mux.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CB_MUX_H
+#define CB_MUX_H
+
 /**
  * @defgroup    sys_cb_mux Callback multiplexer
  * @ingroup     sys
@@ -25,9 +28,6 @@
  *
  * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  */
-
-#ifndef CB_MUX_H
-#define CB_MUX_H
 
 #include <stdint.h>
 

--- a/sys/include/checksum/crc16_ccitt.h
+++ b/sys/include/checksum/crc16_ccitt.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CHECKSUM_CRC16_CCITT_H
+#define CHECKSUM_CRC16_CCITT_H
+
 /**
  * @defgroup    sys_checksum_crc16_ccitt CRC16-CCITT
  * @ingroup     sys_checksum
@@ -28,9 +31,6 @@
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  * @author      Bennet Blischke <bennet.blischke@haw-hamburg.de>
  */
-
-#ifndef CHECKSUM_CRC16_CCITT_H
-#define CHECKSUM_CRC16_CCITT_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -186,6 +186,6 @@ uint16_t crc16_ccitt_aug_calc(const unsigned char *buf, size_t len);
 }
 #endif
 
-#endif /* CHECKSUM_CRC16_CCITT_H */
-
 /** @} */
+
+#endif /* CHECKSUM_CRC16_CCITT_H */

--- a/sys/include/checksum/crc32.h
+++ b/sys/include/checksum/crc32.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CHECKSUM_CRC32_H
+#define CHECKSUM_CRC32_H
+
 /**
  * @defgroup    sys_checksum_crc32 CRC32
  * @ingroup     sys_checksum
@@ -16,9 +19,6 @@
  * @file
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef CHECKSUM_CRC32_H
-#define CHECKSUM_CRC32_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -46,6 +46,6 @@ uint32_t crc32(const void *buf, size_t size);
 }
 #endif
 
-#endif /* CHECKSUM_CRC32_H */
-
 /** @} */
+
+#endif /* CHECKSUM_CRC32_H */

--- a/sys/include/checksum/crc8.h
+++ b/sys/include/checksum/crc8.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CHECKSUM_CRC8_H
+#define CHECKSUM_CRC8_H
 /**
  * @defgroup    sys_checksum_crc8     CRC-8
  * @ingroup     sys_checksum
@@ -18,8 +20,6 @@
  *
  * @author  Gunar Schorcht <gunar@schorcht.net>
  */
-#ifndef CHECKSUM_CRC8_H
-#define CHECKSUM_CRC8_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -47,5 +47,5 @@ uint8_t crc8(const uint8_t *data, size_t len, uint8_t poly, uint8_t seed);
 }
 #endif
 
-#endif /* CHECKSUM_CRC8_H */
 /** @} */
+#endif /* CHECKSUM_CRC8_H */

--- a/sys/include/checksum/fletcher16.h
+++ b/sys/include/checksum/fletcher16.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CHECKSUM_FLETCHER16_H
+#define CHECKSUM_FLETCHER16_H
+
 /**
  * @defgroup    sys_checksum_fletcher16 Fletcher16
  * @ingroup     sys_checksum
@@ -16,9 +19,6 @@
  * @file
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef CHECKSUM_FLETCHER16_H
-#define CHECKSUM_FLETCHER16_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -81,6 +81,6 @@ uint16_t fletcher16_finish(fletcher16_ctx_t *ctx);
 }
 #endif
 
-#endif /* CHECKSUM_FLETCHER16_H */
-
 /** @} */
+
+#endif /* CHECKSUM_FLETCHER16_H */

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CHECKSUM_FLETCHER32_H
+#define CHECKSUM_FLETCHER32_H
+
 /**
  * @defgroup    sys_checksum_fletcher32 Fletcher32
  * @ingroup     sys_checksum
@@ -17,9 +20,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef CHECKSUM_FLETCHER32_H
-#define CHECKSUM_FLETCHER32_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -86,6 +86,6 @@ uint32_t fletcher32_finish(fletcher32_ctx_t *ctx);
 }
 #endif
 
-#endif /* CHECKSUM_FLETCHER32_H */
-
 /** @} */
+
+#endif /* CHECKSUM_FLETCHER32_H */

--- a/sys/include/checksum/ucrc16.h
+++ b/sys/include/checksum/ucrc16.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CHECKSUM_UCRC16_H
+#define CHECKSUM_UCRC16_H
 /**
  * @defgroup    sys_checksum_ucrc16     CRC16 (lightweight)
  * @ingroup     sys_checksum
@@ -26,8 +28,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CHECKSUM_UCRC16_H
-#define CHECKSUM_UCRC16_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -78,5 +78,5 @@ uint16_t ucrc16_calc_le(const uint8_t *buf, size_t len, uint16_t poly,
 }
 #endif
 
-#endif /* CHECKSUM_UCRC16_H */
 /** @} */
+#endif /* CHECKSUM_UCRC16_H */

--- a/sys/include/chunked_ringbuffer.h
+++ b/sys/include/chunked_ringbuffer.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CHUNKED_RINGBUFFER_H
+#define CHUNKED_RINGBUFFER_H
+
 /**
  * @defgroup    sys_chunk_buffer    chunked Ringbuffer
  * @ingroup     sys
@@ -19,9 +22,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef CHUNKED_RINGBUFFER_H
-#define CHUNKED_RINGBUFFER_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -247,5 +247,5 @@ bool crb_chunk_foreach(chunk_ringbuf_t *rb, crb_foreach_callback_t func, void *c
 }
 #endif
 
-#endif /* CHUNKED_RINGBUFFER_H */
 /** @} */
+#endif /* CHUNKED_RINGBUFFER_H */

--- a/sys/include/clif.h
+++ b/sys/include/clif.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CLIF_H
+#define CLIF_H
+
 /**
  * @defgroup    sys_clif CoRE Link Format
  * @ingroup     sys_serialization
@@ -91,9 +94,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef CLIF_H
-#define CLIF_H
 
 #include <sys/types.h>
 
@@ -331,5 +331,5 @@ int clif_init_attr(clif_attr_t *attr, clif_attr_type_t type);
 }
 #endif
 
-#endif /* CLIF_H */
 /** @} */
+#endif /* CLIF_H */

--- a/sys/include/clk.h
+++ b/sys/include/clk.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CLK_H
+#define CLK_H
+
 /**
  * @defgroup    sys_clk System core clock
  * @ingroup     sys
@@ -14,9 +17,6 @@
  * @file
  * @brief       System core clock utility functions
  */
-
-#ifndef CLK_H
-#define CLK_H
 
 #include <assert.h>
 #include <stdint.h>
@@ -45,5 +45,5 @@ static inline uint32_t coreclk(void) {
 }
 #endif
 
-#endif /* CLK_H */
 /** @} */
+#endif /* CLK_H */

--- a/sys/include/coding/xor.h
+++ b/sys/include/coding/xor.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CODING_XOR_H
+#define CODING_XOR_H
+
 /**
  * @defgroup    sys_coding_xor  XOR code
  * @ingroup     sys_coding
@@ -23,9 +26,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef CODING_XOR_H
-#define CODING_XOR_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -89,5 +89,5 @@ bool coding_xor_recover(void *data, size_t len, uint8_t *parity,
 }
 #endif
 
-#endif /* CODING_XOR_H */
 /** @} */
+#endif /* CODING_XOR_H */

--- a/sys/include/color.h
+++ b/sys/include/color.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef COLOR_H
+#define COLOR_H
+
 /**
  * @defgroup    sys_color Color
  * @ingroup     sys
@@ -19,9 +22,6 @@
  * @author      Cenk Gündoğan <mail@cgundogan.de>
  * @author      Simon Brummer <brummer.simon@googlemail.com>
  */
-
-#ifndef COLOR_H
-#define COLOR_H
 
 #include <stdint.h>
 
@@ -183,5 +183,5 @@ void color_rgb_complementary(const color_rgb_t *rgb, color_rgb_t *comp_rgb);
 }
 #endif
 
-#endif /* COLOR_H */
 /** @} */
+#endif /* COLOR_H */

--- a/sys/include/congure.h
+++ b/sys/include/congure.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_H
+#define CONGURE_H
 /**
  * @defgroup    sys_congure CongURE - A Congestion control framework
  * @ingroup     sys
@@ -17,8 +19,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONGURE_H
-#define CONGURE_H
 
 #include <stdint.h>
 
@@ -221,5 +221,5 @@ struct congure_snd_driver {
 }
 #endif
 
-#endif /* CONGURE_H */
 /** @} */
+#endif /* CONGURE_H */

--- a/sys/include/congure/abe.h
+++ b/sys/include/congure/abe.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_ABE_H
+#define CONGURE_ABE_H
 /**
  * @defgroup    sys_congure_abe CongURE implementation of TCP ABE
  * @ingroup     sys_congure
@@ -20,8 +22,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONGURE_ABE_H
-#define CONGURE_ABE_H
 
 #include <stdint.h>
 
@@ -91,5 +91,5 @@ static inline void congure_abe_set_mss(congure_abe_snd_t *c, unsigned mss)
 }
 #endif
 
-#endif /* CONGURE_ABE_H */
 /** @} */
+#endif /* CONGURE_ABE_H */

--- a/sys/include/congure/config.h
+++ b/sys/include/congure/config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_CONFIG_H
+#define CONGURE_CONFIG_H
 /**
  * @defgroup    sys_congure_config  CongURE compile time configuration
  * @ingroup     sys_congure
@@ -17,8 +19,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONGURE_CONFIG_H
-#define CONGURE_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,5 +48,5 @@ extern "C" {
 }
 #endif
 
-#endif /* CONGURE_CONFIG_H */
 /** @} */
+#endif /* CONGURE_CONFIG_H */

--- a/sys/include/congure/mock.h
+++ b/sys/include/congure/mock.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_MOCK_H
+#define CONGURE_MOCK_H
 /**
  * @defgroup    sys_congure_mock    CongURE mock implementation
  * @ingroup     sys_congure
@@ -16,8 +18,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONGURE_MOCK_H
-#define CONGURE_MOCK_H
 
 #include <stdint.h>
 
@@ -168,5 +168,5 @@ void congure_mock_snd_setup(congure_mock_snd_t *c,
 }
 #endif
 
-#endif /* CONGURE_MOCK_H */
 /** @} */
+#endif /* CONGURE_MOCK_H */

--- a/sys/include/congure/quic.h
+++ b/sys/include/congure/quic.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_QUIC_H
+#define CONGURE_QUIC_H
 /**
  * @defgroup    sys_congure_quic    CongURE implementation of QUIC's CC
  * @ingroup     sys_congure
@@ -17,8 +19,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONGURE_QUIC_H
-#define CONGURE_QUIC_H
 
 #include "ztimer.h"
 
@@ -229,5 +229,5 @@ void congure_quic_snd_setup(congure_quic_snd_t *c,
 }
 #endif
 
-#endif /* CONGURE_QUIC_H */
 /** @} */
+#endif /* CONGURE_QUIC_H */

--- a/sys/include/congure/reno.h
+++ b/sys/include/congure/reno.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_RENO_H
+#define CONGURE_RENO_H
 /**
  * @defgroup    sys_congure_reno    CongURE implementation of TCP Reno
  * @ingroup     sys_congure
@@ -20,8 +22,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONGURE_RENO_H
-#define CONGURE_RENO_H
 
 #include <stdint.h>
 
@@ -308,5 +308,5 @@ void congure_reno_snd_report_ecn_ce(congure_snd_t *c, ztimer_now_t time);
 }
 #endif
 
-#endif /* CONGURE_RENO_H */
 /** @} */
+#endif /* CONGURE_RENO_H */

--- a/sys/include/congure/test.h
+++ b/sys/include/congure/test.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CONGURE_TEST_H
+#define CONGURE_TEST_H
+
 /**
  * @defgroup    sys_congure_test    CongURE test framework shell commands
  * @ingroup     sys_congure
@@ -32,9 +35,6 @@
  *
  * @author  Martine S Lenders <m.lenders@fu-berlin.de>
  */
-
-#ifndef CONGURE_TEST_H
-#define CONGURE_TEST_H
 
 #include "congure_impl.h"
 
@@ -328,5 +328,5 @@ int congure_test_call_report(int argc, char **argv);
 }
 #endif
 
-#endif /* CONGURE_TEST_H */
 /** @} */
+#endif /* CONGURE_TEST_H */

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_AES_H
+#define CRYPTO_AES_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -26,9 +29,6 @@
  * @author      Fabrice Bellard
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  */
-
-#ifndef CRYPTO_AES_H
-#define CRYPTO_AES_H
 
 #include <stdint.h>
 #include "crypto/ciphers.h"

--- a/sys/include/crypto/chacha20poly1305.h
+++ b/sys/include/crypto/chacha20poly1305.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_CHACHA20POLY1305_H
+#define CRYPTO_CHACHA20POLY1305_H
+
 /**
  * @defgroup    sys_crypto_chacha20poly1305 chacha20poly1305 AEAD cipher
  * @ingroup     sys_crypto
@@ -24,9 +27,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef CRYPTO_CHACHA20POLY1305_H
-#define CRYPTO_CHACHA20POLY1305_H
 
 #include "crypto/poly1305.h"
 
@@ -114,5 +114,5 @@ void chacha20_encrypt_decrypt(const uint8_t *input, uint8_t *output,
 #ifdef __cplusplus
 }
 #endif
-#endif /* CRYPTO_CHACHA20POLY1305_H */
 /** @} */
+#endif /* CRYPTO_CHACHA20POLY1305_H */

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_CIPHERS_H
+#define CRYPTO_CIPHERS_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  * @author      Mark Essien <markessien@gmail.com>
  */
-
-#ifndef CRYPTO_CIPHERS_H
-#define CRYPTO_CIPHERS_H
 
 #include <stdint.h>
 #include "modules.h"

--- a/sys/include/crypto/helper.h
+++ b/sys/include/crypto/helper.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_HELPER_H
+#define CRYPTO_HELPER_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics
  * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
  */
-
-#ifndef CRYPTO_HELPER_H
-#define CRYPTO_HELPER_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -67,5 +67,5 @@ void crypto_secure_wipe(void *buf, size_t len);
 }
 #endif
 
-#endif /* CRYPTO_HELPER_H */
 /** @} */
+#endif /* CRYPTO_HELPER_H */

--- a/sys/include/crypto/modes/cbc.h
+++ b/sys/include/crypto/modes/cbc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_MODES_CBC_H
+#define CRYPTO_MODES_CBC_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics
  * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
  */
-
-#ifndef CRYPTO_MODES_CBC_H
-#define CRYPTO_MODES_CBC_H
 
 #include <stddef.h>
 #include "crypto/ciphers.h"
@@ -68,5 +68,5 @@ int cipher_decrypt_cbc(const cipher_t *cipher, uint8_t iv[16], const uint8_t *in
 }
 #endif
 
-#endif /* CRYPTO_MODES_CBC_H */
 /** @} */
+#endif /* CRYPTO_MODES_CBC_H */

--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_MODES_CCM_H
+#define CRYPTO_MODES_CCM_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics
  * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
  */
-
-#ifndef CRYPTO_MODES_CCM_H
-#define CRYPTO_MODES_CCM_H
 
 #include "crypto/ciphers.h"
 
@@ -109,5 +109,5 @@ int cipher_decrypt_ccm(const cipher_t *cipher,
 }
 #endif
 
-#endif /* CRYPTO_MODES_CCM_H */
 /** @} */
+#endif /* CRYPTO_MODES_CCM_H */

--- a/sys/include/crypto/modes/ctr.h
+++ b/sys/include/crypto/modes/ctr.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_MODES_CTR_H
+#define CRYPTO_MODES_CTR_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics
  * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
  */
-
-#ifndef CRYPTO_MODES_CTR_H
-#define CRYPTO_MODES_CTR_H
 
 #include "crypto/ciphers.h"
 
@@ -75,5 +75,5 @@ int cipher_decrypt_ctr(const cipher_t *cipher, uint8_t nonce_counter[16],
 }
 #endif
 
-#endif /* CRYPTO_MODES_CTR_H */
 /** @} */
+#endif /* CRYPTO_MODES_CTR_H */

--- a/sys/include/crypto/modes/ecb.h
+++ b/sys/include/crypto/modes/ecb.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_MODES_ECB_H
+#define CRYPTO_MODES_ECB_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Freie Universitaet Berlin, Computer Systems & Telematics
  * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
  */
-
-#ifndef CRYPTO_MODES_ECB_H
-#define CRYPTO_MODES_ECB_H
 
 #include "crypto/ciphers.h"
 
@@ -65,5 +65,5 @@ int cipher_decrypt_ecb(const cipher_t *cipher, const uint8_t *input,
 }
 #endif
 
-#endif /* CRYPTO_MODES_ECB_H */
 /** @} */
+#endif /* CRYPTO_MODES_ECB_H */

--- a/sys/include/crypto/modes/ocb.h
+++ b/sys/include/crypto/modes/ocb.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_MODES_OCB_H
+#define CRYPTO_MODES_OCB_H
+
 /**
  * @ingroup     sys_crypto
  * @{
@@ -19,9 +22,6 @@
  *
  * @author      Mathias Tausig <mathias@tausig.at>
  */
-
-#ifndef CRYPTO_MODES_OCB_H
-#define CRYPTO_MODES_OCB_H
 
 #include "crypto/ciphers.h"
 #include <stdint.h>
@@ -112,5 +112,5 @@ int32_t cipher_decrypt_ocb(const cipher_t *cipher,
 }
 #endif
 
-#endif /* CRYPTO_MODES_OCB_H */
 /** @} */
+#endif /* CRYPTO_MODES_OCB_H */

--- a/sys/include/crypto/poly1305.h
+++ b/sys/include/crypto/poly1305.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_POLY1305_H
+#define CRYPTO_POLY1305_H
 /**
  * @ingroup     sys_crypto
  * @defgroup    sys_crypto_poly1305 poly1305
@@ -25,8 +27,6 @@
  *
  * @see         https://tools.ietf.org/html/rfc8439#section-2.5
  */
-#ifndef CRYPTO_POLY1305_H
-#define CRYPTO_POLY1305_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,5 +90,5 @@ void poly1305_auth(uint8_t *mac, const uint8_t *data, size_t len,
 #ifdef __cplusplus
 }
 #endif
-#endif /* CRYPTO_POLY1305_H */
 /** @} */
+#endif /* CRYPTO_POLY1305_H */

--- a/sys/include/crypto/psa/riot_ciphers.h
+++ b/sys/include/crypto/psa/riot_ciphers.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef CRYPTO_PSA_RIOT_CIPHERS_H
+#define CRYPTO_PSA_RIOT_CIPHERS_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -15,9 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef CRYPTO_PSA_RIOT_CIPHERS_H
-#define CRYPTO_PSA_RIOT_CIPHERS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,5 +40,5 @@ typedef cipher_t psa_cipher_aes_256_ctx_t;
 }
 #endif
 
-#endif /* CRYPTO_PSA_RIOT_CIPHERS_H */
 /** @} */
+#endif /* CRYPTO_PSA_RIOT_CIPHERS_H */

--- a/sys/include/debug_irq_disable.h
+++ b/sys/include/debug_irq_disable.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef DEBUG_IRQ_DISABLE_H
+#define DEBUG_IRQ_DISABLE_H
+
 /**
  * @defgroup    debug_irq_disable IRQ Disable Debug helper
  * @ingroup     sys
@@ -16,9 +19,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef DEBUG_IRQ_DISABLE_H
-#define DEBUG_IRQ_DISABLE_H
 
 #include <stdint.h>
 

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef DIV_H
+#define DIV_H
+
 /**
  * @defgroup  sys_div   Integer division functions
  * @ingroup   sys_math
@@ -20,9 +23,6 @@
  * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @{
  */
-
-#ifndef DIV_H
-#define DIV_H
 
 #include <assert.h>
 #include <stdint.h>

--- a/sys/include/ecc/golay2412.h
+++ b/sys/include/ecc/golay2412.h
@@ -21,6 +21,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef ECC_GOLAY2412_H
+#define ECC_GOLAY2412_H
+
 /**
  * @ingroup     sys_ecc
  * @{
@@ -35,9 +38,6 @@
  * @author      Joseph Gaeddert
  * @author      Peter Kietzmann <peter.kietzmann@haw.hamburg.de>
  */
-
-#ifndef ECC_GOLAY2412_H
-#define ECC_GOLAY2412_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,5 +71,5 @@ void golay2412_decode(uint32_t _dec_msg_len,
 }
 #endif
 
-#endif /* ECC_GOLAY2412_H */
 /** @} */
+#endif /* ECC_GOLAY2412_H */

--- a/sys/include/ecc/hamming256.h
+++ b/sys/include/ecc/hamming256.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ECC_HAMMING256_H
+#define ECC_HAMMING256_H
+
 /**
  * @ingroup     sys_ecc
  * @brief
@@ -14,9 +17,6 @@
  * @brief       Hamming Code implementation for 256byte data segments
  * @author      Lucas Jenß <lucas@x3ro.de>
  */
-
-#ifndef ECC_HAMMING256_H
-#define ECC_HAMMING256_H
 
 #include <stdint.h>
 
@@ -64,5 +64,5 @@ uint8_t hamming_verify256x( uint8_t *data, uint32_t size, const uint8_t *code );
 }
 #endif
 
-#endif /* ECC_HAMMING256_H */
 /** @} */
+#endif /* ECC_HAMMING256_H */

--- a/sys/include/ecc/repetition.h
+++ b/sys/include/ecc/repetition.h
@@ -21,6 +21,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef ECC_REPETITION_H
+#define ECC_REPETITION_H
+
 /**
  * @ingroup     sys_ecc
  * @{
@@ -31,9 +34,6 @@
  * @author      Joseph Gaeddert
  * @author      Peter Kietzmann <peter.kietzmann@haw.hamburg.de>
  */
-
-#ifndef ECC_REPETITION_H
-#define ECC_REPETITION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,5 +73,5 @@ void repetition_decode(unsigned int _dec_msg_len,
 }
 #endif
 
-#endif /* ECC_REPETITION_H */
 /** @} */
+#endif /* ECC_REPETITION_H */

--- a/sys/include/eepreg.h
+++ b/sys/include/eepreg.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EEPREG_H
+#define EEPREG_H
+
 /**
  * @defgroup    sys_eepreg EEPROM registration
  * @ingroup     sys
@@ -53,9 +56,6 @@
  *
  * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  */
-
-#ifndef EEPREG_H
-#define EEPREG_H
 
 #include <stdint.h>
 

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef EMBUNIT_COLOROUTPUTTER_H
+#define EMBUNIT_COLOROUTPUTTER_H
 /**
  * @{
  *
@@ -13,8 +15,6 @@
  *
  * @author Janos Kutscherauer <noshky@gmail.com>
  */
-#ifndef EMBUNIT_COLOROUTPUTTER_H
-#define EMBUNIT_COLOROUTPUTTER_H
 
 #include "Outputter.h"
 
@@ -41,5 +41,5 @@ void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);
 }
 #endif
 
-#endif /* EMBUNIT_COLOROUTPUTTER_H */
 /** @} */
+#endif /* EMBUNIT_COLOROUTPUTTER_H */

--- a/sys/include/embUnit/ColorTextOutputter.h
+++ b/sys/include/embUnit/ColorTextOutputter.h
@@ -6,13 +6,13 @@
  * directory for more details.
  */
 
+#ifndef EMBUNIT_COLORTEXTOUTPUTTER_H
+#define EMBUNIT_COLORTEXTOUTPUTTER_H
 /**
  * @{
  *
  * @file    ColorTextOutputter.h
  */
-#ifndef EMBUNIT_COLORTEXTOUTPUTTER_H
-#define EMBUNIT_COLORTEXTOUTPUTTER_H
 
 #include "Outputter.h"
 
@@ -26,5 +26,5 @@ OutputterRef ColorTextOutputter_outputter(void);
 }
 #endif
 
-#endif /* EMBUNIT_COLORTEXTOUTPUTTER_H */
 /** @} */
+#endif /* EMBUNIT_COLORTEXTOUTPUTTER_H */

--- a/sys/include/endian.h
+++ b/sys/include/endian.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ENDIAN_H
+#define ENDIAN_H
+
 /**
  * @defgroup    sys_endian  endian conversions as provided by most libcs
  * @ingroup     sys
@@ -19,9 +22,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
  */
-
-#ifndef ENDIAN_H
-#define ENDIAN_H
 
 #include <stdint.h>
 
@@ -177,5 +177,5 @@ uint64_t le64toh(uint64_t little_endian_64bits);/**< little endian to host, 64 b
 }
 #endif
 
-#endif /* ENDIAN_H */
 /** @} */
+#endif /* ENDIAN_H */

--- a/sys/include/entropy_source.h
+++ b/sys/include/entropy_source.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ENTROPY_SOURCE_H
+#define ENTROPY_SOURCE_H
+
 /**
  * @defgroup   sys_entropy_source_common Entropy Source Common
  * @ingroup    sys_entropy_source
@@ -17,9 +20,6 @@
  *
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
-
-#ifndef ENTROPY_SOURCE_H
-#define ENTROPY_SOURCE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -302,5 +302,5 @@ static inline int entropy_source_test(entropy_source_tests_rep_t *state_rep,
 }
 #endif
 
-#endif /* ENTROPY_SOURCE_H */
 /** @} */
+#endif /* ENTROPY_SOURCE_H */

--- a/sys/include/entropy_source/adc_noise.h
+++ b/sys/include/entropy_source/adc_noise.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ENTROPY_SOURCE_ADC_NOISE_H
+#define ENTROPY_SOURCE_ADC_NOISE_H
+
 /**
  * @defgroup   sys_entropy_source_adc ADC Noise Entropy Source
  * @ingroup    sys_entropy_source
@@ -30,9 +33,6 @@
  *
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
-
-#ifndef ENTROPY_SOURCE_ADC_NOISE_H
-#define ENTROPY_SOURCE_ADC_NOISE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -154,5 +154,5 @@ static inline uint32_t entropy_source_adc_entropy_per_sample(void)
 }
 #endif
 
-#endif /* ENTROPY_SOURCE_ADC_NOISE_H */
 /** @} */
+#endif /* ENTROPY_SOURCE_ADC_NOISE_H */

--- a/sys/include/entropy_source/zero_entropy.h
+++ b/sys/include/entropy_source/zero_entropy.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ENTROPY_SOURCE_ZERO_ENTROPY_H
+#define ENTROPY_SOURCE_ZERO_ENTROPY_H
+
 /**
  * @defgroup   sys_entropy_source_zero Zero Entropy Source
  * @ingroup    sys_entropy_source
@@ -18,9 +21,6 @@
  *
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
-
-#ifndef ENTROPY_SOURCE_ZERO_ENTROPY_H
-#define ENTROPY_SOURCE_ZERO_ENTROPY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,5 +88,5 @@ int entropy_source_zero_get(uint8_t *buf, size_t len);
 }
 #endif
 
-#endif /* ENTROPY_SOURCE_ZERO_ENTROPY_H */
 /** @} */
+#endif /* ENTROPY_SOURCE_ZERO_ENTROPY_H */

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_H
+#define EVENT_H
+
 /**
  * @defgroup    sys_event Event Queue
  * @ingroup     sys
@@ -92,9 +95,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef EVENT_H
-#define EVENT_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -489,5 +489,5 @@ void event_sync(event_queue_t *queue);
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_H */
 /** @} */
+#endif /* EVENT_H */

--- a/sys/include/event/callback.h
+++ b/sys/include/event/callback.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_CALLBACK_H
+#define EVENT_CALLBACK_H
+
 /**
  * @ingroup     sys_event
  * @brief       Provides a callback-with-argument event type
@@ -32,9 +35,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef EVENT_CALLBACK_H
-#define EVENT_CALLBACK_H
 
 #include <assert.h>
 #include "event.h"
@@ -123,5 +123,5 @@ void _event_callback_handler(event_t *event);
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_CALLBACK_H */
 /** @} */
+#endif /* EVENT_CALLBACK_H */

--- a/sys/include/event/periodic.h
+++ b/sys/include/event/periodic.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_PERIODIC_H
+#define EVENT_PERIODIC_H
+
 /**
  * @ingroup     sys_event
  * @brief       Provides functionality to trigger periodic events
@@ -32,9 +35,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  *
  */
-
-#ifndef EVENT_PERIODIC_H
-#define EVENT_PERIODIC_H
 
 #include "event.h"
 #include "ztimer/periodic.h"
@@ -151,5 +151,5 @@ static inline void event_periodic_stop(event_periodic_t *event_periodic)
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_PERIODIC_H */
 /** @} */
+#endif /* EVENT_PERIODIC_H */

--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_PERIODIC_CALLBACK_H
+#define EVENT_PERIODIC_CALLBACK_H
+
 /**
  * @ingroup     sys_event
  * @brief       Provides functionality to trigger periodic event callbacks
@@ -21,9 +24,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  */
-
-#ifndef EVENT_PERIODIC_CALLBACK_H
-#define EVENT_PERIODIC_CALLBACK_H
 
 #include <assert.h>
 #include "event/callback.h"
@@ -180,5 +180,5 @@ static inline void event_periodic_callback_stop(event_periodic_callback_t *event
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_PERIODIC_CALLBACK_H */
 /** @} */
+#endif /* EVENT_PERIODIC_CALLBACK_H */

--- a/sys/include/event/source.h
+++ b/sys/include/event/source.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_SOURCE_H
+#define EVENT_SOURCE_H
+
 /**
  * @ingroup     sys_event
  * @brief       Provides functionality to trigger multiple events at once
@@ -18,9 +21,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  */
-
-#ifndef EVENT_SOURCE_H
-#define EVENT_SOURCE_H
 
 #include "event.h"
 #include "list.h"
@@ -114,5 +114,5 @@ static inline void event_source_trigger(event_source_t *source)
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_SOURCE_H */
 /** @} */
+#endif /* EVENT_SOURCE_H */

--- a/sys/include/event/thread.h
+++ b/sys/include/event/thread.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_THREAD_H
+#define EVENT_THREAD_H
+
 /**
  * @ingroup     sys_event
  * @brief       Provides utility functions for event handler threads
@@ -49,9 +52,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef EVENT_THREAD_H
-#define EVENT_THREAD_H
 
 #include <stddef.h>
 
@@ -124,5 +124,5 @@ extern event_queue_t event_thread_queues[EVENT_QUEUE_PRIO_NUMOF];
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_THREAD_H */
 /** @} */
+#endif /* EVENT_THREAD_H */

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef EVENT_TIMEOUT_H
+#define EVENT_TIMEOUT_H
+
 /**
  * @ingroup     sys_event
  * @brief       Provides functionality to trigger events after timeout
@@ -33,9 +36,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef EVENT_TIMEOUT_H
-#define EVENT_TIMEOUT_H
 
 #include "event.h"
 #include "ztimer.h"
@@ -127,5 +127,5 @@ static inline bool event_timeout_is_pending(const event_timeout_t *event_timeout
 #ifdef __cplusplus
 }
 #endif
-#endif /* EVENT_TIMEOUT_H */
 /** @} */
+#endif /* EVENT_TIMEOUT_H */

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef EVTIMER_H
+#define EVTIMER_H
+
 /**
  * @defgroup    sys_evtimer Millisecond interval event timers
  * @ingroup     sys
@@ -37,9 +40,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
-
-#ifndef EVTIMER_H
-#define EVTIMER_H
 
 #include <stdint.h>
 #include "modules.h"
@@ -121,5 +121,5 @@ static inline uint32_t evtimer_now_msec(void)
 }
 #endif
 
-#endif /* EVTIMER_H */
 /** @} */
+#endif /* EVTIMER_H */

--- a/sys/include/evtimer_mbox.h
+++ b/sys/include/evtimer_mbox.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef EVTIMER_MBOX_H
+#define EVTIMER_MBOX_H
 /**
  * @addtogroup  sys_evtimer
  * @{
@@ -15,8 +17,6 @@
  *
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
-#ifndef EVTIMER_MBOX_H
-#define EVTIMER_MBOX_H
 
 #include "assert.h"
 #include "msg.h"
@@ -87,5 +87,5 @@ static inline void evtimer_init_mbox(evtimer_t *evtimer)
 }
 #endif
 
-#endif /* EVTIMER_MBOX_H */
 /** @} */
+#endif /* EVTIMER_MBOX_H */

--- a/sys/include/evtimer_msg.h
+++ b/sys/include/evtimer_msg.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef EVTIMER_MSG_H
+#define EVTIMER_MSG_H
 /**
  * @addtogroup  sys_evtimer
  * @{
@@ -17,8 +19,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef EVTIMER_MSG_H
-#define EVTIMER_MSG_H
 
 #include "msg.h"
 #include "evtimer.h"
@@ -84,5 +84,5 @@ static inline void evtimer_init_msg(evtimer_t *evtimer)
 }
 #endif
 
-#endif /* EVTIMER_MSG_H */
 /** @} */
+#endif /* EVTIMER_MSG_H */

--- a/sys/include/fido2/ctap.h
+++ b/sys/include/fido2/ctap.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_H
+#define FIDO2_CTAP_H
+
 /**
  * @defgroup    fido2_ctap CTAP
  * @ingroup     fido2
@@ -21,9 +24,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_H
-#define FIDO2_CTAP_H
 
 #include <stdint.h>
 
@@ -230,5 +230,5 @@ ctap_status_code_t fido2_ctap_reset(ctap_resp_t *resp);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_H */
 /** @} */
+#endif /* FIDO2_CTAP_H */

--- a/sys/include/fido2/ctap/ctap.h
+++ b/sys/include/fido2/ctap/ctap.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_CTAP_H
+#define FIDO2_CTAP_CTAP_H
+
 /**
  * @defgroup    fido2_ctap_ctap FIDO2 CTAP
  * @ingroup     fido2_ctap
@@ -21,9 +24,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_CTAP_H
-#define FIDO2_CTAP_CTAP_H
 
 #include <stdint.h>
 
@@ -680,5 +680,5 @@ ctap_state_t *fido2_ctap_get_state(void);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_CTAP_H */
 /** @} */
+#endif /* FIDO2_CTAP_CTAP_H */

--- a/sys/include/fido2/ctap/ctap_cbor.h
+++ b/sys/include/fido2/ctap/ctap_cbor.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_CTAP_CBOR_H
+#define FIDO2_CTAP_CTAP_CBOR_H
+
 /**
  * @defgroup    fido2_ctap_cbor FIDO2 CTAP CBOR
  * @ingroup     fido2_ctap
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_CTAP_CBOR_H
-#define FIDO2_CTAP_CTAP_CBOR_H
 
 #include "fido2/ctap/ctap.h"
 
@@ -334,5 +334,5 @@ void fido2_ctap_cbor_init_encoder(uint8_t *buf, size_t len);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_CTAP_CBOR_H */
 /** @} */
+#endif /* FIDO2_CTAP_CTAP_CBOR_H */

--- a/sys/include/fido2/ctap/ctap_crypto.h
+++ b/sys/include/fido2/ctap/ctap_crypto.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_CTAP_CRYPTO_H
+#define FIDO2_CTAP_CTAP_CRYPTO_H
+
 /**
  * @defgroup    fido2_ctap_crypto FIDO2 CTAP crypto
  * @ingroup     fido2_ctap
@@ -19,9 +22,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_CTAP_CRYPTO_H
-#define FIDO2_CTAP_CTAP_CRYPTO_H
 
 #include <stdint.h>
 
@@ -298,5 +298,5 @@ ctap_status_code_t fido2_ctap_crypto_aes_ccm_dec(uint8_t *out, size_t out_len,
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_CTAP_CRYPTO_H */
 /** @} */
+#endif /* FIDO2_CTAP_CTAP_CRYPTO_H */

--- a/sys/include/fido2/ctap/ctap_mem.h
+++ b/sys/include/fido2/ctap/ctap_mem.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_CTAP_MEM_H
+#define FIDO2_CTAP_CTAP_MEM_H
+
 /**
  * @defgroup    fido2_ctap_mem FIDO2 CTAP flash
  * @ingroup     fido2_ctap
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_CTAP_MEM_H
-#define FIDO2_CTAP_CTAP_MEM_H
 
 #include <stdint.h>
 
@@ -170,5 +170,5 @@ ctap_status_code_t fido2_ctap_mem_write_rk_to_flash(ctap_resident_key_t *rk);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_CTAP_MEM_H */
 /** @} */
+#endif /* FIDO2_CTAP_CTAP_MEM_H */

--- a/sys/include/fido2/ctap/ctap_utils.h
+++ b/sys/include/fido2/ctap/ctap_utils.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_CTAP_UTILS_H
+#define FIDO2_CTAP_CTAP_UTILS_H
+
 /**
  * @defgroup    fido2_ctap_utils FIDO2 CTAP utils
  * @ingroup     fido2_ctap
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_CTAP_UTILS_H
-#define FIDO2_CTAP_CTAP_UTILS_H
 
 #include <stdint.h>
 #include "fido2/ctap/ctap.h"
@@ -90,5 +90,5 @@ static inline bool fido2_ctap_utils_ks_equal(const ctap_resident_key_t *k1,
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_CTAP_UTILS_H */
 /** @} */
+#endif /* FIDO2_CTAP_CTAP_UTILS_H */

--- a/sys/include/fido2/ctap/transport/ctap_transport.h
+++ b/sys/include/fido2/ctap/transport/ctap_transport.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_TRANSPORT_CTAP_TRANSPORT_H
+#define FIDO2_CTAP_TRANSPORT_CTAP_TRANSPORT_H
+
 /**
  * @defgroup    fido2_ctap_transport FIDO2 CTAP transport
  * @ingroup     fido2_ctap
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_TRANSPORT_CTAP_TRANSPORT_H
-#define FIDO2_CTAP_TRANSPORT_CTAP_TRANSPORT_H
 
 #include <stdint.h>
 #include "mutex.h"
@@ -44,5 +44,5 @@ void fido2_ctap_transport_init(void);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_TRANSPORT_CTAP_TRANSPORT_H */
 /** @} */
+#endif /* FIDO2_CTAP_TRANSPORT_CTAP_TRANSPORT_H */

--- a/sys/include/fido2/ctap/transport/hid/ctap_hid.h
+++ b/sys/include/fido2/ctap/transport/hid/ctap_hid.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FIDO2_CTAP_TRANSPORT_HID_CTAP_HID_H
+#define FIDO2_CTAP_TRANSPORT_HID_CTAP_HID_H
+
 /**
  * @defgroup    fido2_ctap_transport_hid FIDO2 CTAPHID
  * @ingroup     fido2_ctap_transport
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef FIDO2_CTAP_TRANSPORT_HID_CTAP_HID_H
-#define FIDO2_CTAP_TRANSPORT_HID_CTAP_HID_H
 
 #include <stdint.h>
 
@@ -251,5 +251,5 @@ bool fido2_ctap_transport_hid_should_cancel(void);
 #ifdef __cplusplus
 }
 #endif
-#endif /* FIDO2_CTAP_TRANSPORT_HID_CTAP_HID_H */
 /** @} */
+#endif /* FIDO2_CTAP_TRANSPORT_HID_CTAP_HID_H */

--- a/sys/include/flash_utils.h
+++ b/sys/include/flash_utils.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef FLASH_UTILS_H
+#define FLASH_UTILS_H
+
 /**
  * @defgroup    sys_flash_utils Utility functions, macros, and types for
  *                              read-only memory
@@ -43,9 +46,6 @@
  * @brief       Utility functions, macros, and types for read-only memory
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef FLASH_UTILS_H
-#define FLASH_UTILS_H
 
 #include <stdio.h>
 #include <string.h>
@@ -251,5 +251,5 @@ static inline void flash_print_str(FLASH_ATTR const char *flash)
 }
 #endif
 
-#endif /* FLASH_UTILS_H */
 /** @} */
+#endif /* FLASH_UTILS_H */

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FMT_H
+#define FMT_H
+
 /**
  * @defgroup    sys_fmt String formatting (fmt)
  * @ingroup     sys
@@ -37,9 +40,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef FMT_H
-#define FMT_H
 
 #include <stddef.h>
 #include <stdint.h>

--- a/sys/include/fmt_table.h
+++ b/sys/include/fmt_table.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FMT_TABLE_H
+#define FMT_TABLE_H
+
 /**
  * @defgroup    sys_fmt_table Table extension of the string formatting API (fmt_table)
  * @ingroup     sys_fmt
@@ -23,9 +26,6 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef FMT_TABLE_H
-#define FMT_TABLE_H
 
 #include <stdint.h>
 #include <stddef.h>

--- a/sys/include/frac.h
+++ b/sys/include/frac.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FRAC_H
+#define FRAC_H
+
 /**
  * @defgroup  sys_frac   Fractional integer operations
  * @ingroup   sys
@@ -37,9 +40,6 @@
  * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @{
  */
-
-#ifndef FRAC_H
-#define FRAC_H
 
 #include <stdint.h>
 

--- a/sys/include/fs/constfs.h
+++ b/sys/include/fs/constfs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_CONSTFS_H
+#define FS_CONSTFS_H
+
 /**
  * @defgroup  sys_fs_constfs ConstFS static file system
  * @ingroup   sys_fs
@@ -20,9 +23,6 @@
  * @brief   ConstFS public API
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef FS_CONSTFS_H
-#define FS_CONSTFS_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -61,6 +61,6 @@ extern const vfs_file_system_t constfs_file_system;
 }
 #endif
 
-#endif /* FS_CONSTFS_H */
-
 /** @} */
+
+#endif /* FS_CONSTFS_H */

--- a/sys/include/fs/devfs.h
+++ b/sys/include/fs/devfs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_DEVFS_H
+#define FS_DEVFS_H
+
 /**
  * @defgroup  sys_fs_devfs DevFS device file system
  * @ingroup   sys_fs
@@ -21,9 +24,6 @@
  * @brief   DevFS public API
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef FS_DEVFS_H
-#define FS_DEVFS_H
 
 #include "clist.h"
 #include "vfs.h"
@@ -89,6 +89,6 @@ int devfs_unregister(devfs_t *node);
 }
 #endif
 
-#endif /* FS_DEVFS_H */
-
 /** @} */
+
+#endif /* FS_DEVFS_H */

--- a/sys/include/fs/fatfs.h
+++ b/sys/include/fs/fatfs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_FATFS_H
+#define FS_FATFS_H
+
 /**
  * @defgroup    sys_fatfs  FatFs integration
  * @ingroup     sys_fs
@@ -16,9 +19,6 @@
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
-
-#ifndef FS_FATFS_H
-#define FS_FATFS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,6 +101,6 @@ extern const vfs_file_system_t fatfs_file_system;
 }
 #endif
 
-#endif /* FS_FATFS_H */
-
 /** @} */
+
+#endif /* FS_FATFS_H */

--- a/sys/include/fs/littlefs2_fs.h
+++ b/sys/include/fs/littlefs2_fs.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef FS_LITTLEFS2_FS_H
+#define FS_LITTLEFS2_FS_H
+
 /**
  * @defgroup    sys_littlefs2 littlefs v2 integration
  * @ingroup     pkg_littlefs2
@@ -20,9 +23,6 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef FS_LITTLEFS2_FS_H
-#define FS_LITTLEFS2_FS_H
 
 #include <stdalign.h>
 
@@ -124,5 +124,5 @@ extern const vfs_file_system_t littlefs2_file_system;
 }
 #endif
 
-#endif /* FS_LITTLEFS2_FS_H */
 /** @} */
+#endif /* FS_LITTLEFS2_FS_H */

--- a/sys/include/fs/littlefs_fs.h
+++ b/sys/include/fs/littlefs_fs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_LITTLEFS_FS_H
+#define FS_LITTLEFS_FS_H
+
 /**
  * @defgroup    sys_littlefs  littlefs integration
  * @ingroup     pkg_littlefs
@@ -18,9 +21,6 @@
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef FS_LITTLEFS_FS_H
-#define FS_LITTLEFS_FS_H
 
 #include <stdalign.h>
 
@@ -106,5 +106,5 @@ extern const vfs_file_system_t littlefs_file_system;
 }
 #endif
 
-#endif /* FS_LITTLEFS_FS_H */
 /** @} */
+#endif /* FS_LITTLEFS_FS_H */

--- a/sys/include/fs/lwext4_fs.h
+++ b/sys/include/fs/lwext4_fs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_LWEXT4_FS_H
+#define FS_LWEXT4_FS_H
+
 /**
  * @defgroup    sys_lwext4 lwEXT4 integration
  * @ingroup     pkg_lwext4
@@ -18,9 +21,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef FS_LWEXT4_FS_H
-#define FS_LWEXT4_FS_H
 
 #include <stdalign.h>
 
@@ -54,5 +54,5 @@ extern const vfs_file_system_t lwext4_file_system;
 }
 #endif
 
-#endif /* FS_LWEXT4_FS_H */
 /** @} */
+#endif /* FS_LWEXT4_FS_H */

--- a/sys/include/fs/native_fs.h
+++ b/sys/include/fs/native_fs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_NATIVE_FS_H
+#define FS_NATIVE_FS_H
+
 /**
  * @defgroup sys_fs_native Native FS Integration
  * @ingroup cpu_native
@@ -18,9 +21,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef FS_NATIVE_FS_H
-#define FS_NATIVE_FS_H
 
 #include <stdalign.h>
 
@@ -46,5 +46,5 @@ extern const vfs_file_system_t native_file_system;
 }
 #endif
 
-#endif /* FS_NATIVE_FS_H */
 /** @} */
+#endif /* FS_NATIVE_FS_H */

--- a/sys/include/fs/spiffs_fs.h
+++ b/sys/include/fs/spiffs_fs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef FS_SPIFFS_FS_H
+#define FS_SPIFFS_FS_H
+
 /**
  * @defgroup    sys_spiffs  SPIFFS integration
  * @ingroup     pkg_spiffs
@@ -40,9 +43,6 @@
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
-
-#ifndef FS_SPIFFS_FS_H
-#define FS_SPIFFS_FS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -150,6 +150,6 @@ void spiffs_unlock(struct spiffs_t *fs);
 }
 #endif
 
-#endif /* FS_SPIFFS_FS_H */
-
 /** @} */
+
+#endif /* FS_SPIFFS_FS_H */

--- a/sys/include/fuzzing.h
+++ b/sys/include/fuzzing.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef FUZZING_H
+#define FUZZING_H
+
 /**
  * @defgroup    sys_fuzzing FUZZING utilities
  * @ingroup     sys
@@ -18,9 +21,6 @@
  *
  * @author      Sören Tempel <tempel@uni-bremen.de>
  */
-
-#ifndef FUZZING_H
-#define FUZZING_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_H
+#define HASHES_H
+
 /**
  * @ingroup     sys_hashes_non_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Jason Linehan <patientulysses@gmail.com>
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
-
-#ifndef HASHES_H
-#define HASHES_H
 
 #include <stddef.h>
 #include <inttypes.h>

--- a/sys/include/hashes/aes128_cmac.h
+++ b/sys/include/hashes/aes128_cmac.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_AES128_CMAC_H
+#define HASHES_AES128_CMAC_H
+
 /**
  * @defgroup    sys_hashes_aes128_cmac AES128_CMAC
  * @ingroup     sys_hashes_keyed
@@ -18,9 +21,6 @@
  *
  * @author      José Ignacio Alamos <jose.alamos@inria.cl>
  */
-
-#ifndef HASHES_AES128_CMAC_H
-#define HASHES_AES128_CMAC_H
 
 #include <stdio.h>
 #include "crypto/ciphers.h"
@@ -84,5 +84,5 @@ void aes128_cmac_final(aes128_cmac_context_t *ctx, void *digest);
 }
 #endif
 
-#endif /* HASHES_AES128_CMAC_H */
 /** @} */
+#endif /* HASHES_AES128_CMAC_H */

--- a/sys/include/hashes/md5.h
+++ b/sys/include/hashes/md5.h
@@ -17,6 +17,9 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#ifndef HASHES_MD5_H
+#define HASHES_MD5_H
+
 /**
  * @defgroup    sys_hashes_md5 MD5
  * @ingroup     sys_hashes_unkeyed
@@ -50,9 +53,6 @@
  * @author      Christopher R. Hertel <crh@ubiqx.mn.org>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef HASHES_MD5_H
-#define HASHES_MD5_H
 
 #include <stdint.h>
 #include <string.h>
@@ -124,5 +124,5 @@ void md5(void *digest, const void *data, size_t len);
 }
 #endif
 
-#endif /* HASHES_MD5_H */
 /** @} */
+#endif /* HASHES_MD5_H */

--- a/sys/include/hashes/psa/riot_hashes.h
+++ b/sys/include/hashes/psa/riot_hashes.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_PSA_RIOT_HASHES_H
+#define HASHES_PSA_RIOT_HASHES_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -15,9 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef HASHES_PSA_RIOT_HASHES_H
-#define HASHES_PSA_RIOT_HASHES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,5 +89,5 @@ typedef keccak_state_t psa_hashes_sha3_ctx_t;
 }
 #endif
 
-#endif /* HASHES_PSA_RIOT_HASHES_H */
 /** @} */
+#endif /* HASHES_PSA_RIOT_HASHES_H */

--- a/sys/include/hashes/sha1.h
+++ b/sys/include/hashes/sha1.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_SHA1_H
+#define HASHES_SHA1_H
+
 /**
  * @defgroup    sys_hashes_sha1 SHA-1
  * @ingroup     sys_hashes_unkeyed
@@ -23,9 +26,6 @@
 /* This code is public-domain - it is based on libcrypt
  * placed in the public domain by Wei Dai and other contributors. */
 
-#ifndef HASHES_SHA1_H
-#define HASHES_SHA1_H
-
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -35,12 +35,12 @@ extern "C" {
 /**
  * @brief   Length of SHA-1 digests in byte
  */
-#define SHA1_DIGEST_LENGTH  (20)
+#define SHA1_DIGEST_LENGTH (20)
 
 /**
  * @brief   Length of SHA-1 block in byte
  */
-#define SHA1_BLOCK_LENGTH   (64)
+#define SHA1_BLOCK_LENGTH  (64)
 
 /**
  * @brief SHA-1 algorithm context
@@ -117,5 +117,5 @@ void sha1_final_hmac(sha1_context *ctx, void *digest);
 }
 #endif
 
-#endif /* HASHES_SHA1_H */
 /** @} */
+#endif /* HASHES_SHA1_H */

--- a/sys/include/hashes/sha224.h
+++ b/sys/include/hashes/sha224.h
@@ -30,6 +30,9 @@
  * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
  */
 
+#ifndef HASHES_SHA224_H
+#define HASHES_SHA224_H
+
 /**
  * @defgroup    sys_hashes_sha224 SHA-224
  * @ingroup     sys_hashes_unkeyed
@@ -45,9 +48,6 @@
  * @author      Hermann Lelong
  * @author      Peter Kietzmann
  */
-
-#ifndef HASHES_SHA224_H
-#define HASHES_SHA224_H
 
 #include <inttypes.h>
 #include <stddef.h>

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -29,6 +29,9 @@
  * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
  */
 
+#ifndef HASHES_SHA256_H
+#define HASHES_SHA256_H
+
 /**
  * @defgroup    sys_hashes_sha256 SHA-256
  * @ingroup     sys_hashes_unkeyed
@@ -43,9 +46,6 @@
  * @author      Rene Kijewski
  * @author      Hermann Lelong
  */
-
-#ifndef HASHES_SHA256_H
-#define HASHES_SHA256_H
 
 #include <inttypes.h>
 #include <stddef.h>

--- a/sys/include/hashes/sha2xx_common.h
+++ b/sys/include/hashes/sha2xx_common.h
@@ -30,6 +30,9 @@
  * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
  */
 
+#ifndef HASHES_SHA2XX_COMMON_H
+#define HASHES_SHA2XX_COMMON_H
+
 /**
  * @defgroup    sys_hashes_sha2xx_common SHA-2xx common
  * @ingroup     sys_hashes_unkeyed
@@ -45,9 +48,6 @@
  * @author      Hermann Lelong
  * @author      Peter Kietzmann
  */
-
-#ifndef HASHES_SHA2XX_COMMON_H
-#define HASHES_SHA2XX_COMMON_H
 
 #include <string.h>
 #include <stdint.h>

--- a/sys/include/hashes/sha3.h
+++ b/sys/include/hashes/sha3.h
@@ -11,6 +11,9 @@
  * For more information see: http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+#ifndef HASHES_SHA3_H
+#define HASHES_SHA3_H
+
 /**
  * @defgroup    sys_hashes_sha3 SHA-3
  * @ingroup     sys_hashes_unkeyed
@@ -23,9 +26,6 @@
  * @author      Implementation by the Keccak, Keyak and Ketje Teams (https://keccak.team/)
  * @author      RIOT OS adaptations by Mathias Tausig
  */
-
-#ifndef HASHES_SHA3_H
-#define HASHES_SHA3_H
 
 #include <stdlib.h>
 
@@ -189,5 +189,5 @@ void sha3_512(void *digest, const void *data, size_t len);
 }
 #endif
 
-#endif /* HASHES_SHA3_H */
 /** @} */
+#endif /* HASHES_SHA3_H */

--- a/sys/include/hashes/sha384.h
+++ b/sys/include/hashes/sha384.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_SHA384_H
+#define HASHES_SHA384_H
+
 /**
  * @defgroup    sys_hashes_sha384 SHA-384
  * @ingroup     sys_hashes_unkeyed
@@ -17,9 +20,6 @@
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  */
-
-#ifndef HASHES_SHA384_H
-#define HASHES_SHA384_H
 
 #include <inttypes.h>
 #include <stddef.h>

--- a/sys/include/hashes/sha512.h
+++ b/sys/include/hashes/sha512.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_SHA512_H
+#define HASHES_SHA512_H
+
 /**
  * @defgroup    sys_hashes_sha512 SHA-512
  * @ingroup     sys_hashes_unkeyed
@@ -17,9 +20,6 @@
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  */
-
-#ifndef HASHES_SHA512_H
-#define HASHES_SHA512_H
 
 #include <inttypes.h>
 #include <stddef.h>

--- a/sys/include/hashes/sha512_224.h
+++ b/sys/include/hashes/sha512_224.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_SHA512_224_H
+#define HASHES_SHA512_224_H
+
 /**
  * @defgroup    sys_hashes_sha512_224 SHA-512/224
  * @ingroup     sys_hashes_unkeyed
@@ -17,9 +20,6 @@
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  */
-
-#ifndef HASHES_SHA512_224_H
-#define HASHES_SHA512_224_H
 
 #include <inttypes.h>
 #include <stddef.h>

--- a/sys/include/hashes/sha512_256.h
+++ b/sys/include/hashes/sha512_256.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_SHA512_256_H
+#define HASHES_SHA512_256_H
+
 /**
  * @defgroup    sys_hashes_sha512_256 SHA-512/256
  * @ingroup     sys_hashes_unkeyed
@@ -17,9 +20,6 @@
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  */
-
-#ifndef HASHES_SHA512_256_H
-#define HASHES_SHA512_256_H
 
 #include <inttypes.h>
 #include <stddef.h>

--- a/sys/include/hashes/sha512_common.h
+++ b/sys/include/hashes/sha512_common.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef HASHES_SHA512_COMMON_H
+#define HASHES_SHA512_COMMON_H
+
 /**
  * @defgroup    sys_hashes_sha512_common SHA-512 common
  * @ingroup     sys_hashes_unkeyed
@@ -17,9 +20,6 @@
  *
  * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  */
-
-#ifndef HASHES_SHA512_COMMON_H
-#define HASHES_SHA512_COMMON_H
 
 #include <string.h>
 #include <stdint.h>

--- a/sys/include/imath.h
+++ b/sys/include/imath.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef IMATH_H
+#define IMATH_H
+
 /**
  * @defgroup    sys_imath   imath: Integer Math functions
  * @ingroup     sys
@@ -17,9 +20,6 @@
  * @author      Karl Fessel <karl.fessel@ovgu.de>
  * @{
  */
-
-#ifndef IMATH_H
-#define IMATH_H
 
 #include <stdint.h>
 
@@ -140,5 +140,5 @@ static inline uint32_t powi(unsigned x, unsigned y)
 }
 #endif
 
-#endif /* IMATH_H */
 /** @} */
+#endif /* IMATH_H */

--- a/sys/include/iolist.h
+++ b/sys/include/iolist.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef IOLIST_H
+#define IOLIST_H
+
 /**
  * @defgroup    sys_iolist iolist scatter / gather IO
  * @ingroup     sys
@@ -20,9 +23,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef IOLIST_H
-#define IOLIST_H
 
 #include <unistd.h>
 
@@ -97,5 +97,5 @@ ssize_t iolist_to_buffer(const iolist_t *iolist, void *dst, size_t len);
 #ifdef __cplusplus
 }
 #endif
-#endif /* IOLIST_H */
 /** @} */
+#endif /* IOLIST_H */

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ISRPIPE_H
+#define ISRPIPE_H
+
 /**
  * @defgroup isr_pipe ISR Pipe
  * @ingroup sys
@@ -18,9 +21,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
-
-#ifndef ISRPIPE_H
-#define ISRPIPE_H
 
 #include <stdint.h>
 

--- a/sys/include/isrpipe/read_timeout.h
+++ b/sys/include/isrpipe/read_timeout.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ISRPIPE_READ_TIMEOUT_H
+#define ISRPIPE_READ_TIMEOUT_H
+
 /**
  * @defgroup    isr_pipe_read_timeout  Read timeouts with ISR pipe
  * @ingroup     isr_pipe
@@ -18,9 +21,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
-
-#ifndef ISRPIPE_READ_TIMEOUT_H
-#define ISRPIPE_READ_TIMEOUT_H
 
 #include "isrpipe.h"
 

--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef LUID_H
+#define LUID_H
+
 /**
  * @defgroup    sys_luid Locally Unique ID Generator
  * @ingroup     sys
@@ -49,9 +52,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef LUID_H
-#define LUID_H
 
 #include <stddef.h>
 
@@ -199,5 +199,5 @@ void luid_base(void *buf, size_t len);
 }
 #endif
 
-#endif /* LUID_H */
 /** @} */
+#endif /* LUID_H */

--- a/sys/include/matstat.h
+++ b/sys/include/matstat.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MATSTAT_H
+#define MATSTAT_H
+
 /**
  * @ingroup     sys_matstat
  *
@@ -28,9 +31,6 @@
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef MATSTAT_H
-#define MATSTAT_H
 
 #include <stdint.h>
 
@@ -113,6 +113,6 @@ void matstat_merge(matstat_state_t *dest, const matstat_state_t *src);
 }
 #endif
 
-#endif /* MATSTAT_H */
-
 /** @} */
+
+#endif /* MATSTAT_H */

--- a/sys/include/mineplex.h
+++ b/sys/include/mineplex.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef MINEPLEX_H
+#define MINEPLEX_H
+
 /**
  * @defgroup    sys_mineplex 5x5 Font 'Mineplex'
  * @ingroup     sys
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef MINEPLEX_H
-#define MINEPLEX_H
 
 #include <stdint.h>
 
@@ -55,5 +55,5 @@ const uint8_t *mineplex_char(char c);
 }
 #endif
 
-#endif /* MINEPLEX_H */
 /** @} */
+#endif /* MINEPLEX_H */

--- a/sys/include/net/af.h
+++ b/sys/include/net/af.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_AF_H
+#define NET_AF_H
 /**
  * @defgroup    net_af  UNIX address families
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_AF_H
-#define NET_AF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,5 +48,5 @@ typedef enum {
 }
 #endif
 
-#endif /* NET_AF_H */
 /** @} */
+#endif /* NET_AF_H */

--- a/sys/include/net/arp.h
+++ b/sys/include/net/arp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_ARP_H
+#define NET_ARP_H
 /**
  * @defgroup    net_arp    Address resolution protocol (ARP)
  * @ingroup     net_ipv4
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_ARP_H
-#define NET_ARP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,5 +40,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_ARP_H */
 /** @} */
+#endif /* NET_ARP_H */

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_ASYMCUTE_H
+#define NET_ASYMCUTE_H
+
 /**
  * @defgroup    net_asymcute MQTT-SN Client (Asymcute)
  * @ingroup     net
@@ -40,9 +43,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_ASYMCUTE_H
-#define NET_ASYMCUTE_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -574,5 +574,5 @@ int asymcute_unsubscribe(asymcute_con_t *con, asymcute_req_t *req,
 }
 #endif
 
-#endif /* NET_ASYMCUTE_H */
 /** @} */
+#endif /* NET_ASYMCUTE_H */

--- a/sys/include/net/ble.h
+++ b/sys/include/net/ble.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_BLE_H
+#define NET_BLE_H
+
 /**
  * @defgroup    ble_defs Generic BLE defines
  * @ingroup     ble
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_BLE_H
-#define NET_BLE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -496,5 +496,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_BLE_H */
 /** @} */
+#endif /* NET_BLE_H */

--- a/sys/include/net/bluetil/ad.h
+++ b/sys/include/net/bluetil/ad.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_BLUETIL_AD_H
+#define NET_BLUETIL_AD_H
+
 /**
  * @defgroup    ble_bluetil_ad BLE Advertising Data (AD) Processing
  * @ingroup     ble_bluetil
@@ -23,9 +26,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_BLUETIL_AD_H
-#define NET_BLUETIL_AD_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -205,5 +205,5 @@ static inline int bluetil_ad_init_with_flags(bluetil_ad_t *ad,
 }
 #endif
 
-#endif /* NET_BLUETIL_AD_H */
 /** @} */
+#endif /* NET_BLUETIL_AD_H */

--- a/sys/include/net/bluetil/addr.h
+++ b/sys/include/net/bluetil/addr.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_BLUETIL_ADDR_H
+#define NET_BLUETIL_ADDR_H
+
 /**
  * @defgroup    ble_bluetil_addr BLE Address Helper
  * @ingroup     ble_bluetil
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_BLUETIL_ADDR_H
-#define NET_BLUETIL_ADDR_H
 
 #include <stdint.h>
 
@@ -112,5 +112,5 @@ void bluetil_addr_ipv6_l2ll_print(const uint8_t *addr);
 }
 #endif
 
-#endif /* NET_BLUETIL_ADDR_H */
 /** @} */
+#endif /* NET_BLUETIL_ADDR_H */

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_COAP_H
+#define NET_COAP_H
+
 /**
  * @defgroup    net_coap CoAP defines
  * @ingroup     net
@@ -18,9 +21,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  */
-
-#ifndef NET_COAP_H
-#define NET_COAP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -631,5 +631,5 @@ typedef enum {
 }
 #endif
 
-#endif /* NET_COAP_H */
 /** @} */
+#endif /* NET_COAP_H */

--- a/sys/include/net/cord/common.h
+++ b/sys/include/net/cord/common.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CORD_COMMON_H
+#define NET_CORD_COMMON_H
+
 /**
  * @defgroup    net_cord_common CoRE RD Common
  * @ingroup     net_cord
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_CORD_COMMON_H
-#define NET_CORD_COMMON_H
 
 #include "net/cord/config.h"
 
@@ -64,5 +64,5 @@ int cord_common_add_qstring(coap_pkt_t *pkt);
 }
 #endif
 
-#endif /* NET_CORD_COMMON_H */
 /** @} */
+#endif /* NET_CORD_COMMON_H */

--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CORD_CONFIG_H
+#define NET_CORD_CONFIG_H
+
 /**
  * @defgroup    net_cord_config CoRE RD Configuration
  * @ingroup     net_cord
@@ -19,9 +22,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_CORD_CONFIG_H
-#define NET_CORD_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,5 +110,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_CORD_CONFIG_H */
 /** @} */
+#endif /* NET_CORD_CONFIG_H */

--- a/sys/include/net/cord/ep.h
+++ b/sys/include/net/cord/ep.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CORD_EP_H
+#define NET_CORD_EP_H
+
 /**
  * @defgroup    net_cord_ep CoRE RD Endpoint
  * @ingroup     net_cord
@@ -30,9 +33,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_CORD_EP_H
-#define NET_CORD_EP_H
 
 #include "net/sock/udp.h"
 
@@ -115,5 +115,5 @@ void cord_ep_dump_status(void);
 }
 #endif
 
-#endif /* NET_CORD_EP_H */
 /** @} */
+#endif /* NET_CORD_EP_H */

--- a/sys/include/net/cord/ep_standalone.h
+++ b/sys/include/net/cord/ep_standalone.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CORD_EP_STANDALONE_H
+#define NET_CORD_EP_STANDALONE_H
+
 /**
  * @defgroup    net_cord_ep_standalone CoRE RD Endpoint Standalone Extension
  * @ingroup     net_cord_ep
@@ -22,9 +25,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_CORD_EP_STANDALONE_H
-#define NET_CORD_EP_STANDALONE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,5 +84,5 @@ void cord_ep_standalone_signal(bool connected);
 }
 #endif
 
-#endif /* NET_CORD_EP_STANDALONE_H */
 /** @} */
+#endif /* NET_CORD_EP_STANDALONE_H */

--- a/sys/include/net/cord/epsim.h
+++ b/sys/include/net/cord/epsim.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CORD_EPSIM_H
+#define NET_CORD_EPSIM_H
+
 /**
  * @defgroup    net_cord_epsim CoRE RD Simple Registration Endpoint
  * @ingroup     net_cord
@@ -24,9 +27,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_CORD_EPSIM_H
-#define NET_CORD_EPSIM_H
 
 #include "net/sock/udp.h"
 
@@ -71,5 +71,5 @@ int cord_epsim_state(void);
 }
 #endif
 
-#endif /* NET_CORD_EPSIM_H */
 /** @} */
+#endif /* NET_CORD_EPSIM_H */

--- a/sys/include/net/cord/lc.h
+++ b/sys/include/net/cord/lc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CORD_LC_H
+#define NET_CORD_LC_H
+
 /**
  * @defgroup    net_cord_lc CoRE RD Lookup Client
  * @ingroup     net_cord
@@ -45,9 +48,6 @@
  *
  * @author      Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
  */
-
-#ifndef NET_CORD_LC_H
-#define NET_CORD_LC_H
 
 #include "net/sock/udp.h"
 #include "net/nanocoap.h"
@@ -242,5 +242,5 @@ static inline ssize_t cord_lc_ep(cord_lc_rd_t *rd, cord_lc_ep_t *endpoint,
 }
 #endif
 
-#endif /* NET_CORD_LC_H */
 /** @} */
+#endif /* NET_CORD_LC_H */

--- a/sys/include/net/credman.h
+++ b/sys/include/net/credman.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CREDMAN_H
+#define NET_CREDMAN_H
+
 /**
  * @defgroup    net_credman (D)TLS Credential Manager
  * @ingroup     net net_dtls
@@ -23,9 +26,6 @@
  *
  * @author      Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
  */
-
-#ifndef NET_CREDMAN_H
-#define NET_CREDMAN_H
 
 #include <unistd.h>
 #include <stdint.h>
@@ -274,5 +274,5 @@ void credman_reset(void);
 }
 #endif
 
-#endif /* NET_CREDMAN_H */
 /** @} */
+#endif /* NET_CREDMAN_H */

--- a/sys/include/net/csma_sender.h
+++ b/sys/include/net/csma_sender.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_CSMA_SENDER_H
+#define NET_CSMA_SENDER_H
+
 /**
  * @defgroup    net_csma_sender  CSMA/CA helper
  * @ingroup     net
@@ -21,9 +24,6 @@
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-
-#ifndef NET_CSMA_SENDER_H
-#define NET_CSMA_SENDER_H
 
 #include <stdint.h>
 
@@ -142,6 +142,6 @@ int csma_sender_cca_send(netdev_t *dev, iolist_t *iolist);
 }
 #endif
 
-#endif /* NET_CSMA_SENDER_H */
-
 /** @} */
+
+#endif /* NET_CSMA_SENDER_H */

--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DHCPV6_H
+#define NET_DHCPV6_H
 /**
  * @defgroup    net_dhcpv6 Dynamic Host Configuration Protocol for IPv6 (DHCPv6)
  * @ingroup     net_ipv6
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_DHCPV6_H
-#define NET_DHCPV6_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -109,5 +109,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_DHCPV6_H */
 /** @} */
+#endif /* NET_DHCPV6_H */

--- a/sys/include/net/dhcpv6/client.h
+++ b/sys/include/net/dhcpv6/client.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DHCPV6_CLIENT_H
+#define NET_DHCPV6_CLIENT_H
 /**
  * @defgroup net_dhcpv6_client  DHCPv6 client
  * @ingroup  net_dhcpv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_DHCPV6_CLIENT_H
-#define NET_DHCPV6_CLIENT_H
 
 #include "byteorder.h"
 #include "event.h"
@@ -317,5 +317,5 @@ uint8_t dhcpv6_client_get_conf_mode(void);
 }
 #endif
 
-#endif /* NET_DHCPV6_CLIENT_H */
 /** @} */
+#endif /* NET_DHCPV6_CLIENT_H */

--- a/sys/include/net/dhcpv6/relay.h
+++ b/sys/include/net/dhcpv6/relay.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DHCPV6_RELAY_H
+#define NET_DHCPV6_RELAY_H
 /**
  * @defgroup net_dhcpv6_relay   DHCPv6 relay agent
  * @ingroup  net_dhcpv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_DHCPV6_RELAY_H
-#define NET_DHCPV6_RELAY_H
 
 #include <stdint.h>
 
@@ -75,5 +75,5 @@ void dhcpv6_relay_init(event_queue_t *event_queue, uint16_t listen_netif,
 }
 #endif
 
-#endif /* NET_DHCPV6_RELAY_H */
 /** @} */
+#endif /* NET_DHCPV6_RELAY_H */

--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DNS_H
+#define NET_DNS_H
 /**
  * @defgroup    net_dns DNS defines
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_DNS_H
-#define NET_DNS_H
 
 #include "modules.h"
 #include "net/sock/dns.h"
@@ -100,5 +100,5 @@ static inline int dns_query(const char *domain_name, void *addr_out, int family)
 }
 #endif
 
-#endif /* NET_DNS_H */
 /** @} */
+#endif /* NET_DNS_H */

--- a/sys/include/net/dns/cache.h
+++ b/sys/include/net/dns/cache.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_DNS_CACHE_H
+#define NET_DNS_CACHE_H
+
 /**
  * @defgroup    net_dns_cache   DNS cache
  * @ingroup     net_dns
@@ -29,9 +32,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef NET_DNS_CACHE_H
-#define NET_DNS_CACHE_H
 
 #include <stdint.h>
 
@@ -107,5 +107,5 @@ static inline void dns_cache_add(const char *domain_name, const void *addr,
 }
 #endif
 
-#endif /* NET_DNS_CACHE_H */
 /** @} */
+#endif /* NET_DNS_CACHE_H */

--- a/sys/include/net/dns/msg.h
+++ b/sys/include/net/dns/msg.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DNS_MSG_H
+#define NET_DNS_MSG_H
 /**
  * @defgroup    net_dns_msg DNS message parser and composer
  * @ingroup     net_dns
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_DNS_MSG_H
-#define NET_DNS_MSG_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -117,5 +117,5 @@ int dns_msg_parse_reply(const uint8_t *buf, size_t len, int family,
 }
 #endif
 
-#endif /* NET_DNS_MSG_H */
 /** @} */
+#endif /* NET_DNS_MSG_H */

--- a/sys/include/net/dns_mock.h
+++ b/sys/include/net/dns_mock.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DNS_MOCK_H
+#define NET_DNS_MOCK_H
 /**
  * @defgroup    net_dns_mock DNS defines
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
-#ifndef NET_DNS_MOCK_H
-#define NET_DNS_MOCK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,5 +52,5 @@ static const ipv6_addr_t sock_dns_mock_example_com_addr_ipv6 = { {
 }
 #endif
 
-#endif /* NET_DNS_MOCK_H */
 /** @} */
+#endif /* NET_DNS_MOCK_H */

--- a/sys/include/net/dsm.h
+++ b/sys/include/net/dsm.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_DSM_H
+#define NET_DSM_H
+
 /**
  * @defgroup    net_dsm DTLS Session Management (DSM)
  * @ingroup     net net_dtls
@@ -26,9 +29,6 @@
  *
  * @author      János Brodbeck <janos.brodbeck@ml-pa.com>
  */
-
-#ifndef NET_DSM_H
-#define NET_DSM_H
 
 #include <stdint.h>
 
@@ -121,5 +121,5 @@ ssize_t dsm_get_least_recently_used_session(sock_dtls_t *sock, sock_dtls_session
 }
 #endif
 
-#endif /* NET_DSM_H */
 /** @} */
+#endif /* NET_DSM_H */

--- a/sys/include/net/dtls.h
+++ b/sys/include/net/dtls.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_DTLS_H
+#define NET_DTLS_H
 /**
  * @defgroup    net_dtls DTLS
  * @ingroup     net
@@ -33,8 +35,6 @@
  *
  * @author  Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
  */
-#ifndef NET_DTLS_H
-#define NET_DTLS_H
 
 #include "modules.h"
 
@@ -57,5 +57,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_DTLS_H */
 /** @} */
+#endif /* NET_DTLS_H */

--- a/sys/include/net/eddystone.h
+++ b/sys/include/net/eddystone.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_EDDYSTONE_H
+#define NET_EDDYSTONE_H
+
 /**
  * @defgroup    net_eddystone Eddystone
  * @ingroup     net
@@ -19,9 +22,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_EDDYSTONE_H
-#define NET_EDDYSTONE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,5 +59,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_EDDYSTONE_H */
 /** @} */
+#endif /* NET_EDDYSTONE_H */

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_EMCUTE_H
+#define NET_EMCUTE_H
+
 /**
  * @defgroup    net_emcute MQTT-SN Client (emCute)
  * @ingroup     net
@@ -82,9 +85,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_EMCUTE_H
-#define NET_EMCUTE_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -389,5 +389,5 @@ const char *emcute_type_str(uint8_t type);
 }
 #endif
 
-#endif /* NET_EMCUTE_H */
 /** @} */
+#endif /* NET_EMCUTE_H */

--- a/sys/include/net/eui48.h
+++ b/sys/include/net/eui48.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_EUI48_H
+#define NET_EUI48_H
+
 /**
  * @defgroup    net_eui48 IEEE EUI-48 identifier
  * @ingroup     net
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_EUI48_H
-#define NET_EUI48_H
 
 #include <stdint.h>
 
@@ -160,5 +160,5 @@ static inline void eui48_from_ipv6_iid(eui48_t *addr, const eui64_t *iid)
 }
 #endif
 
-#endif /* NET_EUI48_H */
 /** @} */
+#endif /* NET_EUI48_H */

--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_EUI64_H
+#define NET_EUI64_H
 /**
  * @defgroup    net_eui64   IEEE EUI-64 identifier
  * @ingroup     net
@@ -21,8 +23,6 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  */
-#ifndef NET_EUI64_H
-#define NET_EUI64_H
 
 #include <stdint.h>
 #include "byteorder.h"
@@ -88,5 +88,5 @@ static inline void eui64_clear_group(eui64_t *addr)
 }
 #endif
 
-#endif /* NET_EUI64_H */
 /** @} */
+#endif /* NET_EUI64_H */

--- a/sys/include/net/eui_provider.h
+++ b/sys/include/net/eui_provider.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_EUI_PROVIDER_H
+#define NET_EUI_PROVIDER_H
 /**
  * @defgroup    net_eui_provider    IEEE EUI-48/64 provider
  * @ingroup     net
@@ -95,8 +97,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef NET_EUI_PROVIDER_H
-#define NET_EUI_PROVIDER_H
 
 #include "net/eui48.h"
 #include "net/eui64.h"
@@ -201,5 +201,5 @@ static inline void eui_short_from_eui64(eui64_t *addr_long,
 }
 #endif
 
-#endif /* NET_EUI_PROVIDER_H */
 /** @} */
+#endif /* NET_EUI_PROVIDER_H */

--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_FIB_H
+#define NET_FIB_H
+
 /**
  * @defgroup    net_fib Forwarding Information Base (FIB)
  * @ingroup     net
@@ -23,9 +26,6 @@
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
-
-#ifndef NET_FIB_H
-#define NET_FIB_H
 
 #include <stdint.h>
 
@@ -514,5 +514,5 @@ int fib_devel_get_lifetime(fib_table_t *table, uint64_t *lifetime, uint8_t *dst,
 }
 #endif
 
-#endif /* NET_FIB_H */
 /** @} */
+#endif /* NET_FIB_H */

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_FIB_TABLE_H
+#define NET_FIB_TABLE_H
+
 /**
  * @ingroup     net_fib
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
-
-#ifndef NET_FIB_TABLE_H
-#define NET_FIB_TABLE_H
 
 #include <stdint.h>
 
@@ -139,5 +139,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_FIB_TABLE_H */
 /** @} */
+#endif /* NET_FIB_TABLE_H */

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GCOAP_H
+#define NET_GCOAP_H
+
 /**
  * @defgroup    net_gcoap  GCoAP
  * @ingroup     net
@@ -393,9 +396,6 @@
  * @author      Ken Bannister <kb2ma@runbox.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_GCOAP_H
-#define NET_GCOAP_H
 
 #include <stdint.h>
 
@@ -1237,5 +1237,5 @@ static inline coap_hdr_t *gcoap_request_memo_get_hdr(const gcoap_request_memo_t 
 }
 #endif
 
-#endif /* NET_GCOAP_H */
 /** @} */
+#endif /* NET_GCOAP_H */

--- a/sys/include/net/gcoap/dns.h
+++ b/sys/include/net/gcoap/dns.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GCOAP_DNS_H
+#define NET_GCOAP_DNS_H
 /**
  * @defgroup net_gcoap_dns  DNS over CoAP client implementation
  * @ingroup  net_gcoap
@@ -26,8 +28,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GCOAP_DNS_H
-#define NET_GCOAP_DNS_H
 
 #include <stdint.h>
 
@@ -215,5 +215,5 @@ ssize_t gcoap_dns_server_proxy_get(char *proxy, size_t proxy_len);
 }
 #endif
 
-#endif /* NET_GCOAP_DNS_H */
 /** @} */
+#endif /* NET_GCOAP_DNS_H */

--- a/sys/include/net/gcoap/forward_proxy.h
+++ b/sys/include/net/gcoap/forward_proxy.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_GCOAP_FORWARD_PROXY_H
+#define NET_GCOAP_FORWARD_PROXY_H
+
 /**
  * @defgroup    net_gcoap_forward_proxy    GCoAP Forward Proxy
  * @ingroup     net_gcoap
@@ -22,9 +25,6 @@
  *
  * @author      Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
-
-#ifndef NET_GCOAP_FORWARD_PROXY_H
-#define NET_GCOAP_FORWARD_PROXY_H
 
 #include <stdbool.h>
 #include <errno.h>

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_H
+#define NET_GNRC_H
+
 /**
  * @defgroup    net_gnrc    Generic (GNRC) network stack
  * @ingroup     net
@@ -284,9 +287,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NET_GNRC_H
-#define NET_GNRC_H
-
 #include "net/netopt.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netreg.h"
@@ -306,5 +306,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_GNRC_H */
 /** @} */
+#endif /* NET_GNRC_H */

--- a/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
+++ b/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H
+#define NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H
 /**
  * @defgroup    net_dhcpv6_client_simple_pd     gnrc_dhcpv6_client_simple_pd: DHCPv6 client for
  *                                              simple prefix delegation
@@ -19,8 +21,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H
-#define NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,5 +91,5 @@ void gnrc_dhcpv6_client_simple_pd_init(void);
 }
 #endif
 
-#endif /* NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H */
 /** @} */
+#endif /* NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H */

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_GOMACH_GOMACH_H
+#define NET_GNRC_GOMACH_GOMACH_H
+
 /**
  * @defgroup    net_gnrc_gomach GoMacH
  * @ingroup     net_gnrc
@@ -38,9 +41,6 @@
  *
  * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_GOMACH_GOMACH_H
-#define NET_GNRC_GOMACH_GOMACH_H
 
 #include "periph/rtt.h"
 #include "net/gnrc/netif.h"
@@ -374,5 +374,5 @@ int gnrc_netif_gomach_create(gnrc_netif_t *netif, char *stack, int stacksize,
 }
 #endif
 
-#endif /* NET_GNRC_GOMACH_GOMACH_H */
 /** @} */
+#endif /* NET_GNRC_GOMACH_GOMACH_H */

--- a/sys/include/net/gnrc/gomach/hdr.h
+++ b/sys/include/net/gnrc/gomach/hdr.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_GOMACH_HDR_H
+#define NET_GNRC_GOMACH_HDR_H
+
 /**
  * @ingroup     net_gnrc_gomach
  * @{
@@ -15,9 +18,6 @@
  * @internal
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_GOMACH_HDR_H
-#define NET_GNRC_GOMACH_HDR_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -138,5 +138,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NET_GNRC_GOMACH_HDR_H */
 /** @} */
+#endif /* NET_GNRC_GOMACH_HDR_H */

--- a/sys/include/net/gnrc/gomach/timeout.h
+++ b/sys/include/net/gnrc/gomach/timeout.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_GOMACH_TIMEOUT_H
+#define NET_GNRC_GOMACH_TIMEOUT_H
+
 /**
  * @ingroup     net_gnrc_gomach
  * @{
@@ -15,9 +18,6 @@
  * @internal
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_GOMACH_TIMEOUT_H
-#define NET_GNRC_GOMACH_TIMEOUT_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -96,5 +96,5 @@ static inline void gnrc_gomach_timeout_make_expire(gnrc_gomach_timeout_t *timeou
 }
 #endif
 
-#endif /* NET_GNRC_GOMACH_TIMEOUT_H */
 /** @} */
+#endif /* NET_GNRC_GOMACH_TIMEOUT_H */

--- a/sys/include/net/gnrc/gomach/types.h
+++ b/sys/include/net/gnrc/gomach/types.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_GOMACH_TYPES_H
+#define NET_GNRC_GOMACH_TYPES_H
+
 /**
  * @ingroup     net_gnrc_gomach
  * @{
@@ -15,9 +18,6 @@
  * @internal
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_GOMACH_TYPES_H
-#define NET_GNRC_GOMACH_TYPES_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -310,5 +310,5 @@ typedef struct gomach {
 }
 #endif
 
-#endif /* NET_GNRC_GOMACH_TYPES_H */
 /** @} */
+#endif /* NET_GNRC_GOMACH_TYPES_H */

--- a/sys/include/net/gnrc/icmpv6/echo.h
+++ b/sys/include/net/gnrc/icmpv6/echo.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_ICMPV6_ECHO_H
+#define NET_GNRC_ICMPV6_ECHO_H
 /**
  * @defgroup    net_gnrc_icmpv6_echo  ICMPv6 echo messages
  * @ingroup     net_gnrc_icmpv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_ICMPV6_ECHO_H
-#define NET_GNRC_ICMPV6_ECHO_H
 
 #include <inttypes.h>
 
@@ -107,5 +107,5 @@ int gnrc_icmpv6_echo_rsp_handle(gnrc_pktsnip_t *pkt, size_t len,
 }
 #endif
 
-#endif /* NET_GNRC_ICMPV6_ECHO_H */
 /** @} */
+#endif /* NET_GNRC_ICMPV6_ECHO_H */

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_ICMPV6_ERROR_H
+#define NET_GNRC_ICMPV6_ERROR_H
 /**
  * @defgroup    net_gnrc_icmpv6_error ICMPv6 error messages
  * @ingroup     net_gnrc_icmpv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_ICMPV6_ERROR_H
-#define NET_GNRC_ICMPV6_ERROR_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -106,5 +106,5 @@ void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
 }
 #endif
 
-#endif /* NET_GNRC_ICMPV6_ERROR_H */
 /** @} */
+#endif /* NET_GNRC_ICMPV6_ERROR_H */

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_GNRC_IPV6_H
+#define NET_GNRC_IPV6_H
+
 /**
  * @defgroup    net_gnrc_ipv6 IPv6
  * @ingroup     net_gnrc
@@ -94,9 +97,6 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
-
-#ifndef NET_GNRC_IPV6_H
-#define NET_GNRC_IPV6_H
 
 #include "sched.h"
 #include "thread.h"

--- a/sys/include/net/gnrc/ipv6/blacklist.h
+++ b/sys/include/net/gnrc/ipv6/blacklist.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_BLACKLIST_H
+#define NET_GNRC_IPV6_BLACKLIST_H
 /**
  * @defgroup    net_gnrc_ipv6_blacklist IPv6 address blacklist
  * @ingroup     net_gnrc_ipv6
@@ -19,8 +21,6 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
-#ifndef NET_GNRC_IPV6_BLACKLIST_H
-#define NET_GNRC_IPV6_BLACKLIST_H
 
 #include <stdbool.h>
 
@@ -82,5 +82,5 @@ void gnrc_ipv6_blacklist_print(void);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_BLACKLIST_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_BLACKLIST_H */

--- a/sys/include/net/gnrc/ipv6/ext/frag.h
+++ b/sys/include/net/gnrc/ipv6/ext/frag.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_EXT_FRAG_H
+#define NET_GNRC_IPV6_EXT_FRAG_H
 /**
  * @defgroup    net_gnrc_ipv6_ext_frag Support for IPv6 fragmentation extension
  * @ingroup     net_gnrc_ipv6_ext
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_EXT_FRAG_H
-#define NET_GNRC_IPV6_EXT_FRAG_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -211,5 +211,5 @@ gnrc_ipv6_ext_frag_stats_t *gnrc_ipv6_ext_frag_stats(void);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_EXT_FRAG_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_EXT_FRAG_H */

--- a/sys/include/net/gnrc/ipv6/ext/opt.h
+++ b/sys/include/net/gnrc/ipv6/ext/opt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_EXT_OPT_H
+#define NET_GNRC_IPV6_EXT_OPT_H
 /**
  * @defgroup    net_gnrc_ipv6_ext_opt Support for IPv6 option extension headers
  * @ingroup     net_gnrc_ipv6_ext
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_EXT_OPT_H
-#define NET_GNRC_IPV6_EXT_OPT_H
 
 #include <stdint.h>
 
@@ -56,5 +56,5 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_opt_process(gnrc_pktsnip_t *pkt,
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_EXT_OPT_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_EXT_OPT_H */

--- a/sys/include/net/gnrc/ipv6/ext/rh.h
+++ b/sys/include/net/gnrc/ipv6/ext/rh.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_EXT_RH_H
+#define NET_GNRC_IPV6_EXT_RH_H
 /**
  * @defgroup    net_gnrc_ipv6_ext_rh Support for IPv6 routing header extension
  * @ingroup     net_gnrc_ipv6_ext
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_EXT_RH_H
-#define NET_GNRC_IPV6_EXT_RH_H
 
 #include "net/gnrc/pkt.h"
 
@@ -67,5 +67,5 @@ int gnrc_ipv6_ext_rh_process(gnrc_pktsnip_t *pkt);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_EXT_RH_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_EXT_RH_H */

--- a/sys/include/net/gnrc/ipv6/hdr.h
+++ b/sys/include/net/gnrc/ipv6/hdr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_HDR_H
+#define NET_GNRC_IPV6_HDR_H
 /**
  * @defgroup    net_gnrc_ipv6_hdr IPv6 header definitions
  * @ingroup     net_gnrc_ipv6
@@ -16,8 +18,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_HDR_H
-#define NET_GNRC_IPV6_HDR_H
 
 #include <stdint.h>
 
@@ -50,5 +50,5 @@ gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, const ipv6_addr_t *
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_HDR_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_HDR_H */

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_NIB_H
+#define NET_GNRC_IPV6_NIB_H
 /**
  * @defgroup    net_gnrc_ipv6_nib   Neighbor Information Base for IPv6
  * @ingroup     net_gnrc_ipv6
@@ -22,8 +24,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_NIB_H
-#define NET_GNRC_IPV6_NIB_H
 
 #include "net/gnrc/ipv6/nib/abr.h"
 #include "net/gnrc/ipv6/nib/ft.h"
@@ -433,5 +433,5 @@ void gnrc_ipv6_nib_change_rtr_adv_iface(gnrc_netif_t *netif, bool enable);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_NIB_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_NIB_H */

--- a/sys/include/net/gnrc/ipv6/nib/abr.h
+++ b/sys/include/net/gnrc/ipv6/nib/abr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_NIB_ABR_H
+#define NET_GNRC_IPV6_NIB_ABR_H
 /**
  * @defgroup    net_gnrc_ipv6_nib_abr   Authoritative border router list
  * @ingroup     net_gnrc_ipv6_nib
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_NIB_ABR_H
-#define NET_GNRC_IPV6_NIB_ABR_H
 
 #include "modules.h"
 
@@ -140,5 +140,5 @@ void gnrc_ipv6_nib_abr_print(gnrc_ipv6_nib_abr_t *abr);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_NIB_ABR_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_NIB_ABR_H */

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_NIB_CONF_H
+#define NET_GNRC_IPV6_NIB_CONF_H
 /**
  * @defgroup    net_gnrc_ipv6_nib_conf  GNRC IPv6 NIB compile configurations
  * @ingroup     net_gnrc_ipv6_nib
@@ -18,8 +20,6 @@
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_NIB_CONF_H
-#define NET_GNRC_IPV6_NIB_CONF_H
 
 #include "modules.h"
 
@@ -318,5 +318,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_NIB_CONF_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_NIB_CONF_H */

--- a/sys/include/net/gnrc/ipv6/nib/ft.h
+++ b/sys/include/net/gnrc/ipv6/nib/ft.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_NIB_FT_H
+#define NET_GNRC_IPV6_NIB_FT_H
 /**
  * @defgroup    net_gnrc_ipv6_nib_ft    Forwarding table
  * @ingroup     net_gnrc_ipv6_nib
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_NIB_FT_H
-#define NET_GNRC_IPV6_NIB_FT_H
 
 #include <stdint.h>
 
@@ -153,5 +153,5 @@ void gnrc_ipv6_nib_ft_print(const gnrc_ipv6_nib_ft_t *fte);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_NIB_FT_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_NIB_FT_H */

--- a/sys/include/net/gnrc/ipv6/nib/nc.h
+++ b/sys/include/net/gnrc/ipv6/nib/nc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_NIB_NC_H
+#define NET_GNRC_IPV6_NIB_NC_H
 /**
  * @defgroup    net_gnrc_ipv6_nib_nc   Neighbor Cache
  * @ingroup     net_gnrc_ipv6_nib
@@ -17,8 +19,6 @@
  *
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_NIB_NC_H
-#define NET_GNRC_IPV6_NIB_NC_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -313,5 +313,5 @@ void gnrc_ipv6_nib_nc_print(gnrc_ipv6_nib_nc_t *nce);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_NIB_NC_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_NIB_NC_H */

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_NIB_PL_H
+#define NET_GNRC_IPV6_NIB_PL_H
 /**
  * @defgroup    net_gnrc_ipv6_nib_pl    Prefix list
  * @ingroup     net_gnrc_ipv6_nib
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_NIB_PL_H
-#define NET_GNRC_IPV6_NIB_PL_H
 
 #include <stdint.h>
 #include "modules.h"
@@ -178,5 +178,5 @@ void gnrc_ipv6_nib_pl_print(gnrc_ipv6_nib_pl_t *ple);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_NIB_PL_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_NIB_PL_H */

--- a/sys/include/net/gnrc/ipv6/whitelist.h
+++ b/sys/include/net/gnrc/ipv6/whitelist.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_IPV6_WHITELIST_H
+#define NET_GNRC_IPV6_WHITELIST_H
 /**
  * @defgroup    net_gnrc_ipv6_whitelist IPv6 address whitelist
  * @ingroup     net_gnrc_ipv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_IPV6_WHITELIST_H
-#define NET_GNRC_IPV6_WHITELIST_H
 
 #include <stdbool.h>
 
@@ -80,5 +80,5 @@ void gnrc_ipv6_whitelist_print(void);
 }
 #endif
 
-#endif /* NET_GNRC_IPV6_WHITELIST_H */
 /** @} */
+#endif /* NET_GNRC_IPV6_WHITELIST_H */

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_LORAWAN_H
+#define NET_GNRC_LORAWAN_H
 /**
  * @defgroup    net_gnrc_lorawan GNRC LoRaWAN
  * @ingroup     net_gnrc
@@ -20,8 +22,6 @@
  * @author  José Ignacio Alamos <jose.alamos@haw-hamburg.de>
  * @author  Francisco Molina <femolina@uc.cl>
  */
-#ifndef NET_GNRC_LORAWAN_H
-#define NET_GNRC_LORAWAN_H
 
 #include "gnrc_lorawan_internal.h"
 #include "assert.h"
@@ -340,5 +340,5 @@ static inline void gnrc_lorawan_set_uncnf_redundancy(gnrc_lorawan_t *mac,
 }
 #endif
 
-#endif /* NET_GNRC_LORAWAN_H */
 /** @} */
+#endif /* NET_GNRC_LORAWAN_H */

--- a/sys/include/net/gnrc/lorawan/region.h
+++ b/sys/include/net/gnrc/lorawan/region.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_LORAWAN_REGION_H
+#define NET_GNRC_LORAWAN_REGION_H
 /**
  * @ingroup net_gnrc_lorawan
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  José Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef NET_GNRC_LORAWAN_REGION_H
-#define NET_GNRC_LORAWAN_REGION_H
 
 #include "modules.h"
 #include "net/gnrc/lorawan.h"
@@ -75,5 +75,5 @@ bool gnrc_lorawan_validate_dr(uint8_t dr);
 }
 #endif
 
-#endif /* NET_GNRC_LORAWAN_REGION_H */
 /** @} */
+#endif /* NET_GNRC_LORAWAN_REGION_H */

--- a/sys/include/net/gnrc/lwmac/hdr.h
+++ b/sys/include/net/gnrc/lwmac/hdr.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_LWMAC_HDR_H
+#define NET_GNRC_LWMAC_HDR_H
+
 /**
  * @ingroup     net_gnrc_lwmac
  * @{
@@ -17,9 +20,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_LWMAC_HDR_H
-#define NET_GNRC_LWMAC_HDR_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -111,5 +111,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NET_GNRC_LWMAC_HDR_H */
 /** @} */
+#endif /* NET_GNRC_LWMAC_HDR_H */

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_LWMAC_LWMAC_H
+#define NET_GNRC_LWMAC_LWMAC_H
+
 /**
  * @defgroup    net_gnrc_lwmac LWMAC
  * @ingroup     net_gnrc
@@ -71,9 +74,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_LWMAC_LWMAC_H
-#define NET_GNRC_LWMAC_LWMAC_H
 
 #include "net/gnrc/netif.h"
 
@@ -351,5 +351,5 @@ int gnrc_netif_lwmac_create(gnrc_netif_t *netif, char *stack, int stacksize,
 }
 #endif
 
-#endif /* NET_GNRC_LWMAC_LWMAC_H */
 /** @} */
+#endif /* NET_GNRC_LWMAC_LWMAC_H */

--- a/sys/include/net/gnrc/lwmac/timeout.h
+++ b/sys/include/net/gnrc/lwmac/timeout.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_LWMAC_TIMEOUT_H
+#define NET_GNRC_LWMAC_TIMEOUT_H
+
 /**
  * @ingroup     net_gnrc_lwmac
  * @{
@@ -18,9 +21,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_LWMAC_TIMEOUT_H
-#define NET_GNRC_LWMAC_TIMEOUT_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -98,5 +98,5 @@ void gnrc_lwmac_timeout_make_expire(gnrc_lwmac_timeout_t *timeout);
 }
 #endif
 
-#endif /* NET_GNRC_LWMAC_TIMEOUT_H */
 /** @} */
+#endif /* NET_GNRC_LWMAC_TIMEOUT_H */

--- a/sys/include/net/gnrc/lwmac/types.h
+++ b/sys/include/net/gnrc/lwmac/types.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_LWMAC_TYPES_H
+#define NET_GNRC_LWMAC_TYPES_H
+
 /**
  * @ingroup     net_gnrc_lwmac
  * @{
@@ -18,9 +21,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_LWMAC_TYPES_H
-#define NET_GNRC_LWMAC_TYPES_H
 
 #include "msg.h"
 #include "xtimer.h"
@@ -216,5 +216,5 @@ typedef struct lwmac {
 }
 #endif
 
-#endif /* NET_GNRC_LWMAC_TYPES_H */
 /** @} */
+#endif /* NET_GNRC_LWMAC_TYPES_H */

--- a/sys/include/net/gnrc/mac/internal.h
+++ b/sys/include/net/gnrc/mac/internal.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_MAC_INTERNAL_H
+#define NET_GNRC_MAC_INTERNAL_H
+
 /**
  * @ingroup     net_gnrc_mac
  * @{
@@ -17,9 +20,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_MAC_INTERNAL_H
-#define NET_GNRC_MAC_INTERNAL_H
 
 #include <stdint.h>
 
@@ -141,5 +141,5 @@ void gnrc_mac_dispatch(gnrc_mac_rx_t *rx);
 }
 #endif
 
-#endif /* NET_GNRC_MAC_INTERNAL_H */
 /** @} */
+#endif /* NET_GNRC_MAC_INTERNAL_H */

--- a/sys/include/net/gnrc/mac/mac.h
+++ b/sys/include/net/gnrc/mac/mac.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_MAC_MAC_H
+#define NET_GNRC_MAC_MAC_H
+
 /**
  * @defgroup    net_gnrc_mac Common MAC module
  * @ingroup     net_gnrc
@@ -24,9 +27,6 @@
  */
 
 #include "modules.h"
-
-#ifndef NET_GNRC_MAC_MAC_H
-#define NET_GNRC_MAC_MAC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -126,5 +126,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_GNRC_MAC_MAC_H */
 /** @} */
+#endif /* NET_GNRC_MAC_MAC_H */

--- a/sys/include/net/gnrc/mac/timeout.h
+++ b/sys/include/net/gnrc/mac/timeout.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_MAC_TIMEOUT_H
+#define NET_GNRC_MAC_TIMEOUT_H
+
 /**
  * @ingroup     net_gnrc_mac
  * @{
@@ -17,9 +20,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_MAC_TIMEOUT_H
-#define NET_GNRC_MAC_TIMEOUT_H
 
 #include <assert.h>
 #include <stdint.h>
@@ -145,5 +145,5 @@ void gnrc_mac_reset_timeouts(gnrc_mac_timeout_t *mac_timeout);
 }
 #endif
 
-#endif /* NET_GNRC_MAC_TIMEOUT_H */
 /** @} */
+#endif /* NET_GNRC_MAC_TIMEOUT_H */

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_MAC_TYPES_H
+#define NET_GNRC_MAC_TYPES_H
+
 /**
  * @ingroup     net_gnrc_mac
  * @{
@@ -17,9 +20,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_MAC_TYPES_H
-#define NET_GNRC_MAC_TYPES_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -242,5 +242,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_MAC_TYPES_H */
 /** @} */
+#endif /* NET_GNRC_MAC_TYPES_H */

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NDP_H
+#define NET_GNRC_NDP_H
 /**
  * @defgroup    net_gnrc_ndp   IPv6 neighbor discovery (v2)
  * @ingroup     net_gnrc_ipv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NDP_H
-#define NET_GNRC_NDP_H
 
 #include <stdint.h>
 
@@ -415,5 +415,5 @@ void gnrc_ndp_rtr_adv_send(gnrc_netif_t *netif, const ipv6_addr_t *src,
 }
 #endif
 
-#endif /* NET_GNRC_NDP_H */
 /** @} */
+#endif /* NET_GNRC_NDP_H */

--- a/sys/include/net/gnrc/neterr.h
+++ b/sys/include/net/gnrc/neterr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETERR_H
+#define NET_GNRC_NETERR_H
 /**
  * @defgroup    net_gnrc_neterr Error reporting
  * @ingroup     net_gnrc
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETERR_H
-#define NET_GNRC_NETERR_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -88,5 +88,5 @@ static inline int gnrc_neterr_reg(gnrc_pktsnip_t *pkt)
 }
 #endif
 
-#endif /* NET_GNRC_NETERR_H */
 /** @} */
+#endif /* NET_GNRC_NETERR_H */

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_H
+#define NET_GNRC_NETIF_H
 /**
  * @defgroup    net_gnrc_netif Network interface API
  * @ingroup     net_gnrc
@@ -26,8 +28,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_H
-#define NET_GNRC_NETIF_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -774,5 +774,5 @@ bool gnrc_netif_ipv6_wait_for_global_address(gnrc_netif_t *netif,
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_H */

--- a/sys/include/net/gnrc/netif/6lo.h
+++ b/sys/include/net/gnrc/netif/6lo.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_6LO_H
+#define NET_GNRC_NETIF_6LO_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_6LO_H
-#define NET_GNRC_NETIF_6LO_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -72,5 +72,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_6LO_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_6LO_H */

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_CONF_H
+#define NET_GNRC_NETIF_CONF_H
 /**
  * @defgroup    net_gnrc_netif_conf GNRC network interface configurations
  * @ingroup     net_gnrc_netif
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_CONF_H
-#define NET_GNRC_NETIF_CONF_H
 
 #include "modules.h"
 

--- a/sys/include/net/gnrc/netif/dedup.h
+++ b/sys/include/net/gnrc/netif/dedup.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_DEDUP_H
+#define NET_GNRC_NETIF_DEDUP_H
 /**
  * @defgroup    net_gnrc_netif_dedup    Link-layer Broadcast deduplication
  * @ingroup     net_gnrc_netif
@@ -24,8 +26,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_DEDUP_H
-#define NET_GNRC_NETIF_DEDUP_H
 
 #include <stdint.h>
 
@@ -48,5 +48,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_DEDUP_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_DEDUP_H */

--- a/sys/include/net/gnrc/netif/ethernet.h
+++ b/sys/include/net/gnrc/netif/ethernet.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_ETHERNET_H
+#define NET_GNRC_NETIF_ETHERNET_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_ETHERNET_H
-#define NET_GNRC_NETIF_ETHERNET_H
 
 #include "net/gnrc/netif.h"
 
@@ -46,5 +46,5 @@ int gnrc_netif_ethernet_create(gnrc_netif_t *netif, char *stack, int stacksize,
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_ETHERNET_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_ETHERNET_H */

--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_FLAGS_H
+#define NET_GNRC_NETIF_FLAGS_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_FLAGS_H
-#define NET_GNRC_NETIF_FLAGS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -152,5 +152,5 @@ enum {
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_FLAGS_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_FLAGS_H */

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_HDR_H
+#define NET_GNRC_NETIF_HDR_H
+
 /**
  * @defgroup    net_gnrc_netif_hdr Generic network interface header
  * @ingroup     net_gnrc_netif
@@ -17,9 +20,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-
-#ifndef NET_GNRC_NETIF_HDR_H
-#define NET_GNRC_NETIF_HDR_H
 
 #include <errno.h>
 #include <string.h>
@@ -444,5 +444,5 @@ int gnrc_netif_hdr_get_srcaddr(gnrc_pktsnip_t* pkt, uint8_t** pointer_to_addr);
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_HDR_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_HDR_H */

--- a/sys/include/net/gnrc/netif/ieee802154.h
+++ b/sys/include/net/gnrc/netif/ieee802154.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_IEEE802154_H
+#define NET_GNRC_NETIF_IEEE802154_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_IEEE802154_H
-#define NET_GNRC_NETIF_IEEE802154_H
 
 #include "net/gnrc/netif.h"
 
@@ -46,5 +46,5 @@ int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_IEEE802154_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_IEEE802154_H */

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_INTERNAL_H
+#define NET_GNRC_NETIF_INTERNAL_H
 /**
  * @addtogroup  net_gnrc_netif
  * @internal
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_INTERNAL_H
-#define NET_GNRC_NETIF_INTERNAL_H
 
 #include "modules.h"
 

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_IPV6_H
+#define NET_GNRC_NETIF_IPV6_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_IPV6_H
-#define NET_GNRC_NETIF_IPV6_H
 
 #include "modules.h"
 
@@ -261,5 +261,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_IPV6_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_IPV6_H */

--- a/sys/include/net/gnrc/netif/lorawan.h
+++ b/sys/include/net/gnrc/netif/lorawan.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_LORAWAN_H
+#define NET_GNRC_NETIF_LORAWAN_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef NET_GNRC_NETIF_LORAWAN_H
-#define NET_GNRC_NETIF_LORAWAN_H
 
 #include "net/gnrc/lorawan.h"
 
@@ -166,5 +166,5 @@ static inline int gnrc_netif_lorawan_set_nwksenckey(gnrc_netif_lorawan_t *lw_net
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_LORAWAN_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_LORAWAN_H */

--- a/sys/include/net/gnrc/netif/lorawan_base.h
+++ b/sys/include/net/gnrc/netif/lorawan_base.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_LORAWAN_BASE_H
+#define NET_GNRC_NETIF_LORAWAN_BASE_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef NET_GNRC_NETIF_LORAWAN_BASE_H
-#define NET_GNRC_NETIF_LORAWAN_BASE_H
 
 #include "net/gnrc/netif.h"
 
@@ -46,5 +46,5 @@ int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_LORAWAN_BASE_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_LORAWAN_BASE_H */

--- a/sys/include/net/gnrc/netif/mac.h
+++ b/sys/include/net/gnrc/netif/mac.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_MAC_H
+#define NET_GNRC_NETIF_MAC_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_MAC_H
-#define NET_GNRC_NETIF_MAC_H
 
 #include "net/gnrc/mac/types.h"
 #include "net/csma_sender.h"
@@ -110,5 +110,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_MAC_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_MAC_H */

--- a/sys/include/net/gnrc/netif/pktq.h
+++ b/sys/include/net/gnrc/netif/pktq.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_PKTQ_H
+#define NET_GNRC_NETIF_PKTQ_H
 /**
  * @defgroup    net_gnrc_netif_pktq Send queue for @ref net_gnrc_netif
  * @ingroup     net_gnrc_netif
@@ -17,8 +19,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_PKTQ_H
-#define NET_GNRC_NETIF_PKTQ_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -141,5 +141,5 @@ static inline bool gnrc_netif_pktq_empty(gnrc_netif_t *netif)
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_PKTQ_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_PKTQ_H */

--- a/sys/include/net/gnrc/netif/pktq/type.h
+++ b/sys/include/net/gnrc/netif/pktq/type.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_PKTQ_TYPE_H
+#define NET_GNRC_NETIF_PKTQ_TYPE_H
 /**
  * @addtogroup  net_gnrc_netif_pktq
  * @brief
@@ -20,8 +22,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_PKTQ_TYPE_H
-#define NET_GNRC_NETIF_PKTQ_TYPE_H
 
 #include "net/gnrc/pktqueue.h"
 #include "xtimer.h"
@@ -46,5 +46,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_PKTQ_TYPE_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_PKTQ_TYPE_H */

--- a/sys/include/net/gnrc/netif/raw.h
+++ b/sys/include/net/gnrc/netif/raw.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETIF_RAW_H
+#define NET_GNRC_NETIF_RAW_H
 /**
  * @ingroup net_gnrc_netif
  * @{
@@ -16,8 +18,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_NETIF_RAW_H
-#define NET_GNRC_NETIF_RAW_H
 
 #include "net/gnrc/netif.h"
 
@@ -47,5 +47,5 @@ int gnrc_netif_raw_create(gnrc_netif_t *netif, char *stack, int stacksize,
 }
 #endif
 
-#endif /* NET_GNRC_NETIF_RAW_H */
 /** @} */
+#endif /* NET_GNRC_NETIF_RAW_H */

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETREG_H
+#define NET_GNRC_NETREG_H
 /**
  * @defgroup    net_gnrc_netreg  Network protocol registry
  * @ingroup     net_gnrc
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETREG_H
-#define NET_GNRC_NETREG_H
 
 #include <inttypes.h>
 
@@ -435,5 +435,5 @@ int gnrc_netreg_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr);
 }
 #endif
 
-#endif /* NET_GNRC_NETREG_H */
 /** @} */
+#endif /* NET_GNRC_NETREG_H */

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_NETTYPE_H
+#define NET_GNRC_NETTYPE_H
 /**
  * @defgroup    net_gnrc_nettype  gnrc_nettype: Protocol type
  * @ingroup     net_gnrc
@@ -30,8 +32,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_NETTYPE_H
-#define NET_GNRC_NETTYPE_H
 
 #include <inttypes.h>
 
@@ -306,5 +306,5 @@ static inline uint8_t gnrc_nettype_to_protnum(gnrc_nettype_t type)
 }
 #endif
 
-#endif /* NET_GNRC_NETTYPE_H */
 /** @} */
+#endif /* NET_GNRC_NETTYPE_H */

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_PKT_H
+#define NET_GNRC_PKT_H
 /**
  * @defgroup    net_gnrc_pkt Packet
  * @ingroup     net_gnrc_pktbuf
@@ -19,8 +21,6 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-#ifndef NET_GNRC_PKT_H
-#define NET_GNRC_PKT_H
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -293,5 +293,5 @@ gnrc_pktsnip_t *gnrc_pktsnip_search_type(gnrc_pktsnip_t *pkt,
 }
 #endif
 
-#endif /* NET_GNRC_PKT_H */
 /** @} */
+#endif /* NET_GNRC_PKT_H */

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_PKTBUF_H
+#define NET_GNRC_PKTBUF_H
 /**
  * @defgroup    net_gnrc_pktbuf   Packet buffer
  * @ingroup     net_gnrc
@@ -27,8 +29,6 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-#ifndef NET_GNRC_PKTBUF_H
-#define NET_GNRC_PKTBUF_H
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -330,5 +330,5 @@ bool gnrc_pktbuf_is_sane(void);
 }
 #endif
 
-#endif /* NET_GNRC_PKTBUF_H */
 /** @} */
+#endif /* NET_GNRC_PKTBUF_H */

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_PKTDUMP_H
+#define NET_GNRC_PKTDUMP_H
+
 /**
  * @defgroup    net_gnrc_pktdump Dump Network Packets
  * @ingroup     net_gnrc
@@ -18,9 +21,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_GNRC_PKTDUMP_H
-#define NET_GNRC_PKTDUMP_H
 
 #include "sched.h"
 
@@ -88,5 +88,5 @@ kernel_pid_t gnrc_pktdump_init(void);
 }
 #endif
 
-#endif /* NET_GNRC_PKTDUMP_H */
 /** @} */
+#endif /* NET_GNRC_PKTDUMP_H */

--- a/sys/include/net/gnrc/priority_pktqueue.h
+++ b/sys/include/net/gnrc/priority_pktqueue.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_PRIORITY_PKTQUEUE_H
+#define NET_GNRC_PRIORITY_PKTQUEUE_H
+
 /**
  * @defgroup    net_gnrc_priority_pktqueue Priority packet queue for GNRC
  * @ingroup     net_gnrc
@@ -19,9 +22,6 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
  */
-
-#ifndef NET_GNRC_PRIORITY_PKTQUEUE_H
-#define NET_GNRC_PRIORITY_PKTQUEUE_H
 
 #include <stdint.h>
 
@@ -135,5 +135,5 @@ void gnrc_priority_pktqueue_push(gnrc_priority_pktqueue_t *queue,
 }
 #endif
 
-#endif /* NET_GNRC_PRIORITY_PKTQUEUE_H */
 /** @} */
+#endif /* NET_GNRC_PRIORITY_PKTQUEUE_H */

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_RPL_H
+#define NET_GNRC_RPL_H
+
 /**
  * @defgroup    net_gnrc_rpl  RPL
  * @ingroup     net_gnrc
@@ -137,9 +140,6 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
-
-#ifndef NET_GNRC_RPL_H
-#define NET_GNRC_RPL_H
 
 #include <string.h>
 #include <stdint.h>
@@ -761,5 +761,5 @@ void gnrc_rpl_configure_root(gnrc_netif_t *netif, const ipv6_addr_t *dodag_id);
 }
 #endif
 
-#endif /* NET_GNRC_RPL_H */
 /** @} */
+#endif /* NET_GNRC_RPL_H */

--- a/sys/include/net/gnrc/rpl/of_manager.h
+++ b/sys/include/net/gnrc/rpl/of_manager.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_RPL_OF_MANAGER_H
+#define NET_GNRC_RPL_OF_MANAGER_H
+
 /**
  * @ingroup net_gnrc_rpl
  * @{
@@ -15,9 +18,6 @@
  *
  * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
  */
-
-#ifndef NET_GNRC_RPL_OF_MANAGER_H
-#define NET_GNRC_RPL_OF_MANAGER_H
 
 #include "structs.h"
 
@@ -41,5 +41,5 @@ gnrc_rpl_of_t *gnrc_rpl_get_of_for_ocp(uint16_t ocp);
 }
 #endif
 
-#endif /* NET_GNRC_RPL_OF_MANAGER_H */
 /** @} */
+#endif /* NET_GNRC_RPL_OF_MANAGER_H */

--- a/sys/include/net/gnrc/rpl/p2p.h
+++ b/sys/include/net/gnrc/rpl/p2p.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_RPL_P2P_H
+#define NET_GNRC_RPL_P2P_H
 /**
  * @defgroup    net_gnrc_rpl_p2p Reactive Discovery of P2P Routes in LLNs
  * @ingroup     net_gnrc_rpl
@@ -20,8 +22,6 @@
  *
  * @author  Cenk Gündoğan <mail@cgundogan.de>
  */
-#ifndef NET_GNRC_RPL_P2P_H
-#define NET_GNRC_RPL_P2P_H
 
 #include "net/ipv6/addr.h"
 #include "net/gnrc.h"
@@ -176,5 +176,5 @@ void gnrc_rpl_p2p_update(void);
 }
 #endif
 
-#endif /* NET_GNRC_RPL_P2P_H */
 /** @} */
+#endif /* NET_GNRC_RPL_P2P_H */

--- a/sys/include/net/gnrc/rpl/rpble.h
+++ b/sys/include/net/gnrc/rpl/rpble.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_RPL_RPBLE_H
+#define NET_GNRC_RPL_RPBLE_H
+
 /**
  * @ingroup     net_gnrc_rpl
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_GNRC_RPL_RPBLE_H
-#define NET_GNRC_RPL_RPBLE_H
 
 #include <string.h>
 #if IS_USED(MODULE_NIMBLE_RPBLE)
@@ -51,5 +51,5 @@ static inline void gnrc_rpl_rpble_update(const gnrc_rpl_dodag_t *dodag)
 }
 #endif
 
-#endif /* NET_GNRC_RPL_RPBLE_H */
 /** @} */
+#endif /* NET_GNRC_RPL_RPBLE_H */

--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_RPL_SRH_H
+#define NET_GNRC_RPL_SRH_H
 /**
  * @defgroup    net_gnrc_rpl_srh RPL source routing header extension
  * @ingroup     net_gnrc_rpl
@@ -20,8 +22,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_RPL_SRH_H
-#define NET_GNRC_RPL_SRH_H
 
 #include "net/ipv6/hdr.h"
 #include "net/ipv6/addr.h"
@@ -73,5 +73,5 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh, void **err_ptr);
 }
 #endif
 
-#endif /* NET_GNRC_RPL_SRH_H */
 /** @} */
+#endif /* NET_GNRC_RPL_SRH_H */

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_RPL_STRUCTS_H
+#define NET_GNRC_RPL_STRUCTS_H
+
 /**
  * @ingroup net_gnrc_rpl
  * @{
@@ -20,9 +23,6 @@
  * @author      Eric Engel <eric.engel@fu-berlin.de>
  * @author      Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
-
-#ifndef NET_GNRC_RPL_STRUCTS_H
-#define NET_GNRC_RPL_STRUCTS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_H
+#define NET_GNRC_SIXLOWPAN_H
 /**
  * @defgroup    net_gnrc_sixlowpan    6LoWPAN
  * @ingroup     net_gnrc
@@ -132,8 +134,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_H
-#define NET_GNRC_SIXLOWPAN_H
 
 #include <stdbool.h>
 
@@ -166,5 +166,5 @@ kernel_pid_t gnrc_sixlowpan_init(void);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_H */

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_CONFIG_H
+#define NET_GNRC_SIXLOWPAN_CONFIG_H
 /**
  * @defgroup    net_gnrc_sixlowpan_config GNRC 6LoWPAN compile configurations
  * @ingroup     net_gnrc_sixlowpan
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_CONFIG_H
-#define NET_GNRC_SIXLOWPAN_CONFIG_H
 
 #include "modules.h"
 #include "timex.h"
@@ -411,5 +411,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_CONFIG_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_CONFIG_H */

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_CTX_H
+#define NET_GNRC_SIXLOWPAN_CTX_H
 /**
  * @defgroup    net_gnrc_sixlowpan_ctx    Contexts for 6LoWPAN address compression
  * @ingroup     net_gnrc_sixlowpan
@@ -23,8 +25,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_CTX_H
-#define NET_GNRC_SIXLOWPAN_CTX_H
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -200,5 +200,5 @@ void gnrc_sixlowpan_ctx_reset(void);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_CTX_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_CTX_H */

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_H
+#define NET_GNRC_SIXLOWPAN_FRAG_H
 /**
  * @defgroup    net_gnrc_sixlowpan_frag   6LoWPAN Fragmentation
  * @ingroup     net_gnrc_sixlowpan
@@ -22,8 +24,6 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_H
-#define NET_GNRC_SIXLOWPAN_FRAG_H
 
 #include <inttypes.h>
 
@@ -71,5 +71,5 @@ void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/fb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/fb.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_FB_H
+#define NET_GNRC_SIXLOWPAN_FRAG_FB_H
 /**
  * @defgroup net_gnrc_sixlowpan_frag_fb 6LoWPAN fragmentation buffer
  * @ingroup  net_gnrc_sixlowpan_frag
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_FB_H
-#define NET_GNRC_SIXLOWPAN_FRAG_FB_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -139,5 +139,5 @@ static inline bool gnrc_sixlowpan_frag_fb_send(gnrc_sixlowpan_frag_fb_t *fbuf)
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_FB_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_FB_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/hint.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/hint.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_HINT_H
+#define NET_GNRC_SIXLOWPAN_FRAG_HINT_H
 /**
  * @defgroup    net_gnrc_sixlowpan_frag_hint    Fragment size hint
  * @ingroup     net_gnrc_sixlowpan_frag
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_HINT_H
-#define NET_GNRC_SIXLOWPAN_FRAG_HINT_H
 
 #include <stdint.h>
 
@@ -55,5 +55,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_HINT_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_HINT_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/minfwd.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/minfwd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_MINFWD_H
+#define NET_GNRC_SIXLOWPAN_FRAG_MINFWD_H
 /**
  * @defgroup    net_gnrc_sixlowpan_frag_minfwd  Minimal fragment forwarding
  * @ingroup     net_gnrc_sixlowpan_frag
@@ -20,8 +22,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_MINFWD_H
-#define NET_GNRC_SIXLOWPAN_FRAG_MINFWD_H
 
 #include <stddef.h>
 
@@ -96,5 +96,5 @@ int gnrc_sixlowpan_frag_minfwd_frag_iphc(gnrc_pktsnip_t *pkt,
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_MINFWD_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_MINFWD_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_RB_H
+#define NET_GNRC_SIXLOWPAN_FRAG_RB_H
 /**
  * @defgroup net_gnrc_sixlowpan_frag_rb 6LoWPAN reassembly buffer
  * @ingroup  net_gnrc_sixlowpan_frag
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_RB_H
-#define NET_GNRC_SIXLOWPAN_FRAG_RB_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -316,5 +316,5 @@ static inline bool gnrc_sixlowpan_frag_rb_ints_empty(void)
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_RB_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_RB_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_SFR_H
+#define NET_GNRC_SIXLOWPAN_FRAG_SFR_H
 /**
  * @defgroup    net_gnrc_sixlowpan_frag_sfr  6LoWPAN selective fragment recovery
  * @ingroup     net_gnrc_sixlowpan
@@ -31,8 +33,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_SFR_H
-#define NET_GNRC_SIXLOWPAN_FRAG_SFR_H
 
 #include "assert.h"
 #include "bitfield.h"
@@ -203,5 +203,5 @@ void gnrc_sixlowpan_frag_sfr_stats_get(gnrc_sixlowpan_frag_sfr_stats_t *stats);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_SFR_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_SFR_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_SFR_CONGURE_H
+#define NET_GNRC_SIXLOWPAN_FRAG_SFR_CONGURE_H
 /**
  * @defgroup net_gnrc_sixlowpan_frag_sfr_congure Congestion control for 6LoWPAN SFR
  * @ingroup net_gnrc_sixlowpan_frag_sfr
@@ -26,8 +28,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_SFR_CONGURE_H
-#define NET_GNRC_SIXLOWPAN_FRAG_SFR_CONGURE_H
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -427,5 +427,5 @@ static inline void gnrc_sixlowpan_frag_sfr_congure_snd_report_ecn(
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_SFR_CONGURE_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_SFR_CONGURE_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr_types.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_SFR_TYPES_H
+#define NET_GNRC_SIXLOWPAN_FRAG_SFR_TYPES_H
 /**
  * @addtogroup  net_gnrc_sixlowpan_frag_sfr
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_SFR_TYPES_H
-#define NET_GNRC_SIXLOWPAN_FRAG_SFR_TYPES_H
 
 #include <stdint.h>
 
@@ -64,5 +64,5 @@ typedef struct gnrc_sixlowpan_frag_sfr_fb {
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_SFR_TYPES_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_SFR_TYPES_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/stats.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/stats.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_STATS_H
+#define NET_GNRC_SIXLOWPAN_FRAG_STATS_H
 /**
  * @defgroup    net_gnrc_sixlowpan_frag_stats Fragmentation and reassembly statistics
  * @ingroup     net_gnrc_sixlowpan_frag
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_STATS_H
-#define NET_GNRC_SIXLOWPAN_FRAG_STATS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,5 +53,5 @@ gnrc_sixlowpan_frag_stats_t *gnrc_sixlowpan_frag_stats_get(void);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_STATS_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_STATS_H */

--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_VRB_H
+#define NET_GNRC_SIXLOWPAN_FRAG_VRB_H
 /**
  * @defgroup    net_gnrc_sixlowpan_frag_vrb Virtual reassembly buffer
  * @ingroup     net_gnrc_sixlowpan_frag
@@ -18,8 +20,6 @@
  *
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_FRAG_VRB_H
-#define NET_GNRC_SIXLOWPAN_FRAG_VRB_H
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -180,5 +180,5 @@ void gnrc_sixlowpan_frag_vrb_reset(void);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_FRAG_VRB_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_VRB_H */

--- a/sys/include/net/gnrc/sixlowpan/internal.h
+++ b/sys/include/net/gnrc/sixlowpan/internal.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_INTERNAL_H
+#define NET_GNRC_SIXLOWPAN_INTERNAL_H
 /**
  * @ingroup net_gnrc_sixlowpan
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_INTERNAL_H
-#define NET_GNRC_SIXLOWPAN_INTERNAL_H
 
 #include <stddef.h>
 
@@ -73,5 +73,5 @@ void gnrc_sixlowpan_multiplex_by_size(gnrc_pktsnip_t *pkt,
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_INTERNAL_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_INTERNAL_H */

--- a/sys/include/net/gnrc/sixlowpan/iphc.h
+++ b/sys/include/net/gnrc/sixlowpan/iphc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_IPHC_H
+#define NET_GNRC_SIXLOWPAN_IPHC_H
 /**
  * @defgroup    net_gnrc_sixlowpan_iphc   IPv6 header compression (IPHC)
  * @ingroup     net_gnrc_sixlowpan
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_IPHC_H
-#define NET_GNRC_SIXLOWPAN_IPHC_H
 
 #include <stdbool.h>
 
@@ -67,5 +67,5 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page);
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_IPHC_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_IPHC_H */

--- a/sys/include/net/gnrc/sixlowpan/nd.h
+++ b/sys/include/net/gnrc/sixlowpan/nd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_SIXLOWPAN_ND_H
+#define NET_GNRC_SIXLOWPAN_ND_H
 /**
  * @defgroup    net_gnrc_sixlowpan_nd 6LoWPAN neighbor discovery
  * @ingroup     net_gnrc_sixlowpan
@@ -20,8 +22,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_GNRC_SIXLOWPAN_ND_H
-#define NET_GNRC_SIXLOWPAN_ND_H
 
 #include <stdint.h>
 
@@ -83,5 +83,5 @@ gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_abr_build(uint32_t version, uint16_t ltime
 }
 #endif
 
-#endif /* NET_GNRC_SIXLOWPAN_ND_H */
 /** @} */
+#endif /* NET_GNRC_SIXLOWPAN_ND_H */

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_TCP_H
+#define NET_GNRC_TCP_H
+
 /**
  * @defgroup    net_gnrc_tcp TCP
  * @ingroup     net_gnrc
@@ -18,9 +21,6 @@
  *
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
-
-#ifndef NET_GNRC_TCP_H
-#define NET_GNRC_TCP_H
 
 #include <stdint.h>
 #include "net/gnrc/pkt.h"
@@ -371,5 +371,5 @@ gnrc_pktsnip_t *gnrc_tcp_hdr_build(gnrc_pktsnip_t *payload, uint16_t src, uint16
 }
 #endif
 
-#endif /* NET_GNRC_TCP_H */
 /** @} */
+#endif /* NET_GNRC_TCP_H */

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_TCP_CONFIG_H
+#define NET_GNRC_TCP_CONFIG_H
+
 /**
  * @ingroup     net_gnrc_tcp
  *
@@ -16,9 +19,6 @@
  *
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
-
-#ifndef NET_GNRC_TCP_CONFIG_H
-#define NET_GNRC_TCP_CONFIG_H
 
 #include "timex.h"
 
@@ -211,5 +211,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_GNRC_TCP_CONFIG_H */
 /** @} */
+#endif /* NET_GNRC_TCP_CONFIG_H */

--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_TCP_TCB_H
+#define NET_GNRC_TCP_TCB_H
+
 /**
  * @ingroup     net_gnrc_tcp
  *
@@ -16,9 +19,6 @@
  *
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
-
-#ifndef NET_GNRC_TCP_TCB_H
-#define NET_GNRC_TCP_TCB_H
 
 #include <stdint.h>
 #include "ringbuffer.h"
@@ -96,5 +96,5 @@ typedef struct sock_tcp_queue {
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_GNRC_TCP_TCB_H */
 /** @} */
+#endif /* NET_GNRC_TCP_TCB_H */

--- a/sys/include/net/gnrc/tx_sync.h
+++ b/sys/include/net/gnrc/tx_sync.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_TX_SYNC_H
+#define NET_GNRC_TX_SYNC_H
 /**
  * @defgroup    net_gnrc_tx_sync    Helpers for synchronizing with transmission.
  * @ingroup     net_gnrc
@@ -18,8 +20,6 @@
  *
  * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-#ifndef NET_GNRC_TX_SYNC_H
-#define NET_GNRC_TX_SYNC_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -135,5 +135,5 @@ static inline void gnrc_tx_sync(gnrc_tx_sync_t *sync)
 }
 #endif
 
-#endif /* NET_GNRC_TX_SYNC_H */
 /** @} */
+#endif /* NET_GNRC_TX_SYNC_H */

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_GNRC_UDP_H
+#define NET_GNRC_UDP_H
+
 /**
  * @defgroup    net_gnrc_udp UDP
  * @ingroup     net_gnrc
@@ -18,9 +21,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_GNRC_UDP_H
-#define NET_GNRC_UDP_H
 
 #include <stdint.h>
 
@@ -115,5 +115,5 @@ int gnrc_udp_init(void);
 }
 #endif
 
-#endif /* NET_GNRC_UDP_H */
 /** @} */
+#endif /* NET_GNRC_UDP_H */

--- a/sys/include/net/iana/portrange.h
+++ b/sys/include/net/iana/portrange.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IANA_PORTRANGE_H
+#define NET_IANA_PORTRANGE_H
 /**
  * @defgroup    net_iana_portrange  IANA Port Ranges
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  smlng <s@mlng.net>,
  */
-#ifndef NET_IANA_PORTRANGE_H
-#define NET_IANA_PORTRANGE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,5 +43,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_IANA_PORTRANGE_H */
 /** @} */
+#endif /* NET_IANA_PORTRANGE_H */

--- a/sys/include/net/icmp.h
+++ b/sys/include/net/icmp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_ICMP_H
+#define NET_ICMP_H
 /**
  * @defgroup    net_icmp  ICMPV4
  * @ingroup     net_ipv4
@@ -20,8 +22,6 @@
  *
  * @author  José Ignacio Alamos <jialamos@uc.cl>
  */
-#ifndef NET_ICMP_H
-#define NET_ICMP_H
 
 #include "byteorder.h"
 
@@ -48,5 +48,5 @@ typedef struct __attribute__((packed)){
 }
 #endif
 
-#endif /* NET_ICMP_H */
 /** @} */
+#endif /* NET_ICMP_H */

--- a/sys/include/net/icmpv6.h
+++ b/sys/include/net/icmpv6.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_ICMPV6_H
+#define NET_ICMPV6_H
 /**
  * @defgroup    net_icmpv6  ICMPV6
  * @ingroup     net_ipv6
@@ -20,8 +22,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_ICMPV6_H
-#define NET_ICMPV6_H
 
 #include <stdint.h>
 
@@ -231,5 +231,5 @@ void icmpv6_hdr_print(icmpv6_hdr_t *hdr);
 }
 #endif
 
-#endif /* NET_ICMPV6_H */
 /** @} */
+#endif /* NET_ICMPV6_H */

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_IEEE802154_H
+#define NET_IEEE802154_H
+
 /**
  * @defgroup    net_ieee802154_header IEEE 802.15.4 frame headers and definitions
  * @ingroup     net_ieee802154
@@ -17,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_IEEE802154_H
-#define NET_IEEE802154_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -794,5 +794,5 @@ static inline uint8_t ieee802154_dbm_to_rssi(int16_t dbm)
 }
 #endif
 
-#endif /* NET_IEEE802154_H */
 /** @} */
+#endif /* NET_IEEE802154_H */

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef NET_IEEE802154_RADIO_H
+#define NET_IEEE802154_RADIO_H
+
 /**
  * @defgroup     drivers_ieee802154_hal IEEE802.15.4 Radio Hardware Abstraction Layer
  * @ingroup      drivers
@@ -18,9 +21,6 @@
  *
  * @author       José I. Alamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef NET_IEEE802154_RADIO_H
-#define NET_IEEE802154_RADIO_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -1647,5 +1647,5 @@ static inline ieee802154_phy_mode_t ieee802154_cap_to_phy_mode(uint32_t cap)
 }
 #endif
 
-#endif /* NET_IEEE802154_RADIO_H */
 /** @} */
+#endif /* NET_IEEE802154_RADIO_H */

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#ifndef NET_IEEE802154_SUBMAC_H
+#define NET_IEEE802154_SUBMAC_H
 /**
  * @defgroup     net_ieee802154_submac IEEE802.15.4 SubMAC layer
  * @ingroup      net_ieee802154
@@ -104,8 +106,6 @@
  *
  * @author       José I. Alamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef NET_IEEE802154_SUBMAC_H
-#define NET_IEEE802154_SUBMAC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -612,5 +612,5 @@ static inline void ieee802154_submac_tx_done_cb(ieee802154_submac_t *submac)
 }
 #endif
 
-#endif /* NET_IEEE802154_SUBMAC_H */
 /** @} */
+#endif /* NET_IEEE802154_SUBMAC_H */

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_IEEE802154_SECURITY_H
+#define NET_IEEE802154_SECURITY_H
+
 /**
  * @defgroup    net_ieee802154_security  IEEE 802.15.4 security
  * @ingroup     net_ieee802154
@@ -26,9 +29,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-
-#ifndef NET_IEEE802154_SECURITY_H
-#define NET_IEEE802154_SECURITY_H
 
 #include <stdint.h>
 #include "ieee802154.h"
@@ -439,5 +439,5 @@ extern const ieee802154_radio_cipher_ops_t ieee802154_radio_cipher_ops;
 }
 #endif
 
-#endif /* NET_IEEE802154_SECURITY_H */
 /** @} */
+#endif /* NET_IEEE802154_SECURITY_H */

--- a/sys/include/net/inet_csum.h
+++ b/sys/include/net/inet_csum.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_INET_CSUM_H
+#define NET_INET_CSUM_H
 /**
  * @defgroup    net_inet_csum    Internet Checksum
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_INET_CSUM_H
-#define NET_INET_CSUM_H
 
 #include <inttypes.h>
 #include <stddef.h>
@@ -77,5 +77,5 @@ static inline uint16_t inet_csum(uint16_t sum, const uint8_t *buf, uint16_t len)
 }
 #endif
 
-#endif /* NET_INET_CSUM_H */
 /** @} */
+#endif /* NET_INET_CSUM_H */

--- a/sys/include/net/ipv4.h
+++ b/sys/include/net/ipv4.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV4_H
+#define NET_IPV4_H
 /**
  * @defgroup    net_ipv4    IPv4
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_IPV4_H
-#define NET_IPV4_H
 
 #include "net/ipv4/addr.h"
 
@@ -30,5 +30,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_IPV4_H */
 /** @} */
+#endif /* NET_IPV4_H */

--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV4_ADDR_H
+#define NET_IPV4_ADDR_H
 /**
  * @defgroup    net_ipv4_addr   IPv4 addresses
  * @ingroup     net_ipv4
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_IPV4_ADDR_H
-#define NET_IPV4_ADDR_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -141,5 +141,5 @@ void ipv4_addr_print(const ipv4_addr_t *addr);
 }
 #endif
 
-#endif /* NET_IPV4_ADDR_H */
 /** @} */
+#endif /* NET_IPV4_ADDR_H */

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV4_HDR_H
+#define NET_IPV4_HDR_H
 /**
  * @defgroup    net_ipv4_hdr    IPv4 header
  * @ingroup     net_ipv4
@@ -17,8 +19,6 @@
  *
  * @author  José Ignacio Alamos <jialamos@uc.cl>
  */
-#ifndef NET_IPV4_HDR_H
-#define NET_IPV4_HDR_H
 
 #include "byteorder.h"
 #include "net/ipv4/addr.h"
@@ -190,5 +190,5 @@ static inline uint16_t ipv4_hdr_get_fo(ipv4_hdr_t *hdr)
 }
 #endif
 
-#endif /* NET_IPV4_HDR_H */
 /** @} */
+#endif /* NET_IPV4_HDR_H */

--- a/sys/include/net/ipv6.h
+++ b/sys/include/net/ipv6.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV6_H
+#define NET_IPV6_H
 /**
  * @defgroup    net_ipv6    IPv6
  * @ingroup     net
@@ -19,8 +21,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_IPV6_H
-#define NET_IPV6_H
 
 #include "net/ipv6/addr.h"
 #include "net/ipv6/ext.h"
@@ -41,5 +41,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_IPV6_H */
 /** @} */
+#endif /* NET_IPV6_H */

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_IPV6_ADDR_H
+#define NET_IPV6_ADDR_H
+
 /**
  * @defgroup    net_ipv6_addr    IPv6 addresses
  * @ingroup     net_ipv6
@@ -22,9 +25,6 @@
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-
-#ifndef NET_IPV6_ADDR_H
-#define NET_IPV6_ADDR_H
 
 #include <stdbool.h>
 #include <string.h>

--- a/sys/include/net/ipv6/ext.h
+++ b/sys/include/net/ipv6/ext.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV6_EXT_H
+#define NET_IPV6_EXT_H
 /**
  * @defgroup    net_ipv6_ext    IPv6 extension headers
  * @ingroup     net_ipv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_IPV6_EXT_H
-#define NET_IPV6_EXT_H
 
 #include <stdint.h>
 
@@ -59,5 +59,5 @@ static inline ipv6_ext_t *ipv6_ext_get_next(ipv6_ext_t *ext)
 }
 #endif
 
-#endif /* NET_IPV6_EXT_H */
 /** @} */
+#endif /* NET_IPV6_EXT_H */

--- a/sys/include/net/ipv6/ext/frag.h
+++ b/sys/include/net/ipv6/ext/frag.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV6_EXT_FRAG_H
+#define NET_IPV6_EXT_FRAG_H
 /**
  * @defgroup    net_ipv6_ext_frag   IPv6 fragmentation extension
  * @ingroup     net_ipv6_ext
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_IPV6_EXT_FRAG_H
-#define NET_IPV6_EXT_FRAG_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -115,5 +115,5 @@ static inline void ipv6_ext_frag_set_more(ipv6_ext_frag_t *frag)
 }
 #endif
 
-#endif /* NET_IPV6_EXT_FRAG_H */
 /** @} */
+#endif /* NET_IPV6_EXT_FRAG_H */

--- a/sys/include/net/ipv6/ext/opt.h
+++ b/sys/include/net/ipv6/ext/opt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV6_EXT_OPT_H
+#define NET_IPV6_EXT_OPT_H
 /**
  * @defgroup    net_ipv6_ext_opt IPv6 destination and hop-by-hop options
  * @ingroup     net_ipv6_ext
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_IPV6_EXT_OPT_H
-#define NET_IPV6_EXT_OPT_H
 
 #include <stdint.h>
 
@@ -92,5 +92,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_IPV6_EXT_OPT_H */
 /** @} */
+#endif /* NET_IPV6_EXT_OPT_H */

--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV6_EXT_RH_H
+#define NET_IPV6_EXT_RH_H
 /**
  * @defgroup    net_ipv6_ext_rh IPv6 routing header extension
  * @ingroup     net_ipv6_ext
@@ -19,8 +21,6 @@
  * @author  Cenk Gündoğan <cnkgndgn@gmail.com>
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_IPV6_EXT_RH_H
-#define NET_IPV6_EXT_RH_H
 
 #include <stdint.h>
 
@@ -74,5 +74,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NET_IPV6_EXT_RH_H */
 /** @} */
+#endif /* NET_IPV6_EXT_RH_H */

--- a/sys/include/net/ipv6/hdr.h
+++ b/sys/include/net/ipv6/hdr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_IPV6_HDR_H
+#define NET_IPV6_HDR_H
 /**
  * @defgroup    net_ipv6_hdr    IPv6 header
  * @ingroup     net_ipv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_IPV6_HDR_H
-#define NET_IPV6_HDR_H
 
 #include <stdint.h>
 
@@ -303,5 +303,5 @@ void ipv6_hdr_print(ipv6_hdr_t *hdr);
 }
 #endif
 
-#endif /* NET_IPV6_HDR_H */
 /** @} */
+#endif /* NET_IPV6_HDR_H */

--- a/sys/include/net/l2filter.h
+++ b/sys/include/net/l2filter.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_L2FILTER_H
+#define NET_L2FILTER_H
+
 /**
  * @experimental
  * @defgroup    net_l2filter Link layer address filter
@@ -28,9 +31,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_L2FILTER_H
-#define NET_L2FILTER_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -132,5 +132,5 @@ bool l2filter_pass(const l2filter_t *list, const void *addr, size_t addr_len);
 }
 #endif
 
-#endif /* NET_L2FILTER_H */
 /** @} */
+#endif /* NET_L2FILTER_H */

--- a/sys/include/net/l2scan_list.h
+++ b/sys/include/net/l2scan_list.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_L2SCAN_LIST_H
+#define NET_L2SCAN_LIST_H
+
 /**
  * @defgroup    net_l2scanlist   Scan List - List of wireless access points
  * @ingroup     net
@@ -18,9 +21,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
  */
-
-#ifndef NET_L2SCAN_LIST_H
-#define NET_L2SCAN_LIST_H
 
 #include <stdlib.h>
 
@@ -83,5 +83,5 @@ unsigned l2scan_list_to_array(const l2scan_list_t *list,
 }
 #endif
 
-#endif /* NET_L2SCAN_LIST_H */
 /** @} */
+#endif /* NET_L2SCAN_LIST_H */

--- a/sys/include/net/l2util.h
+++ b/sys/include/net/l2util.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_L2UTIL_H
+#define NET_L2UTIL_H
 /**
  * @defgroup    net_l2util Stack-independent helpers for IPv6 over X
  * @ingroup     net
@@ -22,8 +24,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_L2UTIL_H
-#define NET_L2UTIL_H
 
 #include <stdint.h>
 
@@ -214,5 +214,5 @@ static inline bool l2util_addr_equal(const uint8_t *addr_a, uint8_t addr_a_len,
 }
 #endif
 
-#endif /* NET_L2UTIL_H */
 /** @} */
+#endif /* NET_L2UTIL_H */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_LORA_H
+#define NET_LORA_H
+
 /**
  * @defgroup    net_lora LoRa modulation
  * @ingroup     net
@@ -17,9 +20,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef NET_LORA_H
-#define NET_LORA_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -282,5 +282,5 @@ enum {
 }
 #endif
 
-#endif /* NET_LORA_H */
 /** @} */
+#endif /* NET_LORA_H */

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_LORAMAC_H
+#define NET_LORAMAC_H
+
 /**
  * @defgroup    net_loramac LoRaMAC
  * @ingroup     net
@@ -18,9 +21,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef NET_LORAMAC_H
-#define NET_LORAMAC_H
 
 #include <assert.h>
 #include <stdint.h>

--- a/sys/include/net/lorawan/hdr.h
+++ b/sys/include/net/lorawan/hdr.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_LORAWAN_HDR_H
+#define NET_LORAWAN_HDR_H
+
 /**
  * @defgroup    net_lorawan_hdr    LoRaWAN header
  * @ingroup     net_lorawan
@@ -18,9 +21,6 @@
  *
  * @author  Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef NET_LORAWAN_HDR_H
-#define NET_LORAWAN_HDR_H
 
 #include <stdio.h>
 #include <stdint.h>
@@ -297,5 +297,5 @@ static inline bool lorawan_ja_hdr_get_optneg(lorawan_join_accept_t *ja_hdr)
 }
 #endif
 
-#endif /* NET_LORAWAN_HDR_H */
 /** @} */
+#endif /* NET_LORAWAN_HDR_H */

--- a/sys/include/net/mqttsn.h
+++ b/sys/include/net/mqttsn.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_MQTTSN_H
+#define NET_MQTTSN_H
+
 /**
  * @defgroup    net_mqttsn MQTT-SN Defines
  * @ingroup     net
@@ -19,9 +22,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_MQTTSN_H
-#define NET_MQTTSN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,5 +110,5 @@ enum {
 }
 #endif
 
-#endif /* NET_MQTTSN_H */
 /** @} */
+#endif /* NET_MQTTSN_H */

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -9,6 +9,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_H
+#define NET_NANOCOAP_H
+
 /**
  * @defgroup    net_nanocoap nanoCoAP small CoAP library
  * @ingroup     net
@@ -73,9 +76,6 @@
  * @author      Ken Bannister <kb2ma@runbox.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_NANOCOAP_H
-#define NET_NANOCOAP_H
 
 #include <assert.h>
 #include <errno.h>
@@ -2443,5 +2443,5 @@ static inline uint32_t coap_get_observe(coap_pkt_t *pkt)
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_NANOCOAP_H */
 /** @} */
+#endif /* NET_NANOCOAP_H */

--- a/sys/include/net/nanocoap/cache.h
+++ b/sys/include/net/nanocoap/cache.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_CACHE_H
+#define NET_NANOCOAP_CACHE_H
+
 /**
  * @defgroup    net_nanocoap_cache nanoCoAP-Cache implementation
  * @ingroup     net_nanocoap
@@ -18,9 +21,6 @@
  *
  * @author      Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
-
-#ifndef NET_NANOCOAP_CACHE_H
-#define NET_NANOCOAP_CACHE_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -269,5 +269,5 @@ static inline bool nanocoap_cache_entry_is_stale(const nanocoap_cache_entry_t *c
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_NANOCOAP_CACHE_H */
 /** @} */
+#endif /* NET_NANOCOAP_CACHE_H */

--- a/sys/include/net/nanocoap/fileserver.h
+++ b/sys/include/net/nanocoap/fileserver.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_FILESERVER_H
+#define NET_NANOCOAP_FILESERVER_H
+
 /**
  * @defgroup    net_nanocoap_fileserver CoAP file server
  * @ingroup     net_nanocoap
@@ -74,9 +77,6 @@
  *
  * @author      chrysn <chrysn@fsfe.org>
  */
-
-#ifndef NET_NANOCOAP_FILESERVER_H
-#define NET_NANOCOAP_FILESERVER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -156,6 +156,6 @@ ssize_t nanocoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 }
 #endif
 
-#endif /* NET_NANOCOAP_FILESERVER_H */
-
 /** @} */
+
+#endif /* NET_NANOCOAP_FILESERVER_H */

--- a/sys/include/net/nanocoap/fs.h
+++ b/sys/include/net/nanocoap/fs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_FS_H
+#define NET_NANOCOAP_FS_H
 /**
  * @ingroup     net_nanosock
  * @brief       nanoCoAP virtual file system
@@ -16,8 +18,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef NET_NANOCOAP_FS_H
-#define NET_NANOCOAP_FS_H
 
 #include "mutex.h"
 #include "net/nanocoap_sock.h"
@@ -63,5 +63,5 @@ extern const vfs_file_system_t nanocoap_fs_file_system;
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_NANOCOAP_FS_H */
 /** @} */
+#endif /* NET_NANOCOAP_FS_H */

--- a/sys/include/net/nanocoap/link_format.h
+++ b/sys/include/net/nanocoap/link_format.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_LINK_FORMAT_H
+#define NET_NANOCOAP_LINK_FORMAT_H
 /**
  * @ingroup     net_nanosock
  * @brief       NanoCoAP Link Format helper functions
@@ -18,8 +20,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef NET_NANOCOAP_LINK_FORMAT_H
-#define NET_NANOCOAP_LINK_FORMAT_H
 
 #include "net/nanocoap_sock.h"
 
@@ -68,5 +68,5 @@ int nanocoap_link_format_get_url(const char *url,
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_NANOCOAP_LINK_FORMAT_H */
 /** @} */
+#endif /* NET_NANOCOAP_LINK_FORMAT_H */

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_SOCK_H
+#define NET_NANOCOAP_SOCK_H
+
 /**
  * @defgroup    net_nanosock nanoCoAP Sock
  * @ingroup     net
@@ -134,9 +137,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef NET_NANOCOAP_SOCK_H
-#define NET_NANOCOAP_SOCK_H
 
 #include <stdint.h>
 #include <unistd.h>
@@ -972,5 +972,5 @@ int nanocoap_sock_block_request(coap_block_request_t *ctx,
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_NANOCOAP_SOCK_H */
 /** @} */
+#endif /* NET_NANOCOAP_SOCK_H */

--- a/sys/include/net/nanocoap_vfs.h
+++ b/sys/include/net/nanocoap_vfs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NANOCOAP_VFS_H
+#define NET_NANOCOAP_VFS_H
 /**
  * @ingroup     net_nanosock
  * @brief       VFS NanoCoAP helper functions
@@ -17,8 +19,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef NET_NANOCOAP_VFS_H
-#define NET_NANOCOAP_VFS_H
 
 #include "net/nanocoap_sock.h"
 
@@ -85,5 +85,5 @@ int nanocoap_vfs_put(nanocoap_sock_t *sock, const char *path, const char *src,
 #ifdef __cplusplus
 }
 #endif
-#endif /* NET_NANOCOAP_VFS_H */
 /** @} */
+#endif /* NET_NANOCOAP_VFS_H */

--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NDP_H
+#define NET_NDP_H
 /**
  * @defgroup    net_ndp IPv6 neighbor discovery
  * @ingroup     net_ipv6
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_NDP_H
-#define NET_NDP_H
 
 #include <stdint.h>
 
@@ -396,5 +396,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NET_NDP_H */
 /** @} */
+#endif /* NET_NDP_H */

--- a/sys/include/net/netdev_test.h
+++ b/sys/include/net/netdev_test.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NETDEV_TEST_H
+#define NET_NETDEV_TEST_H
 /**
  * @defgroup    sys_netdev_test    netdev dummy test driver
  * @ingroup     drivers_netdev
@@ -75,8 +77,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_NETDEV_TEST_H
-#define NET_NETDEV_TEST_H
 
 #include "mutex.h"
 
@@ -291,5 +291,5 @@ void netdev_test_reset(netdev_test_t *dev);
 }
 #endif
 
-#endif /* NET_NETDEV_TEST_H */
 /** @} */
+#endif /* NET_NETDEV_TEST_H */

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef NET_NETIF_H
+#define NET_NETIF_H
 /**
  * @defgroup    net_netif   Network interfaces
  * @ingroup     net
@@ -30,8 +32,6 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @author  José Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef NET_NETIF_H
-#define NET_NETIF_H
 
 #include <stdint.h>
 #include <string.h>
@@ -265,5 +265,5 @@ void netifs_print_ipv6(const char *separator);
 }
 #endif
 
-#endif /* NET_NETIF_H */
 /** @} */
+#endif /* NET_NETIF_H */

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NETOPT_H
+#define NET_NETOPT_H
+
 /**
  * @defgroup    net_netopt   Netopt - Configuration options for network APIs
  * @ingroup     net
@@ -21,9 +24,6 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef NET_NETOPT_H
-#define NET_NETOPT_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -1085,5 +1085,5 @@ const char *netopt2str(netopt_t opt);
 }
 #endif
 
-#endif /* NET_NETOPT_H */
 /** @} */
+#endif /* NET_NETOPT_H */

--- a/sys/include/net/netstats.h
+++ b/sys/include/net/netstats.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NETSTATS_H
+#define NET_NETSTATS_H
+
 /**
  * @defgroup    net_netstats Packet statistics per module
  * @ingroup     net
@@ -22,9 +25,6 @@
 #include "cib.h"
 #include "net/l2util.h"
 #include "mutex.h"
-
-#ifndef NET_NETSTATS_H
-#define NET_NETSTATS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -132,5 +132,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_NETSTATS_H */
 /** @} */
+#endif /* NET_NETSTATS_H */

--- a/sys/include/net/netstats/neighbor.h
+++ b/sys/include/net/netstats/neighbor.h
@@ -6,6 +6,8 @@
  * more details.
  */
 
+#ifndef NET_NETSTATS_NEIGHBOR_H
+#define NET_NETSTATS_NEIGHBOR_H
 /**
  * @ingroup     net_netstats
  * @brief       Records statistics about link layer neighbors
@@ -16,8 +18,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-#ifndef NET_NETSTATS_NEIGHBOR_H
-#define NET_NETSTATS_NEIGHBOR_H
 
 #include <string.h>
 #include "net/netif.h"

--- a/sys/include/net/ntp_packet.h
+++ b/sys/include/net/ntp_packet.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_NTP_PACKET_H
+#define NET_NTP_PACKET_H
+
 /**
  * @defgroup    net_ntp_packet NTP Packet
  * @ingroup     net
@@ -18,9 +21,6 @@
  * @author      Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
-
-#ifndef NET_NTP_PACKET_H
-#define NET_NTP_PACKET_H
 
 #include <stdint.h>
 #include "byteorder.h"
@@ -169,5 +169,5 @@ static inline ntp_mode_t ntp_packet_get_mode(ntp_packet_t *packet)
 }
 #endif
 
-#endif /* NET_NTP_PACKET_H */
 /** @} */
+#endif /* NET_NTP_PACKET_H */

--- a/sys/include/net/ppp/hdr.h
+++ b/sys/include/net/ppp/hdr.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_PPP_HDR_H
+#define NET_PPP_HDR_H
+
 /**
  * @defgroup    net_ppphdr Point-to-Point Protocol Header
  * @ingroup     net_ppp
@@ -17,9 +20,6 @@
  *
  * @author  José Ignacio Alamos
  */
-
-#ifndef NET_PPP_HDR_H
-#define NET_PPP_HDR_H
 
 #include <inttypes.h>
 
@@ -62,5 +62,5 @@ typedef struct __attribute__((packed)){
 }
 #endif
 
-#endif /* NET_PPP_HDR_H */
 /** @} */
+#endif /* NET_PPP_HDR_H */

--- a/sys/include/net/protnum.h
+++ b/sys/include/net/protnum.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_PROTNUM_H
+#define NET_PROTNUM_H
 /**
  * @defgroup    net_protnum  Protocol Numbers
  * @ingroup     net
@@ -23,8 +25,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_PROTNUM_H
-#define NET_PROTNUM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -181,5 +181,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_PROTNUM_H */
 /** @} */
+#endif /* NET_PROTNUM_H */

--- a/sys/include/net/rpl/rpl_netstats.h
+++ b/sys/include/net/rpl/rpl_netstats.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_RPL_RPL_NETSTATS_H
+#define NET_RPL_RPL_NETSTATS_H
 /**
  * @defgroup    net_netstats_rpl Packet statistics for RPL
  * @ingroup     net_netstats
@@ -19,9 +21,6 @@
  */
 
 #include <stdint.h>
-
-#ifndef NET_RPL_RPL_NETSTATS_H
-#define NET_RPL_RPL_NETSTATS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,5 +55,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NET_RPL_RPL_NETSTATS_H */
 /** @} */
+#endif /* NET_RPL_RPL_NETSTATS_H */

--- a/sys/include/net/sixlowpan.h
+++ b/sys/include/net/sixlowpan.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SIXLOWPAN_H
+#define NET_SIXLOWPAN_H
 /**
  * @defgroup    net_sixlowpan   6LoWPAN
  * @ingroup     net
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_SIXLOWPAN_H
-#define NET_SIXLOWPAN_H
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -343,5 +343,5 @@ void sixlowpan_print(uint8_t *data, size_t size);
 }
 #endif
 
-#endif /* NET_SIXLOWPAN_H */
 /** @} */
+#endif /* NET_SIXLOWPAN_H */

--- a/sys/include/net/sixlowpan/nd.h
+++ b/sys/include/net/sixlowpan/nd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SIXLOWPAN_ND_H
+#define NET_SIXLOWPAN_ND_H
 /**
  * @defgroup    net_sixlowpan_nd    6LoWPAN Neighbor Discovery
  * @ingroup     net_sixlowpan
@@ -19,8 +21,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_SIXLOWPAN_ND_H
-#define NET_SIXLOWPAN_ND_H
 
 #include <stdint.h>
 
@@ -278,5 +278,5 @@ static inline uint16_t gnrc_sixlowpan_nd_opt_get_ltime(const sixlowpan_nd_opt_ab
 }
 #endif
 
-#endif /* NET_SIXLOWPAN_ND_H */
 /** @} */
+#endif /* NET_SIXLOWPAN_ND_H */

--- a/sys/include/net/sixlowpan/sfr.h
+++ b/sys/include/net/sixlowpan/sfr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SIXLOWPAN_SFR_H
+#define NET_SIXLOWPAN_SFR_H
 /**
  * @defgroup    net_sixlowpan_sfr   6LoWPAN selective fragment recovery
  * @ingroup     net_sixlowpan
@@ -19,8 +21,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_SIXLOWPAN_SFR_H
-#define NET_SIXLOWPAN_SFR_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -374,5 +374,5 @@ static inline bool sixlowpan_sfr_ack_is(const sixlowpan_sfr_t *hdr)
 }
 #endif
 
-#endif /* NET_SIXLOWPAN_SFR_H */
 /** @} */
+#endif /* NET_SIXLOWPAN_SFR_H */

--- a/sys/include/net/skald.h
+++ b/sys/include/net/skald.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SKALD_H
+#define NET_SKALD_H
+
 /**
  * @defgroup    ble_skald Skald, who advertises to the world
  * @ingroup     ble
@@ -40,9 +43,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_SKALD_H
-#define NET_SKALD_H
 
 #include <stdint.h>
 
@@ -114,5 +114,5 @@ void skald_generate_random_addr(uint8_t *buf);
 }
 #endif
 
-#endif /* NET_SKALD_H */
 /** @} */
+#endif /* NET_SKALD_H */

--- a/sys/include/net/skald/eddystone.h
+++ b/sys/include/net/skald/eddystone.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SKALD_EDDYSTONE_H
+#define NET_SKALD_EDDYSTONE_H
+
 /**
  * @defgroup    ble_skald_eddystone Skald meets Eddy
  * @ingroup     ble_skald
@@ -31,9 +34,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_SKALD_EDDYSTONE_H
-#define NET_SKALD_EDDYSTONE_H
 
 #include "net/eddystone.h"
 #include "net/skald.h"
@@ -83,5 +83,5 @@ void skald_eddystone_url_adv(skald_ctx_t *ctx,
 }
 #endif
 
-#endif /* NET_SKALD_EDDYSTONE_H */
 /** @} */
+#endif /* NET_SKALD_EDDYSTONE_H */

--- a/sys/include/net/skald/ibeacon.h
+++ b/sys/include/net/skald/ibeacon.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SKALD_IBEACON_H
+#define NET_SKALD_IBEACON_H
+
 /**
  * @defgroup    ble_skald_ibeacon Skald about iBeacon
  * @ingroup     ble_skald
@@ -24,9 +27,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_SKALD_IBEACON_H
-#define NET_SKALD_IBEACON_H
 
 #include "net/skald.h"
 
@@ -52,5 +52,5 @@ void skald_ibeacon_advertise(skald_ctx_t *ctx, const skald_uuid_t *uuid,
 }
 #endif
 
-#endif /* NET_SKALD_IBEACON_H */
 /** @} */
+#endif /* NET_SKALD_IBEACON_H */

--- a/sys/include/net/sntp.h
+++ b/sys/include/net/sntp.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SNTP_H
+#define NET_SNTP_H
+
 /**
  * @defgroup    net_sntp Simple Network Time Protocol
  * @ingroup     net
@@ -19,9 +22,6 @@
  * @author      Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
-
-#ifndef NET_SNTP_H
-#define NET_SNTP_H
 
 #include <stdint.h>
 #include <time.h>
@@ -66,5 +66,5 @@ static inline uint64_t sntp_get_unix_usec(void)
 }
 #endif
 
-#endif /* NET_SNTP_H */
 /** @} */
+#endif /* NET_SNTP_H */

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -9,6 +9,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_H
+#define NET_SOCK_H
+
 /**
  * @defgroup    net_sock    Sock API
  * @ingroup     net
@@ -98,9 +101,6 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef NET_SOCK_H
-#define NET_SOCK_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -352,5 +352,5 @@ typedef uint8_t sock_aux_flags_t;
 }
 #endif
 
-#endif /* NET_SOCK_H */
 /** @} */
+#endif /* NET_SOCK_H */

--- a/sys/include/net/sock/async.h
+++ b/sys/include/net/sock/async.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_ASYNC_H
+#define NET_SOCK_ASYNC_H
 /**
  * @defgroup        net_sock_async  Sock extension for asynchronous access
  * @ingroup         net_sock
@@ -20,8 +22,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_SOCK_ASYNC_H
-#define NET_SOCK_ASYNC_H
 
 #include "net/sock/async/types.h"
 
@@ -235,5 +235,5 @@ sock_async_ctx_t *sock_udp_get_async_ctx(sock_udp_t *sock);
 }
 #endif
 
-#endif /* NET_SOCK_ASYNC_H */
 /** @} */
+#endif /* NET_SOCK_ASYNC_H */

--- a/sys/include/net/sock/async/event.h
+++ b/sys/include/net/sock/async/event.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_ASYNC_EVENT_H
+#define NET_SOCK_ASYNC_EVENT_H
 /**
  * @defgroup        net_sock_async_event    Asynchronous sock with event API
  * @ingroup         net_sock
@@ -165,8 +167,6 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef NET_SOCK_ASYNC_EVENT_H
-#define NET_SOCK_ASYNC_EVENT_H
 
 #include "event.h"
 /* guard required since `sock_dtls_types.h` might not be provided */
@@ -317,5 +317,5 @@ void sock_event_close(sock_async_ctx_t *async_ctx);
 }
 #endif
 
-#endif /* NET_SOCK_ASYNC_EVENT_H */
 /** @} */
+#endif /* NET_SOCK_ASYNC_EVENT_H */

--- a/sys/include/net/sock/async/types.h
+++ b/sys/include/net/sock/async/types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_ASYNC_TYPES_H
+#define NET_SOCK_ASYNC_TYPES_H
 /**
  * @addtogroup      net_sock_async  Sock extension for asynchronous access
  *
@@ -16,8 +18,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_SOCK_ASYNC_TYPES_H
-#define NET_SOCK_ASYNC_TYPES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -176,5 +176,5 @@ typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t flags,
 }
 #endif
 
-#endif /* NET_SOCK_ASYNC_TYPES_H */
 /** @} */
+#endif /* NET_SOCK_ASYNC_TYPES_H */

--- a/sys/include/net/sock/config.h
+++ b/sys/include/net/sock/config.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_CONFIG_H
+#define NET_SOCK_CONFIG_H
+
 /**
  * @defgroup    net_sock_util_conf SOCK utility functions compile configurations
  * @ingroup     net_sock_conf
@@ -17,9 +20,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_SOCK_CONFIG_H
-#define NET_SOCK_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,5 +66,5 @@ extern "C" {
 }
 #endif
 
-#endif /* NET_SOCK_CONFIG_H */
 /** @} */
+#endif /* NET_SOCK_CONFIG_H */

--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_DNS_H
+#define NET_SOCK_DNS_H
+
 /**
  * @defgroup    net_sock_dns    DNS sock API
  * @ingroup     net_sock
@@ -20,9 +23,6 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
-
-#ifndef NET_SOCK_DNS_H
-#define NET_SOCK_DNS_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -114,5 +114,5 @@ extern sock_udp_ep_t sock_dns_server;
 }
 #endif
 
-#endif /* NET_SOCK_DNS_H */
 /** @} */
+#endif /* NET_SOCK_DNS_H */

--- a/sys/include/net/sock/dodtls.h
+++ b/sys/include/net/sock/dodtls.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_DODTLS_H
+#define NET_SOCK_DODTLS_H
+
 /**
  * @defgroup    net_sock_dodtls     DNS over DTLS sock API
  * @ingroup     net_sock
@@ -28,9 +31,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-
-#ifndef NET_SOCK_DODTLS_H
-#define NET_SOCK_DODTLS_H
 
 #include "net/sock/dtls.h"
 #include "net/sock/udp.h"
@@ -143,5 +143,5 @@ int sock_dodtls_set_server(const sock_udp_ep_t *server,
 }
 #endif
 
-#endif /* NET_SOCK_DODTLS_H */
 /** @} */
+#endif /* NET_SOCK_DODTLS_H */

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -10,6 +10,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_DTLS_H
+#define NET_SOCK_DTLS_H
+
 /**
  * @defgroup    net_sock_dtls    DTLS sock API
  * @ingroup     net_sock net_dtls
@@ -526,9 +529,6 @@
  * @author  Ken Bannister <kb2ma@runbox.com>
  * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef NET_SOCK_DTLS_H
-#define NET_SOCK_DTLS_H
 
 #include <assert.h>
 #include <errno.h>
@@ -1124,5 +1124,5 @@ void sock_dtls_close(sock_dtls_t *sock);
 }
 #endif
 
-#endif /* NET_SOCK_DTLS_H */
 /** @} */
+#endif /* NET_SOCK_DTLS_H */

--- a/sys/include/net/sock/dtls/creds.h
+++ b/sys/include/net/sock/dtls/creds.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_DTLS_CREDS_H
+#define NET_SOCK_DTLS_CREDS_H
+
 /**
  * @defgroup    net_sock_dtls_creds    DTLS sock credentials API
  * @ingroup     net_sock_dtls
@@ -17,9 +20,6 @@
  *
  * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef NET_SOCK_DTLS_CREDS_H
-#define NET_SOCK_DTLS_CREDS_H
 
 #include "net/sock/udp.h"
 
@@ -148,5 +148,5 @@ void sock_dtls_set_rpk_cb(sock_dtls_t *sock, sock_dtls_rpk_cb_t cb);
 }
 #endif
 
-#endif /* NET_SOCK_DTLS_CREDS_H */
 /** @} */
+#endif /* NET_SOCK_DTLS_CREDS_H */

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_IP_H
+#define NET_SOCK_IP_H
 /**
  * @defgroup    net_sock_ip     Raw IPv4/IPv6 sock API
  * @ingroup     net_sock
@@ -265,8 +267,6 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef NET_SOCK_IP_H
-#define NET_SOCK_IP_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -707,5 +707,5 @@ static inline ssize_t sock_ip_send(sock_ip_t *sock,
 }
 #endif
 
-#endif /* NET_SOCK_IP_H */
 /** @} */
+#endif /* NET_SOCK_IP_H */

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_TCP_H
+#define NET_SOCK_TCP_H
 /**
  * @defgroup    net_sock_tcp    TCP sock API
  * @ingroup     net_sock
@@ -296,8 +298,6 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef NET_SOCK_TCP_H
-#define NET_SOCK_TCP_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -547,5 +547,5 @@ ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len);
 
 #include "sock_types.h"
 
-#endif /* NET_SOCK_TCP_H */
 /** @} */
+#endif /* NET_SOCK_TCP_H */

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_UDP_H
+#define NET_SOCK_UDP_H
 /**
  * @defgroup    net_sock_udp    UDP sock API
  * @ingroup     net_sock
@@ -265,8 +267,6 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef NET_SOCK_UDP_H
-#define NET_SOCK_UDP_H
 
 #include <assert.h>
 #include <errno.h>
@@ -848,5 +848,5 @@ static inline bool sock_udp_ep_is_v6(const sock_udp_ep_t *ep)
 }
 #endif
 
-#endif /* NET_SOCK_UDP_H */
 /** @} */
+#endif /* NET_SOCK_UDP_H */

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef NET_SOCK_UTIL_H
+#define NET_SOCK_UTIL_H
+
 /**
  * @defgroup    net_sock_util   sock utility functions
  * @ingroup     net_sock
@@ -21,9 +24,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_SOCK_UTIL_H
-#define NET_SOCK_UTIL_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -301,5 +301,5 @@ int sock_dtls_establish_session(sock_udp_t *sock_udp, sock_dtls_t *sock_dtls,
 }
 #endif
 
-#endif /* NET_SOCK_UTIL_H */
 /** @} */
+#endif /* NET_SOCK_UTIL_H */

--- a/sys/include/net/someip.h
+++ b/sys/include/net/someip.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_SOMEIP_H
+#define NET_SOMEIP_H
 /**
  * @defgroup    net_someip SOME/IP
  * @ingroup     net
@@ -18,8 +20,6 @@
  *
  * @author  Jannes Volkens <jannes.volkens@haw-hamburg.de>
  */
-#ifndef NET_SOMEIP_H
-#define NET_SOMEIP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +69,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NET_SOMEIP_H */
 /** @} */
+#endif /* NET_SOMEIP_H */

--- a/sys/include/net/tcp.h
+++ b/sys/include/net/tcp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_TCP_H
+#define NET_TCP_H
+
 /**
  * @defgroup    net_tcp TCP
  * @ingroup     net
@@ -18,9 +21,6 @@
  *
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
-
-#ifndef NET_TCP_H
-#define NET_TCP_H
 
 #include "byteorder.h"
 
@@ -87,5 +87,5 @@ void tcp_hdr_print(tcp_hdr_t *hdr);
 }
 #endif
 
-#endif /* NET_TCP_H */
 /** @} */
+#endif /* NET_TCP_H */

--- a/sys/include/net/telnet.h
+++ b/sys/include/net/telnet.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_TELNET_H
+#define NET_TELNET_H
 /**
  * @defgroup    net_telnet_stdio    STDIO over telnet
  * @ingroup     sys_stdio
@@ -41,8 +43,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef NET_TELNET_H
-#define NET_TELNET_H
 
 #include "net/sock/tcp.h"
 
@@ -119,5 +119,5 @@ void telnet_cb_disconneced(void);
 }
 #endif
 
-#endif /* NET_TELNET_H */
 /** @} */
+#endif /* NET_TELNET_H */

--- a/sys/include/net/udp.h
+++ b/sys/include/net/udp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_UDP_H
+#define NET_UDP_H
 /**
  * @defgroup    net_udp UDP
  * @ingroup     net
@@ -20,8 +22,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NET_UDP_H
-#define NET_UDP_H
 
 #include "byteorder.h"
 
@@ -50,5 +50,5 @@ void udp_hdr_print(udp_hdr_t *hdr);
 }
 #endif
 
-#endif /* NET_UDP_H */
 /** @} */
+#endif /* NET_UDP_H */

--- a/sys/include/net/uhcp.h
+++ b/sys/include/net/uhcp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_UHCP_H
+#define NET_UHCP_H
+
 /**
  * @defgroup    net_uhcp UHCP
  * @ingroup     net
@@ -26,9 +29,6 @@
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef NET_UHCP_H
-#define NET_UHCP_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -185,5 +185,5 @@ int udp_sendto(uint8_t *buf, size_t len, uint8_t *dst, uint16_t dst_port, uhcp_i
 }
 #endif
 
-#endif /* NET_UHCP_H */
 /** @} */
+#endif /* NET_UHCP_H */

--- a/sys/include/net/utils.h
+++ b/sys/include/net/utils.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef NET_UTILS_H
+#define NET_UTILS_H
+
 /**
  * @defgroup    net_utils   Network helper functions
  * @ingroup     net
@@ -18,9 +21,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
-
-#ifndef NET_UTILS_H
-#define NET_UTILS_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -62,5 +62,5 @@ int netutils_get_ipv6(ipv6_addr_t *addr, netif_t **netif, const char *hostname);
 }
 #endif
 
-#endif /* NET_UTILS_H */
 /** @} */
+#endif /* NET_UTILS_H */

--- a/sys/include/net/wifi.h
+++ b/sys/include/net/wifi.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef NET_WIFI_H
+#define NET_WIFI_H
+
 /**
  * @defgroup    net_wifi Wi-Fi
  * @ingroup     net
@@ -17,9 +20,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
  */
-
-#ifndef NET_WIFI_H
-#define NET_WIFI_H
 
 #include <inttypes.h>
 
@@ -163,5 +163,5 @@ typedef struct wifi_security_wpa_enterprise {
 }
 #endif
 
-#endif /* NET_WIFI_H */
 /** @} */
+#endif /* NET_WIFI_H */

--- a/sys/include/net/wifi_scan_list.h
+++ b/sys/include/net/wifi_scan_list.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef NET_WIFI_SCAN_LIST_H
+#define NET_WIFI_SCAN_LIST_H
+
 /**
  * @defgroup    net_wifi_scan_list List of scanned WiFis access points
  * @ingroup     net
@@ -16,9 +19,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
  */
-
-#ifndef NET_WIFI_SCAN_LIST_H
-#define NET_WIFI_SCAN_LIST_H
 
 #include <stddef.h>
 
@@ -82,5 +82,5 @@ static inline unsigned wifi_scan_list_to_array(const wifi_scan_list_t *list,
 }
 #endif
 
-#endif /* NET_WIFI_SCAN_LIST_H */
 /** @} */
+#endif /* NET_WIFI_SCAN_LIST_H */

--- a/sys/include/net/zep.h
+++ b/sys/include/net/zep.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef NET_ZEP_H
+#define NET_ZEP_H
 /**
  * @defgroup    net_zep  ZigBee Encapsulation Protocol
  * @ingroup     net
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_ZEP_H
-#define NET_ZEP_H
 
 #include <stdint.h>
 
@@ -100,5 +100,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NET_ZEP_H */
 /** @} */
+#endif /* NET_ZEP_H */

--- a/sys/include/od.h
+++ b/sys/include/od.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef OD_H
+#define OD_H
 /**
  * @defgroup sys_od Object dump
  * @ingroup  sys
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef OD_H
-#define OD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,5 +71,5 @@ static inline void od_hex_dump(const void *data, size_t data_len, uint8_t width)
 }
 #endif
 
-#endif /* OD_H */
 /** @} */
+#endif /* OD_H */

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PHYDAT_H
+#define PHYDAT_H
+
 /**
  * @defgroup    sys_phydat Phydat
  * @ingroup     sys
@@ -31,9 +34,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PHYDAT_H
-#define PHYDAT_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -324,5 +324,5 @@ int64_t phydat_unix(int16_t year, int16_t month, int16_t day,
 }
 #endif
 
-#endif /* PHYDAT_H */
 /** @} */
+#endif /* PHYDAT_H */

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PM_LAYERED_H
+#define PM_LAYERED_H
+
 /**
  * @defgroup    sys_pm_layered Layered PM Infrastructure
  * @ingroup     sys
@@ -31,9 +34,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef PM_LAYERED_H
-#define PM_LAYERED_H
 
 #include <stdint.h>
 #include "periph_cpu.h"
@@ -105,5 +105,5 @@ pm_blocker_t pm_get_blocker(void);
 }
 #endif
 
-#endif /* PM_LAYERED_H */
 /** @} */
+#endif /* PM_LAYERED_H */

--- a/sys/include/progress_bar.h
+++ b/sys/include/progress_bar.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PROGRESS_BAR_H
+#define PROGRESS_BAR_H
+
 /**
  * @ingroup     sys_progress_bar
  * @{
@@ -15,9 +18,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef PROGRESS_BAR_H
-#define PROGRESS_BAR_H
 
 #include <stdlib.h>
 #include <inttypes.h>

--- a/sys/include/ps.h
+++ b/sys/include/ps.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PS_H
+#define PS_H
+
 /**
  * @defgroup    sys_ps PS
  * @ingroup     sys
@@ -18,9 +21,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
-
-#ifndef PS_H
-#define PS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,5 +35,5 @@ void ps(void);
 }
 #endif
 
-#endif /* PS_H */
 /** @} */
+#endif /* PS_H */

--- a/sys/include/psa_crypto/psa/aead/algorithm.h
+++ b/sys/include/psa_crypto/psa/aead/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_AEAD_ALGORITHM_H
+#define PSA_CRYPTO_PSA_AEAD_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_AEAD_ALGORITHM_H
-#define PSA_CRYPTO_PSA_AEAD_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -225,5 +225,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_AEAD_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_AEAD_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/algorithm.h
+++ b/sys/include/psa_crypto/psa/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_ALGORITHM_H
+#define PSA_CRYPTO_PSA_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_ALGORITHM_H
-#define PSA_CRYPTO_PSA_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,5 +54,5 @@ typedef uint32_t psa_algorithm_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/asymmetric_encryption/algorithm.h
+++ b/sys/include/psa_crypto/psa/asymmetric_encryption/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_ASYMMETRIC_ENCRYPTION_ALGORITHM_H
+#define PSA_CRYPTO_PSA_ASYMMETRIC_ENCRYPTION_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_ASYMMETRIC_ENCRYPTION_ALGORITHM_H
-#define PSA_CRYPTO_PSA_ASYMMETRIC_ENCRYPTION_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -98,5 +98,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_ASYMMETRIC_ENCRYPTION_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_ASYMMETRIC_ENCRYPTION_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/asymmetric_signature/algorithm.h
+++ b/sys/include/psa_crypto/psa/asymmetric_signature/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_ASYMMETRIC_SIGNATURE_ALGORITHM_H
+#define PSA_CRYPTO_PSA_ASYMMETRIC_SIGNATURE_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_ASYMMETRIC_SIGNATURE_ALGORITHM_H
-#define PSA_CRYPTO_PSA_ASYMMETRIC_SIGNATURE_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -630,5 +630,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_ASYMMETRIC_SIGNATURE_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_ASYMMETRIC_SIGNATURE_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/cipher/algorithm.h
+++ b/sys/include/psa_crypto/psa/cipher/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CIPHER_ALGORITHM_H
+#define PSA_CRYPTO_PSA_CIPHER_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CIPHER_ALGORITHM_H
-#define PSA_CRYPTO_PSA_CIPHER_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -337,5 +337,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CIPHER_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CIPHER_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/crypto.h
+++ b/sys/include/psa_crypto/psa/crypto.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_H
+#define PSA_CRYPTO_PSA_CRYPTO_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @see         https://armmbed.github.io/mbed-crypto/html/index.html
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_H
-#define PSA_CRYPTO_PSA_CRYPTO_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -4078,5 +4078,5 @@ psa_status_t psa_verify_message(psa_key_id_t key,
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_H */

--- a/sys/include/psa_crypto/psa/crypto_contexts.h
+++ b/sys/include/psa_crypto/psa/crypto_contexts.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_CONTEXTS_H
+#define PSA_CRYPTO_PSA_CRYPTO_CONTEXTS_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_CONTEXTS_H
-#define PSA_CRYPTO_PSA_CRYPTO_CONTEXTS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -105,5 +105,5 @@ typedef struct {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_CONTEXTS_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_CONTEXTS_H */

--- a/sys/include/psa_crypto/psa/crypto_includes.h
+++ b/sys/include/psa_crypto/psa/crypto_includes.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_INCLUDES_H
+#define PSA_CRYPTO_PSA_CRYPTO_INCLUDES_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -15,9 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_INCLUDES_H
-#define PSA_CRYPTO_PSA_CRYPTO_INCLUDES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,5 +57,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_INCLUDES_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_INCLUDES_H */

--- a/sys/include/psa_crypto/psa/crypto_se_config.h
+++ b/sys/include/psa_crypto/psa/crypto_se_config.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_SE_CONFIG_H
+#define PSA_CRYPTO_PSA_CRYPTO_SE_CONFIG_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_SE_CONFIG_H
-#define PSA_CRYPTO_PSA_CRYPTO_SE_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +44,5 @@ typedef union {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_SE_CONFIG_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_SE_CONFIG_H */

--- a/sys/include/psa_crypto/psa/crypto_sizes.h
+++ b/sys/include/psa_crypto/psa/crypto_sizes.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_SIZES_H
+#define PSA_CRYPTO_PSA_CRYPTO_SIZES_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -21,9 +24,6 @@
  *              or "implementation-defined".
  *              These macros will be implemented successively in the future.
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_SIZES_H
-#define PSA_CRYPTO_PSA_CRYPTO_SIZES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -1111,5 +1111,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_SIZES_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_SIZES_H */

--- a/sys/include/psa_crypto/psa/crypto_struct.h
+++ b/sys/include/psa_crypto/psa/crypto_struct.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_STRUCT_H
+#define PSA_CRYPTO_PSA_CRYPTO_STRUCT_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_STRUCT_H
-#define PSA_CRYPTO_PSA_CRYPTO_STRUCT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -186,5 +186,5 @@ static inline struct psa_mac_operation_s psa_mac_operation_init(void)
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_STRUCT_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_STRUCT_H */

--- a/sys/include/psa_crypto/psa/crypto_types.h
+++ b/sys/include/psa_crypto/psa/crypto_types.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_TYPES_H
+#define PSA_CRYPTO_PSA_CRYPTO_TYPES_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -16,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_TYPES_H
-#define PSA_CRYPTO_PSA_CRYPTO_TYPES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -209,5 +209,5 @@ typedef struct psa_cipher_operation_s psa_cipher_operation_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_TYPES_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_TYPES_H */

--- a/sys/include/psa_crypto/psa/crypto_values.h
+++ b/sys/include/psa_crypto/psa/crypto_values.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_CRYPTO_VALUES_H
+#define PSA_CRYPTO_PSA_CRYPTO_VALUES_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -21,9 +24,6 @@
  *              or "implementation-defined".
  *              These macros will be implemented successively in the future.
  */
-
-#ifndef PSA_CRYPTO_PSA_CRYPTO_VALUES_H
-#define PSA_CRYPTO_PSA_CRYPTO_VALUES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -189,5 +189,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_CRYPTO_VALUES_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_CRYPTO_VALUES_H */

--- a/sys/include/psa_crypto/psa/error.h
+++ b/sys/include/psa_crypto/psa/error.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_ERROR_H
+#define PSA_CRYPTO_PSA_ERROR_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -20,9 +23,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_ERROR_H
-#define PSA_CRYPTO_PSA_ERROR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -212,5 +212,5 @@ typedef int32_t psa_status_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_ERROR_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_ERROR_H */

--- a/sys/include/psa_crypto/psa/hash/algorithm.h
+++ b/sys/include/psa_crypto/psa/hash/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_HASH_ALGORITHM_H
+#define PSA_CRYPTO_PSA_HASH_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_HASH_ALGORITHM_H
-#define PSA_CRYPTO_PSA_HASH_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -239,5 +239,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_HASH_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_HASH_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/key/attributes.h
+++ b/sys/include/psa_crypto/psa/key/attributes.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_ATTRIBUTES_H
+#define PSA_CRYPTO_PSA_KEY_ATTRIBUTES_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_ATTRIBUTES_H
-#define PSA_CRYPTO_PSA_KEY_ATTRIBUTES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,5 +182,5 @@ static inline psa_key_attributes_t psa_key_attributes_init(void)
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_ATTRIBUTES_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_ATTRIBUTES_H */

--- a/sys/include/psa_crypto/psa/key/bits.h
+++ b/sys/include/psa_crypto/psa/key/bits.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_BITS_H
+#define PSA_CRYPTO_PSA_KEY_BITS_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_BITS_H
-#define PSA_CRYPTO_PSA_KEY_BITS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,5 +37,5 @@ typedef uint16_t psa_key_bits_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_BITS_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_BITS_H */

--- a/sys/include/psa_crypto/psa/key/id.h
+++ b/sys/include/psa_crypto/psa/key/id.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_ID_H
+#define PSA_CRYPTO_PSA_KEY_ID_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_ID_H
-#define PSA_CRYPTO_PSA_KEY_ID_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,5 +68,5 @@ typedef uint32_t psa_key_id_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_ID_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_ID_H */

--- a/sys/include/psa_crypto/psa/key/lifetime.h
+++ b/sys/include/psa_crypto/psa/key/lifetime.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_LIFETIME_H
+#define PSA_CRYPTO_PSA_KEY_LIFETIME_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_LIFETIME_H
-#define PSA_CRYPTO_PSA_KEY_LIFETIME_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -278,5 +278,5 @@ typedef uint32_t psa_key_location_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_LIFETIME_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_LIFETIME_H */

--- a/sys/include/psa_crypto/psa/key/type.h
+++ b/sys/include/psa_crypto/psa/key/type.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_TYPE_H
+#define PSA_CRYPTO_PSA_KEY_TYPE_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_TYPE_H
-#define PSA_CRYPTO_PSA_KEY_TYPE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -877,5 +877,5 @@ typedef uint8_t psa_dh_family_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_TYPE_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_TYPE_H */

--- a/sys/include/psa_crypto/psa/key/usage.h
+++ b/sys/include/psa_crypto/psa/key/usage.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_USAGE_H
+#define PSA_CRYPTO_PSA_KEY_USAGE_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_USAGE_H
-#define PSA_CRYPTO_PSA_KEY_USAGE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -220,5 +220,5 @@ typedef uint32_t psa_key_usage_t;
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_USAGE_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_USAGE_H */

--- a/sys/include/psa_crypto/psa/key_agreement/algorithm.h
+++ b/sys/include/psa_crypto/psa/key_agreement/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_AGREEMENT_ALGORITHM_H
+#define PSA_CRYPTO_PSA_KEY_AGREEMENT_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_AGREEMENT_ALGORITHM_H
-#define PSA_CRYPTO_PSA_KEY_AGREEMENT_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -251,5 +251,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_AGREEMENT_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_AGREEMENT_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/key_derivation/algorithm.h
+++ b/sys/include/psa_crypto/psa/key_derivation/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_KEY_DERIVATION_ALGORITHM_H
+#define PSA_CRYPTO_PSA_KEY_DERIVATION_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_KEY_DERIVATION_ALGORITHM_H
-#define PSA_CRYPTO_PSA_KEY_DERIVATION_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -338,5 +338,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_KEY_DERIVATION_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_KEY_DERIVATION_ALGORITHM_H */

--- a/sys/include/psa_crypto/psa/mac/algorithm.h
+++ b/sys/include/psa_crypto/psa/mac/algorithm.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef PSA_CRYPTO_PSA_MAC_ALGORITHM_H
+#define PSA_CRYPTO_PSA_MAC_ALGORITHM_H
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -18,9 +21,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTO_PSA_MAC_ALGORITHM_H
-#define PSA_CRYPTO_PSA_MAC_ALGORITHM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -222,5 +222,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PSA_CRYPTO_PSA_MAC_ALGORITHM_H */
 /** @} */
+#endif /* PSA_CRYPTO_PSA_MAC_ALGORITHM_H */

--- a/sys/include/ptrtag.h
+++ b/sys/include/ptrtag.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef PTRTAG_H
+#define PTRTAG_H
+
 /**
  * @defgroup    sys_ptrtag          Helpers for pointer tagging
  * @ingroup     sys
@@ -57,9 +60,6 @@
  * @brief       Pointer Tagging Helpers
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef PTRTAG_H
-#define PTRTAG_H
 
 #include <assert.h>
 #include <inttypes.h>
@@ -122,5 +122,5 @@ static inline uint8_t ptrtag_tag(void *tagged_ptr)
 }
 #endif
 
-#endif /* PTRTAG_H */
 /** @} */
+#endif /* PTRTAG_H */

--- a/sys/include/puf_sram.h
+++ b/sys/include/puf_sram.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef PUF_SRAM_H
+#define PUF_SRAM_H
 /**
  * @defgroup     sys_puf_sram SRAM PUF
  * @ingroup      sys
@@ -51,8 +53,6 @@
  *
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
-#ifndef PUF_SRAM_H
-#define PUF_SRAM_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef RANDOM_H
+#define RANDOM_H
+
 /**
  * @defgroup    sys_random Random
  * @ingroup     sys
@@ -31,9 +34,6 @@
  * @file
  * @brief       Common interface to the software PRNG
  */
-
-#ifndef RANDOM_H
-#define RANDOM_H
 
 #include <inttypes.h>
 #include <stddef.h>
@@ -138,5 +138,5 @@ double random_res53(void);
 }
 #endif
 
-#endif /* RANDOM_H */
 /** @} */
+#endif /* RANDOM_H */

--- a/sys/include/riotboot/bootloader_selection.h
+++ b/sys/include/riotboot/bootloader_selection.h
@@ -5,6 +5,13 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef RIOTBOOT_BOOTLOADER_SELECTION_H
+#define RIOTBOOT_BOOTLOADER_SELECTION_H
+
+/* Include guards and cplusplus are more of a formality; this header is local
+ * to the riotboot_dfu application that isn't written in C++ and not included
+ * from anywhere else either, but still here for consistency (and because
+ * otherwise the checks complain) */
 /** @ingroup bootloaders
  *
  * @{
@@ -14,13 +21,6 @@
  *
  * @author Christian Amsüss <chrysn@fsfe.org>
  */
-
-/* Include guards and cplusplus are more of a formality; this header is local
- * to the riotboot_dfu application that isn't written in C++ and not included
- * from anywhere else either, but still here for consistency (and because
- * otherwise the checks complain) */
-#ifndef RIOTBOOT_BOOTLOADER_SELECTION_H
-#define RIOTBOOT_BOOTLOADER_SELECTION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,6 +82,6 @@ extern "C" {
 }
 #endif
 
-#endif /* RIOTBOOT_BOOTLOADER_SELECTION_H */
-
 /** @} */
+
+#endif /* RIOTBOOT_BOOTLOADER_SELECTION_H */

--- a/sys/include/riotboot/hdr.h
+++ b/sys/include/riotboot/hdr.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef RIOTBOOT_HDR_H
+#define RIOTBOOT_HDR_H
+
 /**
  * @defgroup    sys_riotboot_hdr RIOT header helpers and tools
  * @ingroup     sys
@@ -28,9 +31,6 @@
  *
  * @}
  */
-
-#ifndef RIOTBOOT_HDR_H
-#define RIOTBOOT_HDR_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/riotboot/magic.h
+++ b/sys/include/riotboot/magic.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef RIOTBOOT_MAGIC_H
+#define RIOTBOOT_MAGIC_H
+
 /**
  * @defgroup    sys_riotboot_magic     Magic values for riotboot
  * @ingroup     sys
@@ -18,9 +21,6 @@
  *
  * @}
  */
-
-#ifndef RIOTBOOT_MAGIC_H
-#define RIOTBOOT_MAGIC_H
 
 #include "riotboot/hdr.h"
 

--- a/sys/include/riotboot/serial.h
+++ b/sys/include/riotboot/serial.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef RIOTBOOT_SERIAL_H
+#define RIOTBOOT_SERIAL_H
+
 /**
  * @defgroup    sys_riotboot_serial Serial Bootloader Protocol
  * @ingroup     sys
@@ -18,9 +21,6 @@
  *
  * @}
  */
-
-#ifndef RIOTBOOT_SERIAL_H
-#define RIOTBOOT_SERIAL_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/riotboot/usb_dfu.h
+++ b/sys/include/riotboot/usb_dfu.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef RIOTBOOT_USB_DFU_H
+#define RIOTBOOT_USB_DFU_H
+
 /**
  * @defgroup    sys_riotboot_usb_dfu   Initialization of USB Device Firmware
  *                                     Upgrade for riotboot
@@ -19,9 +22,6 @@
  *
  * @}
  */
-
-#ifndef RIOTBOOT_USB_DFU_H
-#define RIOTBOOT_USB_DFU_H
 
 #include "riotboot/hdr.h"
 

--- a/sys/include/rtc_utils.h
+++ b/sys/include/rtc_utils.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef RTC_UTILS_H
+#define RTC_UTILS_H
+
 /**
  * @defgroup    sys_rtc_utils RTC helpers
  * @ingroup     sys
@@ -15,9 +18,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef RTC_UTILS_H
-#define RTC_UTILS_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -96,5 +96,5 @@ bool rtc_tm_valid(const struct tm *t);
 }
 #endif
 
-#endif /* RTC_UTILS_H */
 /** @} */
+#endif /* RTC_UTILS_H */

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SAUL_REG_H
+#define SAUL_REG_H
+
 /**
  * @defgroup    sys_saul_reg SAUL registry
  * @ingroup     sys
@@ -20,9 +23,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef SAUL_REG_H
-#define SAUL_REG_H
 
 #include <stdint.h>
 
@@ -140,5 +140,5 @@ int saul_reg_write(saul_reg_t *dev, const phydat_t *data);
 }
 #endif
 
-#endif /* SAUL_REG_H */
 /** @} */
+#endif /* SAUL_REG_H */

--- a/sys/include/sched_round_robin.h
+++ b/sys/include/sched_round_robin.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef SCHED_ROUND_ROBIN_H
+#define SCHED_ROUND_ROBIN_H
 /**
  * @defgroup    sched_round_robin Round Robin Scheduler
  * @ingroup     sys
@@ -29,8 +31,6 @@
  * @author      Karl Fessel <karl.fessel@ovgu.de>
  *
  */
-#ifndef SCHED_ROUND_ROBIN_H
-#define SCHED_ROUND_ROBIN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,5 +83,5 @@ void sched_round_robin_init(void);
 }
 #endif
 
-#endif /* SCHED_ROUND_ROBIN_H */
 /** @} */
+#endif /* SCHED_ROUND_ROBIN_H */

--- a/sys/include/schedstatistics.h
+++ b/sys/include/schedstatistics.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef SCHEDSTATISTICS_H
+#define SCHEDSTATISTICS_H
+
 /**
  * @defgroup    schedstatistics Schedstatistics
  * @ingroup     sys
@@ -25,9 +28,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  *
  */
-
-#ifndef SCHEDSTATISTICS_H
-#define SCHEDSTATISTICS_H
 
 #include <stdint.h>
 
@@ -60,5 +60,5 @@ void init_schedstatistics(void);
 }
 #endif
 
-#endif /* SCHEDSTATISTICS_H */
 /** @} */
+#endif /* SCHEDSTATISTICS_H */

--- a/sys/include/sema.h
+++ b/sys/include/sema.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef SEMA_H
+#define SEMA_H
+
 /**
  * @defgroup    sys_sema Semaphores
  * @ingroup     sys
@@ -21,9 +24,6 @@
  * @author  René Kijewski <kijewski@inf.fu-berlin.de>
  * @author  Víctor Ariño <victor.arino@zii.aero>
  */
-
-#ifndef SEMA_H
-#define SEMA_H
 
 #include <stdint.h>
 
@@ -253,5 +253,5 @@ int sema_post(sema_t *sema);
 }
 #endif
 
-#endif /* SEMA_H */
 /** @} */
+#endif /* SEMA_H */

--- a/sys/include/sema_inv.h
+++ b/sys/include/sema_inv.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SEMA_INV_H
+#define SEMA_INV_H
+
 /**
  * @defgroup    sys_sema_inv    inverse Semaphores
  * @ingroup     sys
@@ -38,9 +41,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef SEMA_INV_H
-#define SEMA_INV_H
 
 #include "atomic_utils.h"
 #include "mutex.h"
@@ -147,5 +147,5 @@ static inline int sema_inv_wait_timeout(sema_inv_t *s, uint32_t us)
 }
 #endif
 
-#endif /* SEMA_INV_H */
 /** @} */
+#endif /* SEMA_INV_H */

--- a/sys/include/senml.h
+++ b/sys/include/senml.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SENML_H
+#define SENML_H
+
 /**
  * @defgroup    sys_senml SenML
  * @ingroup     sys
@@ -32,9 +35,6 @@
  *
  * @author      Silke Hofstra <silke@slxh.eu>
  */
-
-#ifndef SENML_H
-#define SENML_H
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -522,5 +522,5 @@ const char *senml_unit_to_str(senml_unit_t unit);
 }
 #endif
 
-#endif /* SENML_H */
 /** @} */
+#endif /* SENML_H */

--- a/sys/include/senml/cbor.h
+++ b/sys/include/senml/cbor.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SENML_CBOR_H
+#define SENML_CBOR_H
+
 /**
  * @defgroup    sys_senml_cbor SenML CBOR
  * @ingroup     sys_senml
@@ -21,9 +24,6 @@
  *
  * @author      Silke Hofstra <silke@slxh.eu>
  */
-
-#ifndef SENML_CBOR_H
-#define SENML_CBOR_H
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -117,5 +117,5 @@ int senml_encode_data_cbor(nanocbor_encoder_t *enc, const senml_data_value_t *va
 }
 #endif
 
-#endif /* SENML_CBOR_H */
 /** @} */
+#endif /* SENML_CBOR_H */

--- a/sys/include/senml/phydat.h
+++ b/sys/include/senml/phydat.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SENML_PHYDAT_H
+#define SENML_PHYDAT_H
+
 /**
  * @defgroup    sys_senml_phydat SenML Phydat
  * @ingroup     sys_senml
@@ -21,9 +24,6 @@
  *
  * @author      Silke Hofstra <silke@slxh.eu>
  */
-
-#ifndef SENML_PHYDAT_H
-#define SENML_PHYDAT_H
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -94,5 +94,5 @@ void phydat_to_senml_decimal(senml_value_t *senml, const phydat_t *phydat, const
 }
 #endif
 
-#endif /* SENML_PHYDAT_H */
 /** @} */
+#endif /* SENML_PHYDAT_H */

--- a/sys/include/senml/saul.h
+++ b/sys/include/senml/saul.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SENML_SAUL_H
+#define SENML_SAUL_H
+
 /**
  * @defgroup    sys_senml_saul SenML SAUL
  * @ingroup     sys_senml
@@ -21,9 +24,6 @@
  *
  * @author      Silke Hofstra <silke@slxh.eu>
  */
-
-#ifndef SENML_SAUL_H
-#define SENML_SAUL_H
 
 #include <stdint.h>
 #include "nanocbor/nanocbor.h"
@@ -72,5 +72,5 @@ size_t senml_saul_encode_cbor(uint8_t *buf, size_t len, saul_reg_t *reg);
 }
 #endif
 
-#endif /* SENML_SAUL_H */
 /** @} */
+#endif /* SENML_SAUL_H */

--- a/sys/include/seq.h
+++ b/sys/include/seq.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SEQ_H
+#define SEQ_H
+
 /**
  * @ingroup     sys_seq
  * @{
@@ -18,9 +21,6 @@
  *
  * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
  */
-
-#ifndef SEQ_H
-#define SEQ_H
 
 #include <stdint.h>
 #include <errno.h>

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SHELL_H
+#define SHELL_H
+
 /**
  * @defgroup    sys_shell Shell
  * @ingroup     sys
@@ -43,9 +46,6 @@
  * @file
  * @brief       Shell interface definition
  */
-
-#ifndef SHELL_H
-#define SHELL_H
 
 #include <stdint.h>
 #include "periph/pm.h"
@@ -316,5 +316,5 @@ int shell_parse_file(const shell_command_t *commands,
 }
 #endif
 
-#endif /* SHELL_H */
 /** @} */
+#endif /* SHELL_H */

--- a/sys/include/shell_lock.h
+++ b/sys/include/shell_lock.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SHELL_LOCK_H
+#define SHELL_LOCK_H
+
 /**
  * @defgroup     sys_shell_lock Shell lock
  * @ingroup      sys
@@ -20,9 +23,6 @@
  * @file
  * @brief       Shell interface definition
  */
-
-#ifndef SHELL_LOCK_H
-#define SHELL_LOCK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,5 +85,5 @@ void shell_lock_auto_lock_refresh(void);
 }
 #endif
 
-#endif /* SHELL_LOCK_H */
 /** @} */
+#endif /* SHELL_LOCK_H */

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef STDIO_BASE_H
+#define STDIO_BASE_H
+
 /**
  * @defgroup    sys_stdio STDIO abstraction
  * @ingroup     sys
@@ -20,9 +23,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef STDIO_BASE_H
-#define STDIO_BASE_H
 
 #include <unistd.h>
 

--- a/sys/include/stdio_nimble.h
+++ b/sys/include/stdio_nimble.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef STDIO_NIMBLE_H
+#define STDIO_NIMBLE_H
+
 /**
  * @defgroup     sys_stdio_nimble STDIO over NimBLE
  * @ingroup      sys_stdio
@@ -160,9 +163,6 @@
  *
  * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
-
-#ifndef STDIO_NIMBLE_H
-#define STDIO_NIMBLE_H
 
 #include "stdio_base.h"
 

--- a/sys/include/stdio_rtt.h
+++ b/sys/include/stdio_rtt.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef STDIO_RTT_H
+#define STDIO_RTT_H
+
 /**
  * @ingroup     sys_stdio_rtt
  *
@@ -16,9 +19,6 @@
  * @author      Michael Andersen <m.andersen@cs.berkeley.edu>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef STDIO_RTT_H
-#define STDIO_RTT_H
 
 #include "stdio_base.h"
 

--- a/sys/include/stdio_semihosting.h
+++ b/sys/include/stdio_semihosting.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef STDIO_SEMIHOSTING_H
+#define STDIO_SEMIHOSTING_H
+
 /**
  * @defgroup    sys_stdio_semihosting STDIO over Semihosting
  * @ingroup     sys_stdio
@@ -55,9 +58,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef STDIO_SEMIHOSTING_H
-#define STDIO_SEMIHOSTING_H
 
 #include "stdio_base.h"
 

--- a/sys/include/stdio_uart.h
+++ b/sys/include/stdio_uart.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef STDIO_UART_H
+#define STDIO_UART_H
+
 /**
  * @defgroup    sys_stdio_uart STDIO over UART
  * @ingroup     sys_stdio
@@ -85,9 +88,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef STDIO_UART_H
-#define STDIO_UART_H
 
 /* Boards may override the default STDIO UART device */
 #include "board.h"

--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef STRING_UTILS_H
+#define STRING_UTILS_H
+
 /**
  * @defgroup    sys_string_utils    Utility functions that are missing in `string.h`
  * @ingroup     sys
@@ -32,9 +35,6 @@
 
 #include "flash_utils.h"
 #include "modules.h"
-
-#ifndef STRING_UTILS_H
-#define STRING_UTILS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -183,5 +183,5 @@ const void *memchk(const void *data, uint8_t c, size_t len);
 }
 #endif
 
-#endif /* STRING_UTILS_H */
 /** @} */
+#endif /* STRING_UTILS_H */

--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -6,6 +6,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_H
+#define SUIT_H
+
 /**
  * @defgroup    sys_suit SUIT secure firmware OTA upgrade infrastructure
  * @ingroup     sys
@@ -26,9 +29,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
-
-#ifndef SUIT_H
-#define SUIT_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -329,5 +329,5 @@ int suit_component_name_to_string(const suit_manifest_t *manifest,
 }
 #endif
 
-#endif /* SUIT_H */
 /** @} */
+#endif /* SUIT_H */

--- a/sys/include/suit/conditions.h
+++ b/sys/include/suit/conditions.h
@@ -6,6 +6,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_CONDITIONS_H
+#define SUIT_CONDITIONS_H
+
 /**
  * @ingroup     sys_suit
  * @brief       SUIT conditions
@@ -17,9 +20,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
-
-#ifndef SUIT_CONDITIONS_H
-#define SUIT_CONDITIONS_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -105,5 +105,5 @@ uuid_t *suit_get_device_id(void);
 }
 #endif
 
-#endif /* SUIT_CONDITIONS_H */
 /** @} */
+#endif /* SUIT_CONDITIONS_H */

--- a/sys/include/suit/handlers.h
+++ b/sys/include/suit/handlers.h
@@ -8,6 +8,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_HANDLERS_H
+#define SUIT_HANDLERS_H
+
 /**
  * @ingroup     sys_suit
  * @brief       SUIT draft-ietf-suit-manifest-03 manifest handlers
@@ -20,9 +23,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef SUIT_HANDLERS_H
-#define SUIT_HANDLERS_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -227,5 +227,5 @@ void suit_param_cbor_to_ref(const suit_manifest_t *manifest,
 }
 #endif
 
-#endif /* SUIT_HANDLERS_H */
 /** @} */
+#endif /* SUIT_HANDLERS_H */

--- a/sys/include/suit/policy.h
+++ b/sys/include/suit/policy.h
@@ -8,6 +8,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_POLICY_H
+#define SUIT_POLICY_H
+
 /**
  * @ingroup     sys_suit
  * @brief       SUIT policy definitions
@@ -19,9 +22,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
-
-#ifndef SUIT_POLICY_H
-#define SUIT_POLICY_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -55,5 +55,5 @@ extern "C" {
 }
 #endif
 
-#endif /* SUIT_POLICY_H */
 /** @} */
+#endif /* SUIT_POLICY_H */

--- a/sys/include/suit/storage.h
+++ b/sys/include/suit/storage.h
@@ -6,6 +6,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_STORAGE_H
+#define SUIT_STORAGE_H
+
 /**
  * @defgroup    sys_suit_storage SUIT secure firmware OTA upgrade storage
  *                               infrastructure
@@ -94,9 +97,6 @@
  *
  * @warning This API is by design not thread safe
  */
-
-#ifndef SUIT_STORAGE_H
-#define SUIT_STORAGE_H
 
 #include "suit.h"
 
@@ -611,5 +611,5 @@ static inline int suit_storage_set_seq_no(suit_storage_t *storage,
 }
 #endif
 
-#endif /* SUIT_STORAGE_H */
 /** @} */
+#endif /* SUIT_STORAGE_H */

--- a/sys/include/suit/storage/flashwrite.h
+++ b/sys/include/suit/storage/flashwrite.h
@@ -6,6 +6,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_STORAGE_FLASHWRITE_H
+#define SUIT_STORAGE_FLASHWRITE_H
+
 /**
  * @defgroup    sys_suit_storage_flashwrite  riotboot flashwrite storage backend
  * @ingroup     sys_suit_storage
@@ -16,9 +19,6 @@
  * @brief       riotboot Flashwrite storage backend functions for SUIT manifests
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef SUIT_STORAGE_FLASHWRITE_H
-#define SUIT_STORAGE_FLASHWRITE_H
 
 #include "suit.h"
 #include "riotboot/flashwrite.h"
@@ -39,5 +39,5 @@ typedef struct {
 }
 #endif
 
-#endif /* SUIT_STORAGE_FLASHWRITE_H */
 /** @} */
+#endif /* SUIT_STORAGE_FLASHWRITE_H */

--- a/sys/include/suit/storage/ram.h
+++ b/sys/include/suit/storage/ram.h
@@ -6,6 +6,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_STORAGE_RAM_H
+#define SUIT_STORAGE_RAM_H
+
 /**
  * @defgroup    sys_suit_storage_ram  ram storage backend
  * @ingroup     sys_suit_storage
@@ -27,9 +30,6 @@
  * @warning The install function is implemented as a noop. There is no
  * distinction between valid content and not yet invalidated content.
  */
-
-#ifndef SUIT_STORAGE_RAM_H
-#define SUIT_STORAGE_RAM_H
 
 #include <stdint.h>
 
@@ -101,5 +101,5 @@ typedef struct CONFIG_SUIT_STORAGE_RAM_ATTR {
 }
 #endif
 
-#endif /* SUIT_STORAGE_RAM_H */
 /** @} */
+#endif /* SUIT_STORAGE_RAM_H */

--- a/sys/include/suit/storage/vfs.h
+++ b/sys/include/suit/storage/vfs.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_STORAGE_VFS_H
+#define SUIT_STORAGE_VFS_H
+
 /**
  * @defgroup    sys_suit_storage_vfs  riotboot vfs storage backend
  * @ingroup     sys_suit_storage
@@ -29,9 +32,6 @@
  * @brief       riotboot vfs storage backend functions for SUIT manifests
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef SUIT_STORAGE_VFS_H
-#define SUIT_STORAGE_VFS_H
 
 #include "suit.h"
 #include "../../sys/include/vfs.h"
@@ -68,5 +68,5 @@ typedef struct {
 }
 #endif
 
-#endif /* SUIT_STORAGE_VFS_H */
 /** @} */
+#endif /* SUIT_STORAGE_VFS_H */

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef SUIT_TRANSPORT_COAP_H
+#define SUIT_TRANSPORT_COAP_H
+
 /**
  * @ingroup     sys_suit
  * @defgroup    sys_suit_transport_coap SUIT firmware CoAP transport
@@ -21,9 +24,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *
  */
-
-#ifndef SUIT_TRANSPORT_COAP_H
-#define SUIT_TRANSPORT_COAP_H
 
 #include "net/nanocoap.h"
 #include "suit/transport/worker.h"
@@ -74,5 +74,5 @@ static inline void suit_coap_trigger(const uint8_t *url, size_t len)
 }
 #endif
 
-#endif /* SUIT_TRANSPORT_COAP_H */
 /** @} */
+#endif /* SUIT_TRANSPORT_COAP_H */

--- a/sys/include/suit/transport/mock.h
+++ b/sys/include/suit/transport/mock.h
@@ -6,6 +6,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_TRANSPORT_MOCK_H
+#define SUIT_TRANSPORT_MOCK_H
+
 /**
  * @defgroup    sys_suit_transport_mock SUIT secure firmware OTA mock transport
  * @ingroup     sys_suit
@@ -22,9 +25,6 @@
  * Both the array of payloads named `payloads` and the size with name
  * `num_payloads` must be provided.
  */
-
-#ifndef SUIT_TRANSPORT_MOCK_H
-#define SUIT_TRANSPORT_MOCK_H
 
 #include "suit.h"
 
@@ -57,5 +57,5 @@ int suit_transport_mock_fetch(const suit_manifest_t *manifest);
 }
 #endif
 
-#endif /* SUIT_TRANSPORT_MOCK_H */
 /** @} */
+#endif /* SUIT_TRANSPORT_MOCK_H */

--- a/sys/include/suit/transport/vfs.h
+++ b/sys/include/suit/transport/vfs.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef SUIT_TRANSPORT_VFS_H
+#define SUIT_TRANSPORT_VFS_H
+
 /**
  * @defgroup    sys_suit_transport_vfs SUIT secure firmware OTA VFS transport
  * @ingroup     sys_suit
@@ -21,9 +24,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  */
-
-#ifndef SUIT_TRANSPORT_VFS_H
-#define SUIT_TRANSPORT_VFS_H
 
 #include "net/nanocoap.h"
 #include "suit.h"
@@ -48,5 +48,5 @@ int suit_transport_vfs_fetch(const suit_manifest_t *manifest, coap_blockwise_cb_
 }
 #endif
 
-#endif /* SUIT_TRANSPORT_VFS_H */
 /** @} */
+#endif /* SUIT_TRANSPORT_VFS_H */

--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef SUIT_TRANSPORT_WORKER_H
+#define SUIT_TRANSPORT_WORKER_H
+
 /**
  * @ingroup     sys_suit
  * @defgroup    sys_suit_transport_worker SUIT firmware worker thread
@@ -135,5 +138,5 @@ int suit_handle_manifest_buf(const uint8_t *buffer, size_t size);
 }
 #endif
 
-#endif /* SUIT_TRANSPORT_WORKER_H */
 /** @} */
+#endif /* SUIT_TRANSPORT_WORKER_H */

--- a/sys/include/sys/bus.h
+++ b/sys/include/sys/bus.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef SYS_BUS_H
+#define SYS_BUS_H
+
 /**
  * @ingroup     sys
  * @defgroup    sys_bus System Buses for common events
@@ -18,9 +21,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef SYS_BUS_H
-#define SYS_BUS_H
 
 #include <assert.h>
 #include "msg_bus.h"
@@ -73,5 +73,5 @@ static inline msg_bus_t *sys_bus_get(sys_bus_t bus)
 }
 #endif
 
-#endif /* SYS_BUS_H */
 /** @} */
+#endif /* SYS_BUS_H */

--- a/sys/include/test_utils/benchmark_udp.h
+++ b/sys/include/test_utils/benchmark_udp.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TEST_UTILS_BENCHMARK_UDP_H
+#define TEST_UTILS_BENCHMARK_UDP_H
+
 /**
  * @defgroup    test_utils_benchmark_udp    UDP benchmark
  * @ingroup     sys
@@ -16,9 +19,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef TEST_UTILS_BENCHMARK_UDP_H
-#define TEST_UTILS_BENCHMARK_UDP_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -109,5 +109,5 @@ bool benchmark_udp_stop(void);
 }
 #endif
 
-#endif /* TEST_UTILS_BENCHMARK_UDP_H */
 /** @} */
+#endif /* TEST_UTILS_BENCHMARK_UDP_H */

--- a/sys/include/test_utils/expect.h
+++ b/sys/include/test_utils/expect.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef TEST_UTILS_EXPECT_H
+#define TEST_UTILS_EXPECT_H
+
 /**
  * @defgroup    test_utils_expect expect() utility function
  * @ingroup     sys
@@ -21,9 +24,6 @@
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef TEST_UTILS_EXPECT_H
-#define TEST_UTILS_EXPECT_H
 
 #include <stdio.h>
 #include "compiler_hints.h"
@@ -83,5 +83,5 @@ NORETURN static inline void _expect_failure(const char *file, unsigned line)
 }
 #endif
 
-#endif /* TEST_UTILS_EXPECT_H */
 /** @} */
+#endif /* TEST_UTILS_EXPECT_H */

--- a/sys/include/test_utils/interactive_sync.h
+++ b/sys/include/test_utils/interactive_sync.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TEST_UTILS_INTERACTIVE_SYNC_H
+#define TEST_UTILS_INTERACTIVE_SYNC_H
+
 /**
  * @defgroup    test_utils_interactive_sync Test interactive synchronization
  * @ingroup     sys
@@ -17,9 +20,6 @@
  *
  * @author      Gaëtan Harter <gaetan.harter@fu-berlin.de>
  */
-
-#ifndef TEST_UTILS_INTERACTIVE_SYNC_H
-#define TEST_UTILS_INTERACTIVE_SYNC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,5 +40,5 @@ static inline void test_utils_interactive_sync(void) {}
 #ifdef __cplusplus
 }
 #endif
-#endif /* TEST_UTILS_INTERACTIVE_SYNC_H */
 /** @} */
+#endif /* TEST_UTILS_INTERACTIVE_SYNC_H */

--- a/sys/include/test_utils/netdev_eth_minimal.h
+++ b/sys/include/test_utils/netdev_eth_minimal.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TEST_UTILS_NETDEV_ETH_MINIMAL_H
+#define TEST_UTILS_NETDEV_ETH_MINIMAL_H
+
 /**
  * @defgroup    test_utils_netdev_eth_minimal Minimal netdev Ethernet device processing
  * @ingroup     sys
@@ -22,9 +25,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef TEST_UTILS_NETDEV_ETH_MINIMAL_H
-#define TEST_UTILS_NETDEV_ETH_MINIMAL_H
 
 #include "net/netdev.h"
 
@@ -63,5 +63,5 @@ int netdev_eth_minimal_init(void);
 }
 #endif
 
-#endif /* TEST_UTILS_NETDEV_ETH_MINIMAL_H */
 /** @} */
+#endif /* TEST_UTILS_NETDEV_ETH_MINIMAL_H */

--- a/sys/include/test_utils/netdev_ieee802154_minimal.h
+++ b/sys/include/test_utils/netdev_ieee802154_minimal.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TEST_UTILS_NETDEV_IEEE802154_MINIMAL_H
+#define TEST_UTILS_NETDEV_IEEE802154_MINIMAL_H
+
 /**
  * @defgroup    test_utils_netdev_ieee802154_minimal Minimal netdev IEEE 802.15.4 device processing
  * @ingroup     sys
@@ -25,9 +28,6 @@
  *
  * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
  */
-
-#ifndef TEST_UTILS_NETDEV_IEEE802154_MINIMAL_H
-#define TEST_UTILS_NETDEV_IEEE802154_MINIMAL_H
 
 #include "net/netdev.h"
 
@@ -112,5 +112,5 @@ int netdev_ieee802154_minimal_set(struct netdev *dev, netopt_t opt, void *data, 
 }
 #endif
 
-#endif /* TEST_UTILS_NETDEV_IEEE802154_MINIMAL_H */
 /** @} */
+#endif /* TEST_UTILS_NETDEV_IEEE802154_MINIMAL_H */

--- a/sys/include/test_utils/result_output.h
+++ b/sys/include/test_utils/result_output.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TEST_UTILS_RESULT_OUTPUT_H
+#define TEST_UTILS_RESULT_OUTPUT_H
+
 /**
  * @defgroup    test_utils_result_output Test result output
  * @ingroup     sys
@@ -46,9 +49,6 @@
  *
  * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
  */
-
-#ifndef TEST_UTILS_RESULT_OUTPUT_H
-#define TEST_UTILS_RESULT_OUTPUT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -353,5 +353,5 @@ void turo_simple_exit_status(turo_t *ctx, int exit_status);
 #ifdef __cplusplus
 }
 #endif
-#endif /* TEST_UTILS_RESULT_OUTPUT_H */
 /** @} */
+#endif /* TEST_UTILS_RESULT_OUTPUT_H */

--- a/sys/include/time_units.h
+++ b/sys/include/time_units.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef TIME_UNITS_H
+#define TIME_UNITS_H
+
 /**
  * @defgroup    sys_time_units Time unit representations
  * @brief       Timestamp representation, computation, and conversion
@@ -16,9 +19,6 @@
  * @file
  * @brief       Utility header providing time unit defines
  */
-
-#ifndef TIME_UNITS_H
-#define TIME_UNITS_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef TIMEX_H
+#define TIMEX_H
+
 /**
  * @defgroup    sys_timex Timex
  * @brief       Timestamp representation, computation, and conversion
@@ -16,9 +19,6 @@
  * @file
  * @brief       Utility library for comparing and computing timestamps
  */
-
-#ifndef TIMEX_H
-#define TIMEX_H
 
 #include <stdint.h>
 #include <inttypes.h>

--- a/sys/include/tiny_strerror.h
+++ b/sys/include/tiny_strerror.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef TINY_STRERROR_H
+#define TINY_STRERROR_H
+
 /**
  * @defgroup    sys_tiny_strerror   Tiny strerror() implementation
  * @ingroup     sys
@@ -40,9 +43,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-
-#ifndef TINY_STRERROR_H
-#define TINY_STRERROR_H
 
 #include <errno.h>
 #include <string.h>
@@ -79,5 +79,5 @@ const char *tiny_strerror(int errnum);
 }
 #endif
 
-#endif /* TINY_STRERROR_H */
 /** @} */
+#endif /* TINY_STRERROR_H */

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TM_H
+#define TM_H
+
 /**
  * @addtogroup  sys_timex
  * @{
@@ -13,9 +16,6 @@
  * @file
  * @brief       Utility library for `struct tm`.
  */
-
-#ifndef TM_H
-#define TM_H
 
 #include <time.h>
 #include <sys/time.h>
@@ -121,5 +121,5 @@ int tm_is_valid_time(int hour, int min, int sec);
 }
 #endif
 
-#endif /* TM_H */
 /** @} */
+#endif /* TM_H */

--- a/sys/include/trace.h
+++ b/sys/include/trace.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef TRACE_H
+#define TRACE_H
+
 /**
  * @ingroup     sys
  * @brief       Trace program flows
@@ -49,9 +52,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  */
-
-#ifndef TRACE_H
-#define TRACE_H
 
 #include <stdint.h>
 
@@ -96,5 +96,5 @@ void trace_reset(void);
 }
 #endif
 
-#endif /* TRACE_H */
 /** @} */
+#endif /* TRACE_H */

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -9,6 +9,9 @@
  * directory for more details.
  */
 
+#ifndef TRICKLE_H
+#define TRICKLE_H
+
 /**
  * @defgroup sys_trickle Trickle Timer
  * @ingroup sys
@@ -24,9 +27,6 @@
  * @author  Eric Engel <eric.engel@fu-berlin.de>
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
-
-#ifndef TRICKLE_H
-#define TRICKLE_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -123,5 +123,5 @@ void trickle_callback(trickle_t *trickle);
 }
 #endif
 
-#endif /* TRICKLE_H */
 /** @} */
+#endif /* TRICKLE_H */

--- a/sys/include/tsrb.h
+++ b/sys/include/tsrb.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef TSRB_H
+#define TSRB_H
+
 /**
  * @defgroup    sys_tsrb Thread safe ringbuffer
  * @ingroup     sys
@@ -19,9 +22,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef TSRB_H
-#define TSRB_H
 
 #include <assert.h>
 #include <stddef.h>
@@ -196,5 +196,5 @@ int tsrb_add(tsrb_t *rb, const uint8_t *src, size_t n);
 }
 #endif
 
-#endif /* TSRB_H */
 /** @} */
+#endif /* TSRB_H */

--- a/sys/include/unaligned.h
+++ b/sys/include/unaligned.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef UNALIGNED_H
+#define UNALIGNED_H
+
 /**
  * @defgroup    sys_unaligned unaligned memory access methods
  * @ingroup     sys
@@ -33,9 +36,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef UNALIGNED_H
-#define UNALIGNED_H
 
 #include <stdint.h>
 

--- a/sys/include/universal_address.h
+++ b/sys/include/universal_address.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef UNIVERSAL_ADDRESS_H
+#define UNIVERSAL_ADDRESS_H
+
 /**
  * @defgroup    sys_universal_address Universal Address Container
  * @ingroup     sys
@@ -17,9 +20,6 @@
  * @brief       Types and functions for operating universal addresses
  * @author      Martin Landsmann
  */
-
-#ifndef UNIVERSAL_ADDRESS_H
-#define UNIVERSAL_ADDRESS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -170,5 +170,5 @@ void universal_address_print_table(void);
 }
 #endif
 
-#endif /* UNIVERSAL_ADDRESS_H */
 /** @} */
+#endif /* UNIVERSAL_ADDRESS_H */

--- a/sys/include/uri_parser.h
+++ b/sys/include/uri_parser.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef URI_PARSER_H
+#define URI_PARSER_H
+
 /**
  * @defgroup    sys_uri_parser A minimal, non-destructive URI parser
  * @ingroup     sys
@@ -23,9 +26,6 @@
  * @author      Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  *
  */
-
-#ifndef URI_PARSER_H
-#define URI_PARSER_H
 
 #include <string.h>
 #include <stdint.h>
@@ -178,5 +178,5 @@ int uri_parser_split_query(const uri_parser_result_t *uri_parsed,
 }
 #endif
 
-#endif /* URI_PARSER_H */
 /** @} */
+#endif /* URI_PARSER_H */

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for
  * more details.
  */
+#ifndef USB_H
+#define USB_H
+
 /**
  * @defgroup    usb   USB
  * @ingroup     sys
@@ -16,9 +19,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_H
-#define USB_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -271,5 +271,5 @@ typedef enum {
 }
 #endif
 
-#endif /* USB_H */
 /** @} */
+#endif /* USB_H */

--- a/sys/include/usb/cdc.h
+++ b/sys/include/usb/cdc.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_CDC_H
+#define USB_CDC_H
+
 /**
  * @defgroup    usb_cdc   CDC - USB communications device class
  * @ingroup     usb
@@ -19,9 +22,6 @@
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_CDC_H
-#define USB_CDC_H
 
 #include <stdint.h>
 
@@ -301,5 +301,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* USB_CDC_H */
 /** @} */
+#endif /* USB_CDC_H */

--- a/sys/include/usb/descriptor.h
+++ b/sys/include/usb/descriptor.h
@@ -5,6 +5,8 @@
  * Public License v2.1. See the file LICENSE in the top level directory for
  * more details.
  */
+#ifndef USB_DESCRIPTOR_H
+#define USB_DESCRIPTOR_H
 /**
  * @defgroup    usb_descriptor   USB descriptors
  * @ingroup     usb
@@ -16,8 +18,6 @@
  *
  * @author  Koen Zandberg <koen@bergzand.net>
  */
-#ifndef USB_DESCRIPTOR_H
-#define USB_DESCRIPTOR_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -229,5 +229,5 @@ static inline bool usb_setup_is_read(usb_setup_t *pkt)
 }
 #endif
 
-#endif /* USB_DESCRIPTOR_H */
 /** @} */
+#endif /* USB_DESCRIPTOR_H */

--- a/sys/include/usb/dfu.h
+++ b/sys/include/usb/dfu.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_DFU_H
+#define USB_DFU_H
+
 /**
  * @defgroup    usb_dfu   DFU - USB Device Firmware Upgrade
  * @ingroup     usb
@@ -18,9 +21,6 @@
  *
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef USB_DFU_H
-#define USB_DFU_H
 
 #include <stdint.h>
 
@@ -132,5 +132,5 @@ typedef struct __attribute__((packed))  {
 }
 #endif
 
-#endif /* USB_DFU_H */
 /** @} */
+#endif /* USB_DFU_H */

--- a/sys/include/usb/hid.h
+++ b/sys/include/usb/hid.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_HID_H
+#define USB_HID_H
+
 /**
  * @defgroup    usb_hid   HID - USB communications device class
  * @ingroup     usb
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef USB_HID_H
-#define USB_HID_H
 
 #include <stdint.h>
 
@@ -513,5 +513,5 @@ typedef struct __attribute__((packed)){
 }
 #endif
 
-#endif /* USB_HID_H */
 /** @} */
+#endif /* USB_HID_H */

--- a/sys/include/usb/hid/hid_usage.h
+++ b/sys/include/usb/hid/hid_usage.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for
  * more details.
  */
+#ifndef USB_HID_HID_USAGE_H
+#define USB_HID_HID_USAGE_H
+
 /**
  * @defgroup    usb_hid_usage   USB HID usage tables
  * @ingroup     usb_hid
@@ -19,9 +22,6 @@
  *
  * @see Based on HID Usage Tables 1.21, https://www.usb.org/sites/default/files/hut1_21.pdf
  */
-
-#ifndef USB_HID_HID_USAGE_H
-#define USB_HID_HID_USAGE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -2729,5 +2729,5 @@ extern "C" {
 }
 #endif
 
-#endif /* USB_HID_HID_USAGE_H */
 /** @} */
+#endif /* USB_HID_HID_USAGE_H */

--- a/sys/include/usb/msc.h
+++ b/sys/include/usb/msc.h
@@ -8,6 +8,9 @@
  *
  */
 
+#ifndef USB_MSC_H
+#define USB_MSC_H
+
 /**
  * @defgroup    usbus_msc USBUS Mass Storage Class functions
  * @ingroup     usb
@@ -19,9 +22,6 @@
  *
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef USB_MSC_H
-#define USB_MSC_H
 
 #include <stdint.h>
 #include "usb/usbus.h"
@@ -100,5 +100,5 @@ extern "C" {
 }
 #endif
 
-#endif /* USB_MSC_H */
 /** @} */
+#endif /* USB_MSC_H */

--- a/sys/include/usb/usbopt.h
+++ b/sys/include/usb/usbopt.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for
  * more details.
  */
+#ifndef USB_USBOPT_H
+#define USB_USBOPT_H
+
 /**
  * @defgroup    usb_usbopt   usbopt - Configuration options for USB APIs
  * @ingroup     usb
@@ -18,9 +21,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_USBOPT_H
-#define USB_USBOPT_H
 
 #include <stdint.h>
 
@@ -120,5 +120,5 @@ typedef enum {
 }
 #endif
 
-#endif /* USB_USBOPT_H */
 /** @} */
+#endif /* USB_USBOPT_H */

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef USB_USBUS_H
+#define USB_USBUS_H
+
 /**
  * @defgroup    usb_usbus USBUS device and endpoint manager
  * @ingroup     usb
@@ -19,9 +22,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_USBUS_H
-#define USB_USBUS_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -789,5 +789,5 @@ static inline bool usbus_urb_isset_flag(usbus_urb_t *urb,
 #ifdef __cplusplus
 }
 #endif
-#endif /* USB_USBUS_H */
 /** @} */
+#endif /* USB_USBUS_H */

--- a/sys/include/usb/usbus/cdc/acm.h
+++ b/sys/include/usb/usbus/cdc/acm.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_USBUS_CDC_ACM_H
+#define USB_USBUS_CDC_ACM_H
+
 /**
  * @defgroup    usbus_cdc_acm_stdio  STDIO over CDC ACM (usbus)
  * @ingroup     sys_stdio
@@ -37,9 +40,6 @@
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_USBUS_CDC_ACM_H
-#define USB_USBUS_CDC_ACM_H
 
 #include <stdint.h>
 #include "usb/cdc.h"
@@ -226,5 +226,5 @@ void usbus_cdc_acm_set_coding_cb(usbus_cdcacm_device_t *cdcacm,
 }
 #endif
 
-#endif /* USB_USBUS_CDC_ACM_H */
 /** @} */
+#endif /* USB_USBUS_CDC_ACM_H */

--- a/sys/include/usb/usbus/cdc/ecm.h
+++ b/sys/include/usb/usbus/cdc/ecm.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_USBUS_CDC_ECM_H
+#define USB_USBUS_CDC_ECM_H
+
 /**
  * @defgroup    usbus_cdc_ecm USBUS CDC ECM - USBUS CDC ethernet control model
  * @ingroup     usb
@@ -18,9 +21,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_USBUS_CDC_ECM_H
-#define USB_USBUS_CDC_ECM_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -163,5 +163,5 @@ void usbus_cdcecm_init(usbus_t *usbus, usbus_cdcecm_device_t *handler);
 }
 #endif
 
-#endif /* USB_USBUS_CDC_ECM_H */
 /** @} */
+#endif /* USB_USBUS_CDC_ECM_H */

--- a/sys/include/usb/usbus/control.h
+++ b/sys/include/usb/usbus/control.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef USB_USBUS_CONTROL_H
+#define USB_USBUS_CONTROL_H
+
 /**
  * @ingroup     usb_usbus
  * @brief       USBUS control endpoint module
@@ -17,9 +20,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_USBUS_CONTROL_H
-#define USB_USBUS_CONTROL_H
 
 /**
  * @brief   Number of IN EPs required for the control interface
@@ -162,5 +162,5 @@ uint8_t *usbus_control_get_out_data(usbus_t *usbus, size_t *len);
 #ifdef __cplusplus
 }
 #endif
-#endif /* USB_USBUS_CONTROL_H */
 /** @} */
+#endif /* USB_USBUS_CONTROL_H */

--- a/sys/include/usb/usbus/dfu.h
+++ b/sys/include/usb/usbus/dfu.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_USBUS_DFU_H
+#define USB_USBUS_DFU_H
+
 /**
  * @defgroup    usbus_dfu   USBUS DFU - USB Device Firmware Upgrade
  * @ingroup     usb
@@ -15,9 +18,6 @@
  *
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef USB_USBUS_DFU_H
-#define USB_USBUS_DFU_H
 
 #include "usb/dfu.h"
 #include "riotboot/flashwrite.h"
@@ -59,5 +59,5 @@ void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, unsigned mode);
 }
 #endif
 
-#endif /* USB_USBUS_DFU_H */
 /** @} */
+#endif /* USB_USBUS_DFU_H */

--- a/sys/include/usb/usbus/fmt.h
+++ b/sys/include/usb/usbus/fmt.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef USB_USBUS_FMT_H
+#define USB_USBUS_FMT_H
+
 /**
  * @defgroup    usb_usbus_fmt USBUS descriptor formatter functions
  * @ingroup     usb_usbus
@@ -17,9 +20,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef USB_USBUS_FMT_H
-#define USB_USBUS_FMT_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -50,5 +50,5 @@ size_t usbus_fmt_descriptor_dev(usbus_t *usbus);
 #ifdef __cplusplus
 }
 #endif
-#endif /* USB_USBUS_FMT_H */
 /** @} */
+#endif /* USB_USBUS_FMT_H */

--- a/sys/include/usb/usbus/hid.h
+++ b/sys/include/usb/usbus/hid.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_USBUS_HID_H
+#define USB_USBUS_HID_H
+
 /**
  * @defgroup    usbus_hid USBUS HID
  * @ingroup     usb
@@ -23,9 +26,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef USB_USBUS_HID_H
-#define USB_USBUS_HID_H
 
 #include <stdint.h>
 
@@ -106,5 +106,5 @@ void usbus_hid_init(usbus_t *usbus, usbus_hid_device_t *hid,
 }
 #endif
 
-#endif /* USB_USBUS_HID_H */
 /** @} */
+#endif /* USB_USBUS_HID_H */

--- a/sys/include/usb/usbus/hid_io.h
+++ b/sys/include/usb/usbus/hid_io.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_USBUS_HID_IO_H
+#define USB_USBUS_HID_IO_H
+
 /**
  * @defgroup    usbus_hid_io USBUS HID IO
  * @ingroup     usb_hid
@@ -18,9 +21,6 @@
  *
  * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
-
-#ifndef USB_USBUS_HID_IO_H
-#define USB_USBUS_HID_IO_H
 
 #include <string.h>
 #include <stdint.h>
@@ -96,5 +96,5 @@ void usb_hid_io_init(usbus_t *usbus, const uint8_t *report_desc, size_t report_d
 }
 #endif
 
-#endif /* USB_USBUS_HID_IO_H */
 /** @} */
+#endif /* USB_USBUS_HID_IO_H */

--- a/sys/include/usb/usbus/msc.h
+++ b/sys/include/usb/usbus/msc.h
@@ -8,6 +8,9 @@
  *
  */
 
+#ifndef USB_USBUS_MSC_H
+#define USB_USBUS_MSC_H
+
 /**
  * @ingroup     usbus_msc
  *
@@ -18,9 +21,6 @@
  *
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef USB_USBUS_MSC_H
-#define USB_USBUS_MSC_H
 
 #include <stdint.h>
 #include "usb/usbus.h"
@@ -131,5 +131,5 @@ int usbus_msc_remove_lun(usbus_t *usbus, mtd_dev_t *dev);
 }
 #endif
 
-#endif /* USB_USBUS_MSC_H */
 /** @} */
+#endif /* USB_USBUS_MSC_H */

--- a/sys/include/usb/usbus/msc/scsi.h
+++ b/sys/include/usb/usbus/msc/scsi.h
@@ -6,6 +6,9 @@
  * more details.
  */
 
+#ifndef USB_USBUS_MSC_SCSI_H
+#define USB_USBUS_MSC_SCSI_H
+
 /**
  * @ingroup     usbus_msc
  *
@@ -16,9 +19,6 @@
  *
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef USB_USBUS_MSC_SCSI_H
-#define USB_USBUS_MSC_SCSI_H
 
 #include "byteorder.h"
 
@@ -291,5 +291,5 @@ void scsi_gen_csw(usbus_handler_t *handler, cbw_info_t *cmd);
 }
 #endif
 
-#endif /* USB_USBUS_MSC_SCSI_H */
 /** @} */
+#endif /* USB_USBUS_MSC_SCSI_H */

--- a/sys/include/usb_board_reset.h
+++ b/sys/include/usb_board_reset.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef USB_BOARD_RESET_H
+#define USB_BOARD_RESET_H
+
 /**
  * @defgroup    sys_usb_board_reset Board reset via USB CDC ACM
  * @ingroup     sys
@@ -16,9 +19,6 @@
  * @file
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef USB_BOARD_RESET_H
-#define USB_BOARD_RESET_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,5 +38,5 @@ void usb_board_reset_in_bootloader(void);
 }
 #endif
 
-#endif /* USB_BOARD_RESET_H */
 /** @} */
+#endif /* USB_BOARD_RESET_H */

--- a/sys/include/usb_board_reset_internal.h
+++ b/sys/include/usb_board_reset_internal.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef USB_BOARD_RESET_INTERNAL_H
+#define USB_BOARD_RESET_INTERNAL_H
+
 /**
  * @defgroup    sys_usb_board_reset_internal Board reset via USB CDC ACM internals
  * @ingroup     sys_usb_board_reset
@@ -16,9 +19,6 @@
  * @file
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef USB_BOARD_RESET_INTERNAL_H
-#define USB_BOARD_RESET_INTERNAL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,5 +47,5 @@ int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
 }
 #endif
 
-#endif /* USB_BOARD_RESET_INTERNAL_H */
 /** @} */
+#endif /* USB_BOARD_RESET_INTERNAL_H */

--- a/sys/include/ut_process.h
+++ b/sys/include/ut_process.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef UT_PROCESS_H
+#define UT_PROCESS_H
 /**
  * @defgroup sys_ut_process URI template processor
  * @ingroup  sys
@@ -23,8 +25,6 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef UT_PROCESS_H
-#define UT_PROCESS_H
 
 #include <stddef.h>
 #include <string.h>
@@ -97,5 +97,5 @@ static inline int ut_process_str_expand(const char *ut,
 }
 #endif
 
-#endif /* UT_PROCESS_H */
 /** @} */
+#endif /* UT_PROCESS_H */

--- a/sys/include/utlist.h
+++ b/sys/include/utlist.h
@@ -21,6 +21,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef UTLIST_H
+#define UTLIST_H
+
 /**
  * @defgroup    sys_ut utlist
  * @ingroup     sys
@@ -33,9 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *              For in-depth documentation see
  *              http://troydhanson.github.io/uthash/utlist.html
  */
-
-#ifndef UTLIST_H
-#define UTLIST_H
 
 /** @brief Version number */
 #define UTLIST_VERSION 1.9.9
@@ -868,5 +868,5 @@ do {                                                                            
 }
 #endif
 
-#endif /* UTLIST_H */
 /** @} */
+#endif /* UTLIST_H */

--- a/sys/include/uuid.h
+++ b/sys/include/uuid.h
@@ -7,6 +7,9 @@
  * directory for more details.
  */
 
+#ifndef UUID_H
+#define UUID_H
+
 /**
  * @defgroup    sys_uuid RFC 4122 compliant UUID's
  * @ingroup     sys
@@ -22,9 +25,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef UUID_H
-#define UUID_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -161,5 +161,5 @@ int uuid_from_string(uuid_t *uuid, const char *str);
 #ifdef __cplusplus
 }
 #endif
-#endif /* UUID_H */
 /** @} */
+#endif /* UUID_H */

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef VFS_H
+#define VFS_H
+
 /**
  * @defgroup  sys_vfs Virtual File System (VFS) layer
  * @ingroup   sys
@@ -49,9 +52,6 @@
  * @brief   VFS layer API declarations
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef VFS_H
-#define VFS_H
 
 #include <stdint.h>
 #include <sys/stat.h> /* for struct stat */
@@ -1228,6 +1228,6 @@ int vfs_sysop_stat_from_fstat(vfs_mount_t *mountp,
 }
 #endif
 
-#endif /* VFS_H */
-
 /** @} */
+
+#endif /* VFS_H */

--- a/sys/include/vfs_default.h
+++ b/sys/include/vfs_default.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef VFS_DEFAULT_H
+#define VFS_DEFAULT_H
+
 /**
  * @ingroup   sys_vfs
  * @brief     VFS default mount points
@@ -16,9 +19,6 @@
  *
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef VFS_DEFAULT_H
-#define VFS_DEFAULT_H
 
 #include "board.h"
 #include "modules.h"
@@ -83,6 +83,6 @@ extern "C" {
 }
 #endif
 
-#endif /* VFS_DEFAULT_H */
-
 /** @} */
+
+#endif /* VFS_DEFAULT_H */

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef VFS_UTIL_H
+#define VFS_UTIL_H
+
 /**
  * @defgroup    sys_vfs_util    VFS helper functions
  * @ingroup     sys_vfs
@@ -16,9 +19,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef VFS_UTIL_H
-#define VFS_UTIL_H
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -144,5 +144,5 @@ int vfs_unlink_recursive(const char *root, char *path_buf, size_t max_size);
 }
 #endif
 
-#endif /* VFS_UTIL_H */
 /** @} */
+#endif /* VFS_UTIL_H */

--- a/sys/include/volatile_utils.h
+++ b/sys/include/volatile_utils.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef VOLATILE_UTILS_H
+#define VOLATILE_UTILS_H
+
 /**
  * @defgroup    sys_atomic_utils_volatile   Helpers for volatile accesses
  * @ingroup     sys_atomic_utils
@@ -24,9 +27,6 @@
  *
  * @warning     In most cases using this over @ref sys_atomic_utils is a bug!
  */
-
-#ifndef VOLATILE_UTILS_H
-#define VOLATILE_UTILS_H
 
 #include <stdint.h>
 
@@ -351,5 +351,5 @@ static inline uint64_t volatile_fetch_and_u64(volatile uint64_t *dest,
 }
 #endif
 
-#endif /* VOLATILE_UTILS_H */
 /** @} */
+#endif /* VOLATILE_UTILS_H */

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#ifndef XTIMER_H
+#define XTIMER_H
 /**
  * @defgroup    sys_xtimer xtimer high level timer abstraction layer (deprecated)
  * @ingroup     sys
@@ -39,8 +41,6 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-#ifndef XTIMER_H
-#define XTIMER_H
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#ifndef XTIMER_IMPLEMENTATION_H
+#define XTIMER_IMPLEMENTATION_H
 /**
  * @ingroup   sys_xtimer
 
@@ -20,8 +22,6 @@
  * @author  Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  */
-#ifndef XTIMER_IMPLEMENTATION_H
-#define XTIMER_IMPLEMENTATION_H
 
 #ifndef XTIMER_H
 #error "Do not include this file directly! Use xtimer.h instead"
@@ -335,5 +335,5 @@ static inline bool xtimer_is_set(const xtimer_t *timer)
 }
 #endif
 
-#endif /* XTIMER_IMPLEMENTATION_H */
 /** @} */
+#endif /* XTIMER_IMPLEMENTATION_H */

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef XTIMER_TICK_CONVERSION_H
+#define XTIMER_TICK_CONVERSION_H
+
 /**
  * @ingroup sys_xtimer
  *
@@ -14,9 +17,6 @@
  * @brief   xtimer tick <-> seconds conversions for different values of XTIMER_HZ
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef XTIMER_TICK_CONVERSION_H
-#define XTIMER_TICK_CONVERSION_H
 
 #ifndef XTIMER_H
 #error "Do not include this file directly! Use xtimer.h instead"
@@ -135,5 +135,5 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 }
 #endif
 
-#endif /* XTIMER_TICK_CONVERSION_H */
 /** @} */
+#endif /* XTIMER_TICK_CONVERSION_H */

--- a/sys/include/zptr.h
+++ b/sys/include/zptr.h
@@ -6,6 +6,9 @@
  * directory for more details.
  */
 
+#ifndef ZPTR_H
+#define ZPTR_H
+
 /**
  * @defgroup    sys_util_zptr Pointer Compression
  * @ingroup     sys
@@ -53,9 +56,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZPTR_H
-#define ZPTR_H
 
 #include <assert.h>
 #include <stdint.h>
@@ -135,5 +135,5 @@ static inline void *zptrd(zptr_t zptr) { return (void *)zptr; }
 }
 #endif
 
-#endif /* ZPTR_H */
 /** @} */
+#endif /* ZPTR_H */

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef ZTIMER_H
+#define ZTIMER_H
+
 /**
  * @defgroup    sys_ztimer ztimer high level timer abstraction layer
  * @ingroup     sys
@@ -258,9 +261,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-
-#ifndef ZTIMER_H
-#define ZTIMER_H
 
 #include <stdint.h>
 
@@ -895,5 +895,5 @@ extern ztimer_clock_t *const ZTIMER_MSEC_BASE;
 }
 #endif
 
-#endif /* ZTIMER_H */
 /** @} */
+#endif /* ZTIMER_H */

--- a/sys/include/ztimer/config.h
+++ b/sys/include/ztimer/config.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ZTIMER_CONFIG_H
+#define ZTIMER_CONFIG_H
+
 /**
  * @ingroup     sys_ztimer
  * @{
@@ -16,9 +19,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_CONFIG_H
-#define ZTIMER_CONFIG_H
 
 #include "board.h"
 #include "periph_conf.h"
@@ -202,5 +202,5 @@ extern "C" {
 }
 #endif
 
-#endif /* ZTIMER_CONFIG_H */
 /** @} */
+#endif /* ZTIMER_CONFIG_H */

--- a/sys/include/ztimer/convert.h
+++ b/sys/include/ztimer/convert.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ZTIMER_CONVERT_H
+#define ZTIMER_CONVERT_H
+
 /**
  * @defgroup    sys_ztimer_convert ztimer frequency conversion modules
  * @ingroup     sys_ztimer
@@ -26,9 +29,6 @@
  * @brief       ztimer frequency conversion base module
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_CONVERT_H
-#define ZTIMER_CONVERT_H
 
 #include "ztimer.h"
 
@@ -93,5 +93,5 @@ void ztimer_convert_stop(ztimer_clock_t *clock);
 }
 #endif
 
-#endif /* ZTIMER_CONVERT_H */
 /** @} */
+#endif /* ZTIMER_CONVERT_H */

--- a/sys/include/ztimer/convert_frac.h
+++ b/sys/include/ztimer/convert_frac.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#ifndef ZTIMER_CONVERT_FRAC_H
+#define ZTIMER_CONVERT_FRAC_H
 /**
  * @defgroup  sys_ztimer_convert_frac ztimer_convert_frac frequency conversion layer
  * @ingroup   sys_ztimer_convert
@@ -25,8 +27,6 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
-#ifndef ZTIMER_CONVERT_FRAC_H
-#define ZTIMER_CONVERT_FRAC_H
 
 #include <stdint.h>
 #include "ztimer.h"
@@ -88,5 +88,5 @@ void ztimer_convert_frac_change_rate(ztimer_convert_frac_t *self,
 }
 #endif
 
-#endif /* ZTIMER_CONVERT_FRAC_H */
 /** @} */
+#endif /* ZTIMER_CONVERT_FRAC_H */

--- a/sys/include/ztimer/convert_muldiv64.h
+++ b/sys/include/ztimer/convert_muldiv64.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ZTIMER_CONVERT_MULDIV64_H
+#define ZTIMER_CONVERT_MULDIV64_H
+
 /**
  * @defgroup    sys_ztimer_convert_muldiv64 plain 64bit carithmetic
  * @ingroup     sys_ztimer_convert
@@ -46,9 +49,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef ZTIMER_CONVERT_MULDIV64_H
-#define ZTIMER_CONVERT_MULDIV64_H
-
 #include "ztimer.h"
 #include "ztimer/convert.h"
 
@@ -81,5 +81,5 @@ void ztimer_convert_muldiv64_init(
 }
 #endif
 
-#endif /* ZTIMER_CONVERT_MULDIV64_H */
 /** @} */
+#endif /* ZTIMER_CONVERT_MULDIV64_H */

--- a/sys/include/ztimer/convert_shift.h
+++ b/sys/include/ztimer/convert_shift.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#ifndef ZTIMER_CONVERT_SHIFT_H
+#define ZTIMER_CONVERT_SHIFT_H
 /**
  * @defgroup  sys_ztimer_convert_shift conversion using shifts
  * @ingroup   sys_ztimer_convert
@@ -21,8 +23,6 @@
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef ZTIMER_CONVERT_SHIFT_H
-#define ZTIMER_CONVERT_SHIFT_H
 
 #include <stdint.h>
 
@@ -67,5 +67,5 @@ void ztimer_convert_shift_up_init(ztimer_convert_shift_t *clock,
 }
 #endif
 
-#endif /* ZTIMER_CONVERT_SHIFT_H */
 /** @} */
+#endif /* ZTIMER_CONVERT_SHIFT_H */

--- a/sys/include/ztimer/mock.h
+++ b/sys/include/ztimer/mock.h
@@ -7,6 +7,9 @@
  * details.
  */
 
+#ifndef ZTIMER_MOCK_H
+#define ZTIMER_MOCK_H
+
 /**
  * @defgroup    sys_ztimer_mock ztimer mock clock backend
  * @ingroup     sys_ztimer
@@ -23,9 +26,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_MOCK_H
-#define ZTIMER_MOCK_H
 
 #include <stdint.h>
 #include "ztimer.h"
@@ -96,5 +96,5 @@ void ztimer_mock_init(ztimer_mock_t *self, unsigned width);
 }
 #endif
 
-#endif /* ZTIMER_MOCK_H */
 /** @} */
+#endif /* ZTIMER_MOCK_H */

--- a/sys/include/ztimer/overhead.h
+++ b/sys/include/ztimer/overhead.h
@@ -8,6 +8,9 @@
  * details.
  */
 
+#ifndef ZTIMER_OVERHEAD_H
+#define ZTIMER_OVERHEAD_H
+
 /**
  * @defgroup    sys_ztimer_overhead  ztimer overhead utility
  * @ingroup     sys_ztimer
@@ -20,9 +23,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_OVERHEAD_H
-#define ZTIMER_OVERHEAD_H
 
 #include "ztimer.h"
 
@@ -54,5 +54,5 @@ int32_t ztimer_overhead_set(ztimer_clock_t *clock, uint32_t base);
  */
 int32_t ztimer_overhead_sleep(ztimer_clock_t *clock, uint32_t base);
 
-#endif /* ZTIMER_OVERHEAD_H */
 /** @} */
+#endif /* ZTIMER_OVERHEAD_H */

--- a/sys/include/ztimer/periodic.h
+++ b/sys/include/ztimer/periodic.h
@@ -7,6 +7,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+#ifndef ZTIMER_PERIODIC_H
+#define ZTIMER_PERIODIC_H
+
 /**
  * @ingroup     sys_ztimer
  * @brief       Periodic ztimer API
@@ -65,9 +68,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_PERIODIC_H
-#define ZTIMER_PERIODIC_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -156,5 +156,5 @@ void ztimer_periodic_stop(ztimer_periodic_t *timer);
 }
 #endif
 
-#endif /* ZTIMER_PERIODIC_H */
 /** @} */
+#endif /* ZTIMER_PERIODIC_H */

--- a/sys/include/ztimer/periph_ptp.h
+++ b/sys/include/ztimer/periph_ptp.h
@@ -7,6 +7,9 @@
  * details.
  */
 
+#ifndef ZTIMER_PERIPH_PTP_H
+#define ZTIMER_PERIPH_PTP_H
+
 /**
  * @defgroup    sys_ztimer_periph_ptp  ztimer periph/ptp backend
  * @ingroup     sys_ztimer
@@ -21,9 +24,6 @@
  *
  * @author      Jana Eisoldt <jana.eisoldt@ovgu.de>
  */
-
-#ifndef ZTIMER_PERIPH_PTP_H
-#define ZTIMER_PERIPH_PTP_H
 
 #include "ztimer.h"
 
@@ -50,5 +50,5 @@ void ztimer_periph_ptp_init(ztimer_periph_ptp_t *clock);
 }
 #endif
 
-#endif /* ZTIMER_PERIPH_PTP_H */
 /** @} */
+#endif /* ZTIMER_PERIPH_PTP_H */

--- a/sys/include/ztimer/periph_rtc.h
+++ b/sys/include/ztimer/periph_rtc.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ZTIMER_PERIPH_RTC_H
+#define ZTIMER_PERIPH_RTC_H
+
 /**
  * @defgroup    sys_ztimer_periph_rtc  ztimer periph/rtc backend
  * @ingroup     sys_ztimer
@@ -20,9 +23,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_PERIPH_RTC_H
-#define ZTIMER_PERIPH_RTC_H
 
 #include "ztimer.h"
 
@@ -48,5 +48,5 @@ void ztimer_periph_rtc_init(ztimer_periph_rtc_t *clock);
 }
 #endif
 
-#endif /* ZTIMER_PERIPH_RTC_H */
 /** @} */
+#endif /* ZTIMER_PERIPH_RTC_H */

--- a/sys/include/ztimer/periph_rtt.h
+++ b/sys/include/ztimer/periph_rtt.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ZTIMER_PERIPH_RTT_H
+#define ZTIMER_PERIPH_RTT_H
+
 /**
  * @defgroup    sys_ztimer_periph_rtt  ztimer periph/rtt backend
  * @ingroup     sys_ztimer
@@ -20,9 +23,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_PERIPH_RTT_H
-#define ZTIMER_PERIPH_RTT_H
 
 #include "ztimer.h"
 
@@ -49,5 +49,5 @@ void ztimer_periph_rtt_init(ztimer_periph_rtt_t *clock);
 }
 #endif
 
-#endif /* ZTIMER_PERIPH_RTT_H */
 /** @} */
+#endif /* ZTIMER_PERIPH_RTT_H */

--- a/sys/include/ztimer/periph_timer.h
+++ b/sys/include/ztimer/periph_timer.h
@@ -6,6 +6,9 @@
  * details.
  */
 
+#ifndef ZTIMER_PERIPH_TIMER_H
+#define ZTIMER_PERIPH_TIMER_H
+
 /**
  * @defgroup    sys_ztimer_periph_timer  ztimer periph/timer backend
  * @ingroup     sys_ztimer
@@ -23,9 +26,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER_PERIPH_TIMER_H
-#define ZTIMER_PERIPH_TIMER_H
 
 #include "ztimer.h"
 #include "periph/timer.h"
@@ -60,5 +60,5 @@ void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
 }
 #endif
 
-#endif /* ZTIMER_PERIPH_TIMER_H */
 /** @} */
+#endif /* ZTIMER_PERIPH_TIMER_H */

--- a/sys/include/ztimer/stopwatch.h
+++ b/sys/include/ztimer/stopwatch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef ZTIMER_STOPWATCH_H
+#define ZTIMER_STOPWATCH_H
 /**
  * @defgroup    sys_ztimer_stopwatch ztimer stop watch
  * @ingroup     sys_ztimer
@@ -14,8 +16,6 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  * @{
  */
-#ifndef ZTIMER_STOPWATCH_H
-#define ZTIMER_STOPWATCH_H
 
 #include "ztimer.h"
 
@@ -98,5 +98,5 @@ static inline void ztimer_stopwatch_stop(ztimer_stopwatch_t *timer)
 }
 #endif
 
-#endif /* ZTIMER_STOPWATCH_H */
 /** @} */
+#endif /* ZTIMER_STOPWATCH_H */

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef ZTIMER_XTIMER_COMPAT_H
+#define ZTIMER_XTIMER_COMPAT_H
 /**
  * @defgroup  sys_ztimer_xtimer_compat ztimer_xtimer_compat: xtimer wrapper
  * @ingroup   sys_ztimer
@@ -17,8 +19,6 @@
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef ZTIMER_XTIMER_COMPAT_H
-#define ZTIMER_XTIMER_COMPAT_H
 
 #include <assert.h>
 #include <stdbool.h>

--- a/sys/include/ztimer64.h
+++ b/sys/include/ztimer64.h
@@ -8,6 +8,9 @@
  * directory for more details.
  */
 
+#ifndef ZTIMER64_H
+#define ZTIMER64_H
+
 /**
  * @ingroup     sys_ztimer
  * @defgroup    sys_ztimer64 ztimer 64bit version
@@ -60,9 +63,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef ZTIMER64_H
-#define ZTIMER64_H
 
 #include <stdint.h>
 
@@ -531,5 +531,5 @@ int64_t ztimer64_overhead(ztimer64_clock_t *clock, uint64_t base);
 }
 #endif
 
-#endif /* ZTIMER64_H */
 /** @} */
+#endif /* ZTIMER64_H */

--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#ifndef ZTIMER64_XTIMER_COMPAT_H
+#define ZTIMER64_XTIMER_COMPAT_H
 /**
  * @defgroup  sys_ztimer64_xtimer_compat ztimer64_xtimer_compat: 64 Bit xtimer wrapper
  * @ingroup   sys_ztimer64
@@ -17,8 +19,6 @@
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef ZTIMER64_XTIMER_COMPAT_H
-#define ZTIMER64_XTIMER_COMPAT_H
 
 #include <assert.h>
 #include <stdbool.h>


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This is part of the greater effort to fix the headers according to #21335. It only covers the header files in sys/include.

I needed to edit some (~10) files manually. So before merging this needs to be checked. I receive some CI errors @mguetschow.
