### PR TITLE
boards/telosb: fix stdio_uart symbol rate

### DIFF
--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -4,4 +4,6 @@ GOODFET_FLAGS ?= --telosb
 
 PROGRAMMERS_SUPPORTED += goodfet
 
+BAUD := 9600
+
 include $(RIOTBOARD)/common/msp430/Makefile.include

--- a/boards/telosb/doc.txt
+++ b/boards/telosb/doc.txt
@@ -50,7 +50,7 @@ This should take care of everything!
 
 ## Using the shell
 
-The shell is using the UART interface of the TelosB at 115200 baud.
+The shell is using the UART interface of the TelosB at 9600 baud.
 
 ## More information
 


### PR DESCRIPTION
### Contribution description

The stdio UART symbol rate is configured to 9600 Bd, and not to 115200 Bd. This updates `make term` and the doc to match what is implemented.

### Testing procedure

```
make BOARD=telosb flash term
```

Should now work again

### Issues/PRs references

Regression introduced in b51ea4ca2422ac0f024fb4c22b662459d34fa7cc