### PR TITLE
tree wide: various doc fixes

### DIFF
--- a/core/lib/atomic_c11.c
+++ b/core/lib/atomic_c11.c
@@ -344,13 +344,13 @@ void __atomic_exchange_c(size_t size, void *ptr, void *val, void *ret,
  * __ATOMIC_ACQ_REL. It also cannot be a stronger order than that specified by
  * success_memorder.
  *
- * @param[in]  len
- * @param[in]  ptr
- * @param[in]  expected  the expected value of ptr
- * @param[in]  desired   the desired value of ptr
- * @param[in]  weak      ignored in this implementation
- * @param[in]  success_memorder ignored in this implementation
- * @param[in]  failure_memorder ignored in this implementation
+ * @param[in]  len                  Length of @p ptr and @p expected in bytes
+ * @param[in]  ptr                  The value to check
+ * @param[in]  expected             the expected value of ptr
+ * @param[in]  desired              the desired value of ptr
+ * @param[in]  weak                 ignored in this implementation
+ * @param[in]  success_memorder     ignored in this implementation
+ * @param[in]  failure_memorder     ignored in this implementation
  *
  * @return true if *ptr had the expected value before the exchange and *ptr was updated
  * @return false otherwise

--- a/core/lib/include/panic.h
+++ b/core/lib/include/panic.h
@@ -85,8 +85,6 @@ typedef enum {
  *
  * @param[in] crash_code    a unique code for identifying the crash reason
  * @param[in] message       a human readable reason for the crash
- *
- * @return                  this function never returns
  * */
 NORETURN void core_panic(core_panic_t crash_code, const char *message);
 

--- a/cpu/esp8266/vendor/esp-idf/bootloader_support/include/esp_image_format.h
+++ b/cpu/esp8266/vendor/esp-idf/bootloader_support/include/esp_image_format.h
@@ -141,9 +141,9 @@ typedef enum {
  *
  * If encryption is enabled, data will be transparently decrypted.
  *
- * @param mode Mode of operation (verify, silent verify, or load).
- * @param part Partition to load the app from.
- * @param[inout] data Pointer to the image metadata structure which is be filled in by this function. 'start_addr' member should be set (to the start address of the image.) Other fields will all be initialised by this function.
+ * @param         mode  Mode of operation (verify, silent verify, or load).
+ * @param         part  Partition to load the app from.
+ * @param[in,out] data  Pointer to the image metadata structure which is be filled in by this function. 'start_addr' member should be set (to the start address of the image.) Other fields will all be initialised by this function.
  *
  * Image validation checks:
  * - Magic byte.

--- a/cpu/esp8266/vendor/esp-idf/esp8266/include/esp_phy_init.h
+++ b/cpu/esp8266/vendor/esp-idf/esp8266/include/esp_phy_init.h
@@ -141,8 +141,8 @@ esp_err_t esp_phy_store_cal_data_to_nvs(const esp_phy_calibration_data_t *cal_da
  * @param init_data  PHY parameters. Default set of parameters can
  *                   be obtained by calling esp_phy_get_default_init_data
  *                   function.
- * @param mode  Calibration mode (Full, partial, or no calibration)
- * @param[inout] calibration_data
+ * @param         mode              Calibration mode (Full, partial, or no calibration)
+ * @param[in,out] calibration_data  Calibration data to use.
  * @return ESP_OK on success.
  * @return ESP_FAIL on fail.
  */

--- a/cpu/esp8266/vendor/esp-idf/esp8266/include/esp_wifi.h
+++ b/cpu/esp8266/vendor/esp-idf/esp8266/include/esp_wifi.h
@@ -140,7 +140,7 @@ extern wifi_osi_funcs_t s_wifi_osi_funcs;
   * @attention 2. Always use WIFI_INIT_CONFIG_DEFAULT macro to init the config to default values, this can
   *               guarantee all the fields got correct value when more fields are added into wifi_init_config_t
   *               in future release. If you want to set your owner initial values, overwrite the default values
-  *               which are set by WIFI_INIT_CONFIG_DEFAULT, please be notified that the field 'magic' of 
+  *               which are set by WIFI_INIT_CONFIG_DEFAULT, please be notified that the field 'magic' of
   *               wifi_init_config_t should always be WIFI_INIT_CONFIG_MAGIC!
   *
   * @param  config pointer to WiFi init configuration structure; can point to a temporary variable.
@@ -239,7 +239,7 @@ esp_err_t esp_wifi_restore(void);
   * @attention 1. This API only impact WIFI_MODE_STA or WIFI_MODE_APSTA mode
   * @attention 2. If the ESP8266 is connected to an AP, call esp_wifi_disconnect to disconnect.
   *
-  * @return 
+  * @return
   *    - ESP_OK: succeed
   *    - ESP_ERR_WIFI_NOT_INIT: WiFi is not initialized by esp_wifi_init
   *    - ESP_ERR_WIFI_NOT_START: WiFi is not started by esp_wifi_start
@@ -333,9 +333,9 @@ esp_err_t esp_wifi_scan_get_ap_num(uint16_t *number);
 /**
   * @brief     Get AP list found in last scan
   *
-  * @param[inout]  number As input param, it stores max AP number ap_records can hold. 
-  *                As output param, it receives the actual AP number this API returns.
-  * @param         ap_records  wifi_ap_record_t array to hold the found APs
+  * @param[in,out] number       As input param, it stores max AP number ap_records can hold.
+  *                             As output param, it receives the actual AP number this API returns.
+  * @param         ap_records   wifi_ap_record_t array to hold the found APs
   *
   * @return
   *    - ESP_OK: succeed
@@ -358,7 +358,7 @@ esp_err_t esp_wifi_scan_get_ap_records(uint16_t *number, wifi_ap_record_t *ap_re
   * @return
   *    - ESP_OK: succeed
   *    - ESP_ERR_WIFI_CONN: The station interface don't initialized
-  *    - ESP_ERR_WIFI_NOT_CONNECT: The station is in disconnect status 
+  *    - ESP_ERR_WIFI_NOT_CONNECT: The station is in disconnect status
   */
 esp_err_t esp_wifi_sta_get_ap_info(wifi_ap_record_t *ap_info);
 
@@ -496,7 +496,7 @@ esp_err_t esp_wifi_get_channel(uint8_t *primary, wifi_second_chan_t *second);
   * @attention 4. When the country info is changed because of configuration or because the station connects to a different
   *               external AP, the country IE in probe response/beacon of the soft-AP is changed also.
   * @attention 5. The country configuration is not stored into flash
-  * @attention 6. This API doesn't validate the per-country rules, it's up to the user to fill in all fields according to 
+  * @attention 6. This API doesn't validate the per-country rules, it's up to the user to fill in all fields according to
   *               local regulations.
   *
   * @param     country   the configured country info
@@ -558,7 +558,7 @@ esp_err_t esp_wifi_set_mac(wifi_interface_t ifx, const uint8_t mac[6]);
 esp_err_t esp_wifi_get_mac(wifi_interface_t ifx, uint8_t mac[6]);
 
 /**
-  * @brief The RX callback function in the promiscuous mode. 
+  * @brief The RX callback function in the promiscuous mode.
   *        Each time a packet is received, the callback function will be called.
   *
   * @param buf  Data received. Type of data in buffer (wifi_promiscuous_pkt_t or wifi_pkt_rx_ctrl_t) indicated by 'type' parameter.
@@ -879,7 +879,7 @@ esp_err_t esp_wifi_get_event_mask(uint32_t *mask);
   * @return    ESP_OK, succeed;
   * @return    ESP_FAIL, fail.
   */
-esp_err_t esp_wifi_send_pkt_freedom(uint8_t *buf, int32_t len, bool sys_seq); 
+esp_err_t esp_wifi_send_pkt_freedom(uint8_t *buf, int32_t len, bool sys_seq);
 
 #ifdef __cplusplus
 }

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -232,7 +232,7 @@ union gpio_conf_sam0 {
          * consulted.
          */
         bool initial_value                      : 1;
-        uint8_t                                 : 1; /*< padding */
+        uint8_t                                 : 1; /**< padding */
     };
 };
 
@@ -602,35 +602,35 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 /**
  * @brief   Called before the power management enters a power mode
  *
- * @param[in] deep
+ * @param[in] deep      1 for deep sleep, 0 otherwise
  */
 void gpio_pm_cb_enter(int deep);
 
 /**
  * @brief   Called after the power management left a power mode
  *
- * @param[in] deep
+ * @param[in] deep      1 for deep sleep, 0 otherwise
  */
 void gpio_pm_cb_leave(int deep);
 
 /**
  * @brief   Called before the power management enters a power mode
  *
- * @param[in] deep
+ * @param[in] deep      1 for deep sleep, 0 otherwise
  */
 void cpu_pm_cb_enter(int deep);
 
 /**
  * @brief   Called after the power management left a power mode
  *
- * @param[in] deep
+ * @param[in] deep      1 for deep sleep, 0 otherwise
  */
 void cpu_pm_cb_leave(int deep);
 
 /**
  * @brief   Wrapper for cortexm_sleep calling power management callbacks
  *
- * @param[in] deep
+ * @param[in] deep      1 for deep sleep, 0 otherwise
  */
 static inline void sam0_cortexm_sleep(int deep)
 {
@@ -660,9 +660,9 @@ void gpio_disable_mux(gpio_t pin);
  * @brief   Available voltage regulators on the supply controller.
  */
 typedef enum {
-    SAM0_VREG_LDO,  /*< LDO, always available but not very power efficient */
-    SAM0_VREG_BUCK  /*< Buck converter, efficient but may clash with internal
-                        fast clock generators (see errata sheets) */
+    SAM0_VREG_LDO,  /**< LDO, always available but not very power efficient */
+    SAM0_VREG_BUCK  /**< Buck converter, efficient but may clash with internal
+                         fast clock generators (see errata sheets) */
 } sam0_supc_t;
 
 /**
@@ -676,7 +676,8 @@ typedef enum {
  *                 Please refer to the errata sheet, further restrictions may
  *                 apply depending on the MCU.
  *
- * @param[in]   src
+ * @param[in]   src     Voltage regulator to use, see @ref sam0_supc_t for
+ *                      options
  */
 static inline void sam0_set_voltage_regulator(sam0_supc_t src)
 {

--- a/drivers/include/at24cxxx.h
+++ b/drivers/include/at24cxxx.h
@@ -125,7 +125,7 @@ int at24cxxx_init(at24cxxx_t *dev, const at24cxxx_params_t *params);
  *
  * @return          AT24CXXX_OK on success
  * @return          -ERANGE if @p pos is out of bounds
- * @return          @see i2c_read_regs
+ * @return          Same as @ref i2c_read_regs
  */
 int at24cxxx_read_byte(const at24cxxx_t *dev, uint32_t pos, void *dest);
 
@@ -139,7 +139,7 @@ int at24cxxx_read_byte(const at24cxxx_t *dev, uint32_t pos, void *dest);
  *
  * @return          AT24CXXX_OK on success
  * @return          -ERANGE if @p pos + @p len is out of bounds
- * @return          @see i2c_read_regs
+ * @return          Same as @ref i2c_read_regs
  */
 int at24cxxx_read(const at24cxxx_t *dev, uint32_t pos, void *data, size_t len);
 
@@ -152,7 +152,7 @@ int at24cxxx_read(const at24cxxx_t *dev, uint32_t pos, void *data, size_t len);
  *
  * @return          AT24CXXX_OK on success
  * @return          -ERANGE if @p pos is out of bounds
- * @return          @see i2c_write_regs
+ * @return          Same as @ref i2c_write_regs
  */
 int at24cxxx_write_byte(const at24cxxx_t *dev, uint32_t pos, uint8_t data);
 
@@ -168,7 +168,7 @@ int at24cxxx_write_byte(const at24cxxx_t *dev, uint32_t pos, uint8_t data);
  *
  * @return          AT24CXXX_OK on success
  * @return          -ERANGE if @p pos + @p len is out of bounds
- * @return          @see i2c_write_regs
+ * @return          Same as @ref i2c_write_regs
  */
 int at24cxxx_write(const at24cxxx_t *dev, uint32_t pos, const void *data,
                    size_t len);
@@ -186,7 +186,7 @@ int at24cxxx_write(const at24cxxx_t *dev, uint32_t pos, const void *data,
  *
  * @return          AT24CXXX_OK on success
  * @return          -ERANGE if @p pos + @p len is out of bounds
- * @return          @see i2c_write_byte
+ * @return          Same as @ref i2c_write_byte
  */
 int at24cxxx_set(const at24cxxx_t *dev, uint32_t pos, uint8_t val,
                  size_t len);
@@ -195,24 +195,24 @@ int at24cxxx_set(const at24cxxx_t *dev, uint32_t pos, uint8_t val,
  * @brief Set @p len bytes from position @p pos to
  * AT24CXXX_CLEAR_BYTE
  *
- * This is a wrapper around @see at24cxxx_set.
+ * This is a wrapper around @ref at24cxxx_set.
  *
  * @param[in]       dev       AT24CXXX device handle
  * @param[in]       pos       Position in EEPROM memory
  * @param[in]       len       Requested length to be written
  *
- * @return          @see at24cxxx_set
+ * @return          same as @ref at24cxxx_set
  */
 int at24cxxx_clear(const at24cxxx_t *dev, uint32_t pos, size_t len);
 
 /**
  * @brief Set the entire EEPROM memory to AT24CXXX_CLEAR_BYTE
  *
- * This is a wrapper around @see at24cxxx_clear.
+ * This is a wrapper around same as @ref at24cxxx_clear.
  *
  * @param[in]       dev       AT24CXXX device handle
  *
- * @return          @see at24cxxx_set
+ * @return          same as @ref at24cxxx_set
  */
 int at24cxxx_erase(const at24cxxx_t *dev);
 

--- a/drivers/include/ft5x06.h
+++ b/drivers/include/ft5x06.h
@@ -135,10 +135,10 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in] params        Initialization parameters
- * @param[in] cb            Callback function called on touch interrupts
- * @param[in] arg           Context argument used in callback function
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
+ * @param[in]     cb        Callback function called on touch interrupts
+ * @param[in]     arg       Context argument used in callback function
  *
  * @return                  0 on success
  * @return                  -ENODEV when no valid device

--- a/drivers/include/hm330x.h
+++ b/drivers/include/hm330x.h
@@ -92,8 +92,8 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    params     Initialization parameters
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
  *
  * @retval  0         Success
  * @retval -EIO       Failed to initialize GPIO pins

--- a/drivers/include/ir_nec.h
+++ b/drivers/include/ir_nec.h
@@ -62,8 +62,8 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    params     Initialization parameters
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
  *
  * @return                  0 on success
  */
@@ -72,8 +72,8 @@ int ir_nec_init(ir_nec_t *dev, const ir_nec_params_t *params);
 /**
  * @brief   Read a command packet. Blocks until one is received
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[out]   command    Structure to write the result into
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[out]    command   Structure to write the result into
  *
  * @retval       0          Success
  * @retval       -1         Isrpipe returned too few bytes. Should never happen

--- a/drivers/include/matrix_keypad.h
+++ b/drivers/include/matrix_keypad.h
@@ -198,10 +198,10 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    params     Initialization parameters
- * @param[in]    callback   Callback to call on state changes
- * @param[in]    arg        Context argument for the callback
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
+ * @param[in]     callback  Callback to call on state changes
+ * @param[in]     arg       Context argument for the callback
  *
  * @return                  0 on success
  */
@@ -216,7 +216,7 @@ int matrix_keypad_init(matrix_keypad_t *dev,
  * This updates the state of the device descriptor, calling
  * @ref matrix_keypad_cb_t when a key press or release has been detected
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  *
  * @return                  Number of keys that changed state
  */

--- a/drivers/include/max31855.h
+++ b/drivers/include/max31855.h
@@ -82,8 +82,8 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    params     Initialization parameters
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
  *
  * @retval    0 on success
  * @retval    -ENXIO invalid SPI device

--- a/drivers/include/mfrc522.h
+++ b/drivers/include/mfrc522.h
@@ -233,9 +233,9 @@ void mfrc522_pcd_soft_power_up(mfrc522_t *dev);
  * @param[in]     send_len    Number of bytes to transfer to the FIFO
  * @param[out]    back_data   Buffer if data should be read back after executing
  *                            the command, otherwise NULL
- * @param[inout]  back_len    Max number of bytes to write to *back_data.
+ * @param[in,out] back_len    Max number of bytes to write to *back_data.
  *                            Returns number of bytes returned.
- * @param[inout]  valid_bits  Number of valid bits in the last byte. 0 for 8
+ * @param[in,out] valid_bits  Number of valid bits in the last byte. 0 for 8
  *                            valid bits
  * @param[in]     rx_align    Defines the bit position in back_data[0] for the
  *                            first bit received
@@ -267,9 +267,9 @@ int mfrc522_pcd_transceive_data(mfrc522_t *dev,
  * @param[in]     send_len    Number of bytes to transfer to the FIFO
  * @param[out]    back_data   Buffer if data should be read back after executing
  *                            the command, otherwise NULL
- * @param[inout]  back_len    Max number of bytes to write to *back_data.
+ * @param[in,out] back_len    Max number of bytes to write to *back_data.
  *                            Returns number of bytes returned.
- * @param[inout]  valid_bits  Number of valid bits in the last byte. 0 for 8
+ * @param[in,out] valid_bits  Number of valid bits in the last byte. 0 for 8
  *                            valid bits.
  * @param[in]     rx_align    Defines the bit position in back_data[0] for the
  *                            first bit received
@@ -297,7 +297,7 @@ int mfrc522_pcd_communicate_with_picc(mfrc522_t *dev, mfrc522_pcd_command_t comm
  *
  * @param[in]      dev          Device descriptor of the MFRC522
  * @param[out]     buffer_atqa  Buffer to store the ATQA in
- * @param[inout]   buffer_size  Buffer size, at least two bytes. Also number of
+ * @param[in,out]  buffer_size  Buffer size, at least two bytes. Also number of
  *                              bytes returned on success.
  *
  * @retval  0             on success
@@ -318,7 +318,7 @@ int mfrc522_picc_request_a(mfrc522_t *dev, uint8_t *buffer_atqa, uint8_t *buffer
  *
  * @param[in]      dev          Device descriptor of the MFRC522
  * @param[out]     buffer_atqa  Buffer to store the ATQA in
- * @param[inout]   buffer_size  Buffer size, at least two bytes. Also number of
+ * @param[in,out]  buffer_size  Buffer size, at least two bytes. Also number of
  *                              bytes returned on success.
  *
  * @retval  0             on success
@@ -340,7 +340,7 @@ int mfrc522_picc_wakeup_a(mfrc522_t *dev, uint8_t *buffer_atqa, uint8_t *buffer_
  * @param[in]     command      Command to send - MFRC522_PICC_CMD_ISO_14443_REQA
  *                             or MFRC522_PICC_CMD_ISO_14443_WUPA
  * @param[out]    buffer_atqa  Buffer to store the ATQA in
- * @param[inout]  buffer_size  Buffer size, at least two bytes. Also number of
+ * @param[in,out] buffer_size  Buffer size, at least two bytes. Also number of
  *                             bytes returned on success.
  *
  * @retval  0             on success
@@ -376,7 +376,7 @@ int mfrc522_picc_reqa_or_wupa(mfrc522_t *dev, mfrc522_picc_command_t command,
  * triple            10                   3       Not currently in use?
  *
  * @param[in]     dev         Device descriptor of the MFRC522
- * @param[inout]  uid         Normally output, but can also be used to supply a
+ * @param[in,out] uid         Normally output, but can also be used to supply a
  *                            known UID
  * @param[in]     valid_bits  Number of known UID bits supplied in *uid.
  *                            Normally 0. If set you must also supply uid->size.
@@ -462,7 +462,7 @@ void mfrc522_pcd_stop_crypto1(mfrc522_t *dev);
  * @param[in]      block_addr   MIFARE Classic: The block (0-0xff) number.
  *                              MIFARE Ultralight: The first page to return data from.
  * @param[out]     buffer       Buffer to store the data in
- * @param[inout]   buffer_size  Buffer size, at least 18 bytes. Also number of
+ * @param[in,out]  buffer_size  Buffer size, at least 18 bytes. Also number of
  *                              bytes returned on success.
  *
  * @retval  0             on success

--- a/drivers/include/periph/usbdev.h
+++ b/drivers/include/periph/usbdev.h
@@ -420,9 +420,9 @@ typedef struct usbdev_driver {
      * @note The @p buf passed here must have been declared as
      * @ref usbdev_ep_buf_t before so that DMA restrictions are applied to it
      *
-     * @param[in] ep        USB endpoint descriptor
-     * @param[inout] buf    Buffer with the data to transfer
-     * @param[in] len       (Max) Length of the data to transfer
+     * @param[in]       ep      USB endpoint descriptor
+     * @param[in,out]   buf     Buffer with the data to transfer
+     * @param[in]       len     (Max) Length of the data to transfer
      */
     int (*xmit)(usbdev_ep_t *ep, uint8_t *buf, size_t len);
 } usbdev_driver_t;
@@ -672,9 +672,9 @@ static inline void usbdev_ep_esr(usbdev_ep_t *ep)
  * @pre `(ep != NULL)`
  * @pre `(ep->dev != NULL)`
  *
- * @param[in]    ep     USB endpoint descriptor
- * @param[inout] buf    Buffer to submit for transmission
- * @param[in]    len    length of the buffer in bytes to be transmitted or received
+ * @param[in]     ep    USB endpoint descriptor
+ * @param[in,out] buf   Buffer to submit for transmission
+ * @param[in]     len   length of the buffer in bytes to be transmitted or received
  */
 static inline int usbdev_ep_xmit(usbdev_ep_t *ep, uint8_t *buf, size_t len)
 {

--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -96,8 +96,8 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    params     Initialization parameters
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
  *
  * @return                  0 on success
  */
@@ -108,7 +108,7 @@ int sgp30_init(sgp30_t *dev, const sgp30_params_t *params);
  *
  * @note    Must be called after every power-cycle or soft reset.
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  *
  * @retval  0         Success
  * @retval -PROTO     Sensor did not acknowledge command

--- a/drivers/include/stmpe811.h
+++ b/drivers/include/stmpe811.h
@@ -123,10 +123,10 @@ typedef struct {
 /**
  * @brief   Initialize the given STMPE811 device
  *
- * @param[inout] dev        Device descriptor of the STMPE811
- * @param[in] params        Initialization parameters of the STMPE811 device
- * @param[in] cb            Callback function called on touch interrupts
- * @param[in] arg           Context argument used in callback function
+ * @param[in,out] dev       Device descriptor of the STMPE811
+ * @param[in]     params    Initialization parameters of the STMPE811 device
+ * @param[in]     cb        Callback function called on touch interrupts
+ * @param[in]     arg       Context argument used in callback function
  *
  * @return                  0 on success
  * @return                  -ENODEV when no valid device

--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -125,7 +125,7 @@ void sx126x_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index);
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev                    Device descriptor of the driver
+ * @param[in,out] dev                   Device descriptor of the driver
  *
  * @return                  0 on success
  */

--- a/drivers/include/sx1280.h
+++ b/drivers/include/sx1280.h
@@ -92,7 +92,7 @@ void sx1280_setup(sx1280_t *dev, const sx1280_params_t *params, uint8_t index);
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev                    Device descriptor of the driver
+ * @param[in,out] dev                   Device descriptor of the driver
  *
  * @return 0 on success
  */

--- a/pkg/littlefs/lfs_log.h
+++ b/pkg/littlefs/lfs_log.h
@@ -33,9 +33,9 @@ extern "C" {
 /**
  * @brief Private macro for routing littlefs log msgs to RIOT's log module.
  *
- * @param[in] level             log level of this log message
- * @param[in] fmt               printf style format string
- * @param[inout] ...            printf style variadic args
+ * @param[in]     level         log level of this log message
+ * @param[in]     fmt           printf style format string
+ * @param[in,out] ...           printf style variadic args
  */
 #define _LFS_LOG(level, fmt, ...)\
     LOG(level, "lfs: " fmt "%s\n", __VA_ARGS__)

--- a/pkg/littlefs2/lfs_log.h
+++ b/pkg/littlefs2/lfs_log.h
@@ -38,8 +38,8 @@ extern "C" {
 /**
  * @brief Private macro for routing littlefs trace msgs to RIOT's DEBUG macro.
  *
- * @param[in] fmt               printf style format string
- * @param[inout] ...            printf style variadic args
+ * @param[in]     fmt           printf style format string
+ * @param[in,out] ...           printf style variadic args
  */
 #define _LFS_TRACE(fmt, ...) \
     DEBUG("%s:%d: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
@@ -47,9 +47,9 @@ extern "C" {
 /**
  * @brief Private macro for routing littlefs log msgs to RIOT's log module.
  *
- * @param[in] level             log level of this log message
- * @param[in] fmt               printf style format string
- * @param[inout] ...            printf style variadic args
+ * @param[in]     level         log level of this log message
+ * @param[in]     fmt           printf style format string
+ * @param[in,out] ...           printf style variadic args
  */
 #define _LFS_LOG(level, fmt, ...)\
     LOG(level, "lfs: " fmt "%s\n", __VA_ARGS__)

--- a/sys/arduino/include/spiport.hpp
+++ b/sys/arduino/include/spiport.hpp
@@ -166,7 +166,7 @@ public:
 
     /**
      * @brief   Transfer data
-     * @param[inout]    buf     Buffer containing the data to send, received
+     * @param[in,out]   buf     Buffer containing the data to send, received
      *                          data will be written here
      * @param[in]       count   Number of bytes to send
      */

--- a/sys/cpp11-compat/include/riot/mutex.hpp
+++ b/sys/cpp11-compat/include/riot/mutex.hpp
@@ -302,8 +302,8 @@ void unique_lock<Mutex>::unlock() {
 
 /**
  * @brief Swaps two mutexes.
- * @param[inout] lhs    Reference to one mutex.
- * @param[inout] rhs    Reference to the other mutex.
+ * @param[in,out] lhs   Reference to one mutex.
+ * @param[in,out] rhs   Reference to the other mutex.
  */
 template <class Mutex>
 inline void swap(unique_lock<Mutex>& lhs, unique_lock<Mutex>& rhs) noexcept {

--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -261,7 +261,7 @@ public:
 
   /**
    * @brief Swap threads.
-   * @param[inout] t    Thread to swap data with.
+   * @param[in,out] t   Thread to swap data with.
    */
   void swap(thread& t) noexcept {
     std::swap(m_data, t.m_data);
@@ -309,8 +309,8 @@ private:
 
 /**
  * @brief Swaps two threads.
- * @param[inout] lhs    Reference to one thread.
- * @param[inout] rhs    Reference to the other thread.
+ * @param[in,out] lhs   Reference to one thread.
+ * @param[in,out] rhs   Reference to the other thread.
  */
 void swap(thread& lhs, thread& rhs) noexcept;
 

--- a/sys/include/can/conn/isotp.h
+++ b/sys/include/can/conn/isotp.h
@@ -90,8 +90,8 @@ struct conn_can_isotp_master {
  * This must be called on slave connections when conn_can_isotp_multi is used.
  * Does not exist otherwise.
  *
- * @param[in]    master     the master connection
- * @param[inout] slave      the slave connection to initialize
+ * @param[in]       master      the master connection
+ * @param[in,out]   slave       the slave connection to initialize
  */
 static inline void conn_can_isotp_init_slave(conn_can_isotp_t *master, conn_can_isotp_slave_t *slave)
 {
@@ -124,9 +124,9 @@ typedef struct conn_can_isotp {
 /**
  * @brief  Create can isotp connection socket
  *
- * @param[inout] conn       ISO-TP connection
- * @param[in] options       ISO-TP options
- * @param[in] ifnum         can device Interface
+ * @param[in,out] conn      ISO-TP connection
+ * @param[in]     options   ISO-TP options
+ * @param[in]     ifnum     can device Interface
  *
  * @return 0 if socket was successfully connected
  * @return any other negative number in case of an error
@@ -136,11 +136,11 @@ int conn_can_isotp_create(conn_can_isotp_t *conn, struct isotp_options *options,
 /**
  * @brief Bind a can isotp connection
  *
- * @param[inout] conn       ISO-TP connection
- * @param[in] fc_options    ISO-TP flow control options, can be NULL for default parameters
+ * @param[in,out] conn          ISO-TP connection
+ * @param[in]     fc_options    ISO-TP flow control options, can be NULL for default parameters
  *
- * @return 0 on success
- * @return any other negative number in case of an error
+ * @retval        0             on success
+ * @retval        !=0           in case of an error
  */
 int conn_can_isotp_bind(conn_can_isotp_t *conn, struct isotp_fc_options *fc_options);
 

--- a/sys/include/can/conn/raw.h
+++ b/sys/include/can/conn/raw.h
@@ -66,11 +66,11 @@ typedef struct conn_can_raw {
 /**
  * @brief  Create can connection socket
  *
- * @param[inout] conn       CAN connection
- * @param[in] filter        list of filters to set
- * @param[in] count         number of filters in @p filter
- * @param[in] ifnum         can device Interface
- * @param[in] flags         conn flags to set (CONN_CAN_RECVONLY)
+ * @param[in,out]   conn    CAN connection
+ * @param[in]       filter  list of filters to set
+ * @param[in]       count   number of filters in @p filter
+ * @param[in]       ifnum   can device Interface
+ * @param[in]       flags   conn flags to set (CONN_CAN_RECVONLY)
  *
  * @post   @p filter must remain allocated until @p conn is closed
  *

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -562,7 +562,7 @@ void print_str(const char* str);
  *
  * @note Caller must ensure @p str can take pad_len characters!
  *
- * @param[inout]    str         string to pad (or NULL)
+ * @param[in,out]   str         string to pad (or NULL)
  * @param[in]       in_len      length of str
  * @param[in]       pad_len     total length after padding
  * @param[in]       pad_char    char to use as pad char

--- a/sys/include/matstat.h
+++ b/sys/include/matstat.h
@@ -104,7 +104,7 @@ uint64_t matstat_variance(const matstat_state_t *state);
  * Add the sums and count of @p src and @p dest, take the maximum of the max
  * values and minimum of the min values. The result is written to @p dest.
  *
- * @param[inout]    dest    destination state struct
+ * @param[in,out]   dest    destination state struct
  * @param[out]      src     source state struct
  */
 void matstat_merge(matstat_state_t *dest, const matstat_state_t *src);

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -695,10 +695,10 @@ static inline int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
  * @pre There is enough allocated space in @p l2_group for an address for a
  *      device of type @p dev_type (e.g. 6 bytes for an ethernet address).
  *
- * @param[in] dev_type      The network interface @p l2_addr should be generated
+ * @param[in]   netif       The network interface @p l2_addr should be generated
  *                          for.
- * @param[in] ipv6_group    An IPv6 multicast address.
- * @param[out] l2_group     A link layer multicast address
+ * @param[in]   ipv6_group  An IPv6 multicast address.
+ * @param[out]  l2_group    A link layer multicast address
  *
  * @return  Length of @p l2_group in bytes
  * @return  `-ENOTSUP` if link layer does not support multicast.

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -53,7 +53,7 @@ enum {
     STDIO_UDP,                  /**< stdio via UDP */
     STDIO_TELNET,               /**< stdio via telnet */
     STDIO_ETHOS,                /**< stdio via ethos (mutiplex) */
-    STDIO_SLIP,                 /*<< stdio via SLIP (mutiplex) */
+    STDIO_SLIP,                 /**< stdio via SLIP (mutiplex) */
 };
 
 /**

--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -65,9 +65,9 @@ void suit_worker_trigger_prepared(const uint8_t *manifest, size_t size);
  * area into which the manifest is to be written. The lock must be released by
  * calling @ref suit_worker_trigger_prepared later.
  *
- * @param[out]   buffer    On success, buffer into which the image may be
+ * @param[out]    buffer   On success, buffer into which the image may be
  *                         written.
- * @param[inout] size      Requested buffer size. On some errors, this will be
+ * @param[in,out] size     Requested buffer size. On some errors, this will be
  *                         decreased to a size that would be acceptable.
  *
  * @return 0 on success

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -1188,7 +1188,7 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur);
  *
  * @see @c sc_vfs.c (@c df command) for a usage example
  *
- * @param[inout]  dir     The root directory of the discovered mount point
+ * @param[in,out] dir     The root directory of the discovered mount point
  *
  * @return     @c true if another file system is mounted; @p dir then contains an open directory.
  * @return     @c false if the file system list is exhausted; @p dir is uninitialized then.

--- a/sys/include/ztimer/periodic.h
+++ b/sys/include/ztimer/periodic.h
@@ -107,7 +107,7 @@ typedef struct {
  * After initializing, use @ref ztimer_periodic_start() to start the timer.
  *
  * @param[in]       clock       the clock to configure this timer on
- * @param[inout]    timer       periodic timer object to initialize
+ * @param[in,out]   timer       periodic timer object to initialize
  * @param[in]       callback    function to call on each trigger
  *                              returns `true` if the timer should keep going
  * @param[in]       arg         argument to pass to callback function

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -655,7 +655,7 @@ static void _on_resp_timeout(void *arg) {
  * current design because the discriminator is the send_limit field, which is
  * still used to count down).
  *
- * @param[inout]   memo   The memo indicating the pending request
+ * @param[in,out]  memo   The memo indicating the pending request
  *
  * @pre The @p memo is GCOAP_MEMO_RETRANSMIT or GCOAP_MEMO_WAIT, and its
  *      send_limit is not GCOAP_SEND_LIMIT_NON.

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -94,7 +94,7 @@ typedef struct {
 #define GNRC_SOCK_RECV_AUX_FLAG_RSSI        0x02    /**< RSSI valid */
 
 /**
- * @brief   Internal helper functions for GNRC
+ * @name    Internal helper functions for GNRC
  * @internal
  * @{
  */

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -51,7 +51,7 @@ static msg_t _msg_queue[GNRC_UDP_MSG_QUEUE_SIZE];
  * @note    If the checksum turns out to be 0x0000, the function returns 0xffff
  *          as specified in RFC768
  *
- * @param[in] pkt           pointer to the packet in the packet buffer
+ * @param[in] hdr           pointer to the packet in the packet header
  * @param[in] pseudo_hdr    pointer to the network layer header
  * @param[in] payload       pointer to the payload
  *

--- a/sys/psa_crypto/include/psa_ecc.h
+++ b/sys/psa_crypto/include/psa_ecc.h
@@ -259,7 +259,7 @@ psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer, uint8_
  * @param[in]       priv_key_buffer
  * @param[out]      pub_key_buffer
  * @param[in]       priv_key_buffer_length
- * @param[inout]    pub_key_buffer_length
+ * @param[in,out]   pub_key_buffer_length
  * @return          @ref psa_status_t
  */
 psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,

--- a/sys/random/fortuna/fortuna.h
+++ b/sys/random/fortuna/fortuna.h
@@ -171,7 +171,7 @@ typedef uint32_t fortuna_seed_t[FORTUNA_SEED_SIZE];
  *
  * It is possible to use this method to clear an existing state.
  *
- * @param[inout] state      PRNG state
+ * @param[in,out] state     PRNG state
  *
  * @return                  zero on successful initialization
  * @return                  non-zero on error
@@ -182,9 +182,9 @@ int fortuna_init(fortuna_state_t *state);
  * @brief   Read random bytes from the PRNG. The number of bytes may not exceed
  *          FORTUNA_RESEED_LIMIT bytes.
  *
- * @param[inout] state      PRNG state
- * @param[out] out          pointer to buffer
- * @param[in] bytes         number of bytes to write in buffer
+ * @param[in,out] state     PRNG state
+ * @param[out]    out       pointer to buffer
+ * @param[in]     bytes     number of bytes to write in buffer
  *
  * @return                  zero on success
  * @return                  -1 on reading more that FORTUNA_RESEED_LIMIT bytes
@@ -197,11 +197,11 @@ int fortuna_random_data(fortuna_state_t *state, uint8_t *out, size_t bytes);
  * @brief   Add a entropy of a random event to one PRNG pool. The pool must
  *          exist and the source length must be 1-32 bytes.
  *
- * @param[inout] state      PRNG state
- * @param[in] data          pointer to entropy source
- * @param[in] length        length of entropy source
- * @param[in] source        source identifier (each source has its own ID)
- * @param[in] pool          pool number to add entropy to
+ * @param[in,out] state     PRNG state
+ * @param[in]     data      pointer to entropy source
+ * @param[in]     length    length of entropy source
+ * @param[in]     source    source identifier (each source has its own ID)
+ * @param[in]     pool      pool number to add entropy to
  *
  * @return                  zero on success
  * @return                  -1 on zero bytes or more than 32 bytes
@@ -217,8 +217,8 @@ int fortuna_add_random_event(fortuna_state_t *state, const uint8_t *data,
  * This method must be invoked before shutting down the PRNG (e.g. on system
  * shutdown).
  *
- * @param[inout] state      PRNG state
- * @param[out] data         pointer to output buffer for the seed
+ * @param[in,out] state     PRNG state
+ * @param[out]    data      pointer to output buffer for the seed
  *
  * @return                  zero on success
  */
@@ -231,8 +231,8 @@ int fortuna_write_seed(fortuna_state_t *state, fortuna_seed_t *out);
  * This method should be invoked once on PRNG startup, in case a seed is
  * available.
  *
- * @param[inout] state      PRNG state
- * @param[inout] data       pointer to input and output buffer for the seed
+ * @param[in,out] state     PRNG state
+ * @param[in,out] data      pointer to input and output buffer for the seed
  *
  * @return                  zero on success
  */


### PR DESCRIPTION
### Contribution description

This fixes a batch of incorrect Doxygen comments that building with LLVM/clang and `-Wdocumentation` uncovered.

### Testing procedure

```
diff --git a/makefiles/cflags.inc.mk b/makefiles/cflags.inc.mk
index 3ba16a20f3..18a4dac3fc 100644
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -40,6 +40,7 @@ CFLAGS += -Wstrict-overflow
 # Worse yet they hide errors by accepting wildcard argument types.
 OPTIONAL_CFLAGS += -Wstrict-prototypes
 OPTIONAL_CFLAGS += -Wold-style-definition
+OPTIONAL_CFLAGS += -Wdocumentation -Wno-error=documentation -Wno-documentation-deprecated-sync
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%
diff --git a/makefiles/toolchain/gnu.inc.mk b/makefiles/toolchain/gnu.inc.mk
index f2f2435a20..20245c2756 100644
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -30,6 +30,9 @@ ifneq (8, $(firstword $(shell echo 8 $(GCC_VERSION) | tr ' ' '\n' | sort -n)))
   OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=
 endif
 
+# GCC does not warn about documentation (yet)
+OPTIONAL_CFLAGS_BLACKLIST += -Wdocumentation -Wno-error=documentation -Wno-documentation-deprecated-sync
+
 # We use GDB for debugging
 include $(RIOTMAKE)/tools/gdb.inc.mk
 
```

And now building with `TOOLCHAIN=llvm` should print less warnings.

### Issues/PRs references

None