### PR TITLE
cpu/stm32f2: Fix Sampling Time for VBat

### DIFF
--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -96,6 +96,13 @@ int adc_init(adc_t line)
     assume((periph_apb_clk(APB2) / clk_div) <= ADC_CLK_MAX);
     ADC->CCR = ((clk_div / 2) - 1) << 16;
 
+    if (IS_USED(MODULE_PERIPH_VBAT)) {
+        /* Set the sampling rate for the VBat channel to 112 cycles. It reads
+        * correct with 84 cycles already, so this adds some margin. */
+        ADC1->SMPR1 = (ADC1->SMPR1 & ~ADC_SMPR1_SMP18) | \
+                      (ADC_SMPR1_SMP18_2 | ADC_SMPR1_SMP18_0);
+    }
+
     /* enable the ADC module */
     dev(line)->CR2 = ADC_CR2_ADON;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

During the testing of #20971 I noticed that the sampling time for reading VBat is insufficient. This happened on other platforms as well, apparently I did not test the F2 yet...

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

To test this PR, #20971 has to be applied as well, otherwise the sampling will freeze after the zero-th to second sampling due to incorrect resolution settings (I guess?).

With current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-stm32adc/RIOT$ BOARD=nucleo-f207zg USEMODULE+=periph_vbat  make -C tests/periph/vbat flash term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/tests/periph/vbat'
Building application "tests_vbat" for "nucleo-f207zg" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/boards/nucleo-f207zg
...
shutdown command invoked
Done flashing
/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2025-04-02_21.33.29-tests_vbat-nucleo-f207zg"
2025-04-02 21:33:29,475 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2025-04-02 21:33:30,483 # 89[mV]
*freeze*
```

With #20971:
```
cbuec@W11nMate:~/RIOTstuff/riot-stm32adc/RIOT$ BOARD=nucleo-f207zg USEMODULE+=periph_vbat  make -C tests/per
iph/vbat flash term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/tests/periph/vbat'
Building application "tests_vbat" for "nucleo-f207zg" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/boards
...
shutdown command invoked
Done flashing
/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2025-04-02_21.36.39-tests_vbat-nucleo-f207zg"
2025-04-02 21:36:39,903 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2025-04-02 21:36:40,910 # VBAT: 106[mV]
2025-04-02 21:36:41,566 # VBAT: 98[mV]
2025-04-02 21:36:42,544 # VBAT: 93[mV]
2025-04-02 21:36:43,525 # VBAT: 87[mV]
2025-04-02 21:36:44,504 # VBAT: 75[mV]
2025-04-02 21:36:45,484 # VBAT: 96[mV]
2025-04-02 21:36:46,463 # VBAT: 91[mV]
```

With this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-stm32adc/RIOT$ BOARD=nucleo-f207zg USEMODULE+=periph_vbat  make -C tests/periph/vbat flash term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/tests/periph/vbat'
Building application "tests_vbat" for "nucleo-f207zg" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/boards
...

shutdown command invoked
Done flashing
/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2025-04-02_21.38.46-tests_vbat-nucleo-f207zg"
2025-04-02 21:38:46,799 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2025-04-02 21:38:47,806 # BAT: 91[mV]
2025-04-02 21:38:47,806 # VBAT: 83[mV]
*freeze*
```

With this PR and #20971:
```
cbuec@W11nMate:~/RIOTstuff/riot-stm32adc/RIOT$ BOARD=nucleo-f207zg USEMODULE+=periph_vbat  make -C tests/periph/vbat flash term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/tests/periph/vbat'
Building application "tests_vbat" for "nucleo-f207zg" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-stm32adc/RIOT/boards
...
Done flashing
/home/cbuec/RIOTstuff/riot-stm32adc/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2025-04-02_21.27.21-tests_vbat-nucleo-f207zg"
2025-04-02 21:27:22,189 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2025-04-02 21:27:23,195 # VBAT: 3291[mV]
2025-04-02 21:27:23,820 # VBAT: 3291[mV]
2025-04-02 21:27:24,799 # VBAT: 3289[mV]
2025-04-02 21:27:25,780 # VBAT: 3289[mV]
2025-04-02 21:27:26,758 # VBAT: 3291[mV]
2025-04-02 21:27:27,738 # VBAT: 3289[mV]
2025-04-02 21:27:28,718 # VBAT: 3289[mV]
2025-04-02 21:27:29,697 # VBAT: 3289[mV]
2025-04-02 21:27:31,407 # VBAT: 3289[mV]
...
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Prerequisite for #20971.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
