### PR TITLE
buildsystem: Fix Supported Board List in `info-build`

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -35,7 +35,7 @@ info-build:
 	@echo 'APPDIR:      $(APPDIR)'
 	@echo ''
 	@echo 'supported boards:'
-	@echo $$($(MAKE) info-boards-supported)
+	@echo $$(env -i PATH='$(PATH)' LANG='$(LANG)' HOME='$(HOME)' SHELL='$(SHELL)' $(MAKE) info-boards-supported)
 	@echo ''
 	@echo 'BOARD:   $(BOARD)'
 	@echo 'CPU:     $(CPU)'


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

@mguetschow documented in #21019 that the `info-build` target does not show the all the boards that are *actually* supported, depending on the board that is set on the command line.

The reason for this is that the Make system creates a lot of environment variables and hands them down to the next instance. In this case, the `FEATURES_REQUIRED` variable was set and had some requirements that not all of the supported boards could fulfill, therefore they were (errorneously) sorted out.

Therefore this PR starts the submake in a clean environment, so that Make is not influenced by what's set by the parent.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

With `master`:
```
$ BOARD=feather-nrf52840-sense make -C tests/drivers/nrf802154 info-build 
...
supported boards:
adafruit-clue adafruit-itsybitsy-nrf52 arduino-nano-33-ble arduino-nano-33-ble-sense feather-nrf52840 feather-nrf52840-sense nrf52840-mdk-dongle nrf52840dongle particle-argon particle-boron particle-xenon
...
```

With this PR:
```
$ BOARD=feather-nrf52840-sense make -C tests/drivers/nrf802154 info-build 
...
supported boards:
adafruit-clue adafruit-itsybitsy-nrf52 arduino-nano-33-ble arduino-nano-33-ble-sense e104-bt5011a-tb feather-nrf52840 feather-nrf52840-sense microbit-v2 nrf52840-mdk nrf52840-mdk-dongle nrf52840dk nrf52840dongle particle-argon particle-boron particle-xenon reel seeedstudio-xiao-nrf52840 seeedstudio-xiao-nrf52840-sense waveshare-nrf52840-eval-kit
...
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #21019.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
