### PR TITLE
doc: deprecate RIOT_FILE_* macros

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -65,8 +65,9 @@
  * @warning This only works within `*.c` and `*.cpp` files. For `*.h`/`*.hpp` files the
  *          source compiles, however, the including `*.c`/`*.cpp` file will be
  *          substituted.
- * @see     `__FILE__` for absolute filenames that also work with *.h files
  * @see     @ref RIOT_FILE_NOPATH
+ * @deprecated  This macro will be removed after the 2025.10 release.
+ *              Use the compiler builtin `__FILE__` instead (GCC 8+, clang 10+)
  */
 #if DOXYGEN
 #   define RIOT_FILE_RELATIVE
@@ -78,8 +79,9 @@
  * @warning This only works within `*.c` and `*.cpp` files. For `*.h`/`*.hpp` files the
  *          source compiles, however, the including `*.c`/`*.cpp` file will be
  *          substituted.
- * @see     `__FILE__` for absolute filenames that also work with *.h files
  * @see     @ref RIOT_FILE_RELATIVE
+ * @deprecated  This macro will be removed after the 2025.10 release.
+ *              Use the compiler builtin `__FILE_NAME__` instead (GCC 12+, clang 9+)
  */
 #if DOXYGEN
 #   define RIOT_FILE_NOPATH


### PR DESCRIPTION
### Contribution description

Alternative to #21320. Quoting from there:

> #21170 added documentation about RIOT_FILE_RELATIVE and RIOT_FILE_NOPATH which were already considered obsolete in #18936.

@miri64 insisted on going through the normal deprecation process even for such previously non-publicly documented macros, so lets do that instead.

There are replacements for both macros as compiler built-ins from gcc 8/12 and clang 10/9.


### Testing procedure

Read the CI generated docs. Also check list of deprecated features.


### Issues/PRs references

#4053, #21320, #21170, #18936
