### PR TITLE
.github/labeler: recognize boards/common/native as native

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -117,6 +117,7 @@
   - "sys/include/usb.h"
 
 "Platform: native":
+  - "boards/common/native/**/*"
   - "boards/native32/**/*"
   - "boards/native64/**/*"
   - "cpu/native/**/*"


### PR DESCRIPTION
### Contribution description

As per the title.

### Testing procedure

Look at the change, see that it's good.


### Issues/PRs references

Noticed at https://github.com/RIOT-OS/RIOT/pull/20023#event-17112144771

Fixup after #21242 
