### PR TITLE
gnrc_sock/udp: zero-init sock struct on create

### DIFF
--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -40,6 +40,8 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
     int res;
     struct netconn *tmp = NULL;
 
+    memset(sock, 0, sizeof(*sock));
+
     if ((res = lwip_sock_create(&tmp, (struct _sock_tl_ep *)local,
                                 (struct _sock_tl_ep *)remote, 0, flags,
                                 NETCONN_UDP)) == 0) {

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -101,7 +101,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
         (local->netif != remote->netif)) {
         return -EINVAL;
     }
-    memset(&sock->local, 0, sizeof(sock_udp_ep_t));
+    memset(sock, 0, sizeof(*sock));
     if (local != NULL) {
         uint16_t port = local->port;
 
@@ -130,7 +130,6 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
         memcpy(&sock->local, local, sizeof(sock_udp_ep_t));
         sock->local.port = port;
     }
-    memset(&sock->remote, 0, sizeof(sock_udp_ep_t));
     if (remote != NULL) {
         if (gnrc_af_not_supported(remote->family)) {
             return -EAFNOSUPPORT;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`sock_udp_create()` leaves some fields (e.g. `reg.async_ctx`) uninitialized.
This blows up when accessing the field later as introduced by #21180

Just bring the whole `sock` struct to a sane state on init to avoid this. 


### Testing procedure




### Issues/PRs references

fixes issue described in https://github.com/RIOT-OS/RIOT/pull/21180#discussion_r2027268460
