### PR TITLE
sys/event/periodic: fix event count footgun

### DIFF
--- a/sys/event/periodic.c
+++ b/sys/event/periodic.c
@@ -27,8 +27,10 @@ static bool _event_periodic_callback(void *arg)
     event_periodic_t *event_periodic = (event_periodic_t *)arg;
     event_post(event_periodic->queue, event_periodic->event);
 
-    if (event_periodic->count && --event_periodic->count == 0) {
-        return !ZTIMER_PERIODIC_KEEP_GOING;
+    if (event_periodic->count) {
+        if (--event_periodic->count == 0) {
+            return !ZTIMER_PERIODIC_KEEP_GOING;
+        }
     }
 
     return ZTIMER_PERIODIC_KEEP_GOING;


### PR DESCRIPTION
### Contribution description

As the event count code is written, I believe that it should not work according to the rules of operator precedence for c. Perhaps some compiler optimization is covering the issue up though.

Regardless, swapping the left and right hand sides of the && operator does create a problem and the statement just looks like a potential footgun. Further, when I did trigger the problem the counter goes negative counting down. Eventually it should hit 0 and stop periodic events which don't have a counter set on them. Therefore, this would be a very hard to find bug.

This patch makes the code much more explicit to defend against future bugs.


### Testing procedure

``` bash
make -C tests/sys/event_periodic_callback/ all test
```


### Issues/PRs references

none known
