### PR TITLE
dist/tools: add `#pragma once` to headerguard check

### DIFF
--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -43,11 +43,14 @@ def fix_headerguard(filename):
     tmp.seek(0)
 
     guard_found = 0
+    pragma_once_found = 0
     include_next_found = 0
     guard_name = ""
     ifstack = 0
     for line in inlines:
-        if guard_found == 0:
+        if line.startswith("#pragma once"):
+            pragma_once_found += 1
+        if guard_found == 0 and pragma_once_found == 0:
             if line.startswith("#ifndef"):
                 guard_found += 1
                 guard_name = line[8:].rstrip()
@@ -73,7 +76,8 @@ def fix_headerguard(filename):
         tmp.write(line)
 
     tmp.seek(0)
-    if guard_found == 3:
+    if (pragma_once_found == 0 and guard_found == 3) or \
+       (pragma_once_found == 1 and guard_found == 0):
         if include_next_found == 0:
             for line in difflib.unified_diff(inlines, tmp.readlines(),
                                              "%s" % filename, "%s" % filename):


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The headerguards static check currently does not know anything about `#pragma once`. However in #21335, the consensus was reached to use `#pragma once`, the static test should not fail for it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1) Add a `#pragma once` to a header of your choice that already has the classic include guards (without removing them): the static test `./dist/tools/headerguard/check.sh` should fail.
2) Remove the classic include guards, the static test `./dist/tools/headerguard/check.sh` should not fail.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
