### PR TITLE
cpu/samd5x/periph_can: Expose more CAN controller configs

### DIFF
--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -131,6 +131,13 @@ typedef struct {
      "Babbling Idiot Syndrome").
      */
     bool enable_transmit_pause            : 1;
+    /**
+     * @brief Whether to start in monitor mode after initialization
+     *
+     * When set to `true`, the CAN controller will start in monitor mode instead
+     * of regular mode after initialization.
+     */
+    bool start_in_monitor_mode            : 1;
 } can_conf_t;
 #define HAVE_CAN_CONF_T
 

--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -118,6 +118,16 @@ typedef struct {
      * again until it succeeds or the CAN controller goes into an error state.
      */
     bool disable_automatic_retransmission : 1;
+    /**
+     * @brief Whether to enable the transmit pause feature
+     *
+     * When set to `true`, the CAN controller will insert a delay of two bit
+     * times between two subsequent frames. This decreases the maximum
+     * throughput, but it ensures that other nodes with a lower priority
+     * (according to the CAN ID) will not starve (in other words it prevents
+     "Babbling Idiot Syndrome").
+     */
+    bool enable_transmit_pause            : 1;
 } can_conf_t;
 #define HAVE_CAN_CONF_T
 

--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -109,7 +109,15 @@ typedef struct {
      *  @ref can_conf_t::enable_pin will be set HIGH when active and LOW when
      * inactive.
      */
-     bool enable_pin_active_low;
+    bool enable_pin_active_low            : 1;
+    /**
+     * @brief Whether to disable automatic retransmission
+     *
+     * When set to `true`, a CAN frame will not be retransmitted on transmission
+     * failure (e.g. on missing ACK). Otherwise the frame will be transmitted
+     * again until it succeeds or the CAN controller goes into an error state.
+     */
+    bool disable_automatic_retransmission : 1;
 } can_conf_t;
 #define HAVE_CAN_CONF_T
 

--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -28,7 +28,9 @@ extern "C" {
 #include "can/candev.h"
 
 #ifndef CANDEV_SAMD5X_DEFAULT_BITRATE
-/** Default bitrate */
+/**
+ * @brief   Bitrate to use on init if @ref can_conf_t::bitrate is zero
+ */
 #define CANDEV_SAMD5X_DEFAULT_BITRATE 500000U
 #endif
 
@@ -91,6 +93,7 @@ extern "C" {
 typedef struct {
     /** CAN device handler */
     Can *can;
+    uint32_t bitrate; /**< initial bitrate after init */
     /** CAN Rx pin */
     gpio_t rx_pin;
     /** CAN Tx pin */

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -454,10 +454,14 @@ static int _init(candev_t *candev)
     }
 
     uint32_t cccr = dev->conf->can->CCCR.reg;
-    cccr &= ~(CAN_CCCR_DAR);
+    cccr &= ~(CAN_CCCR_DAR | CAN_CCCR_TXP);
 
     if (dev->conf->disable_automatic_retransmission) {
          cccr |= CAN_CCCR_DAR;
+    }
+
+    if (dev->conf->enable_transmit_pause) {
+        cccr |= CAN_CCCR_TXP;
     }
 
     dev->conf->can->CCCR.reg = cccr;

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -365,8 +365,10 @@ void can_init(can_t *dev, const can_conf_t *conf)
 {
     dev->candev.driver = &candev_samd5x_driver;
 
-    struct can_bittiming timing = { .bitrate = CANDEV_SAMD5X_DEFAULT_BITRATE,
-                                    .sample_point = CANDEV_SAMD5X_DEFAULT_SPT };
+    struct can_bittiming timing = {
+        .bitrate = conf->bitrate ? conf->bitrate : CANDEV_SAMD5X_DEFAULT_BITRATE,
+        .sample_point = CANDEV_SAMD5X_DEFAULT_SPT
+    };
 
     uint32_t clk_freq = sam0_gclk_freq(conf->gclk_src);
     can_device_calc_bittiming(clk_freq, &bittiming_const, &timing);

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -452,9 +452,15 @@ static int _init(candev_t *candev)
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         _dump_msg_ram_section(dev);
     }
-    /* Disable automatic retransmission by default */
-    /* This can be added as a configuration parameter for the CAN controller */
-    dev->conf->can->CCCR.reg = CAN_CCCR_DAR;
+
+    uint32_t cccr = dev->conf->can->CCCR.reg;
+    cccr &= ~(CAN_CCCR_DAR);
+
+    if (dev->conf->disable_automatic_retransmission) {
+         cccr |= CAN_CCCR_DAR;
+    }
+
+    dev->conf->can->CCCR.reg = cccr;
 
     /* Reject all remote frames */
     dev->conf->can->GFC.reg = CAN_GFC_RRFE | CAN_GFC_RRFS;

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -465,7 +465,7 @@ static int _init(candev_t *candev)
     }
 
     uint32_t cccr = dev->conf->can->CCCR.reg;
-    cccr &= ~(CAN_CCCR_DAR | CAN_CCCR_TXP);
+    cccr &= ~(CAN_CCCR_DAR | CAN_CCCR_TXP | CAN_CCCR_MON);
 
     if (dev->conf->disable_automatic_retransmission) {
          cccr |= CAN_CCCR_DAR;
@@ -473,6 +473,10 @@ static int _init(candev_t *candev)
 
     if (dev->conf->enable_transmit_pause) {
         cccr |= CAN_CCCR_TXP;
+    }
+
+    if (dev->conf->start_in_monitor_mode) {
+        cccr |= CAN_CCCR_MON;
     }
 
     dev->conf->can->CCCR.reg = cccr;


### PR DESCRIPTION
### Contribution description

This expose a few more configuration knobs, namely:

- automatic retransmission of failed CAN frames
- transmit pause
- monitoring mode

### Testing procedure

Run `tests/drivers/candev` after playing with can config and confirm that the new configuration is applied

### Issues/PRs references

None