### PR TITLE
drivers/lis2dh12: int32_t lis2dh12_wait_event()

### DIFF
--- a/drivers/include/lis2dh12.h
+++ b/drivers/include/lis2dh12.h
@@ -312,7 +312,7 @@ void lis2dh12_cfg_disable_event(const lis2dh12_t *dev, uint8_t event, uint8_t pi
  * @return  negative error
  * @return  positive LIS2DH12_INT_SRC bit mask on success
  */
-int lis2dh12_wait_event(const lis2dh12_t *dev, uint8_t pin, bool stale_events);
+int32_t lis2dh12_wait_event(const lis2dh12_t *dev, uint8_t pin, bool stale_events);
 #endif /* MODULE_LIS2DH12_INT */
 
 /**

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -437,7 +437,7 @@ static uint32_t _merge_int_flags(const lis2dh12_t *dev, uint8_t events)
                               ((uint32_t)LIS2DH12_INT_SRC_IA <<  8) | \
                               ((uint32_t)LIS2DH12_INT_SRC_IA << 16))
 
-int lis2dh12_wait_event(const lis2dh12_t *dev, uint8_t line, bool stale_events)
+int32_t lis2dh12_wait_event(const lis2dh12_t *dev, uint8_t line, bool stale_events)
 {
     uint32_t int_src;
     uint8_t events = 0;

--- a/tests/drivers/lis2dh12/main.c
+++ b/tests/drivers/lis2dh12/main.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <inttypes.h>
 #include "fmt.h"
 #include "thread.h"
 #include "shell.h"
@@ -79,10 +80,10 @@ void* lis2dh12_test_process(void* arg) {
     while (1) {
 
         /* wait for interrupt */
-        int int1_src = lis2dh12_wait_event(&dev, LIS2DH12_INT1, false);
+        int32_t int1_src = lis2dh12_wait_event(&dev, LIS2DH12_INT1, false);
 
         if (int1_src <= 0) {
-            printf("error: %d\n", int1_src);
+            printf("error: %" PRId32 "\n", int1_src);
             continue;
         }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The return value of `lis2dh12_wait_event` is a 24-bit mask.
An `int` is not necessarily 32 bits.
If it really would have been an issue in practice, I think the compiler should have thrown a warning for any architecture.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
