### PR TITLE
sys/net/ipv6: use markdown links in doc

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -11,9 +11,7 @@
  * @ingroup     net_ipv6
  * @brief       IPv6 address architecture
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291">
- *          RFC 4291
- *      </a>
+ * @see [RFC 4291](http://tools.ietf.org/html/rfc4291)
  *
  * @{
  *
@@ -56,12 +54,10 @@ extern "C" {
 /**
  * @brief The first 10 bits of a site-local IPv6 unicast address
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.7">
- *          RFC 4291, section 2.5.7
- *      </a>
+ * @see [RFC 4291, section 2.5.7](http://tools.ietf.org/html/rfc4291#section-2.5.7)
  *
- * @note Site-local addresses are now deprecated as defined in <a
- *       href="http://tools.ietf.org/html/rfc3879">SLDEP</a>. They are only
+ * @note Site-local addresses are now deprecated as defined in
+ *       [SLDEP](http://tools.ietf.org/html/rfc3879). They are only
  *       defined here for the distinction of global unicast addresses.
  */
 #define IPV6_ADDR_SITE_LOCAL_PREFIX (0xfec0)
@@ -79,9 +75,7 @@ typedef union {
 /**
  * @brief   Static initializer for the unspecified IPv6 address (::)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.2">
- *          RFC 4291, section 2.5.2
- *      </a>
+ * @see [RFC 4291, section 2.5.2](http://tools.ietf.org/html/rfc4291#section-2.5.2)
  */
 #define IPV6_ADDR_UNSPECIFIED               {{ 0x00, 0x00, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -91,9 +85,7 @@ typedef union {
 /**
  * @brief   Static initializer for the loopback IPv6 address (::1)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.3">
- *          RFC 4291, section 2.5.3
- *      </a>
+ * @see [RFC 4291, section 2.5.3](http://tools.ietf.org/html/rfc4291#section-2.5.3)
  */
 #define IPV6_ADDR_LOOPBACK                  {{ 0x00, 0x00, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -102,9 +94,7 @@ typedef union {
 /**
  * @brief   Static initializer for the link-local prefix (fe80::/64)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.6">
- *          RFC 4291, section 2.5.6
- *      </a>
+ * @see [RFC 4291, section 2.5.6](http://tools.ietf.org/html/rfc4291#section-2.5.6)
  */
 #define IPV6_ADDR_LINK_LOCAL_PREFIX         {{ 0xfe, 0x80, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -115,9 +105,7 @@ typedef union {
  * @brief   Static initializer for the interface-local all nodes multicast IPv6
  *          address (ff01::1)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_ALL_NODES_IF_LOCAL        {{ 0xff, 0x01, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -128,9 +116,7 @@ typedef union {
  * @brief   Static initializer for the link-local all nodes multicast IPv6
  *          address (ff02::1)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_ALL_NODES_LINK_LOCAL      {{ 0xff, 0x02, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -141,9 +127,7 @@ typedef union {
  * @brief   Static initializer for the interface-local all routers multicast IPv6
  *          address (ff01::2)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_ALL_ROUTERS_IF_LOCAL      {{ 0xff, 0x01, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -154,9 +138,7 @@ typedef union {
  * @brief   Static initializer for the link-local all routers multicast IPv6
  *          address (ff02::2)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL    {{ 0xff, 0x02, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -167,9 +149,7 @@ typedef union {
  * @brief   Static initializer for the site-local all routers multicast IPv6
  *          address (ff05::2)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL    {{ 0xff, 0x05, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -180,9 +160,7 @@ typedef union {
  * @brief   Static initializer for the solicited node multicast prefix
  *          (ff02:0:0:0:0:1:ff00::/104)
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_SOLICITED_NODE_PREFIX     {{ 0xff, 0x02, 0x00, 0x00, \
                                                0x00, 0x00, 0x00, 0x00, \
@@ -194,9 +172,7 @@ typedef union {
  * @brief   Values for the flag field in multicast addresses.
  * @{
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 /**
  * @brief   The address is transient, i.e. not well-known, permanently
@@ -207,18 +183,14 @@ typedef union {
 /**
  * @brief   The address is based on a network prefix
  *
- * @see <a href="http://tools.ietf.org/html/rfc3306#section-4">
- *          RFC 3306, section 4
- *      </a>
+ * @see [RFC 3306, section 4](http://tools.ietf.org/html/rfc3306#section-4)
  */
 #define IPV6_ADDR_MCAST_FLAG_PREFIX_BASED   (0x02)
 
 /**
  * @brief   The address embeds the address on the rendezvous point
  *
- * @see <a href="http://tools.ietf.org/html/rfc3956#section-3">
- *          RFC 3956, section 3
- *      </a>
+ * @see [RFC 3956, section 3](http://tools.ietf.org/html/rfc3956#section-3)
  */
 #define IPV6_ADDR_MCAST_FLAG_EMBED_ON_RP    (0x04)
 /** @} */
@@ -228,9 +200,7 @@ typedef union {
  * @brief   Values for the scope field in multicast addresses.
  * @{
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  */
 #define IPV6_ADDR_MCAST_SCP_IF_LOCAL        (0x1)   /**< interface-local scope */
 #define IPV6_ADDR_MCAST_SCP_LINK_LOCAL      (0x2)   /**< link-local scope */
@@ -238,12 +208,8 @@ typedef union {
 /**
  * @brief realm-local scope
  *
- * @see <a href="http://tools.ietf.org/html/rfc7346#section-3">
- *          RFC 7346, section 3
- *      </a> and
- *      <a href="http://tools.ietf.org/html/rfc7346#section-5">
- *          RFC 7346, section 5
- *      </a> and
+ * @see [RFC 7346, section 3](http://tools.ietf.org/html/rfc7346#section-3) and
+ *      [RFC 7346, section 5](http://tools.ietf.org/html/rfc7346#section-5)
  */
 #define IPV6_ADDR_MCAST_SCP_REALM_LOCAL (0x3)
 #define IPV6_ADDR_MCAST_SCP_ADMIN_LOCAL (0x4)      /**< admin-local scope */
@@ -307,9 +273,7 @@ extern const ipv6_addr_t ipv6_addr_solicited_node_prefix;
 /**
  * @brief   Checks if @p addr is unspecified (all zero).
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.2">
- *          RFC 4291, section 2.5.2
- *      </a>
+ * @see [RFC 4291, section 2.5.2](http://tools.ietf.org/html/rfc4291#section-2.5.2)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -324,9 +288,7 @@ static inline bool ipv6_addr_is_unspecified(const ipv6_addr_t *addr)
 /**
  * @brief   Checks if @p addr is a loopback address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.3">
- *          RFC 4291, section 2.5.3
- *      </a>
+ * @see [RFC 4291, section 2.5.3](http://tools.ietf.org/html/rfc4291#section-2.5.3)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -341,9 +303,7 @@ static inline bool ipv6_addr_is_loopback(const ipv6_addr_t *addr)
 /**
  * @brief   Checks if @p addr is a IPv4-compatible IPv6 address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.5.1">
- *          RFC 4291, section 2.5.5.1
- *      </a>
+ * @see [RFC 4291, section 2.5.5.1](http://tools.ietf.org/html/rfc4291#section-2.5.5.1)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -359,9 +319,7 @@ static inline bool ipv6_addr_is_ipv4_compat(const ipv6_addr_t *addr)
 /**
  * @brief   Checks if @p addr is a IPv4-mapped IPv6 address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.5.2">
- *          RFC 4291, section 2.5.5.2
- *      </a>
+ * @see [RFC 4291, section 2.5.5.2](http://tools.ietf.org/html/rfc4291#section-2.5.5.2)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -378,9 +336,7 @@ static inline bool ipv6_addr_is_ipv4_mapped(const ipv6_addr_t *addr)
 /**
  * @brief   Check if @p addr is a multicast address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -395,12 +351,8 @@ static inline bool ipv6_addr_is_multicast(const ipv6_addr_t *addr)
 /**
  * @brief   Check if @p addr is a link-local address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.6">
- *          RFC 4291, section 2.5.6
- *      </a>
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.5.6](http://tools.ietf.org/html/rfc4291#section-2.5.6)
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -417,12 +369,10 @@ static inline bool ipv6_addr_is_link_local(const ipv6_addr_t *addr)
 /**
  * @brief   Checks if @p addr is a site-local address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.7">
- *          RFC 4291, section 2.5.7
- *      </a>
+ * @see [RFC 4291, section 2.5.7](http://tools.ietf.org/html/rfc4291#section-2.5.7)
  *
- * @note Site-local addresses are now deprecated as defined in <a
- *       href="http://tools.ietf.org/html/rfc3879">SLDEP</a>. They are only
+ * @note Site-local addresses are now deprecated as defined in
+ *       [SLDEP](http://tools.ietf.org/html/rfc3879). They are only
  *       defined here for the distinction of global unicast addresses.
  *
  * @param[in] addr  An IPv6 address.
@@ -441,9 +391,7 @@ static inline bool ipv6_addr_is_site_local(const ipv6_addr_t *addr)
 /**
  * @brief   Check if @p addr is unique local unicast address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4193">
- *          RFC 4193
- *      </a>
+ * @see [RFC 4193](http://tools.ietf.org/html/rfc4193)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -458,9 +406,7 @@ static inline bool ipv6_addr_is_unique_local_unicast(const ipv6_addr_t *addr)
 /**
  * @brief   Check if @p addr is global unicast address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.4">
- *          RFC 4291, section 2.5.4
- *      </a>
+ * @see [RFC 4291, section 2.5.4](http://tools.ietf.org/html/rfc4291#section-2.5.4)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -483,9 +429,7 @@ static inline bool ipv6_addr_is_global(const ipv6_addr_t *addr)
 /**
  * @brief   Check if @p addr is solicited-node multicast address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7.1">
- *          RFC 4291, section 2.7.1
- *      </a>
+ * @see [RFC 4291, section 2.7.1](http://tools.ietf.org/html/rfc4291#section-2.7.1)
  *
  * @param[in] addr  An IPv6 address.
  *
@@ -558,9 +502,7 @@ void ipv6_addr_init_iid(ipv6_addr_t *out, const uint8_t *iid, uint8_t bits);
 /**
  * @brief   Sets @p addr dynamically to the unspecified IPv6 address (::).
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.2">
- *          RFC 4291, section 2.5.2
- *      </a>
+ * @see [RFC 4291, section 2.5.2](http://tools.ietf.org/html/rfc4291#section-2.5.2)
  *
  * @param[in,out] addr  The address to set.
  */
@@ -572,9 +514,7 @@ static inline void ipv6_addr_set_unspecified(ipv6_addr_t *addr)
 /**
  * @brief   Sets @p addr dynamically to the loopback IPv6 address (::1).
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.3">
- *          RFC 4291, section 2.5.3
- *      </a>
+ * @see [RFC 4291, section 2.5.3](http://tools.ietf.org/html/rfc4291#section-2.5.3)
  *
  * @param[in,out] addr  The address to set.
  */
@@ -587,9 +527,7 @@ static inline void ipv6_addr_set_loopback(ipv6_addr_t *addr)
 /**
  * @brief   Sets the first 64 bit of @p addr to link local prefix (fe08::/64).
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.6">
- *          RFC 4291, section 2.5.6
- *      </a>
+ * @see [RFC 4291, section 2.5.6](http://tools.ietf.org/html/rfc4291#section-2.5.6)
  *
  * @param[in,out] addr  The address to set.
  */
@@ -602,9 +540,7 @@ static inline void ipv6_addr_set_link_local_prefix(ipv6_addr_t *addr)
  * @brief   Sets the 64-bit interface ID (as integer) of a unicast or anycast
  *          IPv6 address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.4">
- *          RFC 4291, section 2.5.4
- *      </a>
+ * @see [RFC 4291, section 2.5.4](http://tools.ietf.org/html/rfc4291#section-2.5.4)
  *
  * @param[in,out] addr  The address to set.
  * @param[in] iid       The interface ID as integer to set.
@@ -618,9 +554,7 @@ static inline void ipv6_addr_set_iid(ipv6_addr_t *addr, uint64_t iid)
  * @brief   Sets the 64-bit interface ID (as array) of a unicast or anycast
  *          IPv6 address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.5.4">
- *          RFC 4291, section 2.5.4
- *      </a>
+ * @see [RFC 4291, section 2.5.4](http://tools.ietf.org/html/rfc4291#section-2.5.4)
  *
  * @param[in,out] addr  The address to set.
  * @param[in] iid       The interface ID as array of at least length 8 to set.
@@ -633,9 +567,7 @@ static inline void ipv6_addr_set_aiid(ipv6_addr_t *addr, uint8_t *iid)
 /**
  * @brief   Sets the bits for an address required to be a multicast address.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7">
- *          RFC 4291, section 2.7
- *      </a>
+ * @see [RFC 4291, section 2.7](http://tools.ietf.org/html/rfc4291#section-2.7)
  *
  * @param[in,out] addr  The address to set.
  * @param[in] flags     The multicast address' flags.
@@ -652,9 +584,7 @@ static inline void ipv6_addr_set_multicast(ipv6_addr_t *addr, unsigned int flags
  * @brief   Sets @p addr dynamically to an all nodes multicast IPv6 address (ff0S::1,
  *          where S is the scope).
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7.1">
- *          RFC 4291, section 2.7.1
- *      </a>
+ * @see [RFC 4291, section 2.7.1](http://tools.ietf.org/html/rfc4291#section-2.7.1)
  *
  * @param[in,out] addr  The address to set.
  * @param[in] scope     The multicast address' scope.
@@ -669,9 +599,7 @@ static inline void ipv6_addr_set_all_nodes_multicast(ipv6_addr_t *addr, unsigned
  * @brief   Sets @p addr dynamically to an all routers multicast IPv6 address (ff0S::2,
  *          where S is the scope).
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291#section-2.7.1">
- *          RFC 4291, section 2.7.1
- *      </a>
+ * @see [RFC 4291, section 2.7.1](http://tools.ietf.org/html/rfc4291#section-2.7.1)
  *
  * @param[in,out] addr  The address to set.
  * @param[in] scope     The multicast address' scope.
@@ -686,9 +614,7 @@ static inline void ipv6_addr_set_all_routers_multicast(ipv6_addr_t *addr, unsign
  * @brief   Set @p out to the solicited-node multicast address
  *          computed from @p in.
  *
- * @see <a href="http://tools.ietf.org/html/rfc4291">
- *          RFC 4291
- *      </a>
+ * @see [RFC 4291](http://tools.ietf.org/html/rfc4291)
  *
  * @param[out]  out   Is set to solicited-node address of this node.
  * @param[in]   in    The IPv6 address the solicited-node address.
@@ -705,9 +631,7 @@ static inline void ipv6_addr_set_solicited_nodes(ipv6_addr_t *out, const ipv6_ad
 /**
  * @brief   Converts an IPv6 address to its string representation
  *
- * @see <a href="https://tools.ietf.org/html/rfc5952">
- *          RFC 5952
- *      </a>
+ * @see [RFC 5952](https://tools.ietf.org/html/rfc5952)
  *
  * @param[out] result       The resulting string representation of at least
  *                          @ref IPV6_ADDR_MAX_STR_LEN
@@ -724,9 +648,7 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
  * @brief   Converts an IPv6 address string representation to a byte-represented
  *          IPv6 address
  *
- * @see <a href="https://tools.ietf.org/html/rfc5952">
- *          RFC 5952
- *      </a>
+ * @see [RFC 5952](https://tools.ietf.org/html/rfc5952)
  *
  * @param[out] result    The resulting byte representation
  * @param[in] addr       An IPv6 address string representation
@@ -741,9 +663,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
  * @brief   Converts an IPv6 prefix string representation to a byte-represented
  *          IPv6 address
  *
- * @see <a href="https://tools.ietf.org/html/rfc5952">
- *          RFC 5952
- *      </a>
+ * @see [RFC 5952](https://tools.ietf.org/html/rfc5952)
  *
  * @param[out] result    The resulting byte representation
  * @param[in]  prefix    An IPv6 prefix string representation
@@ -757,9 +677,7 @@ int ipv6_prefix_from_str(ipv6_addr_t *result, const char *prefix);
  * @brief   Converts an IPv6 address from a buffer of characters to a
  *          byte-represented IPv6 address
  *
- * @see <a href="https://tools.ietf.org/html/rfc5952">
- *          RFC 5952
- *      </a>
+ * @see [RFC 5952](https://tools.ietf.org/html/rfc5952)
  *
  * @note    @p addr_len should be between 0 and IPV6_ADDR_MAX_STR_LEN
  *


### PR DESCRIPTION
### Contribution description

This makes the header a lot more readable and `clang -Wdocumentation` happy, which does not like HTML tags (`<a href="...">...</a>`) to contain random line breaks.

### Testing procedure

The Doxygen output should still contain the same links as before.

(I tested this with Doxygen `1.14.0 (75f8cf7020304421786ec3ab3aaea99de7c49354)` locally, where it worked. But let's see if the one in the CI also likes this.)

### Issues/PRs references

None