### PR TITLE
buildsystem: Call Buildtest with Clean Environment

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -60,6 +60,13 @@ DLCACHE                         ?= $(RIOTTOOLS)/dlcache/dlcache.sh
 DLCACHE_DIR                     ?= $(RIOTBASE)/.dlcache
 RIOT_VERSION_DUMMY_CODE         ?= RIOT_VERSION_NUM\(2042,5,23,0\)
 
+# Undefine the board for the `buildtest` target, as the `makefiles/buildtest.inc.mk`
+# will override the BOARD anyway and the BOARD might be set with an (incorrect)
+# default from the application or test Makefile.
+ifneq (,$(filter buildtest,$(MAKECMDGOALS)))
+  BOARD=
+endif
+
 # Resolve potential BOARD alias to canonical name before defining BINDIR
 include $(RIOTMAKE)/board_alias.inc.mk
 

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -8,7 +8,7 @@ buildtest:
 	for board in $(BOARDS); do \
 		if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
 			$(COLOR_ECHO) -n "Building for $$board ... " ; \
-			BOARD=$${board} RIOT_CI_BUILD=1 \
+			env --unset=MAKEFLAGS BOARD=$${board} RIOT_CI_BUILD=1 \
 				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
 			RES=$$? ; \
 			if [ $$RES -eq 0 ]; then \
@@ -17,7 +17,7 @@ buildtest:
 				$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
 				RESULT=false ; \
 			fi ; \
-			BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
+			env --unset=MAKEFLAGS BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
 		fi; \
 	done ; \
 	$${RESULT}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The builds for individual boards for the `buildtest` goal were not called with a clean environment, leading to the Make system building the binaries in the incorrect folder. For more details see #9742.

The change in the `Makefile.include` is necessary to avoid `makefiles/board_alias.inc.mk` printing a warning about the alias from `native` to `native64`, but other bad effects are possible from having the wrong `BOARD` defined.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Outlined in #9742.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #9742.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
