### PR TITLE
buildsystem: Set `term` Goal to NOTPARALLEL

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -870,6 +870,10 @@ TERMFLASHDEPS ?= $(filter flash flash-only,$(MAKECMDGOALS))
 TERMDEPS += $(TERMFLASHDEPS)
 termdeps: $(TERMDEPS)
 
+# (At least) the native targets don't have `flash` as a dependency,
+# therefore the terminal will be called before the compilation is done.
+# Setting `term` to NOTPARALLEL makes sure it is not executed during compilation.
+.NOTPARALLEL: term
 term: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
 	${TERMENV} $(TERMPROG) $(TERMFLAGS) $(TERMTEE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

@maribu described a bug in #20948 that `native` will experience a race condition when compiling with multiple threads and directly calling the terminal, causing the terminal to execute an old file or other weird behavior.

The reason for that is that `term` does not have any `$(TERMDEPS)` in `native`, because `native` does not have to be flashed.
Therefore Make wants to "build" the `term` goal parallel to the `all` goal, which leads to the described race condition.

Some information about `.NOTPARALLEL`: https://www.gnu.org/software/make/manual/html_node/Parallel-Disable.html

(How could anyone work with `native` with that bug? That's annoying AF and I thought I was crazy when working on the isrpipe PR 🤣 )

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1) Compile a program of your liking with multiple threads: `make -C tests/sys/shell all term -j12`

On `master`, in a fresh environment, the terminal will have nothing to execute yet, therefore failing:
```
cbuec@W11nMate:~/RIOTstuff/riot-native-term/RIOT$ make -C tests/sys/shell all term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_shell" for "native64" with CPU "native".

/home/cbuec/RIOTstuff/riot-native-term/RIOT/dist/tools/pyterm/pyterm -ps /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf --process-args tap0
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards/native64
...
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/sys/ztimer
Traceback (most recent call last):
  File "/home/cbuec/RIOTstuff/riot-native-term/RIOT/dist/tools/pyterm/pyterm", line 967, in <module>
    myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
  File "/usr/lib/python3.10/cmd.py", line 105, in cmdloop
    self.preloop()
  File "/home/cbuec/RIOTstuff/riot-native-term/RIOT/dist/tools/pyterm/pyterm", line 279, in preloop
    self.ser = Popen(process_call, stdout=PIPE, stdin=PIPE, stderr=PIPE)
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf'
make: *** [/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/../../../Makefile.include:875: term] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
```

2) Change the `tests/sys/shell/main.c` to include another printf, for example `printf("Change happens.\n");` and compile again. The new print will not be included. In my case, the terminal even closed instantly:
```
cbuec@W11nMate:~/RIOTstuff/riot-native-term/RIOT$ make -C tests/sys/shell all term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_shell" for "native64" with CPU "native".

/home/cbuec/RIOTstuff/riot-native-term/RIOT/dist/tools/pyterm/pyterm -ps /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf --process-args tap0
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards/native64
...
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  36316    1784   59440   97540   17d04 /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf
Welcome to pyterm!
Type '/exit' to exit.
2025-04-03 21:54:30,992 # RIOT native interrupts/signals initialized.
2025-04-03 21:54:30,993 # Exiting Pyterm
2025-04-03 21:54:30,996 # RIOT native64 board initialized.
2025-04-03 21:54:30,999 # RIOT native hardware initialization complete.
2025-04-03 21:54:30,999 #
2025-04-03 21:54:31,000 # main(): This is RIOT! (Version: 2025.04-devel-406-g5d0de)
2025-04-03 21:54:31,001 # test_shell.
> make: Leaving directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
```

3) Compile again without changing the `main.c`. Now the change is applied.
```
cbuec@W11nMate:~/RIOTstuff/riot-native-term/RIOT$ make -C tests/sys/shell all term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_shell" for "native64" with CPU "native".

/home/cbuec/RIOTstuff/riot-native-term/RIOT/dist/tools/pyterm/pyterm -ps /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf --process-args tap0
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards/native64
...
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  36316    1784   59440   97540   17d04 /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf
2025-04-03 21:55:07,152 # RIOT native interrupts/signals initialized.
Welcome to pyterm!
Type '/exit' to exit.
2025-04-03 21:55:07,153 # RIOT native64 board initialized.
2025-04-03 21:55:07,153 # RIOT native hardware initialization complete.
2025-04-03 21:55:07,154 #
2025-04-03 21:55:07,154 # Exiting Pyterm
2025-04-03 21:55:07,154 # main(): This is RIOT! (Version: 2025.04-devel-406-g5d0de)
2025-04-03 21:55:07,155 # test_shell.
2025-04-03 21:55:07,155 # change happens
> make: Leaving directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
```

<hr/>

Now switch to this PR and start clean by executing `rm -rf tests/sys/shell/bin`. You can stash the changes to `main.c` with `git stash` or just keep them, because now it works on the first try and the terminal doesn't crash.
```
cbuec@W11nMate:~/RIOTstuff/riot-native-term/RIOT$ make -C tests/sys/shell all term -j12
make: Entering directory '/home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_shell" for "native64" with CPU "native".

"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/boards/native64
...
"make" -C /home/cbuec/RIOTstuff/riot-native-term/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  36348    1784   59440   97572   17d24 /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf
/home/cbuec/RIOTstuff/riot-native-term/RIOT/dist/tools/pyterm/pyterm -ps /home/cbuec/RIOTstuff/riot-native-term/RIOT/tests/sys/shell/bin/native64/tests_shell.elf --process-args tap0
Welcome to pyterm!
Type '/exit' to exit.
2025-04-03 21:56:25,552 # RIOT native interrupts/signals initialized.
2025-04-03 21:56:25,553 # RIOT native64 board initialized.
2025-04-03 21:56:25,554 # RIOT native hardware initialization complete.
2025-04-03 21:56:25,554 #
2025-04-03 21:56:25,554 # main(): This is RIOT! (Version: 2025.04-devel-407-g6d8a2-pr/native_term)
2025-04-03 21:56:25,555 # test_shell.
2025-04-03 21:56:25,555 # change happens
>
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #20948.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
