### PR TITLE
build system: create cargo folders more robustly

### DIFF
--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -95,7 +95,7 @@ $(APPLICATION_RUST_MODULE).module: $(CARGO_LIB) FORCE
 # This prevents cargo inside docker from creating them with root permissions
 # (should they not exist), and also from re-building everything every time
 # because the .cargo inside is as ephemeral as the build container.
-$(shell mkdir -p ~/.cargo/git ~/.cargo/registry)
+$(shell mkdir -p $(HOME)/.cargo/git $(HOME)/.cargo/registry)
 
 FORCE:
 .phony: FORCE


### PR DESCRIPTION
### Contribution description

On some systems, `$(shell mkdir -p ~/.cargo/registry)` ended up not replacing `~` with the home directory, but rather created a directory named `~`.

The new approach should be a bit more robust.

### Testing procedure

The `~/.cargo` folder should now be created correctly across systems.

### Issues/PRs references

None