### PR TITLE
tests/unittests: if include guards in doc example

### DIFF
--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -140,6 +140,9 @@ The test header ``tests-<modulename>/tests-<module>.h`` of a module you add to `
  * directory for more details.
  */
 
+#ifndef TESTS_<MODULE>_H
+#define TESTS_<MODULE>_H
+
 /**
  * @addtogroup  unittests
  * @{
@@ -149,8 +152,7 @@ The test header ``tests-<modulename>/tests-<module>.h`` of a module you add to `
  *
  * @author      <author>
  */
-#ifndef TESTS_<MODULE>_H
-#define TESTS_<MODULE>_H
+
 #include "embUnit/embUnit.h"
 
 #ifdef __cplusplus
@@ -177,8 +179,8 @@ Test *tests_<module>_<header2>_tests(void);
 }
 #endif
 
-#endif /* TESTS_<MODULE>_H */
 /** @} */
+#endif /* TESTS_<MODULE>_H */
 ```
 
 #### Implement tests


### PR DESCRIPTION
### Contribution description

This patch updates the example given to conform to the recomended placement of include guards.

### Testing procedure

This document is not yet part of the Doxygen output, and therefore does not show up in the doc preview. Testing can be done by viewing the document in Github's file viewer [here](https://github.com/Enoch247/RIOT/blob/fix-unittests-example/tests/unittests/README.md).

### Issues/PRs references

See issue #21335