### PR TITLE
buildsystem: Enable -Wdocumentation for LLVM

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -40,6 +40,7 @@ CFLAGS += -Wstrict-overflow
 # Worse yet they hide errors by accepting wildcard argument types.
 OPTIONAL_CFLAGS += -Wstrict-prototypes
 OPTIONAL_CFLAGS += -Wold-style-definition
+OPTIONAL_CFLAGS += -Wdocumentation -Wno-error=documentation -Wno-documentation-deprecated-sync
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -30,6 +30,9 @@ ifneq (8, $(firstword $(shell echo 8 $(GCC_VERSION) | tr ' ' '\n' | sort -n)))
   OPTIONAL_CFLAGS_BLACKLIST += -fmacro-prefix-map=$(RIOTBASE)/=
 endif
 
+# GCC does not warn about documentation (yet)
+OPTIONAL_CFLAGS_BLACKLIST += -Wdocumentation -Wno-error=documentation -Wno-documentation-deprecated-sync
+
 # We use GDB for debugging
 include $(RIOTMAKE)/tools/gdb.inc.mk
 


### PR DESCRIPTION
### Contribution description

This enables warnings for incorrect Doxygen comments when build with LLVM. To my experience, LLVM provides a low false positive rate (e.g. it does not complain about undocumented internal macros) and has very helpful output.

This disable `-Wdocumentation-deprecated-sync` for now, as we do not deprecate code with attributes yet.

The warnings are not set as errors, so that we can enable this without breaking builds.

### Testing procedure

```
make TOOLCHAIN=llvm BOARD=<SOME_BOARD> -C <path/to/some/app>
```

Should now warn about broken doc

### Issues/PRs references

None